### PR TITLE
MINOR: Remove -SNAPSHOT in version.py

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -128,7 +128,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("4.2.1-SNAPSHOT")
+DEV_VERSION = KafkaVersion("4.2.1")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java


### PR DESCRIPTION
Remove `-SNAPSHOT` in version.py for 4.2.1 release.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
