### PR TITLE
MINOR: Fix misleading log message when lastOffset < firstOffset in SharePartition

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -503,9 +503,9 @@ public class SharePartition {
                     }
 
                     if (stateBatch.lastOffset() < stateBatch.firstOffset()) {
-                        log.error("Invalid state batch found for the share partition: {}-{}. The first offset: {}"
-                                + " is less than the last offset of the batch: {}.", groupId, topicIdPartition,
-                            stateBatch.firstOffset(), stateBatch.lastOffset());
+                        log.error("Invalid state batch found for the share partition: {}-{}. The last offset: {}"
+                                + " is less than the first offset of the batch: {}.", groupId, topicIdPartition,
+                            stateBatch.lastOffset(), stateBatch.firstOffset());
                         throwable = new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition));
                         return;
                     }


### PR DESCRIPTION
Fix inverted log message text and argument order in `SharePartition`
when `lastOffset < firstOffset`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
