### PR TITLE
KAFKA-10369: Add deduplication operator to Streams DSL (KIP-655)

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamDeduplicateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamDeduplicateIntegrationTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Deduplicated;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("integration")
+@Timeout(600)
+public class KStreamDeduplicateIntegrationTest {
+
+    private static final int NUM_BROKERS = 1;
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    @BeforeAll
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterAll
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    private String inputTopic;
+    private String outputTopic;
+    private String applicationId;
+    private Properties streamsConfig;
+    private KafkaStreams kafkaStreams;
+
+    @BeforeEach
+    public void before(final TestInfo testInfo) throws InterruptedException {
+        final String safeTestName = safeUniqueTestName(testInfo);
+        inputTopic = "input-" + safeTestName;
+        outputTopic = "output-" + safeTestName;
+        applicationId = "app-" + safeTestName;
+        CLUSTER.createTopic(inputTopic, 1, 1);
+        CLUSTER.createTopic(outputTopic, 1, 1);
+        streamsConfig = buildStreamsConfig();
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        if (kafkaStreams != null) {
+            kafkaStreams.close(Duration.ofSeconds(60));
+            kafkaStreams = null;
+        }
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfig);
+    }
+
+    @Test
+    public void shouldDeduplicateByKeyWithinInterval() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.<String, String>stream(inputTopic)
+               .deduplicateByKey(Duration.ofSeconds(10))
+               .to(outputTopic);
+        kafkaStreams = new KafkaStreams(builder.build(), streamsConfig);
+        startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produce(Collections.singletonList(new KeyValue<>("k1", "v1")), 0L);
+        produce(Collections.singletonList(new KeyValue<>("k1", "v2")), 5_000L);
+        produce(Collections.singletonList(new KeyValue<>("k1", "v3")), 9_999L);
+        produce(Collections.singletonList(new KeyValue<>("k2", "end")), 9_999L);
+
+        final List<KeyValue<String, String>> output = waitUntilMinKeyValueRecordsReceived(
+            buildConsumerConfig(), outputTopic, 2);
+
+        assertEquals(2, output.size());
+        assertEquals(new KeyValue<>("k1", "v1"), output.get(0));
+        assertEquals(new KeyValue<>("k2", "end"), output.get(1));
+    }
+
+    @Test
+    public void shouldForwardSameKeyAfterIntervalExpiry() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.<String, String>stream(inputTopic)
+               .deduplicateByKey(Duration.ofSeconds(10))
+               .to(outputTopic);
+        kafkaStreams = new KafkaStreams(builder.build(), streamsConfig);
+        startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        // k1 window opens at t=0.
+        produce(Collections.singletonList(new KeyValue<>("k1", "v1")), 0L);
+        // Advance stream time to 11000ms. Punctuator fires; k1 entry (t=0) is evicted
+        produce(Collections.singletonList(new KeyValue<>("k2", "advance")), 11_000L);
+        produce(Collections.singletonList(new KeyValue<>("k1", "v_new")), 11_000L);
+
+        final List<KeyValue<String, String>> output = waitUntilMinKeyValueRecordsReceived(
+            buildConsumerConfig(), outputTopic, 3);
+
+        assertEquals(3, output.size());
+        assertEquals(new KeyValue<>("k1", "v1"), output.get(0));
+        assertEquals(new KeyValue<>("k2", "advance"), output.get(1));
+        assertEquals(new KeyValue<>("k1", "v_new"), output.get(2));
+    }
+
+    @Test
+    public void shouldDeduplicateByKeyValueOnKeyAndId() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.<String, String>stream(inputTopic)
+               .deduplicateByKeyValue((k, v) -> k + "|" + v, Duration.ofSeconds(10), Deduplicated.idSerde(Serdes.String()))
+               .to(outputTopic);
+        kafkaStreams = new KafkaStreams(builder.build(), streamsConfig);
+        startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produce(Collections.singletonList(new KeyValue<>("k1", "id-A")), 0L);
+        produce(Collections.singletonList(new KeyValue<>("k2", "id-A")), 0L);
+        produce(Collections.singletonList(new KeyValue<>("k1", "id-A")), 5_000L);
+
+        final List<KeyValue<String, String>> output = waitUntilMinKeyValueRecordsReceived(
+            buildConsumerConfig(), outputTopic, 2);
+
+        assertEquals(2, output.size());
+        assertEquals(new KeyValue<>("k1", "id-A"), output.get(0));
+        assertEquals(new KeyValue<>("k2", "id-A"), output.get(1));
+    }
+
+    private void produce(final List<KeyValue<String, String>> records, final long timestamp) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            inputTopic, records, buildProducerConfig(), timestamp);
+    }
+
+    private Properties buildStreamsConfig() {
+        final Properties p = new Properties();
+        p.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        return p;
+    }
+
+    private Properties buildProducerConfig() {
+        return TestUtils.producerConfig(
+            CLUSTER.bootstrapServers(),
+            StringSerializer.class,
+            StringSerializer.class,
+            new Properties()
+        );
+    }
+
+    private Properties buildConsumerConfig() {
+        final Properties p = new Properties();
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        p.put(ConsumerConfig.GROUP_ID_CONFIG, "consumer-" + applicationId);
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return p;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Deduplicated.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Deduplicated.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.common.serialization.Serde;
+
+/**
+ * The class that is used to capture the key and value {@link Serde}s and set the name used for
+ * the internal processor and state store when performing
+ * {@link KStream#deduplicateByKey(java.time.Duration, Deduplicated)} or
+ * {@link KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)} operations.
+ *
+ * @param <K>  the record key type
+ * @param <KR> the computed deduplication ID type (same as {@code K} for {@code deduplicateByKey})
+ * @param <V>  the value type
+ */
+public class Deduplicated<K, KR, V> implements NamedOperation<Deduplicated<K, KR, V>> {
+
+    protected final String name;
+    protected final String storeName;
+    protected final Serde<K> keySerde;
+    protected final Serde<KR> idSerde;
+    protected final Serde<V> valueSerde;
+
+    private Deduplicated(final String name,
+                         final String storeName,
+                         final Serde<K> keySerde,
+                         final Serde<KR> idSerde,
+                         final Serde<V> valueSerde) {
+        this.name = name;
+        this.storeName = storeName;
+        this.keySerde = keySerde;
+        this.idSerde = idSerde;
+        this.valueSerde = valueSerde;
+    }
+
+    protected Deduplicated(final Deduplicated<K, KR, V> deduplicated) {
+        this(deduplicated.name, deduplicated.storeName, deduplicated.keySerde, deduplicated.idSerde, deduplicated.valueSerde);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided name used as the processor name
+     * and as part of the internal store name.
+     *
+     * @param name
+     *        the name used for the processor and state store
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the name
+     *
+     * @see KStream#deduplicateByKey(java.time.Duration, Deduplicated)
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> as(final String name) {
+        return new Deduplicated<>(name, null, null, null, null);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided keySerde.  If {@code null} the default key serde from config will be used.
+     *
+     * @param keySerde
+     *        the Serde used for serializing the record key. If {@code null} the default key serde from config will be used
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the keySerde
+     *
+     * @see KStream#deduplicateByKey(java.time.Duration, Deduplicated)
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> keySerde(final Serde<K> keySerde) {
+        return new Deduplicated<>(null, null, keySerde, null, null);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided idSerde.  Required for
+     * {@link KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)}.
+     *
+     * @param idSerde
+     *        the {@link Serde} used for serializing the computed deduplication ID
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the idSerde
+     *
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> idSerde(final Serde<KR> idSerde) {
+        return new Deduplicated<>(null, null, null, idSerde, null);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided valueSerde.  If {@code null} the default value serde from config will be used.
+     *
+     * @param valueSerde
+     *        the {@link Serde} used for serializing the value. If {@code null} the default value serde from config will be used
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the valueSerde
+     *
+     * @see KStream#deduplicateByKey(java.time.Duration, Deduplicated)
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> valueSerde(final Serde<V> valueSerde) {
+        return new Deduplicated<>(null, null, null, null, valueSerde);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided keySerde and valueSerde.  If the keySerde and/or the valueSerde is
+     * {@code null} the default value for the respective serde from config will be used.
+     *
+     * @param keySerde
+     *        the {@link Serde} used for serializing the record key. If {@code null} the default key serde from config will be used
+     * @param valueSerde
+     *        the {@link Serde} used for serializing the value. If {@code null} the default value serde from config will be used
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the keySerde and valueSerde
+     *
+     * @see KStream#deduplicateByKey(java.time.Duration, Deduplicated)
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> with(final Serde<K> keySerde,
+                                                          final Serde<V> valueSerde) {
+        return new Deduplicated<>(null, null, keySerde, null, valueSerde);
+    }
+
+    /**
+     * Create a {@link Deduplicated} instance with the provided keySerde, idSerde, and valueSerde.  If the keySerde and/or the valueSerde is
+     * {@code null} the default value for the respective serde from config will be used.
+     *
+     * @param keySerde
+     *        the {@link Serde} used for serializing the record key. If {@code null} the default key serde from config will be used
+     * @param idSerde
+     *        the {@link Serde} used for serializing the computed deduplication ID
+     * @param valueSerde
+     *        the {@link Serde} used for serializing the value. If {@code null} the default value serde from config will be used
+     * @param <K>   the record key type
+     * @param <KR>  the computed deduplication ID type
+     * @param <V>   the value type
+     *
+     * @return a new {@link Deduplicated} configured with the keySerde, idSerde, and valueSerde
+     *
+     * @see KStream#deduplicateByKeyValue(KeyValueMapper, java.time.Duration, Deduplicated)
+     */
+    public static <K, KR, V> Deduplicated<K, KR, V> with(final Serde<K> keySerde,
+                                                          final Serde<KR> idSerde,
+                                                          final Serde<V> valueSerde) {
+        return new Deduplicated<>(null, null, keySerde, idSerde, valueSerde);
+    }
+
+    /**
+     * Set the name to be used for the deduplication processor and state store.
+     *
+     * @param name
+     *        the name used for the processor and as part of the state store name
+     *
+     * @return a new {@link Deduplicated} instance configured with the name
+     */
+    @Override
+    public Deduplicated<K, KR, V> withName(final String name) {
+        return new Deduplicated<>(name, storeName, keySerde, idSerde, valueSerde);
+    }
+
+    /**
+     * Set the name to be used for the internal deduplication state store.
+     *
+     * @param storeName
+     *        the name to use for the state store
+     *
+     * @return a new {@link Deduplicated} instance configured with the store name
+     */
+    public Deduplicated<K, KR, V> withStoreName(final String storeName) {
+        return new Deduplicated<>(name, storeName, keySerde, idSerde, valueSerde);
+    }
+
+    /**
+     * Set the keySerde to be used for serializing the record key.
+     *
+     * @param keySerde
+     *        {@link Serde} to use for serializing the record key. If {@code null} the default key serde from config will be used
+     *
+     * @return a new {@link Deduplicated} instance configured with the keySerde
+     */
+    public Deduplicated<K, KR, V> withKeySerde(final Serde<K> keySerde) {
+        return new Deduplicated<>(name, storeName, keySerde, idSerde, valueSerde);
+    }
+
+    /**
+     * Set the idSerde to be used for serializing the computed deduplication ID.
+     *
+     * @param idSerde
+     *        {@link Serde} to use for serializing the computed deduplication ID
+     *
+     * @return a new {@link Deduplicated} instance configured with the idSerde
+     */
+    public Deduplicated<K, KR, V> withIdSerde(final Serde<KR> idSerde) {
+        return new Deduplicated<>(name, storeName, keySerde, idSerde, valueSerde);
+    }
+
+    /**
+     * Set the valueSerde to be used for serializing the value.
+     *
+     * @param valueSerde
+     *        {@link Serde} to use for serializing the value. If {@code null} the default value serde from config will be used
+     *
+     * @return a new {@link Deduplicated} instance configured with the valueSerde
+     */
+    public Deduplicated<K, KR, V> withValueSerde(final Serde<V> valueSerde) {
+        return new Deduplicated<>(name, storeName, keySerde, idSerde, valueSerde);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -683,6 +683,120 @@ public interface KStream<K, V> {
                                            final Grouped<KOut, V> grouped);
 
     /**
+     * Filter out duplicates from this stream based on record's key, within the provided time interval.
+     * After receiving a non-duplicate record, any record with the same key that is received within the provided deduplicationInterval
+     * (interval bounds are inclusive) will be discarded. This applies to both in-order and out-of-order duplicates (see example below).
+     * After deduplicationInterval has elapsed since a non-duplicate record is received, a new record having
+     * the same key is considered a non-duplicate, and is forwarded to the resulting {@link KStream}.
+     * <p>
+     * A late record that is late by strictly more than deduplicationInterval from the current stream time
+     * is systematically forwarded, unless it had a forwarded duplicate (within its deduplicationInterval)
+     * whose timestamp is in the window [currentStreamTime-deduplicationInterval, currentStreamTime] (see example below).
+     * Records with a {@code null} key are always forwarded to the resulting {@link KStream}, no deduplication is performed on them.
+     * <p>
+     * In the following example, events r1 to r6 have the same key.
+     * <pre>{@code
+     * r1 at t -> forwarded
+     * r2 at t+deduplicationInterval -> discarded
+     * r3 at t-deduplicationInterval -> discarded
+     * r4 at t+deduplicationInterval+1 -> forwarded
+     * r5 at t -> forwarded (late record)
+     * r6 at t -> forwarded (late record)
+     * }</pre>
+     * In the following example, we consider events having different keys k1 and k2.
+     * <pre>{@code
+     * k1 at t -> forwarded
+     * k2 at t+deduplicationInterval -> forwarded (currentStreamTime = t+deduplicationInterval)
+     * k1 at t-deduplicationInterval -> discarded (although this is a late event, it has a duplicate which is in the window [currentStreamTime-deduplicationInterval, currentStreamTime]
+     * }</pre>
+     * <p>
+     * If a key changing operator was used before this operation (e.g., {@link #selectKey(KeyValueMapper)},
+     * {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
+     * {@link #process(ProcessorSupplier, String...)}) an internal repartitioning topic will be created in Kafka.
+     * This topic will be named "${applicationId}-<name>-repartition", where "applicationId" is user-specified in
+     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * <name> is an internally generated name, and "-repartition" is a fixed suffix.
+     *
+     * @param deduplicationInterval             the duration within which subsequent duplicates of a record will be discarded
+     * @return                                  a KStream that contains the same records of this KStream without duplicates
+     */
+    KStream<K, V> deduplicateByKey(final Duration deduplicationInterval);
+
+    /**
+     * See {@link #deduplicateByKey(Duration)}.
+     *
+     * <p>Takes an additional {@link Deduplicated} parameter, that allows to explicitly set key/value serdes or to customize
+     * the name of the internal processor and state store.
+     *
+     * @param deduplicationInterval             the duration within which subsequent duplicates of a record will be discarded
+     * @param deduplicated                      a {@link Deduplicated} instance used to configure serdes and the processor/store name
+     * @return                                  a KStream that contains the same records of this KStream without duplicates
+     */
+    KStream<K, V> deduplicateByKey(final Duration deduplicationInterval,
+                                   final Deduplicated<K, K, V> deduplicated);
+
+    /**
+     * Filter out duplicates from this stream based on record's key and the provided {@link KeyValueMapper}, within the provided time interval.
+     * The provided {@link KeyValueMapper} maps a record to an id.
+     * For two records to be duplicate, they must have the same key **AND** the same id.
+     * In case you want to deduplicate on id alone, you should first repartition by the id and use {@link #deduplicateByKey(Duration)} instead.
+     * <p>
+     * Example of usage.
+     * <pre>{@code
+     * KStream<String, Object> inputStream = builder.stream("topic");
+     *
+     * KStream<String, Object> outputStream = inputStream.deduplicateByKeyValue(
+     *     (key, value) -> value.id,
+     *     Duration.ofSeconds(60),
+     *     Deduplicated.idSerde(Serdes.String()));
+     * }</pre>
+     * </p>
+     * After receiving a non-duplicate record, any duplicates received within the provided deduplicationInterval
+     * (interval bounds are inclusive) will be discarded. This applies to both in-order and out-of-order duplicates (see examples below).
+     * After deduplicationInterval has elapsed since a non-duplicate record is received, a new record having
+     * the same (key, id) is considered a non-duplicate, and is forwarded to the resulting {@link KStream}.
+     * <p>
+     * A late record that is late by strictly more than deduplicationInterval from the current stream time
+     * is systematically forwarded, unless it had a forwarded duplicate (within its deduplicationInterval)
+     * whose timestamp is in the window [currentStreamTime-deduplicationInterval, currentStreamTime] (see example below).
+     * Records with a {@code null} key OR a {@code null} id are always forwarded to the resulting {@link KStream}, no deduplication is performed on them.
+     * <p>
+     * In the following example, events r1 to r6 have the same key and id.
+     * <pre>{@code
+     * r1 at t -> forwarded
+     * r2 at t+deduplicationInterval -> discarded
+     * r3 at t-deduplicationInterval -> discarded
+     * r4 at t+deduplicationInterval+1 -> forwarded
+     * r5 at t -> forwarded (late record)
+     * r6 at t -> forwarded (late record)
+     * }</pre>
+     * In the following example, we consider events having different id k1 and k2.
+     * <pre>{@code
+     * k1 at t -> forwarded
+     * k2 at t+deduplicationInterval -> forwarded (and currentStreamTime = t+deduplicationInterval)
+     * k1 at t-deduplicationInterval -> discarded (although this is a late event, it has a duplicate which is in the window [currentStreamTime-deduplicationInterval, currentStreamTime]
+     * }</pre>
+     * <p>
+     * This operator does not repartition by (key, id). If a key-changing operator was used before this operation
+     * (e.g., {@link #selectKey(KeyValueMapper)}, {@link #map(KeyValueMapper)}, {@link #flatMap(KeyValueMapper)} or
+     * {@link #process(ProcessorSupplier, String...)}) an internal repartitioning topic will be created in Kafka
+     * to repartition by the key only, not by the (key, id) pair.
+     * This topic will be named "${applicationId}-<name>-repartition", where "applicationId" is user-specified in
+     * {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * <name> is an internally generated name, and "-repartition" is a fixed suffix.
+     *
+     * @param idSelector                        a {@link KeyValueMapper} that returns the unique id of the record
+     * @param deduplicationInterval             the duration within which subsequent duplicates of a record will be discarded
+     * @param deduplicated                      a {@link Deduplicated} instance used to configure serdes and the processor/store name;
+     *                                          the {@code idSerde} must be set
+     * @param <KR>                              the type of the deduplication id
+     * @return                                  a KStream that contains the same records of this KStream without duplicates
+     */
+    <KR> KStream<K, V> deduplicateByKeyValue(final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector,
+                                             final Duration deduplicationInterval,
+                                             final Deduplicated<K, KR, V> deduplicated);
+
+    /**
      * Join records of this (left) stream with another (right) {@code KStream}'s records using a windowed inner equi-join.
      * The join is computed using the records' key as join attribute, i.e., {@code leftRecord.key == rightRight.key}.
      * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/DeduplicatedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/DeduplicatedInternal.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.Deduplicated;
+
+public class DeduplicatedInternal<K, KR, V> extends Deduplicated<K, KR, V> {
+
+    public DeduplicatedInternal(final Deduplicated<K, KR, V> deduplicated) {
+        super(deduplicated);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String storeName() {
+        return storeName;
+    }
+
+    public Serde<K> keySerde() {
+        return keySerde;
+    }
+
+    public Serde<KR> idSerde() {
+        return idSerde;
+    }
+
+    public Serde<V> valueSerde() {
+        return valueSerde;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicate.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
+
+import java.time.Duration;
+import java.util.Set;
+
+class KStreamDeduplicate<K, V, KR> implements ProcessorSupplier<K, V, K, V> {
+
+    private final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector;
+    private final Duration deduplicationInterval;
+    private final String baseStoreName;
+    private final String timeIndexStoreName;
+    private final Set<StoreBuilder<?>> stores;
+    private final Serde<K> keySerde;
+    private final Serde<KR> idSerde;
+
+    KStreamDeduplicate(final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector,
+                       final Duration deduplicationInterval,
+                       final Serde<K> keySerde,
+                       final Serde<KR> idSerde,
+                       final Serde<V> valueSerde,
+                       final String name,
+                       final String baseStoreName) {
+        this.idSelector = idSelector;
+        this.deduplicationInterval = deduplicationInterval;
+        this.baseStoreName = baseStoreName;
+        this.timeIndexStoreName = baseStoreName + "-time-index";
+
+        final StoreBuilder<KeyValueStore<Bytes, TimestampAndOffset>> baseStoreBuilder =
+            Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(baseStoreName),
+                Serdes.Bytes(),
+                new TimestampAndOffsetSerde()
+            );
+
+        final StoreBuilder<?> timeIndexStoreBuilder =
+            new RocksDBTimeOrderedKeyValueBuffer.Builder<>(
+                timeIndexStoreName,
+                Serdes.Bytes(),
+                valueSerde,
+                deduplicationInterval,
+                name
+            );
+
+        this.stores = Set.of(baseStoreBuilder, timeIndexStoreBuilder);
+        this.keySerde = keySerde;
+        this.idSerde = idSerde;
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+        return stores;
+    }
+
+    @Override
+    public Processor<K, V, K, V> get() {
+        return new KStreamDeduplicateProcessor<>(idSelector, deduplicationInterval, keySerde, idSerde, baseStoreName, timeIndexStoreName);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicateProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicateProcessor.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.SerdeGetter;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
+
+class KStreamDeduplicateProcessor<K, V, KR> extends ContextualProcessor<K, V, K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KStreamDeduplicateProcessor.class);
+
+    private final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector;
+    private final Duration deduplicationInterval;
+    private final String baseStoreName;
+    private final String timeIndexStoreName;
+    private final Serde<K> keySerde;
+    private final Serde<KR> idSerde;
+    private Serializer<K> keySerializer;
+
+
+    private KeyValueStore<Bytes, TimestampAndOffset> baseStore;
+    private TimeOrderedKeyValueBuffer<Bytes, V, V> timeIndexStore;
+    private InternalProcessorContext<K, V> internalProcessorContext;
+    private Sensor droppedRecordsSensor;
+    protected long observedStreamTime = ConsumerRecord.NO_TIMESTAMP;
+
+    KStreamDeduplicateProcessor(final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector,
+                                final Duration deduplicationInterval,
+                                final Serde<K> keySerde,
+                                final Serde<KR> idSerde,
+                                final String baseStoreName,
+                                final String timeIndexStoreName) {
+        this.idSelector = idSelector;
+        this.deduplicationInterval = deduplicationInterval;
+        this.keySerde = keySerde;
+        this.idSerde = idSerde;
+        this.baseStoreName = baseStoreName;
+        this.timeIndexStoreName = timeIndexStoreName;
+    }
+
+    @SuppressWarnings({"unchecked", "resource"})
+    @Override
+    public void init(final ProcessorContext<K, V> context) {
+        super.init(context);
+        final StreamsMetricsImpl metrics = (StreamsMetricsImpl) context.metrics();
+        droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
+        baseStore = context.getStateStore(baseStoreName);
+        timeIndexStore = context.getStateStore(timeIndexStoreName);
+        timeIndexStore.setSerdesIfNull(new SerdeGetter(context));
+        internalProcessorContext = asInternalProcessorContext(context);
+
+        if (keySerde == null || keySerde.serializer() == null) {
+            keySerializer = (Serializer<K>) context.keySerde().serializer();
+        } else {
+            keySerializer = keySerde.serializer();
+        }
+
+        context.schedule(
+            Duration.ofMillis(Math.max(1, deduplicationInterval.toMillis() / 10)),
+            PunctuationType.STREAM_TIME,
+            timestamp -> timeIndexStore.evictWhile(() -> true, eviction -> {
+                final TimestampAndOffset stored = baseStore.get(eviction.key());
+                // Only delete if the stored entry is still the expired one.
+                // If a newer record overwrote the entry, stored.timestamp >= threshold, we don't delete.
+                if (stored != null && stored.timestamp < observedStreamTime - deduplicationInterval.toMillis()) {
+                    baseStore.delete(eviction.key());
+                }
+            })
+        );
+    }
+
+    @Override
+    public void process(final Record<K, V> record) {
+        observedStreamTime = Math.max(observedStreamTime, record.timestamp());
+
+        final KR id = idSelector.apply(record.key(), record.value());
+
+        if (record.key() == null || id == null) {
+            context().forward(record);
+            return;
+        }
+
+        final Bytes dedupKey = computeDedupKey(record.key(), id);
+
+        final TimestampAndOffset storedEntry = baseStore.get(dedupKey);
+
+        if (storedEntry == null
+            || (observedStreamTime - storedEntry.timestamp) > deduplicationInterval.toMillis()
+            || (storedEntry.timestamp - record.timestamp()) > deduplicationInterval.toMillis()) {
+            // - No active duplicate entry
+            // - stale duplicate entry not yet cleaned up by punctuator
+            // - record arrives more than deduplicationInterval before the stored entry (out-of-order late event).
+            context().forward(record);
+
+            // buffer.put returns false if the record is older than deduplicationInterval (late record).
+            // In that case, forward it but don't start a dedup window — no baseStore entry needed.
+            final boolean withinWindow = timeIndexStore.put(
+                observedStreamTime,
+                new Record<>(dedupKey, record.value(), record.timestamp()).withHeaders(record.headers()),
+                internalProcessorContext.recordContext()
+            );
+            if (withinWindow) {
+                baseStore.put(dedupKey, new TimestampAndOffset(record.timestamp(), currentOffset()));
+            }
+        } else {
+            // Active entry exists and is within the deduplication interval.
+            final Optional<Long> currentOffset = currentOffset();
+
+            if (currentOffset.isPresent() && currentOffset.equals(storedEntry.offset)) {
+                // Reprocessing a record that was put in the dedup store but wasn't committed -> forward (see KIP-655)
+                context().forward(record);
+            } else if (currentOffset.isEmpty()) {
+                // Punctuated record (null offset)
+                droppedRecordsSensor.record();
+                LOG.debug("Dropping punctuated duplicate record for dedupKey=[{}]", dedupKey);
+            } else {
+                // Normal duplicate within the active window — drop.
+                droppedRecordsSensor.record();
+                LOG.debug("Dropping duplicate record for dedupKey=[{}]", dedupKey);
+            }
+        }
+    }
+
+    private Bytes computeDedupKey(final K key, final KR id) {
+        final byte[] keyBytes = keySerializer.serialize(null, key);
+        if (idSerde == null) {
+            return Bytes.wrap(keyBytes);
+        }
+        final byte[] idBytes = idSerde.serializer().serialize(null, id);
+        return Bytes.wrap(ByteBuffer.allocate(4 + keyBytes.length + idBytes.length)
+            .putInt(keyBytes.length)
+            .put(keyBytes)
+            .put(idBytes)
+            .array());
+    }
+
+    private Optional<Long> currentOffset() {
+        return context().recordMetadata().map(RecordMetadata::offset);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.internals.ApiUtils;
 import org.apache.kafka.streams.kstream.BranchedKStream;
 import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Deduplicated;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.Joined;
@@ -66,6 +67,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -126,6 +128,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     private static final String TO_KTABLE_NAME = "KSTREAM-TOTABLE-";
 
     private static final String REPARTITION_NAME = "KSTREAM-REPARTITION-";
+
+    static final String DEDUPLICATE_NAME = "KSTREAM-DEDUPLICATE-";
 
     private final boolean repartitionRequired;
 
@@ -715,6 +719,87 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             builder);
     }
 
+    @Override
+    public KStream<K, V> deduplicateByKey(final Duration deduplicationInterval) {
+        return doDeduplicate((k, v) -> k, deduplicationInterval, Deduplicated.with(keySerde, valueSerde));
+    }
+
+    @Override
+    public KStream<K, V> deduplicateByKey(final Duration deduplicationInterval,
+                                          final Deduplicated<K, K, V> deduplicated) {
+        Objects.requireNonNull(deduplicated, "deduplicated cannot be null");
+        return doDeduplicate((k, v) -> k, deduplicationInterval, deduplicated);
+    }
+
+    @Override
+    public <KR> KStream<K, V> deduplicateByKeyValue(
+            final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector,
+            final Duration deduplicationInterval,
+            final Deduplicated<K, KR, V> deduplicated) {
+        Objects.requireNonNull(deduplicated, "deduplicated cannot be null");
+        Objects.requireNonNull(new DeduplicatedInternal<>(deduplicated).idSerde(),
+            "deduplicateByKeyValue requires an idSerde; use Deduplicated.withIdSerde(...) " +
+            "to provide the Serde for the computed id type");
+        return doDeduplicate(idSelector, deduplicationInterval, deduplicated);
+    }
+
+    private <KR> KStream<K, V> doDeduplicate(
+            final KeyValueMapper<? super K, ? super V, ? extends KR> idSelector,
+            final Duration deduplicationInterval,
+            final Deduplicated<K, KR, V> deduplicated) {
+
+        Objects.requireNonNull(idSelector, "idSelector cannot be null");
+        Objects.requireNonNull(deduplicationInterval, "deduplicationInterval cannot be null");
+
+        final DeduplicatedInternal<K, KR, V> deduplicatedInternal = new DeduplicatedInternal<>(deduplicated);
+
+        final String name = new NamedInternal(deduplicatedInternal.name())
+            .orElseGenerateWithPrefix(builder, DEDUPLICATE_NAME);
+
+        final Serde<KR> idSerde = deduplicatedInternal.idSerde();
+        final Serde<K> keySerde = deduplicatedInternal.keySerde() != null
+            ? deduplicatedInternal.keySerde()
+            : this.keySerde;
+        final Serde<V> valueSerde = deduplicatedInternal.valueSerde() != null
+            ? deduplicatedInternal.valueSerde()
+            : this.valueSerde;
+
+        final String baseStoreName = deduplicatedInternal.storeName() != null
+            ? deduplicatedInternal.storeName()
+            : name;
+
+        final GraphNode parentNode;
+        final Set<String> sourceNodes;
+        if (repartitionRequired) {
+            final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder =
+                optimizableRepartitionNodeBuilder();
+            final String sourceName = createRepartitionedSource(
+                builder, this.keySerde, this.valueSerde, name, null,
+                repartitionNodeBuilder, deduplicatedInternal.name() != null);
+            final OptimizableRepartitionNode<K, V> repartitionNode = repartitionNodeBuilder.build();
+            builder.addGraphNode(graphNode, repartitionNode);
+            parentNode = repartitionNode;
+            sourceNodes = Collections.singleton(sourceName);
+        } else {
+            parentNode = graphNode;
+            sourceNodes = subTopologySourceNodes;
+        }
+
+        final ProcessorSupplier<K, V, K, V> processorSupplier =
+            new KStreamDeduplicate<>(idSelector, deduplicationInterval, keySerde, idSerde, valueSerde, name, baseStoreName);
+
+        final ProcessorParameters<K, V, K, V> processorParameters =
+            new ProcessorParameters<>(processorSupplier, name);
+
+        final ProcessorGraphNode<K, V> deduplicateNode =
+            new ProcessorGraphNode<>(name, processorParameters);
+
+        builder.addGraphNode(parentNode, deduplicateNode);
+
+        return new KStreamImpl<>(name, this.keySerde, this.valueSerde,
+            sourceNodes, false, deduplicateNode, builder);
+    }
+
     public <VRight, VOut> KStream<K, VOut> join(final KStream<K, VRight> otherStream,
                                                 final ValueJoiner<? super V, ? super VRight, ? extends VOut> joiner,
                                                 final JoinWindows windows) {
@@ -1287,6 +1372,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             Named.as(builder.newProcessorName(PROCESSOR_NAME)),
             stateStoreNames
         );
+
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffset.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffset.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import java.util.Optional;
+
+class TimestampAndOffset {
+
+    final long timestamp;
+    final Optional<Long> offset; // for punctuated records
+
+    TimestampAndOffset(final long timestamp, final Optional<Long> offset) {
+        this.timestamp = timestamp;
+        this.offset = offset;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffsetSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffsetSerde.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+class TimestampAndOffsetSerde implements Serde<TimestampAndOffset> {
+
+    private static final int SIZE = 8 + 1 + 8; // timestamp + hasOffset flag + offset
+
+    @Override
+    public Serializer<TimestampAndOffset> serializer() {
+        return (topic, data) -> {
+            if (data == null) return null;
+            final ByteBuffer buf = ByteBuffer.allocate(SIZE);
+            buf.putLong(data.timestamp);
+            if (data.offset.isPresent()) {
+                buf.put((byte) 0x01);
+                buf.putLong(data.offset.get());
+            } else {
+                buf.put((byte) 0x00);
+                buf.putLong(0L); // padding
+            }
+            return buf.array();
+        };
+    }
+
+    @Override
+    public Deserializer<TimestampAndOffset> deserializer() {
+        return (topic, data) -> {
+            if (data == null) return null;
+            final ByteBuffer buf = ByteBuffer.wrap(data);
+            final long timestamp = buf.getLong();
+            final boolean hasOffset = buf.get() == 0x01;
+            final long offsetValue = buf.getLong();
+            final Optional<Long> offset = hasOffset ? Optional.of(offsetValue) : Optional.empty();
+            return new TimestampAndOffset(timestamp, offset);
+        };
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamDeduplicateTest.java
@@ -1,0 +1,514 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Deduplicated;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.test.MockInternalProcessorContext;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.apache.kafka.streams.state.Stores.keyValueStoreBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KStreamDeduplicateTest {
+
+    private static final Duration DEDUP_INTERVAL = Duration.ofMillis(100);
+    private static final String INPUT_TOPIC = "input";
+    private static final String OUTPUT_TOPIC = "output";
+
+    private TopologyTestDriver deduplicateByKeyDriver() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(INPUT_TOPIC, Consumed.with(Serdes.String(), Serdes.String()))
+               .deduplicateByKey(DEDUP_INTERVAL)
+               .to(OUTPUT_TOPIC);
+        return new TopologyTestDriver(builder.build(),
+            StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
+    }
+
+    private TopologyTestDriver deduplicateByKeyValueDriver(final KeyValueMapper<String, String, String> mapper) {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(INPUT_TOPIC, Consumed.with(Serdes.String(), Serdes.String()))
+               .deduplicateByKeyValue(mapper, DEDUP_INTERVAL, Deduplicated.<String, String, String>idSerde(Serdes.String()))
+               .to(OUTPUT_TOPIC);
+        return new TopologyTestDriver(builder.build(),
+            StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()));
+    }
+
+    private TestInputTopic<String, String> input(final TopologyTestDriver driver) {
+        return driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer(),
+            Instant.ofEpochMilli(0L), Duration.ZERO);
+    }
+
+    private TestOutputTopic<String, String> output(final TopologyTestDriver driver) {
+        return driver.createOutputTopic(OUTPUT_TOPIC, new StringDeserializer(), new StringDeserializer());
+    }
+
+    @Test
+    void shouldForwardFirstAndDropDuplicateWithinIntervalByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 50L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(1, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+        }
+    }
+
+    @Test
+    void shouldForwardFirstAndDropDuplicateWithinIntervalByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 50L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(1, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+        }
+    }
+
+    @Test
+    void shouldDropDuplicateAtExactIntervalBoundaryByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 100L);
+            assertEquals(1, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldDropDuplicateAtExactIntervalBoundaryByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 100L);
+            assertEquals(1, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldForwardRecordJustAfterIntervalExpiryByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 101L); // (101 - 0) = 101 > 100 → FORWARD
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldForwardRecordJustAfterIntervalExpiryByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 101L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldAlwaysForwardNullKeyByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput(null, "v1", 0L);
+            in.pipeInput(null, "v2", 50L);
+            assertEquals(2, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldAlwaysForwardNullComputedIdByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> null)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k1", "v2", 50L);
+            assertEquals(2, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldAlwaysForwardNullKeyByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> v)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput(null, "id1", 0L);
+            in.pipeInput(null, "id1", 50L);
+            assertEquals(2, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldDropOutOfOrderDuplicateWithinIntervalByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 50L); // observedStreamTime=50, stored at t=50
+            in.pipeInput("k1", "v2", 30L); // (50 - 30) = 20 <= 100 → DROP
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(1, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0)); // first-arriving forwarded
+        }
+    }
+
+    @Test
+    void shouldDropOutOfOrderDuplicateWithinIntervalByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 50L);
+            in.pipeInput("k1", "v2", 30L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(1, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+        }
+    }
+
+    @Test
+    void shouldForwardOutOfOrderRecordBeyondIntervalByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 200L); // stored at t=200
+            in.pipeInput("k1", "v2", 50L);  // (200 - 50) = 150 > 100 → FORWARD
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldForwardOutOfOrderRecordBeyondIntervalByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 200L);
+            in.pipeInput("k1", "v2", 50L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldDropLateRecordWhenActiveWindowExistsByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 150L);
+            in.pipeInput("other", "vX", 200L); // advance observedStreamTime
+            in.pipeInput("k1", "v2", 60L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0)); // first-arriving forwarded
+            assertEquals(new KeyValue<>("other", "vX"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldDropLateRecordWhenActiveWindowExistsByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 150L);
+            in.pipeInput("other", "vX", 200L);
+            in.pipeInput("k1", "v2", 60L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("other", "vX"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldForwardLateRecordWhenWindowExpiredByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("other", "vX", 200L); // observedStreamTime=200
+            in.pipeInput("k1", "v1", 50L);
+            in.pipeInput("k1", "v2", 10L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(3, results.size());
+            assertEquals(new KeyValue<>("other", "vX"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(1));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(2));
+        }
+    }
+
+    @Test
+    void shouldForwardLateRecordWhenWindowExpiredByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("other", "vX", 200L); // observedStreamTime=200
+            in.pipeInput("k1", "v1", 50L);
+            in.pipeInput("k1", "v2", 10L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(3, results.size());
+            assertEquals(new KeyValue<>("other", "vX"), results.get(0));
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(1));
+            assertEquals(new KeyValue<>("k1", "v2"), results.get(2));
+        }
+    }
+
+    @Test
+    void shouldDropDuplicateWhenSameKeyAndSameComputedIdByKeyValue() {
+        // deduplication id = key + "|" + value
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k + "|" + v)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "id1", 0L);
+            in.pipeInput("k1", "id1", 50L);
+            assertEquals(1, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldForwardBothWhenSameIdButDifferentKeysByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> v)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "id1", 0L);
+            in.pipeInput("k2", "id1", 50L);
+            assertEquals(2, output(driver).readKeyValuesToList().size());
+        }
+    }
+
+    @Test
+    void shouldDeduplicateDifferentKeysIndependentlyByKey() {
+        try (final TopologyTestDriver driver = deduplicateByKeyDriver()) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k2", "v2", 0L);
+            in.pipeInput("k1", "dup1", 50L); // DROP — k1 window still open
+            in.pipeInput("k2", "dup2", 50L); // DROP — k2 window still open
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k2", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldDeduplicateDifferentKeysIndependentlyByKeyValue() {
+        try (final TopologyTestDriver driver = deduplicateByKeyValueDriver((k, v) -> k)) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("k2", "v2", 0L);
+            in.pipeInput("k1", "dup1", 50L);
+            in.pipeInput("k2", "dup2", 50L);
+            final List<KeyValue<String, String>> results = output(driver).readKeyValuesToList();
+            assertEquals(2, results.size());
+            assertEquals(new KeyValue<>("k1", "v1"), results.get(0));
+            assertEquals(new KeyValue<>("k2", "v2"), results.get(1));
+        }
+    }
+
+    @Test
+    void shouldForwardOnSameOffsetRedelivery() throws Exception {
+        final java.io.File stateDir = TestUtils.tempDirectory();
+        KeyValueStore<Bytes, TimestampAndOffset> baseStore = null;
+        TimeOrderedKeyValueBuffer<Bytes, String, String> timeIndexStore = null;
+        try {
+            final java.util.Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+            final MockInternalProcessorContext<String, String> context =
+                new MockInternalProcessorContext<>(props,
+                    new org.apache.kafka.streams.processor.TaskId(0, 0), stateDir);
+
+            final String baseStoreName = "base";
+            final String timeIndexStoreName = baseStoreName + "-time-index";
+
+            baseStore = keyValueStoreBuilder(
+                org.apache.kafka.streams.state.Stores.persistentKeyValueStore(baseStoreName),
+                Serdes.Bytes(), new TimestampAndOffsetSerde())
+                .withLoggingDisabled()
+                .build();
+
+            timeIndexStore =
+                new RocksDBTimeOrderedKeyValueBuffer.Builder<>(
+                    timeIndexStoreName, Serdes.Bytes(), Serdes.String(), DEDUP_INTERVAL, "topic")
+                    .withLoggingDisabled()
+                    .build();
+
+            context.addStateStore(baseStore);
+            baseStore.init(context, baseStore);
+            context.addStateStore(timeIndexStore);
+            timeIndexStore.init(context, timeIndexStore);
+
+            final KStreamDeduplicateProcessor<String, String, String> processor =
+                new KStreamDeduplicateProcessor<>((k, v) -> k, DEDUP_INTERVAL,
+                    Serdes.String(), null, baseStoreName, timeIndexStoreName);
+            processor.init(context);
+
+            context.setRecordMetadata("input", 0, 42L);
+            processor.process(new Record<>("k1", "v1", 0L));
+
+            // Same offset received -> Forward
+            context.setRecordMetadata("input", 0, 42L);
+            processor.process(new Record<>("k1", "v1", 0L));
+
+            assertEquals(2, context.forwarded().size());
+        } finally {
+            if (baseStore != null) baseStore.close();
+            if (timeIndexStore != null) timeIndexStore.close();
+            org.apache.kafka.common.utils.Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    void shouldDropDuplicatePunctuatedRecords() throws Exception {
+        final java.io.File stateDir = TestUtils.tempDirectory();
+        KeyValueStore<Bytes, TimestampAndOffset> baseStore = null;
+        TimeOrderedKeyValueBuffer<Bytes, String, String> timeIndexStore = null;
+        try {
+            final java.util.Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+            final MockInternalProcessorContext<String, String> context =
+                new MockInternalProcessorContext<>(props,
+                    new org.apache.kafka.streams.processor.TaskId(0, 0), stateDir) {
+                    @Override
+                    public java.util.Optional<RecordMetadata> recordMetadata() {
+                        return java.util.Optional.empty(); // punctuated record
+                    }
+                    @Override
+                    public ProcessorRecordContext recordContext() {
+                        return new ProcessorRecordContext(timestamp(), 0L, 0, "topic", headers());
+                    }
+                };
+
+            final String baseStoreName = "base";
+            final String timeIndexStoreName = baseStoreName + "-time-index";
+
+            baseStore = keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(baseStoreName),
+                Serdes.Bytes(), new TimestampAndOffsetSerde())
+                .withLoggingDisabled()
+                .build();
+
+            timeIndexStore = new RocksDBTimeOrderedKeyValueBuffer.Builder<>(
+                    timeIndexStoreName, Serdes.Bytes(), Serdes.String(), DEDUP_INTERVAL, "topic")
+                    .withLoggingDisabled()
+                    .build();
+
+            context.addStateStore(baseStore);
+            baseStore.init(context, baseStore);
+            context.addStateStore(timeIndexStore);
+            timeIndexStore.init(context, timeIndexStore);
+
+            final KStreamDeduplicateProcessor<String, String, String> processor =
+                new KStreamDeduplicateProcessor<>((k, v) -> k, DEDUP_INTERVAL,
+                    Serdes.String(), null, baseStoreName, timeIndexStoreName);
+            processor.init(context);
+
+            // Empty offset for both
+            processor.process(new Record<>("k1", "v1", 0L));
+            processor.process(new Record<>("k1", "v2", 50L));
+
+            assertEquals(1, context.forwarded().size(), "punctuated duplicate must be dropped");
+        } finally {
+            if (baseStore != null) baseStore.close();
+            if (timeIndexStore != null) timeIndexStore.close();
+            org.apache.kafka.common.utils.Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    void shouldEvictExpiredEntryFromBothStoresByKey() {
+        final String storeName = "eviction-test-store";
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(INPUT_TOPIC, Consumed.with(Serdes.String(), Serdes.String()))
+               .deduplicateByKey(DEDUP_INTERVAL, Deduplicated.as(storeName))
+               .to(OUTPUT_TOPIC);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(),
+                 StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()))) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("dummy", "vX", 200L); // advances stream time → punctuator fires → k1 evicted
+
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            final KeyValueStore<Bytes, TimestampAndOffset> baseStore =
+                (KeyValueStore<Bytes, TimestampAndOffset>) (KeyValueStore) driver.getKeyValueStore(storeName);
+            long baseStoreCount = 0;
+            try (final KeyValueIterator<Bytes, TimestampAndOffset> it = baseStore.all()) {
+                while (it.hasNext()) {
+                    it.next();
+                    baseStoreCount++;
+                }
+            }
+            assertEquals(1L, baseStoreCount);
+
+            @SuppressWarnings("unchecked")
+            final TimeOrderedKeyValueBuffer<Bytes, String, String> timeIndexStore =
+                (TimeOrderedKeyValueBuffer<Bytes, String, String>) driver.getStateStore(storeName + "-time-index");
+            assertEquals(1, timeIndexStore.numRecords());
+        }
+    }
+
+    @Test
+    void shouldEvictExpiredEntryFromBothStoresByKeyValue() {
+        final String storeName = "eviction-test-store";
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(INPUT_TOPIC, Consumed.with(Serdes.String(), Serdes.String()))
+               .deduplicateByKeyValue((k, v) -> k, DEDUP_INTERVAL, Deduplicated.<String, String, String>idSerde(Serdes.String()).withStoreName(storeName))
+               .to(OUTPUT_TOPIC);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(),
+                 StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String()))) {
+            final TestInputTopic<String, String> in = input(driver);
+            in.pipeInput("k1", "v1", 0L);
+            in.pipeInput("dummy", "vX", 200L); // advances stream time → punctuator fires → k1 evicted
+
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            final KeyValueStore<Bytes, TimestampAndOffset> baseStore =
+                (KeyValueStore<Bytes, TimestampAndOffset>) (KeyValueStore) driver.getKeyValueStore(storeName);
+            long baseStoreCount = 0;
+            try (final KeyValueIterator<Bytes, TimestampAndOffset> it = baseStore.all()) {
+                while (it.hasNext()) {
+                    it.next();
+                    baseStoreCount++;
+                }
+            }
+            assertEquals(1L, baseStoreCount);
+
+            @SuppressWarnings("unchecked")
+            final TimeOrderedKeyValueBuffer<Bytes, String, String> timeIndexStore =
+                (TimeOrderedKeyValueBuffer<Bytes, String, String>) driver.getStateStore(storeName + "-time-index");
+            assertEquals(1, timeIndexStore.numRecords());
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Deduplicated;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.JoinWindows;
@@ -1119,6 +1120,38 @@ public class KStreamImplTest {
                     (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
                     Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner cannot be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullIntervalOnDeduplicateByKey() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.deduplicateByKey(null));
+        assertThat(exception.getMessage(), equalTo("deduplicationInterval cannot be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullIntervalOnDeduplicateByKeyValue() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.deduplicateByKeyValue((k, v) -> k, null, Deduplicated.<String, String, String>idSerde(Serdes.String())));
+        assertThat(exception.getMessage(), equalTo("deduplicationInterval cannot be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullIdSelectorOnDeduplicateByKeyValue() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.deduplicateByKeyValue(null, Duration.ofMillis(100), Deduplicated.<String, String, String>idSerde(Serdes.String())));
+        assertThat(exception.getMessage(), equalTo("idSelector cannot be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullDeduplicated() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.deduplicateByKey(Duration.ofMillis(100), null));
+        assertThat(exception.getMessage(), equalTo("deduplicated cannot be null"));
     }
 
     @SuppressWarnings({"rawtypes", "deprecation"})  // specifically testing the deprecated variant


### PR DESCRIPTION
### Summary                                                                                                                                                             
                                                                                                                                                                      
Implement [KIP-655](https://cwiki.apache.org/confluence/display/KAFKA/KIP-655%3A+Windowed+Distinct+Operation+for+Kafka+Streams+API): Add built-in windowed deduplication to the Kafka Streams DSL.

                                                                                                                                                           
### New public API:                                       
  - `KStream#deduplicateByKey(Duration)` — deduplicates records with the same key within a time window
  - `KStream#deduplicateByKeyValue(KeyValueMapper, Duration)` — deduplicates records with the same (key, computed ID) within a time window

### Testing

- [x] Unit  tests
- [x] Integration tests


### JIRA
- [KAFKA-10369](https://issues.apache.org/jira/browse/KAFKA-10369)                   