### PR TITLE
MINOR: Remove unnecessary min.assignment.interval.ms config from test

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -1276,8 +1276,7 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
 
   @ClusterTest(
     serverProperties = Array(
-      new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0"),
-      new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_MIN_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG, value = "0")
     )
   )
   def testStaticMembersRejoinWithDifferentServerAssignor(): Unit = {


### PR DESCRIPTION
Remove the group.consumer.min.assignment.interval.ms config override
from ConsumerGroupHeartbeatRequestTest's
testStaticMembersRejoinWithDifferentServerAssignor. The config already
defaults to 0 and we are very unlikely to ever change it, since we
always want to allow a 0 value to disable assignment batching.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
