### PR TITLE
KAFKA-20448: Fix Docker image builds when using local kafka archive

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux ; \
     apk upgrade ; \
     apk add --no-cache bash procps-ng; \
     mkdir opt/kafka; \
-    if [ -n "$kafka_url" ]; then \
+    if [ -n "${kafka_url:-}" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
@@ -73,7 +73,7 @@ RUN mkdir opt/kafka; \
     apk update ; \
     apk upgrade ; \
     apk add --no-cache bash procps-ng; \
-    if [ -n "$kafka_url" ]; then \
+    if [ -n "${kafka_url:-}" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir opt/kafka; \
     apk update ; \
     apk upgrade ; \
     apk add --no-cache bash procps-ng; \
-    if [ -n "${kafka_url:-}" ]; then \
+    if [ -n "$kafka_url" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -21,7 +21,7 @@ FROM docker.io/library/eclipse-temurin:21-jre-alpine AS build-jsa
 USER root
 
 # Get kafka from https://archive.apache.org/dist/kafka and pass the url through build arguments
-ARG kafka_url
+ARG kafka_url=""
 
 COPY jsa_launch /etc/kafka/docker/jsa_launch
 COPY server.properties /etc/kafka/docker/server.properties
@@ -33,7 +33,7 @@ RUN set -eux ; \
     apk upgrade ; \
     apk add --no-cache bash procps-ng; \
     mkdir opt/kafka; \
-    if [ -n "${kafka_url:-}" ]; then \
+    if [ -n "$kafka_url" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -20,6 +20,7 @@ TOPIC="test-topic"
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c opt/kafka/config/server.properties
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=kafka.jsa" opt/kafka/bin/kafka-server-start.sh opt/kafka/config/server.properties &
+KAFKA_PID=$!
 
 check_timeout() {
     if [ $TIMEOUT -eq 0 ]; then
@@ -39,7 +40,8 @@ echo "test" | opt/kafka/bin/kafka-console-producer.sh --topic $TOPIC --bootstrap
 opt/kafka/bin/kafka-console-consumer.sh --topic $TOPIC --from-beginning --bootstrap-server localhost:9092 --max-messages 1 --timeout-ms 20000
 [ $? -eq 0 ] || exit 1
 
-opt/kafka/bin/kafka-server-stop.sh
+kill -TERM $KAFKA_PID
+wait $KAFKA_PID
 
 # Wait until jsa file is generated
 TIMEOUT=20

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -30,7 +30,8 @@ COPY native_command.sh native_command.sh
 
 COPY *kafka.tgz /app
 
-RUN if [ -n "$kafka_url" ]; then \
+RUN set -eux ; \
+    if [ -n "${kafka_url:-}" ]; then \
         microdnf install wget; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -15,7 +15,7 @@
 
 FROM ghcr.io/graalvm/graalvm-community:21 AS build-native-image
 
-ARG kafka_url
+ARG kafka_url=""
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ COPY native_command.sh native_command.sh
 COPY *kafka.tgz /app
 
 RUN set -eux ; \
-    if [ -n "${kafka_url:-}" ]; then \
+    if [ -n "$kafka_url" ]; then \
         microdnf install wget; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \


### PR DESCRIPTION
Fix Docker JVM image build when using local kafka archive.

- Default ARG `kafka_url=""` in both JVM and native Dockerfiles. An
unset build arg is not exported to the shell, so `set -eux` failed with
"unbound variable". Also add `set -eux` to the native Dockerfile for
consistency.
- In `jsa_launch`, stop the broker with `kill -TERM $!` + `wait` instead
of `kafka-server-stop.sh`, which finds the PID by grepping ps and
returns before the JVM exits. Waiting on the PID guarantees the CDS
archive is written before the script checks for it.

Reviewers: dino2895 <dino2895un@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
