### PR TITLE
KAFKA-20546: Lazily call generateNewClientId when handling GetTelemetrySubscriptionsRequest

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -162,7 +162,7 @@ public class ClientMetricsManager implements AutoCloseable {
         long now = time.milliseconds();
         Uuid clientInstanceId = Optional.ofNullable(request.data().clientInstanceId())
             .filter(id -> !id.equals(Uuid.ZERO_UUID))
-            .orElse(generateNewClientId());
+            .orElseGet(this::generateNewClientId);
 
         /*
          Get the client instance from the cache or create a new one. If subscription has changed


### PR DESCRIPTION
Generate new client id only when id does not exist with lazy evaluation

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
