### PR TITLE
[DO-NOT-MERGE] KAFKA-20246: Add clusterId and nodeId to ApiVersionsRequest (2/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -221,7 +221,8 @@ public final class ClientUtils {
                     hostResolver,
                     clientTelemetrySender,
                     config.getLong(CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_CONFIG),
-                    MetadataRecoveryStrategy.forName(config.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG))
+                    MetadataRecoveryStrategy.forName(config.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)),
+                    config.getBoolean(CommonClientConfigs.METADATA_CLUSTER_CHECK_ENABLE_CONFIG)
             );
         } catch (Throwable t) {
             closeQuietly(selector, "Selector");

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -36,6 +36,14 @@ import java.util.Optional;
 public interface MetadataUpdater extends Closeable {
 
     /**
+     * Gets the current cluster id without blocking.
+     * @return the cluster id, or null if unknown
+     */
+    default String clusterId() {
+        return null;
+    }
+
+    /**
      * Gets the current cluster info without blocking.
      */
     List<Node> fetchNodes();

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1316,7 +1316,6 @@ public class NetworkClient implements KafkaClient {
 
             if (metadataRecoveryStrategy == MetadataRecoveryStrategy.REBOOTSTRAP && response.topLevelError() == Errors.REBOOTSTRAP_REQUIRED) {
                 log.info("Rebootstrap requested by server.");
-                log.error("REBOOTSTRAP REQUESTED BY SERVER.");
                 initiateRebootstrap();
             } else if (response.brokers().isEmpty()) {
                 // When talking to the startup phase of a broker, it is possible to receive an empty metadata set, which

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1110,10 +1110,13 @@ public class NetworkClient implements KafkaClient {
                 ApiVersionsRequest.Builder apiVersionRequestBuilder = entry.getValue();
                 String clusterId = this.metadataUpdater.clusterId();
                 int nodeId = Integer.parseInt(node);
-                if (clusterId != null && nodeId < Integer.MAX_VALUE / 2) {
-                    System.out.println("CLUSTER_ID(" + clusterId + "), NODE_ID(" + nodeId + ")");
+                if (clusterId != null && nodeId > 0 && nodeId < Integer.MAX_VALUE / 2) {
+                    // If we know the cluster ID and node ID we are connecting to, we can include
+                    // those details in the ApiVersions request for checking in the broker.
+                    // The client uses large positive node ID values for connecting to coordinators
+                    // which do not match the target broker's node ID so exclude those.
                     apiVersionRequestBuilder.setClusterId(clusterId);
-                    apiVersionRequestBuilder.setNodeId(Integer.parseInt(node));
+                    apiVersionRequestBuilder.setNodeId(nodeId);
                 }
                 ClientRequest clientRequest = newClientRequest(node, apiVersionRequestBuilder, now, true);
                 doSend(clientRequest, true, now);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1110,7 +1110,7 @@ public class NetworkClient implements KafkaClient {
                 ApiVersionsRequest.Builder apiVersionRequestBuilder = entry.getValue();
                 String clusterId = this.metadataUpdater.clusterId();
                 int nodeId = Integer.parseInt(node);
-                if (clusterId != null && nodeId < Integer.MAX_VALUE/2) {
+                if (clusterId != null && nodeId < Integer.MAX_VALUE / 2) {
                     System.out.println("CLUSTER_ID(" + clusterId + "), NODE_ID(" + nodeId + ")");
                     apiVersionRequestBuilder.setClusterId(clusterId);
                     apiVersionRequestBuilder.setNodeId(Integer.parseInt(node));

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1038,7 +1038,10 @@ public class NetworkClient implements KafkaClient {
                                            InFlightRequest req, long now, ApiVersionsResponse apiVersionsResponse) {
         final String node = req.destination;
         if (apiVersionsResponse.data().errorCode() != Errors.NONE.code()) {
-            if (req.request.version() == 0 || apiVersionsResponse.data().errorCode() != Errors.UNSUPPORTED_VERSION.code()) {
+            if (metadataRecoveryStrategy == MetadataRecoveryStrategy.REBOOTSTRAP && apiVersionsResponse.data().errorCode() == Errors.REBOOTSTRAP_REQUIRED.code()) {
+                log.info("Rebootstrap requested by server due to cluster metadata mismatch.");
+                metadataUpdater.rebootstrap(now);
+            } else if (req.request.version() == 0 || apiVersionsResponse.data().errorCode() != Errors.UNSUPPORTED_VERSION.code()) {
                 log.warn("Received error {} from node {} when making an ApiVersionsRequest with correlation id {}. Disconnecting.",
                         Errors.forCode(apiVersionsResponse.data().errorCode()), node, req.header.correlationId());
                 this.selector.close(node);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.ClusterResource;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -1107,6 +1108,13 @@ public class NetworkClient implements KafkaClient {
                 // not before ready.
                 this.connectionStates.checkingApiVersions(node);
                 ApiVersionsRequest.Builder apiVersionRequestBuilder = entry.getValue();
+                String clusterId = this.metadataUpdater.clusterId();
+                int nodeId = Integer.parseInt(node);
+                if (clusterId != null && nodeId < Integer.MAX_VALUE/2) {
+                    System.out.println("CLUSTER_ID(" + clusterId + "), NODE_ID(" + nodeId + ")");
+                    apiVersionRequestBuilder.setClusterId(clusterId);
+                    apiVersionRequestBuilder.setNodeId(Integer.parseInt(node));
+                }
                 ClientRequest clientRequest = newClientRequest(node, apiVersionRequestBuilder, now, true);
                 doSend(clientRequest, true, now);
                 iter.remove();
@@ -1191,6 +1199,15 @@ public class NetworkClient implements KafkaClient {
         DefaultMetadataUpdater(Metadata metadata) {
             this.metadata = metadata;
             this.inProgress = null;
+        }
+
+        @Override
+        public String clusterId() {
+            ClusterResource clusterResource = metadata.fetch().clusterResource();
+            if (clusterResource != null) {
+                return clusterResource.clusterId();
+            }
+            return null;
         }
 
         @Override
@@ -1296,6 +1313,7 @@ public class NetworkClient implements KafkaClient {
 
             if (metadataRecoveryStrategy == MetadataRecoveryStrategy.REBOOTSTRAP && response.topLevelError() == Errors.REBOOTSTRAP_REQUIRED) {
                 log.info("Rebootstrap requested by server.");
+                log.error("REBOOTSTRAP REQUESTED BY SERVER.");
                 initiateRebootstrap();
             } else if (response.brokers().isEmpty()) {
                 // When talking to the startup phase of a broker, it is possible to receive an empty metadata set, which

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -121,6 +121,9 @@ public class NetworkClient implements KafkaClient {
 
     private final MetadataRecoveryStrategy metadataRecoveryStrategy;
 
+    /* Whether to send the cluster ID and node ID on ApiVersions RPC for checking by the broker */
+    private final boolean metadataClusterCheckEnable;
+
     private final Time time;
 
     /**
@@ -155,7 +158,8 @@ public class NetworkClient implements KafkaClient {
                          boolean discoverBrokerVersions,
                          ApiVersions apiVersions,
                          LogContext logContext,
-                         MetadataRecoveryStrategy metadataRecoveryStrategy) {
+                         MetadataRecoveryStrategy metadataRecoveryStrategy,
+                         boolean metadataClusterCheckEnable) {
         this(selector,
              metadata,
              clientId,
@@ -172,7 +176,8 @@ public class NetworkClient implements KafkaClient {
              apiVersions,
              logContext,
              Long.MAX_VALUE,
-             metadataRecoveryStrategy);
+             metadataRecoveryStrategy,
+             metadataClusterCheckEnable);
     }
 
     public NetworkClient(Selectable selector,
@@ -191,7 +196,8 @@ public class NetworkClient implements KafkaClient {
                          ApiVersions apiVersions,
                          LogContext logContext,
                          long rebootstrapTriggerMs,
-                         MetadataRecoveryStrategy metadataRecoveryStrategy) {
+                         MetadataRecoveryStrategy metadataRecoveryStrategy,
+                         boolean metadataClusterCheckEnable) {
         this(null,
                 metadata,
                 selector,
@@ -212,7 +218,8 @@ public class NetworkClient implements KafkaClient {
                 new DefaultHostResolver(),
                 null,
                 rebootstrapTriggerMs,
-                metadataRecoveryStrategy);
+                metadataRecoveryStrategy,
+                metadataClusterCheckEnable);
     }
 
     public NetworkClient(Selectable selector,
@@ -231,7 +238,8 @@ public class NetworkClient implements KafkaClient {
                          ApiVersions apiVersions,
                          Sensor throttleTimeSensor,
                          LogContext logContext,
-                         MetadataRecoveryStrategy metadataRecoveryStrategy) {
+                         MetadataRecoveryStrategy metadataRecoveryStrategy,
+                         boolean metadataClusterCheckEnable) {
         this(null,
              metadata,
              selector,
@@ -252,7 +260,8 @@ public class NetworkClient implements KafkaClient {
              new DefaultHostResolver(),
              null,
              Long.MAX_VALUE,
-             metadataRecoveryStrategy);
+             metadataRecoveryStrategy,
+             metadataClusterCheckEnable);
     }
 
     public NetworkClient(Selectable selector,
@@ -270,7 +279,8 @@ public class NetworkClient implements KafkaClient {
                          boolean discoverBrokerVersions,
                          ApiVersions apiVersions,
                          LogContext logContext,
-                         MetadataRecoveryStrategy metadataRecoveryStrategy) {
+                         MetadataRecoveryStrategy metadataRecoveryStrategy,
+                         boolean metadataClusterCheckEnable) {
         this(metadataUpdater,
              null,
              selector,
@@ -291,7 +301,8 @@ public class NetworkClient implements KafkaClient {
              new DefaultHostResolver(),
              null,
              Long.MAX_VALUE,
-             metadataRecoveryStrategy);
+             metadataRecoveryStrategy,
+             metadataClusterCheckEnable);
     }
 
     public NetworkClient(MetadataUpdater metadataUpdater,
@@ -314,7 +325,8 @@ public class NetworkClient implements KafkaClient {
                          HostResolver hostResolver,
                          ClientTelemetrySender clientTelemetrySender,
                          long rebootstrapTriggerMs,
-                         MetadataRecoveryStrategy metadataRecoveryStrategy) {
+                         MetadataRecoveryStrategy metadataRecoveryStrategy,
+                         boolean metadataClusterCheckEnable) {
         /* It would be better if we could pass `DefaultMetadataUpdater` from the public constructor, but it's not
          * possible because `DefaultMetadataUpdater` is an inner class and it can only be instantiated after the
          * super constructor is invoked.
@@ -347,6 +359,7 @@ public class NetworkClient implements KafkaClient {
         this.telemetrySender = (clientTelemetrySender != null) ? new TelemetrySender(clientTelemetrySender) : null;
         this.rebootstrapTriggerMs = rebootstrapTriggerMs;
         this.metadataRecoveryStrategy = metadataRecoveryStrategy;
+        this.metadataClusterCheckEnable = metadataClusterCheckEnable;
     }
 
     /**
@@ -1108,15 +1121,17 @@ public class NetworkClient implements KafkaClient {
                 // not before ready.
                 this.connectionStates.checkingApiVersions(node);
                 ApiVersionsRequest.Builder apiVersionRequestBuilder = entry.getValue();
-                String clusterId = this.metadataUpdater.clusterId();
-                int nodeId = Integer.parseInt(node);
-                if (clusterId != null && nodeId > 0 && nodeId < Integer.MAX_VALUE / 2) {
-                    // If we know the cluster ID and node ID we are connecting to, we can include
-                    // those details in the ApiVersions request for checking in the broker.
-                    // The client uses large positive node ID values for connecting to coordinators
-                    // which do not match the target broker's node ID so exclude those.
-                    apiVersionRequestBuilder.setClusterId(clusterId);
-                    apiVersionRequestBuilder.setNodeId(nodeId);
+                // If we know the cluster ID and node ID we are connecting to, we can include
+                // those details in the ApiVersions request for checking in the broker.
+                if (metadataClusterCheckEnable) {
+                    String clusterId = this.metadataUpdater.clusterId();
+                    int nodeId = Integer.parseInt(node);
+                    if (clusterId != null && nodeId > 0 && nodeId < Integer.MAX_VALUE / 2) {
+                        // The client uses large positive node ID values for connecting to coordinators
+                        // which do not match the target broker's node ID so exclude those.
+                        apiVersionRequestBuilder.setClusterId(clusterId);
+                        apiVersionRequestBuilder.setNodeId(nodeId);
+                    }
                 }
                 ClientRequest clientRequest = newClientRequest(node, apiVersionRequestBuilder, now, true);
                 doSend(clientRequest, true, now);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1122,13 +1122,14 @@ public class NetworkClient implements KafkaClient {
                 this.connectionStates.checkingApiVersions(node);
                 ApiVersionsRequest.Builder apiVersionRequestBuilder = entry.getValue();
                 // If we know the cluster ID and node ID we are connecting to, we can include
-                // those details in the ApiVersions request for checking in the broker.
-                if (metadataClusterCheckEnable) {
+                // those details in the ApiVersions request for checking in the broker,
+                // provided that the metadata recovery strategy is not NONE. (KIP-1242)
+                if (metadataRecoveryStrategy != MetadataRecoveryStrategy.NONE && metadataClusterCheckEnable) {
                     String clusterId = this.metadataUpdater.clusterId();
                     int nodeId = Integer.parseInt(node);
+                    // When connecting to coordinators, the client uses large positive node ID
+                    // values which do not match the target broker's node ID. Exclude those.
                     if (clusterId != null && nodeId > 0 && nodeId < Integer.MAX_VALUE / 2) {
-                        // The client uses large positive node ID values for connecting to coordinators
-                        // which do not match the target broker's node ID so exclude those.
                         apiVersionRequestBuilder.setClusterId(clusterId);
                         apiVersionRequestBuilder.setNodeId(nodeId);
                     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -56,6 +56,14 @@ public class ApiVersionsRequest extends AbstractRequest {
             this.data = data.duplicate();
         }
 
+        public void setClusterId(String clusterId) {
+            this.data.setClusterId(clusterId);
+        }
+
+        public void setNodeId(int nodeId) {
+            this.data.setNodeId(nodeId);
+        }
+
         @Override
         public ApiVersionsRequest build(short version) {
             return new ApiVersionsRequest(data, version);
@@ -94,6 +102,12 @@ public class ApiVersionsRequest extends AbstractRequest {
     }
 
     public boolean isValid() {
+        if (version() >= 5) {
+            // Either cluster ID and node ID are both specified, or neither is.
+            if ((data.clusterId() == null && data.nodeId() != -1) || (data.clusterId() != null && data.nodeId() == -1)) {
+                return false;
+            }
+        }
         if (version() >= 3) {
             return SOFTWARE_NAME_VERSION_PATTERN.matcher(data.clientSoftwareName()).matches() &&
                 SOFTWARE_NAME_VERSION_PATTERN.matcher(data.clientSoftwareVersion()).matches();

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -132,7 +132,7 @@ public class NetworkClientTest {
         return new NetworkClient(selector, metadataUpdater, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, reconnectBackoffMaxMs, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     private NetworkClient createNetworkClientWithMaxInFlightRequestsPerConnection(
@@ -140,7 +140,7 @@ public class NetworkClientTest {
         return new NetworkClient(selector, metadataUpdater, "mock", maxInFlightRequestsPerConnection,
                 reconnectBackoffMsTest, reconnectBackoffMaxMs, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     private NetworkClient createNetworkClientWithMultipleNodes(long reconnectBackoffMaxMs, long connectionSetupTimeoutMsTest, int nodeNumber) {
@@ -149,21 +149,21 @@ public class NetworkClientTest {
         return new NetworkClient(selector, metadataUpdater, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, reconnectBackoffMaxMs, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     private NetworkClient createNetworkClientWithStaticNodes() {
         return new NetworkClient(selector, metadataUpdater,
                 "mock-static", Integer.MAX_VALUE, 0, 0, 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
                 connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     private NetworkClient createNetworkClientWithNoVersionDiscovery(Metadata metadata) {
         return new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, 0, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, false, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     private NetworkClient createNetworkClientWithNoVersionDiscovery() {
@@ -171,7 +171,7 @@ public class NetworkClientTest {
                 reconnectBackoffMsTest, reconnectBackoffMaxMsTest,
                 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
                 connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, false, new ApiVersions(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
     }
 
     @BeforeEach
@@ -258,8 +258,7 @@ public class NetworkClientTest {
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, 0, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, false, new ApiVersions(), new LogContext(),
-                rebootstrapTriggerMs,
-                MetadataRecoveryStrategy.REBOOTSTRAP);
+                rebootstrapTriggerMs, MetadataRecoveryStrategy.REBOOTSTRAP, true);
         MetadataUpdater metadataUpdater = TestUtils.fieldValue(client, NetworkClient.class, "metadataUpdater");
         metadata.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 9999)));
 
@@ -313,7 +312,7 @@ public class NetworkClientTest {
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 reconnectBackoffMsTest, 0, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, false, new ApiVersions(), new LogContext(),
-                rebootstrapTriggerMs, MetadataRecoveryStrategy.REBOOTSTRAP);
+                rebootstrapTriggerMs, MetadataRecoveryStrategy.REBOOTSTRAP, true);
 
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith(2, Collections.emptyMap());
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
@@ -1152,7 +1151,7 @@ public class NetworkClientTest {
                 reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest,
                 time, false, new ApiVersions(), null, new LogContext(), mockHostResolver, mockClientTelemetrySender,
-                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE);
+                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE, false);
 
         // Connect to one the initial addresses, then change the addresses and disconnect
         client.ready(node, time.milliseconds());
@@ -1213,7 +1212,7 @@ public class NetworkClientTest {
                 reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest,
                 time, false, new ApiVersions(), null, new LogContext(), mockHostResolver, mockClientTelemetrySender,
-                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE);
+                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE, false);
 
         // First connection attempt should fail
         client.ready(node, time.milliseconds());
@@ -1266,7 +1265,7 @@ public class NetworkClientTest {
                 reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
                 defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest,
                 time, false, new ApiVersions(), null, new LogContext(), mockHostResolver, mockClientTelemetrySender,
-                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE);
+                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE, false);
 
         // Connect to one the initial addresses, then change the addresses and disconnect
         client.ready(node, time.milliseconds());
@@ -1375,7 +1374,7 @@ public class NetworkClientTest {
             reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
             defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest,
             time, true, new ApiVersions(), null, new LogContext(), new DefaultHostResolver(), mockClientTelemetrySender,
-            Long.MAX_VALUE, MetadataRecoveryStrategy.NONE);
+            Long.MAX_VALUE, MetadataRecoveryStrategy.NONE, false);
 
         // Send the ApiVersionsRequest
         client.ready(node, time.milliseconds());

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -153,8 +153,8 @@ public class NetworkClientTest {
     }
 
     private NetworkClient createNetworkClientWithStaticNodes() {
-        return new NetworkClient(selector, metadataUpdater,
-                "mock-static", Integer.MAX_VALUE, 0, 0, 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
+        return new NetworkClient(selector, metadataUpdater, "mock-static", Integer.MAX_VALUE,
+                0, 0, 64 * 1024, 64 * 1024, defaultRequestTimeoutMs,
                 connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
                 MetadataRecoveryStrategy.NONE, false);
     }
@@ -296,6 +296,41 @@ public class NetworkClientTest {
     }
 
     @Test
+    public void testMetadataClusterCheckFailureCausesRebootstrap() {
+        List<Node> nodes = TestUtils.clusterWith(2).nodes();
+        Node node0 = nodes.get(0);
+        Node node1 = nodes.get(1);
+        TestMetadataUpdater metadataUpdater = new TestMetadataUpdater(nodes);
+        NetworkClient client = new NetworkClient(selector, metadataUpdater, "mock", Integer.MAX_VALUE,
+            reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
+            defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
+            MetadataRecoveryStrategy.REBOOTSTRAP, true);
+
+        // Send the ApiVersionsRequest to the first node
+        client.ready(node0, time.milliseconds());
+        client.poll(0, time.milliseconds());
+        delayedApiVersionsResponse(node0, 0, ApiKeys.API_VERSIONS.latestVersion(),
+            TestUtils.defaultApiVersionsResponse(ApiMessageType.ListenerType.BROKER));
+        // handle ApiVersionsResponse
+        client.poll(0, time.milliseconds());
+        // the ApiVersionsRequest is gone
+        assertFalse(client.hasInFlightRequests(node0.idString()));
+        selector.clear();
+
+        // Send the ApiVersionsRequest to the second node
+        client.ready(node1, time.milliseconds());
+        client.poll(0, time.milliseconds());
+        delayedApiVersionsResponse(node1, 1, ApiKeys.API_VERSIONS.latestVersion(),
+            TestUtils.errorApiVersionsResponse(0, Errors.REBOOTSTRAP_REQUIRED, ApiMessageType.ListenerType.BROKER));
+        // handle ApiVersionsResponse
+        client.poll(0, time.milliseconds());
+        // the ApiVersionsRequest is gone
+        assertFalse(client.hasInFlightRequests(node1.idString()));
+        selector.clear();
+        assertEquals(1, metadataUpdater.getRebootstrapCount());
+    }
+
+    @Test
     public void testInflightRequestsDuringRebootstrap() {
         long refreshBackoffMs = 50;
         long rebootstrapTriggerMs = 1000;
@@ -372,6 +407,10 @@ public class NetworkClientTest {
     }
 
     private void delayedApiVersionsResponse(int correlationId, short version, ApiVersionsResponse response) {
+        delayedApiVersionsResponse(node, correlationId, version, response);
+    }
+
+    private void delayedApiVersionsResponse(Node node, int correlationId, short version, ApiVersionsResponse response) {
         ByteBuffer buffer = RequestTestUtils.serializeResponseWithHeader(response, version, correlationId);
         selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
     }
@@ -1452,6 +1491,7 @@ public class NetworkClientTest {
     // ManualMetadataUpdater with ability to keep track of failures
     private static class TestMetadataUpdater extends ManualMetadataUpdater {
         KafkaException failure;
+        AtomicInteger rebootstrapCount = new AtomicInteger();
 
         public TestMetadataUpdater(List<Node> nodes) {
             super(nodes);
@@ -1470,6 +1510,16 @@ public class NetworkClientTest {
             maybeFatalException.ifPresent(exception ->
                 failure = exception
             );
+        }
+
+        @Override
+        public void rebootstrap(long now) {
+            rebootstrapCount.incrementAndGet();
+            super.rebootstrap(now);
+        }
+
+        public int getRebootstrapCount() {
+            return rebootstrapCount.get();
         }
 
         public KafkaException getAndClearFailure() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -1906,7 +1906,7 @@ public class FetchRequestManagerTest {
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, 127 * 1000,
                 time, true, new ApiVersions(), metricsManager.throttleTimeSensor(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
 
         ApiVersionsResponse apiVersionsResponse = TestUtils.defaultApiVersionsResponse(
                 400, ApiMessageType.ListenerType.BROKER);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1893,7 +1893,7 @@ public class FetcherTest {
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, 127 * 1000,
                 time, true, new ApiVersions(), metricsManager.throttleTimeSensor(), new LogContext(),
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
 
         ApiVersionsResponse apiVersionsResponse = TestUtils.defaultApiVersionsResponse(
             400, ApiMessageType.ListenerType.BROKER);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -241,7 +241,7 @@ public class SenderTest {
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
                 1000, 1000, 64 * 1024, 64 * 1024, 1000, 10 * 1000, 127 * 1000,
                 time, true, new ApiVersions(), throttleTimeSensor, logContext,
-                MetadataRecoveryStrategy.NONE);
+                MetadataRecoveryStrategy.NONE, false);
 
         ApiVersionsResponse apiVersionsResponse = TestUtils.defaultApiVersionsResponse(
             400, ApiMessageType.ListenerType.BROKER);

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -729,6 +729,22 @@ public class TestUtils {
         );
     }
 
+    public static ApiVersionsResponse errorApiVersionsResponse(
+            int throttleTimeMs,
+            Errors error,
+            ApiMessageType.ListenerType listenerType
+    ) {
+        return new ApiVersionsResponse.Builder().
+            setError(error).
+            setThrottleTimeMs(throttleTimeMs).
+            setApiVersions(ApiVersionsResponse.filterApis(listenerType, false, true)).
+            setSupportedFeatures(Features.emptySupportedFeatures()).
+            setFinalizedFeatures(Collections.emptyMap()).
+            setFinalizedFeaturesEpoch(ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH).
+            setZkMigrationEnabled(false).
+            build();
+    }
+
     public static ApiVersionsResponse createApiVersionsResponse(
             int throttleTimeMs,
             ApiVersionsResponseData.ApiVersionCollection apiVersions

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -123,7 +123,8 @@ public class WorkerGroupMember {
                     new ApiVersions(),
                     logContext,
                     config.getLong(CommonClientConfigs.METADATA_RECOVERY_REBOOTSTRAP_TRIGGER_MS_CONFIG),
-                    MetadataRecoveryStrategy.forName(config.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG))
+                    MetadataRecoveryStrategy.forName(config.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)),
+                    config.getBoolean(CommonClientConfigs.METADATA_CLUSTER_CHECK_ENABLE_CONFIG)
             );
             this.client = new ConsumerNetworkClient(
                     logContext,

--- a/core/src/main/java/kafka/server/NetworkUtils.java
+++ b/core/src/main/java/kafka/server/NetworkUtils.java
@@ -85,7 +85,8 @@ public class NetworkUtils {
             true,
             new ApiVersions(),
             logContext,
-            MetadataRecoveryStrategy.NONE
+            MetadataRecoveryStrategy.NONE,
+            false
         );
     }
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -98,7 +98,8 @@ object TransactionMarkerChannelManager {
       true,
       new ApiVersions,
       logContext,
-      MetadataRecoveryStrategy.NONE
+      MetadataRecoveryStrategy.NONE,
+      false
     )
 
     new TransactionMarkerChannelManager(config,

--- a/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
+++ b/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
@@ -253,7 +253,8 @@ class KafkaRaftManager[T](
       discoverBrokerVersions,
       apiVersions,
       logContext,
-      MetadataRecoveryStrategy.NONE
+      MetadataRecoveryStrategy.NONE,
+      false
     )
 
     (controllerListenerName, networkClient)

--- a/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
+++ b/core/src/main/scala/kafka/server/BrokerBlockingSender.scala
@@ -94,7 +94,8 @@ class BrokerBlockingSender(sourceBroker: BrokerEndPoint,
       false,
       new ApiVersions,
       logContext,
-      MetadataRecoveryStrategy.NONE
+      MetadataRecoveryStrategy.NONE,
+      false
     )
     (networkClient, reconfigurableChannelBuilder)
   }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1529,10 +1529,22 @@ class KafkaApis(val requestChannel: RequestChannel,
         apiVersionRequest.getErrorResponse(requestThrottleMs, Errors.UNSUPPORTED_VERSION.exception)
       } else if (!apiVersionRequest.isValid) {
         apiVersionRequest.getErrorResponse(requestThrottleMs, Errors.INVALID_REQUEST.exception)
+      } else if (clusterIdOrNodeIdIsInvalid(apiVersionRequest)) {
+        apiVersionRequest.getErrorResponse(requestThrottleMs, Errors.REBOOTSTRAP_REQUIRED.exception)
       } else {
         apiVersionManager.apiVersionResponse(requestThrottleMs, request.header.apiVersion() < 4)
       }
     }
+
+    // KIP-1242 checks the cluster ID and node ID in the request if provided to ensure the
+    // client is connecting to the correct broker. If both are specified, they must match
+    // the expected values for this broker.
+    def clusterIdOrNodeIdIsInvalid(apiVersionRequest: ApiVersionsRequest): Boolean = {
+      apiVersionRequest.version >= 5 &&
+        apiVersionRequest.data.clusterId != null &&
+        (!apiVersionRequest.data.clusterId.equals(clusterId) || apiVersionRequest.data.nodeId != brokerId)
+    }
+
     requestHelper.sendResponseMaybeThrottle(request, createResponseCallback)
   }
 

--- a/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
+++ b/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
@@ -129,7 +129,8 @@ public class NodeToControllerChannelManagerImpl implements NodeToControllerChann
                 true,
                 apiVersions,
                 logContext,
-                MetadataRecoveryStrategy.NONE
+                MetadataRecoveryStrategy.NONE,
+                false
         );
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -170,7 +170,7 @@ public class ProducerAppendInfo {
             if (appendFirstSeq != 0) {
                 if (updatedEntry.producerEpoch() != RecordBatch.NO_PRODUCER_EPOCH) {
                     throw new OutOfOrderSequenceException("Invalid sequence number for new epoch of producer " + producerId +
-                            "at offset " + offset + " in partition " + topicPartition + ": " + producerEpoch + " (request epoch), "
+                            " at offset " + offset + " in partition " + topicPartition + ": " + producerEpoch + " (request epoch), "
                             + appendFirstSeq + " (seq. number), " + updatedEntry.producerEpoch() + " (current producer epoch)");
                 }
             }

--- a/tools/src/main/java/org/apache/kafka/tools/BrokerApiVersionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/BrokerApiVersionsCommand.java
@@ -198,7 +198,8 @@ public class BrokerApiVersionsCommand {
                     true,
                     new ApiVersions(),
                     logContext,
-                    MetadataRecoveryStrategy.NONE);
+                    MetadataRecoveryStrategy.NONE,
+                    false);
             ConsumerNetworkClient highLevelClient = new ConsumerNetworkClient(
                     logContext,
                     networkClient,

--- a/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ReplicaVerificationTool.java
@@ -688,7 +688,8 @@ public class ReplicaVerificationTool {
                 false,
                 new ApiVersions(),
                 logContext,
-                MetadataRecoveryStrategy.forName(consumerConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG))
+                MetadataRecoveryStrategy.forName(consumerConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)),
+                consumerConfig.getBoolean(CommonClientConfigs.METADATA_CLUSTER_CHECK_ENABLE_CONFIG)
             );
         }
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -179,7 +179,8 @@ public class ConnectionStressWorker implements TaskWorker {
                             false,
                             new ApiVersions(),
                             logContext,
-                            MetadataRecoveryStrategy.NONE)) {
+                            MetadataRecoveryStrategy.NONE,
+                            false)) {
                             NetworkClientUtils.awaitReady(client, targetNode, Time.SYSTEM, 500);
                         }
                     }


### PR DESCRIPTION
Part of the implementation of
https://cwiki.apache.org/confluence/display/KAFKA/KIP-1242%3A+Detection+and+handling+of+misrouted+connections.

Adds cluster ID and node ID to the `ApiVersionsRequest` and checks it on
the broker.
