### PR TITLE
KAFKA-20517: Backport KAFKA-19748 Streams memory-leak note to 4.1 docs

### DIFF
--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -49,6 +49,8 @@ type: docs
 
 ### Upgrading Servers to 4.1.0 from any version 3.3.x through 4.0.x
 
+The rolling upgrade procedure for 4.1.x is identical to the 4.0 upgrade. Please refer to the [Upgrading Servers to 4.0.x](/41/getting-started/upgrade/#upgrading-servers-to-401-from-any-version-33x-through-39x) section for detailed step-by-step instructions.
+
 ### Notable changes in 4.1.0
 
   * Apache Kafka 4.1 ships with a preview of Queues for Kafka ([KIP-932](https://cwiki.apache.org/confluence/x/4hA0Dw)). This feature introduces a new kind of group called share groups, as an alternative to consumer groups. Consumers in a share group cooperatively consume records from topics, without assigning each partition to just one consumer. Share groups also introduce per-record acknowledgement and counting of delivery attempts. Use share groups in cases where records are processed one at a time, rather than as part of an ordered stream. To enable share groups, use the `kafka-features.sh` tool to upgrade to `share.version=1`. For more information, please read the [ release notes](https://cwiki.apache.org/confluence/x/CIq3FQ). 

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -45,6 +45,8 @@ type: docs
 
 ## Upgrading to 4.1.0
 
+**Note:** Kafka Streams 4.1.0 contains a critical memory leak bug ([KAFKA-19748](https://issues.apache.org/jira/browse/KAFKA-19748)) that affects users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins). Users running Kafka Streams should consider upgrading directly to 4.1.1, which includes the fix for it.
+
 ### Upgrading Servers to 4.1.0 from any version 3.3.x through 4.0.x
 
 ### Notable changes in 4.1.0

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -49,7 +49,7 @@ type: docs
 
 ### Upgrading Servers to 4.1.0 from any version 3.3.x through 4.0.x
 
-The rolling upgrade procedure for 4.1.x is identical to the 4.0 upgrade. Please refer to the [Upgrading Servers to 4.0.x](/41/getting-started/upgrade/#upgrading-servers-to-401-from-any-version-33x-through-39x) section for detailed step-by-step instructions.
+The rolling upgrade procedure for 4.1.x is identical to the 4.0 upgrade. Please refer to the [Upgrading Servers to 4.0.x](#upgrading-servers-to-401-from-any-version-33x-through-39x) section for detailed step-by-step instructions.
 
 ### Notable changes in 4.1.0
 

--- a/docs/streams/upgrade-guide.md
+++ b/docs/streams/upgrade-guide.md
@@ -71,6 +71,8 @@ In deprecated `KStreamBuilder` class, when a `KTable` is created from a source t
 
 ## Streams API changes in 4.1.0
 
+**Note:** Kafka Streams 4.1.0 contains a critical memory leak bug ([KAFKA-19748](https://issues.apache.org/jira/browse/KAFKA-19748)) that affects users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins). Users running Kafka Streams should consider upgrading directly to 4.1.1, which includes the fix for it.
+
 ### Early Access of the Streams Rebalance Protocol
 
 The Streams Rebalance Protocol is a broker-driven rebalancing system designed specifically for Kafka Streams applications. Following the pattern of KIP-848, which moved rebalance coordination of plain consumers from clients to brokers, KIP-1071 extends this model to Kafka Streams workloads. Instead of clients computing new assignments on the client during rebalance events involving all members of the group, assignments are computed continuously on the broker. Instead of using a consumer group, the streams application registers as a streams group with the broker, which manages and exposes all metadata required for coordination of the streams application instances. 


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-20517

Backports the KAFKA-19748 Kafka Streams memory-leak warning from trunk (f5a87b3703, #20639) to the 4.1 branch.

The original commit did not apply cleanly because trunk's HTML upgrade docs have been migrated to Markdown on 4.1, so the same note is added to `docs/getting-started/upgrade.md` and `docs/streams/upgrade-guide.md`. 

Wording updated from "when available" to "which includes the fix for it" since 4.1.1 is released. 

Reviewers: Erik Skytthe <joerg@thalheim.io>, Chia-Ping Tsai <chia7712@gmail.com>


