### PR TITLE
MINOR: Caching immutable voterKeys

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/VoterSet.java
+++ b/raft/src/main/java/org/apache/kafka/raft/VoterSet.java
@@ -47,9 +47,13 @@ import java.util.stream.Stream;
  */
 public final class VoterSet {
     private final Map<Integer, VoterNode> voters;
+    private final Set<ReplicaKey> voterKeys;
 
     private VoterSet(Map<Integer, VoterNode> voters) {
         this.voters = voters;
+        this.voterKeys = voters.values().stream()
+            .map(VoterNode::voterKey)
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -144,11 +148,7 @@ public final class VoterSet {
      * Returns all of the voters.
      */
     public Set<ReplicaKey> voterKeys() {
-        return voters
-            .values()
-            .stream()
-            .map(VoterNode::voterKey)
-            .collect(Collectors.toSet());
+        return voterKeys;
     }
 
     /**


### PR DESCRIPTION
The `voters` field within the `VoterSet` is final an initialized within
the constructor only and never changes.  The `voterKeys()` method is
called several times and it always computes the mapping and the
collection from the `voters` field on each call creating stream overhead
and allocating a new HashSet. Unless I am missing anything it seems to
be useless.  This PR changes such behaviour computing an immutable
HashSet `voterKeys` one time in the constructor.

Reviewers: Mickael Maison <mimaison@apache.org>
