### PR TITLE
KAFKA-20440: Use default Keystore type instead of hardcoding PKCS12 keystore type

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -460,7 +460,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
 
         private KeyStore createKeyStoreFromPem(String privateKeyPem, String certChainPem, char[] keyPassword) {
             try {
-                KeyStore ks = KeyStore.getInstance("PKCS12");
+                KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                 ks.load(null, null);
                 Key key = privateKey(privateKeyPem, keyPassword);
                 Certificate[] certChain = certs(certChainPem);
@@ -473,7 +473,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
 
         private KeyStore createTrustStoreFromPem(String trustedCertsPem) {
             try {
-                KeyStore ts = KeyStore.getInstance("PKCS12");
+                KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
                 ts.load(null, null);
                 Certificate[] certs = certs(trustedCertsPem);
                 for (int i = 0; i < certs.length; i++) {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -221,7 +221,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka0"), aliases);
         assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not loaded");
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
-        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), trustStore.getType());
     }
 
     @Test
@@ -237,7 +237,7 @@ public class DefaultSslEngineFactoryTest {
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
         assertNotNull(trustStore.getCertificate("kafka1"), "Certificate not loaded");
         assertNull(trustStore.getKey("kafka1", null), "Unexpected private key");
-        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), trustStore.getType());
     }
 
     @Test
@@ -278,7 +278,7 @@ public class DefaultSslEngineFactoryTest {
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
         assertNotNull(keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()),
             "Private key not loaded");
-        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), keyStore.getType());
     }
 
     @Test
@@ -292,7 +292,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka0"), aliases);
         assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not found");
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
-        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), trustStore.getType());
     }
 
     @Test
@@ -308,7 +308,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka"), aliases);
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
         assertNotNull(keyStore.getKey("kafka", null), "Private key not loaded");
-        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), keyStore.getType());
     }
 
     @Test
@@ -324,7 +324,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka"), aliases);
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not found");
         assertNotNull(keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()), "Private key not found");
-        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
+        assertEquals(KeyStore.getDefaultType(), keyStore.getType());
     }
 
     private String pemFilePath(String pem) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -221,6 +221,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka0"), aliases);
         assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not loaded");
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
+        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
     }
 
     @Test
@@ -236,6 +237,7 @@ public class DefaultSslEngineFactoryTest {
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
         assertNotNull(trustStore.getCertificate("kafka1"), "Certificate not loaded");
         assertNull(trustStore.getKey("kafka1", null), "Unexpected private key");
+        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
     }
 
     @Test
@@ -276,6 +278,7 @@ public class DefaultSslEngineFactoryTest {
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
         assertNotNull(keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()),
             "Private key not loaded");
+        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
     }
 
     @Test
@@ -289,6 +292,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka0"), aliases);
         assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not found");
         assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
+        assertEquals(trustStore.getType(), KeyStore.getDefaultType());
     }
 
     @Test
@@ -304,6 +308,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka"), aliases);
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
         assertNotNull(keyStore.getKey("kafka", null), "Private key not loaded");
+        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
     }
 
     @Test
@@ -319,6 +324,7 @@ public class DefaultSslEngineFactoryTest {
         assertEquals(List.of("kafka"), aliases);
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not found");
         assertNotNull(keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()), "Private key not found");
+        assertEquals(keyStore.getType(), KeyStore.getDefaultType());
     }
 
     private String pemFilePath(String pem) throws Exception {

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -33,6 +33,7 @@ type: docs
 ### Notable changes in 4.4.0
 
   * The `ClientQuotaCallback#updateClusterMetadata` method is deprecated and will be removed in Kafka 5.0. Custom implementations of `ClientQuotaCallback` no longer need to override this method, as a default no-op implementation is now provided. For further details, please refer to [KIP-1200](https://cwiki.apache.org/confluence/x/axBJFg).
+  * The in-memory keystores (used for PEM certificates) now use the default type provided by `KeyStore.getDefaultType()` instead of the hardcoded PKCS12 type.   
 
 ## Upgrading to 4.3.0
 


### PR DESCRIPTION
This PR should fix
[KAFKA-20440](https://issues.apache.org/jira/browse/KAFKA-20440). It
removes the hardcoded PKCS12 in-memory keystore type that is used when
users use PEM certificates with Kafka brokers or clients. And it
replaces it with the default Keystore type based on the Java Virtual
Machine configuration. That should make the PEM support more flexible
and make it work even when running Kafka clients or servers in
environments with disabled PKCS12 support (such as the Chainguard
FIPS-compliant Java images that are based on Bouncy Castle and do not
support PKCS12 stores).

Reviewers: Mickael Maison <mimaison@apache.org>, Manikumar Reddy
 <manikumar.reddy@gmail.com>, Mickael Maison <mickael.maison@gmail.com>
