### PR TITLE
KAFKA-20405: Remove redundant `numClassicGroupsTimelineCounter`

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java
@@ -79,10 +79,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
      */
     private final TimelineGaugeCounter numOffsetsTimelineGaugeCounter;
 
-    /**
-     * The number of classic groups metric counter.
-     */
-    private final TimelineGaugeCounter numClassicGroupsTimelineCounter;
 
     /**
      * The topic partition.
@@ -96,7 +92,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
     ) {
         Objects.requireNonNull(snapshotRegistry);
         numOffsetsTimelineGaugeCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
-        numClassicGroupsTimelineCounter = new TimelineGaugeCounter(new TimelineLong(snapshotRegistry), new AtomicLong(0));
 
         this.classicGroupGauges = Map.of();
         this.consumerGroupGauges = Map.of();
@@ -283,11 +278,6 @@ public class GroupCoordinatorMetricsShard implements CoordinatorMetricsShard {
 
     @Override
     public void commitUpTo(long offset) {
-        synchronized (numClassicGroupsTimelineCounter.timelineLong) {
-            long value = numClassicGroupsTimelineCounter.timelineLong.get(offset);
-            numClassicGroupsTimelineCounter.atomicLong.set(value);
-        }
-
         synchronized (numOffsetsTimelineGaugeCounter.timelineLong) {
             long value = numOffsetsTimelineGaugeCounter.timelineLong.get(offset);
             numOffsetsTimelineGaugeCounter.atomicLong.set(value);


### PR DESCRIPTION
The `numClassicGroupsTimelineCounter` is currently redundant.   The same
metric tracking is already being handled effectively with
[`GroupCoordinatorMetricsShard#numClassicGroups`](https://github.com/apache/kafka/blob/7b8549f3c4cc26fd2153ef024c2fb743cfe83461/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShard.java#L189).

Reviewers: Sean Quah <squah@confluent.io>, David Jacot
 <djacot@confluent.io>, nileshkumar3 <nileshkumar3@gmail.com>
