### PR TITLE
MINOR: Migrate controllerSocketTimeoutMs from KafkaConfig to AbstractKafkaConfig

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -236,7 +236,6 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val replicaSelectorClassName = Option(getString(ReplicationConfigs.REPLICA_SELECTOR_CLASS_CONFIG))
 
   /** ********* Replication configuration ***********/
-  val controllerSocketTimeoutMs: Int = getInt(ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_CONFIG)
   val defaultReplicationFactor: Int = getInt(ReplicationConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG)
   val replicaLagTimeMaxMs = getLong(ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_CONFIG)
   val replicaSocketTimeoutMs = getInt(ReplicationConfigs.REPLICA_SOCKET_TIMEOUT_MS_CONFIG)

--- a/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
+++ b/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
@@ -38,7 +38,6 @@ import org.apache.kafka.raft.KRaftConfigs;
 import org.apache.kafka.server.common.ControllerRequestCompletionHandler;
 import org.apache.kafka.server.common.NodeToControllerChannelManager;
 import org.apache.kafka.server.config.AbstractKafkaConfig;
-import org.apache.kafka.server.config.ReplicationConfigs;
 import org.apache.kafka.server.config.ServerConfigs;
 
 import org.slf4j.Logger;
@@ -122,7 +121,7 @@ public class NodeToControllerChannelManagerImpl implements NodeToControllerChann
                 50,
                 Selectable.USE_DEFAULT_BUFFER_SIZE,
                 Selectable.USE_DEFAULT_BUFFER_SIZE,
-                Math.min(Integer.MAX_VALUE, (int) Math.min(config.getInt(ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_CONFIG), retryTimeoutMs)), // request timeout should not exceed the provided retry timeout
+                Math.min(Integer.MAX_VALUE, (int) Math.min(config.controllerSocketTimeoutMs(), retryTimeoutMs)), // request timeout should not exceed the provided retry timeout
                 config.getLong(ServerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG),
                 config.getLong(ServerConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG),
                 time,

--- a/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
+++ b/server/src/main/java/org/apache/kafka/server/NodeToControllerChannelManagerImpl.java
@@ -81,7 +81,7 @@ public class NodeToControllerChannelManagerImpl implements NodeToControllerChann
                 buildNetworkClient(controllerInformation),
                 manualMetadataUpdater,
                 controllerNodeProvider,
-                config,
+                config.controllerSocketTimeoutMs(),
                 time,
                 threadName,
                 retryTimeoutMs

--- a/server/src/main/java/org/apache/kafka/server/NodeToControllerRequestThread.java
+++ b/server/src/main/java/org/apache/kafka/server/NodeToControllerRequestThread.java
@@ -21,10 +21,8 @@ import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.ManualMetadataUpdater;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.server.config.ReplicationConfigs;
 import org.apache.kafka.server.util.InterBrokerSendThread;
 import org.apache.kafka.server.util.RequestAndCompletionHandler;
 
@@ -67,11 +65,11 @@ public class NodeToControllerRequestThread extends InterBrokerSendThread {
     public NodeToControllerRequestThread(KafkaClient initialNetworkClient,
                                          ManualMetadataUpdater metadataUpdater,
                                          Supplier<ControllerInformation> controllerNodeProvider,
-                                         AbstractConfig config,
+                                         int controllerSocketTimeoutMs,
                                          Time time,
                                          String threadName,
                                          Long retryTimeoutMs) {
-        super(threadName, initialNetworkClient, Math.min(Integer.MAX_VALUE, (int) Math.min(config.getInt(ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_CONFIG), retryTimeoutMs)), time, false);
+        super(threadName, initialNetworkClient, Math.min(Integer.MAX_VALUE, (int) Math.min(controllerSocketTimeoutMs, retryTimeoutMs)), time, false);
         this.time = time;
         this.controllerNodeProvider = controllerNodeProvider;
         this.metadataUpdater = metadataUpdater;

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -113,6 +113,10 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         return getInt(ReplicationConfigs.NUM_REPLICA_FETCHERS_CONFIG);
     }
 
+    public int controllerSocketTimeoutMs() {
+        return getInt(ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_CONFIG);
+    }
+
     public int numRecoveryThreadsPerDataDir() {
         return getInt(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG);
     }

--- a/server/src/test/java/org/apache/kafka/server/NodeToControllerRequestThreadTest.java
+++ b/server/src/test/java/org/apache/kafka/server/NodeToControllerRequestThreadTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.message.EnvelopeResponseData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.network.ListenerName;
@@ -60,10 +59,6 @@ import static org.mockito.Mockito.mock;
 
 class NodeToControllerRequestThreadTest {
 
-    private static AbstractConfig createConfig() {
-        return new AbstractConfig(ReplicationConfigs.CONFIG_DEF, Map.of());
-    }
-
     private static ControllerInformation controllerInfo(Optional<Node> node) {
         return new ControllerInformation(node, new ListenerName(""), SecurityProtocol.PLAINTEXT, "");
     }
@@ -89,7 +84,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testRetryTimeoutWhileControllerNotAvailable() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         Metadata metadata = mock(Metadata.class);
         MockClient mockClient = new MockClient(time, metadata);
 
@@ -98,7 +92,7 @@ class NodeToControllerRequestThreadTest {
         long retryTimeoutMs = 30000;
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", retryTimeoutMs);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", retryTimeoutMs);
         testRequestThread.setStarted(true);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -123,7 +117,6 @@ class NodeToControllerRequestThreadTest {
     void testRequestsSent() {
         // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int controllerId = 2;
 
         Metadata metadata = mock(Metadata.class);
@@ -136,7 +129,7 @@ class NodeToControllerRequestThreadTest {
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(2, Map.of("a", 2));
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
         mockClient.prepareResponse(expectedResponse);
 
@@ -164,7 +157,6 @@ class NodeToControllerRequestThreadTest {
     void testControllerChanged() {
         // in this test the controller changes from node 1 -> node 2
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int oldControllerId = 1;
         int newControllerId = 2;
 
@@ -180,7 +172,7 @@ class NodeToControllerRequestThreadTest {
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(3, Map.of("a", 2));
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -212,7 +204,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testNotController() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int oldControllerId = 1;
         int newControllerId = 2;
 
@@ -232,7 +223,7 @@ class NodeToControllerRequestThreadTest {
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(3, Map.of("a", 2));
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -271,7 +262,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testEnvelopeResponseWithNotControllerError() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int oldControllerId = 1;
         int newControllerId = 2;
 
@@ -296,7 +286,7 @@ class NodeToControllerRequestThreadTest {
 
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -343,7 +333,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testRetryTimeout() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int controllerId = 1;
 
         Metadata metadata = mock(Metadata.class);
@@ -359,7 +348,7 @@ class NodeToControllerRequestThreadTest {
             Map.of("a", 2));
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", retryTimeoutMs);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", retryTimeoutMs);
         testRequestThread.setStarted(true);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -391,7 +380,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testUnsupportedVersionHandling() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int controllerId = 2;
 
         Metadata metadata = mock(Metadata.class);
@@ -424,7 +412,7 @@ class NodeToControllerRequestThreadTest {
 
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
 
         testRequestThread.enqueue(queueItem);
@@ -435,7 +423,6 @@ class NodeToControllerRequestThreadTest {
     @Test
     void testAuthenticationExceptionHandling() {
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
         int controllerId = 2;
 
         Metadata metadata = mock(Metadata.class);
@@ -468,7 +455,7 @@ class NodeToControllerRequestThreadTest {
 
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
         testRequestThread.setStarted(true);
 
         testRequestThread.enqueue(queueItem);
@@ -481,7 +468,6 @@ class NodeToControllerRequestThreadTest {
     void testThreadNotStarted() {
         // Make sure we throw if we enqueue anything while the thread is not running
         MockTime time = new MockTime();
-        AbstractConfig config = createConfig();
 
         Metadata metadata = mock(Metadata.class);
         MockClient mockClient = new MockClient(time, metadata);
@@ -490,7 +476,7 @@ class NodeToControllerRequestThreadTest {
 
         NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
             mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, config, time, "", Long.MAX_VALUE);
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler(null);

--- a/server/src/test/java/org/apache/kafka/server/NodeToControllerRequestThreadTest.java
+++ b/server/src/test/java/org/apache/kafka/server/NodeToControllerRequestThreadTest.java
@@ -81,6 +81,25 @@ class NodeToControllerRequestThreadTest {
         return () -> ref.getAndSet(second);
     }
 
+    private static NodeToControllerRequestThread createAndStartRequestThread(
+            MockClient mockClient,
+            Supplier<ControllerInformation> controllerNodeProvider,
+            MockTime time,
+            long retryTimeoutMs) {
+        NodeToControllerRequestThread thread = new NodeToControllerRequestThread(
+            mockClient, new ManualMetadataUpdater(),
+            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", retryTimeoutMs);
+        thread.setStarted(true);
+        return thread;
+    }
+
+    private static NodeToControllerRequestThread createAndStartRequestThread(
+            MockClient mockClient,
+            Supplier<ControllerInformation> controllerNodeProvider,
+            MockTime time) {
+        return createAndStartRequestThread(mockClient, controllerNodeProvider, time, Long.MAX_VALUE);
+    }
+
     @Test
     void testRetryTimeoutWhileControllerNotAvailable() {
         MockTime time = new MockTime();
@@ -90,10 +109,8 @@ class NodeToControllerRequestThreadTest {
         Supplier<ControllerInformation> controllerNodeProvider = NodeToControllerRequestThreadTest::emptyControllerInfo;
 
         long retryTimeoutMs = 30000;
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", retryTimeoutMs);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time, retryTimeoutMs);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler(null);
@@ -127,10 +144,8 @@ class NodeToControllerRequestThreadTest {
             () -> controllerInfo(Optional.of(activeController));
 
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(2, Map.of("a", 2));
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
         mockClient.prepareResponse(expectedResponse);
 
         TestControllerRequestCompletionHandler completionHandler =
@@ -170,10 +185,8 @@ class NodeToControllerRequestThreadTest {
             controllerInfo(Optional.of(newController)));
 
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(3, Map.of("a", 2));
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler(expectedResponse);
@@ -221,10 +234,8 @@ class NodeToControllerRequestThreadTest {
             Map.of("a", Errors.NOT_CONTROLLER),
             Map.of("a", 2));
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(3, Map.of("a", 2));
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler(expectedResponse);
@@ -284,10 +295,8 @@ class NodeToControllerRequestThreadTest {
         // response for retry request after receiving NOT_CONTROLLER error
         MetadataResponse expectedResponse = RequestTestUtils.metadataUpdateWith(3, Map.of("a", 2));
 
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler(expectedResponse);
@@ -346,10 +355,8 @@ class NodeToControllerRequestThreadTest {
         MetadataResponse responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
             Map.of("a", Errors.NOT_CONTROLLER),
             Map.of("a", 2));
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", retryTimeoutMs);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time, retryTimeoutMs);
 
         TestControllerRequestCompletionHandler completionHandler =
             new TestControllerRequestCompletionHandler();
@@ -410,10 +417,8 @@ class NodeToControllerRequestThreadTest {
 
         mockClient.prepareUnsupportedVersionResponse(request -> request.apiKey() == ApiKeys.METADATA);
 
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
 
         testRequestThread.enqueue(queueItem);
         pollUntil(testRequestThread, () -> callbackResponse.get() != null);
@@ -453,10 +458,8 @@ class NodeToControllerRequestThreadTest {
 
         mockClient.createPendingAuthenticationError(activeController, 50);
 
-        NodeToControllerRequestThread testRequestThread = new NodeToControllerRequestThread(
-            mockClient, new ManualMetadataUpdater(),
-            controllerNodeProvider, ReplicationConfigs.CONTROLLER_SOCKET_TIMEOUT_MS_DEFAULT, time, "", Long.MAX_VALUE);
-        testRequestThread.setStarted(true);
+        NodeToControllerRequestThread testRequestThread = createAndStartRequestThread(
+            mockClient, controllerNodeProvider, time);
 
         testRequestThread.enqueue(queueItem);
         pollUntil(testRequestThread, () -> callbackResponse.get() != null);


### PR DESCRIPTION
- Migratre `controllerSocketTimeoutMs` to `AbstractKafkaConfig`
- Update usage in `NodeToControllerChannelManagerImpl`

Reviewers: Murali Basani <muralidhar.basani@aiven.io>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai   <chia7712@gmail.com>
