### PR TITLE
KAFKA-20462: Preserve source headers in error handlers

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProcessingExceptionHandlerIntegrationTest.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
@@ -43,6 +45,7 @@ import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockProcessorSupplier;
 
 import org.junit.jupiter.api.Tag;
@@ -62,18 +65,24 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
 public class ProcessingExceptionHandlerIntegrationTest {
+    private static final String SOURCE_HEADER = "source-only";
+    private static final byte[] SOURCE_HEADER_VALUE = "kept".getBytes(UTF_8);
     private final String threadId = Thread.currentThread().getName();
 
     private static final Instant TIMESTAMP = Instant.now();
@@ -398,6 +407,39 @@ public class ProcessingExceptionHandlerIntegrationTest {
         }
     }
 
+    @Test
+    public void shouldExposeOriginalHeadersAfterCachedProcessingError() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .stream("TOPIC_NAME", consumedWithHeaderRemovingKeySerde())
+            .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+            .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("count")
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long())
+                .withCachingEnabled())
+            .toStream()
+            .mapValues(value -> {
+                throw new RuntimeException("Error");
+            });
+
+        final Properties properties = new Properties();
+        properties.put(
+            StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG,
+            AssertSourceRawHeadersProcessingExceptionHandler.class
+        );
+
+        try (final TopologyTestDriver driver = new TopologyTestDriverBuilder(builder.build()).withConfig(properties).build()) {
+            final TestInputTopic<String, String> inputTopic =
+                driver.createInputTopic("TOPIC_NAME", new StringSerializer(), new StringSerializer());
+            final ProducerRecord<String, String> event = sourceRecord("TOPIC_NAME", "ID123-1", "ID123-A1");
+
+            assertThrows(
+                StreamsException.class,
+                () -> inputTopic.pipeInput(new TestRecord<>(event.key(), event.value(), event.headers(), TIMESTAMP))
+            );
+        }
+    }
+
     static Stream<Arguments> sourceRawRecordTopologyTestCases() {
         // Validate source raw key and source raw value for fully stateless topology
         final List<ProducerRecord<String, String>> statelessTopologyEvent = List.of(new ProducerRecord<>("TOPIC_NAME", "ID123-1", "ID123-A1"));
@@ -579,6 +621,51 @@ public class ProcessingExceptionHandlerIntegrationTest {
         @Override
         public void configure(final Map<String, ?> configs) {
             // No-op
+        }
+    }
+
+    public static class AssertSourceRawHeadersProcessingExceptionHandler implements ProcessingExceptionHandler {
+        @Override
+        public Response handleError(final ErrorHandlerContext context,
+                                    final Record<?, ?> record,
+                                    final Exception exception) {
+            assertNull(record.headers().lastHeader(SOURCE_HEADER));
+            assertNotNull(context.headers().lastHeader(SOURCE_HEADER));
+            assertArrayEquals(SOURCE_HEADER_VALUE, context.headers().lastHeader(SOURCE_HEADER).value());
+            return Response.fail();
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs) {
+            // No-op
+        }
+    }
+
+    private static ProducerRecord<String, String> sourceRecord(final String topic,
+                                                                final String key,
+                                                                final String value) {
+        final ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+        record.headers().add(SOURCE_HEADER, SOURCE_HEADER_VALUE);
+        return record;
+    }
+
+    private static Consumed<String, String> consumedWithHeaderRemovingKeySerde() {
+        return Consumed.with(
+            Serdes.serdeFrom(new StringSerializer(), new HeaderRemovingStringDeserializer()),
+            Serdes.String()
+        );
+    }
+
+    private static final class HeaderRemovingStringDeserializer implements Deserializer<String> {
+        @Override
+        public String deserialize(final String topic, final byte[] data) {
+            return data == null ? null : new String(data, UTF_8);
+        }
+
+        @Override
+        public String deserialize(final String topic, final Headers headers, final byte[] data) {
+            headers.remove(SOURCE_HEADER);
+            return deserialize(topic, data);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -371,11 +371,6 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                     if (record.key() != null) {
                         // Deserialization phase
                         final Record<?, ?> deserializedRecord;
-                        // Snapshot headers before invoking the user-supplied
-                        // Deserializers so the ErrorHandlerContext seen by the
-                        // DeserializationExceptionHandler reflects the original
-                        // source-record headers, even if a Deserializer mutates
-                        // the live Headers reference.
                         final Headers sourceRecordHeaders = new RecordHeaders(record.headers());
                         try {
                             deserializedRecord = new Record<>(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -23,6 +23,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Time;
@@ -369,6 +371,12 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                     if (record.key() != null) {
                         // Deserialization phase
                         final Record<?, ?> deserializedRecord;
+                        // Snapshot headers before invoking the user-supplied
+                        // Deserializers so the ErrorHandlerContext seen by the
+                        // DeserializationExceptionHandler reflects the original
+                        // source-record headers, even if a Deserializer mutates
+                        // the live Headers reference.
+                        final Headers sourceRecordHeaders = new RecordHeaders(record.headers());
                         try {
                             deserializedRecord = new Record<>(
                                 reprocessFactory.keyDeserializer().deserialize(record.topic(), record.headers(), record.key()),
@@ -384,6 +392,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                                 globalProcessorContext,
                                 deserializationException,
                                 record,
+                                sourceRecordHeaders,
                                 log,
                                 droppedRecordsSensor,
                                 null
@@ -406,7 +415,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                                     record.topic(),
                                     record.partition(),
                                     record.offset(),
-                                    record.headers(),
+                                    sourceRecordHeaders,
                                     reprocessFactory.processorName(),
                                     globalProcessorContext.taskId(),
                                     record.timestamp(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.LogContext;
@@ -109,7 +111,13 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     @Override
     public void update(final ConsumerRecord<byte[], byte[]> record) {
         final RecordDeserializer sourceNodeAndDeserializer = deserializers.get(record.topic());
-        final ConsumerRecord<Object, Object> deserialized = sourceNodeAndDeserializer.deserialize(processorContext, record);
+        // Snapshot headers before invoking the user-supplied Deserializer so
+        // ErrorHandlerContext#headers() observed by the
+        // DeserializationExceptionHandler / ProcessingExceptionHandler exposes
+        // the original source-record headers, even if a Deserializer mutates
+        // the live Headers reference.
+        final Headers sourceRawHeaders = new RecordHeaders(record.headers());
+        final ConsumerRecord<Object, Object> deserialized = sourceNodeAndDeserializer.deserialize(processorContext, record, sourceRawHeaders);
 
         if (deserialized != null) {
             final ProcessorRecordContext recordContext =
@@ -118,7 +126,10 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
                     deserialized.offset(),
                     deserialized.partition(),
                     deserialized.topic(),
-                    deserialized.headers());
+                    deserialized.headers(),
+                    null,
+                    null,
+                    sourceRawHeaders);
             processorContext.setRecordContext(recordContext);
             processorContext.setCurrentNode(sourceNodeAndDeserializer.sourceNode());
             final Record<Object, Object> toProcess = new Record<>(

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -111,11 +111,6 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
     @Override
     public void update(final ConsumerRecord<byte[], byte[]> record) {
         final RecordDeserializer sourceNodeAndDeserializer = deserializers.get(record.topic());
-        // Snapshot headers before invoking the user-supplied Deserializer so
-        // ErrorHandlerContext#headers() observed by the
-        // DeserializationExceptionHandler / ProcessingExceptionHandler exposes
-        // the original source-record headers, even if a Deserializer mutates
-        // the live Headers reference.
         final Headers sourceRawHeaders = new RecordHeaders(record.headers());
         final ConsumerRecord<Object, Object> deserialized = sourceNodeAndDeserializer.deserialize(processorContext, record, sourceRawHeaders);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -262,7 +262,8 @@ public final class ProcessorContextImpl extends AbstractProcessorContext<Object,
                     recordContext.topic(),
                     record.headers(),
                     recordContext.sourceRawKey(),
-                    recordContext.sourceRawValue()
+                    recordContext.sourceRawValue(),
+                    recordContext.sourceRawHeaders()
                 );
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -215,12 +217,21 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                 throw processingException;
             }
 
+            // ErrorHandlerContext#headers() is documented to expose the source
+            // record's headers. When the live recordContext is a
+            // ProcessorRecordContext that captured a sourceRawHeaders snapshot
+            // (i.e. the record came from a deserialized ConsumerRecord), use
+            // that snapshot so the handler -- and any DLQ record built from it
+            // -- sees the original headers even if a Deserializer mutated the
+            // live Headers reference. Fall back to the live headers when no
+            // snapshot is available (e.g. internal/synthetic record contexts).
+            final Headers sourceRecordHeaders = sourceRawHeadersOrLive(internalProcessorContext.recordContext());
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null, // only required to pass for DeserializationExceptionHandler
                 internalProcessorContext.recordContext().topic(),
                 internalProcessorContext.recordContext().partition(),
                 internalProcessorContext.recordContext().offset(),
-                internalProcessorContext.recordContext().headers(),
+                sourceRecordHeaders,
                 internalProcessorContext.currentNode().name(),
                 internalProcessorContext.taskId(),
                 internalProcessorContext.recordContext().timestamp(),
@@ -309,5 +320,15 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
             sb.append("]\n");
         }
         return sb.toString();
+    }
+
+    private static Headers sourceRawHeadersOrLive(final RecordContext recordContext) {
+        if (recordContext instanceof ProcessorRecordContext) {
+            final Headers snapshot = ((ProcessorRecordContext) recordContext).sourceRawHeaders();
+            if (snapshot != null) {
+                return snapshot;
+            }
+        }
+        return recordContext.headers();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -17,9 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -217,21 +215,12 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
                 throw processingException;
             }
 
-            // ErrorHandlerContext#headers() is documented to expose the source
-            // record's headers. When the live recordContext is a
-            // ProcessorRecordContext that captured a sourceRawHeaders snapshot
-            // (i.e. the record came from a deserialized ConsumerRecord), use
-            // that snapshot so the handler -- and any DLQ record built from it
-            // -- sees the original headers even if a Deserializer mutated the
-            // live Headers reference. Fall back to the live headers when no
-            // snapshot is available (e.g. internal/synthetic record contexts).
-            final Headers sourceRecordHeaders = sourceRawHeadersOrLive(internalProcessorContext.recordContext());
             final ErrorHandlerContext errorHandlerContext = new DefaultErrorHandlerContext(
                 null, // only required to pass for DeserializationExceptionHandler
                 internalProcessorContext.recordContext().topic(),
                 internalProcessorContext.recordContext().partition(),
                 internalProcessorContext.recordContext().offset(),
-                sourceRecordHeaders,
+                internalProcessorContext.recordContext().sourceRawHeaders(),
                 internalProcessorContext.currentNode().name(),
                 internalProcessorContext.taskId(),
                 internalProcessorContext.recordContext().timestamp(),
@@ -322,13 +311,4 @@ public class ProcessorNode<KIn, VIn, KOut, VOut> {
         return sb.toString();
     }
 
-    private static Headers sourceRawHeadersOrLive(final RecordContext recordContext) {
-        if (recordContext instanceof ProcessorRecordContext) {
-            final Headers snapshot = ((ProcessorRecordContext) recordContext).sourceRawHeaders();
-            if (snapshot != null) {
-                return snapshot;
-            }
-        }
-        return recordContext.headers();
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -41,13 +41,6 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     private final Headers headers;
     private byte[] sourceRawKey;
     private byte[] sourceRawValue;
-    // Snapshot of the source record's headers taken before any user-supplied
-    // Deserializer ran. Like {@link #sourceRawKey}/{@link #sourceRawValue},
-    // this is transient (not serialized) and is cleared by
-    // {@link #freeRawRecord()}. Used by the error-handler construction sites
-    // in StreamTask and ProcessorNode so that ErrorHandlerContext#headers()
-    // can return the original source-record headers even when a Deserializer
-    // mutated the live Headers instance.
     private Headers sourceRawHeaders;
 
     public ProcessorRecordContext(final long timestamp,
@@ -121,16 +114,8 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         return sourceRawValue;
     }
 
-    /**
-     * Returns the snapshot of the source record's headers taken before any
-     * user-supplied {@code Deserializer} ran, or {@code null} if no snapshot
-     * was captured (e.g., for {@code ProcessorRecordContext} instances that
-     * were not constructed from a live consumer record). This is consumed by
-     * Streams error-handler construction sites and is not part of the public
-     * {@link RecordContext} interface.
-     */
     public Headers sourceRawHeaders() {
-        return sourceRawHeaders;
+        return sourceRawHeaders == null ? headers : sourceRawHeaders;
     }
 
     public long residentMemorySizeEstimate() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -41,19 +41,21 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     private final Headers headers;
     private byte[] sourceRawKey;
     private byte[] sourceRawValue;
+    // Snapshot of the source record's headers taken before any user-supplied
+    // Deserializer ran. Like {@link #sourceRawKey}/{@link #sourceRawValue},
+    // this is transient (not serialized) and is cleared by
+    // {@link #freeRawRecord()}. Used by the error-handler construction sites
+    // in StreamTask and ProcessorNode so that ErrorHandlerContext#headers()
+    // can return the original source-record headers even when a Deserializer
+    // mutated the live Headers instance.
+    private Headers sourceRawHeaders;
 
     public ProcessorRecordContext(final long timestamp,
                                   final long offset,
                                   final int partition,
                                   final String topic,
                                   final Headers headers) {
-        this.timestamp = timestamp;
-        this.offset = offset;
-        this.topic = topic;
-        this.partition = partition;
-        this.headers = Objects.requireNonNull(headers);
-        this.sourceRawKey = null;
-        this.sourceRawValue = null;
+        this(timestamp, offset, partition, topic, headers, null, null, null);
     }
 
     public ProcessorRecordContext(final long timestamp,
@@ -63,6 +65,17 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
                                   final Headers headers,
                                   final byte[] sourceRawKey,
                                   final byte[] sourceRawValue) {
+        this(timestamp, offset, partition, topic, headers, sourceRawKey, sourceRawValue, null);
+    }
+
+    public ProcessorRecordContext(final long timestamp,
+                                  final long offset,
+                                  final int partition,
+                                  final String topic,
+                                  final Headers headers,
+                                  final byte[] sourceRawKey,
+                                  final byte[] sourceRawValue,
+                                  final Headers sourceRawHeaders) {
         this.timestamp = timestamp;
         this.offset = offset;
         this.topic = topic;
@@ -70,6 +83,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         this.headers = Objects.requireNonNull(headers);
         this.sourceRawKey = sourceRawKey;
         this.sourceRawValue = sourceRawValue;
+        this.sourceRawHeaders = sourceRawHeaders;
     }
 
     @Override
@@ -105,6 +119,18 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     @Override
     public byte[] sourceRawValue() {
         return sourceRawValue;
+    }
+
+    /**
+     * Returns the snapshot of the source record's headers taken before any
+     * user-supplied {@code Deserializer} ran, or {@code null} if no snapshot
+     * was captured (e.g., for {@code ProcessorRecordContext} instances that
+     * were not constructed from a live consumer record). This is consumed by
+     * Streams error-handler construction sites and is not part of the public
+     * {@link RecordContext} interface.
+     */
+    public Headers sourceRawHeaders() {
+        return sourceRawHeaders;
     }
 
     public long residentMemorySizeEstimate() {
@@ -214,6 +240,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
     public void freeRawRecord() {
         this.sourceRawKey = null;
         this.sourceRawValue = null;
+        this.sourceRawHeaders = null;
     }
 
     @Override
@@ -231,7 +258,8 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             Objects.equals(topic, that.topic) &&
             Objects.equals(headers, that.headers) &&
             Arrays.equals(sourceRawKey, that.sourceRawKey) &&
-            Arrays.equals(sourceRawValue, that.sourceRawValue);
+            Arrays.equals(sourceRawValue, that.sourceRawValue) &&
+            Objects.equals(sourceRawHeaders, that.sourceRawHeaders);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.internals.LogContext;
@@ -55,8 +56,16 @@ public class RecordDeserializer {
      *                          or throws an exception itself
      */
     ConsumerRecord<Object, Object> deserialize(final ProcessorContext<?, ?> processorContext,
-                                               final ConsumerRecord<byte[], byte[]> rawRecord) {
+                                               final ConsumerRecord<byte[], byte[]> rawRecord,
+                                               final Headers sourceRecordHeaders) {
 
+        // sourceRecordHeaders is a snapshot of rawRecord.headers() captured by
+        // the caller BEFORE this method runs, because user-supplied
+        // Deserializers are allowed to mutate the live Headers reference (e.g.
+        // a LargeMessageDeserializer that strips serde-internal headers) and
+        // we still need ErrorHandlerContext#headers() to expose the original
+        // source-record headers per its javadoc, so that DLQ records can be
+        // reconstructed faithfully.
         try {
             return new ConsumerRecord<>(
                 rawRecord.topic(),
@@ -75,7 +84,7 @@ public class RecordDeserializer {
             // while Java distinguishes checked vs unchecked exceptions, other languages
             // like Scala or Kotlin do not, and thus we need to catch `Exception`
             // (instead of `RuntimeException`) to work well with those languages
-            handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, log, droppedRecordsSensor, sourceNode().name());
+            handleDeserializationFailure(deserializationExceptionHandler, processorContext, deserializationException, rawRecord, sourceRecordHeaders, log, droppedRecordsSensor, sourceNode().name());
             return null; //  'handleDeserializationFailure' would either throw or swallow -- if we swallow we need to skip the record by returning 'null'
         }
     }
@@ -84,6 +93,7 @@ public class RecordDeserializer {
                                                     final ProcessorContext<?, ?> processorContext,
                                                     final Exception deserializationException,
                                                     final ConsumerRecord<byte[], byte[]> rawRecord,
+                                                    final Headers sourceRecordHeaders,
                                                     final Logger log,
                                                     final Sensor droppedRecordsSensor,
                                                     final String sourceNodeName) {
@@ -93,7 +103,7 @@ public class RecordDeserializer {
             rawRecord.topic(),
             rawRecord.partition(),
             rawRecord.offset(),
-            rawRecord.headers(),
+            sourceRecordHeaders,
             sourceNodeName,
             processorContext.taskId(),
             rawRecord.timestamp(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordDeserializer.java
@@ -58,14 +58,6 @@ public class RecordDeserializer {
     ConsumerRecord<Object, Object> deserialize(final ProcessorContext<?, ?> processorContext,
                                                final ConsumerRecord<byte[], byte[]> rawRecord,
                                                final Headers sourceRecordHeaders) {
-
-        // sourceRecordHeaders is a snapshot of rawRecord.headers() captured by
-        // the caller BEFORE this method runs, because user-supplied
-        // Deserializers are allowed to mutate the live Headers reference (e.g.
-        // a LargeMessageDeserializer that strips serde-internal headers) and
-        // we still need ErrorHandlerContext#headers() to expose the original
-        // source-record headers per its javadoc, so that DLQ records can be
-        // reconstructed faithfully.
         try {
             return new ConsumerRecord<>(
                 rawRecord.topic(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -214,13 +214,6 @@ public class RecordQueue {
 
         while (headRecord == null && !fifoQueue.isEmpty()) {
             final ConsumerRecord<byte[], byte[]> raw = fifoQueue.pollFirst();
-            // Snapshot raw.headers() before invoking the user-supplied
-            // Deserializer in deserialize(...). The same snapshot is then
-            // attached to the StampedRecord so it can be carried through to
-            // the ProcessingExceptionHandler error path -- a Deserializer is
-            // free to mutate the live Headers reference, but
-            // ErrorHandlerContext#headers() must continue to expose the
-            // original source-record headers per its javadoc.
             final Headers sourceRawHeaders = new RecordHeaders(raw.headers());
             final ConsumerRecord<Object, Object> deserialized =
                 recordDeserializer.deserialize(processorContext, raw, sourceRawHeaders);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
@@ -212,8 +214,16 @@ public class RecordQueue {
 
         while (headRecord == null && !fifoQueue.isEmpty()) {
             final ConsumerRecord<byte[], byte[]> raw = fifoQueue.pollFirst();
+            // Snapshot raw.headers() before invoking the user-supplied
+            // Deserializer in deserialize(...). The same snapshot is then
+            // attached to the StampedRecord so it can be carried through to
+            // the ProcessingExceptionHandler error path -- a Deserializer is
+            // free to mutate the live Headers reference, but
+            // ErrorHandlerContext#headers() must continue to expose the
+            // original source-record headers per its javadoc.
+            final Headers sourceRawHeaders = new RecordHeaders(raw.headers());
             final ConsumerRecord<Object, Object> deserialized =
-                recordDeserializer.deserialize(processorContext, raw);
+                recordDeserializer.deserialize(processorContext, raw, sourceRawHeaders);
 
             if (deserialized == null) {
                 // this only happens if the deserializer decides to skip. It has already logged the reason.
@@ -243,7 +253,7 @@ public class RecordQueue {
                 lastCorruptedRecord = raw;
                 continue;
             }
-            headRecord = new StampedRecord(deserialized, timestamp, raw.key(), raw.value());
+            headRecord = new StampedRecord(deserialized, timestamp, raw.key(), raw.value(), sourceRawHeaders);
             headRecordSizeInBytes = consumerRecordSizeInBytes(raw);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -25,10 +25,6 @@ public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
     private final byte[] rawKey;
     private final byte[] rawValue;
-    // Snapshot of the source record's headers taken before any Deserializer
-    // ran, propagated downstream so that ErrorHandlerContext#headers() can
-    // expose the original source-record headers even after a Deserializer
-    // mutated the live Headers instance.
     private final Headers rawHeaders;
 
     public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StampedRecord.java
@@ -25,20 +25,32 @@ public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
     private final byte[] rawKey;
     private final byte[] rawValue;
+    // Snapshot of the source record's headers taken before any Deserializer
+    // ran, propagated downstream so that ErrorHandlerContext#headers() can
+    // expose the original source-record headers even after a Deserializer
+    // mutated the live Headers instance.
+    private final Headers rawHeaders;
 
     public StampedRecord(final ConsumerRecord<?, ?> record, final long timestamp) {
-        super(record, timestamp);
-        this.rawKey = null;
-        this.rawValue = null;
+        this(record, timestamp, null, null, null);
     }
 
     public StampedRecord(final ConsumerRecord<?, ?> record,
                          final long timestamp,
                          final byte[] rawKey,
                          final byte[] rawValue) {
+        this(record, timestamp, rawKey, rawValue, null);
+    }
+
+    public StampedRecord(final ConsumerRecord<?, ?> record,
+                         final long timestamp,
+                         final byte[] rawKey,
+                         final byte[] rawValue,
+                         final Headers rawHeaders) {
         super(record, timestamp);
         this.rawKey = rawKey;
         this.rawValue = rawValue;
+        this.rawHeaders = rawHeaders;
     }
 
     public String topic() {
@@ -75,6 +87,10 @@ public class StampedRecord extends Stamped<ConsumerRecord<?, ?>> {
 
     public byte[] rawValue() {
         return rawValue;
+    }
+
+    public Headers rawHeaders() {
+        return rawHeaders;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -885,7 +885,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             record.topic(),
             record.headers(),
             record.rawKey(),
-            record.rawValue()
+            record.rawValue(),
+            record.rawHeaders()
         );
         updateProcessorContext(currNode, wallClockTime, recordContext);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -282,7 +282,8 @@ public class CachingKeyValueStore
                     internalContext.recordContext().partition(),
                     internalContext.recordContext().topic(),
                     internalContext.recordContext().sourceRawKey(),
-                    internalContext.recordContext().sourceRawValue()
+                    internalContext.recordContext().sourceRawValue(),
+                    internalContext.recordContext().sourceRawHeaders()
                 )
             );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -223,7 +223,8 @@ public class CachingSessionStore
                 internalContext.recordContext().partition(),
                 internalContext.recordContext().topic(),
                 internalContext.recordContext().sourceRawKey(),
-                internalContext.recordContext().sourceRawValue()
+                internalContext.recordContext().sourceRawValue(),
+                internalContext.recordContext().sourceRawHeaders()
             );
         internalContext.cache().put(cacheName, cacheFunction.cacheKey(binaryKey), entry);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -166,7 +166,8 @@ public class CachingWindowStore
                 internalContext.recordContext().partition(),
                 internalContext.recordContext().topic(),
                 internalContext.recordContext().sourceRawKey(),
-                internalContext.recordContext().sourceRawValue()
+                internalContext.recordContext().sourceRawValue(),
+                internalContext.recordContext().sourceRawHeaders()
             );
         internalContext.cache().put(cacheName, cacheFunction.cacheKey(keyBytes), entry);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
@@ -539,7 +539,8 @@ public final class InMemoryTimeOrderedKeyValueChangeBuffer<K, V, T> implements T
             context.topic(),
             headers,
             context.sourceRawKey(),
-            context.sourceRawValue()
+            context.sourceRawValue(),
+            context.sourceRawHeaders()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
@@ -44,6 +44,19 @@ class LRUCacheEntry {
                   final String topic,
                   final byte[] rawKey,
                   final byte[] rawValue) {
+        this(value, headers, isDirty, offset, timestamp, partition, topic, rawKey, rawValue, null);
+    }
+
+    LRUCacheEntry(final byte[] value,
+                  final Headers headers,
+                  final boolean isDirty,
+                  final long offset,
+                  final long timestamp,
+                  final int partition,
+                  final String topic,
+                  final byte[] rawKey,
+                  final byte[] rawValue,
+                  final Headers sourceRawHeaders) {
         final ProcessorRecordContext context = new ProcessorRecordContext(
             timestamp,
             offset,
@@ -51,7 +64,8 @@ class LRUCacheEntry {
             topic,
             headers,
             rawKey,
-            rawValue
+            rawValue,
+            sourceRawHeaders
         );
 
         this.record = new ContextualRecord(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -274,7 +274,8 @@ public class TimeOrderedCachingWindowStore
                 internalContext.recordContext().partition(),
                 internalContext.recordContext().topic(),
                 internalContext.recordContext().sourceRawKey(),
-                internalContext.recordContext().sourceRawValue()
+                internalContext.recordContext().sourceRawValue(),
+                internalContext.recordContext().sourceRawHeaders()
             );
 
         // Put to index first so that base can be evicted later
@@ -294,7 +295,8 @@ public class TimeOrderedCachingWindowStore
                     internalContext.recordContext().partition(),
                     "",
                     internalContext.recordContext().sourceRawKey(),
-                    internalContext.recordContext().sourceRawValue()
+                    internalContext.recordContext().sourceRawValue(),
+                    internalContext.recordContext().sourceRawHeaders()
                 );
             final Bytes indexKey = KeyFirstWindowKeySchema.toStoreKeyBinary(key, windowStartTimestamp, 0);
             internalContext.cache().put(cacheName, indexKeyCacheFunction.cacheKey(indexKey), emptyEntry);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -19,9 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
@@ -58,7 +56,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -75,8 +72,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -254,14 +249,8 @@ public class ProcessorNodeTest {
 
     @Test
     public void shouldExposeSourceRawHeadersToProcessingExceptionHandlerWhenDeserializerMutatedHeaders() {
-        // Simulate a Deserializer that has mutated the live Headers reference
-        // (e.g. removed a serde-internal marker header) before downstream
-        // processing, while a snapshot of the original source-record headers
-        // was captured upstream by RecordQueue.
         final RecordHeaders mutatedLiveHeaders = new RecordHeaders();
-        final RecordHeaders sourceRawHeaders = new RecordHeaders(new Header[]{
-            new RecordHeader("source-only", "kept".getBytes(StandardCharsets.UTF_8))
-        });
+        final Headers sourceRawHeaders = new RecordHeaders().add("source-only", "kept".getBytes());
         final ProcessorRecordContext recordContextWithSnapshot = new ProcessorRecordContext(
             TIMESTAMP,
             OFFSET,
@@ -297,20 +286,7 @@ public class ProcessorNodeTest {
         node.init(internalProcessorContext, handler);
         node.process(new Record<>(KEY, VALUE, TIMESTAMP));
 
-        // Live headers were mutated to empty, but ErrorHandlerContext#headers()
-        // must expose the original source-record headers from the snapshot.
-        assertNull(mutatedLiveHeaders.lastHeader("source-only"));
-        final Headers seenByHandler = capturedHeaders.get();
-        assertNotNull(seenByHandler);
-        assertNotNull(
-            seenByHandler.lastHeader("source-only"),
-            "ErrorHandlerContext.headers() in ProcessingExceptionHandler should expose the original " +
-                "source-record headers (from sourceRawHeaders), not the post-deserialization (mutated) headers"
-        );
-        assertEquals(
-            "kept",
-            new String(seenByHandler.lastHeader("source-only").value(), StandardCharsets.UTF_8)
-        );
+        assertEquals(sourceRawHeaders, capturedHeaders.get());
     }
 
     private static class ExceptionalProcessor implements Processor<Object, Object, Object, Object> {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -19,6 +19,9 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
@@ -55,6 +58,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -62,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.streams.errors.ProcessingExceptionHandler.Response;
 import static org.apache.kafka.streams.errors.ProcessingExceptionHandler.Result;
@@ -70,6 +75,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -243,6 +250,67 @@ public class ProcessorNodeTest {
         assertEquals("dlq", collector.collected().get(0).topic());
         assertEquals("sourceKey", new String((byte[]) collector.collected().get(0).key()));
         assertEquals("sourceValue", new String((byte[]) collector.collected().get(0).value()));
+    }
+
+    @Test
+    public void shouldExposeSourceRawHeadersToProcessingExceptionHandlerWhenDeserializerMutatedHeaders() {
+        // Simulate a Deserializer that has mutated the live Headers reference
+        // (e.g. removed a serde-internal marker header) before downstream
+        // processing, while a snapshot of the original source-record headers
+        // was captured upstream by RecordQueue.
+        final RecordHeaders mutatedLiveHeaders = new RecordHeaders();
+        final RecordHeaders sourceRawHeaders = new RecordHeaders(new Header[]{
+            new RecordHeader("source-only", "kept".getBytes(StandardCharsets.UTF_8))
+        });
+        final ProcessorRecordContext recordContextWithSnapshot = new ProcessorRecordContext(
+            TIMESTAMP,
+            OFFSET,
+            PARTITION,
+            TOPIC,
+            mutatedLiveHeaders,
+            RAW_KEY,
+            RAW_VALUE,
+            sourceRawHeaders
+        );
+        @SuppressWarnings("unchecked")
+        final InternalProcessorContext<Object, Object> internalProcessorContext =
+            mock(InternalProcessorContext.class, withSettings().strictness(Strictness.LENIENT));
+        when(internalProcessorContext.taskId()).thenReturn(TASK_ID);
+        when(internalProcessorContext.metrics()).thenReturn(new StreamsMetricsImpl(new Metrics(), "test-client", new MockTime()));
+        when(internalProcessorContext.recordContext()).thenReturn(recordContextWithSnapshot);
+        when(internalProcessorContext.currentNode()).thenReturn(new ProcessorNode<>(NAME));
+
+        final AtomicReference<Headers> capturedHeaders = new AtomicReference<>();
+        final ProcessingExceptionHandler handler = new ProcessingExceptionHandler() {
+            @Override
+            public Response handleError(final ErrorHandlerContext context, final Record<?, ?> record, final Exception exception) {
+                capturedHeaders.set(context.headers());
+                return Response.resume();
+            }
+
+            @Override
+            public void configure(final Map<String, ?> configs) { }
+        };
+
+        final ProcessorNode<Object, Object, Object, Object> node =
+            new ProcessorNode<>(NAME, new IgnoredInternalExceptionsProcessor(), Collections.emptySet());
+        node.init(internalProcessorContext, handler);
+        node.process(new Record<>(KEY, VALUE, TIMESTAMP));
+
+        // Live headers were mutated to empty, but ErrorHandlerContext#headers()
+        // must expose the original source-record headers from the snapshot.
+        assertNull(mutatedLiveHeaders.lastHeader("source-only"));
+        final Headers seenByHandler = capturedHeaders.get();
+        assertNotNull(seenByHandler);
+        assertNotNull(
+            seenByHandler.lastHeader("source-only"),
+            "ErrorHandlerContext.headers() in ProcessingExceptionHandler should expose the original " +
+                "source-record headers (from sourceRawHeaders), not the post-deserialization (mutated) headers"
+        );
+        assertEquals(
+            "kept",
+            new String(seenByHandler.lastHeader("source-only").value(), StandardCharsets.UTF_8)
+        );
     }
 
     private static class ExceptionalProcessor implements Processor<Object, Object, Object, Object> {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -407,11 +407,7 @@ public class RecordDeserializerTest {
             assertNull(recordDeserializer.deserialize(context, mutatingRawRecord, new RecordHeaders(mutatingRawRecord.headers())));
         }
 
-        // After the deserializer ran, the live Headers reference is empty.
         assertNull(mutableHeaders.lastHeader("source-only"));
-        // But the ErrorHandlerContext seen by the DeserializationExceptionHandler
-        // must reflect the source record's *original* headers, per the javadoc on
-        // ErrorHandlerContext#headers().
         final Headers seenByHandler = capturedHeaders.get();
         assertNotNull(seenByHandler);
         assertNotNull(
@@ -432,9 +428,6 @@ public class RecordDeserializerTest {
 
         @Override
         public Object deserializeKey(final String topic, final Headers headers, final byte[] data) {
-            // Simulate a Deserializer that strips serde-internal headers before
-            // signaling failure (e.g., a LargeMessageDeserializer-style flow that
-            // realizes the payload is malformed after consuming a marker header).
             headers.remove("source-only");
             throw new RuntimeException("KABOOM!");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -46,12 +46,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.streams.StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG;
 import static org.apache.kafka.streams.errors.DeserializationExceptionHandler.Response;
 import static org.apache.kafka.streams.errors.DeserializationExceptionHandler.Result;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,7 +91,7 @@ public class RecordDeserializerTest {
                     new LogContext(),
                     metrics.sensor("dropped-records")
             );
-            final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(null, rawRecord);
+            final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(null, rawRecord, new RecordHeaders(rawRecord.headers()));
             assertEquals(rawRecord.topic(), record.topic());
             assertEquals(rawRecord.partition(), record.partition());
             assertEquals(rawRecord.offset(), record.offset());
@@ -129,7 +131,7 @@ public class RecordDeserializerTest {
                     metrics.sensor("dropped-records")
             );
 
-            final StreamsException e = assertThrows(StreamsException.class, () -> recordDeserializer.deserialize(context, rawRecord));
+            final StreamsException e = assertThrows(StreamsException.class, () -> recordDeserializer.deserialize(context, rawRecord, new RecordHeaders(rawRecord.headers())));
             assertEquals("Deserialization exception handler is set "
                             + "to fail upon a deserialization error. "
                             + "If you would rather have the streaming pipeline "
@@ -167,7 +169,7 @@ public class RecordDeserializerTest {
                     metrics.sensor("dropped-records")
             );
 
-            final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(context, rawRecord);
+            final ConsumerRecord<Object, Object> record = recordDeserializer.deserialize(context, rawRecord, new RecordHeaders(rawRecord.headers()));
             assertNull(record);
         }
     }
@@ -195,7 +197,7 @@ public class RecordDeserializerTest {
 
             final StreamsException exception = assertThrows(
                     StreamsException.class,
-                    () -> recordDeserializer.deserialize(context, rawRecord)
+                    () -> recordDeserializer.deserialize(context, rawRecord, new RecordHeaders(rawRecord.headers()))
             );
             assertEquals("Fatal user code error in deserialization error callback", exception.getMessage());
             assertInstanceOf(NullPointerException.class, exception.getCause());
@@ -226,7 +228,7 @@ public class RecordDeserializerTest {
 
             final StreamsException exception = assertThrows(
                     StreamsException.class,
-                    () -> recordDeserializer.deserialize(context, rawRecord)
+                    () -> recordDeserializer.deserialize(context, rawRecord, new RecordHeaders(rawRecord.headers()))
             );
             assertEquals("Fatal user code error in deserialization error callback", exception.getMessage());
             assertEquals("CRASH", exception.getCause().getMessage());
@@ -261,6 +263,7 @@ public class RecordDeserializerTest {
                             "world".getBytes(StandardCharsets.UTF_8),
                             new RecordHeaders(),
                             Optional.empty()),
+                    new RecordHeaders(),
                     new LogContext().logger(this.getClass()),
                     metrics.sensor("dropped-records"),
                     "sourceNode"
@@ -301,6 +304,7 @@ public class RecordDeserializerTest {
                             "world".getBytes(StandardCharsets.UTF_8),
                             new RecordHeaders(),
                             Optional.empty()),
+                    new RecordHeaders(),
                     new LogContext().logger(this.getClass()),
                     metrics.sensor("dropped-records"),
                     "sourceNode"
@@ -369,6 +373,95 @@ public class RecordDeserializerTest {
         final Response response = Response.fail();
 
         assertTrue(response.deadLetterQueueRecords().isEmpty());
+    }
+
+    @Test
+    public void shouldExposeOriginalSourceRecordHeadersToErrorHandlerWhenDeserializerMutatesHeaders() {
+        final RecordHeaders mutableHeaders = new RecordHeaders(new Header[]{
+            new RecordHeader("source-only", "kept".getBytes(StandardCharsets.UTF_8))
+        });
+        final ConsumerRecord<byte[], byte[]> mutatingRawRecord = new ConsumerRecord<>(
+            "topic",
+            1,
+            1,
+            10,
+            TimestampType.LOG_APPEND_TIME,
+            3,
+            5,
+            new byte[0],
+            new byte[0],
+            mutableHeaders,
+            Optional.of(5)
+        );
+
+        final AtomicReference<Headers> capturedHeaders = new AtomicReference<>();
+
+        try (final Metrics metrics = new Metrics()) {
+            final RecordDeserializer recordDeserializer = new RecordDeserializer(
+                new HeaderMutatingSourceNode(sourceNodeName),
+                new HeaderCapturingExceptionHandler(capturedHeaders),
+                new LogContext(),
+                metrics.sensor("dropped-records")
+            );
+
+            assertNull(recordDeserializer.deserialize(context, mutatingRawRecord, new RecordHeaders(mutatingRawRecord.headers())));
+        }
+
+        // After the deserializer ran, the live Headers reference is empty.
+        assertNull(mutableHeaders.lastHeader("source-only"));
+        // But the ErrorHandlerContext seen by the DeserializationExceptionHandler
+        // must reflect the source record's *original* headers, per the javadoc on
+        // ErrorHandlerContext#headers().
+        final Headers seenByHandler = capturedHeaders.get();
+        assertNotNull(seenByHandler);
+        assertNotNull(
+            seenByHandler.lastHeader("source-only"),
+            "ErrorHandlerContext.headers() should expose the original source-record headers, " +
+                "not the post-deserialization (mutated) headers"
+        );
+        assertEquals(
+            "kept",
+            new String(seenByHandler.lastHeader("source-only").value(), StandardCharsets.UTF_8)
+        );
+    }
+
+    static class HeaderMutatingSourceNode extends SourceNode<Object, Object> {
+        HeaderMutatingSourceNode(final String name) {
+            super(name, null, null);
+        }
+
+        @Override
+        public Object deserializeKey(final String topic, final Headers headers, final byte[] data) {
+            // Simulate a Deserializer that strips serde-internal headers before
+            // signaling failure (e.g., a LargeMessageDeserializer-style flow that
+            // realizes the payload is malformed after consuming a marker header).
+            headers.remove("source-only");
+            throw new RuntimeException("KABOOM!");
+        }
+
+        @Override
+        public Object deserializeValue(final String topic, final Headers headers, final byte[] data) {
+            return null;
+        }
+    }
+
+    static class HeaderCapturingExceptionHandler implements DeserializationExceptionHandler {
+        private final AtomicReference<Headers> captured;
+
+        HeaderCapturingExceptionHandler(final AtomicReference<Headers> captured) {
+            this.captured = captured;
+        }
+
+        @Override
+        public Response handleError(final ErrorHandlerContext context,
+                                    final ConsumerRecord<byte[], byte[]> record,
+                                    final Exception exception) {
+            captured.set(context.headers());
+            return Response.resume();
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs) { }
     }
 
     static class TheSourceNode extends SourceNode<Object, Object> {


### PR DESCRIPTION
## Problem

A Kafka Streams DLQ record can lose headers needed to deserialize it. A deserializer such as `LargeMessageDeserializer` removes its marker header before throwing or before a later processor fails. Streams passes that mutated `Headers` object to the exception handler, so the DLQ record lacks the marker and cannot be replayed with the same deserializer.

## Fix

Snapshot the source header list before user deserialization and carry it beside `sourceRawKey` and `sourceRawValue` through regular tasks, global-state tasks, forwarding, and in-memory caches. The marker now reaches the DLQ record, so the same deserializer can replay it. Repartition records start a new snapshot for their new source record. Processors still receive the live, possibly mutated headers.

This uses Kafka's `RecordHeaders` copy constructor. It copies the header list, including an empty list, without duplicating each header value. There is one small list allocation per consumed record. No public interface or serialized `ProcessorRecordContext` format changes.

JIRA: https://issues.apache.org/jira/browse/KAFKA-20462

Related: https://github.com/apache/kafka/pull/21370

## Testing

```text
./gradlew :streams:test \
  --tests 'org.apache.kafka.streams.processor.internals.RecordDeserializerTest.shouldExposeOriginalSourceRecordHeadersToErrorHandlerWhenDeserializerMutatesHeaders' \
  --tests 'org.apache.kafka.streams.processor.internals.ProcessorNodeTest.shouldExposeSourceRawHeadersToProcessingExceptionHandlerWhenDeserializerMutatedHeaders'

./gradlew :streams:test :streams:checkstyleMain :streams:checkstyleTest :streams:spotbugsMain

./gradlew :streams:integration-tests:test \
  --tests 'org.apache.kafka.streams.integration.ProcessingExceptionHandlerIntegrationTest'
```

<details>
<summary>Raw logs</summary>

```text
BEFORE
RecordDeserializerTest... FAILED
  expected: not <null>
ProcessorNodeTest... FAILED
  expected: <RecordHeaders(... source-only ...)> but was: <RecordHeaders(headers = [], ...)>
shouldExposeOriginalHeadersAfterCachedProcessingError() FAILED
  expected: not <null>

AFTER
RecordDeserializerTest... PASSED
ProcessorNodeTest... PASSED
streams unit suites=403 tests=9554 skipped=1 failures=0 errors=0
ProcessingExceptionHandlerIntegrationTest tests=15 skipped=0 failures=0 errors=0
BUILD SUCCESSFUL
```
</details>

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
