### PR TITLE
MINOR: Clarify components not considered for security issues

### DIFF
--- a/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
+++ b/connect/basic-auth-extension/src/main/java/org/apache/kafka/connect/rest/basic/auth/extension/PropertyFileLoginModule.java
@@ -45,7 +45,7 @@ import javax.security.auth.spi.LoginModule;
  * The absolute path of the file needs to specified using the option <b>file</b>
  *
  * <p><b>NOTE: This implementation is NOT intended to be used in production since the credentials are stored in PLAINTEXT in the
- * properties file.</b>
+ * properties file. For this reason, Apache Kafka project does not consider this a security issue.</b>
  */
 public class PropertyFileLoginModule implements LoginModule {
     private static final Logger log = LoggerFactory.getLogger(PropertyFileLoginModule.class);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/SafeObjectInputStream.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/SafeObjectInputStream.java
@@ -22,6 +22,12 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.util.Set;
 
+
+/**
+ * Security note: While it seems it possible to build a deserialization gadget to obtain RCE via
+ * FileOffsetBackingStore, it requires having write permissions on the filesystem of the Connect worker.
+ * For that reason the Apache Kafka project does not consider this a security issue.
+ */
 public class SafeObjectInputStream extends ObjectInputStream {
 
     protected static final Set<String> DEFAULT_NO_DESERIALIZE_CLASS_NAMES = Set.of(

--- a/trogdor/README.md
+++ b/trogdor/README.md
@@ -4,6 +4,9 @@ Trogdor is a test framework for Apache Kafka.
 
 Trogdor can run benchmarks and other workloads. Trogdor can also inject faults in order to stress test the system.
 
+Trogdor should only be used in development environment and it is designed to allow users to inject commands.
+For this reason, Apache Kafka project does not consider this a security issue.
+
 Quickstart
 =========================================================
 First, we want to [start a single-node Kafka cluster](https://github.com/apache/kafka/blob/trunk/README.md#running-a-kafka-broker)


### PR DESCRIPTION
The Apache Kafka project regularly receives, and rejects, security
reports for these components. Add notes explaining why the project don't
consider these as security issues. This will hopefully reduce the number
of duplicate reports we receive or at least give us something we can
point reporters to.

Reviewers: Luke Chen <showuon@gmail.com>, Josep Prat
 <josep.prat@aiven.io>
