### PR TITLE
KAFKA-20542 : Fix aggregatedJavadocs build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -696,6 +696,15 @@ subprojects {
 
   task docsJar(dependsOn: javadocJar)
 
+  // Consumed by root aggregatedJavadoc; mirrors compileClasspath.
+  configurations {
+    javadocClasspathElements {
+      canBeConsumed = true
+      canBeResolved = false
+      extendsFrom configurations.compileClasspath
+    }
+  }
+
   check.dependsOn('javadoc')
 
   task systemTestLibs(dependsOn: jar)
@@ -3991,18 +4000,12 @@ project(':connect:test-plugins') {
   }
 }
 
-// Gradle 9+ forbids resolving a subproject's Configuration from the root project.
-// Route the classpath through a resolvable configuration populated with project
-// dependencies so resolution happens under each subproject's own lock.
+// Gradle 9+ forbids resolving a subproject's Configuration from the root.
+// Consume each subproject's javadocClasspathElements via project dependencies instead.
 configurations {
   aggregatedJavadocClasspath {
     canBeConsumed = false
     canBeResolved = true
-    attributes {
-      attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-      attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
-      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-    }
   }
 }
 
@@ -4014,7 +4017,8 @@ gradle.projectsEvaluated {
   def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }
 
   projectsWithJavadoc.each { sp ->
-    dependencies.add('aggregatedJavadocClasspath', dependencies.project(path: sp.path))
+    dependencies.add('aggregatedJavadocClasspath',
+        dependencies.project(path: sp.path, configuration: 'javadocClasspathElements'))
   }
 
   tasks.named('aggregatedJavadoc').configure {

--- a/build.gradle
+++ b/build.gradle
@@ -4010,7 +4010,7 @@ configurations {
 }
 
 task aggregatedJavadoc(type: Javadoc) {
-  destinationDir = file("${buildDir}/docs/javadoc")
+  destinationDir = file("${layout.buildDirectory.get().asFile.path}/docs/javadoc")
 }
 
 gradle.projectsEvaluated {

--- a/build.gradle
+++ b/build.gradle
@@ -3991,12 +3991,39 @@ project(':connect:test-plugins') {
   }
 }
 
-task aggregatedJavadoc(type: Javadoc, dependsOn: compileJava) {
+// Gradle 9+ forbids resolving a subproject's Configuration from the root project.
+// Route the classpath through a resolvable configuration populated with project
+// dependencies so resolution happens under each subproject's own lock.
+configurations {
+  aggregatedJavadocClasspath {
+    canBeConsumed = false
+    canBeResolved = true
+    attributes {
+      attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+      attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+      attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+    }
+  }
+}
+
+task aggregatedJavadoc(type: Javadoc) {
+  destinationDir = file("${buildDir}/docs/javadoc")
+}
+
+gradle.projectsEvaluated {
   def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }
-  source = projectsWithJavadoc.collect { it.sourceSets.main.allJava }
-  classpath = files(projectsWithJavadoc.collect { it.sourceSets.main.compileClasspath })
-  includes = projectsWithJavadoc.collectMany { it.javadoc.getIncludes() }
-  excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
+
+  projectsWithJavadoc.each { sp ->
+    dependencies.add('aggregatedJavadocClasspath', dependencies.project(path: sp.path))
+  }
+
+  tasks.named('aggregatedJavadoc').configure {
+    dependsOn projectsWithJavadoc.collect { "${it.path}:compileJava" }
+    source    projectsWithJavadoc.collect { it.sourceSets.main.allJava }
+    classpath = configurations.aggregatedJavadocClasspath
+    includes  = projectsWithJavadoc.collectMany { it.javadoc.getIncludes() }
+    excludes  = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
+  }
 }
 
 


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-20542

After gradle upgrade to 9.4.1, we notice this issue.  Fix
aggregatedJavadocs.

Tested and works.

Used claude ai.

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>
