### PR TITLE
KAFKA-20446 KAFKA-20447: Fix CVE-2026-28390 and CVE-2026-22184

### DIFF
--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -57,6 +57,7 @@ LABEL org.label-schema.name="kafka" \
       org.opencontainers.image.authors="Apache Kafka"
 
 RUN apk update ; \
+    apk upgrade --no-cache libcrypto3 libssl3 zlib; \
     apk add --no-cache gcompat ; \
     apk add --no-cache bash ; \
     mkdir -p /etc/kafka/docker /mnt/shared/config /opt/kafka/config /etc/kafka/secrets ; \

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -57,6 +57,7 @@ LABEL org.label-schema.name="kafka" \
       org.opencontainers.image.authors="Apache Kafka"
 
 RUN apk update ; \
+    # Fix CVE-2026-28390 and CVE-2026-22184. Remove this if alpine:latest is updated to a version that has these CVEs fixed.
     apk upgrade --no-cache libcrypto3 libssl3 zlib; \
     apk add --no-cache gcompat ; \
     apk add --no-cache bash ; \


### PR DESCRIPTION
Fix CVE for libcrypto3, libssl3, and zlib. We can remove these if alpine
update default version.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>, nileshkumar3 <nileshkumar3@gmail.com>
