### PR TITLE
KAFKA-20437: Fix ssl.enabled.protocols dynamic reconfiguration not being applied

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -155,14 +155,14 @@ public class SslConfigs {
             SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
             SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
             SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
-            SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
+            SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG,
+            SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG);
 
     public static final Set<String> NON_RECONFIGURABLE_CONFIGS = Set.of(
             BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,
             SslConfigs.SSL_PROTOCOL_CONFIG,
             SslConfigs.SSL_PROVIDER_CONFIG,
             SslConfigs.SSL_CIPHER_SUITES_CONFIG,
-            SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
             SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG,
             SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,
             SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG,

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +46,8 @@ import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -83,6 +87,48 @@ public abstract class SslFactoryTest {
             assertNotNull(engine);
             assertEquals(Set.of(tlsProtocol), Set.of(engine.getEnabledProtocols()));
             assertFalse(engine.getUseClientMode());
+        }
+    }
+
+    /**
+     * Regression test for KAFKA-20437.
+     *
+     * Verifies that a dynamic update to ssl.enabled.protocols is actually applied by
+     * SslFactory.reconfigure(). ssl.enabled.protocols must be in RECONFIGURABLE_CONFIGS so
+     * that createNewSslEngineFactory() copies the new value into nextConfigs, triggering
+     * shouldBeRebuilt() and rebuilding the SslEngineFactory with the restricted protocol set.
+     */
+    @Test
+    @DisabledOnJre(JRE.JAVA_8) // TLSv1.3 requires Java 11+
+    public void testReconfigureEnabledProtocolsIsApplied() throws Exception {
+        File trustStoreFile = TestUtils.tempFile("truststore", ".jks");
+        Map<String, Object> sslConfig = sslConfigsBuilder(ConnectionMode.SERVER)
+                .createNewTrustStore(trustStoreFile)
+                .build();
+
+        // Start with both TLSv1.2 and TLSv1.3 enabled.
+        sslConfig.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2", "TLSv1.3"));
+
+        try (SslFactory sslFactory = new SslFactory(ConnectionMode.SERVER)) {
+            sslFactory.configure(sslConfig);
+
+            SSLEngine engineBefore = sslFactory.createSslEngine("localhost", 0);
+            Set<String> protocolsBefore = Set.of(engineBefore.getEnabledProtocols());
+            assertTrue(protocolsBefore.contains("TLSv1.2"), "TLSv1.2 should be enabled before reconfigure");
+            assertTrue(protocolsBefore.contains("TLSv1.3"), "TLSv1.3 should be enabled before reconfigure");
+
+            // Dynamically restrict to TLSv1.3 only.
+            Map<String, Object> updatedConfig = new HashMap<>(sslConfig);
+            updatedConfig.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, List.of("TLSv1.3"));
+            sslFactory.reconfigure(updatedConfig);
+
+            SSLEngine engineAfter = sslFactory.createSslEngine("localhost", 0);
+            Set<String> protocolsAfter = Set.of(engineAfter.getEnabledProtocols());
+
+            assertFalse(protocolsAfter.contains("TLSv1.2"),
+                    "TLSv1.2 must be disabled after reconfiguring ssl.enabled.protocols to [TLSv1.3]");
+            assertTrue(protocolsAfter.contains("TLSv1.3"),
+                    "TLSv1.3 must remain enabled after reconfigure");
         }
     }
 


### PR DESCRIPTION
`ssl.enabled.protocols` is documented as a per-broker dynamically reconfigurable config, but it was classified in `SslConfigs.NON_RECONFIGURABLE_CONFIGS`. Because `SslFactory.createNewSslEngineFactory()` only   
  copies keys present in `RECONFIGURABLE_CONFIGS` into `nextConfigs`, the new value is silently dropped. `DefaultSslEngineFactory.shouldBeRebuilt()` then sees no diff and skips rebuilding the engine, leaving the  
  old protocol set active. As a result, operators who restrict `ssl.enabled.protocols` to TLSv1.3 via kafka-configs.sh see the change reflected in broker logs but TLSv1.2 connections continue to succeed.    
                                                                                                                                                                                                               
  This PR moves `ssl.enabled.protocols` from `NON_RECONFIGURABLE_CONFIGS` to `RECONFIGURABLE_CONFIGS`. With this change, `createNewSslEngineFactory()` copies the updated value into `nextConfigs`, `shouldBeRebuilt()`
  detects the diff, and a new `SslEngineFactory` is instantiated with the restricted protocol set. A regression test is added to `SslFactoryTest` that configures both TLSv1.2 and TLSv1.3, reconfigures to TLSv1.3
   only, and asserts that a newly created `SSLEngine` no longer advertises TLSv1.2.