### PR TITLE
KAFKA-20415: Add share.version=2 for gated DLQ support.

### DIFF
--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -78,7 +78,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       assertEquals(EligibleLeaderReplicasVersion.ELRV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(EligibleLeaderReplicasVersion.FEATURE_NAME).maxVersion())
 
       assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(ShareVersion.FEATURE_NAME).minVersion())
-      assertEquals(ShareVersion.SV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(ShareVersion.FEATURE_NAME).maxVersion())
+      assertEquals(ShareVersion.SV_2.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(ShareVersion.FEATURE_NAME).maxVersion())
 
       assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(StreamsVersion.FEATURE_NAME).minVersion())
       assertEquals(StreamsVersion.SV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(StreamsVersion.FEATURE_NAME).maxVersion())

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -131,7 +131,7 @@ public enum MetadataVersion {
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // IBP_4_4_IV0 enables dead-letter queue support for share groups. When this version
+    // IBP_4_4_IV0 enables dead-letter queue support for share groups (KIP-1191). When this version
     // is finalized, so will the DLQ support.
     IBP_4_4_IV0(31, "4.4", "IV0", false);
 

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -130,6 +130,9 @@ public enum MetadataVersion {
     // they have set the configuration unstable.feature.versions.enable=true.
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
+
+    // IBP_4_4_IV0 enables dead-letter queue support for share groups. When this version
+    // is finalized, so will the DLQ support.
     IBP_4_4_IV0(31, "4.4", "IV0", false);
 
 

--- a/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
@@ -25,7 +25,10 @@ public enum ShareVersion implements FeatureVersion {
 
     // Version 1 enables share groups (KIP-932).
     // This was a preview in 4.1 which required enabling explicitly.
-    SV_1(1, MetadataVersion.IBP_4_2_IV0, Map.of());
+    SV_1(1, MetadataVersion.IBP_4_2_IV0, Map.of()),
+
+    // Version 2 adds supports for DLQ (KIP-1191)
+    SV_2(2, MetadataVersion.IBP_4_4_IV0, Map.of());
 
     public static final String FEATURE_NAME = "share.version";
 
@@ -69,12 +72,18 @@ public enum ShareVersion implements FeatureVersion {
         return featureLevel >= SV_1.featureLevel;
     }
 
+    public boolean supportsShareGroupDLQ() {
+        return featureLevel >= SV_2.featureLevel;
+    }
+
     public static ShareVersion fromFeatureLevel(short version) {
         switch (version) {
             case 0:
                 return SV_0;
             case 1:
                 return SV_1;
+            case 2:
+                return SV_2;
             default:
                 throw new RuntimeException("Unknown share feature level: " + (int) version);
         }

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -71,7 +71,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(features.get(4))
         );
         assertFeatureOutput(
@@ -111,7 +111,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(features.get(4))
         );
         assertFeatureOutput(
@@ -168,7 +168,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(4))
         );
         assertFeatureOutput(
@@ -262,7 +262,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(4))
         );
         assertFeatureOutput(


### PR DESCRIPTION
* DLQ support for share groups KIP-1191 will be gated by a
`share.version` upgrade - slated for 4.4
* In this PR, we have added the appropriate changes and updated tests in
`FeatureCommandTest` and `ApiVersionsRequestTest`

Reviewers: Andrew Schofield <aschofield@confluent.io>
