### PR TITLE
MINOR: bouncycastle upgrade 1.83 -->> 1.84 (in order to prevent multiple vulnerabilities)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.83",
+  bcpkix: "1.84",
   caffeine: "3.2.0",
   bndlib: "7.1.0",
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.3.1",


### PR DESCRIPTION
related links:
- https://github.com/bcgit/bc-java/discussions/2289
-
https://github.com/bcgit/bc-java/blob/r1rv84/docs/releasenotes.html#L21
- https://issues.apache.org/jira/browse/HADOOP-19866 upgrade
bouncycastle to 1.84 due to multiple CVEs
- JGit (future version 7.7.0):
https://github.com/eclipse-jgit/jgit/commit/02b34dc857a7a80fcf26b6d0a37a9592c7da7586

Reviewers: Mickael Maison <mickael.maison@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Murali Basani   <muralidhar.basani@aiven.io>
