### PR TITLE
KAFKA-15768: Fix getOnlyPartitionResult to handle FailedQueryResult

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -801,7 +801,7 @@ public class IQv2StoreIntegrationTest {
                                 shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, -1L));
                             }
                         } else {
-                            assertThrows(AssertionError.class, () -> shouldHandleTimestampedKeyQuery(2, ValueAndTimestamp.make(5, WINDOW_START + Duration.ofMinutes(2).toMillis() * 5)));
+                            shouldHandleFailedTimestampedKeyQuery(2);
                             assertThrows(AssertionError.class, () -> shouldHandleTimestampedRangeQueries(false));
                         }
 
@@ -1702,6 +1702,27 @@ public class IQv2StoreIntegrationTest {
         assertThat(valueAndTimestamp, is(expectedValueAndTimestamp));
         assertThat(queryResult.getExecutionInfo(), is(empty()));
         assertThat(queryResult.getPosition(), is(POSITION_0));
+    }
+
+    public <V> void shouldHandleFailedTimestampedKeyQuery(final Integer key) {
+        final TimestampedKeyQuery<Integer, V> query = TimestampedKeyQuery.withKey(key);
+        final StateQueryRequest<ValueAndTimestamp<V>> request =
+                inStore(STORE_NAME)
+                        .withQuery(query)
+                        .withPartitions(Set.of(0))
+                        .withPositionBound(PositionBound.at(INPUT_POSITION));
+
+        final StateQueryResult<ValueAndTimestamp<V>> result =
+                IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
+
+        final QueryResult<ValueAndTimestamp<V>> queryResult =
+                result.getOnlyPartitionResult();
+
+        assertThat(queryResult.isFailure(), is(true));
+        assertThat(queryResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
+        assertThat(queryResult.getFailureMessage(), containsString("TimestampedKeyQuery"));
+
+        assertThrows(IllegalArgumentException.class, queryResult::getResult);
     }
 
     public <V> void shouldHandleRangeQuery(

--- a/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/StateQueryResult.java
@@ -69,8 +69,7 @@ public class StateQueryResult<R> {
             partitionResults
                 .values()
                 .stream()
-                .filter(QueryResult::isSuccess)
-                .filter(r -> r.getResult() != null)
+                .filter(r -> r.isFailure() || r.getResult() != null)
                 .collect(Collectors.toList());
 
         if (nonempty.size() > 1) {

--- a/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
@@ -58,7 +58,7 @@ class StateQueryResultTest {
     void getOnlyPartitionResultWithSingleFailureResultTest() {
         stringStateQueryResult.addResult(0, invalidResult);
         final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
-        assertThat("Single partition failure result should be returned as failure", result.isFailure(), is(true));
+        assertThat("Invalid query result should be a failure", result.isFailure(), is(true));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.query;
 
+import org.apache.kafka.streams.query.internals.FailedQueryResult;
 import org.apache.kafka.streams.query.internals.SucceededQueryResult;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ class StateQueryResultTest {
     StateQueryResult<String> stringStateQueryResult;
     final QueryResult<String> noResultsFound = new SucceededQueryResult<>(null);
     final QueryResult<String> validResult = new SucceededQueryResult<>("Foo");
+    final QueryResult<String> invalidResult = new FailedQueryResult<>(FailureReason.DOES_NOT_EXIST, "Does not exist");
 
     @BeforeEach
     public void setUp() {
@@ -50,6 +52,13 @@ class StateQueryResultTest {
         stringStateQueryResult.addResult(0, validResult);
         final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
         assertThat("Valid query results still works", result.getResult(), is("Foo"));
+    }
+
+    @Test
+    void getOnlyPartitionResultWithSingleFailureResultTest() {
+        stringStateQueryResult.addResult(0, invalidResult);
+        final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
+        assertThat("Single partition failure result should be returned as failure", result.isFailure(), is(true));
     }
 
     @Test


### PR DESCRIPTION
`getOnlyPartitionResult()` was silently discarding `FailedQueryResult`
entries by filtering only for successful results, making failures
indistinguishable from "not found". Fix the filter to treat failed
results as meaningful so callers can inspect the failure via
`isFailure()`/`getFailureReason()`/`getFailureMessage()`.

Reviewers: Evan Zhou <ezhou@confluent.io>, Bill Bejeck <bbejeck@apache.org>
