### PR TITLE
KAFKA-20461: Support -1 (infinite retention) for offsets.retention.minutes

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.record.internal.CompressionType;
 import org.apache.kafka.common.record.internal.Records;
 import org.apache.kafka.common.utils.Utils;
@@ -146,7 +147,8 @@ public class GroupCoordinatorConfig {
         "2) this retention period has elapsed since the last time an offset is committed for the partition and the group is no longer subscribed to the corresponding topic. " +
         "For standalone consumers (using manual assignment), offsets will be expired after this retention period has elapsed since the time of last commit. " +
         "Note that when a group is deleted via the delete-group request, its committed offsets will also be deleted without extra retention period; " +
-        "also when a topic is deleted via the delete-topic request, upon propagated metadata update any group's committed offsets for that topic will also be deleted without extra retention period.";
+        "also when a topic is deleted via the delete-topic request, upon propagated metadata update any group's committed offsets for that topic will also be deleted without extra retention period. " +
+        "Set to -1 for infinite retention, meaning committed offsets are never expired due to inactivity.";
 
     public static final String OFFSETS_RETENTION_CHECK_INTERVAL_MS_CONFIG = "offsets.retention.check.interval.ms";
     public static final long OFFSETS_RETENTION_CHECK_INTERVAL_MS_DEFAULT = 600000L;
@@ -381,6 +383,19 @@ public class GroupCoordinatorConfig {
     public static final int STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_DEFAULT = 15000;
     public static final String STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_DOC = "The minimum allowed value for the group-level configuration of " + GroupConfig.STREAMS_TASK_OFFSET_INTERVAL_MS_CONFIG;
 
+    /**
+     * Validator for {@link #OFFSETS_RETENTION_MINUTES_CONFIG}: accepts -1 (infinite retention)
+     * or any positive integer. Zero is excluded because it would cause all offsets to expire
+     * on the very next cleanup cycle, which is never useful in practice.
+     */
+    public static final ConfigDef.Validator OFFSETS_RETENTION_MINUTES_VALIDATOR = (name, value) -> {
+        int intValue = (Integer) value;
+        if (intValue != -1 && intValue < 1) {
+            throw new ConfigException(name, value,
+                "Must be -1 (infinite retention) or a positive integer representing minutes.");
+        }
+    };
+
     public static final Set<String> RECONFIGURABLE_CONFIGS = Set.of(
         CACHED_BUFFER_MAX_BYTES_CONFIG,
         CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG,
@@ -410,7 +425,7 @@ public class GroupCoordinatorConfig {
 
         // Offset configs
         .define(OFFSET_METADATA_MAX_SIZE_CONFIG, INT, OFFSET_METADATA_MAX_SIZE_DEFAULT, HIGH, OFFSET_METADATA_MAX_SIZE_DOC)
-        .define(OFFSETS_RETENTION_MINUTES_CONFIG, INT, OFFSETS_RETENTION_MINUTES_DEFAULT, atLeast(1), HIGH, OFFSETS_RETENTION_MINUTES_DOC)
+        .define(OFFSETS_RETENTION_MINUTES_CONFIG, INT, OFFSETS_RETENTION_MINUTES_DEFAULT, OFFSETS_RETENTION_MINUTES_VALIDATOR, HIGH, OFFSETS_RETENTION_MINUTES_DOC)
         .define(OFFSETS_RETENTION_CHECK_INTERVAL_MS_CONFIG, LONG, OFFSETS_RETENTION_CHECK_INTERVAL_MS_DEFAULT, atLeast(1), HIGH, OFFSETS_RETENTION_CHECK_INTERVAL_MS_DOC)
 
         // Classic group configs
@@ -549,7 +564,8 @@ public class GroupCoordinatorConfig {
         this.classicGroupMinSessionTimeoutMs = config.getInt(GroupCoordinatorConfig.GROUP_MIN_SESSION_TIMEOUT_MS_CONFIG);
         this.classicGroupMaxSessionTimeoutMs = config.getInt(GroupCoordinatorConfig.GROUP_MAX_SESSION_TIMEOUT_MS_CONFIG);
         this.offsetsRetentionCheckIntervalMs = config.getLong(GroupCoordinatorConfig.OFFSETS_RETENTION_CHECK_INTERVAL_MS_CONFIG);
-        this.offsetsRetentionMs = config.getInt(GroupCoordinatorConfig.OFFSETS_RETENTION_MINUTES_CONFIG) * 60L * 1000L;
+        int offsetsRetentionMinutes = config.getInt(GroupCoordinatorConfig.OFFSETS_RETENTION_MINUTES_CONFIG);
+        this.offsetsRetentionMs = offsetsRetentionMinutes < 0 ? -1L : offsetsRetentionMinutes * 60L * 1000L;
         this.offsetCommitTimeoutMs = config.getInt(GroupCoordinatorConfig.OFFSET_COMMIT_TIMEOUT_MS_CONFIG);
         this.consumerGroupMigrationPolicy = ConsumerGroupMigrationPolicy.parse(
                 config.getString(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG));

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetExpirationConditionImpl.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/OffsetExpirationConditionImpl.java
@@ -38,6 +38,10 @@ public record OffsetExpirationConditionImpl(
      */
     @Override
     public boolean isOffsetExpired(OffsetAndMetadata offset, long currentTimestampMs, long offsetsRetentionMs) {
+        if (offsetsRetentionMs < 0) {
+            // Negative value means infinite retention; offsets never expire due to inactivity.
+            return false;
+        }
         if (offset.expireTimestampMs.isPresent()) {
             // Older versions with explicit expire_timestamp field => old expiration semantics is used
             return currentTimestampMs >= offset.expireTimestampMs.getAsLong();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -724,6 +724,26 @@ public class GroupCoordinatorConfigTest {
         assertEquals(20000, config.streamsGroupMinTaskOffsetIntervalMs());
     }
 
+    @Test
+    public void testOffsetsRetentionMinutesInfinite() {
+        // -1 should be accepted and stored as -1L (infinite retention sentinel)
+        GroupCoordinatorConfig config = createConfig(
+            Map.of(GroupCoordinatorConfig.OFFSETS_RETENTION_MINUTES_CONFIG, -1)
+        );
+        assertEquals(-1L, config.offsetsRetentionMs());
+    }
+
+    @Test
+    public void testOffsetsRetentionMinutesInvalidValuesRejected() {
+        // 0 and values below -1 are not valid; only -1 (infinite) and positive integers are accepted
+        assertThrows(ConfigException.class, () ->
+            createConfig(Map.of(GroupCoordinatorConfig.OFFSETS_RETENTION_MINUTES_CONFIG, 0))
+        );
+        assertThrows(ConfigException.class, () ->
+            createConfig(Map.of(GroupCoordinatorConfig.OFFSETS_RETENTION_MINUTES_CONFIG, -2))
+        );
+    }
+
     public static GroupCoordinatorConfig createConfig(Map<String, Object> configs) {
         return new GroupCoordinatorConfig(new AbstractConfig(
             GroupCoordinatorConfig.CONFIG_DEF,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetExpirationConditionImplTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/OffsetExpirationConditionImplTest.java
@@ -71,4 +71,36 @@ public class OffsetExpirationConditionImplTest {
         currentTimestamp = 999L;
         assertFalse(condition.isOffsetExpired(offsetAndMetadata, currentTimestamp, offsetsRetentionMs));
     }
+
+    @Test
+    public void testIsOffsetExpiredWithInfiniteRetention() {
+        long currentTimestamp = Long.MAX_VALUE;
+        long commitTimestamp = 0L;
+        long infiniteRetentionMs = -1L;
+
+        OffsetExpirationConditionImpl condition = new OffsetExpirationConditionImpl(__ -> commitTimestamp);
+
+        // With an explicit expire timestamp, infinite retention still prevents expiration.
+        OffsetAndMetadata offsetWithExpireTimestamp = new OffsetAndMetadata(
+            100,
+            OptionalInt.of(1),
+            "metadata",
+            commitTimestamp,
+            OptionalLong.of(0L),
+            Uuid.ZERO_UUID
+        );
+        assertFalse(condition.isOffsetExpired(offsetWithExpireTimestamp, currentTimestamp, infiniteRetentionMs));
+
+        // Without an explicit expire timestamp, infinite retention prevents expiration even when
+        // an arbitrarily large amount of time has elapsed since the commit.
+        OffsetAndMetadata offsetWithoutExpireTimestamp = new OffsetAndMetadata(
+            100,
+            OptionalInt.of(1),
+            "metadata",
+            commitTimestamp,
+            OptionalLong.empty(),
+            Uuid.ZERO_UUID
+        );
+        assertFalse(condition.isOffsetExpired(offsetWithoutExpireTimestamp, currentTimestamp, infiniteRetentionMs));
+    }
 }


### PR DESCRIPTION
KAFKA-20461: Support -1 (infinite retention) for offsets.retention.minutes

Author: Claude Sonnet 4.6

- https://cwiki.apache.org/confluence/display/KAFKA/KIP-20461%3A+Support+Infinite+Retention+for+Consumer+Group+Offsets
- https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-20461