### PR TITLE
KAFKA-20182: Upgrade gradle to 9.4.1 and spotless to 8.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -871,6 +871,10 @@ subprojects {
     java {
       targetExclude('**/generated/**/*.java','**/generated-test/**/*.java')
       importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
+      // Use the cleanthat/JavaParser engine instead of the default google-java-format engine.
+      // The default engine depends on com.sun.tools.javac internals, which are not accessible
+      // under the Gradle 9.3+ / Spotless 8.x worker setup and blocked upgrading this project.
+      // cleanthat uses JavaParser and does not touch JDK internals. See KAFKA-20182.
       removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -871,10 +871,13 @@ subprojects {
     java {
       targetExclude('**/generated/**/*.java','**/generated-test/**/*.java')
       importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
-      // Use the cleanthat/JavaParser engine instead of the default google-java-format engine.
-      // The default engine depends on com.sun.tools.javac internals, which are not accessible
-      // under the Gradle 9.3+ / Spotless 8.x worker setup and blocked upgrading this project.
-      // cleanthat uses JavaParser and does not touch JDK internals. See KAFKA-20182.
+      // The default engine (google-java-format) uses the JDK compiler's internal
+      // parser (com.sun.tools.javac.*), which JPMS blocks without --add-exports.
+      // Gradle 9.3+ / Spotless 8.x no longer pass those exports to the worker JVM,
+      // so the default engine fails at runtime. The cleanthat engine uses the
+      // JavaParser library instead, which ships its own Java parser and does not
+      // rely on any JDK internal classes, so it works out of the box.
+      // See KAFKA-20182.
       removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ plugins {
   id "com.github.spotbugs" version '6.4.4' apply false
   id 'org.scoverage' version '8.1' apply false
   id 'com.gradleup.shadow' version '9.3.1' apply false
-  id 'com.diffplug.spotless' version "8.0.0"
+  id 'com.diffplug.spotless' version "8.3.0"
 }
 
 ext {
@@ -871,7 +871,7 @@ subprojects {
     java {
       targetExclude('**/generated/**/*.java','**/generated-test/**/*.java')
       importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
-      removeUnusedImports()
+      removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
     }
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ versions += [
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.2.0",
   commonsValidator: "1.10.1",
   classgraph: "4.8.179",
-  gradle: "9.2.1",
+  gradle: "9.4.1",
   grgit: "5.3.3",
   httpclient: "4.5.14",
   jackson: "2.21.2",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=72f44c9f8ebcb1af43838f45ee5c4aa9c5444898b3468ab3f4af7b6076c5bc3f
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -201,10 +201,10 @@ fi
 
 
 # Loop in case we encounter an error.
-REQUIRED_WRAPPER_JAR_CHECKSUM="423cb469ccc0ecc31f0e4e1c309976198ccb734cdcbb7029d4bda0f18f57e8d9"
+REQUIRED_WRAPPER_JAR_CHECKSUM="55243ef57851f12b070ad14f7f5bb8302daceeebc5bce5ece5fa6edb23e1145c"
 for attempt in 1 2 3; do
   if [ ! -e "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v9.2.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v9.4.1/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -40,7 +40,7 @@ task bootstrapWrapper() {
         // of curl (built against OpenSSL library that doesn't support TLSv1.2) would fail to
         // fetch the jar.
         // IMPORTANT: This checksum **must** be updated whenever the Gradle version changes.
-        String wrapperChecksum = "423cb469ccc0ecc31f0e4e1c309976198ccb734cdcbb7029d4bda0f18f57e8d9"
+        String wrapperChecksum = "55243ef57851f12b070ad14f7f5bb8302daceeebc5bce5ece5fa6edb23e1145c"
         def wrapperJarUrl = "https://raw.githubusercontent.com/gradle/gradle/v$versions.gradle/gradle/wrapper/gradle-wrapper.jar"
 
         def bootstrapString = """


### PR DESCRIPTION
Upgrades Gradle from 9.2.1 to 9.4.1 and the Spotless plugin from 8.0.0
to 8.3.0.

The upgrade was previously blocked because Spotless' default
`removeUnusedImports()` relies on google-java-format, which depends on
`com.sun.tools.javac.*` internals and breaks under the newer
Gradle/Spotless worker setup. Worked around by switching to the
`cleanthat-javaparser-unnecessaryimport` engine, which uses JavaParser
and does not touch JDK internals:

```
removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
```

The wrapper files (`gradle/wrapper/gradle-wrapper.properties`,
`gradlew`, `wrapper.gradle`) were regenerated following the procedure
documented in `gradle/wrapper/README.md`, using the wrapper-jar and
binary-distribution checksums published at
https://gradle.org/release-checksums/.

Verified locally:
- `./gradlew --version` reports Gradle 9.4.1
- `./gradlew build -x test` passes (spotlessCheck + checkstyle +
spotbugs + compile all green)
- `./gradlew spotlessApply --rerun-tasks --no-build-cache` ran 100 times
in a loop — 0 dirty iterations, 0 build failures, confirming the
cleanthat engine produces stable output under Gradle's parallel workers
on this codebase

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, PoAn Yang
 <payang@apache.org>, Ken Huang <s7133700@gmail.com>, Dejan Stojadinović
 <dejan2609@gmail.com>
