### PR TITLE
KAFKA-20440: PEM certificate support should not depend on PKCS12

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -460,7 +460,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
 
         private KeyStore createKeyStoreFromPem(String privateKeyPem, String certChainPem, char[] keyPassword) {
             try {
-                KeyStore ks = KeyStore.getInstance("PKCS12");
+                KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                 ks.load(null, null);
                 Key key = privateKey(privateKeyPem, keyPassword);
                 Certificate[] certChain = certs(certChainPem);
@@ -473,7 +473,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
 
         private KeyStore createTrustStoreFromPem(String trustedCertsPem) {
             try {
-                KeyStore ts = KeyStore.getInstance("PKCS12");
+                KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
                 ts.load(null, null);
                 Certificate[] certs = certs(trustedCertsPem);
                 for (int i = 0; i < certs.length; i++) {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -321,6 +321,30 @@ public class DefaultSslEngineFactoryTest {
         assertNotNull(keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()), "Private key not found");
     }
 
+    @Test  // KAFKA-20440
+    public void testPemKeyStoreUsesDefaultKeyStoreType() throws Exception {
+        configs.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, pemAsConfigValue(KEY));
+        configs.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, pemAsConfigValue(CERTCHAIN));
+        configs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, null);
+        configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore keyStore = factory.keystore();
+        assertEquals(KeyStore.getDefaultType(), keyStore.getType(),
+                "PEM keystore should be backed by the JVM-default keystore type");
+    }
+
+    @Test  // KAFKA-20440
+    public void testPemTrustStoreUsesDefaultKeyStoreType() throws Exception {
+        configs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, pemAsConfigValue(CA1));
+        configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore trustStore = factory.truststore();
+        assertEquals(KeyStore.getDefaultType(), trustStore.getType(),
+                "PEM truststore should be backed by the JVM-default keystore type");
+    }
+
     private String pemFilePath(String pem) throws Exception {
         return TestUtils.tempFile(pem).getAbsolutePath();
     }


### PR DESCRIPTION
## Problem

`DefaultSslEngineFactory.PemStore` hardcodes `"PKCS12"` when creating the in-memory `KeyStore` that backs PEM-formatted key and trust material:

- `clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java:463` (`createKeyStoreFromPem`)
- `clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java:476` (`createTrustStoreFromPem`)

In JVMs where the PKCS12 keystore type is disabled (for example Chainguard FIPS container images that use BouncyCastle and disable PKCS12), this prevents PEM-format certificates from being used at all even though the in-memory keystore itself does not depend on PKCS12 specifically.

## Root Cause

`KeyStore.getInstance("PKCS12")` is a hard-coded literal. There is no reason to pin the in-memory store type — the rest of the code only relies on the `KeyStore` API and works with any default keystore type the JVM provides.

## Fix

Replace the two hard-coded `"PKCS12"` literals with `KeyStore.getDefaultType()`. On a default JVM the security property `keystore.type` is `pkcs12` (since JDK 9), so existing users see no behavioural change. On a JVM where the operator has selected a different default type, PEM material now uses that type instead of failing.

## Tests Added

| Change point | Test |
|--------------|------|
| `createKeyStoreFromPem` no longer hard-codes PKCS12 | `testPemKeyStoreUsesDefaultKeyStoreType()` — asserts the keystore returned by `factory.keystore()` reports `KeyStore.getDefaultType()` as its type |
| `createTrustStoreFromPem` no longer hard-codes PKCS12 | `testPemTrustStoreUsesDefaultKeyStoreType()` — asserts the truststore returned by `factory.truststore()` reports `KeyStore.getDefaultType()` as its type |
| Existing PEM key/trust store behaviour preserved | Existing `testPemTrustStoreConfig*`, `testPemKeyStoreConfig*`, `testPemKeyStoreFile*` tests continue to load aliases, certificates and private keys |

## Impact

- PEM certificate users on default JVMs: no behavioural change (default type is still PKCS12).
- PEM certificate users on JVMs that disable PKCS12 (e.g. FIPS containers): PEM now works using the configured default keystore type.
- Other keystore types (`SslConfigs.SSL_KEYSTORE_TYPE_CONFIG` ≠ `PEM`): unaffected — this code path only handles `PEM_TYPE`.