### PR TITLE
MINOR: Suppress the deprecation warning for `LOG_CLEANER_ENABLE_PROP` in `LogCleanerIntegrationTest`

### DIFF
--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogCleanerIntegrationTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogCleanerIntegrationTest.java
@@ -541,6 +541,7 @@ public class LogCleanerIntegrationTest {
 
     @ParameterizedTest
     @EnumSource(CompressionType.class)
+    @SuppressWarnings("removal")
     public void cleanerConfigUpdateTest(CompressionType compressionType) throws Exception {
         Compression codec = Compression.of(compressionType).build();
         int largeMessageKey = 20;


### PR DESCRIPTION
```
> Task :storage:compileTestJava
/Users/lansg/Project/OpenSource/kafka/kafka/storage/src/test/java/org/apache/kafka/storage/internals/log/LogCleanerIntegrationTest.java:578:
warning: [removal] LOG_CLEANER_ENABLE_PROP in CleanerConfig has been
deprecated and marked for removal
        oldConfigMap.put(CleanerConfig.LOG_CLEANER_ENABLE_PROP,
currentConfig.enableCleaner);
                                      ^
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning

```

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
