### PR TITLE
MINOR: Fix tool package in kafka-dump-log.bat

### DIFF
--- a/bin/windows/kafka-dump-log.bat
+++ b/bin/windows/kafka-dump-log.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-"%~dp0kafka-run-class.bat" kafka.tools.DumpLogSegments %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.DumpLogSegments %*


### PR DESCRIPTION
DumpLogSegments was moved to org.apache.kafka.tools.DumpLogSegments

Reviewers: Andrew Schofield <aschofield@confluent.io>
