### PR TITLE
KAFKA-20114: Fix producer ID retry backoff race

### DIFF
--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -111,14 +111,24 @@ public class RPCProducerIdManager implements ProducerIdManager {
     }
 
     private void maybeRequestNextBlock() {
-        var retryTimestamp = backoffDeadlineMs.get();
-        if (retryTimestamp == NO_RETRY || time.milliseconds() >= retryTimestamp) {
-            // Send a request only if we reached the retry deadline, or if no deadline was set.
-            if (nextProducerIdBlock.get() == null &&
-                    requestInFlight.compareAndSet(false, true)) {
-                sendRequest();
-            }
+        if (nextProducerIdBlock.get() != null) {
+            return;
         }
+        // KAFKA-20114 - Acquire requestInFlight before reading backoffDeadlineMs. The response handler
+        // updates backoffDeadlineMs before clearing requestInFlight, so a successful CAS
+        // after that clear observes the updated backoff and avoids a premature retry.
+        if (!requestInFlight.compareAndSet(false, true)) {
+            return;
+        }
+
+        var retryTimestamp = backoffDeadlineMs.get();
+        var now = time.milliseconds();
+
+        if (retryTimestamp != NO_RETRY && now < retryTimestamp) {
+            requestInFlight.set(false);
+            return;
+        }
+        sendRequest();
     }
 
     protected void sendRequest() {
@@ -146,6 +156,9 @@ public class RPCProducerIdManager implements ProducerIdManager {
     private void handleUnsuccessfulResponse() {
         // There is no need to compare and set because only one thread
         // handles the AllocateProducerIds response.
+
+        // KAFKA-20114 - Update the backoff before clearing requestInFlight. maybeRequestNextBlock
+        // relies on this ordering when it acquires requestInFlight before reading the deadline.
         backoffDeadlineMs.set(time.milliseconds() + RETRY_BACKOFF_MS);
         requestInFlight.set(false);
     }

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -60,9 +60,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
     final AtomicReference<ProducerIdsBlock> nextProducerIdBlock = new AtomicReference<>(null);
     final AtomicReference<ProducerIdsBlock> currentProducerIdBlock = new AtomicReference<>(ProducerIdsBlock.EMPTY);
     private final AtomicBoolean requestInFlight = new AtomicBoolean(false);
-    
-    // Setting the value of backoffDeadlineMs should be handled only in the response handler thread.
-    // Otherwise, consider using compareAndSet() instead of set().
+
     private final AtomicLong backoffDeadlineMs = new AtomicLong(NO_RETRY);
 
     public RPCProducerIdManager(int brokerId,
@@ -102,7 +100,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
                     throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception("Producer ID block is full. Waiting for next block");
                 } else {
                     currentProducerIdBlock.set(block);
-                    requestInFlight.set(false);
+                    clearRequestInFlight(NO_RETRY);
                     iteration++;
                 }
             }
@@ -197,8 +195,6 @@ public class RPCProducerIdManager implements ProducerIdManager {
         }
         if (!successfulResponse) {
             handleUnsuccessfulResponse();
-        } else {
-            backoffDeadlineMs.set(NO_RETRY);
         }
     }
 

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -124,6 +124,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
         var retryTimestamp = backoffDeadlineMs.get();
         var now = time.milliseconds();
 
+        // Don't send a request if there is a retry deadline and the deadline has not passed yet.
         if (retryTimestamp != NO_RETRY && now < retryTimestamp) {
             requestInFlight.set(false);
             return;

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -130,6 +130,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
             requestInFlight.set(false);
             return;
         }
+
         sendRequest();
     }
 

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -102,7 +102,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
                     throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception("Producer ID block is full. Waiting for next block");
                 } else {
                     currentProducerIdBlock.set(block);
-                    clearRequestInFlight(NO_RETRY);
+                    requestInFlight.set(false);
                     iteration++;
                 }
             }

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -114,6 +114,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
         if (nextProducerIdBlock.get() != null) {
             return;
         }
+
         // KAFKA-20114 - Acquire requestInFlight before reading backoffDeadlineMs. The response handler
         // updates backoffDeadlineMs before clearing requestInFlight, so a successful CAS
         // after that clear observes the updated backoff and avoids a premature retry.

--- a/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
+++ b/transaction-coordinator/src/main/java/org/apache/kafka/coordinator/transaction/RPCProducerIdManager.java
@@ -102,7 +102,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
                     throw Errors.COORDINATOR_LOAD_IN_PROGRESS.exception("Producer ID block is full. Waiting for next block");
                 } else {
                     currentProducerIdBlock.set(block);
-                    requestInFlight.set(false);
+                    clearRequestInFlight(NO_RETRY);
                     iteration++;
                 }
             }
@@ -150,8 +150,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
             @Override
             public void onTimeout() {
                 log.warn("{} Timed out when requesting AllocateProducerIds from the controller.", logPrefix);
-                backoffDeadlineMs.set(NO_RETRY);
-                requestInFlight.set(false);
+                clearRequestInFlight(NO_RETRY);
             }
         });
     }
@@ -159,11 +158,7 @@ public class RPCProducerIdManager implements ProducerIdManager {
     private void handleUnsuccessfulResponse() {
         // There is no need to compare and set because only one thread
         // handles the AllocateProducerIds response.
-
-        // KAFKA-20114 - Update the backoff before clearing requestInFlight. maybeRequestNextBlock
-        // relies on this ordering when it acquires requestInFlight before reading the deadline.
-        backoffDeadlineMs.set(time.milliseconds() + RETRY_BACKOFF_MS);
-        requestInFlight.set(false);
+        clearRequestInFlight(time.milliseconds() + RETRY_BACKOFF_MS);
     }
 
     protected void handleAllocateProducerIdsResponse(ClientResponse clientResponse) {
@@ -217,5 +212,12 @@ public class RPCProducerIdManager implements ProducerIdManager {
             return true;
         }
         return false;
+    }
+    
+    private void clearRequestInFlight(long newBackoffDeadlineMs) {
+        // KAFKA-20114 - Update the backoff before clearing requestInFlight. maybeRequestNextBlock
+        // relies on this ordering when it acquires requestInFlight before reading the deadline.
+        backoffDeadlineMs.set(newBackoffDeadlineMs);
+        requestInFlight.set(false);
     }
 }


### PR DESCRIPTION
### Description
In `RPCProducerIDManager`, there was a race condition between
`maybeRequestNextBlock()` and `handleUnsuccessfulResponse()`, which may
be called by different threads. This race condition could lead to a
premature retry. To fix this issue, this patch reorders the operation in
`maybeRequestNextBlock()`.

### Considered parts
- It is difficult to add a unit test for this diff because the race
condition cannot be controlled deterministically without relying on
scheduling. Instead of adding a unit test, I added comments to the
paired methods to clarify the intended ordering and concurrency
assumptions.
- Race condition between `if (nextProducerIdBlock.get() != null)`and `if
(!requestInFlight.compareAndSet(false, true))`
  - After `if (nextProducerIdBlock.get() != null)` is checked, another
thread may set `nextProducerIdBlock`. However, this does not cause a
premature retry. In `sanityCheckResponse(...)`, the thread only sets
`nextProducerIdBlock` and does not update `requestInFlight`. Therefore,
CAS in `maybeRequestNextBlock()`will will fail, and a premature retry
will not occur.

Reviewers: Sean Quah <squah@confluent.io>
