### PR TITLE
MINOR: system-tests: fix KafkaServer#leader

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1657,10 +1657,11 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             # e.g. Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2
             if not requested_partition_line:
                 raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
-            leader_idx = int(requested_partition_line.split()[5]) # 6th column from above
+            leader_idx_str = requested_partition_line.split()[5] # 6th column from above
+            leader_idx = int(leader_idx_str) if leader_idx_str != "none" else None
 
-        self.logger.info("Leader for topic %s and partition %d is now: %d" % (topic, partition, leader_idx))
-        return self.get_node(leader_idx)
+        self.logger.info("Leader for topic %s and partition %d is now: %s" % (topic, partition, leader_idx))
+        return self.get_node(leader_idx) if leader_idx is not None and leader_idx != -1 else None
 
     def cluster_id(self):
         """ Get the current cluster id


### PR DESCRIPTION
PR #7136 standardised the output format for TopicCommand to print `none`
when the leader for a TP is unknown. `KafkaServer#leader` in
system-tests however fails to account for this change and possibly
panics trying to type cast `none` to an integer.

This change fixes the regression so that we parse the value correctly
and return None if the leader is undefined.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Federico Valeri
 <fedevaleri@gmail.com>
