### PR TITLE
KAFKA-20400: Enable VersionedKeyValueStoreWithHeaders in DSL

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreWithHeadersIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreWithHeadersIntegrationTest.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("integration")
+public class VersionedKeyValueStoreWithHeadersIntegrationTest {
+
+    private static final String STORE_NAME = "versioned-headers-store";
+    private static final Duration HISTORY_RETENTION = Duration.ofMinutes(10);
+
+    private String inputStream;
+    private String outputStream;
+    private long baseTimestamp;
+
+    private KafkaStreams kafkaStreams;
+
+    private static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    public TestInfo testInfo;
+
+    @BeforeAll
+    public static void before() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterAll
+    public static void after() {
+        CLUSTER.stop();
+    }
+
+    @BeforeEach
+    public void setUp(final TestInfo testInfo) throws Exception {
+        this.testInfo = testInfo;
+        final String testName = safeUniqueTestName(testInfo);
+        inputStream = "input-" + testName;
+        outputStream = "output-" + testName;
+        baseTimestamp = System.currentTimeMillis() - Duration.ofMinutes(5).toMillis();
+        CLUSTER.createTopic(inputStream, 1, 1);
+        CLUSTER.createTopic(outputStream, 1, 1);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (kafkaStreams != null) {
+            kafkaStreams.close(Duration.ofSeconds(30));
+        }
+    }
+
+    @Test
+    public void shouldPutAndGetWithHeaders() throws Exception {
+        final Topology topology = buildTopology(() -> new VersionedStoreWithHeadersCheckerProcessor(true));
+        kafkaStreams = new KafkaStreams(topology, streamsConfiguration());
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp, headers1(),
+            new KeyValue<>(1, "value1"));
+
+        final List<KeyValue<Integer, Integer>> results =
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                consumerConfig(), outputStream, 1);
+
+        assertEquals(0, results.get(0).value, "Store content check failed");
+    }
+
+    @Test
+    public void shouldPutAndGetWithEmptyHeaders() throws Exception {
+        final Topology topology = buildTopology(() -> new VersionedStoreWithHeadersCheckerProcessor(true));
+        kafkaStreams = new KafkaStreams(topology, streamsConfiguration());
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp, emptyHeaders(),
+            new KeyValue<>(1, "value1"));
+
+        final List<KeyValue<Integer, Integer>> results =
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                consumerConfig(), outputStream, 1);
+
+        assertEquals(0, results.get(0).value, "Store content check failed for empty headers");
+    }
+
+    @Test
+    public void shouldPreserveHeadersAcrossMultipleVersions() throws Exception {
+        final Topology topology = buildTopology(() -> new VersionedStoreWithHeadersCheckerProcessor(true));
+        kafkaStreams = new KafkaStreams(topology, streamsConfiguration());
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        int numRecordsProduced = 0;
+        numRecordsProduced += produceDataToTopicWithHeaders(inputStream, baseTimestamp, headers1(),
+            new KeyValue<>(1, "version1"));
+        numRecordsProduced += produceDataToTopicWithHeaders(inputStream, baseTimestamp + 1000, headers2(),
+            new KeyValue<>(1, "version2"));
+
+        final List<KeyValue<Integer, Integer>> results =
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                consumerConfig(), outputStream, numRecordsProduced);
+
+        for (final KeyValue<Integer, Integer> result : results) {
+            assertEquals(0, result.value, "Store content check failed");
+        }
+    }
+
+    @Test
+    public void shouldRestoreHeadersFromChangelog() throws Exception {
+        final Properties config = streamsConfiguration();
+        // Use a fixed state dir so we can restart and restore
+        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+
+        Topology topology = buildTopology(() -> new VersionedStoreWithHeadersCheckerProcessor(true));
+        kafkaStreams = new KafkaStreams(topology, config);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp, headers1(),
+            new KeyValue<>(1, "restored-value"));
+
+        final List<KeyValue<Integer, Integer>> firstRunResults =
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                consumerConfig(), outputStream, 1);
+        assertEquals(0, firstRunResults.get(0).value, "First run store check failed");
+
+        kafkaStreams.close(Duration.ofSeconds(30));
+        kafkaStreams.cleanUp();
+
+        topology = buildTopology(() -> {
+            final VersionedStoreWithHeadersCheckerProcessor processor =
+                new VersionedStoreWithHeadersCheckerProcessor(false);
+            processor.seedExpectedData(1, "restored-value", baseTimestamp, headers1());
+            return processor;
+        });
+        kafkaStreams = new KafkaStreams(topology, config);
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp + 5000, emptyHeaders(),
+            new KeyValue<>(99, "trigger"));
+
+        final List<KeyValue<Integer, Integer>> secondRunResults =
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                consumerConfig(), outputStream, 2);
+        assertEquals(0, secondRunResults.get(1).value, "Restoration check failed: headers not preserved");
+    }
+
+    private Topology buildTopology(
+            final ProcessorSupplier<Integer, String, Integer, Integer> processorSupplier) {
+        final var supplier = Stores.persistentVersionedKeyValueStoreWithHeaders(
+            STORE_NAME, HISTORY_RETENTION);
+
+        final Topology topology = new Topology();
+        topology.addSource("source", new IntegerDeserializer(),
+            Serdes.String().deserializer(), inputStream);
+        topology.addProcessor("processor", processorSupplier, "source");
+        topology.addStateStore(
+            Stores.versionedKeyValueStoreBuilderWithHeaders(
+                supplier, Serdes.Integer(), Serdes.String()),
+            "processor");
+        topology.addSink("sink", outputStream, new IntegerSerializer(),
+            new IntegerSerializer(), "processor");
+        return topology;
+    }
+
+    private Properties streamsConfiguration() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG,
+            "versioned-headers-it-" + safeUniqueTestName(testInfo));
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+        config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
+        return config;
+    }
+
+    private Properties consumerConfig() {
+        return TestUtils.consumerConfig(CLUSTER.bootstrapServers(), IntegerDeserializer.class, IntegerDeserializer.class);
+    }
+
+    private static Headers headers1() {
+        return new RecordHeaders()
+            .add("source", "test".getBytes())
+            .add("version", "1.0".getBytes());
+    }
+
+    private static Headers headers2() {
+        return new RecordHeaders()
+            .add("source", "test".getBytes())
+            .add("version", "2.0".getBytes());
+    }
+
+    private static Headers emptyHeaders() {
+        return new RecordHeaders();
+    }
+
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    private final int produceDataToTopicWithHeaders(final String topic,
+                                                    final long timestamp,
+                                                    final Headers headers,
+                                                    final KeyValue<Integer, String>... keyValues) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            topic,
+            Arrays.asList(keyValues),
+            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
+                IntegerSerializer.class,
+                StringSerializer.class),
+            headers,
+            timestamp,
+            false);
+        return keyValues.length;
+    }
+
+    /**
+     * Processor that stores records in a VersionedKeyValueStoreWithHeaders and validates
+     * that the store contents match expectations. Forwards the number of failed checks
+     * as the output value.
+     */
+    private static class VersionedStoreWithHeadersCheckerProcessor
+            implements Processor<Integer, String, Integer, Integer> {
+
+        private ProcessorContext<Integer, Integer> context;
+        private VersionedKeyValueStoreWithHeaders<Integer, String> store;
+
+        private final boolean writeToStore;
+        private final Map<Integer, Optional<VersionedRecordExpectation>> data;
+
+        VersionedStoreWithHeadersCheckerProcessor(final boolean writeToStore) {
+            this.writeToStore = writeToStore;
+            this.data = new HashMap<>();
+        }
+
+        void seedExpectedData(final int key, final String value,
+                              final long timestamp, final Headers headers) {
+            data.put(key, Optional.of(new VersionedRecordExpectation(value, timestamp, headers)));
+        }
+
+        @Override
+        public void init(final ProcessorContext<Integer, Integer> context) {
+            this.context = context;
+            store = context.getStateStore(STORE_NAME);
+        }
+
+        @Override
+        public void process(final Record<Integer, String> record) {
+            if (writeToStore) {
+                store.put(record.key(), record.value(), record.timestamp(), record.headers());
+                data.put(record.key(), Optional.of(
+                    new VersionedRecordExpectation(record.value(), record.timestamp(), record.headers())));
+            }
+
+            final int failedChecks = checkStoreContents();
+            context.forward(record.withValue(failedChecks));
+        }
+
+        private int checkStoreContents() {
+            int failedChecks = 0;
+            for (final Map.Entry<Integer, Optional<VersionedRecordExpectation>> entry : data.entrySet()) {
+                final Integer key = entry.getKey();
+                final VersionedRecordExpectation expected = entry.getValue().orElse(null);
+                if (expected == null) {
+                    continue;
+                }
+
+                final VersionedRecord<String> actual = store.get(key);
+                if (actual == null) {
+                    failedChecks++;
+                    continue;
+                }
+
+                if (!Objects.equals(actual.value(), expected.value)
+                        || actual.timestamp() != expected.timestamp) {
+                    failedChecks++;
+                    continue;
+                }
+
+                final Headers actualHeaders = actual.headers();
+                final Headers expectedHeaders = expected.headers;
+                if (!headersEqual(actualHeaders, expectedHeaders)) {
+                    failedChecks++;
+                }
+            }
+            return failedChecks;
+        }
+
+        private static boolean headersEqual(final Headers a, final Headers b) {
+            if (a == b) return true;
+            if (a == null || b == null) return false;
+
+            final var iterA = a.iterator();
+            final var iterB = b.iterator();
+            while (iterA.hasNext() && iterB.hasNext()) {
+                final var hA = iterA.next();
+                final var hB = iterB.next();
+                if (!Objects.equals(hA.key(), hB.key())) return false;
+                if (!java.util.Arrays.equals(hA.value(), hB.value())) return false;
+            }
+            return !iterA.hasNext() && !iterB.hasNext();
+        }
+    }
+
+    private static class VersionedRecordExpectation {
+        final String value;
+        final long timestamp;
+        final Headers headers;
+
+        VersionedRecordExpectation(final String value, final long timestamp, final Headers headers) {
+            this.value = value;
+            this.timestamp = timestamp;
+            this.headers = headers;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
@@ -135,7 +134,7 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
 
             newAgg = aggregator.apply(record.key(), record.value(), oldAgg);
 
-            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, new RecordHeaders());
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, record.headers());
             // if not put to store, do not forward downstream either
             if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                 tupleForwarder.maybeForward(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -130,7 +129,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K,
                 newTimestamp = Math.max(record.timestamp(), oldAggAndTimestamp.timestamp());
             }
 
-            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, new RecordHeaders());
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, record.headers());
             // if not put to store, do not forward downstream either
             if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                 tupleForwarder.maybeForward(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -218,7 +218,7 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
 
                 agg = aggregator.apply(record.key(), record.value(), agg);
                 final Windowed<KIn> sessionKey = new Windowed<>(record.key(), mergedWindow);
-                store.put(sessionKey, AggregationWithHeaders.make(agg, new RecordHeaders()));
+                store.put(sessionKey, AggregationWithHeaders.make(agg, record.headers()));
 
                 maybeForwardUpdate(sessionKey, null, agg);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Aggregator;
@@ -134,7 +133,7 @@ public class KTableAggregate<KIn, VIn, VAgg> implements
             }
 
             // update the store with the new value
-            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, new RecordHeaders());
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, record.headers());
             // if not put to store, do not forward downstream either
             if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                 tupleForwarder.maybeForward(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -148,7 +147,7 @@ public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn,
             }
 
             if (queryableName != null) {
-                final long putReturnCode = store.put(key, newValue, record.timestamp(), new RecordHeaders());
+                final long putReturnCode = store.put(key, newValue, record.timestamp(), record.headers());
                 // if not put to store, do not forward downstream either
                 if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                     tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinMerger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinMerger.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -134,7 +133,7 @@ public class KTableKTableJoinMerger<K, V> implements KTableProcessorSupplier<K, 
         @Override
         public void process(final Record<K, Change<V>> record) {
             if (queryableName != null) {
-                final long putReturnCode = store.put(record.key(), record.value().newValue, record.timestamp(), new RecordHeaders());
+                final long putReturnCode = store.put(record.key(), record.value().newValue, record.timestamp(), record.headers());
                 // if not put to store, do not forward downstream either
                 if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                     tupleForwarder.maybeForward(record.withValue(new Change<>(record.value().newValue, record.value().oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -152,7 +151,7 @@ class KTableMapValues<KIn, VIn, VOut> implements KTableProcessorSupplier<KIn, VI
             final VOut oldValue = computeOldValue(record.key(), record.value());
 
             if (queryableName != null) {
-                final long putReturnCode = store.put(record.key(), newValue, record.timestamp(), new RecordHeaders());
+                final long putReturnCode = store.put(record.key(), newValue, record.timestamp(), record.headers());
                 // if not put to store, do not forward downstream either
                 if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                     tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Reducer;
@@ -126,7 +125,7 @@ public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, K, V> {
             }
 
             // update the store with the new value
-            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, new RecordHeaders());
+            final long putReturnCode = store.put(record.key(), newAgg, newTimestamp, record.headers());
             // if not put to store, do not forward downstream either
             if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                 tupleForwarder.maybeForward(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.api.Processor;
@@ -168,7 +167,7 @@ public class KTableSource<KIn, VIn> implements ProcessorSupplier<KIn, VIn, KIn, 
                     oldValue = null;
                 }
                 final long putReturnCode;
-                putReturnCode = store.put(record.key(), record.value(), record.timestamp(), new RecordHeaders());
+                putReturnCode = store.put(record.key(), record.value(), record.timestamp(), record.headers());
                 // if not put to store, do not forward downstream either
                 if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                     tupleForwarder.maybeForward(record.withValue(new Change<>(record.value(), oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
@@ -120,7 +120,7 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
             if (queryableName != null) {
                 final VOut oldValue = sendOldValues ? getValueOrNull(store.get(record.key())) : null;
-                final long putReturnCode = store.put(record.key(), newValue, record.timestamp(), new RecordHeaders());
+                final long putReturnCode = store.put(record.key(), newValue, record.timestamp(), record.headers());
                 // if not put to store, do not forward downstream either
                 if (putReturnCode != PUT_RETURN_CODE_NOT_PUT) {
                     tupleForwarder.maybeForward(record.withValue(new Change<>(newValue, oldValue, putReturnCode == PUT_RETURN_CODE_IS_LATEST)));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilderWithHeaders;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,12 @@ public class KeyValueStoreMaterializer<K, V> extends MaterializedStoreFactory<K,
                 : (KeyValueBytesStoreSupplier) materialized.storeSupplier();
 
         final StoreBuilder<?> builder;
-        if (supplier instanceof VersionedBytesStoreSupplier) {
+        if (supplier instanceof VersionedBytesStoreSupplier && supplier instanceof HeadersBytesStoreSupplier) {
+            builder = Stores.versionedKeyValueStoreBuilderWithHeaders(
+                    (VersionedBytesStoreSupplier) supplier,
+                    materialized.keySerde(),
+                    materialized.valueSerde());
+        } else if (supplier instanceof VersionedBytesStoreSupplier) {
             builder = Stores.versionedKeyValueStoreBuilder(
                     (VersionedBytesStoreSupplier) supplier,
                     materialized.keySerde(),
@@ -75,7 +81,7 @@ public class KeyValueStoreMaterializer<K, V> extends MaterializedStoreFactory<K,
         }
 
         if (materialized.cachingEnabled()) {
-            if (builder instanceof VersionedKeyValueStoreBuilder) {
+            if (builder instanceof VersionedKeyValueStoreBuilder || builder instanceof VersionedKeyValueStoreBuilderWithHeaders) {
                 LOG.info("Not enabling caching for store '{}' as versioned stores do not support caching.", supplier.name());
             } else {
                 builder.withCachingEnabled();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -34,6 +35,7 @@ import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.VersionedRecord;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -71,6 +73,8 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
             return new TimestampedKeyValueStoreReadWriteDecoratorWithHeaders<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store);
         } else if (store instanceof TimestampedKeyValueStore) {
             return new TimestampedKeyValueStoreReadWriteDecorator<>((TimestampedKeyValueStore<?, ?>) store);
+        } else if (store instanceof VersionedKeyValueStoreWithHeaders) {
+            return new VersionedKeyValueStoreReadWriteDecoratorWithHeaders<>((VersionedKeyValueStoreWithHeaders<?, ?>) store);
         } else if (store instanceof VersionedKeyValueStore) {
             return new VersionedKeyValueStoreReadWriteDecorator<>((VersionedKeyValueStore<?, ?>) store);
         } else if (store instanceof KeyValueStore) {
@@ -194,6 +198,21 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
         @Override
         public VersionedRecord<V> get(final K key, final long asOfTimestamp) {
             return wrapped().get(key, asOfTimestamp);
+        }
+    }
+
+    static class VersionedKeyValueStoreReadWriteDecoratorWithHeaders<K, V>
+        extends VersionedKeyValueStoreReadWriteDecorator<K, V>
+        implements VersionedKeyValueStoreWithHeaders<K, V> {
+
+        VersionedKeyValueStoreReadWriteDecoratorWithHeaders(final VersionedKeyValueStoreWithHeaders<K, V> inner) {
+            super(inner);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public long put(final K key, final V value, final long timestamp, final Headers headers) {
+            return ((VersionedKeyValueStoreWithHeaders<K, V>) wrapped()).put(key, value, timestamp, headers);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.state.internals.RocksDBKeyValueHeadersBytesStore
 import org.apache.kafka.streams.state.internals.RocksDbSessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDbSessionHeadersBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier;
 import org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDbWindowHeadersBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
@@ -39,6 +40,7 @@ import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilderW
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreWithHeadersBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilderWithHeaders;
 import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
 
 import java.time.Duration;
@@ -732,5 +734,42 @@ public final class Stores {
     ) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
         return new SessionStoreWithHeadersBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+    }
+
+    /**
+     * Creates a {@link VersionedBytesStoreSupplier} that also supports headers, backed by RocksDB.
+     *
+     * @param name              name of the store (cannot be {@code null})
+     * @param historyRetention  length of time that old record versions are available for query
+     * @return an instance of {@link VersionedBytesStoreSupplier} that also implements {@link HeadersBytesStoreSupplier}
+     */
+    public static VersionedBytesStoreSupplier persistentVersionedKeyValueStoreWithHeaders(final String name,
+                                                                                           final Duration historyRetention) {
+        Objects.requireNonNull(name, "name cannot be null");
+        final String msgPrefix = prepareMillisCheckFailMsgPrefix(historyRetention, "historyRetention");
+        final long historyRetentionMs = validateMillisecondDuration(historyRetention, msgPrefix);
+        if (historyRetentionMs < 0L) {
+            throw new IllegalArgumentException("historyRetention cannot be negative");
+        }
+        return new RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier(name, historyRetentionMs);
+    }
+
+    /**
+     * Creates a {@link StoreBuilder} that can be used to build a {@link VersionedKeyValueStoreWithHeaders}
+     * with headers support.
+     *
+     * @param supplier      a {@link VersionedBytesStoreSupplier} (cannot be {@code null})
+     * @param keySerde      the key serde to use
+     * @param valueSerde    the value serde to use
+     * @param <K>           key type
+     * @param <V>           value type
+     * @return an instance of a {@link StoreBuilder} that can build a {@link VersionedKeyValueStoreWithHeaders}
+     */
+    public static <K, V> StoreBuilder<VersionedKeyValueStoreWithHeaders<K, V>> versionedKeyValueStoreBuilderWithHeaders(
+            final VersionedBytesStoreSupplier supplier,
+            final Serde<K> keySerde,
+            final Serde<V> valueSerde) {
+        Objects.requireNonNull(supplier, "supplier cannot be null");
+        return new VersionedKeyValueStoreBuilderWithHeaders<>(supplier, keySerde, valueSerde, Time.SYSTEM);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/VersionedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/VersionedBytesStore.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.annotation.InterfaceAudience;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 
 /**
@@ -31,6 +32,14 @@ public interface VersionedBytesStore extends KeyValueStore<Bytes, byte[]>, Times
      * The analog of {@link VersionedKeyValueStore#put(Object, Object, long)}.
      */
     long put(Bytes key, byte[] value, long timestamp);
+
+    /**
+     * The analog of {@link VersionedKeyValueStore#put(Object, Object, long)} with headers.
+     * Default implementation discards headers for backward compatibility.
+     */
+    default long put(final Bytes key, final byte[] value, final long timestamp, final Headers headers) {
+        return put(key, value, timestamp);
+    }
 
     /**
      * The analog of {@link VersionedKeyValueStore#get(Object, long)}.

--- a/streams/src/main/java/org/apache/kafka/streams/state/VersionedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/VersionedKeyValueStoreWithHeaders.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * A versioned key-value store that additionally preserves record headers.
+ * <p>
+ * This interface extends {@link VersionedKeyValueStore} with a headers-aware
+ * {@link #put(Object, Object, long, Headers)} method. On reads, headers are
+ * available via {@link VersionedRecord#headers()}.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+public interface VersionedKeyValueStoreWithHeaders<K, V> extends VersionedKeyValueStore<K, V> {
+
+    /**
+     * Add a new record version associated with the specified key, timestamp, and headers.
+     *
+     * @param key       The key
+     * @param value     The value, it can be {@code null}. {@code null} is interpreted as a delete.
+     * @param timestamp The timestamp for this record version
+     * @param headers   The record headers; must not be {@code null}
+     * @return The validTo timestamp of the newly put record, or special values as defined
+     *         in {@link VersionedKeyValueStore#put(Object, Object, long)}.
+     * @throws NullPointerException if {@code headers} is {@code null}
+     */
+    long put(K key, V value, long timestamp, Headers headers);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/VersionedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/VersionedRecord.java
@@ -18,6 +18,8 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.annotation.InterfaceAudience;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -33,6 +35,7 @@ public final class VersionedRecord<V> {
     private final V value;
     private final long timestamp;
     private final Optional<Long> validTo;
+    private final Headers headers;
 
     /**
      * Create a new {@link VersionedRecord} instance. {@code value} cannot be {@code null}.
@@ -41,9 +44,7 @@ public final class VersionedRecord<V> {
      * @param timestamp  The type of the result returned by this query.
      */
     public VersionedRecord(final V value, final long timestamp) {
-        this.value = Objects.requireNonNull(value, "value cannot be null.");
-        this.timestamp = timestamp;
-        this.validTo = Optional.empty();
+        this(value, timestamp, Optional.empty(), new RecordHeaders());
     }
 
     /**
@@ -54,11 +55,38 @@ public final class VersionedRecord<V> {
      * @param validTo    The exclusive upper bound of the validity interval
      */
     public VersionedRecord(final V value, final long timestamp, final long validTo) {
-        this.value = Objects.requireNonNull(value);
-        this.timestamp = timestamp;
-        this.validTo = Optional.of(validTo);
+        this(value, timestamp, Optional.of(validTo), new RecordHeaders());
     }
 
+    /**
+     * Create a new {@link VersionedRecord} instance with headers. {@code value} cannot be {@code null}.
+     *
+     * @param value      The value
+     * @param timestamp  The timestamp
+     * @param headers    The record headers
+     */
+    public VersionedRecord(final V value, final long timestamp, final Headers headers) {
+        this(value, timestamp, Optional.empty(), headers);
+    }
+
+    /**
+     * Create a new {@link VersionedRecord} instance with headers. {@code value} cannot be {@code null}.
+     *
+     * @param value      The value
+     * @param timestamp  The timestamp
+     * @param validTo    The exclusive upper bound of the validity interval
+     * @param headers    The record headers
+     */
+    public VersionedRecord(final V value, final long timestamp, final long validTo, final Headers headers) {
+        this(value, timestamp, Optional.of(validTo), headers);
+    }
+
+    private VersionedRecord(final V value, final long timestamp, final Optional<Long> validTo, final Headers headers) {
+        this.value = Objects.requireNonNull(value, "value cannot be null.");
+        this.timestamp = timestamp;
+        this.validTo = validTo;
+        this.headers = Objects.requireNonNull(headers, "headers cannot be null.");
+    }
 
     public V value() {
         return value;
@@ -72,9 +100,16 @@ public final class VersionedRecord<V> {
         return validTo;
     }
 
+    /**
+     * @return the record headers. Never {@code null} (returns empty headers if none were set).
+     */
+    public Headers headers() {
+        return headers;
+    }
+
     @Override
     public String toString() {
-        return "<" + value + "," + timestamp + "," + validTo + ">";
+        return "<" + value + "," + timestamp + "," + validTo + "," + headers + ">";
     }
 
     @Override
@@ -86,12 +121,13 @@ public final class VersionedRecord<V> {
             return false;
         }
         final VersionedRecord<?> that = (VersionedRecord<?>) o;
-        return timestamp == that.timestamp && validTo == that.validTo &&
-            Objects.equals(value, that.value);
+        return timestamp == that.timestamp && Objects.equals(validTo, that.validTo) &&
+            Objects.equals(value, that.value) &&
+            Objects.equals(headers, that.headers);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, timestamp, validTo);
+        return Objects.hash(value, timestamp, validTo, headers);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStore.java
@@ -47,6 +47,14 @@ public class ChangeLoggingVersionedKeyValueBytesStore extends ChangeLoggingKeyVa
     }
 
     @Override
+    public long put(final Bytes key, final byte[] value, final long timestamp, final Headers headers) {
+        final Headers nonNullHeaders = headers != null ? headers : new RecordHeaders();
+        final long validTo = inner.put(key, value, timestamp, nonNullHeaders);
+        log(key, value, timestamp, nonNullHeaders);
+        return validTo;
+    }
+
+    @Override
     public byte[] get(final Bytes key, final long asOfTimestamp) {
         return inner.get(key, asOfTimestamp);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapper.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -32,6 +31,7 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.VersionedRecord;
 
 import java.util.Map;
@@ -51,6 +51,7 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
 
     private TimestampedKeyValueStoreWithHeaders<K, V> headersStore = null;
     private VersionedKeyValueStore<K, V> versionedStore = null;
+    private VersionedKeyValueStoreWithHeaders<K, V> versionedStoreWithHeaders = null;
 
     // same as either timestampedStore or versionedStore above. kept merely as a convenience
     // to simplify implementation for methods which do not depend on store type.
@@ -79,6 +80,9 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
         try {
             versionedStore = context.getStateStore(storeName);
             store = versionedStore;
+            if (versionedStore instanceof VersionedKeyValueStoreWithHeaders) {
+                versionedStoreWithHeaders = (VersionedKeyValueStoreWithHeaders<K, V>) versionedStore;
+            }
         } catch (final ClassCastException e) {
             store = context.getStateStore(storeName);
             final String storeType = store == null ? "null" : store.getClass().getName();
@@ -93,9 +97,13 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
         }
         if (versionedStore != null) {
             final VersionedRecord<V> versionedRecord = versionedStore.get(key);
-            return versionedRecord == null
-                ? null
-                : ValueTimestampHeaders.make(versionedRecord.value(), versionedRecord.timestamp(), new RecordHeaders());
+            if (versionedRecord == null) {
+                return null;
+            }
+            return ValueTimestampHeaders.make(
+                versionedRecord.value(),
+                versionedRecord.timestamp(),
+                versionedRecord.headers());
         }
         throw new IllegalStateException("KeyValueStoreWrapper must be initialized with either headers or versioned store");
     }
@@ -105,7 +113,13 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
             throw new UnsupportedOperationException("get(key, timestamp) is only supported for versioned stores");
         }
         final VersionedRecord<V> versionedRecord = versionedStore.get(key, asOfTimestamp);
-        return versionedRecord == null ? null : ValueTimestampHeaders.make(versionedRecord.value(), versionedRecord.timestamp(), new RecordHeaders());
+        if (versionedRecord == null) {
+            return null;
+        }
+        return ValueTimestampHeaders.make(
+            versionedRecord.value(),
+            versionedRecord.timestamp(),
+            versionedRecord.headers());
     }
 
     /**
@@ -119,6 +133,9 @@ public class KeyValueStoreWrapper<K, V> implements StateStore {
             return PUT_RETURN_CODE_IS_LATEST;
         }
         if (versionedStore != null) {
+            if (versionedStoreWithHeaders != null) {
+                return versionedStoreWithHeaders.put(key, value, timestamp, headers);
+            }
             return versionedStore.put(key, value, timestamp);
         }
         throw new IllegalStateException("KeyValueStoreWrapper must be initialized with either headers or versioned store");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
@@ -42,6 +44,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.VersionedBytesStore;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
 import org.apache.kafka.streams.state.VersionedRecord;
@@ -145,13 +148,19 @@ public class MeteredVersionedKeyValueStore<K, V>
         }
 
         public long put(final K key, final V value, final long timestamp) {
+            return put(key, value, timestamp, internalContext.headers());
+        }
+
+        public long put(final K key, final V value, final long timestamp, final Headers headers) {
             Objects.requireNonNull(key, "key cannot be null");
+            final Headers nonNullHeaders = headers == null ? new RecordHeaders() : headers;
             try {
                 final long validTo = maybeMeasureLatency(
                     () -> inner.put(
-                        serializeKey(key),
-                        plainValueSerdes.rawValue(value, internalContext.headers()),
-                        timestamp
+                        Bytes.wrap(serdes.rawKey(key, nonNullHeaders)),
+                        plainValueSerdes.rawValue(value, nonNullHeaders),
+                        timestamp,
+                        nonNullHeaders
                     ),
                     time,
                     putSensor
@@ -174,6 +183,34 @@ public class MeteredVersionedKeyValueStore<K, V>
             }
         }
 
+        public ValueTimestampHeaders<V> getWithHeaders(final K key) {
+            return getWithHeaders(inner, key);
+        }
+
+        public ValueTimestampHeaders<V> getWithHeaders(final VersionedBytesStore store, final K key) {
+            Objects.requireNonNull(key, "key cannot be null");
+            try {
+                return maybeMeasureLatency(() -> deserializeValueWithHeaders(store.get(serializeKey(key))), time, getSensor);
+            } catch (final ProcessorStateException e) {
+                final String message = String.format(e.getMessage(), key);
+                throw new ProcessorStateException(message, e);
+            }
+        }
+
+        public ValueTimestampHeaders<V> getWithHeaders(final K key, final long asOfTimestamp) {
+            return getWithHeaders(inner, key, asOfTimestamp);
+        }
+
+        public ValueTimestampHeaders<V> getWithHeaders(final VersionedBytesStore store, final K key, final long asOfTimestamp) {
+            Objects.requireNonNull(key, "key cannot be null");
+            try {
+                return maybeMeasureLatency(() -> deserializeValueWithHeaders(store.get(serializeKey(key), asOfTimestamp)), time, getSensor);
+            } catch (final ProcessorStateException e) {
+                final String message = String.format(e.getMessage(), key);
+                throw new ProcessorStateException(message, e);
+            }
+        }
+
         public ValueAndTimestamp<V> delete(final K key, final long timestamp) {
             Objects.requireNonNull(key, "key cannot be null");
             try {
@@ -182,6 +219,24 @@ public class MeteredVersionedKeyValueStore<K, V>
                 final String message = String.format(e.getMessage(), key);
                 throw new ProcessorStateException(message, e);
             }
+        }
+
+        public ValueTimestampHeaders<V> deleteWithHeaders(final K key, final long timestamp) {
+            Objects.requireNonNull(key, "key cannot be null");
+            try {
+                return maybeMeasureLatency(() -> deserializeValueWithHeaders(inner.delete(serializeKey(key), timestamp)), time, deleteSensor);
+            } catch (final ProcessorStateException e) {
+                final String message = String.format(e.getMessage(), key);
+                throw new ProcessorStateException(message, e);
+            }
+        }
+
+        private ValueTimestampHeaders<V> deserializeValueWithHeaders(final byte[] rawValueTimestampHeaders) {
+            if (rawValueTimestampHeaders == null) {
+                return null;
+            }
+            return new ValueTimestampHeadersDeserializer<>(plainValueSerdes.valueDeserializer())
+                .deserialize(plainValueSerdes.topic(), rawValueTimestampHeaders);
         }
 
         @SuppressWarnings("unchecked")
@@ -341,6 +396,30 @@ public class MeteredVersionedKeyValueStore<K, V>
         return internal.put(key, value, timestamp);
     }
 
+    protected long putWithHeaders(final K key, final V value, final long timestamp, final Headers headers) {
+        return internal.put(key, value, timestamp, headers);
+    }
+
+    protected VersionedRecord<V> getWithHeaders(final K key) {
+        return toVersionedRecord(internal.getWithHeaders(key));
+    }
+
+    protected VersionedRecord<V> getWithHeaders(final K key, final long asOfTimestamp) {
+        return toVersionedRecord(internal.getWithHeaders(key, asOfTimestamp));
+    }
+
+    protected VersionedRecord<V> getWithHeaders(final VersionedBytesStore store, final K key) {
+        return toVersionedRecord(internal.getWithHeaders(store, key));
+    }
+
+    protected VersionedRecord<V> getWithHeaders(final VersionedBytesStore store, final K key, final long asOfTimestamp) {
+        return toVersionedRecord(internal.getWithHeaders(store, key, asOfTimestamp));
+    }
+
+    protected VersionedRecord<V> deleteWithHeaders(final K key, final long timestamp) {
+        return toVersionedRecord(internal.deleteWithHeaders(key, timestamp));
+    }
+
     @Override
     public VersionedRecord<V> delete(final K key, final long timestamp) {
         final ValueAndTimestamp<V> valueAndTimestamp = internal.delete(key, timestamp);
@@ -363,6 +442,16 @@ public class MeteredVersionedKeyValueStore<K, V>
         return valueAndTimestamp == null
             ? null
             : new VersionedRecord<>(valueAndTimestamp.value(), valueAndTimestamp.timestamp());
+    }
+
+    private VersionedRecord<V> toVersionedRecord(final ValueTimestampHeaders<V> valueTimestampHeaders) {
+        return valueTimestampHeaders == null
+            ? null
+            : new VersionedRecord<>(
+                valueTimestampHeaders.value(),
+                valueTimestampHeaders.timestamp(),
+                valueTimestampHeaders.headers()
+            );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreWithHeaders.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.VersionedBytesStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.VersionedRecord;
+
+class MeteredVersionedKeyValueStoreWithHeaders<K, V>
+    extends MeteredVersionedKeyValueStore<K, V>
+    implements VersionedKeyValueStoreWithHeaders<K, V> {
+
+    MeteredVersionedKeyValueStoreWithHeaders(final VersionedBytesStore inner,
+                                             final String metricScope,
+                                             final Time time,
+                                             final Serde<K> keySerde,
+                                             final Serde<V> valueSerde) {
+        super(inner, metricScope, time, keySerde, valueSerde);
+    }
+
+    @Override
+    public long put(final K key, final V value, final long timestamp, final Headers headers) {
+        return putWithHeaders(key, value, timestamp, headers);
+    }
+
+    @Override
+    public VersionedRecord<V> delete(final K key, final long timestamp) {
+        return deleteWithHeaders(key, timestamp);
+    }
+
+    @Override
+    public VersionedRecord<V> get(final K key) {
+        return getWithHeaders(key);
+    }
+
+    @Override
+    public VersionedRecord<V> get(final K key, final long asOfTimestamp) {
+        return getWithHeaders(key, asOfTimestamp);
+    }
+
+    @Override
+    public VersionedKeyValueStoreWithHeaders<K, V> readOnly(final IsolationLevel isolationLevel) {
+        return new ReadOnlyView(wrapped().readOnly(isolationLevel));
+    }
+
+    private final class ReadOnlyView implements VersionedKeyValueStoreWithHeaders<K, V> {
+        private final VersionedBytesStore underlying;
+
+        private ReadOnlyView(final VersionedBytesStore underlying) {
+            this.underlying = underlying;
+        }
+
+        @Override
+        public VersionedRecord<V> get(final K key) {
+            return getWithHeaders(underlying, key);
+        }
+
+        @Override
+        public VersionedRecord<V> get(final K key, final long asOfTimestamp) {
+            return getWithHeaders(underlying, key, asOfTimestamp);
+        }
+
+        @Override
+        public long put(final K key, final V value, final long timestamp) {
+            throw new UnsupportedOperationException("put is not supported on a read-only view");
+        }
+
+        @Override
+        public long put(final K key, final V value, final long timestamp, final Headers headers) {
+            throw new UnsupportedOperationException("put is not supported on a read-only view");
+        }
+
+        @Override
+        public VersionedRecord<V> delete(final K key, final long timestamp) {
+            throw new UnsupportedOperationException("delete is not supported on a read-only view");
+        }
+
+        @Override
+        public String name() {
+            return MeteredVersionedKeyValueStoreWithHeaders.this.name();
+        }
+
+        @Override
+        public void init(final StateStoreContext stateStoreContext, final StateStore root) {
+            throw new UnsupportedOperationException("init is not supported on a read-only view");
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException("close is not supported on a read-only view");
+        }
+
+        @Override
+        public boolean persistent() {
+            return MeteredVersionedKeyValueStoreWithHeaders.this.persistent();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return MeteredVersionedKeyValueStoreWithHeaders.this.isOpen();
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreWithHeaders.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.internals.ByteUtils;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.ResultOrder;
+import org.apache.kafka.streams.state.HeadersBytesStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.apache.kafka.streams.state.VersionedRecordIterator;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A persistent, versioned key-value store based on RocksDB that additionally
+ * preserves record headers.
+ * <p>
+ * Headers are embedded into the value bytes using the format:
+ * {@code [headersSize(varint)][headersBytes][rawValue]}
+ * before delegating to the parent {@link RocksDBVersionedStore}. On reads,
+ * headers are extracted from the stored value bytes.
+ */
+public class RocksDBVersionedStoreWithHeaders
+        extends RocksDBVersionedStore
+        implements VersionedKeyValueStoreWithHeaders<Bytes, byte[]> {
+
+    RocksDBVersionedStoreWithHeaders(final String name,
+                                     final String metricsScope,
+                                     final long historyRetention,
+                                     final long segmentInterval) {
+        super(name, metricsScope, historyRetention, segmentInterval);
+    }
+
+    @Override
+    public long put(final Bytes key, final byte[] value, final long timestamp, final Headers headers) {
+        Objects.requireNonNull(headers, "headers cannot be null");
+        return super.put(key, encodeValue(value, headers), timestamp);
+    }
+
+    @Override
+    public long put(final Bytes key, final byte[] value, final long timestamp) {
+        // non-headers put: embed empty headers
+        return put(key, value, timestamp, new RecordHeaders());
+    }
+
+    @Override
+    public VersionedRecord<byte[]> get(final Bytes key) {
+        final VersionedRecord<byte[]> record = super.get(key);
+        return decodeRecord(record);
+    }
+
+    @Override
+    public VersionedRecord<byte[]> get(final Bytes key, final long asOfTimestamp) {
+        final VersionedRecord<byte[]> record = super.get(key, asOfTimestamp);
+        return decodeRecord(record);
+    }
+
+    @Override
+    public VersionedRecord<byte[]> delete(final Bytes key, final long timestamp) {
+        final VersionedRecord<byte[]> record = super.delete(key, timestamp);
+        return decodeRecord(record);
+    }
+
+    @Override
+    VersionedRecordIterator<byte[]> get(final Bytes key, final long fromTimestamp, final long toTimestamp, final ResultOrder order) {
+        return new DecodingVersionedRecordIterator(super.get(key, fromTimestamp, toTimestamp, order, IsolationLevel.READ_UNCOMMITTED));
+    }
+
+    @Override
+    VersionedRecordIterator<byte[]> get(final Bytes key,
+                                        final long fromTimestamp,
+                                        final long toTimestamp,
+                                        final ResultOrder order,
+                                        final IsolationLevel level) {
+        return new DecodingVersionedRecordIterator(super.get(key, fromTimestamp, toTimestamp, order, level));
+    }
+
+    @Override
+    public VersionedKeyValueStoreWithHeaders<Bytes, byte[]> readOnly(final IsolationLevel isolationLevel) {
+        final VersionedKeyValueStore<Bytes, byte[]> readOnly = super.readOnly(isolationLevel);
+        if (readOnly == this) {
+            return this;
+        }
+        return new ReadOnlyView(readOnly);
+    }
+
+    @Override
+    void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+        final List<ConsumerRecord<byte[], byte[]>> encodedRecords = new ArrayList<>(records.size());
+        for (final ConsumerRecord<byte[], byte[]> record : records) {
+            encodedRecords.add(recordWithEncodedValue(record));
+        }
+        super.restoreBatch(encodedRecords);
+    }
+
+    private static ConsumerRecord<byte[], byte[]> recordWithEncodedValue(final ConsumerRecord<byte[], byte[]> record) {
+        final byte[] encodedValue = encodeValue(record.value(), record.headers());
+        return new ConsumerRecord<>(
+            record.topic(),
+            record.partition(),
+            record.offset(),
+            record.timestamp(),
+            record.timestampType(),
+            record.serializedKeySize(),
+            encodedValue == null ? ConsumerRecord.NULL_SIZE : encodedValue.length,
+            record.key(),
+            encodedValue,
+            record.headers(),
+            record.leaderEpoch()
+        );
+    }
+
+    private static byte[] encodeValue(final byte[] value, final Headers headers) {
+        if (value == null) {
+            return null;
+        }
+        if (!headers.iterator().hasNext()) {
+            return HeadersBytesStore.convertToHeaderFormat(value);
+        }
+
+        final HeadersSerializer.PreSerializedHeaders prep = HeadersSerializer.prepareSerialization(headers);
+        final int payloadSize = prep.requiredBufferSizeForHeaders + value.length;
+        final ByteBuffer buffer = ByteBuffer.allocate(ByteUtils.sizeOfVarint(prep.requiredBufferSizeForHeaders) + payloadSize);
+        ByteUtils.writeVarint(prep.requiredBufferSizeForHeaders, buffer);
+        HeadersSerializer.serialize(prep, buffer);
+        buffer.put(value);
+        return buffer.array();
+    }
+
+    private static VersionedRecord<byte[]> decodeRecord(final VersionedRecord<byte[]> record) {
+        if (record == null) {
+            return null;
+        }
+        final byte[] encodedValue = record.value();
+        final Headers headers = Utils.headers(encodedValue);
+        final byte[] rawValue = extractRawValue(encodedValue);
+        if (record.validTo().isPresent()) {
+            return new VersionedRecord<>(rawValue, record.timestamp(), record.validTo().get(), headers);
+        } else {
+            return new VersionedRecord<>(rawValue, record.timestamp(), headers);
+        }
+    }
+
+    /**
+     * Extract raw value from encoded value bytes, stripping the headers prefix.
+     * Format: [headersSize(varint)][headersBytes][rawValue]
+     */
+    private static byte[] extractRawValue(final byte[] encodedValue) {
+        if (encodedValue == null) {
+            return null;
+        }
+        final ByteBuffer buffer = ByteBuffer.wrap(encodedValue);
+        final int headersSize = ByteUtils.readVarint(buffer);
+        buffer.position(buffer.position() + headersSize);
+        final byte[] rawValue = new byte[buffer.remaining()];
+        buffer.get(rawValue);
+        return rawValue;
+    }
+
+    private static final class DecodingVersionedRecordIterator implements VersionedRecordIterator<byte[]> {
+        private final VersionedRecordIterator<byte[]> inner;
+
+        private DecodingVersionedRecordIterator(final VersionedRecordIterator<byte[]> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public void close() {
+            inner.close();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return inner.hasNext();
+        }
+
+        @Override
+        public VersionedRecord<byte[]> next() {
+            return decodeRecord(inner.next());
+        }
+    }
+
+    private static final class ReadOnlyView implements VersionedKeyValueStoreWithHeaders<Bytes, byte[]> {
+        private final VersionedKeyValueStore<Bytes, byte[]> inner;
+
+        private ReadOnlyView(final VersionedKeyValueStore<Bytes, byte[]> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public VersionedRecord<byte[]> get(final Bytes key) {
+            return decodeRecord(inner.get(key));
+        }
+
+        @Override
+        public VersionedRecord<byte[]> get(final Bytes key, final long asOfTimestamp) {
+            return decodeRecord(inner.get(key, asOfTimestamp));
+        }
+
+        @Override
+        public long put(final Bytes key, final byte[] value, final long timestamp) {
+            throw new UnsupportedOperationException("put not supported on a read-only view");
+        }
+
+        @Override
+        public long put(final Bytes key, final byte[] value, final long timestamp, final Headers headers) {
+            throw new UnsupportedOperationException("put not supported on a read-only view");
+        }
+
+        @Override
+        public VersionedRecord<byte[]> delete(final Bytes key, final long timestamp) {
+            throw new UnsupportedOperationException("delete not supported on a read-only view");
+        }
+
+        @Override
+        public String name() {
+            return inner.name();
+        }
+
+        @Override
+        public void init(final StateStoreContext stateStoreContext, final StateStore root) {
+            throw new UnsupportedOperationException("init not supported on a read-only view");
+        }
+
+        @Override
+        public void close() { }
+
+        @Override
+        public boolean persistent() {
+            return inner.persistent();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return inner.isOpen();
+        }
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.HeadersBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
+
+/**
+ * A {@link VersionedBytesStoreSupplier} that also implements {@link HeadersBytesStoreSupplier},
+ * providing a versioned store with headers support backed by RocksDB.
+ */
+public class RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier
+        implements VersionedBytesStoreSupplier, HeadersBytesStoreSupplier {
+
+    private final String name;
+    private final long historyRetentionMs;
+    private final long segmentIntervalMs;
+
+    public RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier(final String name,
+                                                                  final long historyRetentionMs) {
+        this(name, historyRetentionMs, defaultSegmentInterval(historyRetentionMs));
+    }
+
+    public RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier(final String name,
+                                                                  final long historyRetentionMs,
+                                                                  final long segmentIntervalMs) {
+        this.name = name;
+        this.historyRetentionMs = historyRetentionMs;
+        this.segmentIntervalMs = segmentIntervalMs;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public long historyRetentionMs() {
+        return historyRetentionMs;
+    }
+
+    public long segmentIntervalMs() {
+        return segmentIntervalMs;
+    }
+
+    @Override
+    public KeyValueStore<Bytes, byte[]> get() {
+        return new VersionedKeyValueToBytesStoreAdapter(
+            new RocksDBVersionedStoreWithHeaders(name, metricsScope(), historyRetentionMs, segmentIntervalMs),
+            true
+        );
+    }
+
+    @Override
+    public String metricsScope() {
+        return "rocksdb";
+    }
+
+    private static long defaultSegmentInterval(final long historyRetentionMs) {
+        if (historyRetentionMs <= 60_000L) {
+            return Math.max(historyRetentionMs / 3, 2_000L);
+        } else if (historyRetentionMs <= 300_000L) {
+            return Math.max(historyRetentionMs / 5, 20_000L);
+        } else if (historyRetentionMs <= 3600_000L) {
+            return Math.max(historyRetentionMs / 12, 60_000L);
+        } else {
+            return Math.max(historyRetentionMs / 24, 300_000L);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreQueryUtils.java
@@ -460,26 +460,25 @@ public final class StoreQueryUtils {
         return rawVersionedRecord ->
             rawVersionedRecord.validTo().isPresent()
                 ? new VersionedRecord<>(
-                      // deserializeValue s only used via IQ, so it's ok to not pass any headers
-                      deserializer.deserialize(serdes.topic(), new RecordHeaders(), rawVersionedRecord.value()),
+                      deserializer.deserialize(serdes.topic(), rawVersionedRecord.headers(), rawVersionedRecord.value()),
                       rawVersionedRecord.timestamp(),
-                      rawVersionedRecord.validTo().get()
+                      rawVersionedRecord.validTo().get(),
+                      rawVersionedRecord.headers()
                   )
                 : new VersionedRecord<>(
-                      // deserializeValue s only used via IQ, so it's ok to not pass any headers
-                      deserializer.deserialize(serdes.topic(), new RecordHeaders(), rawVersionedRecord.value()),
-                      rawVersionedRecord.timestamp()
+                      deserializer.deserialize(serdes.topic(), rawVersionedRecord.headers(), rawVersionedRecord.value()),
+                      rawVersionedRecord.timestamp(),
+                      rawVersionedRecord.headers()
                   );
     }
 
     @SuppressWarnings("resource")
     public static <V> VersionedRecord<V> deserializeVersionedRecord(final StateSerdes<?, V> serdes, final VersionedRecord<byte[]> rawVersionedRecord) {
         final Deserializer<V> valueDeserializer = serdes.valueDeserializer();
-        // deserializeValue s only used via IQ, so it's ok to not pass any headers
-        final V value = valueDeserializer.deserialize(serdes.topic(), new RecordHeaders(), rawVersionedRecord.value());
+        final V value = valueDeserializer.deserialize(serdes.topic(), rawVersionedRecord.headers(), rawVersionedRecord.value());
         return rawVersionedRecord.validTo().isPresent()
-            ? new VersionedRecord<>(value, rawVersionedRecord.timestamp(), rawVersionedRecord.validTo().get())
-            : new VersionedRecord<>(value, rawVersionedRecord.timestamp());
+            ? new VersionedRecord<>(value, rawVersionedRecord.timestamp(), rawVersionedRecord.validTo().get(), rawVersionedRecord.headers())
+            : new VersionedRecord<>(value, rawVersionedRecord.timestamp(), rawVersionedRecord.headers());
     }
 
     public static void checkpointPosition(final OffsetCheckpoint checkpointFile, final Position position) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderWithHeaders.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.VersionedBytesStore;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+
+import java.util.Objects;
+
+/**
+ * Builder for versioned key-value stores with headers support.
+ * Follows the same pattern as {@link VersionedKeyValueStoreBuilder} but wraps
+ * with a headers-aware changelog store.
+ */
+public class VersionedKeyValueStoreBuilderWithHeaders<K, V>
+    extends AbstractStoreBuilder<K, V, VersionedKeyValueStoreWithHeaders<K, V>> {
+
+    private final VersionedBytesStoreSupplier storeSupplier;
+
+    public VersionedKeyValueStoreBuilderWithHeaders(final VersionedBytesStoreSupplier storeSupplier,
+                                                     final Serde<K> keySerde,
+                                                     final Serde<V> valueSerde,
+                                                     final Time time) {
+        super(
+            storeSupplier.name(),
+            keySerde,
+            valueSerde,
+            time);
+        Objects.requireNonNull(storeSupplier, "storeSupplier can't be null");
+        Objects.requireNonNull(storeSupplier.metricsScope(), "storeSupplier's metricsScope can't be null");
+        this.storeSupplier = storeSupplier;
+    }
+
+    @Override
+    public VersionedKeyValueStoreWithHeaders<K, V> build() {
+        final KeyValueStore<Bytes, byte[]> store = storeSupplier.get();
+        if (!(store instanceof VersionedBytesStore)) {
+            throw new IllegalStateException(
+                "VersionedBytesStoreSupplier.get() must return an instance of VersionedBytesStore");
+        }
+
+        return new MeteredVersionedKeyValueStoreWithHeaders<>(
+            maybeWrapLogging((VersionedBytesStore) store),
+            storeSupplier.metricsScope(),
+            time,
+            keySerde,
+            valueSerde);
+    }
+
+    @Override
+    public StoreBuilder<VersionedKeyValueStoreWithHeaders<K, V>> withCachingEnabled() {
+        throw new IllegalStateException("Versioned stores do not support caching");
+    }
+
+    public long historyRetention() {
+        return storeSupplier.historyRetentionMs();
+    }
+
+    private VersionedBytesStore maybeWrapLogging(final VersionedBytesStore inner) {
+        if (!enableLogging) {
+            return inner;
+        }
+        return new ChangeLoggingVersionedKeyValueBytesStore(inner);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/VersionedKeyValueToBytesStoreAdapter.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes.ByteArraySerde;
 import org.apache.kafka.common.serialization.Serializer;
@@ -37,6 +38,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.VersionedBytesStore;
 import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.VersionedRecord;
 
 import java.util.List;
@@ -57,13 +59,29 @@ public class VersionedKeyValueToBytesStoreAdapter implements VersionedBytesStore
         = VALUE_AND_TIMESTAMP_SERDE.serializer();
 
     final VersionedKeyValueStore<Bytes, byte[]> inner;
+    private final boolean includeHeaders;
 
     public VersionedKeyValueToBytesStoreAdapter(final VersionedKeyValueStore<Bytes, byte[]> inner) {
+        this(inner, false);
+    }
+
+    public VersionedKeyValueToBytesStoreAdapter(final VersionedKeyValueStore<Bytes, byte[]> inner,
+                                                final boolean includeHeaders) {
         this.inner = Objects.requireNonNull(inner);
+        this.includeHeaders = includeHeaders;
     }
 
     @Override
     public long put(final Bytes key, final byte[] value, final long timestamp) {
+        return inner.put(key, value, timestamp);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public long put(final Bytes key, final byte[] value, final long timestamp, final Headers headers) {
+        if (inner instanceof VersionedKeyValueStoreWithHeaders) {
+            return ((VersionedKeyValueStoreWithHeaders<Bytes, byte[]>) inner).put(key, value, timestamp, headers);
+        }
         return inner.put(key, value, timestamp);
     }
 
@@ -87,7 +105,7 @@ public class VersionedKeyValueToBytesStoreAdapter implements VersionedBytesStore
 
     @Override
     public VersionedBytesStore readOnly(final IsolationLevel isolationLevel) {
-        return new VersionedKeyValueToBytesStoreAdapter(inner.readOnly(isolationLevel));
+        return new VersionedKeyValueToBytesStoreAdapter(inner.readOnly(isolationLevel), includeHeaders);
     }
 
     @Override
@@ -196,9 +214,16 @@ public class VersionedKeyValueToBytesStoreAdapter implements VersionedBytesStore
         throw new UnsupportedOperationException("Versioned key-value stores do not support approximateNumEntries()");
     }
 
-    private static byte[] serializeAsBytes(final VersionedRecord<byte[]> versionedRecord) {
+    private byte[] serializeAsBytes(final VersionedRecord<byte[]> versionedRecord) {
         if (versionedRecord == null) {
             return null;
+        }
+        if (includeHeaders) {
+            return RecordConverters.reconstructFromRaw(
+                versionedRecord.value(),
+                versionedRecord.timestamp(),
+                versionedRecord.headers()
+            );
         }
         return VALUE_AND_TIMESTAMP_SERIALIZER.serialize(
             null,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializerWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializerWithHeadersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.HeadersBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
+import org.apache.kafka.streams.state.internals.RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilderWithHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class KeyValueStoreMaterializerWithHeadersTest {
+
+    @Test
+    public void shouldReturnDualInterfaceSupplier() {
+        final VersionedBytesStoreSupplier supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+
+        assertInstanceOf(VersionedBytesStoreSupplier.class, supplier);
+        assertInstanceOf(HeadersBytesStoreSupplier.class, supplier);
+        assertInstanceOf(RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier.class, supplier);
+    }
+
+    @Test
+    public void shouldRouteVersionedHeadersSupplierToVersionedHeadersBuilder() {
+        final VersionedBytesStoreSupplier supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized =
+            new MaterializedInternal<>(Materialized.as(supplier));
+
+        final StoreBuilder<?> builder = new KeyValueStoreMaterializer<>(materialized).builder();
+
+        assertInstanceOf(VersionedKeyValueStoreBuilderWithHeaders.class, builder);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/VersionedRecordWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/VersionedRecordWithHeadersTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VersionedRecordWithHeadersTest {
+
+    @Test
+    public void shouldCreateRecordWithDefaultEmptyHeaders() {
+        final VersionedRecord<String> record = new VersionedRecord<>("value", 42L);
+
+        assertEquals("value", record.value());
+        assertEquals(42L, record.timestamp());
+        assertFalse(record.validTo().isPresent());
+        assertNotNull(record.headers());
+        assertFalse(record.headers().iterator().hasNext());
+    }
+
+    @Test
+    public void shouldCreateRecordWithValidToAndDefaultEmptyHeaders() {
+        final VersionedRecord<String> record = new VersionedRecord<>("value", 42L, 100L);
+
+        assertEquals("value", record.value());
+        assertEquals(42L, record.timestamp());
+        assertTrue(record.validTo().isPresent());
+        assertEquals(100L, record.validTo().get());
+        assertNotNull(record.headers());
+        assertFalse(record.headers().iterator().hasNext());
+    }
+
+    @Test
+    public void shouldCreateRecordWithExplicitHeaders() {
+        final Headers headers = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("key1", "val1".getBytes(StandardCharsets.UTF_8))
+        });
+        final VersionedRecord<String> record = new VersionedRecord<>("value", 42L, headers);
+
+        assertEquals("value", record.value());
+        assertEquals(42L, record.timestamp());
+        assertFalse(record.validTo().isPresent());
+        assertEquals(headers, record.headers());
+        assertEquals("val1", new String(record.headers().lastHeader("key1").value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldCreateRecordWithValidToAndExplicitHeaders() {
+        final Headers headers = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("traceId", "abc".getBytes(StandardCharsets.UTF_8))
+        });
+        final VersionedRecord<String> record = new VersionedRecord<>("value", 42L, 100L, headers);
+
+        assertEquals("value", record.value());
+        assertEquals(42L, record.timestamp());
+        assertTrue(record.validTo().isPresent());
+        assertEquals(100L, record.validTo().get());
+        assertEquals(headers, record.headers());
+    }
+
+    @Test
+    public void shouldRejectNullValue() {
+        assertThrows(NullPointerException.class, () -> new VersionedRecord<>(null, 42L));
+    }
+
+    @Test
+    public void shouldRejectNullHeaders() {
+        assertThrows(NullPointerException.class, () -> new VersionedRecord<>("value", 42L, null));
+    }
+
+    @Test
+    public void shouldRejectNullHeadersWithValidTo() {
+        assertThrows(NullPointerException.class, () -> new VersionedRecord<>("value", 42L, 100L, null));
+    }
+
+    @Test
+    public void shouldNotBeEqualForRecordsWithDifferentHeaders() {
+        final Headers h1 = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("k", "v1".getBytes(StandardCharsets.UTF_8))
+        });
+        final Headers h2 = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("k", "v2".getBytes(StandardCharsets.UTF_8))
+        });
+        final VersionedRecord<String> r1 = new VersionedRecord<>("val", 10L, h1);
+        final VersionedRecord<String> r2 = new VersionedRecord<>("val", 10L, h2);
+
+        assertNotEquals(r1, r2);
+    }
+
+    @Test
+    public void shouldBeEqualForRecordsWithSameHeaders() {
+        final Headers h1 = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("k", "v1".getBytes(StandardCharsets.UTF_8))
+        });
+        final Headers h2 = new RecordHeaders(new RecordHeader[]{
+            new RecordHeader("k", "v1".getBytes(StandardCharsets.UTF_8))
+        });
+        final VersionedRecord<String> r1 = new VersionedRecord<>("val", 10L, h1);
+        final VersionedRecord<String> r2 = new VersionedRecord<>("val", 10L, h2);
+
+        assertEquals(r1, r2);
+        assertEquals(r1.hashCode(), r2.hashCode());
+    }
+
+    @Test
+    public void shouldReturnCorrectToString() {
+        final VersionedRecord<String> record = new VersionedRecord<>("value", 42L);
+        final String str = record.toString();
+        assertTrue(str.startsWith("<value,42,Optional.empty,"));
+        assertTrue(str.contains("RecordHeaders"));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreWithHeadersTest.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.ResultOrder;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.apache.kafka.streams.state.VersionedRecordIterator;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class RocksDBVersionedStoreWithHeadersTest {
+
+    private static final long HISTORY_RETENTION = 60_000L;
+    private static final long SEGMENT_INTERVAL = 20_000L;
+
+    private RocksDBVersionedStoreWithHeaders store;
+
+    @BeforeEach
+    void setUp() {
+        store = new RocksDBVersionedStoreWithHeaders("test-store", "rocksdb", HISTORY_RETENTION, SEGMENT_INTERVAL);
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(
+            TestUtils.tempDirectory(),
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig())
+        );
+        store.init((StateStoreContext) context, store);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    private static Bytes key(final String k) {
+        return Bytes.wrap(k.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static byte[] value(final String v) {
+        return v.getBytes(StandardCharsets.UTF_8);
+    }
+
+    // End-to-end tests using the store's public API
+
+    @Test
+    public void shouldPutAndGetWithHeaders() {
+        final Bytes key = key("testKey");
+        final byte[] val = value("testValue");
+        final long timestamp = 1000L;
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("traceId", "trace-123".getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("userId", "user-456".getBytes(StandardCharsets.UTF_8)));
+
+        store.put(key, val, timestamp, headers);
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertEquals(timestamp, record.timestamp());
+
+        final Headers returnedHeaders = record.headers();
+        assertNotNull(returnedHeaders);
+        assertEquals("trace-123",
+            new String(returnedHeaders.lastHeader("traceId").value(), StandardCharsets.UTF_8));
+        assertEquals("user-456",
+            new String(returnedHeaders.lastHeader("userId").value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldPutAndGetWithEmptyHeaders() {
+        final Bytes key = key("emptyHeadersKey");
+        final byte[] val = value("emptyHeadersValue");
+        final long timestamp = 2000L;
+        final RecordHeaders headers = new RecordHeaders();
+
+        store.put(key, val, timestamp, headers);
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertEquals(timestamp, record.timestamp());
+
+        final Headers returnedHeaders = record.headers();
+        assertNotNull(returnedHeaders);
+        assertFalse(returnedHeaders.iterator().hasNext());
+    }
+
+    @Test
+    public void shouldGetByTimestampWithHeaders() {
+        final Bytes key = key("versionedKey");
+        final long ts1 = 1000L;
+        final long ts2 = 2000L;
+
+        final RecordHeaders headers1 = new RecordHeaders();
+        headers1.add(new RecordHeader("version", "1".getBytes(StandardCharsets.UTF_8)));
+
+        final RecordHeaders headers2 = new RecordHeaders();
+        headers2.add(new RecordHeader("version", "2".getBytes(StandardCharsets.UTF_8)));
+
+        store.put(key, value("value1"), ts1, headers1);
+        store.put(key, value("value2"), ts2, headers2);
+
+        // Get as of ts2
+        final VersionedRecord<byte[]> record = store.get(key, ts2);
+        assertNotNull(record);
+        assertArrayEquals(value("value2"), record.value());
+        assertEquals(ts2, record.timestamp());
+        assertEquals("2",
+            new String(record.headers().lastHeader("version").value(), StandardCharsets.UTF_8));
+
+        // Get as of ts1 (should return version 1)
+        final VersionedRecord<byte[]> record1 = store.get(key, ts1);
+        assertNotNull(record1);
+        assertArrayEquals(value("value1"), record1.value());
+        assertEquals(ts1, record1.timestamp());
+        assertEquals("1",
+            new String(record1.headers().lastHeader("version").value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldDeleteRecordWithHeaders() {
+        final Bytes key = key("deleteKey");
+        final byte[] val = value("deleteValue");
+        final long timestamp = 1000L;
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("operation", "put".getBytes(StandardCharsets.UTF_8)));
+
+        store.put(key, val, timestamp, headers);
+
+        // Verify the record exists before deletion
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertEquals(timestamp, record.timestamp());
+        assertEquals("put",
+            new String(record.headers().lastHeader("operation").value(), StandardCharsets.UTF_8));
+
+        // Delete the record by putting a tombstone at a later timestamp
+        store.put(key, null, 2000L, new RecordHeaders());
+
+        // Verify the record is now deleted (returns null for get)
+        final VersionedRecord<byte[]> afterDelete = store.get(key);
+        assertNull(afterDelete);
+    }
+
+    @Test
+    public void shouldHandleTombstoneViaHeadersPut() {
+        final Bytes key = key("tombstoneKey");
+        final long timestamp = 1000L;
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("tombstoneMarker", "true".getBytes(StandardCharsets.UTF_8)));
+
+        // Put null value with headers (tombstone)
+        store.put(key, null, timestamp, headers);
+
+        // Get should return null for the value
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNull(record);
+    }
+
+    @Test
+    public void shouldPutWithoutHeadersDefaultsToEmptyHeaders() {
+        final Bytes key = key("noHeadersKey");
+        final byte[] val = value("noHeadersValue");
+        final long timestamp = 3000L;
+
+        // Use put without headers argument
+        store.put(key, val, timestamp);
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertEquals(timestamp, record.timestamp());
+
+        final Headers returnedHeaders = record.headers();
+        assertNotNull(returnedHeaders);
+        assertFalse(returnedHeaders.iterator().hasNext());
+    }
+
+    @Test
+    public void shouldPreserveHeadersWithNullHeaderValues() {
+        final Bytes key = key("nullHeaderValueKey");
+        final byte[] val = value("testValue");
+        final long timestamp = 4000L;
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("nullValue", null));
+        headers.add(new RecordHeader("normalValue", "normal".getBytes(StandardCharsets.UTF_8)));
+
+        store.put(key, val, timestamp, headers);
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+
+        final Headers returnedHeaders = record.headers();
+        assertNotNull(returnedHeaders);
+        assertNull(returnedHeaders.lastHeader("nullValue").value());
+        assertEquals("normal",
+            new String(returnedHeaders.lastHeader("normalValue").value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldPreserveMultipleHeadersSameKey() {
+        final Bytes key = key("multiHeaderKey");
+        final byte[] val = value("multiHeaderValue");
+        final long timestamp = 5000L;
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("tag", "tag1".getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("tag", "tag2".getBytes(StandardCharsets.UTF_8)));
+        headers.add(new RecordHeader("tag", "tag3".getBytes(StandardCharsets.UTF_8)));
+
+        store.put(key, val, timestamp, headers);
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+
+        final Headers returnedHeaders = record.headers();
+        assertNotNull(returnedHeaders);
+
+        // Verify all headers with same key are preserved
+        final java.util.List<Header> tagHeaders = new java.util.ArrayList<>();
+        for (final Header h : returnedHeaders) {
+            if (h.key().equals("tag")) {
+                tagHeaders.add(h);
+            }
+        }
+        assertEquals(3, tagHeaders.size());
+        assertEquals("tag1", new String(tagHeaders.get(0).value(), StandardCharsets.UTF_8));
+        assertEquals("tag2", new String(tagHeaders.get(1).value(), StandardCharsets.UTF_8));
+        assertEquals("tag3", new String(tagHeaders.get(2).value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldRestoreNativeChangelogHeadersIntoLocalFormat() {
+        final Bytes key = key("restoreKey");
+        final byte[] val = value("restoreValue");
+        final RecordHeaders headers = new RecordHeaders();
+        headers.add(new RecordHeader("traceId", value("trace-restore")));
+
+        store.restoreBatch(List.of(changelogRecord(key, val, 1000L, headers)));
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertEquals("trace-restore", new String(record.headers().lastHeader("traceId").value(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldRestoreEmptyNativeChangelogHeadersIntoLocalFormat() {
+        final Bytes key = key("restoreEmptyHeadersKey");
+        final byte[] val = value("restoreEmptyHeadersValue");
+
+        store.restoreBatch(List.of(changelogRecord(key, val, 1000L, new RecordHeaders())));
+
+        final VersionedRecord<byte[]> record = store.get(key);
+        assertNotNull(record);
+        assertArrayEquals(val, record.value());
+        assertFalse(record.headers().iterator().hasNext());
+    }
+
+    @Test
+    public void shouldDecodeMultiVersionedQueryResults() {
+        final Bytes key = key("multiVersionKey");
+        final RecordHeaders headers1 = new RecordHeaders();
+        headers1.add(new RecordHeader("version", value("1")));
+        final RecordHeaders headers2 = new RecordHeaders();
+        headers2.add(new RecordHeader("version", value("2")));
+
+        store.put(key, value("value1"), 1000L, headers1);
+        store.put(key, value("value2"), 2000L, headers2);
+
+        try (final VersionedRecordIterator<byte[]> iterator = store.get(key, 0L, 3000L, ResultOrder.DESCENDING)) {
+            final VersionedRecord<byte[]> latest = iterator.next();
+            assertArrayEquals(value("value2"), latest.value());
+            assertEquals("2", new String(latest.headers().lastHeader("version").value(), StandardCharsets.UTF_8));
+
+            final VersionedRecord<byte[]> older = iterator.next();
+            assertArrayEquals(value("value1"), older.value());
+            assertEquals("1", new String(older.headers().lastHeader("version").value(), StandardCharsets.UTF_8));
+
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    private static ConsumerRecord<byte[], byte[]> changelogRecord(final Bytes key,
+                                                                  final byte[] value,
+                                                                  final long timestamp,
+                                                                  final Headers headers) {
+        return new ConsumerRecord<>(
+            "test-store-changelog",
+            0,
+            0L,
+            timestamp,
+            TimestampType.CREATE_TIME,
+            key.get().length,
+            value == null ? ConsumerRecord.NULL_SIZE : value.length,
+            key.get(),
+            value,
+            headers,
+            Optional.empty()
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderWithHeadersTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.HeadersBytesStoreSupplier;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VersionedKeyValueStoreBuilderWithHeadersTest {
+
+    @Test
+    public void shouldCreateSupplierWithDualInterface() {
+        final VersionedBytesStoreSupplier supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+
+        assertNotNull(supplier);
+        assertInstanceOf(VersionedBytesStoreSupplier.class, supplier);
+        assertInstanceOf(HeadersBytesStoreSupplier.class, supplier);
+        assertInstanceOf(RocksDbVersionedKeyValueBytesStoreWithHeadersSupplier.class, supplier);
+    }
+
+    @Test
+    public void shouldRejectNullName() {
+        assertThrows(NullPointerException.class,
+            () -> Stores.persistentVersionedKeyValueStoreWithHeaders(null, Duration.ofMinutes(5)));
+    }
+
+    @Test
+    public void shouldRejectNegativeHistoryRetention() {
+        assertThrows(IllegalArgumentException.class,
+            () -> Stores.persistentVersionedKeyValueStoreWithHeaders("test", Duration.ofMillis(-1)));
+    }
+
+    @Test
+    public void shouldCreateBuilderWithHeaders() {
+        final var supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+        final var builder = Stores.versionedKeyValueStoreBuilderWithHeaders(supplier, null, null);
+
+        assertNotNull(builder);
+        assertInstanceOf(VersionedKeyValueStoreBuilderWithHeaders.class, builder);
+    }
+
+    @Test
+    public void shouldBuildHeadersAwareMeteredStore() {
+        final var supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+        final var builder = Stores.versionedKeyValueStoreBuilderWithHeaders(supplier, null, null);
+
+        assertInstanceOf(VersionedKeyValueStoreWithHeaders.class, builder.build());
+    }
+
+    @Test
+    public void shouldRejectNullSupplier() {
+        assertThrows(NullPointerException.class,
+            () -> Stores.versionedKeyValueStoreBuilderWithHeaders(null, null, null));
+    }
+
+    @Test
+    public void shouldRejectCachingOnBuilder() {
+        final var supplier =
+            Stores.persistentVersionedKeyValueStoreWithHeaders("test-store", Duration.ofMinutes(5));
+        final var builder = Stores.versionedKeyValueStoreBuilderWithHeaders(supplier, null, null);
+
+        assertThrows(IllegalStateException.class, builder::withCachingEnabled);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreWithHeadersTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreWithHeadersTopologyTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.apache.kafka.streams.test.TestRecord;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class VersionedKeyValueStoreWithHeadersTopologyTest {
+
+    private static final String INPUT_TOPIC = "input-topic";
+    private static final String OUTPUT_TOPIC = "output-topic";
+    private static final String STORE_NAME = "versioned-headers-store";
+    private static final Duration HISTORY_RETENTION = Duration.ofMinutes(10);
+
+    private StreamsBuilder builder() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.table(
+            INPUT_TOPIC,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.as(Stores.persistentVersionedKeyValueStoreWithHeaders(STORE_NAME, HISTORY_RETENTION))
+        ).toStream().to(OUTPUT_TOPIC, Produced.with(Serdes.String(), Serdes.String()));
+        return builder;
+    }
+
+    private Properties props() {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-versioned-headers");
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        return props;
+    }
+
+    private static Headers headers(final String key, final String value) {
+        return headers(key, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Headers headers(final String key, final byte[] value) {
+        return new RecordHeaders().add(key, value);
+    }
+
+    private static void assertHeaderValue(final Headers headers,
+                                          final String key,
+                                          final String expectedValue) {
+        assertNotNull(headers.lastHeader(key));
+        assertEquals(expectedValue, new String(headers.lastHeader(key).value(), StandardCharsets.UTF_8));
+    }
+
+    private static void assertHeaderValue(final Headers headers,
+                                          final String key,
+                                          final byte[] expectedValue) {
+        assertNotNull(headers.lastHeader(key));
+        assertArrayEquals(expectedValue, headers.lastHeader(key).value());
+    }
+
+    @Test
+    public void shouldMaterializeVersionedStoreWithHeaders() {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder().build(), props())) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic(
+                INPUT_TOPIC, new StringSerializer(), new StringSerializer());
+
+            final TestOutputTopic<String, String> outputTopic = driver.createOutputTopic(
+                OUTPUT_TOPIC, new StringDeserializer(), new StringDeserializer());
+
+            final Headers headers = headers("traceId", "trace-123");
+            headers.add("schemaId", new byte[]{0, 0, 0, 42});
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "value1", headers, 1000L));
+
+            final TestRecord<String, String> outputRecord = outputTopic.readRecord();
+            assertNotNull(outputRecord);
+            assertEquals("key1", outputRecord.key());
+            assertEquals("value1", outputRecord.value());
+
+            final VersionedKeyValueStore<String, String> store = driver.getVersionedKeyValueStore(STORE_NAME);
+            assertInstanceOf(VersionedKeyValueStoreWithHeaders.class, store);
+            final VersionedRecord<String> storedRecord = store.get("key1");
+            assertEquals("value1", storedRecord.value());
+            assertHeaderValue(storedRecord.headers(), "traceId", "trace-123");
+            assertHeaderValue(storedRecord.headers(), "schemaId", new byte[]{0, 0, 0, 42});
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "value2", headers("traceId", "trace-456"), 2000L));
+
+            final TestRecord<String, String> outputRecord2 = outputTopic.readRecord();
+            assertNotNull(outputRecord2);
+            assertEquals("key1", outputRecord2.key());
+            assertEquals("value2", outputRecord2.value());
+
+            final VersionedRecord<String> updatedRecord = store.get("key1");
+            assertEquals("value2", updatedRecord.value());
+            assertHeaderValue(updatedRecord.headers(), "traceId", "trace-456");
+        }
+    }
+
+    @Test
+    public void shouldCreateDualInterfaceSupplier() {
+        final var supplier = Stores.persistentVersionedKeyValueStoreWithHeaders(STORE_NAME, HISTORY_RETENTION);
+
+        assertInstanceOf(org.apache.kafka.streams.state.VersionedBytesStoreSupplier.class, supplier);
+        assertInstanceOf(org.apache.kafka.streams.state.HeadersBytesStoreSupplier.class, supplier);
+    }
+
+    @Test
+    public void shouldHandleMultipleVersionsWithHeaders() {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder().build(), props())) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic(
+                INPUT_TOPIC, new StringSerializer(), new StringSerializer());
+
+            final TestOutputTopic<String, String> outputTopic = driver.createOutputTopic(
+                OUTPUT_TOPIC, new StringDeserializer(), new StringDeserializer());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "val-v1", headers("version", "v1"), 1000L));
+
+            final TestRecord<String, String> out1 = outputTopic.readRecord();
+            assertEquals("val-v1", out1.value());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "val-v2", headers("version", "v2"), 2000L));
+
+            final TestRecord<String, String> out2 = outputTopic.readRecord();
+            assertEquals("val-v2", out2.value());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "val-v3", headers("version", "v3"), 3000L));
+
+            final TestRecord<String, String> out3 = outputTopic.readRecord();
+            assertEquals("val-v3", out3.value());
+
+            final VersionedKeyValueStore<String, String> store = driver.getVersionedKeyValueStore(STORE_NAME);
+            final VersionedRecord<String> version1 = store.get("key1", 1000L);
+            final VersionedRecord<String> version2 = store.get("key1", 2000L);
+            final VersionedRecord<String> version3 = store.get("key1", 3000L);
+            assertEquals("val-v1", version1.value());
+            assertEquals("val-v2", version2.value());
+            assertEquals("val-v3", version3.value());
+            assertHeaderValue(version1.headers(), "version", "v1");
+            assertHeaderValue(version2.headers(), "version", "v2");
+            assertHeaderValue(version3.headers(), "version", "v3");
+        }
+    }
+
+    @Test
+    public void shouldHandleTombstonesWithHeaders() {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder().build(), props())) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic(
+                INPUT_TOPIC, new StringSerializer(), new StringSerializer());
+
+            final TestOutputTopic<String, String> outputTopic = driver.createOutputTopic(
+                OUTPUT_TOPIC, new StringDeserializer(), new StringDeserializer());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "value1", headers("op", "insert"), 1000L));
+
+            final TestRecord<String, String> putOutput = outputTopic.readRecord();
+            assertEquals("value1", putOutput.value());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", (String) null, new RecordHeaders(), 2000L));
+
+            final TestRecord<String, String> deleteOutput = outputTopic.readRecord();
+            assertNull(deleteOutput.value());
+        }
+    }
+
+    @Test
+    public void shouldForwardHeadersToChangelog() {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder().build(), props())) {
+            final TestInputTopic<String, String> inputTopic = driver.createInputTopic(
+                INPUT_TOPIC, new StringSerializer(), new StringSerializer());
+
+            final String changelogTopic = "test-versioned-headers-" + STORE_NAME + "-changelog";
+
+            final TestOutputTopic<String, String> changelogOutputTopic = driver.createOutputTopic(
+                changelogTopic, new StringDeserializer(), new StringDeserializer());
+
+            inputTopic.pipeInput(new TestRecord<>("key1", "value1", headers("traceId", "abc"), 1000L));
+
+            final TestRecord<String, String> changelogRecord = changelogOutputTopic.readRecord();
+            assertNotNull(changelogRecord);
+            assertEquals("key1", changelogRecord.key());
+            assertHeaderValue(changelogRecord.headers(), "traceId", "abc");
+        }
+    }
+}


### PR DESCRIPTION
Ref https://issues.apache.org/jira/browse/KAFKA-20400

This PR extends the KIP-1285 headers-aware state store infrastructure to versioned key-value stores. Prior to this change, KIP-1285 was implemented for timestamped, windowed, and session stores, but versioned stores silently dropped record headers on both the write and read paths.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
---

Record headers carry metadata (tracing IDs, schema references, auth tokens) that downstream processors and interactive query clients may need. Versioned stores (RocksDBVersionedStore) were the only remaining store type that discarded headers. This PR closes that gap.

---
 API changes:

VersionedRecord<V> -- Added Headers headers field with new constructors and a headers() accessor. Existing constructors default to empty headers (backward compatible).

Stores.persistentVersionedKeyValueStoreWithHeaders(String, Duration) -- Factory method returning a dual-interface supplier.

Stores.versionedKeyValueStoreBuilderWithHeaders(VersionedBytesStoreSupplier, Serde, Serde) -- Builder factory method.

RocksDBVersionedStoreWithHeaders -- Extends RocksDBVersionedStore, encodes headers into value bytes using [headersSize(varint)][headersBytes][rawValue] format before delegating to the parent store. Decodes on read.

ChangeLoggingVersionedKeyValueBytesStore -- Added put(key, value, timestamp, headers) override to forward real headers to the changelog instead of empty headers.

KeyValueStoreWrapper -- get() now returns VersionedRecord.headers() instead of empty headers; put() forwards headers to VersionedKeyValueStoreWithHeaders when available.
