### PR TITLE
MINOR: Fix Punctuator Javadocs for old and new ProcessorContext reference

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/Punctuator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/Punctuator.java
@@ -33,15 +33,15 @@ public interface Punctuator {
      * Perform the scheduled periodic operation.
      *
      * <p> If this method accesses {@link org.apache.kafka.streams.processor.api.ProcessorContext} or
-     * {@link org.apache.kafka.streams.processor.api.ProcessorContext}, record metadata like topic,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext}, record metadata like topic,
      * partition, and offset or {@link org.apache.kafka.streams.processor.api.RecordMetadata} won't
      * be available.
      *
      * <p> Furthermore, for any record that is sent downstream via
      * {@link org.apache.kafka.streams.processor.api.ProcessorContext#forward(Record)}
-     * or {@link org.apache.kafka.streams.processor.api.ProcessorContext#forward(Record)}, there
+     * or {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)}, there
      * won't be any record metadata. If
-     * {@link org.apache.kafka.streams.processor.api.ProcessorContext#forward(Record)} is used,
+     * {@link org.apache.kafka.streams.processor.ProcessorContext#forward(Object, Object)} is used,
      * it's also not possible to set records headers.
      *
      * @param timestamp when the operation is being called, depending on {@link PunctuationType}


### PR DESCRIPTION
This PR fixes a few Javadoc issues in `Punctuator`.

The current documentation accidentally repeats references to the new
Processor API’s `ProcessorContext` where it appears to be trying to
distinguish between the old Processor API and the new Processor API.

Specifically, this PR updates the Javadocs to correctly reference:

- `org.apache.kafka.streams.processor.ProcessorContext` for the old
Processor API
- `org.apache.kafka.streams.processor.api.ProcessorContext` for the new
Processor API
- the old `ProcessorContext#forward(Object, Object)` method where the
documentation discusses forwarding without being able to set record
headers
- the new `ProcessorContext#forward(Record)` method where forwarding
with a `Record` is intended

Reviewers: Pratyaksh Sharma <pratyaksh13@gmail.com>, Matthias J. Sax
 <matthias@confluent.io>
