### PR TITLE
KAFKA-20456: Bound waitForFuture() timeout to less than max.poll.interval

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -483,6 +483,11 @@ public class StreamThread extends Thread implements ProcessingThread {
                 threadIdx
             );
 
+        final int dummyThreadIdxForConfig = 1;
+        final long maxPollIntervalMs = new InternalConsumerConfig(
+            config.getMainConsumerConfigs("dummyGroupId", "dummyClientId", dummyThreadIdxForConfig))
+            .getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
+
         final TaskManager taskManager = new TaskManager(
             time,
             changelogReader,
@@ -495,7 +500,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             adminClient,
             stateDirectory,
             stateUpdater,
-            schedulingTaskManager
+            schedulingTaskManager,
+            maxPollIntervalMs / 2
         );
         referenceContainer.taskManager = taskManager;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -500,7 +500,7 @@ public class StreamThread extends Thread implements ProcessingThread {
             stateDirectory,
             stateUpdater,
             schedulingTaskManager,
-            maxPollIntervalMs / 2
+            maxPollIntervalMs * 3 / 4
         );
         referenceContainer.taskManager = taskManager;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -483,10 +483,9 @@ public class StreamThread extends Thread implements ProcessingThread {
                 threadIdx
             );
 
-        final int dummyThreadIdxForConfig = 1;
-        final long maxPollIntervalMs = new InternalConsumerConfig(
-            config.getMainConsumerConfigs("dummyGroupId", "dummyClientId", dummyThreadIdxForConfig))
-            .getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
+        final long maxPollIntervalMs = Integer.parseInt(
+            config.getMainConsumerConfigs("dummy", "dummy", threadIdx)
+                .getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000").toString());
 
         final TaskManager taskManager = new TaskManager(
             time,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -158,6 +158,11 @@ public class TaskManager {
         this.mainConsumer = mainConsumer;
     }
 
+    // visible for testing
+    long waitForFutureTimeoutMs() {
+        return waitForFutureTimeoutMs;
+    }
+
     public double totalProducerBlockedTime() {
         return activeTaskCreator.totalProducerBlockedTime();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -110,6 +110,7 @@ public class TaskManager {
     private final StandbyTaskCreator standbyTaskCreator;
     private final StateUpdater stateUpdater;
     private final DefaultTaskManager schedulingTaskManager;
+    private final long waitForFutureTimeoutMs;
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
                 final ProcessId processId,
@@ -121,7 +122,8 @@ public class TaskManager {
                 final Admin adminClient,
                 final StateDirectory stateDirectory,
                 final StateUpdater stateUpdater,
-                final DefaultTaskManager schedulingTaskManager
+                final DefaultTaskManager schedulingTaskManager,
+                final long waitForFutureTimeoutMs
                 ) {
         this.time = time;
         this.processId = processId;
@@ -139,6 +141,7 @@ public class TaskManager {
 
         this.stateUpdater = stateUpdater;
         this.schedulingTaskManager = schedulingTaskManager;
+        this.waitForFutureTimeoutMs = waitForFutureTimeoutMs;
         this.tasks = tasks;
         this.taskExecutor = new TaskExecutor(
             this.tasks,
@@ -705,7 +708,7 @@ public class TaskManager {
                                                          final CompletableFuture<StateUpdater.RemovedTaskResult> future) {
         final StateUpdater.RemovedTaskResult removedTaskResult;
         try {
-            removedTaskResult = future.get(5, TimeUnit.MINUTES);
+            removedTaskResult = future.get(waitForFutureTimeoutMs, TimeUnit.MILLISECONDS);
             if (removedTaskResult == null) {
                 throw new IllegalStateException("Task " + taskId + " was not found in the state updater. "
                     + BUG_ERROR_MESSAGE);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -111,6 +111,7 @@ public class TaskManager {
     private final StateUpdater stateUpdater;
     private final DefaultTaskManager schedulingTaskManager;
     private final long waitForFutureTimeoutMs;
+    
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
                 final ProcessId processId,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -4207,14 +4207,14 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(properties);
         thread = createStreamThread(CLIENT_ID, config);
 
-        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(10_000L));
+        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(15_000L));
     }
 
     @Test
     public void shouldSetDefaultWaitForFutureTimeoutFromDefaultMaxPollIntervalMs() {
         thread = createStreamThread(CLIENT_ID, false);
 
-        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(150_000L));
+        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(225_000L));
     }
 
     private boolean runUntilTimeoutOrCondition(final Runnable action, final TestCondition testCondition) throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -4197,6 +4198,23 @@ public class StreamThreadTest {
             action.run();
             mockTime.sleep(10);
         }
+    }
+
+    @Test
+    public void shouldSetWaitForFutureTimeoutFromMaxPollIntervalMs() {
+        final Properties properties = configProps(false, false);
+        properties.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "20000");
+        final StreamsConfig config = new StreamsConfig(properties);
+        thread = createStreamThread(CLIENT_ID, config);
+
+        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(10_000L));
+    }
+
+    @Test
+    public void shouldSetDefaultWaitForFutureTimeoutFromDefaultMaxPollIntervalMs() {
+        thread = createStreamThread(CLIENT_ID, false);
+
+        assertThat(thread.taskManager().waitForFutureTimeoutMs(), equalTo(150_000L));
     }
 
     private boolean runUntilTimeoutOrCondition(final Runnable action, final TestCondition testCondition) throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1067,7 +1067,8 @@ public class StreamThreadTest {
             null,
             null,
             null,
-            null
+            null,
+            300_000L
         ) {
             @Override
             int commit(final Collection<? extends Task> tasksToCommit) {
@@ -1175,7 +1176,8 @@ public class StreamThreadTest {
             null,
             stateDirectory,
             stateUpdater,
-            schedulingTaskManager
+            schedulingTaskManager,
+            300_000L
         ) {
             @Override
             int commit(final Collection<? extends Task> tasksToCommit) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -228,7 +228,8 @@ public class TaskManagerTest {
             adminClient,
             stateDirectory,
             stateUpdater,
-            processingThreadsEnabled ? schedulingTaskManager : null
+            processingThreadsEnabled ? schedulingTaskManager : null,
+            300_000L
         );
         taskManager.setMainConsumer(consumer);
         return taskManager;


### PR DESCRIPTION
- `TaskManager.waitForFuture()` previously used a hardcoded 5-minute
timeout when waiting for the `StateUpdater` to process a REMOVE action.
When the `StateUpdater` is blocked (e.g., RocksDB write stall during
  changelog restoration), the StreamThread blocks for the full timeout
duration and cannot poll, exceeding `max.poll.interval.ms` and getting
kicked from the consumer group. This triggers a rebalance cascade
  that can lead to a crash loop.
- The timeout is now derived from the consumer's `max.poll.interval.ms`
config (maxPollIntervalMs / 2), ensuring the `StreamThread `regains
control and can poll before the consumer is removed from the group.
- This is a mitigation — the underlying task leak (when waitForFuture()
times out and the task is silently dropped) is addressed in a follow-up
PR.

Reviewers: Uladzislau Blok
 <123193120+UladzislauBlok@users.noreply.github.com>
