### PR TITLE
KAFKA-20449: Downgrade "not updating high watermark" log from WARN to DEBUG

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java
@@ -279,9 +279,9 @@ class OffsetFetcherUtils {
                 }
             } else {
                 if (isolationLevel == IsolationLevel.READ_COMMITTED) {
-                    log.warn("Not updating last stable offset for partition {} as it is no longer assigned", partition);
+                    log.debug("Not updating last stable offset for partition {} as it is no longer assigned", partition);
                 } else {
-                    log.warn("Not updating high watermark for partition {} as it is no longer assigned", partition);
+                    log.debug("Not updating high watermark for partition {} as it is no longer assigned", partition);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Downgrade the "Not updating high watermark" and "Not updating last
stable offset" log messages in
`OffsetFetcherUtils.updateSubscriptionState()` from `WARN` to `DEBUG`.
- These messages were added in KAFKA-20131 (commit abcbef6a4c) for the
case where a `LIST_OFFSETS` response arrives after a partition has
already been revoked during a rebalance.
- This is a benign race condition that requires no operator action, but
the `WARN` level causes problems for deployments that use warning rates
as a health signal — e.g., canary releases get rolled back due to the
high volume of warnings during rebalances.

## Test plan

- [x] Verify existing `OffsetFetcherUtils` tests pass
- [x] Confirm no tests assert on the log level of these messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewers: Lianet Magrans <98415067+lianetm@users.noreply.github.com>, vfpanjacek (github:vfpanjacek), Ken Huang <s7133700@gmail.com>
