### PR TITLE
KAFKA-20523: Fix logger class name in KStreamKTableJoinProcessor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -45,7 +45,7 @@ import static org.apache.kafka.streams.state.ValueTimestampHeaders.getValueOrNul
 class KStreamKTableJoinProcessor<StreamKey, StreamValue, TableKey, TableValue, VOut>
     extends ContextualProcessor<StreamKey, StreamValue, StreamKey, VOut> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KStreamKTableJoin.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KStreamKTableJoinProcessor.class);
 
     private final KTableValueGetter<TableKey, TableValue> valueGetter;
     private final KeyValueMapper<? super StreamKey, ? super StreamValue, ? extends TableKey> keyMapper;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -453,7 +453,7 @@ public class KStreamKTableJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldLogAndMeterWhenSkippingNullLeftKey(final boolean withHeaders) {
         setUp(withHeaders);
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoinProcessor.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
             inputTopic.pipeInput(null, "A");
@@ -484,7 +484,7 @@ public class KStreamKTableJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldLogAndMeterWhenSkippingNullLeftValue(final boolean withHeaders) {
         setUp(withHeaders);
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoinProcessor.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
             inputTopic.pipeInput(1, null);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -221,7 +221,7 @@ public class KStreamKTableLeftJoinTest {
         pushToTable(1, "Y");
         processor.checkAndClearProcessResult(EMPTY);
 
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoinProcessor.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
             inputTopic.pipeInput(null, "A", 0);
@@ -251,7 +251,7 @@ public class KStreamKTableLeftJoinTest {
     @ValueSource(booleans = {false, true})
     public void shouldLogAndMeterWhenSkippingNullLeftValue(final boolean withHeaders) {
         setUp(withHeaders);
-        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoinProcessor.class)) {
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
             inputTopic.pipeInput(1, null);


### PR DESCRIPTION
Fix logger class name in `KStreamKTableJoinProcessor` — it was
initialized with `KStreamKTableJoin.class` (the `ProcessorSupplier`)
instead of its own class, so warnings like `Skipping record due to null
join key or value` were logged under the wrong logger name and were
effectively invisible when grepping for `KStreamKTableJoinProcessor`.

One-line change: pass `KStreamKTableJoinProcessor.class` to
`LoggerFactory.getLogger`.

Reviewers: Matthias J. Sax <matthias@confluent.io>
