### PR TITLE
MINOR: Fix ListValueStore's restoration in headers mode

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
@@ -50,9 +50,9 @@ import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForCompletion;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
@@ -63,8 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Timeout(600)
 @Tag("integration")
 public class OuterJoinListValueStoreRestorationTest {
-
-    private static final Logger log = LoggerFactory.getLogger(OuterJoinListValueStoreRestorationTest.class);
 
     private static final int NUM_BROKERS = 1;
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for verifying ListValueStore deserialization behavior after state restoration
+ * in header-aware stores used by outer join operations.
+ */
+@Timeout(600)
+@Tag("integration")
+public class OuterJoinListValueStoreRestorationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(OuterJoinListValueStoreRestorationTest.class);
+
+    private static final int NUM_BROKERS = 1;
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    private static final String LEFT_TOPIC = "left-topic";
+    private static final String RIGHT_TOPIC = "right-topic";
+    private static final String OUTPUT_TOPIC = "output-topic";
+
+    private String applicationId;
+    private Properties streamsConfig;
+    private KafkaStreams streams;
+
+    @BeforeAll
+    public static void startCluster() throws Exception {
+        CLUSTER.start();
+        CLUSTER.createTopic(LEFT_TOPIC, 1, 1);
+        CLUSTER.createTopic(RIGHT_TOPIC, 1, 1);
+        CLUSTER.createTopic(OUTPUT_TOPIC, 1, 1);
+    }
+
+    @AfterAll
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    @BeforeEach
+    public void before(final TestInfo testInfo) {
+        applicationId = "outer-join-restoration-test-" + safeUniqueTestName(testInfo);
+        streamsConfig = getStreamsConfig();
+    }
+
+    @AfterEach
+    public void after() {
+        if (streams != null) {
+            streams.close(Duration.ofSeconds(30));
+            streams.cleanUp();
+        }
+    }
+
+    private static Stream<Arguments> processingGuaranteeAndStoreFormat() {
+        return Stream.of(
+            Arguments.of(StreamsConfig.EXACTLY_ONCE_V2, StreamsConfig.DSL_STORE_FORMAT_DEFAULT),
+            Arguments.of(StreamsConfig.EXACTLY_ONCE_V2, StreamsConfig.DSL_STORE_FORMAT_HEADERS),
+            Arguments.of(StreamsConfig.AT_LEAST_ONCE, StreamsConfig.DSL_STORE_FORMAT_DEFAULT),
+            Arguments.of(StreamsConfig.AT_LEAST_ONCE, StreamsConfig.DSL_STORE_FORMAT_HEADERS)
+        );
+    }
+
+    private Properties getStreamsConfig() {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
+
+    private KafkaStreams createOuterJoinTopology() {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, String> leftStream = builder.stream(LEFT_TOPIC);
+        final KStream<String, String> rightStream = builder.stream(RIGHT_TOPIC);
+
+        leftStream.outerJoin(
+            rightStream,
+            (leftValue, rightValue) -> "left=" + leftValue + ", right=" + rightValue,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(60)),
+            StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
+        ).to(OUTPUT_TOPIC);
+
+        return new KafkaStreams(builder.build(), streamsConfig);
+    }
+
+    @ParameterizedTest
+    @MethodSource("processingGuaranteeAndStoreFormat")
+    public void testOuterJoinRestorationWithMultipleRecords(final String processingGuarantee,
+                                                            final String storeFormat) throws Exception {
+        // Configure processing guarantee and store format
+        streamsConfig.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee);
+        streamsConfig.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, storeFormat);
+
+        // Step 1: Initial Topology Start
+        streams = createOuterJoinTopology();
+        startApplicationAndWaitUntilRunning(streams);
+
+        // Step 2: Create Non-Joined Records
+        // Produce multiple records to left topic only (no match → non-joined records)
+        // CRITICAL: Do NOT advance window yet! Records must stay in store before restoration.
+        long timestamp = 1000L;
+        for (int i = 0; i < 10; i++) {
+            final String key = "key" + i;
+            produceRecord(LEFT_TOPIC, key, "left-" + i, timestamp);
+            timestamp += 100;
+        }
+
+        // Wait for processing and commit to changelog
+        Thread.sleep(5000);
+
+        // Step 3: Force State Restoration
+        streams.close(Duration.ofSeconds(30));
+        purgeLocalStreamsState(streamsConfig);
+
+        // Step 4: Restart with Restoration
+        streams = createOuterJoinTopology();
+        startApplicationAndWaitUntilRunning(streams);
+
+        // Wait for restoration
+        Thread.sleep(5000);
+
+        // Step 5: Trigger Window Advancement
+        // NOW advance window to trigger emitNonJoinedOuterRecords()
+        final long timestampBeyondWindow = 62000L; // Beyond 60-second window
+        produceRecord(LEFT_TOPIC, "trigger", "trigger-value", timestampBeyondWindow);
+
+        // Step 6: Verify output (would crash before the fix)
+        Thread.sleep(5000);
+
+        final List<KeyValue<String, String>> results = waitUntilMinKeyValueRecordsReceived(
+            getConsumerConfig(),
+            OUTPUT_TOPIC,
+            1,
+            30000
+        );
+
+        assertTrue(!results.isEmpty(), "Should have received output records");
+    }
+
+    @ParameterizedTest
+    @MethodSource("processingGuaranteeAndStoreFormat")
+    public void testOuterJoinWithGracePeriod(final String processingGuarantee,
+                                             final String storeFormat) throws Exception {
+        // Configure processing guarantee and store format
+        streamsConfig.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee);
+        streamsConfig.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, storeFormat);
+
+        // Test with grace period (60s window + 10s grace)
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, String> leftStream = builder.stream(LEFT_TOPIC);
+        final KStream<String, String> rightStream = builder.stream(RIGHT_TOPIC);
+
+        leftStream.outerJoin(
+            rightStream,
+            (leftValue, rightValue) -> "left=" + leftValue + ", right=" + rightValue,
+            JoinWindows.ofTimeDifferenceAndGrace(Duration.ofSeconds(60), Duration.ofSeconds(10)),
+            StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
+        ).to(OUTPUT_TOPIC);
+
+        // Step 1: Initial Topology Start
+        streams = new KafkaStreams(builder.build(), streamsConfig);
+        startApplicationAndWaitUntilRunning(streams);
+
+        // Step 2: Create Non-Joined Records
+        // CRITICAL: Do NOT advance window yet!
+        produceRecord(LEFT_TOPIC, "keyX", "leftX", 1000L);
+        Thread.sleep(5000);
+
+        // Step 3: Force State Restoration
+        streams.close(Duration.ofSeconds(30));
+        purgeLocalStreamsState(streamsConfig);
+
+        // Step 4: Restart with Restoration
+        streams = new KafkaStreams(builder.build(), streamsConfig);
+        startApplicationAndWaitUntilRunning(streams);
+        Thread.sleep(5000);
+
+        // Step 5: Trigger Window Advancement
+        // NOW advance beyond window + grace (60s + 10s = 70s)
+        produceRecord(LEFT_TOPIC, "trigger", "trigger-value", 72000L);
+        Thread.sleep(5000);
+
+        final List<KeyValue<String, String>> results = waitUntilMinKeyValueRecordsReceived(
+            getConsumerConfig(),
+            OUTPUT_TOPIC,
+            1,
+            30000
+        );
+
+        assertTrue(!results.isEmpty(), "Should have received output records");
+    }
+
+    private void produceRecord(final String topic, final String key, final String value, final long timestamp) {
+        final Properties producerConfig = new Properties();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            topic,
+            List.of(new KeyValue<>(key, value)),
+            producerConfig,
+            timestamp
+        );
+    }
+
+    private Properties getConsumerConfig() {
+        final Properties consumerConfig = new Properties();
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + applicationId);
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return consumerConfig;
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
@@ -52,6 +52,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.pu
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
@@ -116,7 +117,7 @@ public class OuterJoinListValueStoreRestorationTest {
         props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
+        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;
     }
@@ -166,13 +167,16 @@ public class OuterJoinListValueStoreRestorationTest {
         // 1- Use a probe record to verify end-to-end: process + commit
         produceRecord(LEFT_TOPIC, "probe", "probe-left", timestamp);
         produceRecord(RIGHT_TOPIC, "probe", "probe-right", timestamp);
-        // 2- Wait for the join result - this proves processing + commit happened
+        // 2- Wait for the join result - this proves processing happened
         waitUntilMinKeyValueRecordsReceived(
             getConsumerConfig(),
             OUTPUT_TOPIC,
-            1,  // Just need to see the probe result
+            1,
             30000
         );
+        // 3- Wait for all records to be processed and committed (zero lag)
+        // This ensures changelog commits have completed before we close
+        waitForCompletion(streams, 2, 30000);
 
         // Step 3: Force State Restoration
         streams.close(Duration.ofSeconds(30));

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OuterJoinListValueStoreRestorationTest.java
@@ -52,11 +52,11 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.pu
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Integration test for verifying ListValueStore deserialization behavior after state restoration
- * in header-aware stores used by outer join operations.
+ * in header-aware and default stores used by outer join operations.
  */
 @Timeout(600)
 @Tag("integration")
@@ -150,6 +150,7 @@ public class OuterJoinListValueStoreRestorationTest {
         startApplicationAndWaitUntilRunning(streams);
 
         // Step 2: Create Non-Joined Records
+
         // Produce multiple records to left topic only (no match → non-joined records)
         // CRITICAL: Do NOT advance window yet! Records must stay in store before restoration.
         long timestamp = 1000L;
@@ -159,8 +160,19 @@ public class OuterJoinListValueStoreRestorationTest {
             timestamp += 100;
         }
 
+
         // Wait for processing and commit to changelog
-        Thread.sleep(5000);
+
+        // 1- Use a probe record to verify end-to-end: process + commit
+        produceRecord(LEFT_TOPIC, "probe", "probe-left", timestamp);
+        produceRecord(RIGHT_TOPIC, "probe", "probe-right", timestamp);
+        // 2- Wait for the join result - this proves processing + commit happened
+        waitUntilMinKeyValueRecordsReceived(
+            getConsumerConfig(),
+            OUTPUT_TOPIC,
+            1,  // Just need to see the probe result
+            30000
+        );
 
         // Step 3: Force State Restoration
         streams.close(Duration.ofSeconds(30));
@@ -170,17 +182,12 @@ public class OuterJoinListValueStoreRestorationTest {
         streams = createOuterJoinTopology();
         startApplicationAndWaitUntilRunning(streams);
 
-        // Wait for restoration
-        Thread.sleep(5000);
-
         // Step 5: Trigger Window Advancement
+
         // NOW advance window to trigger emitNonJoinedOuterRecords()
         final long timestampBeyondWindow = 62000L; // Beyond 60-second window
         produceRecord(LEFT_TOPIC, "trigger", "trigger-value", timestampBeyondWindow);
 
-        // Step 6: Verify output (would crash before the fix)
-        Thread.sleep(5000);
-
         final List<KeyValue<String, String>> results = waitUntilMinKeyValueRecordsReceived(
             getConsumerConfig(),
             OUTPUT_TOPIC,
@@ -188,61 +195,7 @@ public class OuterJoinListValueStoreRestorationTest {
             30000
         );
 
-        assertTrue(!results.isEmpty(), "Should have received output records");
-    }
-
-    @ParameterizedTest
-    @MethodSource("processingGuaranteeAndStoreFormat")
-    public void testOuterJoinWithGracePeriod(final String processingGuarantee,
-                                             final String storeFormat) throws Exception {
-        // Configure processing guarantee and store format
-        streamsConfig.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingGuarantee);
-        streamsConfig.put(StreamsConfig.DSL_STORE_FORMAT_CONFIG, storeFormat);
-
-        // Test with grace period (60s window + 10s grace)
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final KStream<String, String> leftStream = builder.stream(LEFT_TOPIC);
-        final KStream<String, String> rightStream = builder.stream(RIGHT_TOPIC);
-
-        leftStream.outerJoin(
-            rightStream,
-            (leftValue, rightValue) -> "left=" + leftValue + ", right=" + rightValue,
-            JoinWindows.ofTimeDifferenceAndGrace(Duration.ofSeconds(60), Duration.ofSeconds(10)),
-            StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
-        ).to(OUTPUT_TOPIC);
-
-        // Step 1: Initial Topology Start
-        streams = new KafkaStreams(builder.build(), streamsConfig);
-        startApplicationAndWaitUntilRunning(streams);
-
-        // Step 2: Create Non-Joined Records
-        // CRITICAL: Do NOT advance window yet!
-        produceRecord(LEFT_TOPIC, "keyX", "leftX", 1000L);
-        Thread.sleep(5000);
-
-        // Step 3: Force State Restoration
-        streams.close(Duration.ofSeconds(30));
-        purgeLocalStreamsState(streamsConfig);
-
-        // Step 4: Restart with Restoration
-        streams = new KafkaStreams(builder.build(), streamsConfig);
-        startApplicationAndWaitUntilRunning(streams);
-        Thread.sleep(5000);
-
-        // Step 5: Trigger Window Advancement
-        // NOW advance beyond window + grace (60s + 10s = 70s)
-        produceRecord(LEFT_TOPIC, "trigger", "trigger-value", 72000L);
-        Thread.sleep(5000);
-
-        final List<KeyValue<String, String>> results = waitUntilMinKeyValueRecordsReceived(
-            getConsumerConfig(),
-            OUTPUT_TOPIC,
-            1,
-            30000
-        );
-
-        assertTrue(!results.isEmpty(), "Should have received output records");
+        assertFalse(results.isEmpty(), "Should have received output records");
     }
 
     private void produceRecord(final String topic, final String key, final String value, final long timestamp) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/OuterStreamJoinStoreFactory.java
@@ -96,7 +96,8 @@ public class OuterStreamJoinStoreFactory<K, V1, V2> extends AbstractConfigurable
         final TimestampedKeyAndJoinSideSerde<K> timestampedKeyAndJoinSideSerde = new TimestampedKeyAndJoinSideSerde<>(streamJoined.keySerde());
         final LeftOrRightValueSerde<V1, V2> leftOrRightValueSerde = new LeftOrRightValueSerde<>(streamJoined.valueSerde(), streamJoined.otherValueSerde());
 
-        final DslKeyValueParams dslKeyValueParams = new DslKeyValueParams(name, dslStoreFormat());
+        // Once the headers-aware version of ListValueStore is implemented (planned for AK 4.4), replace the PLAIN constant with the dslStoreFormat() method.
+        final DslKeyValueParams dslKeyValueParams = new DslKeyValueParams(name, DslStoreFormat.PLAIN);
         final KeyValueBytesStoreSupplier supplier;
 
         if (passedInDslStoreSuppliers != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -27,6 +27,8 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.internals.ChangeLoggingListValueBytesStore;
+import org.apache.kafka.streams.state.internals.ListValueStore;
 import org.apache.kafka.streams.state.internals.PlainToHeadersStoreAdapter;
 import org.apache.kafka.streams.state.internals.PlainToHeadersWindowStoreAdapter;
 import org.apache.kafka.streams.state.internals.RecordConverter;
@@ -59,6 +61,25 @@ final class StateManagerUtil {
     private StateManagerUtil() {}
 
     static RecordConverter converterForStore(final StateStore store) {
+        // Special case: ListValueStore logs raw serialized list bytes to changelog,
+        // NOT headers-wrapped bytes, even when the underlying store is headers-aware.
+        // We must use identity converter to avoid double-wrapping during restoration.
+        StateStore current = store;
+        while (current != null) {
+            // This will be removed in AK 4.4 when ListValueStore is a header store as well
+            if (current instanceof ListValueStore || current instanceof ChangeLoggingListValueBytesStore) {
+                return identity();
+            }
+
+            // If not a WrappedStateStore, we've reached the innermost store
+            if (!(current instanceof WrappedStateStore)) {
+                break;
+            }
+
+            // Unwrap one more level
+            current = ((WrappedStateStore<?, ?, ?>) current).wrapped();
+        }
+
         // First check if the top-level store implements HeadersBytesStore or TimestampedBytesStore
         if (isHeadersAware(store)) {
             if (store instanceof SessionStore) {
@@ -73,7 +94,7 @@ final class StateManagerUtil {
 
         // If top-level check didn't find the type, unwrap to find adapters
         // This handles persistent stores that use adapters
-        StateStore current = store;
+        current = store;
         while (current != null) {
             if (current instanceof TimestampedToHeadersStoreAdapter || current instanceof TimestampedToHeadersWindowStoreAdapter) {
                 // Adapter wraps a timestamped store, so restore in timestamped format

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -64,9 +64,9 @@ final class StateManagerUtil {
         // Special case: ListValueStore logs raw serialized list bytes to changelog,
         // NOT headers-wrapped bytes, even when the underlying store is headers-aware.
         // We must use identity converter to avoid double-wrapping during restoration.
+        // This will be removed in AK 4.4 when ListValueStore is a header store as well
         StateStore current = store;
         while (current != null) {
-            // This will be removed in AK 4.4 when ListValueStore is a header store as well
             if (current instanceof ListValueStore || current instanceof ChangeLoggingListValueBytesStore) {
                 return identity();
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -27,8 +27,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.state.SessionStore;
-import org.apache.kafka.streams.state.internals.ChangeLoggingListValueBytesStore;
-import org.apache.kafka.streams.state.internals.ListValueStore;
 import org.apache.kafka.streams.state.internals.PlainToHeadersStoreAdapter;
 import org.apache.kafka.streams.state.internals.PlainToHeadersWindowStoreAdapter;
 import org.apache.kafka.streams.state.internals.RecordConverter;
@@ -61,25 +59,6 @@ final class StateManagerUtil {
     private StateManagerUtil() {}
 
     static RecordConverter converterForStore(final StateStore store) {
-        // Special case: ListValueStore logs raw serialized list bytes to changelog,
-        // NOT headers-wrapped bytes, even when the underlying store is headers-aware.
-        // We must use identity converter to avoid double-wrapping during restoration.
-        // This will be removed in AK 4.4 when ListValueStore is a header store as well
-        StateStore current = store;
-        while (current != null) {
-            if (current instanceof ListValueStore || current instanceof ChangeLoggingListValueBytesStore) {
-                return identity();
-            }
-
-            // If not a WrappedStateStore, we've reached the innermost store
-            if (!(current instanceof WrappedStateStore)) {
-                break;
-            }
-
-            // Unwrap one more level
-            current = ((WrappedStateStore<?, ?, ?>) current).wrapped();
-        }
-
         // First check if the top-level store implements HeadersBytesStore or TimestampedBytesStore
         if (isHeadersAware(store)) {
             if (store instanceof SessionStore) {
@@ -94,7 +73,7 @@ final class StateManagerUtil {
 
         // If top-level check didn't find the type, unwrap to find adapters
         // This handles persistent stores that use adapters
-        current = store;
+        StateStore current = store;
         while (current != null) {
             if (current instanceof TimestampedToHeadersStoreAdapter || current instanceof TimestampedToHeadersWindowStoreAdapter) {
                 // Adapter wraps a timestamped store, so restore in timestamped format


### PR DESCRIPTION
Problem:  ListValueStore logs raw serialized list bytes to its
changelog, but during restoration, the headers-aware converter was
incorrectly wrapping the data again, causing deserialization failures
when reading restored records (EOFException/NullPointerException in
outer join operations).

Solution:  To get the right RocksDB store, change
`OuterStreamJoinStoreFactory` and create the
`KeyValueBytesStoreSupplier` by hard-coding the supplier type to PLAIN.

Reviewers: Matthias J. Sax <matthias@confluent.io>
