### PR TITLE
KAFKA-20558: NPE ClusterInstance.waitUntilLeaderIsElectedOrChanged

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1667,6 +1667,7 @@ project(':test-common:test-common-runtime') {
     implementation libs.jacksonDataformatYaml
     implementation libs.slf4jApi
 
+    testImplementation testFixtures(project(':clients'))
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
     testImplementation testLog4j2Libs

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AddPartitionsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AddPartitionsTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
+import org.apache.kafka.common.test.AdminUtils;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
@@ -102,8 +103,8 @@ public class AddPartitionsTest {
 
             admin.createPartitions(Map.of("topic1", NewPartitions.increaseTo(3))).all().get();
 
-            cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(admin, "topic1", 1, 30000);
-            cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(admin, "topic1", 2, 30000);
+            AdminUtils.fetchOrWaitForLeader(admin, "topic1", 1, 30000);
+            AdminUtils.fetchOrWaitForLeader(admin, "topic1", 2, 30000);
 
             cluster.waitTopicCreation("topic1", 3);
 
@@ -127,8 +128,8 @@ public class AddPartitionsTest {
             admin.createPartitions(Map.of("topic2", NewPartitions.increaseTo(3,
                 List.of(List.of(0, 1), List.of(2, 3))))).all().get();
 
-            cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(admin, "topic2", 1, 30000);
-            cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(admin, "topic2", 2, 30000);
+            AdminUtils.fetchOrWaitForLeader(admin, "topic2", 1, 30000);
+            AdminUtils.fetchOrWaitForLeader(admin, "topic2", 2, 30000);
 
             cluster.waitTopicCreation("topic2", 3);
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.record.internal.MemoryRecords;
 import org.apache.kafka.common.record.internal.SimpleRecord;
+import org.apache.kafka.common.test.AdminUtils;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
@@ -221,7 +222,7 @@ public class DeleteTopicTest {
             cluster.waitTopicDeletion(topic);
 
             waitForReplicaCreated(cluster.brokers(), topicPartition, "Replicas for topic test not created.");
-            cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(admin, DEFAULT_TOPIC, 0, 1000);
+            AdminUtils.fetchOrWaitForLeader(admin, DEFAULT_TOPIC, 0, 1000);
         }
     }
 

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
@@ -20,78 +20,67 @@ package org.apache.kafka.common.test;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-public class AdminUtils {
+public final class AdminUtils {
+
+    private AdminUtils() {}
 
     /**
-     * Wait for a leader to be elected or changed using the provided admin client.
-     *
-     * @param admin           the admin client to use for describing the topic.
-     * @param topic           the topic to check for leadership.
-     * @param partitionNumber the partition number to check for leadership.
-     * @param timeoutMs       the maximum time to wait for a leader to be elected or changed in milliseconds.
-     * @return the id of the elected leader.
-     * @throws ExecutionException   if an unexpected exception occurs while describing the topic.
-     * @throws InterruptedException if the thread is interrupted while waiting for a leader to be elected or changed.
-     * @throws AssertionError       if a leader is not elected within the specified timeout.
+     * Fetch the partition leader or wait until one is elected using the provided admin client.
      */
-    public static int waitUntilLeaderIsElectedOrChanged(Admin admin,
+    public static int fetchOrWaitForLeader(Admin admin,
                                                         String topic,
                                                         int partitionNumber,
-                                                        long timeoutMs) throws ExecutionException, InterruptedException, AssertionError {
-        return waitUntilLeaderIsElectedOrChanged(admin, topic, partitionNumber, timeoutMs, System::currentTimeMillis);
-    }
+                                                        long timeoutMs) throws InterruptedException {
 
-
-    // overload with time supplier for testing
-    static int waitUntilLeaderIsElectedOrChanged(Admin admin,
-                                                 String topic,
-                                                 int partitionNumber,
-                                                 long timeoutMs,
-                                                 Supplier<Long> timeProvider) throws ExecutionException, InterruptedException, AssertionError {
-        long startTime = timeProvider.get();
-        TopicPartition topicPartition = new TopicPartition(topic, partitionNumber);
-
-        while (timeProvider.get() < startTime + timeoutMs) {
-            try {
-                TopicDescription topicDescription = admin.describeTopics(List.of(topic))
-                        .allTopicNames().get().get(topic);
-
-                Optional<Integer> leader = topicDescription.partitions().stream()
-                        .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
-                        .findFirst()
-                        .flatMap(partitionInfo -> Optional.ofNullable(partitionInfo.leader()))
-                        .map(node -> {
-                            int leaderId = node.id();
-                            return leaderId == Node.noNode().id() ? null : leaderId;
-                        });
-
-                if (leader.isPresent()) {
-                    return leader.get();
-                }
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof UnknownTopicOrPartitionException ||
-                        cause instanceof LeaderNotAvailableException) {
-                    continue;
-                } else {
-                    throw e;
-                }
+        var condition = new Supplier<Boolean>() {
+            int leader = Node.noNode().id();
+            @Override
+            public Boolean get() {
+                checkLeader();
+                return this.leader != Node.noNode().id();
             }
 
-            TimeUnit.MILLISECONDS.sleep(Math.min(100L, timeoutMs));
-        }
+            public void checkLeader() {
+                try {
+                    TopicDescription topicDescription = admin.describeTopics(List.of(topic))
+                            .allTopicNames().get().get(topic);
 
-        throw new AssertionError("Timing out after " + timeoutMs +
-                " ms since a leader was not elected for partition " + topicPartition);
+                    Optional<Integer> leader = topicDescription.partitions().stream()
+                            .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
+                            .findFirst()
+                            .flatMap(partitionInfo -> Optional.ofNullable(partitionInfo.leader()))
+                            .map(node -> {
+                                int leaderId = node.id();
+                                return leaderId == Node.noNode().id() ? null : leaderId;
+                            });
+
+                    if (leader.isPresent()) {
+                        this.leader = leader.get();
+                    }
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    boolean isTransient = cause instanceof UnknownTopicOrPartitionException
+                            || cause instanceof LeaderNotAvailableException;
+                    if (!isTransient) {
+                        throw new RuntimeException(e);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        TestUtils.waitForCondition(condition, timeoutMs, "Timing out after %d ms since a leader was not elected for partition %s-%d".formatted(timeoutMs, topic, partitionNumber));
+
+        return condition.leader;
     }
 }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
@@ -36,9 +36,9 @@ public final class AdminUtils {
      * Fetch the partition leader or wait until one is elected using the provided admin client.
      */
     public static int fetchOrWaitForLeader(Admin admin,
-                                                        String topic,
-                                                        int partitionNumber,
-                                                        long timeoutMs) throws InterruptedException {
+                                           String topic,
+                                           int partitionNumber,
+                                           long timeoutMs) throws InterruptedException {
 
         var condition = new Supplier<Boolean>() {
             int leader = Node.noNode().id();
@@ -62,9 +62,7 @@ public final class AdminUtils {
                                 return leaderId == Node.noNode().id() ? null : leaderId;
                             });
 
-                    if (leader.isPresent()) {
-                        this.leader = leader.get();
-                    }
+                    leader.ifPresent(integer -> this.leader = integer);
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause();
                     boolean isTransient = cause instanceof UnknownTopicOrPartitionException

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.test;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.LeaderNotAvailableException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class AdminUtils {
+
+    /**
+     * Wait for a leader to be elected or changed using the provided admin client.
+     *
+     * @param admin           the admin client to use for describing the topic.
+     * @param topic           the topic to check for leadership.
+     * @param partitionNumber the partition number to check for leadership.
+     * @param timeoutMs       the maximum time to wait for a leader to be elected or changed in milliseconds.
+     * @return the id of the elected leader.
+     * @throws ExecutionException   if an unexpected exception occurs while describing the topic.
+     * @throws InterruptedException if the thread is interrupted while waiting for a leader to be elected or changed.
+     * @throws AssertionError       if a leader is not elected within the specified timeout.
+     */
+    public static int waitUntilLeaderIsElectedOrChanged(Admin admin,
+                                                        String topic,
+                                                        int partitionNumber,
+                                                        long timeoutMs) throws ExecutionException, InterruptedException, AssertionError {
+        return waitUntilLeaderIsElectedOrChanged(admin, topic, partitionNumber, timeoutMs, System::currentTimeMillis);
+    }
+
+
+    // overload with time supplier for testing
+    static int waitUntilLeaderIsElectedOrChanged(Admin admin,
+                                                 String topic,
+                                                 int partitionNumber,
+                                                 long timeoutMs,
+                                                 Supplier<Long> timeProvider) throws ExecutionException, InterruptedException, AssertionError {
+        long startTime = timeProvider.get();
+        TopicPartition topicPartition = new TopicPartition(topic, partitionNumber);
+
+        while (timeProvider.get() < startTime + timeoutMs) {
+            try {
+                TopicDescription topicDescription = admin.describeTopics(List.of(topic))
+                        .allTopicNames().get().get(topic);
+
+                Optional<Integer> leader = topicDescription.partitions().stream()
+                        .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
+                        .findFirst()
+                        .flatMap(partitionInfo -> Optional.ofNullable(partitionInfo.leader()))
+                        .map(node -> {
+                            int leaderId = node.id();
+                            return leaderId == Node.noNode().id() ? null : leaderId;
+                        });
+
+                if (leader.isPresent()) {
+                    return leader.get();
+                }
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof UnknownTopicOrPartitionException ||
+                        cause instanceof LeaderNotAvailableException) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+
+            TimeUnit.MILLISECONDS.sleep(Math.min(100L, timeoutMs));
+        }
+
+        throw new AssertionError("Timing out after " + timeoutMs +
+                " ms since a leader was not elected for partition " + topicPartition);
+    }
+}

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
@@ -409,16 +409,4 @@ public interface ClusterInstance {
                     .orElseThrow(() -> new RuntimeException("Leader not found for tp " + topicPartition));
         }
     }
-
-
-
-    /**
-     * Wait for a leader to be elected or changed using the provided admin client.
-     */
-    default int waitUntilLeaderIsElectedOrChangedWithAdmin(Admin admin,
-                                                           String topic,
-                                                           int partitionNumber,
-                                                           long timeoutMs) throws Exception {
-        return AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partitionNumber, timeoutMs);
-    }
 }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
@@ -35,13 +35,10 @@ import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.errors.LeaderNotAvailableException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -68,7 +65,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -414,6 +410,8 @@ public interface ClusterInstance {
         }
     }
 
+
+
     /**
      * Wait for a leader to be elected or changed using the provided admin client.
      */
@@ -421,39 +419,6 @@ public interface ClusterInstance {
                                                            String topic,
                                                            int partitionNumber,
                                                            long timeoutMs) throws Exception {
-        long startTime = System.currentTimeMillis();
-        TopicPartition topicPartition = new TopicPartition(topic, partitionNumber);
-
-        while (System.currentTimeMillis() < startTime + timeoutMs) {
-            try {
-                TopicDescription topicDescription = admin.describeTopics(List.of(topic))
-                        .allTopicNames().get().get(topic);
-
-                Optional<Integer> leader = topicDescription.partitions().stream()
-                        .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
-                        .findFirst()
-                        .map(partitionInfo -> {
-                            int leaderId = partitionInfo.leader().id();
-                            return leaderId == Node.noNode().id() ? null : leaderId;
-                        });
-
-                if (leader.isPresent()) {
-                    return leader.get();
-                }
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof UnknownTopicOrPartitionException ||
-                        cause instanceof LeaderNotAvailableException) {
-                    continue;
-                } else {
-                    throw e;
-                }
-            }
-
-            TimeUnit.MILLISECONDS.sleep(Math.min(100L, timeoutMs));
-        }
-
-        throw new AssertionError("Timing out after " + timeoutMs +
-                " ms since a leader was not elected for partition " + topicPartition);
+        return AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partitionNumber, timeoutMs);
     }
 }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 public class AdminUtilsTest {
 
     @Test
-    void testWaitUntilLeaderIsElectedOrChanged() throws Exception {
+    void testFetchOrWaitForLeader() throws Exception {
         String topic = "test-topic";
         int partition = 0;
         Admin admin = mock(Admin.class);
@@ -64,13 +64,13 @@ public class AdminUtilsTest {
             }
         });
 
-        int result = AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partition, 1000);
+        int result = AdminUtils.fetchOrWaitForLeader(admin, topic, partition, 1000);
 
         assertEquals(1, result);
     }
 
     @Test
-    void testWaitUntilLeaderIsElectedOrChangedTimesOut() throws Exception {
+    void testFetchOrWaitForLeaderTimesOut() throws Exception {
         String topic = "test-topic";
         int partition = 0;
         Node leader = null;
@@ -81,7 +81,7 @@ public class AdminUtilsTest {
         when(admin.describeTopics(anyCollection())).thenReturn(describeResult);
 
         assertThrows(AssertionError.class, () ->
-                        AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partition, 1),
+                        AdminUtils.fetchOrWaitForLeader(admin, topic, partition, 1),
                 "Timing out after 1 ms since a leader was not elected for partition test-topic-0");
     }
 }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.test;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientTestUtils;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("resource")
+public class AdminUtilsTest {
+
+    @Test
+    void testWaitUntilLeaderIsElectedOrChanged() throws Exception {
+        String topic = "test-topic";
+        int partition = 0;
+        Admin admin = mock(Admin.class);
+        when(admin.describeTopics(anyCollection())).thenAnswer(new Answer<Object>() {
+            boolean called = false;
+
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                if (called) {
+                    return resultWithLeader(new Node(0, "", 0));
+                } else {
+                    called = true;
+                    return resultWithLeader(new Node(1, "", 0));
+                }
+            }
+
+            DescribeTopicsResult resultWithLeader(Node leader) {
+                TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(partition, leader, List.of(), List.of());
+                return AdminClientTestUtils.describeTopicsResult(topic,
+                        new TopicDescription(topic, false, List.of(topicPartitionInfo)));
+            }
+        });
+
+        int result = AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partition, 1000);
+
+        assertEquals(1, result);
+    }
+
+    @Test
+    void testWaitUntilLeaderIsElectedOrChangedTimesOut() throws Exception {
+        String topic = "test-topic";
+        int partition = 0;
+        Node leader = null;
+        TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(partition, leader, List.of(), List.of());
+        DescribeTopicsResult describeResult = AdminClientTestUtils.describeTopicsResult(topic,
+                new TopicDescription(topic, false, List.of(topicPartitionInfo)));
+        Admin admin = mock(Admin.class);
+        when(admin.describeTopics(anyCollection())).thenReturn(describeResult);
+
+        assertThrows(AssertionError.class, () ->
+                        AdminUtils.waitUntilLeaderIsElectedOrChanged(admin, topic, partition, 1),
+                "Timing out after 1 ms since a leader was not elected for partition test-topic-0");
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.test.AdminUtils;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
@@ -446,7 +447,7 @@ public class LeaderElectionCommandTest {
     }
 
     private void assertLeader(Admin client, TopicPartition topicPartition, int expectedLeader) throws Exception {
-        int leader = cluster.waitUntilLeaderIsElectedOrChangedWithAdmin(client, topicPartition.topic(), topicPartition.partition(), 30000);
+        int leader = AdminUtils.fetchOrWaitForLeader(client, topicPartition.topic(), topicPartition.partition(), 30000);
         assertEquals(expectedLeader, leader);
     }
 


### PR DESCRIPTION
TopicPartitionInfo.leader() may return null, but the existing code in
ClusterInstance called .id() without a null check. Extract the logic
into a new AdminUtils class with null handling, delegate from
ClusterInstance, and add unit tests.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
