### PR TITLE
MINOR: Fix double negative typos in Javadoc and exception messages

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -49,7 +49,7 @@ public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptio
 
     /**
      * Specify if authorized operations should be included in the response.  Note that some
-     * older brokers cannot not supply this information even if it is requested.
+     * older brokers cannot supply this information even if it is requested.
      */
     public boolean includeAuthorizedOperations() {
         return includeAuthorizedOperations;
@@ -57,7 +57,7 @@ public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptio
 
     /**
      * Specify if fenced brokers should be included in the response.  Note that some
-     * older brokers cannot not supply this information even if it is requested.
+     * older brokers cannot supply this information even if it is requested.
      */
     public boolean includeFencedBrokers() {
         return includeFencedBrokers;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnect.java
@@ -504,7 +504,7 @@ abstract class EmbeddedConnect {
         } catch (IOException e) {
             log.error("Could not read connector state from response: {}",
                     responseToString(response), e);
-            throw new ConnectException("Could not not parse connector state", e);
+            throw new ConnectException("Could not parse connector state", e);
         }
     }
     /**
@@ -525,7 +525,7 @@ abstract class EmbeddedConnect {
                 log.error("Could not parse connector list from response: {}",
                         responseToString(response), e
                 );
-                throw new ConnectException("Could not not parse connector list", e);
+                throw new ConnectException("Could not parse connector list", e);
             }
         }
         throw new ConnectRestException(response.getStatus(),
@@ -552,7 +552,7 @@ abstract class EmbeddedConnect {
         } catch (IOException e) {
             log.error("Could not read connector state from response: {}",
                     responseToString(response), e);
-            throw new ConnectException("Could not not parse connector state", e);
+            throw new ConnectException("Could not parse connector state", e);
         }
         throw new ConnectRestException(response.getStatus(),
                 "Could not read connector state. Error response: " + responseToString(response));
@@ -581,7 +581,7 @@ abstract class EmbeddedConnect {
         } catch (IOException e) {
             log.error("Could not read connector state from response: {}",
                     responseToString(response), e);
-            throw new ConnectException("Could not not parse connector state", e);
+            throw new ConnectException("Could not parse connector state", e);
         }
         throw new ConnectRestException(response.getStatus(),
                 "Could not read connector state. Error response: " + responseToString(response));
@@ -604,7 +604,7 @@ abstract class EmbeddedConnect {
         } catch (IOException e) {
             log.error("Could not read connector info from response: {}",
                     responseToString(response), e);
-            throw new ConnectException("Could not not parse connector info", e);
+            throw new ConnectException("Could not parse connector info", e);
         }
         throw new ConnectRestException(response.getStatus(),
                 "Could not read connector info. Error response: " + responseToString(response));
@@ -629,7 +629,7 @@ abstract class EmbeddedConnect {
         } catch (IOException e) {
             log.error("Could not read task configs from response: {}",
                     responseToString(response), e);
-            throw new ConnectException("Could not not parse task configs", e);
+            throw new ConnectException("Could not parse task configs", e);
         }
         throw new ConnectRestException(response.getStatus(),
                 "Could not read task configs. Error response: " + responseToString(response));
@@ -668,7 +668,7 @@ abstract class EmbeddedConnect {
                 return mapper.readerFor(ConnectorOffsets.class).readValue(responseToString(response));
             }
         } catch (IOException e) {
-            throw new ConnectException("Could not not parse connector offsets", e);
+            throw new ConnectException("Could not parse connector offsets", e);
         }
         throw new ConnectRestException(response.getStatus(),
                 "Could not fetch connector offsets. Error response: " + responseToString(response));
@@ -768,7 +768,7 @@ abstract class EmbeddedConnect {
             } catch (IOException e) {
                 log.error("Could not read logger level from response: {}",
                         responseToString(response), e);
-                throw new ConnectException("Could not not parse logger level", e);
+                throw new ConnectException("Could not parse logger level", e);
             }
         } else {
             throw new ConnectRestException(
@@ -796,7 +796,7 @@ abstract class EmbeddedConnect {
             } catch (IOException e) {
                 log.error("Could not read logger levels from response: {}",
                         responseToString(response), e);
-                throw new ConnectException("Could not not parse logger levels", e);
+                throw new ConnectException("Could not parse logger levels", e);
             }
         } else {
             throw new ConnectRestException(
@@ -842,7 +842,7 @@ abstract class EmbeddedConnect {
             } catch (IOException e) {
                 log.error("Could not read loggers from response: {}",
                         responseToString(response), e);
-                throw new ConnectException("Could not not parse loggers", e);
+                throw new ConnectException("Could not parse loggers", e);
             }
         } else {
             throw new ConnectRestException(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -625,7 +625,7 @@ public class InternalTopologyBuilder {
 
         if (processorNames != null) {
             for (final String processorName : processorNames) {
-                Objects.requireNonNull(processorName, "processor cannot not be null");
+                Objects.requireNonNull(processorName, "processor cannot be null");
                 connectProcessorAndStateStore(processorName, storeName);
             }
         }


### PR DESCRIPTION
Fix repeated word `not` in ConnectException messages.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
