### PR TITLE
MINOR: Removed `setMetadataLogDirectory` unused method

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -207,11 +207,6 @@ public class Formatter {
         return this;
     }
 
-    public Formatter setMetadataLogDirectory(Optional<String> metadataLogDirectory) {
-        this.metadataLogDirectory = metadataLogDirectory;
-        return this;
-    }
-
     public Formatter setInitialControllers(DynamicVoters initialControllers) {
         this.initialControllers = Optional.of(initialControllers);
         return this;


### PR DESCRIPTION
Trivial PR to remove an overload of the
`Formatter.setMetadataLogDirectory` which takes the metadata log
directory as an `Optional<String>`, because it's not used. The overall
codebase uses the other overload taking just a String (because most of
the callers have a String to pass) and then wrapping it into an
`Optional`.

Reviewers: Andrew Schofield <aschofield@confluent.io>
