### PR TITLE
MINOR: fix typo in KafkaAdminClient to align the meaning

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5051,10 +5051,10 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse response) {
                 handleNotControllerError(response);
-                RemoveRaftVoterResponse removeRaftVoterResponse = (RemoveRaftVoterResponse) response;
-                Errors error = Errors.forCode(removeRaftVoterResponse.data().errorCode());
+                RemoveRaftVoterResponse removeResponse = (RemoveRaftVoterResponse) response;
+                Errors error = Errors.forCode(removeResponse.data().errorCode());
                 if (error != Errors.NONE)
-                    future.completeExceptionally(error.exception(removeRaftVoterResponse.data().errorMessage()));
+                    future.completeExceptionally(error.exception(removeResponse.data().errorMessage()));
                 else
                     future.complete(null);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5051,10 +5051,10 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse response) {
                 handleNotControllerError(response);
-                RemoveRaftVoterResponse addResponse = (RemoveRaftVoterResponse) response;
-                Errors error = Errors.forCode(addResponse.data().errorCode());
+                RemoveRaftVoterResponse removeRaftVoterResponse = (RemoveRaftVoterResponse) response;
+                Errors error = Errors.forCode(removeRaftVoterResponse.data().errorCode());
                 if (error != Errors.NONE)
-                    future.completeExceptionally(error.exception(addResponse.data().errorMessage()));
+                    future.completeExceptionally(error.exception(removeRaftVoterResponse.data().errorMessage()));
                 else
                     future.complete(null);
             }


### PR DESCRIPTION
Summary: fix the typo `addResponse` to `removeResponse` to align the
meaning of the code.

Reviewers: Ken Huang <s7133700@gmail.com>, Jiayao Sun
 <jiayao.s@outlook.com>, Chia-Ping Tsai   <chia7712@gmail.com>
