### PR TITLE
[POC] KAFKA-20171: Kafka Streams use topic ids. (other version)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/RequestManagers.java
@@ -227,7 +227,8 @@ public class RequestManagers implements Closeable {
                             backgroundEventHandler,
                             logContext,
                             time,
-                            metrics);
+                            metrics, 
+                            metadata);
                         streamsMembershipManager.registerStateListener(commitRequestManager);
                         streamsMembershipManager.registerStateListener(applicationThreadMemberStateListener);
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -81,6 +82,7 @@ public class StreamsMembershipManager implements RequestManager {
             Collections.emptyMap(),
             Collections.emptyMap(),
             Collections.emptyMap(),
+            Collections.emptyMap(),
             false
         );
 
@@ -88,17 +90,20 @@ public class StreamsMembershipManager implements RequestManager {
         public final Map<String, SortedSet<Integer>> activeTasks;
         public final Map<String, SortedSet<Integer>> standbyTasks;
         public final Map<String, SortedSet<Integer>> warmupTasks;
+        public final Map<String, SortedSet<Uuid>> resolvedTopicIds;
         public final boolean isGroupReady;
 
         public LocalAssignment(final long localEpoch,
                                final Map<String, SortedSet<Integer>> activeTasks,
                                final Map<String, SortedSet<Integer>> standbyTasks,
                                final Map<String, SortedSet<Integer>> warmupTasks,
+                               final Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                final boolean isGroupReady) {
             this.localEpoch = localEpoch;
             this.activeTasks = activeTasks;
             this.standbyTasks = standbyTasks;
             this.warmupTasks = warmupTasks;
+            this.resolvedTopicIds = resolvedTopicIds;
             this.isGroupReady = isGroupReady;
             if (localEpoch == NONE_EPOCH &&
                     (!activeTasks.isEmpty() || !standbyTasks.isEmpty() || !warmupTasks.isEmpty())) {
@@ -109,18 +114,20 @@ public class StreamsMembershipManager implements RequestManager {
         Optional<LocalAssignment> updateWith(final Map<String, SortedSet<Integer>> activeTasks,
                                              final Map<String, SortedSet<Integer>> standbyTasks,
                                              final Map<String, SortedSet<Integer>> warmupTasks,
+                                             final Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                              final boolean isGroupReady) {
             if (localEpoch != NONE_EPOCH &&
                     activeTasks.equals(this.activeTasks) &&
                     standbyTasks.equals(this.standbyTasks) &&
                     warmupTasks.equals(this.warmupTasks) &&
+                    resolvedTopicIds.equals(this.resolvedTopicIds) &&
                     isGroupReady == this.isGroupReady
             ) {
                 return Optional.empty();
             }
 
             long nextLocalEpoch = localEpoch + 1;
-            return Optional.of(new LocalAssignment(nextLocalEpoch, activeTasks, standbyTasks, warmupTasks, isGroupReady));
+            return Optional.of(new LocalAssignment(nextLocalEpoch, activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady));
         }
 
         @Override
@@ -130,6 +137,7 @@ public class StreamsMembershipManager implements RequestManager {
                 ", activeTasks=" + activeTasks +
                 ", standbyTasks=" + standbyTasks +
                 ", warmupTasks=" + warmupTasks +
+                ", resolvedTopicIds=" + resolvedTopicIds +
                 ", isGroupReady=" + isGroupReady +
                 '}';
         }
@@ -143,12 +151,13 @@ public class StreamsMembershipManager implements RequestManager {
                 Objects.equals(activeTasks, that.activeTasks) &&
                 Objects.equals(standbyTasks, that.standbyTasks) &&
                 Objects.equals(warmupTasks, that.warmupTasks) &&
+                Objects.equals(resolvedTopicIds, that.resolvedTopicIds) &&
                 isGroupReady == that.isGroupReady;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(localEpoch, activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return Objects.hash(localEpoch, activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady);
         }
     }
 
@@ -281,6 +290,14 @@ public class StreamsMembershipManager implements RequestManager {
      */
     private boolean isPollTimerExpired;
 
+    private final ConsumerMetadata metadata;
+
+    private final Map<Uuid, String> assignedTopicNamesCache;
+    
+    private boolean maybeRefreshMaterialization = false;
+
+    private int lastMetadataVersion = -1;
+
     /**
      * Constructs the Streams membership manager.
      *
@@ -298,13 +315,17 @@ public class StreamsMembershipManager implements RequestManager {
                                     final BackgroundEventHandler backgroundEventHandler,
                                     final LogContext logContext,
                                     final Time time,
-                                    final Metrics metrics) {
+                                    final Metrics metrics,
+                                    final ConsumerMetadata metadata
+    ) {
         log = logContext.logger(StreamsMembershipManager.class);
         this.state = MemberState.UNSUBSCRIBED;
         this.groupId = groupId;
         this.backgroundEventHandler = backgroundEventHandler;
         this.streamsRebalanceData = streamsRebalanceData;
         this.subscriptionState = subscriptionState;
+        this.metadata = metadata;
+        this.assignedTopicNamesCache = new HashMap<>();
         metricsManager = new ConsumerRebalanceMetricsManager(metrics, subscriptionState);
         this.time = time;
     }
@@ -712,27 +733,27 @@ public class StreamsMembershipManager implements RequestManager {
         }
         
         updateMemberEpoch(responseData.memberEpoch());
-//        responseData.activeTasks();
-        final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks = responseData.standbyTasks();
+        final List<StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds> activeTasksWithTopicIds = responseData.activeTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> standbyTasks = responseData.standbyTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> warmupTasks = responseData.warmupTasks();
         final boolean isGroupReady = isGroupReady(responseData.status());
 
-        if (activeTasks != null && standbyTasks != null && warmupTasks != null) {
+        if (activeTasksWithTopicIds != null && standbyTasks != null && warmupTasks != null) {
             if (!state.canHandleNewAssignment()) {
                 log.debug("Ignoring new assignment: active tasks {}, standby tasks {}, and warm-up tasks {} received " +
                         "from server because member is in {} state.",
-                    activeTasks, standbyTasks, warmupTasks, state);
+                    activeTasksWithTopicIds, standbyTasks, warmupTasks, state);
                 return;
             }
 
             processAssignmentReceived(
-                toTasksAssignment(activeTasks),
+                toTasksAssignmentFromTaskIdsWithResolvedTopicIds(activeTasksWithTopicIds),
                 toTasksAssignment(standbyTasks),
                 toTasksAssignment(warmupTasks),
+                toSortedTopicIds(activeTasksWithTopicIds),
                 isGroupReady
             );
-        } else if (responseData.activeTasks() != null || responseData.standbyTasks() != null || responseData.warmupTasks() != null) {
+        } else if (responseData.activeTasks() != null || responseData.standbyTasks() != null || responseData.warmupTasks() != null){    
             throw new IllegalStateException("Invalid response data, task collections must be all null or all non-null: "
                 + responseData);
         } else if (isGroupReady != targetAssignment.isGroupReady) {
@@ -742,6 +763,7 @@ public class StreamsMembershipManager implements RequestManager {
                 targetAssignment.activeTasks,
                 targetAssignment.standbyTasks,
                 targetAssignment.warmupTasks,
+                targetAssignment.resolvedTopicIds,
                 isGroupReady
             );
         }
@@ -898,6 +920,16 @@ public class StreamsMembershipManager implements RequestManager {
             .collect(Collectors.toMap(StreamsGroupHeartbeatResponseData.TaskIds::subtopologyId, taskId -> new TreeSet<>(taskId.partitions())));
     }
 
+    private static Map<String, SortedSet<Integer>> toTasksAssignmentFromTaskIdsWithResolvedTopicIds(final List<StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds> taskIdsWithResolvedTopicIds) {
+        return taskIdsWithResolvedTopicIds.stream()
+                .collect(Collectors.toMap(StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds::subtopologyId, taskId -> new TreeSet<>(taskId.partitions())));
+    }
+
+    private static Map<String, SortedSet<Uuid>> toSortedTopicIds(final List<StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds> taskIdsWithResolvedTopicIds) {
+        return taskIdsWithResolvedTopicIds.stream()
+                .collect(Collectors.toMap(StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds::subtopologyId, taskId -> new TreeSet<>(taskId.topicIds())));
+    }
+
     /**
      * Leaves the group when the member closes.
      *
@@ -973,7 +1005,7 @@ public class StreamsMembershipManager implements RequestManager {
 
     private CompletableFuture<Void> releaseActiveTasks() {
         if (memberEpoch > 0) {
-            return revokeActiveTasks(toTaskIdSet(currentAssignment.activeTasks));
+            return revokeActiveTasks(toTaskIdSet(currentAssignment.activeTasks), subscriptionState.assignedPartitions());
         } else {
             return releaseLostActiveTasks();
         }
@@ -1012,8 +1044,9 @@ public class StreamsMembershipManager implements RequestManager {
     private void processAssignmentReceived(Map<String, SortedSet<Integer>> activeTasks,
                                            Map<String, SortedSet<Integer>> standbyTasks,
                                            Map<String, SortedSet<Integer>> warmupTasks,
+                                           Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                            boolean isGroupReady) {
-        replaceTargetAssignmentWithNewAssignment(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+        replaceTargetAssignmentWithNewAssignment(activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady);
         if (!targetAssignmentReconciled()) {
             transitionTo(MemberState.RECONCILING);
         } else {
@@ -1033,8 +1066,9 @@ public class StreamsMembershipManager implements RequestManager {
     private void replaceTargetAssignmentWithNewAssignment(Map<String, SortedSet<Integer>> activeTasks,
                                                           Map<String, SortedSet<Integer>> standbyTasks,
                                                           Map<String, SortedSet<Integer>> warmupTasks,
+                                                          Map<String, SortedSet<Uuid>> resolvedTopicIds,
                                                           boolean isGroupReady) {
-        targetAssignment.updateWith(activeTasks, standbyTasks, warmupTasks, isGroupReady)
+        targetAssignment.updateWith(activeTasks, standbyTasks, warmupTasks, resolvedTopicIds, isGroupReady)
             .ifPresent(updatedAssignment -> {
                 log.debug("Target assignment updated from {} to {}. Member will reconcile it on the next poll.",
                     targetAssignment, updatedAssignment);
@@ -1047,7 +1081,7 @@ public class StreamsMembershipManager implements RequestManager {
      */
     @Override
     public NetworkClientDelegate.PollResult poll(long currentTimeMs) {
-        if (state == MemberState.RECONCILING) {
+        if (state == MemberState.RECONCILING || maybeRefreshMaterialization) {
             maybeReconcile();
         }
         return NetworkClientDelegate.PollResult.EMPTY;
@@ -1062,17 +1096,32 @@ public class StreamsMembershipManager implements RequestManager {
      *  - Another reconciliation is already in progress.
      */
     private void maybeReconcile() {
-        if (targetAssignmentReconciled()) {
+        final boolean assignmentChanged = !targetAssignmentReconciled();
+        final MaterializationPlan targetMaterializationPlan = buildMaterializationPlan(targetAssignment);
+
+        final SortedSet<TopicPartition> targetFetchablePartitions = targetMaterializationPlan.fetchablePartitions();
+        final SortedSet<TopicPartition> currentFetchablePartitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        currentFetchablePartitions.addAll(subscriptionState.assignedPartitions());
+
+        if (!assignmentChanged && currentFetchablePartitions.equals(targetFetchablePartitions) && targetMaterializationPlan.unresolvedActiveTasks.isEmpty()) {
             log.trace("Ignoring reconciliation attempt. Target assignment is equal to the " +
-                "current assignment.");
+                    "current assignment and the materialized partitions are already applied.");
+            maybeRefreshMaterialization = false;
             return;
         }
+        
+        if (!assignmentChanged && targetMaterializationPlan.metadataVersion == lastMetadataVersion) {
+            // If metadata version is not updated yet, there is no changes to update.
+            return;
+        }
+        
         if (reconciliationInProgress) {
             log.trace("Ignoring reconciliation attempt. Another reconciliation is already in progress. Assignment {}" +
                 " will be handled in the next reconciliation loop.", targetAssignment);
             return;
         }
 
+        lastMetadataVersion = targetMaterializationPlan.metadataVersion;
         markReconciliationInProgress();
 
         SortedSet<StreamsRebalanceData.TaskId> assignedActiveTasks = toTaskIdSet(targetAssignment.activeTasks);
@@ -1085,70 +1134,84 @@ public class StreamsMembershipManager implements RequestManager {
         SortedSet<StreamsRebalanceData.TaskId> ownedWarmupTasks = toTaskIdSet(currentAssignment.warmupTasks);
         boolean isGroupReady = targetAssignment.isGroupReady;
 
-        log.info("Assigned tasks with local epoch {} and group {}\n" +
-                "\tMember:                        {}\n" +
-                "\tAssigned active tasks:         {}\n" +
-                "\tOwned active tasks:            {}\n" +
-                "\tActive tasks to revoke:        {}\n" +
-                "\tAssigned standby tasks:        {}\n" +
-                "\tOwned standby tasks:           {}\n" +
-                "\tAssigned warm-up tasks:        {}\n" +
-                "\tOwned warm-up tasks:           {}\n",
-            targetAssignment.localEpoch,
-            isGroupReady ? "is ready" : "is not ready",
-            memberId,
-            assignedActiveTasks,
-            ownedActiveTasks,
-            activeTasksToRevoke,
-            assignedStandbyTasks,
-            ownedStandbyTasks,
-            assignedWarmupTasks,
-            ownedWarmupTasks
-        );
-
-        SortedSet<TopicPartition> ownedTopicPartitionsFromSubscriptionState = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
-        ownedTopicPartitionsFromSubscriptionState.addAll(subscriptionState.assignedPartitions());
-        SortedSet<TopicPartition> ownedTopicPartitionsFromAssignedTasks =
-            topicPartitionsForActiveTasks(currentAssignment.activeTasks);
-        if (!ownedTopicPartitionsFromAssignedTasks.equals(ownedTopicPartitionsFromSubscriptionState)) {
-            throw new IllegalStateException("Owned partitions from subscription state and owned partitions from " +
-                "assigned active tasks are not equal. " +
-                "Owned partitions from subscription state: " + ownedTopicPartitionsFromSubscriptionState + ", " +
-                "Owned partitions from assigned active tasks: " + ownedTopicPartitionsFromAssignedTasks);
+        if (assignmentChanged) {
+            log.info("Assigned tasks with local epoch {} and group {}\n" +
+                            "\tMember:                        {}\n" +
+                            "\tAssigned active tasks:         {}\n" +
+                            "\tOwned active tasks:            {}\n" +
+                            "\tActive tasks to revoke:        {}\n" +
+                            "\tAssigned standby tasks:        {}\n" +
+                            "\tOwned standby tasks:           {}\n" +
+                            "\tAssigned warm-up tasks:        {}\n" +
+                            "\tOwned warm-up tasks:           {}\n",
+                    targetAssignment.localEpoch,
+                    isGroupReady ? "is ready" : "is not ready",
+                    memberId,
+                    assignedActiveTasks,
+                    ownedActiveTasks,
+                    activeTasksToRevoke,
+                    assignedStandbyTasks,
+                    ownedStandbyTasks,
+                    assignedWarmupTasks,
+                    ownedWarmupTasks
+            );
         }
-        SortedSet<TopicPartition> assignedTopicPartitions = topicPartitionsForActiveTasks(targetAssignment.activeTasks);
-        SortedSet<TopicPartition> partitionsToRevoke = new TreeSet<>(ownedTopicPartitionsFromSubscriptionState);
-        partitionsToRevoke.removeAll(assignedTopicPartitions);
 
-        final CompletableFuture<Void> tasksRevoked = revokeActiveTasks(activeTasksToRevoke);
+        final SortedSet<TopicPartition> partitionsToRevoke = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToRevoke.addAll(currentFetchablePartitions);
+        partitionsToRevoke.removeAll(targetFetchablePartitions);
+        final CompletableFuture<Void> tasksRevoked = revokeActiveTasks(activeTasksToRevoke, partitionsToRevoke);
 
+        // The current target assignment is captured to ensure that acknowledging the current assignment is done with
+        // the same target assignment that was used when this reconciliation was initiated.
+        final LocalAssignment currentTargetAssignment = targetAssignment;
+        final long snapshotEpoch = currentTargetAssignment.localEpoch;
         final CompletableFuture<Void> tasksRevokedAndAssigned = tasksRevoked.thenCompose(__ -> {
-            if (!maybeAbortReconciliation()) {
-                return assignTasks(assignedActiveTasks, ownedActiveTasks, assignedStandbyTasks, assignedWarmupTasks, isGroupReady);
+            final boolean shouldAbort = assignmentChanged
+                    ? maybeAbortReconciliation()
+                    : maybeAbortMaterializationRefresh(snapshotEpoch, assignmentChanged);
+            if (!shouldAbort) {
+                return assignTasks(
+                        assignedActiveTasks,
+                        ownedActiveTasks,
+                        assignedStandbyTasks,
+                        assignedWarmupTasks,
+                        targetMaterializationPlan.activeTaskInputPartitions,
+                        targetFetchablePartitions,
+                        currentFetchablePartitions,
+                        isGroupReady);
             }
             return CompletableFuture.completedFuture(null);
         });
 
-        // The current target assignment is captured to ensure that acknowledging the current assignment is done with
-        // the same target assignment that was used when this reconciliation was initiated.
-        LocalAssignment currentTargetAssignment = targetAssignment;
+        
         tasksRevokedAndAssigned.whenComplete((__, callbackError) -> {
             if (callbackError != null) {
                 log.error("Reconciliation failed for tasks {}",
                     currentTargetAssignment, callbackError);
                 markReconciliationCompleted();
             } else {
-                if (reconciliationInProgress && !maybeAbortReconciliation()) {
-                    currentAssignment = currentTargetAssignment;
-                    transitionTo(MemberState.ACKNOWLEDGING);
+                final boolean shouldAbort = assignmentChanged
+                        ? maybeAbortReconciliation()
+                        : maybeAbortMaterializationRefresh(snapshotEpoch, assignmentChanged);
+                if (reconciliationInProgress && !shouldAbort) {
+                    if (assignmentChanged) {
+                        currentAssignment = currentTargetAssignment;
+                        transitionTo(MemberState.ACKNOWLEDGING);
+                    }
                     markReconciliationCompleted();
                 }
             }
         });
     }
-
-    private CompletableFuture<Void> revokeActiveTasks(final SortedSet<StreamsRebalanceData.TaskId> activeTasksToRevoke) {
+    
+    private CompletableFuture<Void> revokeActiveTasks(final SortedSet<StreamsRebalanceData.TaskId> activeTasksToRevoke,
+                                                      final Set<TopicPartition> partitionsToRevoke) {
         if (activeTasksToRevoke.isEmpty()) {
+            if (!partitionsToRevoke.isEmpty()) {
+                log.debug("Marking effective partitions pending for revocation: {}", partitionsToRevoke);
+                subscriptionState.markPendingRevocation(partitionsToRevoke);
+            }
             return CompletableFuture.completedFuture(null);
         }
 
@@ -1156,8 +1219,8 @@ public class StreamsMembershipManager implements RequestManager {
             .map(StreamsRebalanceData.TaskId::toString)
             .collect(Collectors.joining(", ")));
 
-        final SortedSet<TopicPartition> partitionsToRevoke = topicPartitionsForActiveTasks(activeTasksToRevoke);
-        log.debug("Marking partitions pending for revocation: {}", partitionsToRevoke);
+        log.debug("Marking effective partitions pending for revocation: {}", partitionsToRevoke);
+        
         subscriptionState.markPendingRevocation(partitionsToRevoke);
 
         CompletableFuture<Void> tasksRevoked = new CompletableFuture<>();
@@ -1178,6 +1241,9 @@ public class StreamsMembershipManager implements RequestManager {
                                                 final SortedSet<StreamsRebalanceData.TaskId> ownedActiveTasks,
                                                 final SortedSet<StreamsRebalanceData.TaskId> standbyTasksToAssign,
                                                 final SortedSet<StreamsRebalanceData.TaskId> warmupTasksToAssign,
+                                                final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions,
+                                                final SortedSet<TopicPartition> targetFetchablePartitions,
+                                                final SortedSet<TopicPartition> currentFetchablePartitions,
                                                 final boolean isGroupReady) {
         log.info("Assigning active tasks {{}}, standby tasks {{}}, and warm-up tasks {{}} to the member.",
             activeTasksToAssign.stream()
@@ -1191,9 +1257,15 @@ public class StreamsMembershipManager implements RequestManager {
                 .collect(Collectors.joining(", "))
         );
 
-        final SortedSet<TopicPartition> partitionsToAssign = topicPartitionsForActiveTasks(activeTasksToAssign);
-        final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned =
-            partitionsToAssignNotPreviouslyOwned(partitionsToAssign, topicPartitionsForActiveTasks(ownedActiveTasks));
+        
+        final SortedSet<TopicPartition> partitionsToAssign = targetFetchablePartitions;
+        final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToAssignNotPreviouslyOwned.addAll(targetFetchablePartitions);
+        partitionsToAssignNotPreviouslyOwned.removeAll(currentFetchablePartitions);
+
+        // final SortedSet<TopicPartition> partitionsToAssign = topicPartitionsForActiveTasks(activeTasksToAssign);
+        // final SortedSet<TopicPartition> partitionsToAssignNotPreviouslyOwned =
+        //    partitionsToAssignNotPreviouslyOwned(partitionsToAssign, topicPartitionsForActiveTasks(ownedActiveTasks));
 
         // Enqueue event to app thread to apply assignment within poll() and invoke callback.
         // The app thread will trigger ApplyAssignmentEvent to update subscription state on background thread.
@@ -1205,6 +1277,7 @@ public class StreamsMembershipManager implements RequestManager {
                     activeTasksToAssign,
                     standbyTasksToAssign,
                     warmupTasksToAssign,
+                    activeTaskInputPartitions,
                     isGroupReady
                 )
             );
@@ -1229,7 +1302,8 @@ public class StreamsMembershipManager implements RequestManager {
             .map(StreamsRebalanceData.TaskId::toString)
             .collect(Collectors.joining(", ")));
 
-        final SortedSet<TopicPartition> partitionsToRelease = topicPartitionsForActiveTasks(activeTasksToRelease);
+        final SortedSet<TopicPartition> partitionsToRelease = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+        partitionsToRelease.addAll(subscriptionState.assignedPartitions());
         log.debug("Marking lost partitions pending for revocation: {}", partitionsToRelease);
         subscriptionState.markPendingRevocation(partitionsToRelease);
 
@@ -1289,6 +1363,21 @@ public class StreamsMembershipManager implements RequestManager {
         return shouldAbort;
     }
 
+    private boolean maybeAbortMaterializationRefresh(final long snapshotEpoch, boolean assignmentChanged) {
+        final boolean shouldAbort = 
+                snapshotEpoch != targetAssignment.localEpoch ||
+                assignmentChanged ||
+                (state != MemberState.STABLE && state != MemberState.ACKNOWLEDGING);
+
+        if (shouldAbort) {
+            log.info("Interrupting materialization refresh because assignment/state changed. " +
+                            "snapshotEpoch={}, currentTargetEpoch={}, state={}",
+                    snapshotEpoch, targetAssignment.localEpoch, state);
+            markReconciliationCompleted();
+        }
+        return shouldAbort;
+    }
+
     private void markReconciliationInProgress() {
         reconciliationInProgress = true;
         rejoinedWhileReconciliationInProgress = false;
@@ -1306,6 +1395,106 @@ public class StreamsMembershipManager implements RequestManager {
         return onTasksRevokedCallbackNeededEvent.future();
     }
 
+    static final class MaterializationPlan {
+        // Assigned tasks and resolved topic.
+        final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions;
+
+        // Assigned tasks but topic is unresolved.
+        final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks;
+
+        final int metadataVersion; 
+
+        MaterializationPlan(final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions,
+                            final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks, 
+                            int metadataVersion
+                            ) {
+            this.activeTaskInputPartitions = Map.copyOf(activeTaskInputPartitions);
+            this.unresolvedActiveTasks = Set.copyOf(unresolvedActiveTasks);
+            this.metadataVersion = metadataVersion;
+        }
+
+        SortedSet<TopicPartition> fetchablePartitions() {
+            final SortedSet<TopicPartition> partitions = new TreeSet<>(TOPIC_PARTITION_COMPARATOR);
+            activeTaskInputPartitions.values().forEach(partitions::addAll);
+            return partitions;
+        }
+    }
+
+    private MaterializationPlan buildMaterializationPlan(final LocalAssignment assignment) {
+        final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> activeTaskInputPartitions = new HashMap<>();
+        final Set<StreamsRebalanceData.TaskId> unresolvedActiveTasks = new TreeSet<>();
+        boolean needsMetadataUpdate = false;
+        int metadataVersion = metadata.updateVersion();
+
+        for (final Map.Entry<String, SortedSet<Integer>> taskEntry : assignment.activeTasks.entrySet()) {
+            final String subtopologyId = taskEntry.getKey();
+            final SortedSet<Integer> taskPartitions = taskEntry.getValue();
+            final SortedSet<Uuid> topicIdsForSubtopology = assignment.resolvedTopicIds.get(subtopologyId);
+
+            if (topicIdsForSubtopology == null) {
+                throw new IllegalStateException("Missing resolved topic IDs for active subtopology " + subtopologyId);
+            }
+
+            
+
+            final List<String> resolvedSourceTopicNames = new ArrayList<>();
+            boolean subtopologyResolved = true;
+
+            for (final Uuid topicId : topicIdsForSubtopology) {
+                final Optional<String> maybeTopicName = findTopicNameInGlobalOrLocalCache(topicId);
+                if (maybeTopicName.isEmpty()) {
+                    subtopologyResolved = false;
+                    needsMetadataUpdate = true;
+                    break;
+                }
+                resolvedSourceTopicNames.add(maybeTopicName.get());
+            }
+
+            if (!subtopologyResolved) {
+                for (final int partitionId : taskPartitions) {
+                    unresolvedActiveTasks.add(new StreamsRebalanceData.TaskId(subtopologyId, partitionId));
+                }
+                continue;
+            }
+
+            final StreamsRebalanceData.Subtopology subtopology = streamsRebalanceData.subtopologies().get(subtopologyId);
+            final List<String> inputTopics = new ArrayList<>(resolvedSourceTopicNames);
+            inputTopics.addAll(subtopology.repartitionSourceTopics().keySet());
+
+            for (final int partitionId : taskPartitions) {
+                final StreamsRebalanceData.TaskId taskId = new StreamsRebalanceData.TaskId(subtopologyId, partitionId);
+                final Set<TopicPartition> taskInputPartitions = inputTopics.stream()
+                        .map(topic -> new TopicPartition(topic, partitionId))
+                        .collect(Collectors.toSet());
+                activeTaskInputPartitions.put(taskId, taskInputPartitions);
+            }
+        }
+
+        if (needsMetadataUpdate) {
+            metadata.requestUpdate(true);
+        }
+        
+        maybeRefreshMaterialization = needsMetadataUpdate;
+        return new MaterializationPlan(activeTaskInputPartitions, unresolvedActiveTasks, metadataVersion);
+    }
+
+    private Optional<String> findTopicNameInGlobalOrLocalCache(Uuid topicId) {
+        String nameFromMetadataCache = metadata.topicNames().getOrDefault(topicId, null);
+        if (nameFromMetadataCache != null) {
+            // Add topic name to local cache, so it can be reused if included in a next target
+            // assignment if metadata cache not available.
+            assignedTopicNamesCache.put(topicId, nameFromMetadataCache);
+            return Optional.of(nameFromMetadataCache);
+        } else {
+            // Topic ID was not found in metadata. Check if the topic name is in the local
+            // cache of topics currently assigned. This will avoid a metadata request in the
+            // case where the metadata cache may have been flushed right before the
+            // revocation of a previously assigned topic.
+            String nameFromSubscriptionCache = assignedTopicNamesCache.getOrDefault(topicId, null);
+            return Optional.ofNullable(nameFromSubscriptionCache);
+        }
+    }
+    
     /**
      * Enqueue event to notify the app thread that new partitions have been reconciled.
      * The app thread will trigger the assignment update (via ApplyAssignmentEvent) and invoke

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -712,8 +712,8 @@ public class StreamsMembershipManager implements RequestManager {
         }
         
         updateMemberEpoch(responseData.memberEpoch());
-
-        final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks = responseData.activeTasks();
+//        responseData.activeTasks();
+        final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks = responseData.standbyTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> standbyTasks = responseData.standbyTasks();
         final List<StreamsGroupHeartbeatResponseData.TaskIds> warmupTasks = responseData.warmupTasks();
         final boolean isGroupReady = isGroupReady(responseData.status());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * This class holds the data that is needed to participate in the Streams rebalance protocol.
@@ -157,27 +158,41 @@ public class StreamsRebalanceData {
 
         private final Set<TaskId> warmupTasks;
 
+        private final Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions;
+        
         private final boolean isGroupReady;
 
         private Assignment() {
             this.activeTasks = Set.of();
             this.standbyTasks = Set.of();
             this.warmupTasks = Set.of();
+            this.activeTaskInputPartitions = Map.of();
             this.isGroupReady = false;
         }
 
         public Assignment(final Set<TaskId> activeTasks,
                           final Set<TaskId> standbyTasks,
                           final Set<TaskId> warmupTasks,
+                          final Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions,
                           final boolean isGroupReady) {
             this.activeTasks = Set.copyOf(Objects.requireNonNull(activeTasks, "Active tasks cannot be null"));
             this.standbyTasks = Set.copyOf(Objects.requireNonNull(standbyTasks, "Standby tasks cannot be null"));
             this.warmupTasks = Set.copyOf(Objects.requireNonNull(warmupTasks, "Warmup tasks cannot be null"));
             this.isGroupReady = isGroupReady;
+            this.activeTaskInputPartitions = activeTaskInputPartitions.entrySet().stream().collect(
+                    Collectors.toUnmodifiableMap(
+                            Map.Entry::getKey,
+                            entry -> Set.copyOf(entry.getValue())
+                    )
+            );
         }
 
         public Set<TaskId> activeTasks() {
             return activeTasks;
+        }
+
+        public Map<TaskId, Set<TopicPartition>> activeTaskInputPartitions() {
+            return activeTaskInputPartitions;
         }
 
         public Set<TaskId> standbyTasks() {
@@ -204,16 +219,17 @@ public class StreamsRebalanceData {
             return Objects.equals(activeTasks, that.activeTasks)
                 && Objects.equals(standbyTasks, that.standbyTasks)
                 && Objects.equals(warmupTasks, that.warmupTasks)
+                && Objects.equals(activeTaskInputPartitions, that.activeTaskInputPartitions)
                 && isGroupReady == that.isGroupReady;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return Objects.hash(activeTasks, standbyTasks, warmupTasks, activeTaskInputPartitions, isGroupReady);
         }
 
         public Assignment copy() {
-            return new Assignment(activeTasks, standbyTasks, warmupTasks, isGroupReady);
+            return new Assignment(activeTasks, standbyTasks, warmupTasks, activeTaskInputPartitions, isGroupReady);
         }
 
         @Override
@@ -222,6 +238,7 @@ public class StreamsRebalanceData {
                 "activeTasks=" + activeTasks +
                 ", standbyTasks=" + standbyTasks +
                 ", warmupTasks=" + warmupTasks +
+                ", activeTaskInputPartitions=" + activeTaskInputPartitions +
                 ", isGroupReady=" + isGroupReady +
                 '}';
         }

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
@@ -18,7 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "StreamsGroupHeartbeatRequest",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -17,7 +17,7 @@
   "apiKey": 88,
   "type": "response",
   "name": "StreamsGroupHeartbeatResponse",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
@@ -57,7 +57,7 @@
       "about": "Indicate zero or more status for the group." },
 
     // The streams app knows which partitions to fetch from given this information
-    { "name": "ActiveTasks", "type": "[]TaskIds", "versions": "0+", "nullableVersions": "0+", "default": "null",
+    { "name": "ActiveTasks", "type": "[]TaskIdsWithResolvedTopicIds", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "Assigned active tasks for this client. Null if unchanged since last heartbeat." },
     { "name": "StandbyTasks", "type": "[]TaskIds", "versions": "0+", "nullableVersions": "0+", "default": "null",
       "about": "Assigned standby tasks for this client. Null if unchanged since last heartbeat." },
@@ -111,6 +111,15 @@
         "about": "The subtopology identifier." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
         "about": "The partitions of the input topics processed by this member." }
+    ]},
+    { "name": "TaskIdsWithResolvedTopicIds", "versions": "0+", "fields": [
+      { "name": "SubtopologyId", "type": "string", "versions": "0+",
+        "about": "The subtopology identifier." },
+      { "name": "Partitions", "type": "[]int32", "versions": "0+",
+        "about": "The partitions of the input topics processed by this member." },
+      { "name": "TopicIds", "type": "[]uuid", "versions": "1+",
+        "about": "The resolved topic ids."
+      }
     ]},
     { "name": "Endpoint", "versions": "0+", "fields": [
       { "name": "Host", "type": "string", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
@@ -2511,7 +2511,7 @@ public class StreamsMembershipManagerTest {
             .setErrorCode(Errors.NONE.code())
             .setMemberId(membershipManager.memberId())
             .setMemberEpoch(memberEpoch)
-            .setActiveTasks(activeTasks)
+//            .setActiveTasks(activeTasks)
             .setStandbyTasks(standbyTasks)
             .setWarmupTasks(warmupTasks);
         if (statuses != null) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
@@ -78,6 +78,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
 
 @ExtendWith(MockitoExtension.class)
 public class StreamsMembershipManagerTest {
@@ -128,7 +130,8 @@ public class StreamsMembershipManagerTest {
             streamsRebalanceData, subscriptionState, backgroundEventHandler,
             new LogContext("test"),
             time,
-            metrics
+            metrics,
+            mock(ConsumerMetadata.class)
         );
         membershipManager.registerStateListener(memberStateListener);
         verifyInStateUnsubscribed(membershipManager);
@@ -2511,7 +2514,7 @@ public class StreamsMembershipManagerTest {
             .setErrorCode(Errors.NONE.code())
             .setMemberId(membershipManager.memberId())
             .setMemberEpoch(memberEpoch)
-//            .setActiveTasks(activeTasks)
+            .setActiveTasks(activeTasks)
             .setStandbyTasks(standbyTasks)
             .setWarmupTasks(warmupTasks);
         if (statuses != null) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -116,6 +116,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
@@ -1295,6 +1297,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 );
                 break;
 
+            case STREAMS_GROUP_TARGET_ASSIGNMENT_RESOLVED_TOPIC_IDS:
+                groupMetadataManager.replay(
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsKey) key,
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsValue) Utils.messageOrNull(value)
+                );
+                break;
+                
             case STREAMS_GROUP_TARGET_ASSIGNMENT_MEMBER:
                 groupMetadataManager.replay(
                     (StreamsGroupTargetAssignmentMemberKey) key,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -134,6 +134,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
 import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.coordinator.group.modern.MemberState;
@@ -156,13 +158,11 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
+import org.apache.kafka.coordinator.group.streams.TasksTupleAndResolvedTopicIds;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
-import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
-import org.apache.kafka.coordinator.group.streams.topics.TopicConfigurationException;
+import org.apache.kafka.coordinator.group.streams.topics.*;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.authorizer.Authorizer;
 import org.apache.kafka.server.share.persister.DeleteShareGroupStateParameters;
@@ -301,19 +301,18 @@ public class GroupMetadataManager {
             );
         }
 
-        private static UpdateTargetAssignmentResult<TasksTuple> fromLastTargetAssignment(
+        private static UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> fromLastTargetAssignment(
             StreamsGroup group,
             Optional<StreamsGroupMember> member
         ) {
             if (member.isPresent()) {
-                return new UpdateTargetAssignmentResult<>(
-                    group.assignmentEpoch(),
-                    group.targetAssignment(member.get().memberId())
-                );
+                TasksTuple tasksTuple = group.targetAssignment(member.get().memberId());
+                TasksTupleAndResolvedTopicIds result = TasksTupleAndResolvedTopicIds.resolved(tasksTuple, group.targetAssignmentResolvedTopicIdPerSubTopology());
+                return new UpdateTargetAssignmentResult<>(group.assignmentEpoch(), result);
             } else {
                 return new UpdateTargetAssignmentResult<>(
                     group.assignmentEpoch(),
-                    TasksTuple.EMPTY
+                    TasksTupleAndResolvedTopicIds.EMPTY
                 );
             }
         }
@@ -2028,7 +2027,9 @@ public class GroupMetadataManager {
         ConfiguredTopology updatedConfiguredTopology;
         boolean reconfigureTopology = group.topology().isEmpty();
         long metadataHash = group.metadataHash();
-        if (reconfigureTopology || group.configuredTopology().isEmpty() || group.hasMetadataExpired(currentTimeMs)) {
+        if (reconfigureTopology || group.configuredTopology().isEmpty() || group.hasMetadataExpired(currentTimeMs) ||
+            group.needsResolvedTopicIdsBackfill() // For Upgrade Path.
+        ) {
 
             metadataHash = group.computeMetadataHash(
                 metadataImage,
@@ -2041,6 +2042,16 @@ public class GroupMetadataManager {
                     groupId, memberId, metadataHash);
                 bumpGroupEpoch = true;
                 reconfigureTopology = true;
+            }
+            
+            if (group.needsResolvedTopicIdsBackfill()) {
+                log.info("[GroupId {}][MemberId {}] There is inconsistent assignment epoch. " +
+                                "resolved Topic Id Assignment Epoch {} " +
+                                "group assignment epoch {}.",
+                        groupId, memberId,
+                        group.targetAssignmentResolvedTopicIdsAssignmentEpoch(),
+                        group.assignmentEpoch());
+                bumpGroupEpoch = true;
             }
 
             if (reconfigureTopology || group.configuredTopology().isEmpty()) {
@@ -2104,7 +2115,7 @@ public class GroupMetadataManager {
         // 4. Update the target assignment if the group epoch is larger than the target assignment epoch or a static member
         // replaces an existing static member.
         // The delta between the existing and the new target assignment is persisted to the partition.
-        UpdateTargetAssignmentResult<TasksTuple> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
+        UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
             group,
             groupEpoch,
             Optional.of(updatedMember),
@@ -2124,11 +2135,12 @@ public class GroupMetadataManager {
             group::currentStandbyTaskProcessIds,
             group::currentWarmupTaskProcessIds,
             updateTargetAssignmentResult.targetAssignmentEpoch(),
-            updateTargetAssignmentResult.targetAssignment(),
+            updateTargetAssignmentResult.targetAssignment().tasksTuple(),
             ownedActiveTasks,
             ownedStandbyTasks,
             ownedWarmupTasks,
-            records
+            records,
+            updateTargetAssignmentResult.targetAssignment().isResolved()
         );
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
@@ -2142,11 +2154,23 @@ public class GroupMetadataManager {
             .setMemberEpoch(updatedMember.memberEpoch())
             .setHeartbeatIntervalMs(streamsGroupHeartbeatIntervalMs(groupId))
             .setTaskOffsetIntervalMs(streamsGroupTaskOffsetIntervalMs(groupId));
+        
         // The assignment is only provided in the following cases:
         // 1. The member is joining.
         // 2. The member's assignment has been updated.
-        if (memberEpoch == 0 || hasAssignedTasksChanged(member, updatedMember)) {
-            response.setActiveTasks(createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(updatedMember.assignedTasks().activeTasksWithEpochs()));
+        // 3. The member epoch is different with updated member epoch. (resolved topic ids may be updated.)
+        boolean shouldSendAssignment = updateTargetAssignmentResult.targetAssignment().isResolved() && (
+                memberEpoch == 0 ||
+                hasAssignedTasksChanged(member, updatedMember) ||
+                !member.memberEpoch().equals(updatedMember.memberEpoch())
+        );
+        if (shouldSendAssignment) {
+            response.setActiveTasks(
+                    createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
+                            updatedMember.assignedTasks().activeTasksWithEpochs(),
+                            updateTargetAssignmentResult.targetAssignment().resolvedTopicIds().get()
+                    )
+            );
             response.setStandbyTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().standbyTasks()));
             response.setWarmupTasks(createStreamsGroupHeartbeatResponseTaskIds(updatedMember.assignedTasks().warmupTasks()));
             group.invalidateCachedEndpointToPartitions(updatedMember.memberId());
@@ -2265,14 +2289,26 @@ public class GroupMetadataManager {
             .collect(Collectors.toList());
     }
 
-    private static List<StreamsGroupHeartbeatResponseData.TaskIds> createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
-        final Map<String, Map<Integer, Integer>> taskIdsWithEpochs
+    private static List<StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds> createStreamsGroupHeartbeatResponseTaskIdsFromEpochs(
+            final Map<String, Map<Integer, Integer>> taskIdsWithEpochs,
+            final Map<String, List<Uuid>> resolvedTopicIds
     ) {
-        return taskIdsWithEpochs.entrySet().stream()
-            .map(entry -> new StreamsGroupHeartbeatResponseData.TaskIds()
-                .setSubtopologyId(entry.getKey())
-                .setPartitions(entry.getValue().keySet().stream().sorted().toList()))
-            .collect(Collectors.toList());
+
+        final List<StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds> results = new ArrayList<>();
+        for (Map.Entry<String, Map<Integer, Integer>> entry : taskIdsWithEpochs.entrySet()) {
+            StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds res = new StreamsGroupHeartbeatResponseData.TaskIdsWithResolvedTopicIds();
+            
+            String subTopologyId = entry.getKey();
+            res.setSubtopologyId(subTopologyId);
+            res.setPartitions(entry.getValue().keySet().stream().sorted().toList());
+
+            // If an active task has a subtopology ID, but the resolved topic IDs do not include that subtopology ID, 
+            // throwIfAssignmentStateInvalid() throws an error, which results in an UnknownServerException.
+            res.setTopicIds(resolvedTopicIds.get(subTopologyId));
+
+            results.add(res);
+        }
+        return results;
     }
 
     /**
@@ -3672,9 +3708,14 @@ public class GroupMetadataManager {
         List<StreamsGroupHeartbeatRequestData.TaskIds> ownedActiveTasks,
         List<StreamsGroupHeartbeatRequestData.TaskIds> ownedStandbyTasks,
         List<StreamsGroupHeartbeatRequestData.TaskIds> ownedWarmupTasks,
-        List<CoordinatorRecord> records
+        List<CoordinatorRecord> records,
+        boolean isResolved
     ) {
         if (member.isReconciledTo(targetAssignmentEpoch)) {
+            return member;
+        }
+
+        if (!isResolved) {
             return member;
         }
 
@@ -3999,7 +4040,7 @@ public class GroupMetadataManager {
      * @param returnedStatus       A mutable collection of status to be returned in the response.
      * @return The new target assignment for the updated member, or EMPTY if no member specified.
      */
-    private UpdateTargetAssignmentResult<TasksTuple> maybeUpdateStreamsTargetAssignment(
+    private UpdateTargetAssignmentResult<TasksTupleAndResolvedTopicIds> maybeUpdateStreamsTargetAssignment(
         StreamsGroup group,
         int groupEpoch,
         Optional<StreamsGroupMember> updatedMember,
@@ -4019,11 +4060,13 @@ public class GroupMetadataManager {
 
             return new UpdateTargetAssignmentResult<>(
                 group.assignmentEpoch(),
-                TasksTuple.EMPTY
+                TasksTupleAndResolvedTopicIds.EMPTY
             );
         }
 
-        if (group.assignmentEpoch() >= groupEpoch) {
+        // If there is no resolved topic ids for previous version, 
+        // We don't allow use last target assignment.
+        if (group.assignmentEpoch() >= groupEpoch && group.hasCurrentTargetAssignmentResolvedTopicIds()) {
             // The assignment is up to date.
             return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
         }
@@ -4033,7 +4076,10 @@ public class GroupMetadataManager {
             streamsGroupAssignmentIntervalMs(group.groupId()),
             time.milliseconds()
         );
-        if (!canComputeNextTargetAssignment) {
+        
+        // If there is no resolved topic ids for previous streams group version, 
+        // We should not allow use last target assignment.
+        if (!canComputeNextTargetAssignment && group.hasCurrentTargetAssignmentResolvedTopicIds()) {
             returnedStatus.ifPresent(statusList -> statusList.add(
                 new Status()
                     .setStatusCode(StreamsGroupHeartbeatResponse.Status.ASSIGNMENT_DELAYED.code())
@@ -4041,6 +4087,24 @@ public class GroupMetadataManager {
             ));
 
             return UpdateTargetAssignmentResult.fromLastTargetAssignment(group, updatedMember);
+        }
+
+        Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology;
+        if (!configuredTopology.isReady()) {
+            resolvedTopicIdsPerSubTopology = Map.of();
+        } else {
+            Optional<Map<String, List<Uuid>>> maybeResolvedTopicIds = 
+                    resolveTopicIdsBySubtopology(configuredTopology, metadataImage);
+
+            if (maybeResolvedTopicIds.isEmpty()) {
+                returnedStatus.ifPresent(statusList -> statusList.add(
+                        new Status()
+                                .setStatusCode(StreamsGroupHeartbeatResponse.Status.ASSIGNMENT_DELAYED.code())
+                                .setStatusDetail("Assignment delayed because some of topic name missed their topic id.")
+                ));
+                return new UpdateTargetAssignmentResult<>(group.assignmentEpoch(), TasksTupleAndResolvedTopicIds.UNRESOLVED);
+            }
+            resolvedTopicIdsPerSubTopology = maybeResolvedTopicIds.get();
         }
 
         TaskAssignor assignor = streamsGroupAssignor(group.groupId());
@@ -4057,6 +4121,7 @@ public class GroupMetadataManager {
                 .withTopology(configuredTopology)
                 .withStaticMembers(group.staticMembers())
                 .withMetadataImage(metadataImage)
+                .withResolvedTopicIdsPerSubTopology(resolvedTopicIdsPerSubTopology)
                 .withTargetAssignment(group.targetAssignment());
 
             updatedMember.ifPresent(member ->
@@ -4076,12 +4141,16 @@ public class GroupMetadataManager {
                     group.groupId(), groupEpoch, assignor, assignorTimeMs);
             }
 
+            throwIfAssignmentStateInvalid(assignmentResult.targetAssignment(), assignmentResult.resolvedTopicIdsPerSubTopology());
             records.addAll(assignmentResult.records());
 
-            return new UpdateTargetAssignmentResult<>(
-                groupEpoch,
-                updatedMember.map(member -> assignmentResult.targetAssignment().get(member.memberId()))
-                    .orElse(TasksTuple.EMPTY)
+            return new UpdateTargetAssignmentResult<>(groupEpoch,
+                    TasksTupleAndResolvedTopicIds.resolved(
+                            updatedMember
+                                    .map(member -> assignmentResult.targetAssignment().get(member.memberId()))
+                                    .orElse(TasksTuple.EMPTY),
+                            assignmentResult.resolvedTopicIdsPerSubTopology()
+                    )
             );
         } catch (TaskAssignorException ex) {
             String msg = String.format("Failed to compute a new target assignment for epoch %d: %s",
@@ -4091,6 +4160,60 @@ public class GroupMetadataManager {
         }
     }
 
+    private void throwIfAssignmentStateInvalid(Map<String, TasksTuple> targetAssignment, 
+                                           Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology) {
+        Set<String> actualSubTopologyIds = new HashSet<>();
+        for (TasksTuple taskTuple : targetAssignment.values()) {
+            actualSubTopologyIds.addAll(taskTuple.activeTasks().keySet());
+        }
+
+        for (String subTopologyId : actualSubTopologyIds) {
+            if (!resolvedTopicIdsPerSubTopology.containsKey(subTopologyId)) {
+                // We can introduce other exception to indicate this situation.
+                throw new TaskAssignorException("Invalid streams target assignment state: missing resolved topic IDs for active subtopologies "
+                        + subTopologyId);
+            }
+        }
+    }
+
+    private Optional<Map<String, List<Uuid>>> resolveTopicIdsBySubtopology(
+            ConfiguredTopology updatedConfiguredTopology,
+            CoordinatorMetadataImage metadataImage) {
+
+        Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology = new HashMap<>();
+        if (updatedConfiguredTopology.subtopologies().isPresent()) {
+            SortedMap<String, ConfiguredSubtopology> stringConfiguredSubtopologySortedMap = updatedConfiguredTopology
+                    .subtopologies()
+                    .get();
+            for (Map.Entry<String, ConfiguredSubtopology> entry : stringConfiguredSubtopologySortedMap.entrySet()) {
+                String subTopologyId = entry.getKey();
+                Set<Uuid> topicIds = new HashSet<>();
+                // TODO. Do we consider all kind of topics as well? (internal topic, sink topic and so on.)
+                for (String topicName : entry.getValue().sourceTopics()) {
+                    Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadata = metadataImage.topicMetadata(topicName);
+                    if (topicMetadata.isEmpty()) {
+                        log.warn("The topic id is missed for topic name '{}'", topicName);
+                        return Optional.empty();
+                    }
+                    topicIds.add(topicMetadata.get().id());
+                }
+
+                for (Map.Entry<String, ConfiguredInternalTopic> stringConfiguredInternalTopicEntry : entry.getValue().repartitionSourceTopics().entrySet()) {
+                    String topicName = stringConfiguredInternalTopicEntry.getValue().name();
+                    Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadata = metadataImage.topicMetadata(topicName);
+                    if (topicMetadata.isEmpty()) {
+                        log.warn("The topic id is missed for topic name '{}'", topicName);
+                        return Optional.empty();
+                    }
+                    topicIds.add(topicMetadata.get().id());
+                }
+
+                resolvedTopicIdsPerSubTopology.put(subTopologyId, topicIds.stream().sorted().toList());
+            }
+        }
+        return Optional.of(resolvedTopicIdsPerSubTopology);
+    }
+    
     /**
      * Fires the initial rebalance for a streams group when the delay timer expires.
      * Computes and persists target assignment for all members if conditions are met.
@@ -5779,6 +5902,37 @@ public class GroupMetadataManager {
                     + " but the assignment still has " + streamsGroup.targetAssignment().size() + " members.");
             }
             streamsGroup.setTargetAssignmentMetadata(-1, 0L);
+        }
+    }
+
+    /**
+     * TBD. should be updated.
+     *
+     * @param key   A StreamsGroupTargetAssignmentResolvedTopicIdsKey key.
+     * @param value A StreamsGroupTargetAssignmentResolvedTopicIdsValue record.
+     */
+    public void replay(
+            StreamsGroupTargetAssignmentResolvedTopicIdsKey key,
+            StreamsGroupTargetAssignmentResolvedTopicIdsValue value
+    ) {
+        String groupId = key.groupId();
+
+        if (value != null) {
+            StreamsGroup streamsGroup = getOrMaybeCreatePersistedStreamsGroup(groupId, true);
+            Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology = new HashMap<>();
+            for (StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds resolvedTopicIds : value.resolvedTopicIdsBySubtopology()) {
+                resolvedTopicIdsPerSubTopology.put(resolvedTopicIds.subtopologyId(), resolvedTopicIds.topicIds());
+            }
+            streamsGroup.setTargetAssignmentResolvedTopicIds(value.assignmentEpoch(), resolvedTopicIdsPerSubTopology);
+        } else {
+            StreamsGroup streamsGroup;
+            try {
+                streamsGroup = getOrMaybeCreatePersistedStreamsGroup(groupId, false);
+            } catch (GroupIdNotFoundException ex) {
+                // If the group does not exist, we can ignore the tombstone.
+                return;
+            }
+            streamsGroup.setTargetAssignmentResolvedTopicIds(-1, new HashMap<>());
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentKey;
@@ -30,6 +31,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import java.util.ArrayList;
@@ -256,6 +259,54 @@ public class StreamsCoordinatorRecordHelpers {
         return CoordinatorRecord.tombstone(
             new StreamsGroupTargetAssignmentMetadataKey()
                 .setGroupId(groupId)
+        );
+    }
+
+    public static CoordinatorRecord newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+            String groupId,
+            int assignmentEpoch,
+            Map<String, List<Uuid>> subTopologyIdAndTopicIds
+    ) {
+        Objects.requireNonNull(groupId, "groupId should not be null here");
+        Objects.requireNonNull(subTopologyIdAndTopicIds, "subTopologyIdAndTopicIds should not be null here");
+
+        StreamsGroupTargetAssignmentResolvedTopicIdsKey key = new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                .setGroupId(groupId);
+
+        List<StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds> resolvedTopicIds = subTopologyIdAndTopicIds.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds ids =
+                            new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds();
+                    ids.setSubtopologyId(entry.getKey());
+                    ids.setTopicIds(entry.getValue());
+                    return ids;
+                })
+                .toList();
+
+        StreamsGroupTargetAssignmentResolvedTopicIdsValue value = new StreamsGroupTargetAssignmentResolvedTopicIdsValue()
+                .setAssignmentEpoch(assignmentEpoch)
+                .setResolvedTopicIdsBySubtopology(resolvedTopicIds);
+        return CoordinatorRecord.record(key, new ApiMessageAndVersion(value, (short) 0)
+        );
+    }
+
+    /**
+     * Creates a StreamsGroupTargetAssignmentResolvedTopicIds tombstone.
+     *
+     * @param groupId The streams group id.
+     * @return The record.
+     */
+    public static CoordinatorRecord newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(
+            String groupId
+
+    ) {
+        Objects.requireNonNull(groupId, "groupId should not be null here");
+
+        return CoordinatorRecord.tombstone(
+                new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                        .setGroupId(groupId)
         );
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroup.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.StaleMemberEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
@@ -173,6 +174,11 @@ public class StreamsGroup implements Group {
     private final TimelineHashMap<String, TasksTuple> targetAssignment;
 
     /**
+     * The target resolved topic ids per subtopology.
+     */
+    private final TimelineObject<TargetResolvedTopicIds> targetResolvedTopics;
+    
+    /**
      * These maps map each active/standby/warmup task to the process ID(s) of their current owner.
      * The mapping is of the form <code>subtopology -> partition -> memberId</code>.
      * When a member revokes a partition, it removes its process ID from this map.
@@ -246,6 +252,7 @@ public class StreamsGroup implements Group {
         this.targetAssignmentMetadata = new TimelineObject<>(snapshotRegistry, TargetAssignmentMetadata.INITIAL);
         this.targetAssignment = new TimelineHashMap<>(snapshotRegistry, 0);
         this.currentActiveTaskToProcessId = new TimelineHashMap<>(snapshotRegistry, 0);
+        this.targetResolvedTopics = new TimelineObject<>(snapshotRegistry, TargetResolvedTopicIds.INITIAL);
         this.currentStandbyTaskToProcessIds = new TimelineHashMap<>(snapshotRegistry, 0);
         this.currentWarmupTaskToProcessIds = new TimelineHashMap<>(snapshotRegistry, 0);
         this.topology = new TimelineObject<>(snapshotRegistry, Optional.empty());
@@ -362,6 +369,51 @@ public class StreamsGroup implements Group {
         this.targetAssignmentMetadata.set(new TargetAssignmentMetadata(targetAssignmentEpoch, targetAssignmentTimestamp));
         maybeUpdateGroupState();
     }
+
+    /**
+     * Sets the assignment resolved topic ids.
+     *
+     * @param assignmentEpoch The assignment Epoch.
+     * @param resolvedTopicIdPerSubTopology The resolved topic ids per sub topology.
+     */
+    public void setTargetAssignmentResolvedTopicIds(int assignmentEpoch,
+                                                    Map<String, List<Uuid>> resolvedTopicIdPerSubTopology) {
+        this.targetResolvedTopics.set(new TargetResolvedTopicIds(assignmentEpoch, resolvedTopicIdPerSubTopology));
+        maybeUpdateGroupState();
+    }
+
+    /**
+     * TBD
+     * @return
+     */
+    public int targetAssignmentResolvedTopicIdsAssignmentEpoch() {
+        return targetResolvedTopics.get().assignmentEpoch();
+    }
+
+    /**
+     * TBD
+     * @return
+     */
+    public Map<String, List<Uuid>> targetAssignmentResolvedTopicIdPerSubTopology() {
+        return targetResolvedTopics.get().topicIdsPerSubTopology();
+    }
+
+    /**
+     * TBD
+     * @return
+     */
+    public boolean hasCurrentTargetAssignmentResolvedTopicIds() {
+        return !targetAssignment().isEmpty() && // Not a bootstrap step
+                targetAssignmentResolvedTopicIdsAssignmentEpoch() == assignmentEpoch();        
+    }
+
+    public boolean needsResolvedTopicIdsBackfill() {
+        return !targetAssignment().isEmpty() // Not a bootstrap step.
+                && targetAssignmentResolvedTopicIdsAssignmentEpoch() != assignmentEpoch()
+                && groupEpoch() == assignmentEpoch();
+    }
+
+
 
     /**
      * Get member ID of a static member that matches the given group instance ID.
@@ -840,6 +892,7 @@ public class StreamsGroup implements Group {
         );
         records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(groupId()));
 
+        records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsTombstoneRecord(groupId()));
         members().forEach((memberId, member) ->
             records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupMemberTombstoneRecord(groupId(), memberId))
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
@@ -96,6 +97,11 @@ public class TargetAssignmentBuilder {
      */
     private ConfiguredTopology topology;
 
+    /**
+     * The topic ids per sub-topology.
+     */
+    private Map<String, List<Uuid>> topicIdsPerSubTopology;
+    
     /**
      * The static members in the group.
      */
@@ -187,6 +193,13 @@ public class TargetAssignmentBuilder {
         return this;
     }
 
+    public TargetAssignmentBuilder withResolvedTopicIdsPerSubTopology(
+            Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology
+    ) {
+        this.topicIdsPerSubTopology = resolvedTopicIdsPerSubTopology;
+        return this;
+    }
+    
     /**
      * Adds the existing target assignment.
      *
@@ -281,6 +294,7 @@ public class TargetAssignmentBuilder {
 
         // Compute the assignment.
         GroupAssignment newGroupAssignment;
+        Map<String, List<Uuid>> newTopicIdsPerSubTopology;
         if (topology.isReady()) {
             if (topology.subtopologies().isEmpty()) {
                 throw new IllegalStateException("Subtopologies must be present if topology is ready.");
@@ -292,9 +306,11 @@ public class TargetAssignmentBuilder {
                 ),
                 new TopologyMetadata(metadataImage, topology.subtopologies().get())
             );
+            newTopicIdsPerSubTopology = topicIdsPerSubTopology;
         } else {
             newGroupAssignment = new GroupAssignment(
                 memberSpecs.keySet().stream().collect(Collectors.toMap(x -> x, x -> MemberAssignment.empty())));
+            newTopicIdsPerSubTopology = Map.of();
         }
 
         // Compute delta from previous to new target assignment and create the
@@ -335,7 +351,18 @@ public class TargetAssignmentBuilder {
             time.milliseconds()
         ));
 
-        return new TargetAssignmentResult(records, newTargetAssignment);
+        // TODO: Should cover all test cases. 
+        // Temporarily insert this for POC.
+        if (newTopicIdsPerSubTopology != null) {
+            // Bump the target resolved topic ids.
+            records.add(StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+                    groupId,
+                    groupEpoch,
+                    newTopicIdsPerSubTopology
+            ));
+        }
+
+        return new TargetAssignmentResult(records, newTargetAssignment, newTopicIdsPerSubTopology);
     }
 
     private TasksTuple newMemberAssignment(
@@ -362,11 +389,13 @@ public class TargetAssignmentBuilder {
      */
     public record TargetAssignmentResult(
         List<CoordinatorRecord> records,
-        Map<String, TasksTuple> targetAssignment
+        Map<String, TasksTuple> targetAssignment,
+        Map<String, List<Uuid>> resolvedTopicIdsPerSubTopology
     ) {
         public TargetAssignmentResult {
             Objects.requireNonNull(records);
             Objects.requireNonNull(targetAssignment);
+            Objects.requireNonNull(resolvedTopicIdsPerSubTopology);
         }
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetResolvedTopicIds.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TargetResolvedTopicIds.java
@@ -1,0 +1,34 @@
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * hello
+ * @param assignmentEpoch
+ * @param topicIdsPerSubTopology
+ */
+public record TargetResolvedTopicIds(int assignmentEpoch, Map<String, List<Uuid>> topicIdsPerSubTopology) {
+
+    /**
+     * TBD.
+     */
+    public static final TargetResolvedTopicIds INITIAL = new TargetResolvedTopicIds(-1, new HashMap<>());
+
+    public TargetResolvedTopicIds {
+        Objects.requireNonNull(topicIdsPerSubTopology, "topicIdsPerSubTopology should not be null");
+
+        Map<String, List<Uuid>> copy = new HashMap<>();
+        topicIdsPerSubTopology.forEach((subtopologyId, topicIds) -> {
+            Objects.requireNonNull(subtopologyId, "subtopologyId should not be null");
+            Objects.requireNonNull(topicIds, "topicIds should not be null");
+            copy.put(subtopologyId, List.copyOf(topicIds));
+        });
+
+        topicIdsPerSubTopology = Map.copyOf(copy);
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleAndResolvedTopicIds.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TasksTupleAndResolvedTopicIds.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.Uuid;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * TBD.
+ * @param tasksTuple
+ * @param resolvedTopicIds
+ */
+public record TasksTupleAndResolvedTopicIds(TasksTuple tasksTuple, 
+                                            Optional<Map<String, List<Uuid>>> resolvedTopicIds) {
+
+    /**
+     * An empty task tuple.
+     */
+    public static final TasksTupleAndResolvedTopicIds EMPTY = new TasksTupleAndResolvedTopicIds(
+            TasksTuple.EMPTY,
+            Optional.of(Map.of())
+    );
+
+    public static final TasksTupleAndResolvedTopicIds UNRESOLVED = new TasksTupleAndResolvedTopicIds(
+            TasksTuple.EMPTY,
+            Optional.empty()
+    );
+
+    public static TasksTupleAndResolvedTopicIds resolved(
+            TasksTuple tasksTuple,
+            Map<String, List<Uuid>> resolvedTopicIds
+    ) {
+        return new TasksTupleAndResolvedTopicIds(tasksTuple, Optional.of(Map.copyOf(resolvedTopicIds)));
+    }
+
+    public static TasksTupleAndResolvedTopicIds unresolved(TasksTuple tasksTuple) {
+        return new TasksTupleAndResolvedTopicIds(tasksTuple, Optional.empty());
+    }
+
+    
+    /**
+     * TBD. 
+     */
+    public boolean isResolved() {
+        return resolvedTopicIds.isPresent();
+    }
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsKey.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 24,
+  "type": "coordinator-key",
+  "name": "StreamsGroupTargetAssignmentResolvedTopicIdsKey",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "0",
+      "about": "The group ID." }
+  ]
+}

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupTargetAssignmentResolvedTopicIdsValue.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 24,
+  "type": "coordinator-value",
+  "name": "StreamsGroupTargetAssignmentResolvedTopicIdsValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "AssignmentEpoch", "versions": "0+", "type": "int32",
+      "about": "The assignment epoch this resolved topic snapshot belongs to." },
+    { "name": "ResolvedTopicIdsBySubtopology", "versions": "0+", "type": "[]ResolvedTopicIds",
+      "about": "The resolved topic ids keyed by subtopology." }
+  ],
+  "commonStructs": [
+    { "name": "ResolvedTopicIds", "versions": "0+", "fields": [
+      { "name": "SubtopologyId", "type": "string", "versions": "0+",
+        "about": "The subtopology identifier." },
+      { "name": "TopicIds", "type": "[]uuid", "versions": "0+",
+        "about": "The resolved topic ids for the subtopology." }
+    ]}
+  ]
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -100,6 +100,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMemberValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShard;
@@ -1762,6 +1764,13 @@ public class GroupMetadataManagerTestContext {
                 );
                 break;
 
+            case STREAMS_GROUP_TARGET_ASSIGNMENT_RESOLVED_TOPIC_IDS:
+                groupMetadataManager.replay(
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsKey) key,
+                        (StreamsGroupTargetAssignmentResolvedTopicIdsValue) Utils.messageOrNull(value)
+                );
+                break;
+            
             case STREAMS_GROUP_TOPOLOGY:
                 groupMetadataManager.replay(
                     (StreamsGroupTopologyKey) key,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentKey;
@@ -32,6 +33,8 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsKey;
+import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentResolvedTopicIdsValue;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
@@ -400,6 +403,42 @@ class StreamsCoordinatorRecordHelpersTest {
         assertEquals(expectedRecord, StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataTombstoneRecord(GROUP_ID));
     }
 
+    @Test
+    public void testNewStreamsGroupTargetAssignmentResolvedTopicIdsRecord() {
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+
+        CoordinatorRecord expectedRecord = CoordinatorRecord.record(
+                new StreamsGroupTargetAssignmentResolvedTopicIdsKey()
+                        .setGroupId(GROUP_ID),
+                new ApiMessageAndVersion(
+                        new StreamsGroupTargetAssignmentResolvedTopicIdsValue()
+                                .setAssignmentEpoch(42)
+                                .setResolvedTopicIdsBySubtopology(List.of(
+                                        new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds()
+                                                .setSubtopologyId(SUBTOPOLOGY_1)
+                                                .setTopicIds(List.of(topicId2)),
+                                        new StreamsGroupTargetAssignmentResolvedTopicIdsValue.ResolvedTopicIds()
+                                                .setSubtopologyId(SUBTOPOLOGY_2)
+                                                .setTopicIds(List.of(topicId1))
+                                )),
+                        (short) 0
+                )
+        );
+
+        assertEquals(
+                expectedRecord,
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentResolvedTopicIdsRecord(
+                        GROUP_ID,
+                        42,
+                        Map.of(
+                                SUBTOPOLOGY_2, List.of(topicId1),
+                                SUBTOPOLOGY_1, List.of(topicId2)
+                        )
+                )
+        );
+    }
+    
     @Test
     public void testNewStreamsGroupCurrentAssignmentRecord() {
         StreamsGroupMember member = new StreamsGroupMember.Builder(MEMBER_ID)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,11 +66,11 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
 
     @Override
     public void onTasksRevoked(final Set<StreamsRebalanceData.TaskId> tasks) {
-        final Map<TaskId, Set<TopicPartition>> activeTasksToRevokeWithPartitions =
-            pairWithTopicPartitions(tasks.stream());
-        final Set<TopicPartition> partitionsToRevoke = activeTasksToRevokeWithPartitions.values().stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
+        final Set<TopicPartition> partitionsToRevoke = tasks.stream()
+                .map(streamsRebalanceData.reconciledAssignment().activeTaskInputPartitions()::get)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
 
         final long start = time.milliseconds();
         try {
@@ -88,8 +89,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
     @Override
     public void onTasksAssigned(final StreamsRebalanceData.Assignment assignment) {
         final long start = time.milliseconds();
-        final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions =
-            pairWithTopicPartitions(assignment.activeTasks().stream());
+        final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions = toTaskPartitionMap(assignment.activeTaskInputPartitions());
         final Map<TaskId, Set<TopicPartition>> standbyTasksWithPartitions =
             pairWithTopicPartitions(Stream.concat(assignment.standbyTasks().stream(), assignment.warmupTasks().stream()));
 
@@ -115,6 +115,15 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
         } finally {
             tasksLostSensor.record(time.milliseconds() - start);
         }
+    }
+
+    private Map<TaskId, Set<TopicPartition>> toTaskPartitionMap(
+            final Map<StreamsRebalanceData.TaskId, Set<TopicPartition>> assignmentMap
+    ) {
+        return assignmentMap.entrySet().stream().collect(Collectors.toMap(
+                entry -> toTaskId(entry.getKey()),
+                entry -> Set.copyOf(entry.getValue())
+        ));
     }
 
     private Map<TaskId, Set<TopicPartition>> pairWithTopicPartitions(final Stream<StreamsRebalanceData.TaskId> taskIdStream) {


### PR DESCRIPTION
## Summary

One possible way to support server-side regex in the StreamsGroup Protocol is for the broker to send topic IDs, and for Kafka Streams to resolve those topic IDs back to topic names on the client side before using them.

The ConsumerGroup Protocol already follows a similar model: the broker sends topic IDs, and the client only consumes topics whose names it can resolve locally. This POC explores the same general approach for the StreamsGroup Protocol.

This change introduces the end-to-end plumbing for that model. The broker continues to produce the authoritative task assignment, while the client materializes that assignment into fetchable `TaskId -> TopicPartition` mappings using local metadata.

## Scope
This is still a POC.

The current implementation does not yet include server-side regex source topic support itself. However, the remaining path appears straightforward: the broker would resolve regex source topics and send the corresponding topic IDs to the client, while the client would relax the regex-related constraints accordingly.

Also, broken method signatures in JavaDoc and some test code have not yet been cleaned up in this POC.

## Layering
This implementation can be divided into four layers.

### (1) Broker Assignment Layer
The broker produces the authoritative assignment and includes resolved topic IDs by subtopology in the response. The source of truth at this layer is the full task snapshot.

### (2) Membership / Client Control Plane Layer
StreamsMembershipManager manages the broker assignment in this layer. It operates on the full task snapshot and is responsible for owned-task reporting to the broker as well as callback sequencing.

### (3) Materialization / Fetch Layer
This layer resolves the topic IDs received from the broker into topic names using client metadata, and builds the actual fetchable TaskId -> TopicPartition plan. The source of truth in this layer is the materialized subset, and active tasks in subtopologies with unresolved source topics are excluded here.

### (4) Streams Runtime Layer
Callbacks and task control-plane behavior continue to use the full task snapshot. In contrast, the TopicPartitions used for actual runtime assignment and revocation are based on the materialized subset.

## Current Behavior
In this POC, if even one source topic ID in a given subtopology cannot be resolved to a topic name, the active tasks for that subtopology:

1. are not registered in SubscriptionState as TopicPartitions, and
2. are not included in the Streams runtime active assignment.
Once topic id -> topic name resolution becomes possible, they are included again in the materialization plan during the next maybeReconcile(), and are then reflected in fetch and runtime.

## Intent
The key idea of this POC is to keep the broker authoritative at the task-assignment level, while allowing the client to materialize only the subset that is currently resolvable from metadata.

In the previous version, the response included ResolvedTopicIds as a top-level field, but in this version, Resolved Topic Ids are included within the ActiveTaskIds structure.
- previous version: https://github.com/apache/kafka/pull/21909

