### PR TITLE
KAFKA-19839: Fix NoSuchFieldError for zstd compression in native image

### DIFF
--- a/docker/native/native-image-configs/jni-config.json
+++ b/docker/native/native-image-configs/jni-config.json
@@ -10,6 +10,10 @@
   "fields":[{"name":"dstPos"}, {"name":"srcPos"}]
 },
 {
+  "name":"com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+  "fields":[{"name":"dstPos"}, {"name":"srcPos"}]
+},
+{
   "name":"com.sun.management.internal.DiagnosticCommandArgumentInfo",
   "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.lang.String","java.lang.String","boolean","boolean","boolean","int"] }]
 },


### PR DESCRIPTION
This fix solves the `NoSuchFieldError` thrown by the native broker if the topic `compression.type` is `zstd`, but the producer sends the message uncompressed.

The fix adds the missing `ZstdOutputStreamNoFinalizer` class with its `dstPos` and `srcPos` fields to the JNI config, so when the native `resetCStream` method is called in `ZstdOutputStreamNoFinalizer`, GraalVM can resolve the fields at runtime instead of throwing `NoSuchFieldError`.

Reviewers: PoAn Yang [payang@apache.org](mailto:payang@apache.org), Chia-Ping Tsai <chia7712@gmail.com>
