### PR TITLE
KAFKA-20362 Resolve reviewer email via GitHub commit search API

### DIFF
--- a/.github/scripts/pr-format.py
+++ b/.github/scripts/pr-format.py
@@ -147,20 +147,15 @@ def resolve_reviewer(login: str) -> tuple:
 
     commits = _run_json(["gh", "api", f"repos/apache/kafka/commits?author={login}&per_page=1"],
                         "commit history") or []
-    commit = commits[0] if commits else {}
-    github_author = commit.get("author") or {}
-    author = commit.get("commit", {}).get("author", {})
+    author = commits[0].get("commit", {}).get("author", {}) if commits else {}
 
-    name = author.get("name") or login
-    email = None
-
-    # Tier 1: find the latest repo commit authored by this GitHub login.
-    # Verify GitHub's associated author login before using the raw commit
-    # author email, so same-name authors cannot be mixed up.
-    if github_author.get("login", "").lower() == login.lower():
-        email = _usable_email(author.get("email"))
-        if email:
-            return (name, email)
+    # Tier 1: latest repo commit authored by this GitHub login. Misses
+    # when the reviewer has no merged commit in apache/kafka, or had
+    # "Keep my email private" enabled at commit time (GitHub rewrites
+    # the author to the noreply form).
+    email = _usable_email(author.get("email"))
+    if email:
+        return (author.get("name") or login, email)
 
     user = _run_json(["gh", "api", f"users/{login}"], "GitHub profile") or {}
 
@@ -200,12 +195,7 @@ def resolve_reviewer(login: str) -> tuple:
 
     # Tier 3: GitHub user profile. Only exposes an email when the reviewer
     # has set a Public email in their profile settings.
-    if not email:
-        email = _usable_email(user.get("email"))
-        if user.get("name"):
-            name = user.get("name")
-
-    return (name, email)
+    return (name, _usable_email(user.get("email")))
 
 
 def already_exists(identity: str, existing_reviewers: List[str]) -> bool:

--- a/.github/scripts/pr-format.py
+++ b/.github/scripts/pr-format.py
@@ -108,11 +108,12 @@ def resolve_reviewer(login: str) -> tuple:
     """Map a GitHub login to (name, email).
 
     Tries three tiers in order: repo commit history, GitHub user profile,
-    and past `Reviewers:` trailers in git log (matched by name).
-    Noreply emails (@users.noreply.github.com) are treated as missing since
-    they are GitHub privacy placeholders that do not identify the reviewer.
-    Returns (name, None) when no usable email is found; the caller falls
-    back to the '(@login)' form in the Reviewers trailer.
+    and past `Reviewers:` trailers searched via GitHub commit search API
+    (matched by name). Noreply emails (@users.noreply.github.com) are
+    treated as missing since they are GitHub privacy placeholders that do
+    not identify the reviewer. Returns (name, None) when no usable email
+    is found; the caller falls back to the '(@login)' form in the
+    Reviewers trailer.
     """
     def _usable_email(e):
         if not e or e.endswith("@users.noreply.github.com"):
@@ -152,29 +153,35 @@ def resolve_reviewer(login: str) -> tuple:
         except Exception as e:
             logger.debug(f"Failed to resolve {login} from GitHub profile: {e}")
 
-    # Tier 3: past Reviewers: trailers in git log, matched by name. Catches
-    # pure reviewers (no commits in apache/kafka, no public profile email)
-    # who have been credited with a real email in an earlier merged PR.
-    # git log is newest-first, so the first usable match is the most recent.
+    # Tier 3: past Reviewers: trailers in commit history, matched by name,
+    # via the GitHub commit search API. Catches pure reviewers (no commits
+    # in apache/kafka, no public profile email) who have been credited
+    # with a real email in an earlier merged PR. Sort by committer-date
+    # desc so the most recent email wins if a reviewer has changed it.
+    # Full-text search is tokenized (not strict substring), so we
+    # re-verify with a regex client-side.
     if name and not email:
         try:
-            p = subprocess.run(
-                ["git", "log",
-                 "--pretty=format:%(trailers:key=Reviewers,valueonly=true,unfold=true)"],
-                capture_output=True, text=True,
-            )
+            cmd = ["gh", "search", "commits",
+                   "--repo", "apache/kafka",
+                   f'"{name} <"',
+                   "--limit", "3",
+                   "--sort", "committer-date",
+                   "--order", "desc",
+                   "--json", "commit",
+                   "--jq", "[.[].commit.message]"]
+            p = subprocess.run(cmd, capture_output=True, text=True)
             if p.returncode == 0:
+                messages = json.loads(p.stdout)
                 pattern = re.compile(rf"{re.escape(name)}\s*<([^>]+)>")
-                for line in p.stdout.splitlines():
-                    for m in pattern.finditer(line):
-                        candidate = _usable_email(m.group(1))
-                        if candidate:
-                            email = candidate
-                            break
-                    if email:
-                        break
+                email = next(
+                    (usable for msg in messages
+                     for m in pattern.finditer(msg)
+                     if (usable := _usable_email(m.group(1)))),
+                    None,
+                )
         except Exception as e:
-            logger.debug(f"Failed to resolve {login} from past Reviewers trailers: {e}")
+            logger.debug(f"Failed to resolve {login} from commit search: {e}")
 
     if not name:
         name = login

--- a/.github/scripts/pr-format.py
+++ b/.github/scripts/pr-format.py
@@ -107,13 +107,14 @@ def split_paragraphs(text: str):
 def resolve_reviewer(login: str) -> tuple:
     """Map a GitHub login to (name, email).
 
-    Tries reviewer email sources in order: past `Reviewers:` trailers
-    searched via GitHub commit search API (matched by name), repo commit
-    author email, and GitHub user profile public email. Noreply emails
-    (@users.noreply.github.com) are treated as missing since they are
-    GitHub privacy placeholders that do not identify the reviewer. Returns
-    (name, None) when no usable email is found; the caller falls back to
-    the '(github:login)' form in the Reviewers trailer.
+    Tries reviewer email sources in order: repo commit author email, past
+    `Reviewers:` trailers searched via GitHub commit search API (matched
+    by name and verified by PR review login), and GitHub user profile
+    public email. Noreply emails (@users.noreply.github.com) are treated
+    as missing since they are GitHub privacy placeholders that do not
+    identify the reviewer. Returns (name, None) when no usable email is
+    found; the caller falls back to the '(github:login)' form in the
+    Reviewers trailer.
     """
     def _usable_email(e):
         if not e or e.endswith("@users.noreply.github.com"):
@@ -130,12 +131,38 @@ def resolve_reviewer(login: str) -> tuple:
             logger.debug(f"Failed to resolve {login} from {source}: {e}")
         return None
 
-    # Collect display-name hints first because `Reviewers:` trailers are
-    # name-based. Emails from these lookups are still applied in tier order.
-    user = _run_json(["gh", "api", f"users/{login}"], "GitHub profile") or {}
+    def _has_pr_review_from_login(commit_sha):
+        pulls = _run_json(["gh", "api", f"repos/apache/kafka/commits/{commit_sha}/pulls"],
+                          f"associated PRs for commit {commit_sha}") or []
+        for pull in pulls:
+            pr_number = pull.get("number")
+            if not pr_number:
+                continue
+            reviews = _run_json(["gh", "api", f"repos/apache/kafka/pulls/{pr_number}/reviews?per_page=100"],
+                                f"reviews for PR {pr_number}") or []
+            if any((review.get("user") or {}).get("login", "").lower() == login.lower()
+                   for review in reviews):
+                return True
+        return False
+
     commits = _run_json(["gh", "api", f"repos/apache/kafka/commits?author={login}&per_page=1"],
                         "commit history") or []
-    author = commits[0].get("commit", {}).get("author", {}) if commits else {}
+    commit = commits[0] if commits else {}
+    github_author = commit.get("author") or {}
+    author = commit.get("commit", {}).get("author", {})
+
+    name = author.get("name") or login
+    email = None
+
+    # Tier 1: find the latest repo commit authored by this GitHub login.
+    # Verify GitHub's associated author login before using the raw commit
+    # author email, so same-name authors cannot be mixed up.
+    if github_author.get("login", "").lower() == login.lower():
+        email = _usable_email(author.get("email"))
+        if email:
+            return (name, email)
+
+    user = _run_json(["gh", "api", f"users/{login}"], "GitHub profile") or {}
 
     name_candidates = []
     for candidate in (user.get("name"), author.get("name"), login):
@@ -143,43 +170,33 @@ def resolve_reviewer(login: str) -> tuple:
             name_candidates.append(candidate)
 
     name = name_candidates[0] if name_candidates else login
-    email = None
 
-    # Tier 1: past Reviewers: trailers in commit history, matched by name,
+    # Tier 2: past Reviewers: trailers in commit history, matched by name,
     # via the GitHub commit search API. Catches pure reviewers (no commits
     # in apache/kafka, no public profile email) who have been credited
     # with a real email in an earlier merged PR. Sort by committer-date
     # desc so the most recent email wins if a reviewer has changed it.
-    # Full-text search is tokenized (not strict substring), so we
-    # re-verify with a regex client-side.
+    # Full-text search is tokenized (not strict substring), so we re-verify
+    # with a regex client-side. To avoid same-name matches, we only accept
+    # a trailer email when the matched commit's associated PR includes a
+    # review from this GitHub login.
     for candidate in name_candidates:
-        messages = _run_json(["gh", "search", "commits",
-                              "--repo", "apache/kafka",
-                              f'"{candidate} <"',
-                              "--limit", "3",
-                              "--sort", "committer-date",
-                              "--order", "desc",
-                              "--json", "commit",
-                              "--jq", "[.[].commit.message]"],
-                             "commit search") or []
+        results = _run_json(["gh", "search", "commits",
+                             "--repo", "apache/kafka",
+                             f'"{candidate} <"',
+                             "--limit", "10",
+                             "--sort", "committer-date",
+                             "--order", "desc",
+                             "--json", "sha,commit"],
+                            "commit search") or []
         pattern = re.compile(rf"{re.escape(candidate)}\s*<([^>]+)>")
-        email = next(
-            (usable for msg in messages
-             for m in pattern.finditer(msg)
-             if (usable := _usable_email(m.group(1)))),
-            None,
-        )
-        if email:
-            name = candidate
-            break
-
-    # Tier 2: find the latest repo commit authored by this GitHub login.
-    # Misses when the reviewer has no merged commit in apache/kafka, or had
-    # "Keep my email private" enabled at commit time.
-    if not email:
-        email = _usable_email(author.get("email"))
-        if author.get("name"):
-            name = author.get("name")
+        for result in results:
+            msg = result.get("commit", {}).get("message", "")
+            commit_sha = result.get("sha")
+            for match in pattern.finditer(msg):
+                candidate_email = _usable_email(match.group(1))
+                if candidate_email and commit_sha and _has_pr_review_from_login(commit_sha):
+                    return (candidate, candidate_email)
 
     # Tier 3: GitHub user profile. Only exposes an email when the reviewer
     # has set a Public email in their profile settings.

--- a/.github/scripts/pr-format.py
+++ b/.github/scripts/pr-format.py
@@ -107,84 +107,86 @@ def split_paragraphs(text: str):
 def resolve_reviewer(login: str) -> tuple:
     """Map a GitHub login to (name, email).
 
-    Tries three tiers in order: repo commit history, GitHub user profile,
-    and past `Reviewers:` trailers searched via GitHub commit search API
-    (matched by name). Noreply emails (@users.noreply.github.com) are
-    treated as missing since they are GitHub privacy placeholders that do
-    not identify the reviewer. Returns (name, None) when no usable email
-    is found; the caller falls back to the '(@login)' form in the
-    Reviewers trailer.
+    Tries reviewer email sources in order: past `Reviewers:` trailers
+    searched via GitHub commit search API (matched by name), repo commit
+    author email, and GitHub user profile public email. Noreply emails
+    (@users.noreply.github.com) are treated as missing since they are
+    GitHub privacy placeholders that do not identify the reviewer. Returns
+    (name, None) when no usable email is found; the caller falls back to
+    the '(github:login)' form in the Reviewers trailer.
     """
     def _usable_email(e):
         if not e or e.endswith("@users.noreply.github.com"):
             return None
         return e
 
-    name = None
+    def _run_json(cmd, source):
+        try:
+            p = subprocess.run(cmd, capture_output=True, text=True)
+            if p.returncode == 0:
+                return json.loads(p.stdout)
+            logger.debug(f"Failed to resolve {login} from {source}: {p.stderr}")
+        except Exception as e:
+            logger.debug(f"Failed to resolve {login} from {source}: {e}")
+        return None
+
+    # Collect display-name hints first because `Reviewers:` trailers are
+    # name-based. Emails from these lookups are still applied in tier order.
+    user = _run_json(["gh", "api", f"users/{login}"], "GitHub profile") or {}
+    commits = _run_json(["gh", "api", f"repos/apache/kafka/commits?author={login}&per_page=1"],
+                        "commit history") or []
+    author = commits[0].get("commit", {}).get("author", {}) if commits else {}
+
+    name_candidates = []
+    for candidate in (user.get("name"), author.get("name"), login):
+        if candidate and candidate not in name_candidates:
+            name_candidates.append(candidate)
+
+    name = name_candidates[0] if name_candidates else login
     email = None
 
-    # Tier 1: find from repo commit history. Misses when the reviewer has no
-    # merged commit in apache/kafka, or had "Keep my email private" enabled
-    # at commit time (GitHub rewrites the author to the noreply form).
-    try:
-        cmd = f"gh api repos/apache/kafka/commits?author={login}&per_page=1"
-        p = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
-        if p.returncode == 0:
-            commits = json.loads(p.stdout)
-            if commits:
-                author = commits[0].get("commit", {}).get("author", {})
-                name = author.get("name")
-                email = _usable_email(author.get("email"))
-    except Exception as e:
-        logger.debug(f"Failed to resolve {login} from commit history: {e}")
-
-    # Tier 2: GitHub user profile. Only exposes an email when the reviewer
-    # has set a Public email in their profile settings.
-    if not name or not email:
-        try:
-            cmd = f"gh api users/{login}"
-            p = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
-            if p.returncode == 0:
-                user = json.loads(p.stdout)
-                if not name:
-                    name = user.get("name")
-                if not email:
-                    email = _usable_email(user.get("email"))
-        except Exception as e:
-            logger.debug(f"Failed to resolve {login} from GitHub profile: {e}")
-
-    # Tier 3: past Reviewers: trailers in commit history, matched by name,
+    # Tier 1: past Reviewers: trailers in commit history, matched by name,
     # via the GitHub commit search API. Catches pure reviewers (no commits
     # in apache/kafka, no public profile email) who have been credited
     # with a real email in an earlier merged PR. Sort by committer-date
     # desc so the most recent email wins if a reviewer has changed it.
     # Full-text search is tokenized (not strict substring), so we
     # re-verify with a regex client-side.
-    if name and not email:
-        try:
-            cmd = ["gh", "search", "commits",
-                   "--repo", "apache/kafka",
-                   f'"{name} <"',
-                   "--limit", "3",
-                   "--sort", "committer-date",
-                   "--order", "desc",
-                   "--json", "commit",
-                   "--jq", "[.[].commit.message]"]
-            p = subprocess.run(cmd, capture_output=True, text=True)
-            if p.returncode == 0:
-                messages = json.loads(p.stdout)
-                pattern = re.compile(rf"{re.escape(name)}\s*<([^>]+)>")
-                email = next(
-                    (usable for msg in messages
-                     for m in pattern.finditer(msg)
-                     if (usable := _usable_email(m.group(1)))),
-                    None,
-                )
-        except Exception as e:
-            logger.debug(f"Failed to resolve {login} from commit search: {e}")
+    for candidate in name_candidates:
+        messages = _run_json(["gh", "search", "commits",
+                              "--repo", "apache/kafka",
+                              f'"{candidate} <"',
+                              "--limit", "3",
+                              "--sort", "committer-date",
+                              "--order", "desc",
+                              "--json", "commit",
+                              "--jq", "[.[].commit.message]"],
+                             "commit search") or []
+        pattern = re.compile(rf"{re.escape(candidate)}\s*<([^>]+)>")
+        email = next(
+            (usable for msg in messages
+             for m in pattern.finditer(msg)
+             if (usable := _usable_email(m.group(1)))),
+            None,
+        )
+        if email:
+            name = candidate
+            break
 
-    if not name:
-        name = login
+    # Tier 2: find the latest repo commit authored by this GitHub login.
+    # Misses when the reviewer has no merged commit in apache/kafka, or had
+    # "Keep my email private" enabled at commit time.
+    if not email:
+        email = _usable_email(author.get("email"))
+        if author.get("name"):
+            name = author.get("name")
+
+    # Tier 3: GitHub user profile. Only exposes an email when the reviewer
+    # has set a Public email in their profile settings.
+    if not email:
+        email = _usable_email(user.get("email"))
+        if user.get("name"):
+            name = user.get("name")
 
     return (name, email)
 
@@ -193,7 +195,7 @@ def already_exists(identity: str, existing_reviewers: List[str]) -> bool:
     """Check if a reviewer identity is already in the existing reviewers list.
 
     identity is the delimited token that uniquely identifies a reviewer, either
-    '<email>' (for the email form) or '(@login)' (for the login fallback).
+    '<email>' (for the email form) or '(github:login)' (for the login fallback).
     """
     return identity.lower() in ", ".join(existing_reviewers).lower()
 
@@ -253,7 +255,8 @@ if __name__ == "__main__":
         if email:
             identity = f"<{email}>"
         else:
-            identity = f"(@{reviewer_login})"
+            # Tier 4: fall back to the GitHub handle without tagging the reviewer.
+            identity = f"(github:{reviewer_login})"
         resolved = f"{name} {identity}"
         existing_reviewers = parse_trailers(title, body).get("Reviewers", [])
         if not already_exists(identity, existing_reviewers):

--- a/.github/workflows/pr-reviewed.yml
+++ b/.github/workflows/pr-reviewed.yml
@@ -29,6 +29,7 @@ jobs:
   save-pr-number:
     name: Save PR Number
     runs-on: ubuntu-latest
+    if: github.event.pull_request.state == 'open'
     steps:
       - name: Env
         run: printenv


### PR DESCRIPTION
The `resolve_reviewer` introduced in #22108 used local `git log` to find
past `Reviewers:` trailers, but the PR linter runs with the default
shallow checkout (`fetch-depth: 1`), so older merged PR trailers are not
available on the runner.

This PR switches reviewer email resolution to GitHub APIs in this order:

1. the reviewer's latest apache/kafka commit author email
2. `gh search commits` for prior `Reviewers:` trailers by display name,
   accepted only when the matched commit's associated PR has a review
   from the same GitHub login
3. the reviewer's GitHub public profile email
4. `Name (github:login)` fallback, without tagging the reviewer

It also skips `pr-reviewed.yml` artifact creation once the PR is no
longer open.

For the motivating #22108 case, this resolves `@mimaison` as `Mickael
Maison <mimaison@apache.org>` instead of falling back to the GitHub
handle.

`gh search commits` uses GitHub's Search API bucket. In CI it is
authenticated via `GH_TOKEN`, so the limit is 30 requests/minute
(unauthenticated is 10 requests/minute). This workflow normally resolves
one reviewer per run. In local checks, `mjsax` and `mingyen066` resolved
via T1 in 0.5-0.8s, while `mimaison` and `UladzislauBlok` resolved via
T2's search-plus-review verification in about 3.0s.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
