### PR TITLE
KAFKA-20403 : streams - Fix stream threads interruptions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -957,8 +957,9 @@ public class DefaultStateUpdater implements StateUpdater {
                 now = time.milliseconds();
             }
             return result;
-        } catch (final InterruptedException ignored) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
+            log.warn("StateUpdaterThread was interrupted while waiting", e);
         }
         return result;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -450,8 +450,8 @@ public class DefaultStateUpdater implements StateUpdater {
                     tasksAndActionsCondition.await();
                 }
             } catch (final InterruptedException ignored) {
-                // we never interrupt the thread, but only signal the condition
-                // and hence this exception should never be thrown
+                Thread.currentThread().interrupt();
+                log.warn("State updater thread was interrupted while waiting for changelogs");
             } finally {
                 tasksAndActionsLock.unlock();
                 isIdle.set(false);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -878,6 +878,8 @@ public class DefaultStateUpdater implements StateUpdater {
                 }
                 stateUpdaterThread = null;
             } catch (final InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for state updater thread to shut down");
             }
         }
     }
@@ -956,6 +958,7 @@ public class DefaultStateUpdater implements StateUpdater {
             }
             return result;
         } catch (final InterruptedException ignored) {
+            Thread.currentThread().interrupt();
         }
         return result;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1786,10 +1786,8 @@ public class TaskManager {
                     schedulingTaskManager.lockTasks(ids).get();
                     locked = true;
                 } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
                     log.warn("Interrupted while waiting for tasks {} to be locked",
                         ids.stream().map(TaskId::toString).collect(Collectors.joining(",")));
-                    break;
                 } catch (final ExecutionException e) {
                     log.info("Failed to lock tasks");
                     throw new RuntimeException(e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1786,8 +1786,10 @@ public class TaskManager {
                     schedulingTaskManager.lockTasks(ids).get();
                     locked = true;
                 } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     log.warn("Interrupted while waiting for tasks {} to be locked",
                         ids.stream().map(TaskId::toString).collect(Collectors.joining(",")));
+                    break;
                 } catch (final ExecutionException e) {
                     log.info("Failed to lock tasks");
                     throw new RuntimeException(e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -232,6 +232,7 @@ public class TopologyMetadata {
                     } catch (final InterruptedException e) {
                         Thread.currentThread().interrupt();
                         log.warn("StreamThread was interrupted while waiting on empty topology", e);
+                        break;
                     }
                 }
             } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -231,7 +231,7 @@ public class TopologyMetadata {
                         version.topologyCV.await();
                     } catch (final InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        log.error("StreamThread was interrupted while waiting on empty topology", e);
+                        log.warn("StreamThread was interrupted while waiting on empty topology", e);
                     }
                 }
             } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -230,6 +230,7 @@ public class TopologyMetadata {
                         log.debug("Detected that the topology is currently empty, waiting for something to process");
                         version.topologyCV.await();
                     } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         log.error("StreamThread was interrupted while waiting on empty topology", e);
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/AddNamedTopologyResult.java
@@ -54,6 +54,7 @@ public class AddNamedTopologyResult {
                 return new StreamsException(e.getCause());
             }
         } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
             return null;
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -306,7 +306,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
                 log.info("Successfully completed resetting offsets.");
                 break;
             } catch (final InterruptedException ex) {
-                ex.printStackTrace();
+                Thread.currentThread().interrupt();
                 log.error("Offset reset failed.", ex);
                 throw new StreamsException(ex);
             } catch (final ExecutionException ex) {
@@ -331,7 +331,9 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
             try {
                 Thread.sleep(100);
             } catch (final InterruptedException ex) {
-                ex.printStackTrace();
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted during offset reset retry backoff", ex);
+                break;
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -268,9 +268,9 @@ public class DefaultTaskExecutor implements TaskExecutor {
                     throw new StreamsException("State updater thread did not shutdown within the timeout");
                 }
                 taskExecutorThread = null;
-            } catch (final InterruptedException ignored) {
+            } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
-                log.warn("Interrupted while waiting for task executor thread to shut down");
+                log.warn("Interrupted while waiting for task executor thread to shut down", e);
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -118,7 +118,8 @@ public class DefaultTaskExecutor implements TaskExecutor {
                 try {
                     taskManager.awaitProcessableTasks(shutdownRequested::get);
                 } catch (final InterruptedException ignored) {
-                    // Can be ignored, the cause of the interrupted will be handled in the event loop
+                    Thread.currentThread().interrupt();
+                    // The event loop will check shutdownRequested on the next iteration
                 }
             } else {
                 boolean progressed = false;
@@ -267,6 +268,8 @@ public class DefaultTaskExecutor implements TaskExecutor {
                 }
                 taskExecutorThread = null;
             } catch (final InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for task executor thread to shut down");
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskExecutor.java
@@ -117,9 +117,10 @@ public class DefaultTaskExecutor implements TaskExecutor {
             if (currentTask == null) {
                 try {
                     taskManager.awaitProcessableTasks(shutdownRequested::get);
-                } catch (final InterruptedException ignored) {
+                } catch (final InterruptedException e) {
                     Thread.currentThread().interrupt();
                     // The event loop will check shutdownRequested on the next iteration
+                    log.warn("TaskExecutorThread was interrupted while waiting", e);
                 }
             } else {
                 boolean progressed = false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -147,8 +147,8 @@ public final class DefaultTaskManager implements TaskManager {
                     log.debug("Not awaiting since shutdown was requested");
                 }
             } catch (final InterruptedException ignored) {
+                Thread.currentThread().interrupt();
                 // we interrupt the thread for shut down and pause.
-                // we can ignore this exception.
                 log.debug("Await unblocked: Interrupted while waiting for processable tasks");
                 return true;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -146,9 +146,9 @@ public final class DefaultTaskManager implements TaskManager {
                 } else {
                     log.debug("Not awaiting since shutdown was requested");
                 }
-            } catch (final InterruptedException ignored) {
+            } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
-                log.warn("Await unblocked: Interrupted while waiting for processable tasks");
+                log.warn("Await unblocked: Interrupted while waiting for processable tasks", e);
                 return true;
             }
             log.debug("Await unblocked: Woken up to check for processable tasks");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -148,7 +148,6 @@ public final class DefaultTaskManager implements TaskManager {
                 }
             } catch (final InterruptedException ignored) {
                 Thread.currentThread().interrupt();
-                // we interrupt the thread for shut down and pause.
                 log.debug("Await unblocked: Interrupted while waiting for processable tasks");
                 return true;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -148,7 +148,7 @@ public final class DefaultTaskManager implements TaskManager {
                 }
             } catch (final InterruptedException ignored) {
                 Thread.currentThread().interrupt();
-                log.debug("Await unblocked: Interrupted while waiting for processable tasks");
+                log.warn("Await unblocked: Interrupted while waiting for processable tasks");
                 return true;
             }
             log.debug("Await unblocked: Woken up to check for processable tasks");


### PR DESCRIPTION
This PR resets thread interrupted signals and improves corresponding
logging.

Reviewers: Bill Bejeck <bbejeck@apache.org>, Apoorv Mittal
 <apoorvmittal10@gmail.com>, Matthias J. Sax <matthias@confluent.io>
