### PR TITLE
MINOR: avoid redundant HashMap lookups and simplify Uuid conversions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -174,11 +174,7 @@ public class Uuid implements Comparable<Uuid> {
      */
     public static Uuid[] toArray(List<Uuid> list) {
         if (list == null) return null;
-        Uuid[] array = new Uuid[list.size()];
-        for (int i = 0; i < list.size(); i++) {
-            array[i] = list.get(i);
-        }
-        return array;
+        return list.toArray(new Uuid[0]);
     }
 
     /**
@@ -189,8 +185,6 @@ public class Uuid implements Comparable<Uuid> {
      */
     public static List<Uuid> toList(Uuid[] array) {
         if (array == null) return null;
-        List<Uuid> list = new ArrayList<>(array.length);
-        list.addAll(Arrays.asList(array));
-        return list;
+        return new ArrayList<>(Arrays.asList(array));
     }
 }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3178,11 +3178,11 @@ public class GroupMetadataManager {
         combinedTopicIdSet.addAll(initializingSet);
 
         for (Uuid topicId : combinedTopicIdSet) {
-            Set<Integer> initializedPartitions = initialized.containsKey(topicId) ? initialized.get(topicId).partitions() : new HashSet<>();
-            long timestamp = initialized.containsKey(topicId) ? initialized.get(topicId).timestamp() : -1;
-            String name = initialized.containsKey(topicId) ? initialized.get(topicId).name() : "UNKNOWN";
+            InitMapValue initializedValue = initialized.get(topicId);
+            Set<Integer> finalPartitions = initializedValue != null ? new HashSet<>(initializedValue.partitions()) : new HashSet<>();
+            long timestamp = initializedValue != null ? initializedValue.timestamp() : -1;
+            String name = initializedValue != null ? initializedValue.name() : "UNKNOWN";
 
-            Set<Integer> finalPartitions = new HashSet<>(initializedPartitions);
             if (initializingSet.contains(topicId)) {
                 finalPartitions.addAll(initializing.get(topicId).partitions());
                 timestamp = initializing.get(topicId).timestamp();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -3184,9 +3184,10 @@ public class GroupMetadataManager {
             String name = initializedValue != null ? initializedValue.name() : "UNKNOWN";
 
             if (initializingSet.contains(topicId)) {
-                finalPartitions.addAll(initializing.get(topicId).partitions());
-                timestamp = initializing.get(topicId).timestamp();
-                name = initializing.get(topicId).name();
+                InitMapValue initializingValue = initializing.get(topicId);
+                finalPartitions.addAll(initializingValue.partitions());
+                timestamp = initializingValue.timestamp();
+                name = initializingValue.name();
             }
             finalInitMap.putIfAbsent(topicId, new InitMapValue(name, finalPartitions, timestamp));
         }


### PR DESCRIPTION
This PR contains 2 small performance optimisations and 1 cosmetic
improvement.

1. remove the repeated HashMap lookups in `GroupMetadataManager`: from 6
to 1;
2. Uuid `toArray` done via idiomatic way. Previously, on LinkedList it
costed O(n^2);
3. Uuid `toList` - no performance improvement, but cleaner
implementation

Reviewers: Mickael Maison <mickael.maison@gmail.com>
