### PR TITLE
MINOR: add comma before "and" in README (for test the upload of gradle report when jdk version is different between trunk and 40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Streams has multiple sub-projects, but you can run all the tests:
     ./gradlew idea
 
 The `eclipse` task has been configured to use `${project_dir}/build_eclipse` as Eclipse's build directory. Eclipse's default
-build directory (`${project_dir}/bin`) clashes with Kafka's scripts directory and we don't use Gradle's build directory
+build directory (`${project_dir}/bin`) clashes with Kafka's scripts directory, and we don't use Gradle's build directory
 to avoid known issues with this configuration.
 
 IntelliJ Language Level awareness:


### PR DESCRIPTION
Summary: Test the upload of gradle report when jdk version is difference.