### PR TITLE
MINOR: Fix outdated Javadoc link in AuthorizableRequestContext

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
@@ -49,16 +49,18 @@ public interface AuthorizableRequestContext {
     InetAddress clientAddress();
 
     /**
-     * The 16-bit API key ({@code request_api_key}) from the request header. See
-     * https://kafka.apache.org/42/design/protocol/#the-messages
-     * Returns the API key from the request header.
+     * Returns the 16-bit API key ({@code request_api_key}) from the request header.
+     * @see <a href="https://kafka.apache.org/42/design/protocol/#the-messages">RequestHeader</a>
+     * <br/>
+     * RequestHeader.json
      */
     int requestType();
 
     /**
-     * The 16-bit API version ({@code request_api_version}) from the request header. See
-     * https://kafka.apache.org/42/design/protocol/#the-messages
-     * Returns the request version from the request header.
+     * Returns the 16-bit API version ({@code request_api_version}) from the request header.
+     * @see <a href="https://kafka.apache.org/42/design/protocol/#the-messages">RequestHeader</a>
+     * <br/>
+     * RequestHeader.json
      */
     int requestVersion();
 

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
@@ -49,12 +49,15 @@ public interface AuthorizableRequestContext {
     InetAddress clientAddress();
 
     /**
-     * 16-bit API key of the request from the request header. See
-     * https://kafka.apache.org/protocol#protocol_api_keys for request types.
+     * The 16-bit API key ({@code request_api_key}) from the request header. See
+     * https://kafka.apache.org/42/design/protocol/#the-messages
+     * Returns the API key from the request header.
      */
     int requestType();
 
     /**
+     * The 16-bit API version ({@code request_api_version}) from the request header. See
+     * https://kafka.apache.org/42/design/protocol/#the-messages
      * Returns the request version from the request header.
      */
     int requestVersion();

--- a/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/AuthorizableRequestContext.java
@@ -50,17 +50,15 @@ public interface AuthorizableRequestContext {
 
     /**
      * Returns the 16-bit API key ({@code request_api_key}) from the request header.
-     * @see <a href="https://kafka.apache.org/42/design/protocol/#the-messages">RequestHeader</a>
-     * <br/>
-     * RequestHeader.json
+     * @see <a href="https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/RequestHeader.json#L29-L30">RequestHeader.json</a>
+     *
      */
     int requestType();
 
     /**
      * Returns the 16-bit API version ({@code request_api_version}) from the request header.
-     * @see <a href="https://kafka.apache.org/42/design/protocol/#the-messages">RequestHeader</a>
-     * <br/>
-     * RequestHeader.json
+     * @see <a href="https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/RequestHeader.json#L31-L32">RequestHeader.json</a>
+     *
      */
     int requestVersion();
 


### PR DESCRIPTION
The Javadoc for `AuthorizableRequestContext#requestType()` contained a
broken link   (`https://kafka.apache.org/protocol#protocol_api_keys`)
that no longer resolves to   the correct anchor after the documentation
site restructure.

This patch updates it to the current working URL and improves the
Javadoc wording   for both `requestType()` and `requestVersion()`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
