### PR TITLE
KAFKA-20372: Fix flaky test in NamedTopologyIntegrationTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -666,7 +666,7 @@ public class NamedTopologyIntegrationTest {
         
         TestUtils.waitForCondition(
                 () -> !streams.hasAnyLocalTaskForTopology(TOPOLOGY_1),
-                "topology tasks still exist internally after remove"
+                "tasks still exist internally after topology removed"
         );
         streams.cleanUpNamedTopology(TOPOLOGY_1);
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -657,7 +657,17 @@ public class NamedTopologyIntegrationTest {
 
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+
+        TestUtils.waitForCondition(
+                () -> streams.allLocalTasksRunningForTopology(TOPOLOGY_1),
+                "topology tasks are still transitioning before remove"
+        );
         streams.removeNamedTopology(TOPOLOGY_1, true).all().get();
+        
+        TestUtils.waitForCondition(
+                () -> !streams.hasAnyLocalTaskForTopology(TOPOLOGY_1),
+                "topology tasks still exist internally after remove"
+        );
         streams.cleanUpNamedTopology(TOPOLOGY_1);
 
         CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog") || t.contains("-repartition")).forEach(t -> {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -659,7 +659,7 @@ public class NamedTopologyIntegrationTest {
         assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
 
         TestUtils.waitForCondition(
-                () -> streams.allLocalTasksRunningForTopology(TOPOLOGY_1),
+                () -> streams.areAllLocalTasksRunningForTopology(TOPOLOGY_1),
                 () -> "Not all local tasks for topology " + TOPOLOGY_1
                         + " are initialized and in RUNNING state before remove. "
                         + "streamsState=" + streams.state()

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -660,13 +660,19 @@ public class NamedTopologyIntegrationTest {
 
         TestUtils.waitForCondition(
                 () -> streams.allLocalTasksRunningForTopology(TOPOLOGY_1),
-                "topology tasks are still transitioning before remove"
+                () -> "Not all local tasks for topology " + TOPOLOGY_1
+                        + " are initialized and in RUNNING state before remove. "
+                        + "streamsState=" + streams.state()
+                        + ", localThreads=" + streams.metadataForLocalThreads()
         );
         streams.removeNamedTopology(TOPOLOGY_1, true).all().get();
         
         TestUtils.waitForCondition(
                 () -> !streams.hasAnyLocalTaskForTopology(TOPOLOGY_1),
-                "tasks still exist internally after topology removed"
+                () -> "Topology " + TOPOLOGY_1
+                        + " still has local tasks after remove. "
+                        + "streamsState=" + streams.state()
+                        + ", localThreads=" + streams.metadataForLocalThreads()
         );
         streams.cleanUpNamedTopology(TOPOLOGY_1);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -2083,6 +2083,17 @@ public class StreamThread extends Thread implements ProcessingThread {
         return taskManager;
     }
 
+    // VisibleForTesting
+    public boolean hasAnyTaskForTopology(final String topologyName) {
+        return taskManager.hasAnyTaskForTopology(topologyName);
+    }
+
+
+    // VisibleForTesting
+    public boolean allTasksRunningForTopology(final String topologyName) {
+        return taskManager.allTasksRunningForTopology(topologyName);
+    }
+    
     int currentNumIterations() {
         return numIterations;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -2090,8 +2090,8 @@ public class StreamThread extends Thread implements ProcessingThread {
 
 
     // VisibleForTesting
-    public boolean allTasksRunningForTopology(final String topologyName) {
-        return taskManager.allTasksRunningForTopology(topologyName);
+    public boolean areAllTasksRunningForTopology(final String topologyName) {
+        return taskManager.areAllTasksRunningForTopology(topologyName);
     }
     
     int currentNumIterations() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -2078,6 +2078,17 @@ public class StreamThread extends Thread implements ProcessingThread {
         return taskManager;
     }
 
+    // VisibleForTesting
+    public boolean hasAnyTaskForTopology(final String topologyName) {
+        return taskManager.hasAnyTaskForTopology(topologyName);
+    }
+
+
+    // VisibleForTesting
+    public boolean allTasksRunningForTopology(final String topologyName) {
+        return taskManager.allTasksRunningForTopology(topologyName);
+    }
+    
     int currentNumIterations() {
         return numIterations;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1635,7 +1635,17 @@ public class TaskManager {
     boolean hasAnyTaskForTopology(final String topologyName) {
         return allTasks().keySet().stream().anyMatch(taskId -> topologyName.equals(taskId.topologyName()));
     }
-    
+
+    /**
+     * Returns {@code true} if every task for the given topology is initialized and in
+     * {@link State#RUNNING}.
+     *
+     * <p>If there are no tasks for the given topology, this method returns {@code true}.
+     *
+     * @param topologyName the topology name
+     * @return {@code true} if all matching tasks are initialized and in {@link State#RUNNING},
+     *         or if there are no matching tasks; {@code false} otherwise
+     */
     // VisibleForTesting
     boolean allTasksRunningForTopology(final String topologyName) {
         final Map<TaskId, Task> allTasks = allTasks();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1647,7 +1647,7 @@ public class TaskManager {
      *         or if there are no matching tasks; {@code false} otherwise
      */
     // VisibleForTesting
-    boolean allTasksRunningForTopology(final String topologyName) {
+    boolean areAllTasksRunningForTopology(final String topologyName) {
         final Map<TaskId, Task> allTasks = allTasks();
         final Set<TaskId> initializedTaskIds = tasks.allInitializedTaskIds();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1631,6 +1631,28 @@ public class TaskManager {
         return ret;
     }
 
+    // VisibleForTesting
+    boolean hasAnyTaskForTopology(final String topologyName) {
+        return allTasks().keySet().stream().anyMatch(taskId -> topologyName.equals(taskId.topologyName()));
+    }
+    
+    // VisibleForTesting
+    boolean allTasksRunningForTopology(final String topologyName) {
+        final Map<TaskId, Task> allTasks = allTasks();
+        final Set<TaskId> initializedTaskIds = tasks.allInitializedTaskIds();
+
+        for (final Map.Entry<TaskId, Task> entry : allTasks.entrySet()) {
+            final TaskId taskId = entry.getKey();
+            if (topologyName.equals(taskId.topologyName())) {
+                if (!initializedTaskIds.contains(taskId) || entry.getValue().state() != State.RUNNING) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+    
     /**
      * Returns tasks owned by the stream thread.
      * This does not return any tasks currently owned by the state updater.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -452,9 +452,9 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
     }
     
     // VisibleForTesting
-    public boolean allLocalTasksRunningForTopology(final String topologyName) {
+    public boolean areAllLocalTasksRunningForTopology(final String topologyName) {
         synchronized (threads) {
-            return threads.stream().allMatch(thread -> thread.allTasksRunningForTopology(topologyName));
+            return threads.stream().allMatch(thread -> thread.areAllTasksRunningForTopology(topologyName));
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -443,4 +443,18 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                 .collect(Collectors.toList())));
         return allLocalStorePartitionLags(allTopologyTasks);
     }
+
+    // VisibleForTesting
+    public boolean hasAnyLocalTaskForTopology(final String topologyName) {
+        synchronized (threads) {
+            return threads.stream().anyMatch(thread -> thread.hasAnyTaskForTopology(topologyName));
+        }
+    }
+    
+    // VisibleForTesting
+    public boolean allLocalTasksRunningForTopology(final String topologyName) {
+        synchronized (threads) {
+            return threads.stream().allMatch(thread -> thread.allTasksRunningForTopology(topologyName));
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a flaky test in `NamedTopologyIntegrationTest`:
`shouldAddToEmptyInitialTopologyRemoveResetOffsetsThenAddSameNamedTopologyWithRepartitioning`.

The failure is caused by a race in the task lifecycle during named
topology removal.

In some runs, local tasks for the topology move to active/running
quickly.  In other runs, some tasks can remain in a transitional state
for a short time, such as state update / restore, before becoming fully
active.

The test currently removes and cleans up the topology without waiting
for this lifecycle to settle. Because of that,
`removeNamedTopology(...)` may run while some local tasks are still
transitioning, and `cleanUpNamedTopology(...)` may follow before those
tasks are fully gone. This makes the subsequent re-add flow
non-deterministic and leads to intermittent failures.

To make the test deterministic, this PR adds explicit waits around the
remove / cleanup sequence:
- wait until all local tasks for the topology are running before calling
`removeNamedTopology(...)`
- wait until no local tasks remain for the topology before calling
`cleanUpNamedTopology(...)`

This keeps the test semantics unchanged and only stabilizes task
lifecycle timing in the test.

## Test result in my local
- Before: 12/17
- After: 89/89

## Considered Alternatives
1. Send records to partition 1 as well
This would make it more likely that both partition 0 and partition 1
tasks are initialized before removal.

However, this changes the test input and can also introduce additional
rebalance and task-transition timing effects, since partition 1
processing becomes part of the exercised path. In other words, it may
reduce one symptom while introducing a different concurrency surface
related to task initialization and reassignment.

More importantly, the root cause of the flake is that the test does not
wait for task lifecycle transitions to settle before calling
`removeNamedTopology(...)` and `cleanUpNamedTopology(...)`. Adding more
input does not address that directly.

2. Reduce the input topic partition count from 2 to 1 This would avoid
the multi-partition timing issue by construction.
However, this also weakens the coverage of the test by removing the
multi-partition setup entirely. Since the production code supports
multiple partitions, reducing the topic to a single partition would hide
the race instead of synchronizing with the intended lifecycle of the
test.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Chia-Yi Chiu
 <cychiu8@gmail.com>
