### PR TITLE
KAFKA-20431: ConsumerGroupDescribe API does not return partitions being revoked

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.requests.{ConsumerGroupDescribeRequest, ConsumerG
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.common.test.ClusterInstance
 import org.apache.kafka.common.utils.Utils
-import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
+import org.apache.kafka.coordinator.group.{Assertions, GroupCoordinatorConfig}
 import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.common.Feature
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
@@ -437,24 +437,9 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
       version = ApiKeys.CONSUMER_GROUP_DESCRIBE.latestVersion(isUnstableApiEnabled),
     )
 
-    // Normalize ordering before comparing since the response does not guarantee order.
-    actual.foreach(normalizeDescribedGroup)
-
-    assertEquals(expected, actual)
-  }
-
-  private def normalizeDescribedGroup(group: DescribedGroup): Unit = {
-    group.members.sort((a, b) => a.memberId.compareTo(b.memberId))
-    group.members.forEach { member =>
-      normalizeAssignment(member.assignment)
-      normalizeAssignment(member.targetAssignment)
-    }
-  }
-
-  private def normalizeAssignment(assignment: Assignment): Unit = {
-    if (assignment != null) {
-      assignment.topicPartitions.sort((a, b) => a.topicId.compareTo(b.topicId))
-      assignment.topicPartitions.forEach(tp => Collections.sort(tp.partitions))
-    }
+    Assertions.assertResponseEquals(
+      new ConsumerGroupDescribeResponseData().setGroups(expected.asJava),
+      new ConsumerGroupDescribeResponseData().setGroups(actual.asJava)
+    )
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol
 import org.apache.kafka.common.{ConsumerGroupState, TopicPartition, Uuid}
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData.{Assignment, DescribedGroup, TopicPartitions}
-import org.apache.kafka.common.message.{ConsumerGroupDescribeRequestData, ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatResponseData}
+import org.apache.kafka.common.message.{ConsumerGroupDescribeRequestData, ConsumerGroupDescribeResponseData, ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse}
 import org.apache.kafka.common.resource.ResourceType
@@ -318,5 +318,125 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
       assertFalse(member2.isEmpty)
       assertEquals(if (version == 0) -1.toByte else 1.toByte, member2.get.memberType)
     }
+  }
+
+  @ClusterTest
+  def testConsumerGroupDescribeIncludesPartitionsPendingRevocation(): Unit = {
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    createOffsetsTopic()
+
+    val topicId = createTopic(
+      topic = "foo",
+      numPartitions = 3
+    )
+
+    val clientId = "client-id"
+    val clientHost = "/127.0.0.1"
+    val authorizedOperationsInt = Utils.to32BitField(
+      AclEntry.supportedOperations(ResourceType.GROUP).asScala
+        .map(_.code.asInstanceOf[JByte]).asJava
+    )
+
+    // Member-1 joins using the range assignor and waits until it gets all 3 partitions.
+    var member1Response: ConsumerGroupHeartbeatResponseData = null
+    TestUtils.waitUntilTrue(() => {
+      member1Response = consumerGroupHeartbeat(
+        groupId = "grp",
+        memberId = "member-1",
+        serverAssignor = "range",
+        rebalanceTimeoutMs = 5 * 60 * 1000,
+        subscribedTopicNames = List("foo"),
+        topicPartitions = List.empty
+      )
+      member1Response.assignment != null && !member1Response.assignment.topicPartitions.isEmpty
+    }, msg = s"Could not join the group successfully. Last response $member1Response.")
+
+    // Member-2 joins, triggering a rebalance. The target assignment changes:
+    // member-1 -> [0, 1], member-2 -> [2].
+    val member2Response = consumerGroupHeartbeat(
+      groupId = "grp",
+      memberId = "member-2",
+      serverAssignor = "range",
+      rebalanceTimeoutMs = 5 * 60 * 1000,
+      subscribedTopicNames = List("foo"),
+      topicPartitions = List.empty
+    )
+
+    // Member-1 heartbeats again, reporting it still owns all 3 partitions.
+    // This triggers reconciliation: assigned becomes [0, 1] and partition 2
+    // moves to partitions pending revocation.
+    consumerGroupHeartbeat(
+      groupId = "grp",
+      memberId = "member-1",
+      memberEpoch = member1Response.memberEpoch,
+      rebalanceTimeoutMs = 5 * 60 * 1000,
+      subscribedTopicNames = List("foo"),
+      topicPartitions = List(
+        new ConsumerGroupHeartbeatRequestData.TopicPartitions()
+          .setTopicId(topicId)
+          .setPartitions(List[Integer](0, 1, 2).asJava)
+      )
+    )
+
+    // Describe the group and verify that member-1's assignment includes
+    // both assigned partitions and partitions pending revocation.
+    val expected = List(
+      new DescribedGroup()
+        .setGroupId("grp")
+        .setGroupState(ConsumerGroupState.RECONCILING.toString)
+        .setGroupEpoch(member2Response.memberEpoch)
+        .setAssignmentEpoch(member2Response.memberEpoch)
+        .setAssignorName("range")
+        .setAuthorizedOperations(authorizedOperationsInt)
+        .setMembers(List(
+          new ConsumerGroupDescribeResponseData.Member()
+            .setMemberId("member-2")
+            .setMemberEpoch(member2Response.memberEpoch)
+            .setClientId(clientId)
+            .setClientHost(clientHost)
+            .setSubscribedTopicRegex("")
+            .setSubscribedTopicNames(List("foo").asJava)
+            .setAssignment(new Assignment())
+            .setTargetAssignment(new Assignment()
+              .setTopicPartitions(List(
+                new TopicPartitions()
+                  .setTopicId(topicId)
+                  .setTopicName("foo")
+                  .setPartitions(List[Integer](2).asJava)
+              ).asJava))
+            .setMemberType(1.toByte),
+          new ConsumerGroupDescribeResponseData.Member()
+            .setMemberId("member-1")
+            .setMemberEpoch(member1Response.memberEpoch)
+            .setClientId(clientId)
+            .setClientHost(clientHost)
+            .setSubscribedTopicRegex("")
+            .setSubscribedTopicNames(List("foo").asJava)
+            .setAssignment(new Assignment()
+              .setTopicPartitions(List(
+                new TopicPartitions()
+                  .setTopicId(topicId)
+                  .setTopicName("foo")
+                  .setPartitions(List[Integer](0, 1, 2).asJava)
+              ).asJava))
+            .setTargetAssignment(new Assignment()
+              .setTopicPartitions(List(
+                new TopicPartitions()
+                  .setTopicId(topicId)
+                  .setTopicName("foo")
+                  .setPartitions(List[Integer](0, 1).asJava)
+              ).asJava))
+            .setMemberType(1.toByte),
+        ).asJava)
+    )
+
+    val actual = consumerGroupDescribe(
+      groupIds = List("grp"),
+      includeAuthorizedOperations = true,
+      version = ApiKeys.CONSUMER_GROUP_DESCRIBE.latestVersion(isUnstableApiEnabled),
+    )
+
+    assertEquals(expected, actual)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupDescribeRequestTest.scala
@@ -391,22 +391,6 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
         .setAuthorizedOperations(authorizedOperationsInt)
         .setMembers(List(
           new ConsumerGroupDescribeResponseData.Member()
-            .setMemberId("member-2")
-            .setMemberEpoch(member2Response.memberEpoch)
-            .setClientId(clientId)
-            .setClientHost(clientHost)
-            .setSubscribedTopicRegex("")
-            .setSubscribedTopicNames(List("foo").asJava)
-            .setAssignment(new Assignment())
-            .setTargetAssignment(new Assignment()
-              .setTopicPartitions(List(
-                new TopicPartitions()
-                  .setTopicId(topicId)
-                  .setTopicName("foo")
-                  .setPartitions(List[Integer](2).asJava)
-              ).asJava))
-            .setMemberType(1.toByte),
-          new ConsumerGroupDescribeResponseData.Member()
             .setMemberId("member-1")
             .setMemberEpoch(member1Response.memberEpoch)
             .setClientId(clientId)
@@ -428,6 +412,22 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
                   .setPartitions(List[Integer](0, 1).asJava)
               ).asJava))
             .setMemberType(1.toByte),
+          new ConsumerGroupDescribeResponseData.Member()
+            .setMemberId("member-2")
+            .setMemberEpoch(member2Response.memberEpoch)
+            .setClientId(clientId)
+            .setClientHost(clientHost)
+            .setSubscribedTopicRegex("")
+            .setSubscribedTopicNames(List("foo").asJava)
+            .setAssignment(new Assignment())
+            .setTargetAssignment(new Assignment()
+              .setTopicPartitions(List(
+                new TopicPartitions()
+                  .setTopicId(topicId)
+                  .setTopicName("foo")
+                  .setPartitions(List[Integer](2).asJava)
+              ).asJava))
+            .setMemberType(1.toByte),
         ).asJava)
     )
 
@@ -437,6 +437,24 @@ class ConsumerGroupDescribeRequestTest(cluster: ClusterInstance) extends GroupCo
       version = ApiKeys.CONSUMER_GROUP_DESCRIBE.latestVersion(isUnstableApiEnabled),
     )
 
+    // Normalize ordering before comparing since the response does not guarantee order.
+    actual.foreach(normalizeDescribedGroup)
+
     assertEquals(expected, actual)
+  }
+
+  private def normalizeDescribedGroup(group: DescribedGroup): Unit = {
+    group.members.sort((a, b) => a.memberId.compareTo(b.memberId))
+    group.members.forEach { member =>
+      normalizeAssignment(member.assignment)
+      normalizeAssignment(member.targetAssignment)
+    }
+  }
+
+  private def normalizeAssignment(assignment: Assignment): Unit = {
+    if (assignment != null) {
+      assignment.topicPartitions.sort((a, b) => a.topicId.compareTo(b.topicId))
+      assignment.topicPartitions.forEach(tp => Collections.sort(tp.partitions))
+    }
   }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.BiConsumer;
 
 /**
  * ConsumerGroupMember contains all the information related to a member
@@ -485,16 +484,8 @@ public class ConsumerGroupMember extends ModernGroupMember {
         // revocation because the member is still responsible for the latter until
         // revocation is complete.
         var topicPartitionsMap = new HashMap<Uuid, ConsumerGroupDescribeResponseData.TopicPartitions>();
-        BiConsumer<Uuid, Map<Integer, Integer>> accumulate = (topicId, eps) ->
-            image.topicMetadata(topicId).ifPresent(metadata ->
-                topicPartitionsMap.computeIfAbsent(topicId, __ ->
-                    new ConsumerGroupDescribeResponseData.TopicPartitions()
-                        .setTopicId(topicId)
-                        .setTopicName(metadata.name())
-                        .setPartitions(new ArrayList<>())
-                ).partitions().addAll(eps.keySet()));
-        assignedPartitions.forEach(accumulate);
-        partitionsPendingRevocation.forEach(accumulate);
+        accumulateTopicPartitions(assignedPartitions, topicPartitionsMap, image);
+        accumulateTopicPartitions(partitionsPendingRevocation, topicPartitionsMap, image);
 
         return new ConsumerGroupDescribeResponseData.Member()
             .setMemberEpoch(memberEpoch)
@@ -513,6 +504,21 @@ public class ConsumerGroupMember extends ModernGroupMember {
             .setSubscribedTopicNames(subscribedTopicNames == null ? null : new ArrayList<>(subscribedTopicNames))
             .setSubscribedTopicRegex(subscribedTopicRegex)
             .setMemberType(useClassicProtocol() ? (byte) 0 : (byte) 1);
+    }
+
+    private static void accumulateTopicPartitions(
+        Map<Uuid, Map<Integer, Integer>> source,
+        Map<Uuid, ConsumerGroupDescribeResponseData.TopicPartitions> target,
+        CoordinatorMetadataImage image
+    ) {
+        source.forEach((topicId, eps) ->
+            image.topicMetadata(topicId).ifPresent(metadata ->
+                target.computeIfAbsent(topicId, __ ->
+                    new ConsumerGroupDescribeResponseData.TopicPartitions()
+                        .setTopicId(topicId)
+                        .setTopicName(metadata.name())
+                        .setPartitions(new ArrayList<>())
+                ).partitions().addAll(eps.keySet())));
     }
 
     private static List<ConsumerGroupDescribeResponseData.TopicPartitions> topicPartitionsFromAssignment(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -480,12 +480,20 @@ public class ConsumerGroupMember extends ModernGroupMember {
         Assignment targetAssignment,
         CoordinatorMetadataImage image
     ) {
+        // The assignment includes both assigned partitions and partitions pending
+        // revocation because the member is still responsible for the latter until
+        // revocation is complete.
+        var mergedAssignment = new HashMap<Uuid, Set<Integer>>();
+        assignedPartitions.forEach((topicId, partitions) ->
+            mergedAssignment.put(topicId, new HashSet<>(partitions.keySet())));
+        partitionsPendingRevocation.forEach((topicId, partitions) ->
+            mergedAssignment.computeIfAbsent(topicId, __ -> new HashSet<>()).addAll(partitions.keySet()));
+
         return new ConsumerGroupDescribeResponseData.Member()
             .setMemberEpoch(memberEpoch)
             .setMemberId(memberId)
             .setAssignment(new ConsumerGroupDescribeResponseData.Assignment()
-                .setTopicPartitions(topicPartitionsFromAssignment(
-                    Utils.toAssignmentWithoutEpochs(assignedPartitions), image)))
+                .setTopicPartitions(topicPartitionsFromAssignment(mergedAssignment, image)))
             .setTargetAssignment(new ConsumerGroupDescribeResponseData.Assignment()
                 .setTopicPartitions(topicPartitionsFromAssignment(
                     targetAssignment != null ? targetAssignment.partitions() : Map.of(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -485,7 +484,7 @@ public class ConsumerGroupMember extends ModernGroupMember {
         // The assignment includes both assigned partitions and partitions pending
         // revocation because the member is still responsible for the latter until
         // revocation is complete.
-        var topicPartitionsMap = new LinkedHashMap<Uuid, ConsumerGroupDescribeResponseData.TopicPartitions>();
+        var topicPartitionsMap = new HashMap<Uuid, ConsumerGroupDescribeResponseData.TopicPartitions>();
         BiConsumer<Uuid, Map<Integer, Integer>> accumulate = (topicId, eps) ->
             image.topicMetadata(topicId).ifPresent(metadata ->
                 topicPartitionsMap.computeIfAbsent(topicId, __ ->

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMember.java
@@ -33,12 +33,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 /**
  * ConsumerGroupMember contains all the information related to a member
@@ -483,17 +485,23 @@ public class ConsumerGroupMember extends ModernGroupMember {
         // The assignment includes both assigned partitions and partitions pending
         // revocation because the member is still responsible for the latter until
         // revocation is complete.
-        var mergedAssignment = new HashMap<Uuid, Set<Integer>>();
-        assignedPartitions.forEach((topicId, partitions) ->
-            mergedAssignment.put(topicId, new HashSet<>(partitions.keySet())));
-        partitionsPendingRevocation.forEach((topicId, partitions) ->
-            mergedAssignment.computeIfAbsent(topicId, __ -> new HashSet<>()).addAll(partitions.keySet()));
+        var topicPartitionsMap = new LinkedHashMap<Uuid, ConsumerGroupDescribeResponseData.TopicPartitions>();
+        BiConsumer<Uuid, Map<Integer, Integer>> accumulate = (topicId, eps) ->
+            image.topicMetadata(topicId).ifPresent(metadata ->
+                topicPartitionsMap.computeIfAbsent(topicId, __ ->
+                    new ConsumerGroupDescribeResponseData.TopicPartitions()
+                        .setTopicId(topicId)
+                        .setTopicName(metadata.name())
+                        .setPartitions(new ArrayList<>())
+                ).partitions().addAll(eps.keySet()));
+        assignedPartitions.forEach(accumulate);
+        partitionsPendingRevocation.forEach(accumulate);
 
         return new ConsumerGroupDescribeResponseData.Member()
             .setMemberEpoch(memberEpoch)
             .setMemberId(memberId)
             .setAssignment(new ConsumerGroupDescribeResponseData.Assignment()
-                .setTopicPartitions(topicPartitionsFromAssignment(mergedAssignment, image)))
+                .setTopicPartitions(new ArrayList<>(topicPartitionsMap.values())))
             .setTargetAssignment(new ConsumerGroupDescribeResponseData.Assignment()
                 .setTopicPartitions(topicPartitionsFromAssignment(
                     targetAssignment != null ? targetAssignment.partitions() : Map.of(),

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -158,8 +158,7 @@ public class Assertions {
             assignment.topicPartitions().sort(Comparator.comparing(
                 ConsumerGroupDescribeResponseData.TopicPartitions::topicId
             ));
-            assignment.topicPartitions().forEach(topic ->
-                topic.partitions().sort(Integer::compareTo));
+            assignment.topicPartitions().forEach(topic -> topic.partitions().sort(Integer::compareTo));
         }
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -151,7 +151,7 @@ public class Assertions {
         }
     }
 
-    private static void normalizeAssignment(
+    public static void normalizeAssignment(
         ConsumerGroupDescribeResponseData.Assignment assignment
     ) {
         if (assignment != null) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
@@ -51,6 +52,7 @@ public class Assertions {
     private static final BiConsumer<ApiMessage, ApiMessage> API_MESSAGE_DEFAULT_COMPARATOR = org.junit.jupiter.api.Assertions::assertEquals;
     private static final Map<Class<?>, BiConsumer<ApiMessage, ApiMessage>> API_MESSAGE_COMPARATORS = Map.of(
         // Register request/response comparators.
+        ConsumerGroupDescribeResponseData.class, Assertions::assertConsumerGroupDescribeResponse,
         ConsumerGroupHeartbeatResponseData.class, Assertions::assertConsumerGroupHeartbeatResponse,
         ShareGroupHeartbeatResponseData.class, Assertions::assertShareGroupHeartbeatResponse,
         SyncGroupResponseData.class, Assertions::assertSyncGroupResponse,
@@ -147,6 +149,42 @@ public class Assertions {
                 .actual(actual)
                 .buildAndThrow();
         }
+    }
+
+    private static void normalizeAssignment(
+        ConsumerGroupDescribeResponseData.Assignment assignment
+    ) {
+        if (assignment != null) {
+            assignment.topicPartitions().sort(Comparator.comparing(
+                ConsumerGroupDescribeResponseData.TopicPartitions::topicId
+            ));
+            assignment.topicPartitions().forEach(topic ->
+                topic.partitions().sort(Integer::compareTo));
+        }
+    }
+
+    private static void assertConsumerGroupDescribeResponse(
+        ApiMessage exp,
+        ApiMessage act
+    ) {
+        var expected = (ConsumerGroupDescribeResponseData) exp.duplicate();
+        var actual = (ConsumerGroupDescribeResponseData) act.duplicate();
+
+        Consumer<ConsumerGroupDescribeResponseData> normalize = message ->
+            message.groups().forEach(group -> {
+                group.members().sort(Comparator.comparing(
+                    ConsumerGroupDescribeResponseData.Member::memberId
+                ));
+                group.members().forEach(member -> {
+                    normalizeAssignment(member.assignment());
+                    normalizeAssignment(member.targetAssignment());
+                });
+            });
+
+        normalize.accept(expected);
+        normalize.accept(actual);
+
+        assertEquals(expected, actual);
     }
 
     private static void assertConsumerGroupHeartbeatResponse(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.coordinator.group.modern.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
+import org.apache.kafka.coordinator.group.Assertions;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
@@ -375,14 +374,8 @@ public class ConsumerGroupMemberTest {
             .setMemberType(withClassicMemberMetadata ? (byte) 0 : (byte) 1);
 
         // Sort to avoid order dependency from HashMap iteration.
-        Consumer<ConsumerGroupDescribeResponseData.Assignment> normalizeAssignment = assignment -> {
-            assignment.topicPartitions().sort(Comparator.comparing(
-                (ConsumerGroupDescribeResponseData.TopicPartitions tp) -> tp.topicId().toString()
-            ));
-            assignment.topicPartitions().forEach(tp -> tp.partitions().sort(Integer::compareTo));
-        };
-        normalizeAssignment.accept(actual.assignment());
-        normalizeAssignment.accept(expected.assignment());
+        Assertions.normalizeAssignment(actual.assignment());
+        Assertions.normalizeAssignment(expected.assignment());
 
         assertEquals(expected, actual);
     }
@@ -420,8 +413,7 @@ public class ConsumerGroupMemberTest {
         );
 
         // The assignment should merge both assigned and pending revocation for the same topic.
-        // Sort partitions to avoid order dependency from HashSet iteration.
-        actual.assignment().topicPartitions().forEach(tp -> tp.partitions().sort(Integer::compareTo));
+        Assertions.normalizeAssignment(actual.assignment());
         assertEquals(
             List.of(
                 new ConsumerGroupDescribeResponseData.TopicPartitions()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -333,8 +334,11 @@ public class ConsumerGroupMemberTest {
                 .setSupportedProtocols(toClassicProtocolCollection("range")) : null)
             .build();
 
-        ConsumerGroupDescribeResponseData.Member actual = member.asConsumerGroupDescribeMember(targetAssignment, new KRaftCoordinatorMetadataImage(metadataImage));
-        ConsumerGroupDescribeResponseData.Member expected = new ConsumerGroupDescribeResponseData.Member()
+        var actual = member.asConsumerGroupDescribeMember(
+            targetAssignment,
+            new KRaftCoordinatorMetadataImage(metadataImage)
+        );
+        var expected = new ConsumerGroupDescribeResponseData.Member()
             .setMemberId(memberId)
             .setMemberEpoch(epoch)
             .setClientId(clientId)
@@ -344,12 +348,19 @@ public class ConsumerGroupMemberTest {
             .setSubscribedTopicNames(new ArrayList<>(subscribedTopicNames))
             .setSubscribedTopicRegex(subscribedTopicRegex)
             .setAssignment(
+                // The assignment should include both assigned partitions and
+                // partitions pending revocation.
                 new ConsumerGroupDescribeResponseData.Assignment()
-                    .setTopicPartitions(List.of(new ConsumerGroupDescribeResponseData.TopicPartitions()
-                        .setTopicId(topicId1)
-                        .setTopicName("topic1")
-                        .setPartitions(assignedPartitions)
-                    ))
+                    .setTopicPartitions(new ArrayList<>(List.of(
+                        new ConsumerGroupDescribeResponseData.TopicPartitions()
+                            .setTopicId(topicId1)
+                            .setTopicName("topic1")
+                            .setPartitions(assignedPartitions),
+                        new ConsumerGroupDescribeResponseData.TopicPartitions()
+                            .setTopicId(topicId2)
+                            .setTopicName("topic2")
+                            .setPartitions(Arrays.asList(3, 4, 5))
+                    )))
             )
             .setTargetAssignment(
                 new ConsumerGroupDescribeResponseData.Assignment()
@@ -362,7 +373,58 @@ public class ConsumerGroupMemberTest {
             )
             .setMemberType(withClassicMemberMetadata ? (byte) 0 : (byte) 1);
 
+        // Sort the topic partitions to avoid order dependency from HashMap iteration.
+        var cmp = Comparator.comparing(
+            (ConsumerGroupDescribeResponseData.TopicPartitions tp) -> tp.topicId().toString()
+        );
+        actual.assignment().topicPartitions().sort(cmp);
+        expected.assignment().topicPartitions().sort(cmp);
+
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAsConsumerGroupDescribeMemberWithSameTopicPendingRevocation() {
+        var topicId1 = Uuid.randomUuid();
+        var metadataImage = new MetadataImageBuilder()
+            .addTopic(topicId1, "topic1", 6)
+            .build();
+
+        // Assigned partitions [0, 1] and partitions pending revocation [2] share the same topic.
+        var record = new ConsumerGroupCurrentMemberAssignmentValue()
+            .setMemberEpoch(5)
+            .setPreviousMemberEpoch(4)
+            .setAssignedPartitions(List.of(
+                new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                    .setTopicId(topicId1)
+                    .setPartitions(Arrays.asList(0, 1))
+            ))
+            .setPartitionsPendingRevocation(List.of(
+                new ConsumerGroupCurrentMemberAssignmentValue.TopicPartitions()
+                    .setTopicId(topicId1)
+                    .setPartitions(List.of(2))
+            ));
+
+        var memberId = Uuid.randomUuid().toString();
+        var member = new ConsumerGroupMember.Builder(memberId)
+            .updateWith(LOG, GROUP_ID, record)
+            .build();
+
+        var actual = member.asConsumerGroupDescribeMember(
+            null,
+            new KRaftCoordinatorMetadataImage(metadataImage)
+        );
+
+        // The assignment should merge both assigned and pending revocation for the same topic.
+        assertEquals(
+            List.of(
+                new ConsumerGroupDescribeResponseData.TopicPartitions()
+                    .setTopicId(topicId1)
+                    .setTopicName("topic1")
+                    .setPartitions(Arrays.asList(0, 1, 2))
+            ),
+            actual.assignment().topicPartitions()
+        );
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -18,10 +18,10 @@ package org.apache.kafka.coordinator.group.modern.consumer;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ConsumerGroupDescribeResponseData;
-import org.apache.kafka.coordinator.group.Assertions;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.coordinator.common.runtime.KRaftCoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
+import org.apache.kafka.coordinator.group.Assertions;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.ConsumerGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.modern.Assignment;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -379,8 +379,7 @@ public class ConsumerGroupMemberTest {
             assignment.topicPartitions().sort(Comparator.comparing(
                 (ConsumerGroupDescribeResponseData.TopicPartitions tp) -> tp.topicId().toString()
             ));
-            assignment.topicPartitions().forEach(tp ->
-                tp.partitions().sort(Integer::compareTo));
+            assignment.topicPartitions().forEach(tp -> tp.partitions().sort(Integer::compareTo));
         };
         normalizeAssignment.accept(actual.assignment());
         normalizeAssignment.accept(expected.assignment());
@@ -422,8 +421,7 @@ public class ConsumerGroupMemberTest {
 
         // The assignment should merge both assigned and pending revocation for the same topic.
         // Sort partitions to avoid order dependency from HashSet iteration.
-        actual.assignment().topicPartitions().forEach(tp ->
-            tp.partitions().sort(Integer::compareTo));
+        actual.assignment().topicPartitions().forEach(tp -> tp.partitions().sort(Integer::compareTo));
         assertEquals(
             List.of(
                 new ConsumerGroupDescribeResponseData.TopicPartitions()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupMemberTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.LEAVE_GROUP_STATIC_MEMBER_EPOCH;
 import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
@@ -373,12 +374,16 @@ public class ConsumerGroupMemberTest {
             )
             .setMemberType(withClassicMemberMetadata ? (byte) 0 : (byte) 1);
 
-        // Sort the topic partitions to avoid order dependency from HashMap iteration.
-        var cmp = Comparator.comparing(
-            (ConsumerGroupDescribeResponseData.TopicPartitions tp) -> tp.topicId().toString()
-        );
-        actual.assignment().topicPartitions().sort(cmp);
-        expected.assignment().topicPartitions().sort(cmp);
+        // Sort to avoid order dependency from HashMap iteration.
+        Consumer<ConsumerGroupDescribeResponseData.Assignment> normalizeAssignment = assignment -> {
+            assignment.topicPartitions().sort(Comparator.comparing(
+                (ConsumerGroupDescribeResponseData.TopicPartitions tp) -> tp.topicId().toString()
+            ));
+            assignment.topicPartitions().forEach(tp ->
+                tp.partitions().sort(Integer::compareTo));
+        };
+        normalizeAssignment.accept(actual.assignment());
+        normalizeAssignment.accept(expected.assignment());
 
         assertEquals(expected, actual);
     }
@@ -416,6 +421,9 @@ public class ConsumerGroupMemberTest {
         );
 
         // The assignment should merge both assigned and pending revocation for the same topic.
+        // Sort partitions to avoid order dependency from HashSet iteration.
+        actual.assignment().topicPartitions().forEach(tp ->
+            tp.partitions().sort(Integer::compareTo));
         assertEquals(
             List.of(
                 new ConsumerGroupDescribeResponseData.TopicPartitions()


### PR DESCRIPTION
The `Assignment` field in the `ConsumerGroupDescribe` response only
included `assignedPartitions`, omitting `partitionsPendingRevocation`.
This caused partitions to disappear from the response during
reconciliation. The fix merges both into the `Assignment` field since
the member is still responsible for those partitions until revocation
completes.

Reviewers: Sean Quah <squah@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
