### PR TITLE
KAFKA-19307: Add file-based config and CLI credentials support to OAuthCompatibilityTool

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -36,12 +36,22 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.security.auth.login.AppConfigurationEntry;
 
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS;
@@ -50,6 +60,10 @@ import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOF
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS_DOC;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID_DOC;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE;
@@ -64,8 +78,10 @@ import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_E
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC;
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL;
@@ -119,6 +135,11 @@ import static org.apache.kafka.common.security.oauthbearer.internals.secured.Con
 
 public class OAuthCompatibilityTool {
 
+    private static final String CLIENT_CONFIG_ARG = "client-config";
+    private static final String BROKER_CONFIG_ARG = "broker-config";
+    private static final String CLIENT_ID_ARG = "client-id";
+    private static final String CLIENT_SECRET_ARG = "client-secret";
+
     public static void main(String[] args) {
         ArgsHandler argsHandler = new ArgsHandler();
         Namespace namespace;
@@ -130,24 +151,19 @@ public class OAuthCompatibilityTool {
             return;
         }
 
-        ConfigHandler configHandler = new ConfigHandler(namespace);
+        Properties clientFileProps = loadConfigFile(namespace, CLIENT_CONFIG_ARG);
+        Properties brokerFileProps = loadConfigFile(namespace, BROKER_CONFIG_ARG);
 
-        Map<String, ?> configs = configHandler.getConfigs();
-        List<AppConfigurationEntry> jaasConfigEntries = List.of(
-            new AppConfigurationEntry(
-                OAuthBearerLoginModule.class.getName(),
-                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                configHandler.getJaasOptions()
-            )
-        );
+        ConfigHandler clientConfigHandler = new ConfigHandler(namespace, clientFileProps);
+        ConfigHandler brokerConfigHandler = new ConfigHandler(namespace, brokerFileProps);
 
         try {
             String jwt;
 
             {
                 // Client side...
-                try (JwtRetriever retriever = createRetriever(configs, jaasConfigEntries)) {
-                    try (JwtValidator validator = createValidator(configs, jaasConfigEntries)) {
+                try (JwtRetriever retriever = createRetriever(clientConfigHandler)) {
+                    try (JwtValidator validator = createValidator(clientConfigHandler)) {
                         System.out.println("PASSED 1/5: client configuration");
 
                         jwt = retriever.retrieve();
@@ -161,7 +177,7 @@ public class OAuthCompatibilityTool {
 
             {
                 // Broker side...
-                try (JwtValidator validator = createValidator(configs, jaasConfigEntries)) {
+                try (JwtValidator validator = createValidator(brokerConfigHandler)) {
                     System.out.println("PASSED 4/5: broker configuration");
 
                     validator.validate(jwt);
@@ -184,27 +200,62 @@ public class OAuthCompatibilityTool {
         }
     }
 
-    private static JwtRetriever createRetriever(Map<String, ?> configs, List<AppConfigurationEntry> jaasConfigEntries) {
-        return getConfiguredInstance(
-            configs,
-            OAUTHBEARER_MECHANISM,
-            jaasConfigEntries,
-            SaslConfigs.SASL_OAUTHBEARER_JWT_RETRIEVER_CLASS,
-            JwtRetriever.class
+    private static Properties loadConfigFile(Namespace namespace, String argName) {
+        String path = namespace.getString(argName);
+
+        if (path == null)
+            return new Properties();
+
+        Properties props = new Properties();
+
+        try (FileInputStream fis = new FileInputStream(path)) {
+            props.load(fis);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load config file for --" + argName + ": " + path, e);
+        }
+
+        return props;
+    }
+
+    private static JwtRetriever createRetriever(ConfigHandler configHandler) {
+        return createConfiguredInstance(
+                configHandler,
+                SaslConfigs.SASL_OAUTHBEARER_JWT_RETRIEVER_CLASS,
+                JwtRetriever.class
         );
     }
 
-    private static JwtValidator createValidator(Map<String, ?> configs, List<AppConfigurationEntry> jaasConfigEntries) {
-        return getConfiguredInstance(
-            configs,
-            OAUTHBEARER_MECHANISM,
-            jaasConfigEntries,
-            SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS,
-            JwtValidator.class
+    private static JwtValidator createValidator(ConfigHandler configHandler) {
+        return createConfiguredInstance(
+                configHandler,
+                SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS,
+                JwtValidator.class
         );
     }
 
-    private static class ArgsHandler {
+    private static <T> T createConfiguredInstance(
+            ConfigHandler configHandler,
+            String configKey,
+            Class<T> clazz
+    ) {
+        List<AppConfigurationEntry> jaasConfigEntries = List.of(
+                new AppConfigurationEntry(
+                        OAuthBearerLoginModule.class.getName(),
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        configHandler.getJaasOptions()
+                )
+        );
+
+        return getConfiguredInstance(
+                configHandler.getConfigs(),
+                OAUTHBEARER_MECHANISM,
+                jaasConfigEntries,
+                configKey,
+                clazz
+        );
+    }
+
+    static class ArgsHandler {
 
         private static final String DESCRIPTION = String.format(
             "This tool is used to verify OAuth/OIDC provider compatibility.%n%n" +
@@ -214,14 +265,27 @@ public class OAuthCompatibilityTool {
 
         private final ArgumentParser parser;
 
-        private ArgsHandler() {
+        ArgsHandler() {
             this.parser = ArgumentParsers
                 .newArgumentParser("oauth-compatibility-tool")
                 .defaultHelp(true)
                 .description(DESCRIPTION);
         }
 
-        private Namespace parseArgs(String[] args) throws ArgumentParserException {
+        Namespace parseArgs(String[] args) throws ArgumentParserException {
+            // File-based config options
+            parser.addArgument("--" + CLIENT_CONFIG_ARG)
+                    .metavar("path")
+                    .dest(CLIENT_CONFIG_ARG)
+                    .help("Path to a .properties file containing the client's OAuth/SSL configuration. " +
+                            "Explicit command line options override any matching keys in this file.");
+
+            parser.addArgument("--" + BROKER_CONFIG_ARG)
+                    .metavar("path")
+                    .dest(BROKER_CONFIG_ARG)
+                    .help("Path to a .properties file containing the broker's OAuth/SSL configuration. " +
+                            "Explicit command line options override any matching keys in this file.");
+
             // SASL/OAuth
             addArgument(SASL_LOGIN_CONNECT_TIMEOUT_MS, SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC, Integer.class);
             addArgument(SASL_LOGIN_READ_TIMEOUT_MS, SASL_LOGIN_READ_TIMEOUT_MS_DOC, Integer.class);
@@ -238,6 +302,9 @@ public class OAuthCompatibilityTool {
             addArgument(SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC);
             addArgument(SASL_OAUTHBEARER_SUB_CLAIM_NAME, SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC);
             addArgument(SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC);
+            addArgument(SASL_OAUTHBEARER_SCOPE, SASL_OAUTHBEARER_SCOPE_DOC);
+            addArgument(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID_DOC);
+            addArgument(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET, SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET_DOC);
 
             // SSL
             addArgument(SSL_CIPHER_SUITES_CONFIG, SSL_CIPHER_SUITES_DOC)
@@ -263,9 +330,16 @@ public class OAuthCompatibilityTool {
             addArgument(SSL_TRUSTSTORE_TYPE_CONFIG, SSL_TRUSTSTORE_TYPE_DOC);
 
             // JAAS options...
-            addArgument(CLIENT_ID_CONFIG, CLIENT_ID_DOC);
-            addArgument(CLIENT_SECRET_CONFIG, CLIENT_SECRET_DOC);
+            parser.addArgument("--" + CLIENT_ID_ARG)
+                    .metavar(CLIENT_ID_ARG)
+                    .dest(CLIENT_ID_CONFIG)
+                    .help(CLIENT_ID_DOC);
+            parser.addArgument("--" + CLIENT_SECRET_ARG)
+                    .metavar(CLIENT_SECRET_ARG)
+                    .dest(CLIENT_SECRET_CONFIG)
+                    .help(CLIENT_SECRET_DOC);
             addArgument(SCOPE_CONFIG, SCOPE_DOC);
+            addArgument(SASL_JAAS_CONFIG, SASL_JAAS_CONFIG_DOC);
 
             try {
                 return parser.parseArgs(args);
@@ -280,7 +354,6 @@ public class OAuthCompatibilityTool {
         }
 
         private Argument addArgument(String option, String help, Class<?> clazz) {
-            // Change foo.bar into --foo.bar.
             String name = "--" + option;
 
             return parser.addArgument(name)
@@ -292,114 +365,154 @@ public class OAuthCompatibilityTool {
 
     }
 
-    private record ConfigHandler(Namespace namespace) {
+    static class ConfigHandler {
+        private final Namespace namespace;
+        private final Properties fileProps;
 
-        private Map<String, ?> getConfigs() {
+        private final Map<String, BiConsumer<Map<String, Object>, String>> saslAdders = Map.ofEntries(
+                Map.entry(SASL_LOGIN_CONNECT_TIMEOUT_MS, this::maybeAddInt),
+                Map.entry(SASL_LOGIN_READ_TIMEOUT_MS, this::maybeAddInt),
+                Map.entry(SASL_LOGIN_RETRY_BACKOFF_MS, this::maybeAddLong),
+                Map.entry(SASL_LOGIN_RETRY_BACKOFF_MAX_MS, this::maybeAddLong),
+                Map.entry(SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_SUB_CLAIM_NAME, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, this::maybeAddLong),
+                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, this::maybeAddLong),
+                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, this::maybeAddLong),
+                Map.entry(SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS, this::maybeAddInt),
+                Map.entry(SASL_OAUTHBEARER_EXPECTED_AUDIENCE, this::maybeAddStringList),
+                Map.entry(SASL_OAUTHBEARER_EXPECTED_ISSUER, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_SCOPE, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, this::maybeAddString),
+                Map.entry(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET, this::maybeAddPassword)
+        );
+        private final Map<String, BiConsumer<Map<String, Object>, String>> jaasOptionAdders = Map.ofEntries(
+                // SASL/OAuth
+                Map.entry(CLIENT_ID_CONFIG, this::maybeAddStringCliOnly),
+                Map.entry(CLIENT_SECRET_CONFIG, this::maybeAddStringCliOnly),
+                Map.entry(SCOPE_CONFIG, this::maybeAddString),
+                Map.entry(SASL_JAAS_CONFIG, this::maybeAddJaasConfig),
+                // SSL
+                Map.entry(SSL_CIPHER_SUITES_CONFIG, this::maybeAddStringList),
+                Map.entry(SSL_ENABLED_PROTOCOLS_CONFIG, this::maybeAddStringList),
+                Map.entry(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, this::maybeAddString),
+                Map.entry(SSL_ENGINE_FACTORY_CLASS_CONFIG, this::maybeAddClass),
+                Map.entry(SSL_KEYMANAGER_ALGORITHM_CONFIG, this::maybeAddString),
+                Map.entry(SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_KEYSTORE_KEY_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_KEYSTORE_LOCATION_CONFIG, this::maybeAddString),
+                Map.entry(SSL_KEYSTORE_PASSWORD_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_KEYSTORE_TYPE_CONFIG, this::maybeAddString),
+                Map.entry(SSL_KEY_PASSWORD_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_PROTOCOL_CONFIG, this::maybeAddString),
+                Map.entry(SSL_PROVIDER_CONFIG, this::maybeAddString),
+                Map.entry(SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, this::maybeAddString),
+                Map.entry(SSL_TRUSTMANAGER_ALGORITHM_CONFIG, this::maybeAddString),
+                Map.entry(SSL_TRUSTSTORE_CERTIFICATES_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_TRUSTSTORE_LOCATION_CONFIG, this::maybeAddString),
+                Map.entry(SSL_TRUSTSTORE_PASSWORD_CONFIG, this::maybeAddPassword),
+                Map.entry(SSL_TRUSTSTORE_TYPE_CONFIG, this::maybeAddString)
+        );
+
+        public ConfigHandler(Namespace namespace, Properties fileProps) {
+            this.namespace = namespace;
+            this.fileProps = fileProps;
+        }
+
+        Map<String, ?> getConfigs() {
             Map<String, Object> m = new HashMap<>();
 
-            // SASL/OAuth
-            maybeAddInt(m, SASL_LOGIN_CONNECT_TIMEOUT_MS);
-            maybeAddInt(m, SASL_LOGIN_READ_TIMEOUT_MS);
-            maybeAddLong(m, SASL_LOGIN_RETRY_BACKOFF_MS);
-            maybeAddLong(m, SASL_LOGIN_RETRY_BACKOFF_MAX_MS);
-            maybeAddString(m, SASL_OAUTHBEARER_SCOPE_CLAIM_NAME);
-            maybeAddString(m, SASL_OAUTHBEARER_SUB_CLAIM_NAME);
-            maybeAddString(m, SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL);
-            maybeAddString(m, SASL_OAUTHBEARER_JWKS_ENDPOINT_URL);
-            maybeAddLong(m, SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS);
-            maybeAddLong(m, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
-            maybeAddLong(m, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS);
-            maybeAddInt(m, SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS);
-            maybeAddStringList(m, SASL_OAUTHBEARER_EXPECTED_AUDIENCE);
-            maybeAddString(m, SASL_OAUTHBEARER_EXPECTED_ISSUER);
+            for (Map.Entry<String, BiConsumer<Map<String, Object>, String>> entry : saslAdders.entrySet())
+                entry.getValue().accept(m, entry.getKey());
 
-            // This here is going to fill in all the defaults for the values we don't specify...
             ConfigDef cd = new ConfigDef();
             SaslConfigs.addClientSaslSupport(cd);
             SslConfigs.addClientSslSupport(cd);
-            AbstractConfig config = new AbstractConfig(cd, m);
-            return config.values();
+
+            return new AbstractConfig(cd, m).values();
         }
 
-        private Map<String, Object> getJaasOptions() {
+        Map<String, Object> getJaasOptions() {
             Map<String, Object> m = new HashMap<>();
 
-            // SASL/OAuth
-            maybeAddString(m, CLIENT_ID_CONFIG);
-            maybeAddString(m, CLIENT_SECRET_CONFIG);
-            maybeAddString(m, SCOPE_CONFIG);
-
-            // SSL
-            maybeAddStringList(m, SSL_CIPHER_SUITES_CONFIG);
-            maybeAddStringList(m, SSL_ENABLED_PROTOCOLS_CONFIG);
-            maybeAddString(m, SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
-            maybeAddClass(m, SSL_ENGINE_FACTORY_CLASS_CONFIG);
-            maybeAddString(m, SSL_KEYMANAGER_ALGORITHM_CONFIG);
-            maybeAddPassword(m, SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG);
-            maybeAddPassword(m, SSL_KEYSTORE_KEY_CONFIG);
-            maybeAddString(m, SSL_KEYSTORE_LOCATION_CONFIG);
-            maybeAddPassword(m, SSL_KEYSTORE_PASSWORD_CONFIG);
-            maybeAddString(m, SSL_KEYSTORE_TYPE_CONFIG);
-            maybeAddPassword(m, SSL_KEY_PASSWORD_CONFIG);
-            maybeAddString(m, SSL_PROTOCOL_CONFIG);
-            maybeAddString(m, SSL_PROVIDER_CONFIG);
-            maybeAddString(m, SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG);
-            maybeAddString(m, SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
-            maybeAddPassword(m, SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
-            maybeAddString(m, SSL_TRUSTSTORE_LOCATION_CONFIG);
-            maybeAddPassword(m, SSL_TRUSTSTORE_PASSWORD_CONFIG);
-            maybeAddString(m, SSL_TRUSTSTORE_TYPE_CONFIG);
+            for (Map.Entry<String, BiConsumer<Map<String, Object>, String>> entry : jaasOptionAdders.entrySet())
+                entry.getValue().accept(m, entry.getKey());
 
             return m;
         }
 
-        private void maybeAddInt(Map<String, Object> m, String option) {
-            Integer value = namespace.getInt(option);
-
-            if (value != null)
-                m.put(option, value);
+        private Optional<String> resolve(String key) {
+            String value = namespace.getString(key);
+            if (value == null)
+                value = fileProps.getProperty(key);
+            return Optional.ofNullable(value);
         }
 
-        private void maybeAddLong(Map<String, Object> m, String option) {
-            Long value = namespace.getLong(option);
-
-            if (value != null)
-                m.put(option, value);
+        private void maybeAddInt(Map<String, Object> m, String key) {
+            resolve(key).map(Integer::parseInt).ifPresent(v -> m.put(key, v));
         }
 
-        private void maybeAddString(Map<String, Object> m, String option) {
-            String value = namespace.getString(option);
-
-            if (value != null)
-                m.put(option, value);
+        private void maybeAddLong(Map<String, Object> m, String key) {
+            resolve(key).map(Long::parseLong).ifPresent(v -> m.put(key, v));
         }
 
-        private void maybeAddPassword(Map<String, Object> m, String option) {
-            String value = namespace.getString(option);
+        private void maybeAddString(Map<String, Object> m, String key) {
+            resolve(key).ifPresent(v -> m.put(key, v));
+        }
 
-            if (value != null)
-                m.put(option, new Password(value));
+        private void maybeAddPassword(Map<String, Object> m, String key) {
+            resolve(key).map(Password::new).ifPresent(v -> m.put(key, v));
+        }
+
+        private void maybeAddStringCliOnly(Map<String, Object> m, String option) {
+            Optional.ofNullable(namespace.getString(option)).ifPresent(v -> m.put(option, v));
+        }
+
+        private void maybeAddJaasConfig(Map<String, Object> m, String option) {
+            String str = fileProps.getProperty(option);
+
+            if (str == null)
+                return;
+
+            Pattern pattern = Pattern.compile("(\\w+)=\"([^\"]*)\"");
+            Matcher matcher = pattern.matcher(str);
+
+            while (matcher.find()) {
+                String key = matcher.group(1);
+                String value = matcher.group(2);
+
+                if ((key.equals(CLIENT_ID_CONFIG) ||
+                        key.equals(CLIENT_SECRET_CONFIG) ||
+                        key.equals(SCOPE_CONFIG)) && !m.containsKey(key)) {
+                    m.put(key, value);
+                }
+            }
         }
 
         private void maybeAddClass(Map<String, Object> m, String option) {
-            String value = namespace.getString(option);
-
-            if (value != null) {
+            resolve(option).ifPresent(v -> {
                 try {
-                    m.put(option, Class.forName(value));
+                    m.put(option, Class.forName(v));
                 } catch (ClassNotFoundException e) {
                     throw new KafkaException("Could not find class for " + option, e);
                 }
-            }
+            });
         }
 
         private void maybeAddStringList(Map<String, Object> m, String option) {
             List<String> value = namespace.getList(option);
 
+            if (value == null) {
+                String str = fileProps.getProperty(option);
+                if (str != null)
+                    value = List.of(str.split("\\s*,\\s*"));
+            }
+
             if (value != null)
                 m.put(option, value);
         }
-
     }
 
 }

--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.utils.internals.Exit;
+import org.apache.kafka.common.utils.Utils;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
@@ -36,9 +37,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -203,18 +202,11 @@ public class OAuthCompatibilityTool {
     private static Properties loadConfigFile(Namespace namespace, String argName) {
         String path = namespace.getString(argName);
 
-        if (path == null)
-            return new Properties();
-
-        Properties props = new Properties();
-
-        try (FileInputStream fis = new FileInputStream(path)) {
-            props.load(fis);
+        try {
+            return Utils.loadProps(path);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to load config file for --" + argName + ": " + path, e);
+            throw new KafkaException("Failed to load config file for --" + argName + ": " + path, e);
         }
-
-        return props;
     }
 
     private static JwtRetriever createRetriever(ConfigHandler configHandler) {

--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
@@ -31,8 +30,6 @@ import org.apache.kafka.common.utils.internals.Exit;
 import org.apache.kafka.common.utils.Utils;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.impl.Arguments;
-import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -43,92 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.function.BiConsumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.TreeMap;
 
 import javax.security.auth.login.AppConfigurationEntry;
 
-import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_READ_TIMEOUT_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_LOGIN_RETRY_BACKOFF_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SCOPE_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL;
-import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_CIPHER_SUITES_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_CIPHER_SUITES_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENABLED_PROTOCOLS_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_ENGINE_FACTORY_CLASS_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_KEY_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_KEY_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_PASSWORD_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_TYPE_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_TYPE_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEY_PASSWORD_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_KEY_PASSWORD_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_PROTOCOL_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_PROTOCOL_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_PROVIDER_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_PROVIDER_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
-import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_DOC;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.CLIENT_ID_CONFIG;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.CLIENT_ID_DOC;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.CLIENT_SECRET_CONFIG;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.CLIENT_SECRET_DOC;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.SCOPE_CONFIG;
-import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.SCOPE_DOC;
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 import static org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils.getConfiguredInstance;
 
@@ -136,8 +51,8 @@ public class OAuthCompatibilityTool {
 
     private static final String CLIENT_CONFIG_ARG = "client-config";
     private static final String BROKER_CONFIG_ARG = "broker-config";
-    private static final String CLIENT_ID_ARG = "client-id";
-    private static final String CLIENT_SECRET_ARG = "client-secret";
+    private static final ConfigDef SASL_CONFIG_DEF = saslConfigs();
+    private static final ConfigDef SSL_CONFIG_DEF = sslConfigs();
 
     public static void main(String[] args) {
         ArgsHandler argsHandler = new ArgsHandler();
@@ -203,6 +118,9 @@ public class OAuthCompatibilityTool {
         String path = namespace.getString(argName);
 
         try {
+            if (path == null || path.isEmpty())
+                return new Properties();
+
             return Utils.loadProps(path);
         } catch (IOException e) {
             throw new KafkaException("Failed to load config file for --" + argName + ": " + path, e);
@@ -234,17 +152,37 @@ public class OAuthCompatibilityTool {
                 new AppConfigurationEntry(
                         OAuthBearerLoginModule.class.getName(),
                         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        configHandler.getJaasOptions()
+                        configHandler.getConfigs(SSL_CONFIG_DEF)
                 )
         );
 
         return getConfiguredInstance(
-                configHandler.getConfigs(),
+                configHandler.getConfigs(SASL_CONFIG_DEF),
                 OAUTHBEARER_MECHANISM,
                 jaasConfigEntries,
                 configKey,
                 clazz
         );
+    }
+
+    private static ConfigDef saslConfigs() {
+        ConfigDef allSaslConfigs = new ConfigDef();
+        SaslConfigs.addClientSaslSupport(allSaslConfigs);
+
+        ConfigDef filteredSaslConfigs = new ConfigDef();
+        allSaslConfigs.configKeys().entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith("sasl.oauthbearer") ||
+                        entry.getKey().startsWith("sasl.login"))
+                .forEach(entry -> filteredSaslConfigs.define(entry.getValue()));
+
+        return filteredSaslConfigs;
+    }
+
+    private static ConfigDef sslConfigs() {
+        ConfigDef cd = new ConfigDef();
+        SslConfigs.addClientSslSupport(cd);
+
+        return cd;
     }
 
     static class ArgsHandler {
@@ -265,7 +203,6 @@ public class OAuthCompatibilityTool {
         }
 
         Namespace parseArgs(String[] args) throws ArgumentParserException {
-            // File-based config options
             parser.addArgument("--" + CLIENT_CONFIG_ARG)
                     .metavar("path")
                     .dest(CLIENT_CONFIG_ARG)
@@ -278,60 +215,10 @@ public class OAuthCompatibilityTool {
                     .help("Path to a .properties file containing the broker's OAuth/SSL configuration. " +
                             "Explicit command line options override any matching keys in this file.");
 
-            // SASL/OAuth
-            addArgument(SASL_LOGIN_CONNECT_TIMEOUT_MS, SASL_LOGIN_CONNECT_TIMEOUT_MS_DOC, Integer.class);
-            addArgument(SASL_LOGIN_READ_TIMEOUT_MS, SASL_LOGIN_READ_TIMEOUT_MS_DOC, Integer.class);
-            addArgument(SASL_LOGIN_RETRY_BACKOFF_MAX_MS, SASL_LOGIN_RETRY_BACKOFF_MAX_MS_DOC, Long.class);
-            addArgument(SASL_LOGIN_RETRY_BACKOFF_MS, SASL_LOGIN_RETRY_BACKOFF_MS_DOC, Long.class);
-            addArgument(SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS, SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS_DOC, Integer.class);
-            addArgument(SASL_OAUTHBEARER_EXPECTED_AUDIENCE, SASL_OAUTHBEARER_EXPECTED_AUDIENCE_DOC)
-                .action(Arguments.append());
-            addArgument(SASL_OAUTHBEARER_EXPECTED_ISSUER, SASL_OAUTHBEARER_EXPECTED_ISSUER_DOC);
-            addArgument(SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS_DOC, Long.class);
-            addArgument(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS_DOC, Long.class);
-            addArgument(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS_DOC, Long.class);
-            addArgument(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, SASL_OAUTHBEARER_JWKS_ENDPOINT_URL_DOC);
-            addArgument(SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, SASL_OAUTHBEARER_SCOPE_CLAIM_NAME_DOC);
-            addArgument(SASL_OAUTHBEARER_SUB_CLAIM_NAME, SASL_OAUTHBEARER_SUB_CLAIM_NAME_DOC);
-            addArgument(SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL_DOC);
-            addArgument(SASL_OAUTHBEARER_SCOPE, SASL_OAUTHBEARER_SCOPE_DOC);
-            addArgument(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID_DOC);
-            addArgument(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET, SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET_DOC);
-
-            // SSL
-            addArgument(SSL_CIPHER_SUITES_CONFIG, SSL_CIPHER_SUITES_DOC)
-                .action(Arguments.append());
-            addArgument(SSL_ENABLED_PROTOCOLS_CONFIG, SSL_ENABLED_PROTOCOLS_DOC)
-                .action(Arguments.append());
-            addArgument(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC);
-            addArgument(SSL_ENGINE_FACTORY_CLASS_CONFIG, SSL_ENGINE_FACTORY_CLASS_DOC);
-            addArgument(SSL_KEYMANAGER_ALGORITHM_CONFIG, SSL_KEYMANAGER_ALGORITHM_DOC);
-            addArgument(SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC);
-            addArgument(SSL_KEYSTORE_KEY_CONFIG, SSL_KEYSTORE_KEY_DOC);
-            addArgument(SSL_KEYSTORE_LOCATION_CONFIG, SSL_KEYSTORE_LOCATION_DOC);
-            addArgument(SSL_KEYSTORE_PASSWORD_CONFIG, SSL_KEYSTORE_PASSWORD_DOC);
-            addArgument(SSL_KEYSTORE_TYPE_CONFIG, SSL_KEYSTORE_TYPE_DOC);
-            addArgument(SSL_KEY_PASSWORD_CONFIG, SSL_KEY_PASSWORD_DOC);
-            addArgument(SSL_PROTOCOL_CONFIG, SSL_PROTOCOL_DOC);
-            addArgument(SSL_PROVIDER_CONFIG, SSL_PROVIDER_DOC);
-            addArgument(SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, SSL_SECURE_RANDOM_IMPLEMENTATION_DOC);
-            addArgument(SSL_TRUSTMANAGER_ALGORITHM_CONFIG, SSL_TRUSTMANAGER_ALGORITHM_DOC);
-            addArgument(SSL_TRUSTSTORE_CERTIFICATES_CONFIG, SSL_TRUSTSTORE_CERTIFICATES_DOC);
-            addArgument(SSL_TRUSTSTORE_LOCATION_CONFIG, SSL_TRUSTSTORE_LOCATION_DOC);
-            addArgument(SSL_TRUSTSTORE_PASSWORD_CONFIG, SSL_TRUSTSTORE_PASSWORD_DOC);
-            addArgument(SSL_TRUSTSTORE_TYPE_CONFIG, SSL_TRUSTSTORE_TYPE_DOC);
-
-            // JAAS options...
-            parser.addArgument("--" + CLIENT_ID_ARG)
-                    .metavar(CLIENT_ID_ARG)
-                    .dest(CLIENT_ID_CONFIG)
-                    .help(CLIENT_ID_DOC);
-            parser.addArgument("--" + CLIENT_SECRET_ARG)
-                    .metavar(CLIENT_SECRET_ARG)
-                    .dest(CLIENT_SECRET_CONFIG)
-                    .help(CLIENT_SECRET_DOC);
-            addArgument(SCOPE_CONFIG, SCOPE_DOC);
-            addArgument(SASL_JAAS_CONFIG, SASL_JAAS_CONFIG_DOC);
+            Map<String, ConfigDef.ConfigKey> configs = new TreeMap<>();
+            configs.putAll(SASL_CONFIG_DEF.configKeys());
+            configs.putAll(SSL_CONFIG_DEF.configKeys());
+            configs.forEach((key, value) -> addArgument(key, value.documentation));
 
             try {
                 return parser.parseArgs(args);
@@ -341,170 +228,51 @@ public class OAuthCompatibilityTool {
             }
         }
 
-        private Argument addArgument(String option, String help) {
-            return addArgument(option, help, String.class);
-        }
-
-        private Argument addArgument(String option, String help, Class<?> clazz) {
+        private void addArgument(String option, String help) {
             String name = "--" + option;
 
-            return parser.addArgument(name)
-                .type(clazz)
+            parser.addArgument(name)
+                .type(String.class)
                 .metavar(option)
                 .dest(option)
                 .help(help);
         }
-
     }
 
     static class ConfigHandler {
         private final Namespace namespace;
         private final Properties fileProps;
 
-        private final Map<String, BiConsumer<Map<String, Object>, String>> saslAdders = Map.ofEntries(
-                Map.entry(SASL_LOGIN_CONNECT_TIMEOUT_MS, this::maybeAddInt),
-                Map.entry(SASL_LOGIN_READ_TIMEOUT_MS, this::maybeAddInt),
-                Map.entry(SASL_LOGIN_RETRY_BACKOFF_MS, this::maybeAddLong),
-                Map.entry(SASL_LOGIN_RETRY_BACKOFF_MAX_MS, this::maybeAddLong),
-                Map.entry(SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_SUB_CLAIM_NAME, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, this::maybeAddLong),
-                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, this::maybeAddLong),
-                Map.entry(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, this::maybeAddLong),
-                Map.entry(SASL_OAUTHBEARER_CLOCK_SKEW_SECONDS, this::maybeAddInt),
-                Map.entry(SASL_OAUTHBEARER_EXPECTED_AUDIENCE, this::maybeAddStringList),
-                Map.entry(SASL_OAUTHBEARER_EXPECTED_ISSUER, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_SCOPE, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_ID, this::maybeAddString),
-                Map.entry(SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET, this::maybeAddPassword)
-        );
-        private final Map<String, BiConsumer<Map<String, Object>, String>> jaasOptionAdders = Map.ofEntries(
-                // SASL/OAuth
-                Map.entry(CLIENT_ID_CONFIG, this::maybeAddStringCliOnly),
-                Map.entry(CLIENT_SECRET_CONFIG, this::maybeAddStringCliOnly),
-                Map.entry(SCOPE_CONFIG, this::maybeAddString),
-                Map.entry(SASL_JAAS_CONFIG, this::maybeAddJaasConfig),
-                // SSL
-                Map.entry(SSL_CIPHER_SUITES_CONFIG, this::maybeAddStringList),
-                Map.entry(SSL_ENABLED_PROTOCOLS_CONFIG, this::maybeAddStringList),
-                Map.entry(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, this::maybeAddString),
-                Map.entry(SSL_ENGINE_FACTORY_CLASS_CONFIG, this::maybeAddClass),
-                Map.entry(SSL_KEYMANAGER_ALGORITHM_CONFIG, this::maybeAddString),
-                Map.entry(SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_KEYSTORE_KEY_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_KEYSTORE_LOCATION_CONFIG, this::maybeAddString),
-                Map.entry(SSL_KEYSTORE_PASSWORD_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_KEYSTORE_TYPE_CONFIG, this::maybeAddString),
-                Map.entry(SSL_KEY_PASSWORD_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_PROTOCOL_CONFIG, this::maybeAddString),
-                Map.entry(SSL_PROVIDER_CONFIG, this::maybeAddString),
-                Map.entry(SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, this::maybeAddString),
-                Map.entry(SSL_TRUSTMANAGER_ALGORITHM_CONFIG, this::maybeAddString),
-                Map.entry(SSL_TRUSTSTORE_CERTIFICATES_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_TRUSTSTORE_LOCATION_CONFIG, this::maybeAddString),
-                Map.entry(SSL_TRUSTSTORE_PASSWORD_CONFIG, this::maybeAddPassword),
-                Map.entry(SSL_TRUSTSTORE_TYPE_CONFIG, this::maybeAddString)
-        );
-
         public ConfigHandler(Namespace namespace, Properties fileProps) {
             this.namespace = namespace;
             this.fileProps = fileProps;
+
+            for (String key : fileProps.stringPropertyNames())
+                if (namespace.getString(key) != null)
+                    System.err.println("WARNING: command-line option --" + key + " overrides value from configuration file");
         }
 
-        Map<String, ?> getConfigs() {
+        Map<String, ?> getConfigs(ConfigDef cd) {
             Map<String, Object> m = new HashMap<>();
 
-            for (Map.Entry<String, BiConsumer<Map<String, Object>, String>> entry : saslAdders.entrySet())
-                entry.getValue().accept(m, entry.getKey());
-
-            ConfigDef cd = new ConfigDef();
-            SaslConfigs.addClientSaslSupport(cd);
-            SslConfigs.addClientSslSupport(cd);
+            for (Map.Entry<String, ConfigDef.ConfigKey> entry : cd.configKeys().entrySet())
+                maybeAdd(m, entry.getKey());
 
             return new AbstractConfig(cd, m).values();
         }
 
-        Map<String, Object> getJaasOptions() {
-            Map<String, Object> m = new HashMap<>();
-
-            for (Map.Entry<String, BiConsumer<Map<String, Object>, String>> entry : jaasOptionAdders.entrySet())
-                entry.getValue().accept(m, entry.getKey());
-
-            return m;
-        }
-
         private Optional<String> resolve(String key) {
-            String value = namespace.getString(key);
-            if (value == null)
-                value = fileProps.getProperty(key);
-            return Optional.ofNullable(value);
+            String cmdValue = namespace.getString(key);
+            String fileValue = fileProps.getProperty(key);
+
+            if (cmdValue != null)
+                return Optional.of(cmdValue);
+
+            return Optional.ofNullable(fileValue);
         }
 
-        private void maybeAddInt(Map<String, Object> m, String key) {
-            resolve(key).map(Integer::parseInt).ifPresent(v -> m.put(key, v));
-        }
-
-        private void maybeAddLong(Map<String, Object> m, String key) {
-            resolve(key).map(Long::parseLong).ifPresent(v -> m.put(key, v));
-        }
-
-        private void maybeAddString(Map<String, Object> m, String key) {
+        private void maybeAdd(Map<String, Object> m, String key) {
             resolve(key).ifPresent(v -> m.put(key, v));
         }
-
-        private void maybeAddPassword(Map<String, Object> m, String key) {
-            resolve(key).map(Password::new).ifPresent(v -> m.put(key, v));
-        }
-
-        private void maybeAddStringCliOnly(Map<String, Object> m, String option) {
-            Optional.ofNullable(namespace.getString(option)).ifPresent(v -> m.put(option, v));
-        }
-
-        private void maybeAddJaasConfig(Map<String, Object> m, String option) {
-            String str = fileProps.getProperty(option);
-
-            if (str == null)
-                return;
-
-            Pattern pattern = Pattern.compile("(\\w+)=\"([^\"]*)\"");
-            Matcher matcher = pattern.matcher(str);
-
-            while (matcher.find()) {
-                String key = matcher.group(1);
-                String value = matcher.group(2);
-
-                if ((key.equals(CLIENT_ID_CONFIG) ||
-                        key.equals(CLIENT_SECRET_CONFIG) ||
-                        key.equals(SCOPE_CONFIG)) && !m.containsKey(key)) {
-                    m.put(key, value);
-                }
-            }
-        }
-
-        private void maybeAddClass(Map<String, Object> m, String option) {
-            resolve(option).ifPresent(v -> {
-                try {
-                    m.put(option, Class.forName(v));
-                } catch (ClassNotFoundException e) {
-                    throw new KafkaException("Could not find class for " + option, e);
-                }
-            });
-        }
-
-        private void maybeAddStringList(Map<String, Object> m, String option) {
-            List<String> value = namespace.getList(option);
-
-            if (value == null) {
-                String str = fileProps.getProperty(option);
-                if (str != null)
-                    value = List.of(str.split("\\s*,\\s*"));
-            }
-
-            if (value != null)
-                m.put(option, value);
-        }
     }
-
 }

--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -26,8 +26,8 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.utils.internals.Exit;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.common.utils.internals.Exit;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.test.TestSslUtils;
+
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class OAuthCompatibilityToolTest {
+
+    @Test
+    public void testParseArgsParsesClientConfig() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--client-config", "/tmp/test/client.properties"
+        });
+
+        assertEquals("/tmp/test/client.properties", namespace.getString("client-config"));
+    }
+
+    @Test
+    public void testParseArgsParsesBrokerConfig() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--broker-config", "/tmp/test/broker.properties"
+        });
+
+        assertEquals("/tmp/test/broker.properties", namespace.getString("broker-config"));
+    }
+
+    @Test
+    public void testParseArgsParsesSaslJaasConfig() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--sasl.jaas.config", "test"
+        });
+
+        assertEquals("test", namespace.getString("sasl.jaas.config"));
+    }
+
+    @Test
+    public void testParseArgsParsesClientId() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--client-id", "testId"
+        });
+
+        assertEquals("testId", namespace.getString("clientId"));
+    }
+
+    @Test
+    public void testParseArgsParsesClientSecret() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--client-secret", "testSecret"
+        });
+
+        assertEquals("testSecret", namespace.getString("clientSecret"));
+    }
+
+    @Test
+    public void testParseArgsThrowsIfArgumentIsEmpty() {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        assertThrows(
+                ArgumentParserException.class,
+                () -> argsHandler.parseArgs(new String[]{"", ""}));
+    }
+
+    @Test
+    public void testGetConfigsReturnsInteger() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--sasl.login.connect.timeout.ms", "100"
+        });
+        Properties properties = new Properties();
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals(100, clientConfigHandler.getConfigs().get("sasl.login.connect.timeout.ms"));
+    }
+
+    @Test
+    public void testGetConfigsReturnsLong() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--sasl.login.retry.backoff.ms", "5"
+        });
+        Properties properties = new Properties();
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals(5L, clientConfigHandler.getConfigs().get("sasl.login.retry.backoff.ms"));
+    }
+
+    @Test
+    public void testGetConfigsReturnsClass() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--ssl.engine.factory.class", "org.apache.kafka.test.TestSslUtils$TestSslEngineFactory"
+        });
+        Properties properties = new Properties();
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals(TestSslUtils.TestSslEngineFactory.class, clientConfigHandler.getJaasOptions().get("ssl.engine.factory.class"));
+    }
+
+    @Test
+    public void testGetConfigsThrowsWhenClassNotFound() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--ssl.engine.factory.class", "SomeClass"
+        });
+        Properties properties = new Properties();
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertThrows(KafkaException.class, () -> clientConfigHandler.getJaasOptions().get("ssl.engine.factory.class"));
+    }
+
+    @Test
+    public void testGetConfigsReturnsStringListFromCli() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--sasl.oauthbearer.expected.audience", "test1",
+            "--sasl.oauthbearer.expected.audience", "test2"
+        });
+        Properties properties = new Properties();
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
+    }
+
+    @Test
+    public void testGetConfigsReturnsStringListFromProperties() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{});
+        Properties properties = new Properties();
+        properties.put("sasl.oauthbearer.expected.audience", "test1,test2");
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
+    }
+
+    @Test
+    public void testGetConfigsReturnsStringListAndCliHasPriority() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--sasl.oauthbearer.expected.audience", "test1",
+            "--sasl.oauthbearer.expected.audience", "test2"
+        });
+        Properties properties = new Properties();
+        properties.put("sasl.oauthbearer.expected.audience", "test3");
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
+        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
+    }
+
+    @Test
+    public void testGetConfigsIgnoresSaslJaasConfigIfCredentialsAreProvidedViaCli() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{
+            "--client-id", "testId1",
+            "--client-secret", "testSecret1",
+            "--scope", "testScope1",
+        });
+        Properties properties = new Properties();
+        properties.put(
+                "sasl.jaas.config",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"testId2\" clientSecret=\"testSecret2\" scope=\"testScope2\";");
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals("testId1", clientConfigHandler.getJaasOptions().get("clientId"));
+        assertEquals("testSecret1", clientConfigHandler.getJaasOptions().get("clientSecret"));
+        assertEquals("testScope1", clientConfigHandler.getJaasOptions().get("scope"));
+    }
+
+    @Test
+    public void testGetJaasOptionsContainsSaslJaasConfigIfCredentialsAreNotProvidedViaCli() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{});
+        Properties properties = new Properties();
+        properties.put(
+            "sasl.jaas.config",
+            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"testId\" clientSecret=\"testSecret\" scope=\"testScope\";");
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals("testId", clientConfigHandler.getJaasOptions().get("clientId"));
+        assertEquals("testSecret", clientConfigHandler.getJaasOptions().get("clientSecret"));
+        assertEquals("testScope", clientConfigHandler.getJaasOptions().get("scope"));
+    }
+
+    @Test
+    public void testGetJaasOptionsContainsUnknownKeyInSaslJaasConfig() throws ArgumentParserException {
+        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
+        Namespace namespace = argsHandler.parseArgs(new String[]{});
+        Properties properties = new Properties();
+        properties.put(
+                "sasl.jaas.config",
+                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unknownKey=\"test\" clientId=\"testId\" clientSecret=\"testSecret\" scope=\"testScope\";");
+        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
+
+        assertEquals("testId", clientConfigHandler.getJaasOptions().get("clientId"));
+        assertEquals("testSecret", clientConfigHandler.getJaasOptions().get("clientSecret"));
+        assertEquals("testScope", clientConfigHandler.getJaasOptions().get("scope"));
+        assertNull(clientConfigHandler.getJaasOptions().get("unknownKey"));
+    }
+
+    @Test
+    public void testExitsWhenOnlyClientIdProvided() {
+        AtomicInteger exitCode = new AtomicInteger(-1);
+        Exit.setExitProcedure((code, message) -> {
+            exitCode.set(code);
+            throw new RuntimeException("exit called");
+        });
+
+        try {
+            OAuthCompatibilityTool.main(new String[]{"--unkown-argument", "value"});
+            fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertEquals(1, exitCode.get());
+        } finally {
+            Exit.resetExitProcedure();
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class OAuthCompatibilityToolTest {
 
@@ -84,7 +83,7 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testExitsWhenOnlyUnknowArgumentIsProvided() {
+    public void testExitsWhenOnlyUnknownArgumentProvided() {
         AtomicInteger exitCode = new AtomicInteger(-1);
         Exit.setExitProcedure((code, message) -> {
             exitCode.set(code);
@@ -92,9 +91,7 @@ class OAuthCompatibilityToolTest {
         });
 
         try {
-            OAuthCompatibilityTool.main(new String[]{"--unkown-argument", "value"});
-            fail("Expected RuntimeException to be thrown");
-        } catch (RuntimeException e) {
+            assertThrows(RuntimeException.class, () -> OAuthCompatibilityTool.main(new String[]{"--unknown-argument", "value"}));
             assertEquals(1, exitCode.get());
         } finally {
             Exit.resetExitProcedure();

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.internals.Exit;
 
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.utils.Exit;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -36,8 +38,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OAuthCompatibilityToolTest {
 
+    private final AtomicInteger exitCode = new AtomicInteger(-1);
+
+    @BeforeEach
+    void setUp() {
+        Exit.setExitProcedure((code, message) -> {
+            exitCode.set(code);
+            throw new RuntimeException("exit called");
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        Exit.resetExitProcedure();
+    }
+
     @Test
-    public void testParseArgsParsesClientConfig() throws ArgumentParserException {
+    void testParseArgsParsesClientConfig() throws ArgumentParserException {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         Namespace namespace = argsHandler.parseArgs(new String[]{
             "--client-config", "/tmp/test/client.properties"
@@ -47,7 +64,7 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testParseArgsParsesBrokerConfig() throws ArgumentParserException {
+    void testParseArgsParsesBrokerConfig() throws ArgumentParserException {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         Namespace namespace = argsHandler.parseArgs(new String[]{
             "--broker-config", "/tmp/test/broker.properties"
@@ -57,7 +74,7 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testParseArgsThrowsIfArgumentIsEmpty() {
+    void testParseArgsThrowsIfArgumentIsEmpty() {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         assertThrows(
             ArgumentParserException.class,
@@ -65,7 +82,7 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testGetConfigsReturnsStringListAndCliHasPriority() throws ArgumentParserException {
+    void testGetConfigsReturnsStringListAndCliHasPriority() throws ArgumentParserException {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         Namespace namespace = argsHandler.parseArgs(new String[]{
             "--sasl.oauthbearer.expected.audience", "test1,test2"
@@ -83,18 +100,14 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testExitsWhenOnlyUnknownArgumentProvided() {
-        AtomicInteger exitCode = new AtomicInteger(-1);
-        Exit.setExitProcedure((code, message) -> {
-            exitCode.set(code);
-            throw new RuntimeException("exit called");
-        });
+    void testExitsWhenOnlyUnknownArgumentProvided() {
+        assertThrows(RuntimeException.class, () -> OAuthCompatibilityTool.main(new String[]{"--unknown-argument", "value"}));
+        assertEquals(1, exitCode.get());
+    }
 
-        try {
-            assertThrows(RuntimeException.class, () -> OAuthCompatibilityTool.main(new String[]{"--unknown-argument", "value"}));
-            assertEquals(1, exitCode.get());
-        } finally {
-            Exit.resetExitProcedure();
-        }
+    @Test
+    void testExitsWhenArgumentValueIsInvalid() {
+        assertThrows(RuntimeException.class, () -> OAuthCompatibilityTool.main(new String[]{"--sasl.login.retry.backoff.ms", "not-a-number"}));
+        assertEquals(1, exitCode.get());
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -78,8 +78,9 @@ class OAuthCompatibilityToolTest {
         ConfigDef cd = new ConfigDef();
         SaslConfigs.addClientSaslSupport(cd);
 
-        assertTrue(((List<?>) clientConfigHandler.getConfigs(cd).get("sasl.oauthbearer.expected.audience")).contains("test1"));
-        assertTrue(((List<?>) clientConfigHandler.getConfigs(cd).get("sasl.oauthbearer.expected.audience")).contains("test2"));
+        List<?> audience = (List<?>) clientConfigHandler.getConfigs(cd).get("sasl.oauthbearer.expected.audience");
+        assertTrue(audience.contains("test1"));
+        assertTrue(audience.contains("test2"));
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/OAuthCompatibilityToolTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.kafka.tools;
 
-import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.utils.Exit;
-import org.apache.kafka.test.TestSslUtils;
 
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -31,7 +31,6 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -59,184 +58,32 @@ class OAuthCompatibilityToolTest {
     }
 
     @Test
-    public void testParseArgsParsesSaslJaasConfig() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--sasl.jaas.config", "test"
-        });
-
-        assertEquals("test", namespace.getString("sasl.jaas.config"));
-    }
-
-    @Test
-    public void testParseArgsParsesClientId() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--client-id", "testId"
-        });
-
-        assertEquals("testId", namespace.getString("clientId"));
-    }
-
-    @Test
-    public void testParseArgsParsesClientSecret() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--client-secret", "testSecret"
-        });
-
-        assertEquals("testSecret", namespace.getString("clientSecret"));
-    }
-
-    @Test
     public void testParseArgsThrowsIfArgumentIsEmpty() {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         assertThrows(
-                ArgumentParserException.class,
-                () -> argsHandler.parseArgs(new String[]{"", ""}));
-    }
-
-    @Test
-    public void testGetConfigsReturnsInteger() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--sasl.login.connect.timeout.ms", "100"
-        });
-        Properties properties = new Properties();
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals(100, clientConfigHandler.getConfigs().get("sasl.login.connect.timeout.ms"));
-    }
-
-    @Test
-    public void testGetConfigsReturnsLong() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--sasl.login.retry.backoff.ms", "5"
-        });
-        Properties properties = new Properties();
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals(5L, clientConfigHandler.getConfigs().get("sasl.login.retry.backoff.ms"));
-    }
-
-    @Test
-    public void testGetConfigsReturnsClass() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--ssl.engine.factory.class", "org.apache.kafka.test.TestSslUtils$TestSslEngineFactory"
-        });
-        Properties properties = new Properties();
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals(TestSslUtils.TestSslEngineFactory.class, clientConfigHandler.getJaasOptions().get("ssl.engine.factory.class"));
-    }
-
-    @Test
-    public void testGetConfigsThrowsWhenClassNotFound() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--ssl.engine.factory.class", "SomeClass"
-        });
-        Properties properties = new Properties();
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertThrows(KafkaException.class, () -> clientConfigHandler.getJaasOptions().get("ssl.engine.factory.class"));
-    }
-
-    @Test
-    public void testGetConfigsReturnsStringListFromCli() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--sasl.oauthbearer.expected.audience", "test1",
-            "--sasl.oauthbearer.expected.audience", "test2"
-        });
-        Properties properties = new Properties();
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
-    }
-
-    @Test
-    public void testGetConfigsReturnsStringListFromProperties() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{});
-        Properties properties = new Properties();
-        properties.put("sasl.oauthbearer.expected.audience", "test1,test2");
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
+            ArgumentParserException.class,
+            () -> argsHandler.parseArgs(new String[]{"", ""}));
     }
 
     @Test
     public void testGetConfigsReturnsStringListAndCliHasPriority() throws ArgumentParserException {
         OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
         Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--sasl.oauthbearer.expected.audience", "test1",
-            "--sasl.oauthbearer.expected.audience", "test2"
+            "--sasl.oauthbearer.expected.audience", "test1,test2"
         });
         Properties properties = new Properties();
         properties.put("sasl.oauthbearer.expected.audience", "test3");
         OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
 
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test1"));
-        assertTrue(((List<?>) clientConfigHandler.getConfigs().get("sasl.oauthbearer.expected.audience")).contains("test2"));
+        ConfigDef cd = new ConfigDef();
+        SaslConfigs.addClientSaslSupport(cd);
+
+        assertTrue(((List<?>) clientConfigHandler.getConfigs(cd).get("sasl.oauthbearer.expected.audience")).contains("test1"));
+        assertTrue(((List<?>) clientConfigHandler.getConfigs(cd).get("sasl.oauthbearer.expected.audience")).contains("test2"));
     }
 
     @Test
-    public void testGetConfigsIgnoresSaslJaasConfigIfCredentialsAreProvidedViaCli() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{
-            "--client-id", "testId1",
-            "--client-secret", "testSecret1",
-            "--scope", "testScope1",
-        });
-        Properties properties = new Properties();
-        properties.put(
-                "sasl.jaas.config",
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"testId2\" clientSecret=\"testSecret2\" scope=\"testScope2\";");
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals("testId1", clientConfigHandler.getJaasOptions().get("clientId"));
-        assertEquals("testSecret1", clientConfigHandler.getJaasOptions().get("clientSecret"));
-        assertEquals("testScope1", clientConfigHandler.getJaasOptions().get("scope"));
-    }
-
-    @Test
-    public void testGetJaasOptionsContainsSaslJaasConfigIfCredentialsAreNotProvidedViaCli() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{});
-        Properties properties = new Properties();
-        properties.put(
-            "sasl.jaas.config",
-            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId=\"testId\" clientSecret=\"testSecret\" scope=\"testScope\";");
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals("testId", clientConfigHandler.getJaasOptions().get("clientId"));
-        assertEquals("testSecret", clientConfigHandler.getJaasOptions().get("clientSecret"));
-        assertEquals("testScope", clientConfigHandler.getJaasOptions().get("scope"));
-    }
-
-    @Test
-    public void testGetJaasOptionsContainsUnknownKeyInSaslJaasConfig() throws ArgumentParserException {
-        OAuthCompatibilityTool.ArgsHandler argsHandler = new OAuthCompatibilityTool.ArgsHandler();
-        Namespace namespace = argsHandler.parseArgs(new String[]{});
-        Properties properties = new Properties();
-        properties.put(
-                "sasl.jaas.config",
-                "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unknownKey=\"test\" clientId=\"testId\" clientSecret=\"testSecret\" scope=\"testScope\";");
-        OAuthCompatibilityTool.ConfigHandler clientConfigHandler = new OAuthCompatibilityTool.ConfigHandler(namespace, properties);
-
-        assertEquals("testId", clientConfigHandler.getJaasOptions().get("clientId"));
-        assertEquals("testSecret", clientConfigHandler.getJaasOptions().get("clientSecret"));
-        assertEquals("testScope", clientConfigHandler.getJaasOptions().get("scope"));
-        assertNull(clientConfigHandler.getJaasOptions().get("unknownKey"));
-    }
-
-    @Test
-    public void testExitsWhenOnlyClientIdProvided() {
+    public void testExitsWhenOnlyUnknowArgumentIsProvided() {
         AtomicInteger exitCode = new AtomicInteger(-1);
         Exit.setExitProcedure((code, message) -> {
             exitCode.set(code);


### PR DESCRIPTION
This PR improves the usability of `OAuthCompatibilityTool` by
introducing file-based configuration.

### New CLI options
- `--client-config`: path to a .properties file containing the client's
OAuth/SSL configuration.
- `--broker-config`: path to a .properties file containing the broker's
OAuth/SSL configuration.
- All `ssl.*` keys and all `sasl.oauthbearer.*` and `sasl.login.*` keys
are exposed as CLI options, so no code changes are needed in the
`OAuthCompatibilityTool` when new configs are added.

### Removed CLI options
- `--clientId` and `--clientSecret` have been removed in favor of the
config file, `sasl.oauthbearer.client.credentials.client.id`, and
`sasl.oauthbearer.client.credentials.client.secret`.

### Precedence rules
- CLI options take precedence over file-based options for the same key.

Reviewers: Kirk True [ktrue@confluent.io](mailto:ktrue@confluent.io)
