### PR TITLE
KAFKA-18735: Return null from ConfigEntity.name() for default quotas

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaEntity.java
+++ b/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaEntity.java
@@ -43,7 +43,8 @@ public interface ClientQuotaEntity {
      */
     interface ConfigEntity {
         /**
-         * Returns the name of this entity. For default quotas, an empty string is returned.
+         * Returns the name of this entity. For default quotas, {@code null} is returned,
+         * consistent with how the Admin API represents default client quota entities.
          */
         String name();
 

--- a/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaEntity.java
+++ b/clients/src/main/java/org/apache/kafka/server/quota/ClientQuotaEntity.java
@@ -43,8 +43,7 @@ public interface ClientQuotaEntity {
      */
     interface ConfigEntity {
         /**
-         * Returns the name of this entity. For default quotas, {@code null} is returned,
-         * consistent with how the Admin API represents default client quota entities.
+         * Returns the name of this entity. For default quotas, {@code null} is returned.
          */
         String name();
 

--- a/core/src/main/scala/kafka/server/metadata/ClientQuotaMetadataManager.scala
+++ b/core/src/main/scala/kafka/server/metadata/ClientQuotaMetadataManager.scala
@@ -74,7 +74,7 @@ class ClientQuotaMetadataManager(private[metadata] val quotaManagers: QuotaManag
       val userVal = entity.entries().get(ClientQuotaEntity.USER)
       val clientIdVal = entity.entries().get(ClientQuotaEntity.CLIENT_ID)
 
-      // In User+Client quota managers, "<default>" is used for default entity, so we need to represent all possible
+      // In User+Client quota managers, null is used for the default entity, so we need to represent all possible
       // combinations of values, defaults, and absent entities
       val userClientEntity = if (entity.entries().containsKey(ClientQuotaEntity.USER) &&
           entity.entries().containsKey(ClientQuotaEntity.CLIENT_ID)) {

--- a/core/src/test/scala/kafka/server/metadata/ClientQuotaMetadataManagerTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/ClientQuotaMetadataManagerTest.scala
@@ -18,7 +18,7 @@ package kafka.server.metadata
 
 import org.apache.kafka.image.ClientQuotaDelta
 import org.apache.kafka.server.quota.ClientQuotaManager
-import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertThrows}
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertNull, assertThrows}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
 import java.util.Optional
@@ -72,5 +72,30 @@ class ClientQuotaMetadataManagerTest {
       (Optional.of(ClientQuotaManager.DEFAULT_USER_ENTITY), Optional.of(ClientQuotaManager.DEFAULT_USER_CLIENT_ID)),
       ClientQuotaMetadataManager.transferToClientQuotaEntity(DefaultUserDefaultClientIdEntity)
     )
+  }
+
+  @Test
+  def testDefaultConfigEntityNameReturnsNull(): Unit = {
+    assertNull(ClientQuotaManager.DEFAULT_USER_ENTITY.name())
+    assertNull(ClientQuotaManager.DEFAULT_USER_CLIENT_ID.name())
+
+    val (defaultUser, _) = ClientQuotaMetadataManager.transferToClientQuotaEntity(DefaultUserEntity)
+    assertNull(defaultUser.get().name())
+
+    val (_, defaultClientId) = ClientQuotaMetadataManager.transferToClientQuotaEntity(DefaultClientIdEntity)
+    assertNull(defaultClientId.get().name())
+
+    val (defaultUser2, defaultClientId2) = ClientQuotaMetadataManager.transferToClientQuotaEntity(DefaultUserDefaultClientIdEntity)
+    assertNull(defaultUser2.get().name())
+    assertNull(defaultClientId2.get().name())
+  }
+
+  @Test
+  def testExplicitConfigEntityNameReturnsValue(): Unit = {
+    val (user, _) = ClientQuotaMetadataManager.transferToClientQuotaEntity(UserEntity("testUser"))
+    assertEquals("testUser", user.get().name())
+
+    val (_, clientId) = ClientQuotaMetadataManager.transferToClientQuotaEntity(ClientIdEntity("testClient"))
+    assertEquals("testClient", clientId.get().name())
   }
 }

--- a/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
+++ b/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
@@ -60,7 +60,6 @@ public class ClientQuotaManager {
 
     // Purge sensors after 1 hour of inactivity
     private static final int INACTIVE_SENSOR_EXPIRATION_TIME_SECONDS = 3600;
-    private static final String DEFAULT_NAME = "<default>";
 
     public record UserEntity(String sanitizedUser) implements ClientQuotaEntity.ConfigEntity {
 
@@ -105,7 +104,7 @@ public class ClientQuotaManager {
 
         @Override
         public String name() {
-            return DEFAULT_NAME;
+            return null;
         }
 
         @Override
@@ -121,7 +120,7 @@ public class ClientQuotaManager {
         }
         @Override
         public String name() {
-            return DEFAULT_NAME;
+            return null;
         }
         @Override
         public String toString() {
@@ -154,14 +153,15 @@ public class ClientQuotaManager {
         public String sanitizedUser() {
             if (userEntity instanceof UserEntity userRecord) {
                 return userRecord.sanitizedUser();
-            } else if (userEntity == DEFAULT_USER_ENTITY) {
-                return DEFAULT_NAME;
             }
             return "";
         }
 
         public String clientId() {
-            return clientIdEntity != null ? clientIdEntity.name() : "";
+            if (clientIdEntity instanceof ClientIdEntity clientIdRecord) {
+                return clientIdRecord.clientId();
+            }
+            return "";
         }
 
         @Override


### PR DESCRIPTION
`ConfigEntity.name()` currently returns the ZooKeeper-era placeholder
string `"<default>"` for default quota entities (`DEFAULT_USER_ENTITY`
and `DEFAULT_USER_CLIENT_ID`). This is asymmetric with the Admin API:
callers create a default quota by passing `null` as the entity name —
the `org.apache.kafka.common.quota.ClientQuotaEntity` constructor
Javadoc states "if a name is null, then it is mapped to the built-in
default entity name" — but when the broker forwards that same default
quota to a custom `ClientQuotaCallback`, the entity name arrives as the
string `"<default>"` rather than `null`. The server-side `ConfigEntity`
Javadoc additionally documented an empty-string return value, which
matched neither the Admin API nor the actual implementation.

This change makes `ConfigEntity.name()` return `null` for default
entities, aligning the `ClientQuotaCallback` interface with the Admin
API, and updates the Javadoc accordingly. The internal `DEFAULT_NAME`
constant in `ClientQuotaManager` is removed, and the `sanitizedUser()` /
`clientId()` helpers on `KafkaQuotaEntity` are simplified to drop their
references to the placeholder string.

Compatibility note: custom `ClientQuotaCallback` implementations that
compare `ConfigEntity.name()` against the literal `"<default>"` will
need to check for `null` instead. In practice this pattern is uncommon:
well-written callbacks distinguish default entities by reference
comparison against the `ClientQuotaManager.DEFAULT_USER_ENTITY` and
`DEFAULT_USER_CLIENT_ID` singletons rather than by string comparison on
`name()`. Since the prior Javadoc documented an empty string return, any
comparison against `"<default>"` was relying on undocumented behavior.

The internal metric-tag lookup path in `updateQuotaMetricConfigs` is
unaffected: default entities are routed through the iterate-all-metrics
branch via `updatedQuotaEntity = Optional.empty()`, so `sanitizedUser()`
and `clientId()` are never invoked on a default-entity
`KafkaQuotaEntity`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
