### PR TITLE
KAFKA-20536 : Fix empty heading - Adding upgrade instructions for 4.1 - in trunk

### DIFF
--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -124,6 +124,8 @@ For further details, please refer to [KIP-1120](https://cwiki.apache.org/conflue
 
 ### Upgrading Servers to 4.1.0 from any version 3.3.x through 4.0.x
 
+The rolling upgrade procedure for 4.1.x is identical to the 4.0 upgrade. Please refer to the [Upgrading Servers to 4.0.x](#upgrading-servers-to-401-from-any-version-33x-through-39x) section for detailed step-by-step instructions.
+
 ### Notable changes in 4.1.0
 
   * Apache Kafka 4.1 ships with a preview of Queues for Kafka ([KIP-932](https://cwiki.apache.org/confluence/x/4hA0Dw)). This feature introduces a new kind of group called share groups, as an alternative to consumer groups. Consumers in a share group cooperatively consume records from topics, without assigning each partition to just one consumer. Share groups also introduce per-record acknowledgement and counting of delivery attempts. Use share groups in cases where records are processed one at a time, rather than as part of an ordered stream. To enable share groups, use the `kafka-features.sh` tool to upgrade to `share.version=1`. For more information, please read the [ release notes](https://cwiki.apache.org/confluence/x/CIq3FQ). 

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -118,6 +118,23 @@ For further details, please refer to [KIP-1120](https://cwiki.apache.org/conflue
   * Added an optional `--node-id` flag to the `FeatureCommand` command. It specifies the node to describe. If not provided, an arbitrary node is used.
 
 
+## Upgrading to 4.1.2
+
+### Notable changes in 4.1.2
+
+* Includes a fix for the rare Kafka producer bug ([KAFKA-19012](https://issues.apache.org/jira/browse/KAFKA-19012)), in which a record could end up on the incorrect topic.
+
+
+
+## Upgrading to 4.1.1
+
+### Notable changes in 4.1.1
+
+* Includes a fix for the critical Kafka Streams bug ([KAFKA-19748](https://issues.apache.org/jira/browse/KAFKA-19748)), solving the memory leak issues that affected users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins).
+* Includes a fix for the critical Kafka Streams bug ([KAFKA-19479](https://issues.apache.org/jira/browse/KAFKA-19479)), related to potential data loss.
+
+
+
 ## Upgrading to 4.1.0
 
 **Note:** Kafka Streams 4.1.0 contains a critical memory leak bug ([KAFKA-19748](https://issues.apache.org/jira/browse/KAFKA-19748)) that affects users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins). Users running Kafka Streams should consider upgrading directly to 4.1.1, which includes the fix for it.


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-20536  Fix empty
heading.

Based on
https://github.com/apache/kafka/pull/22149/changes#diff-c5e3efa4452ee71b237606125679318121ab54a9491902bebf0b7e54e7c35c33R52,
adding upgrade instruction to 4.3 branch as well.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
