### PR TITLE
KAFKA-20370: Register BrokerRegistrationState metrics on snapshot load

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
@@ -236,7 +236,16 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
             BrokerRegistrationState.UNREGISTERED.state()
         );
     }
-    
+
+    /**
+     * True if {@link #setBrokerRegistrationState} has tracked this broker (and a per-broker JMX
+     * gauge is typically registered). Used to avoid duplicate gauge registration when applying a
+     * metadata snapshot after brokers were installed via log deltas.
+     */
+    boolean tracksBrokerRegistrationState(int brokerId) {
+        return brokerRegistrationStates.containsKey(brokerId);
+    }
+
     public void setGlobalTopicCount(int topicCount) {
         this.globalTopicCount.set(topicCount);
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -118,10 +118,19 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
 
     private void publishSnapshot(MetadataImage newImage) {
         metrics.setGlobalTopicCount(newImage.topics().topicsById().size());
+        for (int brokerId : prevImage.cluster().brokers().keySet()) {
+            if (!newImage.cluster().brokers().containsKey(brokerId)) {
+                metrics.setBrokerRegistrationState(brokerId, null);
+            }
+        }
         int fencedBrokers = 0;
         int activeBrokers = 0;
         int controlledShutdownBrokers = 0;
         for (BrokerRegistration broker : newImage.cluster().brokers().values()) {
+            if (!metrics.tracksBrokerRegistrationState(broker.id())) {
+                metrics.addBrokerRegistrationStateMetric(broker.id());
+            }
+            metrics.setBrokerRegistrationState(broker.id(), broker);
             if (broker.fenced()) {
                 fencedBrokers++;
             } else {

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.image.MetadataProvenance;
 import org.apache.kafka.image.ProducerIdsImage;
 import org.apache.kafka.image.ScramImage;
 import org.apache.kafka.image.TopicsImage;
+import org.apache.kafka.image.ClusterImageTest;
 import org.apache.kafka.image.loader.LoaderManifest;
 import org.apache.kafka.image.loader.LogDeltaManifest;
 import org.apache.kafka.image.loader.SnapshotManifest;
@@ -39,8 +40,11 @@ import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.fault.MockFaultHandler;
 
+import com.yammer.metrics.core.MetricsRegistry;
+
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.controller.metrics.ControllerMetricsTestUtils.FakePartitionRegistrationType.NON_PREFERRED_LEADER;
@@ -80,10 +84,14 @@ public class ControllerMetadataMetricsPublisherTest {
     }
 
     static MetadataImage fakeImageFromTopicsImage(TopicsImage topicsImage) {
+        return fakeImage(ClusterImage.EMPTY, topicsImage);
+    }
+
+    static MetadataImage fakeImage(ClusterImage clusterImage, TopicsImage topicsImage) {
         return new MetadataImage(
             MetadataProvenance.EMPTY,
             FeaturesImage.EMPTY,
-            ClusterImage.EMPTY,
+            clusterImage,
             topicsImage,
             ConfigurationsImage.EMPTY,
             ClientQuotasImage.EMPTY,
@@ -115,6 +123,9 @@ public class ControllerMetadataMetricsPublisherTest {
         );
         IMAGE1 = fakeImageFromTopicsImage(TOPICS_IMAGE1);
     }
+
+    static final MetadataImage SNAPSHOT_IMAGE_WITH_BROKERS =
+        fakeImage(ClusterImageTest.IMAGE1, TopicsImage.EMPTY);
 
     @Test
     public void testPublish() {
@@ -156,6 +167,59 @@ public class ControllerMetadataMetricsPublisherTest {
             assertEquals(3, env.metrics.offlinePartitionCount());
             assertEquals(4, env.metrics.preferredReplicaImbalanceCount());
             assertEquals(0, env.metrics.metadataErrorCount());
+        }
+    }
+
+    @Test
+    public void testSnapshotRegistersBrokerRegistrationStateMetrics() {
+        MetricsRegistry registry = new MetricsRegistry();
+        MockFaultHandler faultHandler = new MockFaultHandler("ControllerMetadataMetricsPublisher");
+        try {
+            try (ControllerMetadataMetrics metrics = new ControllerMetadataMetrics(Optional.of(registry));
+                 ControllerMetadataMetricsPublisher publisher =
+                     new ControllerMetadataMetricsPublisher(metrics, faultHandler)) {
+                MetadataDelta delta = new MetadataDelta.Builder()
+                    .setImage(MetadataImage.EMPTY)
+                    .build();
+                publisher.onMetadataUpdate(delta, SNAPSHOT_IMAGE_WITH_BROKERS, fakeManifest(true));
+                assertEquals(1, metrics.fencedBrokerCount());
+                assertEquals(2, metrics.activeBrokerCount());
+                assertEquals(BrokerRegistrationState.FENCED.state(), metrics.brokerRegistrationState(0));
+                assertEquals(BrokerRegistrationState.ACTIVE.state(), metrics.brokerRegistrationState(1));
+                assertEquals(BrokerRegistrationState.ACTIVE.state(), metrics.brokerRegistrationState(2));
+                assertEquals(
+                    3,
+                    registry.allMetrics().keySet().stream()
+                        .filter(n -> "BrokerRegistrationState".equals(n.getName()))
+                        .count()
+                );
+                publisher.onMetadataUpdate(delta, SNAPSHOT_IMAGE_WITH_BROKERS, fakeManifest(true));
+                assertEquals(
+                    3,
+                    registry.allMetrics().keySet().stream()
+                        .filter(n -> "BrokerRegistrationState".equals(n.getName()))
+                        .count()
+                );
+                ClusterImage smallerCluster = new ClusterImage(
+                    Map.of(
+                        0, ClusterImageTest.IMAGE1.brokers().get(0),
+                        1, ClusterImageTest.IMAGE1.brokers().get(1)
+                    ),
+                    Map.of()
+                );
+                MetadataImage smallerImage = fakeImage(smallerCluster, TopicsImage.EMPTY);
+                publisher.onMetadataUpdate(delta, smallerImage, fakeManifest(true));
+                assertEquals(
+                    2,
+                    registry.allMetrics().keySet().stream()
+                        .filter(n -> "BrokerRegistrationState".equals(n.getName()))
+                        .count()
+                );
+                assertEquals(BrokerRegistrationState.UNREGISTERED.state(), metrics.brokerRegistrationState(2));
+            }
+        } finally {
+            registry.shutdown();
+            faultHandler.maybeRethrowFirstException();
         }
     }
 }


### PR DESCRIPTION
Problem
Per-broker kafka.controller:type=KafkaController,name=BrokerRegistrationState,broker=<id> (KIP-1131) was registered only on log deltas when a broker first appeared (prev == null). After loading metadata from a snapshot, existing brokers never hit that path, so JMX had no per-broker gauges even though aggregates like ActiveBrokerCount were updated ([KAFKA-20370](https://issues.apache.org/jira/browse/KAFKA-20370)).

Solution

In publishSnapshot, for each broker in the new image: call addBrokerRegistrationStateMetric when not already tracked, then setBrokerRegistrationState.
For brokers in the previous image but absent from the new snapshot, call setBrokerRegistrationState(id, null) to remove stale gauges and map entries.
Add package-private tracksBrokerRegistrationState on ControllerMetadataMetrics so a snapshot after deltas does not double-register the same Yammer gauge.
Testing

ControllerMetadataMetricsPublisherTest#testSnapshotRegistersBrokerRegistrationStateMetrics (registry-backed snapshot, repeated snapshot, smaller cluster).