### PR TITLE
MINOR: Fix duplicate args in KStreamSessionWindowAggregateProcessorTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -105,8 +105,8 @@ public class KStreamSessionWindowAggregateProcessorTest {
         return Stream.of(
             Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true),
             Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, true),
-            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_UPDATE, false)
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, true),
+            Arguments.of(EmitStrategy.StrategyType.ON_WINDOW_CLOSE, false)
         );
     }
 


### PR DESCRIPTION
The `emitStrategyAndHeadersMatrix()` currently returns four entries but
they are duplicates of ON_WINDOW_UPDATE (and therefore also runs each
case twice). This also drops coverage for
EmitStrategy.StrategyType.ON_WINDOW_CLOSE, which was previously covered
via @EnumSource. Update the method source to generate the full matrix of
strategy type(s) and withHeaders values (eg, include both
ON_WINDOW_UPDATE and ON_WINDOW_CLOSE, each with withHeaders=false/true)
without duplicates.

Reviewers: Murali Basani <muralidhar.basani@aiven.io>, Matthias J. Sax
 <matthias@confluent.io>
