### PR TITLE
KAFKA-20357: Unify method signature for retrieving config names across config classes

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/config/DefaultSupportedConfigChecker.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DefaultSupportedConfigChecker.java
@@ -23,7 +23,6 @@ import org.apache.kafka.metadata.SupportedConfigChecker;
 import org.apache.kafka.server.metrics.ClientMetricsConfigs;
 import org.apache.kafka.storage.internals.log.LogConfig;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -62,10 +61,10 @@ public final class DefaultSupportedConfigChecker implements SupportedConfigCheck
 
     public DefaultSupportedConfigChecker() {
         this.validConfigsByType = Map.of(
-            ConfigResource.Type.TOPIC, new SetContainsPredicate(new HashSet<>(LogConfig.configNames())),
+            ConfigResource.Type.TOPIC, new SetContainsPredicate(LogConfig.configNames()),
             ConfigResource.Type.BROKER, ignore -> true,
-            ConfigResource.Type.CLIENT_METRICS, new SetContainsPredicate(ClientMetricsConfigs.configDef().names()),
-            ConfigResource.Type.GROUP, new SetContainsPredicate(GroupConfig.CONFIG_DEF.names())
+            ConfigResource.Type.CLIENT_METRICS, new SetContainsPredicate(ClientMetricsConfigs.configNames()),
+            ConfigResource.Type.GROUP, new SetContainsPredicate(GroupConfig.configNames())
         );
     }
 

--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
@@ -136,7 +136,7 @@ public class ClientMetricsConfigs extends AbstractConfig {
         return clientMetricsProps;
     }
 
-    public static Set<String> names() {
+    public static Set<String> configNames() {
         return CONFIG.names();
     }
 
@@ -152,7 +152,7 @@ public class ClientMetricsConfigs extends AbstractConfig {
     private static void validateConfigs(Map<?, ?> configs) {
         // Make sure that all the configs are valid
         configs.forEach((key, value) -> {
-            if (!names().contains(key)) {
+            if (!configNames().contains(key)) {
                 throw new InvalidRequestException("Unknown client metrics configuration: " + key);
             }
         });

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -436,8 +436,8 @@ public class LogConfig extends AbstractConfig {
         return Optional.ofNullable(CONFIG.configKeys().get(configName)).map(c -> c.type);
     }
 
-    public static List<String> configNames() {
-        return CONFIG.names().stream().sorted().toList();
+    public static Set<String> configNames() {
+        return CONFIG.names();
     }
 
     public static List<String> nonInternalConfigNames() {
@@ -456,7 +456,7 @@ public class LogConfig extends AbstractConfig {
      * Check that property names are valid
      */
     public static void validateNames(Map<String, String> props) {
-        List<String> names = configNames();
+        Set<String> names = configNames();
         for (String name : props.keySet())
             if (!names.contains(name))
                 throw new InvalidConfigurationException("Unknown topic config name: " + name);


### PR DESCRIPTION
Unify method signature for retrieving config names across config
classes.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
