### PR TITLE
MINOR: remove un-necessary integration tags

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
  * migrated from the primary cluster to the backup cluster. Tests validate that consumer offsets
  * are translated and replicated from the primary cluster to the backup cluster during this failover.
  */
-@Tag("integration")
 public class IdentityReplicationIntegrationTest extends MirrorConnectorsIntegrationBaseTest {
     @BeforeEach
     public void startClusters() throws Exception {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/IdentityReplicationIntegrationTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.mirror.integration;
 import org.apache.kafka.connect.mirror.IdentityReplicationPolicy;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 
 import java.util.Map;
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests MM2 replication with exactly-once support enabled on the Connect clusters.
  */
-@Tag("integration")
 public class MirrorConnectorsIntegrationExactlyOnceTest extends MirrorConnectorsIntegrationBaseTest {
 
     @BeforeEach

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.connect.mirror.MirrorSourceConnector;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 /**
  * Tests MM2 replication with SSL enabled at backup kafka cluster
  */
-@Tag("integration")
 public class MirrorConnectorsIntegrationSSLTest extends MirrorConnectorsIntegrationBaseTest {
 
     @BeforeEach

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationSSLTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 
 import java.util.Map;
 import java.util.Properties;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
@@ -62,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests MM2 is using provided ForwardingAdmin to create/alter topics, partitions and ACLs.
  */
-@Tag("integration")
 public class MirrorConnectorsWithCustomForwardingAdminIntegrationTest extends MirrorConnectorsIntegrationBaseTest {
 
     private static final int TOPIC_ACL_SYNC_DURATION_MS = 30_000;

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsWithCustomForwardingAdminIntegrationTest.java
@@ -40,7 +40,6 @@ import org.apache.kafka.server.config.ServerConfigs;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;

--- a/tools/src/test/java/org/apache/kafka/tools/AbstractResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/AbstractResetIntegrationTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -63,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
+@Tag("integration")
 public abstract class AbstractResetIntegrationTest {
 
     static EmbeddedKafkaCluster cluster;

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -61,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests local state store and global application cleanup.
  */
-@Tag("integration")
 @Timeout(600)
 public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     private static final String NON_EXISTING_TOPIC = "nonExistingTopic";

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationWithSslTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationWithSslTest.java
@@ -36,7 +36,6 @@ import java.util.Properties;
 /**
  * Tests command line SSL setup for reset tool.
  */
-@Tag("integration")
 public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
 
     public static final EmbeddedKafkaCluster CLUSTER;

--- a/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationWithSslTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ResetIntegrationWithSslTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;


### PR DESCRIPTION
This removes un-necessary integration tags from the test suites.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
