### PR TITLE
MINOR: add DCL on get or create meter for performance improvement

### DIFF
--- a/server/src/main/java/org/apache/kafka/network/metrics/RequestMetrics.java
+++ b/server/src/main/java/org/apache/kafka/network/metrics/RequestMetrics.java
@@ -192,9 +192,13 @@ public class RequestMetrics {
             tags.put("error", error.name());
         }
 
-        private synchronized Meter getOrCreateMeter() {
+        private Meter getOrCreateMeter() {
             if (meter == null) {
-                meter = metricsGroup.newMeter(ERRORS_PER_SEC, "requests", TimeUnit.SECONDS, tags);
+                synchronized (this) {
+                    if (meter == null) {
+                        meter = metricsGroup.newMeter(ERRORS_PER_SEC, "requests", TimeUnit.SECONDS, tags);
+                    }
+                }
             }
             return meter;
         }


### PR DESCRIPTION
We have synchronized on method `getOrCreateMeter()`. It will cause the
process lock here every time, it would be better to lock when we
actually need to create the meter, otherwise we can just return the
existed value.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
