### PR TITLE
MINOR: Add a new interface `TimeOrderedStore` to refactor the `isTimeOrderedStore` method

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedSessionStore.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 public class RocksDBTimeOrderedSessionStore
     extends WrappedStateStore<AbstractRocksDBTimeOrderedSegmentedBytesStore<? extends Segment>, Object, Object>
-    implements SessionStore<Bytes, byte[]> {
+    implements SessionStore<Bytes, byte[]>, TimeOrderedStore {
 
     private StateStoreContext stateStoreContext;
 
@@ -160,5 +160,10 @@ public class RocksDBTimeOrderedSessionStore
     @Override
     public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
         wrapped().put(sessionKey, aggregate);
+    }
+
+    @Override
+    public boolean hasIndex() {
+        return wrapped().hasIndex();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 
 public class RocksDBTimeOrderedWindowStore<S extends Segment>
     extends WrappedStateStore<AbstractRocksDBTimeOrderedSegmentedBytesStore<S>, Object, Object>
-    implements WindowStore<Bytes, byte[]>, TimestampedBytesStore {
+    implements WindowStore<Bytes, byte[]>, TimestampedBytesStore, TimeOrderedStore {
 
     private final boolean retainDuplicates;
     private final long windowSize;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapter.java
@@ -53,7 +53,7 @@ import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFo
  * @see SessionToHeadersIteratorAdapter
  */
 @SuppressWarnings("unchecked")
-public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]> {
+public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]>, TimeOrderedStore {
     final SessionStore<Bytes, byte[]> store;
 
     SessionToHeadersStoreAdapter(final SessionStore<Bytes, byte[]> store) {
@@ -210,5 +210,13 @@ public class SessionToHeadersStoreAdapter implements SessionStore<Bytes, byte[]>
     @Override
     public Position getPosition() {
         return store.getPosition();
+    }
+
+    @Override
+    public boolean hasIndex() {
+        if (store instanceof TimeOrderedStore) {
+            return ((TimeOrderedStore) store).hasIndex();
+        }
+        return false;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedStore.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+/**
+ * Marker interface for time-ordered stores that support optional indexing.
+ * <p>
+ * Time-ordered stores maintain data in time order and may optionally have an index
+ * for efficient time-based queries. The {@link #hasIndex()} method indicates whether
+ * the store has been configured with an index.
+ */
+public interface TimeOrderedStore {
+    /**
+     * Indicates whether this store has an index for efficient time-ordered queries.
+     *
+     * @return true if this store has an index, false otherwise
+     */
+    boolean hasIndex();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapter.java
@@ -56,7 +56,7 @@ import static org.apache.kafka.streams.state.internals.Utils.rawTimestampedValue
  *   <li>Read: {@code [timestamp][value]} → {@code [headers][timestamp][value]} (add empty headers)</li>
  * </ul>
  */
-public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte[]> {
+public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte[]>, TimeOrderedStore {
     final WindowStore<Bytes, byte[]> store;
 
     public TimestampedToHeadersWindowStoreAdapter(final WindowStore<Bytes, byte[]> store) {
@@ -244,6 +244,14 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
     @Override
     public Position getPosition() {
         return store.getPosition();
+    }
+
+    @Override
+    public boolean hasIndex() {
+        if (store instanceof TimeOrderedStore) {
+            return ((TimeOrderedStore) store).hasIndex();
+        }
+        return false;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreWithHeadersBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreWithHeadersBuilder.java
@@ -114,11 +114,8 @@ public class TimestampedWindowStoreWithHeadersBuilder<K, V>
     }
 
     private boolean isTimeOrderedStore(final StateStore stateStore) {
-        if (stateStore instanceof RocksDBTimeOrderedWindowStore) {
+        if (stateStore instanceof TimeOrderedStore) {
             return true;
-        }
-        if (stateStore instanceof TimestampedToHeadersWindowStoreAdapter) {
-            return isTimeOrderedStore(((TimestampedToHeadersWindowStoreAdapter) stateStore).store);
         }
         if (stateStore instanceof WrappedStateStore) {
             return isTimeOrderedStore(((WrappedStateStore<?, ?, ?>) stateStore).wrapped());


### PR DESCRIPTION
Currently, `TimestampedWindowStoreWithHeadersBuilder#isTimeOrderedStore`
relies on hardcoded `instanceof` checks for specific adapter classes
(e.g., `TimestampedToHeadersWindowStoreAdapter`), which is a workaround
that is not maintainable. This PR introduces a new `TimeOrderedStore`
interface that all time-ordered stores and their adapters implement.
This makes the check more generic, type-safe, and extensible.
