### PR TITLE
MINOR: Fix typos in comments (targetting, inital, comparision)

### DIFF
--- a/docker/generate_kafka_pr_template.py
+++ b/docker/generate_kafka_pr_template.py
@@ -50,7 +50,7 @@ def dir_commit(directory):
     return file_commit(*files_to_check)
 
 
-# Split the version string into parts and convert them to integers for version comparision
+# Split the version string into parts and convert them to integers for version comparison
 def get_version_parts(version):
     return tuple(int(part) for part in version.name.split('.'))
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -5704,10 +5704,10 @@ public class GroupMetadataManagerTest {
             requiredKnownMemberId
         )).toList();
 
-        // Advance clock by group initial rebalance delay to complete first inital delayed join.
+        // Advance clock by group initial rebalance delay to complete first initial delayed join.
         // This will extend the initial rebalance as new members have joined.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
-        // Advance clock by group initial rebalance delay to complete second inital delayed join.
+        // Advance clock by group initial rebalance delay to complete second initial delayed join.
         // Since there are no new members that joined since the previous delayed join,
         // the join group phase will complete.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
@@ -5753,10 +5753,10 @@ public class GroupMetadataManagerTest {
         assertEquals(groupMaxSize, group.numAwaitingJoinResponse());
         assertTrue(group.isInState(PREPARING_REBALANCE));
 
-        // Advance clock by group initial rebalance delay to complete first inital delayed join.
+        // Advance clock by group initial rebalance delay to complete first initial delayed join.
         // This will extend the initial rebalance as new members have joined.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
-        // Advance clock by group initial rebalance delay to complete second inital delayed join.
+        // Advance clock by group initial rebalance delay to complete second initial delayed join.
         // Since there are no new members that joined since the previous delayed join,
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
@@ -5805,10 +5805,10 @@ public class GroupMetadataManagerTest {
         assertEquals(groupMaxSize, group.numAwaitingJoinResponse());
         assertTrue(group.isInState(PREPARING_REBALANCE));
 
-        // Advance clock by group initial rebalance delay to complete first inital delayed join.
+        // Advance clock by group initial rebalance delay to complete first initial delayed join.
         // This will extend the initial rebalance as new members have joined.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
-        // Advance clock by group initial rebalance delay to complete second inital delayed join.
+        // Advance clock by group initial rebalance delay to complete second initial delayed join.
         // Since there are no new members that joined since the previous delayed join,
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
@@ -5878,10 +5878,10 @@ public class GroupMetadataManagerTest {
             requiredKnownMemberId
         )).toList();
 
-        // Advance clock by group initial rebalance delay to complete first inital delayed join.
+        // Advance clock by group initial rebalance delay to complete first initial delayed join.
         // This will extend the initial rebalance as new members have joined.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));
-        // Advance clock by group initial rebalance delay to complete second inital delayed join.
+        // Advance clock by group initial rebalance delay to complete second initial delayed join.
         // Since there are no new members that joined since the previous delayed join,
         // we will complete the rebalance.
         GroupMetadataManagerTestContext.assertNoOrEmptyResult(context.sleep(50));

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/task/TaskController.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/task/TaskController.java
@@ -26,7 +26,7 @@ import java.util.Set;
  */
 public interface TaskController {
     /**
-     * Get the agent nodes which this task is targetting.
+     * Get the agent nodes which this task is targeting.
      *
      * @param topology      The topology to use.
      *


### PR DESCRIPTION

**Repo:** apache/kafka (⭐ 28000)
**Type:** docs
**Files changed:** 3
**Lines:** +10/-10

## What
Fix three small typos in code comments across the codebase:
- `targetting` → `targeting` in the `TaskController` Trogdor interface Javadoc.
- `inital` → `initial` (8 occurrences) in `GroupMetadataManagerTest` comments describing the rebalance delay.
- `comparision` → `comparison` in a comment in `docker/generate_kafka_pr_template.py`.

## Why
These are obvious misspellings in developer-facing comments and Javadoc. Kafka follows the `MINOR:` convention for trivial cleanups like this, and small typo fixes are routinely accepted. No behavior change.

## Testing
Comment-only changes. No tests affected; verified the diff touches only comment text via `git diff`.

## Risk
Low — comment-only edits, no executable code changed.
