### PR TITLE
MINOR: Avoid eager readNextOffset() call in Cleaner.cleanSegments

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
@@ -253,7 +253,9 @@ public class Cleaner {
                 // Note that it is important to collect aborted transactions from the full log segment
                 // range since we need to rebuild the full transaction index for the new segment.
                 long startOffset = currentSegment.baseOffset();
-                long upperBoundOffset = nextSegmentOpt.map(LogSegment::baseOffset).orElse(currentSegment.readNextOffset());
+                long upperBoundOffset = nextSegmentOpt.isPresent()
+                        ? nextSegmentOpt.get().baseOffset()
+                        : currentSegment.readNextOffset();
                 List<AbortedTxn> abortedTransactions = log.collectAbortedTransactions(startOffset, upperBoundOffset);
                 transactionMetadata.addAbortedTransactions(abortedTransactions);
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/Cleaner.java
@@ -253,6 +253,8 @@ public class Cleaner {
                 // Note that it is important to collect aborted transactions from the full log segment
                 // range since we need to rebuild the full transaction index for the new segment.
                 long startOffset = currentSegment.baseOffset();
+                // readNextOffset() is expensive — keep it lazy. orElse() evaluates eagerly,
+                // and orElseGet() can't be used because readNextOffset() throws IOException.
                 long upperBoundOffset = nextSegmentOpt.isPresent()
                         ? nextSegmentOpt.get().baseOffset()
                         : currentSegment.readNextOffset();


### PR DESCRIPTION
In Cleaner.cleanSegments, the upper bound offset for each LogSegment is
computed as the next segment's baseOffset when available, falling back
to the current segment's readNextOffset() for the last segment.

This is intentional: readNextOffset() reads from disk and is documented
as expensive, so the next segment's baseOffset (an O(1) field access) is
preferred whenever possible.

However, the previous code used:
```java
long upperBoundOffset = nextSegmentOpt.map(LogSegment::baseOffset)
    .orElse(currentSegment.readNextOffset());
```

Optional.orElse evaluates its argument eagerly, so readNextOffset() was
invoked once per segment regardless of whether nextSegmentOpt was
present, defeating the optimization.

Replace orElse with a conditional expression so the fallback is only
evaluated when needed. orElseGet cannot be used here because
readNextOffset() declares IOException, which Supplier does not allow.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>
