### PR TITLE
KAFKA-20314: Update GraalVM to version 25 to fix native image segfault on startup

### DIFF
--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:21 AS build-native-image
+FROM ghcr.io/graalvm/graalvm-community:25 AS build-native-image
 
 ARG kafka_url=""
 

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# GraalVM 25+ required: earlier versions call getpwuid (not thread-safe), causing
+# intermittent segfaults (~2%) on startup. GraalVM 25 switches to getpwuid_r.
 FROM ghcr.io/graalvm/graalvm-community:25 AS build-native-image
 
 ARG kafka_url=""


### PR DESCRIPTION
Update GraalVM to version 25 to fix native image segfault on startup.

`getpwuid` is not thread-safe and caused intermittent segfaults (~2%)
during startup of kafka-native. GraalVM 25 fixes this by calling
`getpwuid_r` instead.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
