### PR TITLE
KAFKA-20357: Persist lastProducerEpoch fields for the transaction log.

### DIFF
--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.requests.{AddPartitionsToTxnResponse, Transaction
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.common.utils.internals.LogContext
 import org.apache.kafka.common.utils.internals.ProducerIdAndEpoch
-import org.apache.kafka.coordinator.transaction.{CoordinatorEpochAndTxnMetadata, InitProducerIdResult, ProducerIdManager, TransactionConfig, TransactionMetadata, TransactionState, TransactionStateManagerConfig, TransactionalIdAndProducerIdEpoch, TxnTransitMetadata}
+import org.apache.kafka.coordinator.transaction.{CoordinatorEpochAndTxnMetadata, InitProducerIdResult, ProducerIdManager, TransactionLog, TransactionConfig, TransactionMetadata, TransactionState, TransactionStateManagerConfig, TransactionalIdAndProducerIdEpoch, TxnTransitMetadata}
 import org.apache.kafka.server.common.{RequestLocal, TransactionVersion}
 import org.apache.kafka.server.common.TransactionVersion.{TV_0, TV_2}
 import org.apache.kafka.server.util.MockScheduler
@@ -1877,6 +1877,80 @@ class TransactionCoordinatorTest {
     val expectedResult = new InitProducerIdResult(rotatedProducerId, rotatedEpoch, Errors.NONE) 
     assertEquals(expectedResult, result)
   }
+
+  @Test
+  def testRetryInitProducerIdAfterFailoverDuringProducerIdRotation(): Unit = {
+    // GIVEN
+    val exhaustedEpoch = (Short.MaxValue - 1).toShort
+    val originalMetadata = new TransactionMetadata(
+      transactionalId,
+      producerId,
+      RecordBatch.NO_PRODUCER_ID,
+      RecordBatch.NO_PRODUCER_ID,
+      exhaustedEpoch,
+      RecordBatch.NO_PRODUCER_EPOCH,
+      txnTimeoutMs,
+      TransactionState.EMPTY,
+      util.Set.of[TopicPartition](),
+      time.milliseconds(),
+      time.milliseconds(),
+      TV_2
+    )
+
+    // First coordinator rotates the producer id and writes the updated state to the log.
+    val rotatedMetadata = originalMetadata.prepareProducerIdRotation(
+      producerId + 1,
+      txnTimeoutMs,
+      time.milliseconds(),
+      true
+    )
+
+    // WHEN1 - Simulate coordinator failover and recovery from the transaction log before the client
+    //         receives a response.
+    val recoveredMetadata = TransactionLog.read(
+      java.nio.ByteBuffer.wrap(TransactionLog.keyToBytes(transactionalId)),
+      java.nio.ByteBuffer.wrap(TransactionLog.valueToBytes(rotatedMetadata, TV_2))
+    ).asInstanceOf[TransactionLog.TxnRecord].metadata()
+
+    // THEN1
+    assertEquals(producerId + 1, recoveredMetadata.producerId)
+    assertEquals(producerId, recoveredMetadata.prevProducerId)
+    assertEquals(0.toShort, recoveredMetadata.producerEpoch)
+    assertEquals(exhaustedEpoch, recoveredMetadata.lastProducerEpoch)
+
+    when(transactionManager.validateTransactionTimeoutMs(anyBoolean(), anyInt()))
+      .thenReturn(true)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(new CoordinatorEpochAndTxnMetadata(coordinatorEpoch, recoveredMetadata))))
+
+    when(transactionManager.appendTransactionToLog(
+      ArgumentMatchers.eq(transactionalId),
+      ArgumentMatchers.eq(coordinatorEpoch),
+      capturedTxnTransitMetadata.capture(),
+      capturedErrorsCallback.capture(),
+      any(),
+      any())
+    ).thenAnswer(_ => {
+      recoveredMetadata.completeTransitionTo(capturedTxnTransitMetadata.getValue)
+      capturedErrorsCallback.getValue.apply(Errors.NONE)
+    })
+
+    // WHEN2 : The client retries InitProducerId because it did not receive the response 
+    //         for the epoch exhaustion rotation.
+    coordinator.handleInitProducerId(
+      transactionalId,
+      txnTimeoutMs,
+      enableTwoPCFlag = false,
+      keepPreparedTxn = false,
+      Some(new ProducerIdAndEpoch(producerId, exhaustedEpoch)),
+      initProducerIdMockCallback
+    )
+
+    // THEN2 :  The retry should succeed. Without persisting lastProducerEpoch, PRODUCER_FENCED would
+    //          be returned.
+    assertEquals(new InitProducerIdResult(producerId + 1, 0, Errors.NONE), result)
+  }
+
 
   @Test
   def testInitProducerIdWithNoLastProducerData(): Unit = {

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TransactionLog.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TransactionLog.java
@@ -19,7 +19,6 @@ package org.apache.kafka.coordinator.transaction;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.apache.kafka.common.record.internal.RecordBatch;
 import org.apache.kafka.coordinator.transaction.generated.CoordinatorRecordType;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKey;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
@@ -89,6 +88,7 @@ public class TransactionLog {
         if (logValueVersion >= 1) {
             value.setPreviousProducerId(txnMetadata.prevProducerId());
             value.setNextProducerId(txnMetadata.nextProducerId());
+            value.setLastProducerEpoch(txnMetadata.lastProducerEpoch());
         }
 
         return MessageUtil.toVersionPrefixedBytes(logValueVersion, value);
@@ -149,7 +149,7 @@ public class TransactionLog {
                     value.previousProducerId(),
                     value.nextProducerId(),
                     value.producerEpoch(),
-                    RecordBatch.NO_PRODUCER_EPOCH,
+                    value.lastProducerEpoch(),
                     value.transactionTimeoutMs(),
                     state,
                     tps,

--- a/transaction-coordinator/src/main/resources/common/message/TransactionLogValue.json
+++ b/transaction-coordinator/src/main/resources/common/message/TransactionLogValue.json
@@ -29,6 +29,8 @@
       "about": "Producer id used by the last committed transaction."},
     { "name": "NextProducerId", "type": "int64", "taggedVersions": "1+", "tag": 1, "default": -1,
       "about": "Latest producer ID sent to the producer for the given transactional id."},
+    { "name": "LastProducerEpoch", "type": "int16", "default": -1, "taggedVersions": "1+", "tag": 4,
+      "about": "Previous producer epoch for the transactional id."},
     { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
       "about": "Epoch associated with the producer id."},
     { "name": "NextProducerEpoch", "type": "int16", "default": -1, "taggedVersions": "1+", "tag": 3,

--- a/transaction-coordinator/src/test/java/org/apache/kafka/coordinator/transaction/TransactionLogTest.java
+++ b/transaction-coordinator/src/test/java/org/apache/kafka/coordinator/transaction/TransactionLogTest.java
@@ -149,6 +149,7 @@ class TransactionLogTest {
         buffer.getShort(); // skip version prefix
         var value = new TransactionLogValue(new ByteBufferAccessor(buffer), (short) 1);
 
+        assertEquals(4, value.lastProducerEpoch());
         assertEquals(200L, value.producerId());
         assertEquals(100L, value.previousProducerId());
         assertEquals(201L, value.nextProducerId());
@@ -157,13 +158,13 @@ class TransactionLogTest {
     @Test
     void shouldNotPersistProducerIdsAtVersion0() {
         // Version 0 is non-flexible, so tagged fields (previousProducerId,
-        // nextProducerId) cannot be written. They fall back to defaults (-1).
+        // nextProducerId, lastProducerEpoch) cannot be written. They fall back to defaults (-1).
         var txnTransitMetadata = new TxnTransitMetadata(
             200L,       // producerId
             100L,       // prevProducerId — not persisted at v0
             201L,       // nextProducerId — not persisted at v0
             (short) 5,  // producerEpoch
-            (short) 4,  // lastProducerEpoch
+            (short) 4,  // lastProducerEpoch - not persisted at v0
             1000,       // txnTimeoutMs
             TransactionState.PREPARE_COMMIT,
             new HashSet<>(Set.of(new TopicPartition("topic", 0))),
@@ -179,6 +180,7 @@ class TransactionLogTest {
         var readResult = assertInstanceOf(TransactionLog.TxnRecord.class, TransactionLog.read(record.key(), record.value()));
         var deserialized = readResult.metadata();
 
+        assertEquals(RecordBatch.NO_PRODUCER_EPOCH, deserialized.lastProducerEpoch());
         assertEquals(200L, deserialized.producerId());
         assertEquals(-1L, deserialized.prevProducerId());
     }
@@ -206,6 +208,7 @@ class TransactionLogTest {
         var txnLogValue = new TransactionLogValue()
             .setProducerId(100)
             .setProducerEpoch((short) 50)
+            .setLastProducerEpoch((short) 49)
             .setTransactionStatus(TransactionState.COMPLETE_COMMIT.id())
             .setTransactionStartTimestampMs(750L)
             .setTransactionLastUpdateTimestampMs(1000L)
@@ -219,6 +222,7 @@ class TransactionLogTest {
 
         assertEquals(100, deserialized.producerId());
         assertEquals(50, deserialized.producerEpoch());
+        assertEquals(49, deserialized.lastProducerEpoch());
         assertEquals(TransactionState.COMPLETE_COMMIT, deserialized.state());
         assertEquals(750L, deserialized.txnStartTimestamp());
         assertEquals(1000L, deserialized.txnLastUpdateTimestamp());


### PR DESCRIPTION
This change follows up on KAFKA-20310.

When producer epoch exhaustion triggers producerId rotation, the
coordinator may fail after writing the updated transaction metadata but
before returning the `InitProducerId` response to the client. After
failover, a retry from the client can be incorrectly rejected with
`PRODUCER_FENCED`.

The failure happens because the recovered transaction metadata does not
restore the previous epoch information needed to recognize the retry
correctly. In particular, `lastProducerEpoch` falls back to
`NO_PRODUCER_EPOCH` after transaction log replay, so
`TransactionMetadata.prepareIncrementProducerEpoch(...)` cannot identify
the request as a valid retry of the earlier producerId rotation.

This PR fixes that by persisting `lastProducerEpoch` in
`TransactionLogValue` for flexible transaction log records and restoring
it during log replay.

With this change, retries of `InitProducerId` after failover are handled
correctly when the original request triggered producerId rotation due to
epoch exhaustion.

### Tests

- add transaction log coverage for serializing and restoring
`lastProducerEpoch`
- add a coordinator test covering `InitProducerId` retry after failover
during producerId rotation caused by epoch exhaustion.

### Other consideration
https://github.com/apache/kafka/blob/8ae35c08fa46aa4b61b37c56e70b59f70a5bb83e/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/TransactionMetadata.java#L476-L480

This code is not affected by this changes  For `InitProducerId`,
`TransactionCoordinator` validates the retry using values from the
client request.  In contrast, this block only validates a local state
transition, so it is not directly affected by coordinator failover.

Reviewers: Justine Olshan <jolshan@confluent.io>
