### PR TITLE
KAFKA-14229 Support for nested structures: HoistField

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HoistField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HoistField.java
@@ -22,58 +22,190 @@ import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
+import org.apache.kafka.connect.transforms.field.SingleFieldPath;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
 public abstract class HoistField<R extends ConnectRecord<R>> implements Transformation<R> {
 
     public static final String OVERVIEW_DOC =
-            "Wrap data using the specified field name in a Struct when schema present, or a Map in the case of schemaless data."
+            "Wrap a field using the specified field name in a Struct when schema present, or a Map in the case of schemaless data. "
                     + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
     private static final String FIELD_CONFIG = "field";
+    private static final String HOISTED_CONFIG = "hoisted";
 
-    public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM,
-                    "Field name for the single field that will be created in the resulting Struct or Map.");
+    private static final String PURPOSE = "hoisting a field";
+
+    public static final ConfigDef CONFIG_DEF = FieldSyntaxVersion.appendConfigTo(
+            new ConfigDef()
+                    .define(FIELD_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM,
+                            "Field name for the single field that will be created in the resulting Struct or Map.")
+                    .define(HOISTED_CONFIG, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM,
+                            "Path to the element to be hoisted. If empty, the root struct/map is hoisted."));
 
     private Cache<Schema, Schema> schemaUpdateCache;
 
-    private String fieldName;
+    private String wrapperName;
+    private String hoisted;
+    private SingleFieldPath fieldPath;
 
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-        fieldName = config.getString("field");
+        wrapperName = config.getString(FIELD_CONFIG);
+        final String hoistedConfig = config.getString(HOISTED_CONFIG);
+        hoisted = hoistedConfig == null ? "" : hoistedConfig;
+        final FieldSyntaxVersion fieldSyntaxVersion = FieldSyntaxVersion.fromConfig(config);
+        fieldPath = new SingleFieldPath(hoisted, fieldSyntaxVersion);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
     }
 
     @Override
     public R apply(R record) {
+        if (operatingSchema(record) == null) {
+            return applySchemaless(record);
+        } else {
+            return applyWithSchema(record);
+        }
+    }
+
+    /**
+     * Handles schemaless (Map) records. When {@code hoisted} is empty the whole value is wrapped
+     * in a single-field Map named {@code wrapperName}; otherwise the element at the {@code hoisted}
+     * path is hoisted in place.
+     */
+    @SuppressWarnings("unchecked")
+    private R applySchemaless(R record) {
+        final Object value = operatingValue(record);
+
+        if (hoisted.isEmpty()) {
+            Map<String, Object> wrapper = new HashMap<>();
+            wrapper.put(wrapperName, value);
+            return newRecord(record, null, wrapper);
+        }
+
+        final Map<String, Object> map = requireMap(value, PURPOSE);
+        return newRecord(record, null, hoistSchemaless(map, 0));
+    }
+
+    /**
+     * Recursively rebuilds a Map along the {@code hoisted} path, copying every sibling untouched.
+     * At the leaf step the targeted entry is replaced by a new field {@code wrapperName} holding a
+     * Map of {@code {leafName: leafValue}}. Throws if a path step is missing or not a Map.
+     */
+    private Map<String, Object> hoistSchemaless(Map<String, Object> current, int idx) {
+        final List<String> steps = fieldPath.steps();
+        final String step = steps.get(idx);
+        if (!current.containsKey(step)) {
+            throw new IllegalArgumentException("Unknown field: " + hoisted);
+        }
+
+        final Map<String, Object> updated = new LinkedHashMap<>(current);
+        if (idx == steps.size() - 1) {
+            final Object leafValue = updated.remove(step);
+            final Map<String, Object> wrapper = new HashMap<>();
+            wrapper.put(step, leafValue);
+            updated.put(wrapperName, wrapper);
+        } else {
+            final Map<String, Object> child = requireMap(current.get(step), PURPOSE);
+            updated.put(step, hoistSchemaless(child, idx + 1));
+        }
+        return updated;
+    }
+
+    /**
+     * Handles schema-based (Struct) records. When {@code hoisted} is empty the whole value is wrapped
+     * in a single-field Struct named {@code wrapperName}; otherwise the element at the {@code hoisted}
+     * path is hoisted in place. Updated schemas are cached by their source schema.
+     */
+    private R applyWithSchema(R record) {
         final Schema schema = operatingSchema(record);
         final Object value = operatingValue(record);
 
-        if (schema == null) {
-            Map<String, Object> updatedValue = new HashMap<>();
-            updatedValue.put(fieldName, value);
-            return newRecord(record, null, updatedValue);
-        } else {
+        if (hoisted.isEmpty()) {
             Schema updatedSchema = schemaUpdateCache.get(schema);
             if (updatedSchema == null) {
-                updatedSchema = SchemaBuilder.struct().field(fieldName, schema).build();
+                updatedSchema = SchemaBuilder.struct().field(wrapperName, schema).build();
                 schemaUpdateCache.put(schema, updatedSchema);
             }
-
-            final Struct updatedValue = new Struct(updatedSchema).put(fieldName, value);
-
+            final Struct updatedValue = new Struct(updatedSchema).put(wrapperName, value);
             return newRecord(record, updatedSchema, updatedValue);
         }
+
+        Schema updatedSchema = schemaUpdateCache.get(schema);
+        if (updatedSchema == null) {
+            updatedSchema = hoistSchema(schema, 0);
+            schemaUpdateCache.put(schema, updatedSchema);
+        }
+        final Struct updatedValue = hoistValue(requireStruct(value, PURPOSE), updatedSchema, 0);
+        return newRecord(record, updatedSchema, updatedValue);
+    }
+
+    /**
+     * Recursively rebuilds a Struct schema along the {@code hoisted} path, preserving every other
+     * field. At the leaf step the targeted field is replaced by {@code wrapperName}, whose schema is
+     * a Struct wrapping the original leaf field. Throws if a path step is not found in the schema.
+     */
+    private Schema hoistSchema(Schema current, int idx) {
+        final List<String> steps = fieldPath.steps();
+        final String step = steps.get(idx);
+        if (current.field(step) == null) {
+            throw new IllegalArgumentException("Unknown field: " + hoisted);
+        }
+
+        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(current, SchemaBuilder.struct());
+        for (Field field : current.fields()) {
+            if (!field.name().equals(step)) {
+                builder.field(field.name(), field.schema());
+            } else if (idx == steps.size() - 1) {
+                final Schema wrapperSchema = SchemaBuilder.struct().field(step, field.schema()).build();
+                builder.field(wrapperName, wrapperSchema);
+            } else {
+                builder.field(field.name(), hoistSchema(field.schema(), idx + 1));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Recursively rebuilds a Struct against {@code updatedSchema} (the schema produced by
+     * {@link #hoistSchema}), mirroring the traversal: siblings are copied as-is, and at the leaf step
+     * the targeted field's value is nested under {@code wrapperName}.
+     */
+    private Struct hoistValue(Struct current, Schema updatedSchema, int idx) {
+        final List<String> steps = fieldPath.steps();
+        final String step = steps.get(idx);
+
+        final Struct updated = new Struct(updatedSchema);
+        for (Field field : current.schema().fields()) {
+            final String name = field.name();
+            if (!name.equals(step)) {
+                updated.put(name, current.get(field));
+            } else if (idx == steps.size() - 1) {
+                final Schema wrapperSchema = updatedSchema.field(wrapperName).schema();
+                final Struct wrapper = new Struct(wrapperSchema).put(step, current.get(field));
+                updated.put(wrapperName, wrapper);
+            } else {
+                final Schema childSchema = updatedSchema.field(name).schema();
+                updated.put(name, hoistValue(requireStruct(current.get(field), PURPOSE), childSchema, idx + 1));
+            }
+        }
+        return updated;
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -143,6 +143,15 @@ public class SingleFieldPath {
     }
 
     /**
+     * Return the path steps of this field path.
+     *
+     * @return unmodifiable list of path steps
+     */
+    public List<String> steps() {
+        return steps;
+    }
+
+    /**
      * Access a {@code Field} at the current path within a schema {@code Schema}
      * If field is not found, then {@code null} is returned.
      */

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -18,55 +18,72 @@ package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class HoistFieldTest {
+class HoistFieldTest {
     private final HoistField<SinkRecord> xform = new HoistField.Key<>();
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         xform.close();
     }
 
+    private static Map<String, String> v2(String field, String hoisted) {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("field", field);
+        configs.put("hoisted", hoisted);
+        configs.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        return configs;
+    }
+
     @Test
-    public void schemaless() {
+    @DisplayName("Schemaless: empty hoisted wraps whole value in a single-field Map")
+    void schemaless() {
         xform.configure(Map.of("field", "magic"));
 
-        final SinkRecord record = new SinkRecord("test", 0, null, 42, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, 42, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
 
         assertNull(transformedRecord.keySchema());
         assertEquals(Map.of("magic", 42), transformedRecord.key());
     }
 
     @Test
-    public void withSchema() {
+    @DisplayName("With schema: empty hoisted wraps whole value in a single-field Struct")
+    void withSchema() {
         xform.configure(Map.of("field", "magic"));
 
-        final SinkRecord record = new SinkRecord("test", 0, Schema.INT32_SCHEMA, 42, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, Schema.INT32_SCHEMA, 42, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
 
         assertEquals(Schema.Type.STRUCT, transformedRecord.keySchema().type());
-        assertEquals(record.keySchema(),  transformedRecord.keySchema().field("magic").schema());
+        assertEquals(sinkRecord.keySchema(), transformedRecord.keySchema().field("magic").schema());
         assertEquals(42, ((Struct) transformedRecord.key()).get("magic"));
     }
 
     @Test
-    public void testSchemalessMapIsMutable() {
+    @DisplayName("Schemaless: resulting wrapper Map is mutable")
+    void testSchemalessMapIsMutable() {
         xform.configure(Map.of("field", "magic"));
 
-        final SinkRecord record = new SinkRecord("test", 0, null, 420, null, null, 0);
-        final SinkRecord transformedRecord = xform.apply(record);
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, 420, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
 
         assertNull(transformedRecord.keySchema());
         @SuppressWarnings("unchecked")
@@ -79,8 +96,256 @@ public class HoistFieldTest {
     }
 
     @Test
-    public void testHoistFieldVersionRetrievedFromAppInfoParser() {
+    @DisplayName("version() returns AppInfoParser version")
+    void testHoistFieldVersionRetrievedFromAppInfoParser() {
         assertEquals(AppInfoParser.getVersion(), xform.version());
     }
 
+    @Test
+    @DisplayName("V2 with empty hoisted behaves like classic hoist")
+    void emptyHoistedV2WrapsWholeValue() {
+        xform.configure(v2("magic", ""));
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, Schema.INT32_SCHEMA, 42, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        assertEquals(Schema.Type.STRUCT, transformedRecord.keySchema().type());
+        assertEquals(sinkRecord.keySchema(), transformedRecord.keySchema().field("magic").schema());
+        assertEquals(42, ((Struct) transformedRecord.key()).get("magic"));
+    }
+
+    @Test
+    @DisplayName("Null hoisted value is treated as empty (classic hoist)")
+    void nullHoistedTreatedAsEmpty() {
+        final Map<String, Object> configs = new HashMap<>();
+        configs.put("field", "magic");
+        configs.put("hoisted", null);
+        xform.configure(configs);
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, 42, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        assertNull(transformedRecord.keySchema());
+        assertEquals(Map.of("magic", 42), transformedRecord.key());
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: hoists nested element, preserving siblings")
+    void schemalessV2() {
+        final HoistField<SinkRecord> valueXform = new HoistField.Value<>();
+        valueXform.configure(v2("other", "parent.child.k2"));
+
+        final Map<String, Object> child = new HashMap<>();
+        child.put("k2", "123");
+        final Map<String, Object> parent = new HashMap<>();
+        parent.put("child", child);
+        final Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        value.put("parent", parent);
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, null, null, value, 0);
+        final SinkRecord transformedRecord = valueXform.apply(sinkRecord);
+
+        final Map<String, Object> expectedChild = Map.of("other", Map.of("k2", "123"));
+        final Map<String, Object> expected = Map.of("k1", 123, "parent", Map.of("child", expectedChild));
+        assertEquals(expected, transformedRecord.value());
+
+        valueXform.close();
+    }
+
+    @Test
+    @DisplayName("V2 with schema: hoists nested element, preserving siblings")
+    void schemaV2() {
+        final HoistField<SinkRecord> valueXform = new HoistField.Value<>();
+        valueXform.configure(v2("other", "parent.child.k2"));
+
+        final Schema childSchema = SchemaBuilder.struct().field("k2", Schema.STRING_SCHEMA).build();
+        final Schema parentSchema = SchemaBuilder.struct().field("child", childSchema).build();
+        final Schema rootSchema = SchemaBuilder.struct()
+                .field("k1", Schema.INT32_SCHEMA)
+                .field("parent", parentSchema)
+                .build();
+        final Struct root = new Struct(rootSchema)
+                .put("k1", 123)
+                .put("parent", new Struct(parentSchema)
+                        .put("child", new Struct(childSchema).put("k2", "123")));
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, null, rootSchema, root, 0);
+        final SinkRecord transformedRecord = valueXform.apply(sinkRecord);
+
+        final Struct out = (Struct) transformedRecord.value();
+        assertEquals(123, out.get("k1"));
+        final Struct parent = (Struct) out.get("parent");
+        final Struct child = (Struct) parent.get("child");
+        final Struct other = assertInstanceOf(Struct.class, child.get("other"));
+        assertEquals("123", other.get("k2"));
+
+        // schema mirrors the wrapped value and preserves the original leaf schema
+        final Schema outSchema = transformedRecord.valueSchema();
+        assertEquals(Schema.INT32_SCHEMA, outSchema.field("k1").schema());
+        final Schema otherSchema = outSchema.field("parent").schema().field("child").schema().field("other").schema();
+        assertEquals(Schema.STRING_SCHEMA, otherSchema.field("k2").schema());
+
+        valueXform.close();
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: hoists a field whose name contains a dot")
+    void escapedDotsSchemaless() {
+        final HoistField<SinkRecord> valueXform = new HoistField.Value<>();
+        valueXform.configure(v2("other", "`parent.child`"));
+
+        final Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        value.put("parent.child", Map.of("k2", "123"));
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, null, null, value, 0);
+        final SinkRecord transformedRecord = valueXform.apply(sinkRecord);
+
+        final Map<String, Object> expected = Map.of(
+                "k1", 123,
+                "other", Map.of("parent.child", Map.of("k2", "123")));
+        assertEquals(expected, transformedRecord.value());
+
+        valueXform.close();
+    }
+
+    @Test
+    @DisplayName("V2 with schema: KIP example 2 hoists a field whose name contains a dot")
+    void escapedDotsWithSchema() {
+        final HoistField<SinkRecord> valueXform = new HoistField.Value<>();
+        valueXform.configure(v2("other", "`parent.child`"));
+
+        final Schema pcSchema = SchemaBuilder.struct().field("k2", Schema.STRING_SCHEMA).build();
+        final Schema rootSchema = SchemaBuilder.struct()
+                .field("k1", Schema.INT32_SCHEMA)
+                .field("parent.child", pcSchema)
+                .build();
+        final Struct root = new Struct(rootSchema)
+                .put("k1", 123)
+                .put("parent.child", new Struct(pcSchema).put("k2", "123"));
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, null, rootSchema, root, 0);
+        final SinkRecord transformedRecord = valueXform.apply(sinkRecord);
+
+        final Struct out = (Struct) transformedRecord.value();
+        assertEquals(123, out.get("k1"));
+        final Struct other = assertInstanceOf(Struct.class, out.get("other"));
+        final Struct pc = (Struct) other.get("parent.child");
+        assertEquals("123", pc.get("k2"));
+
+        valueXform.close();
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: single-level hoisted wraps a root field, preserving siblings")
+    void singleLevelHoistedSchemaless() {
+        xform.configure(v2("other", "k2"));
+
+        final Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        value.put("k2", "New York");
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, value, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        assertEquals(Map.of("k1", 123, "other", Map.of("k2", "New York")), transformedRecord.key());
+    }
+
+    @Test
+    @DisplayName("V2 with schema: hoisting an intermediate node wraps the whole subtree")
+    void intermediateNodeHoistedWithSchema() {
+        xform.configure(v2("other", "parent"));
+
+        final Schema childSchema = SchemaBuilder.struct().field("k2", Schema.STRING_SCHEMA).build();
+        final Schema parentSchema = SchemaBuilder.struct().field("child", childSchema).build();
+        final Schema rootSchema = SchemaBuilder.struct()
+                .field("k1", Schema.INT32_SCHEMA)
+                .field("parent", parentSchema)
+                .build();
+        final Struct root = new Struct(rootSchema)
+                .put("k1", 123)
+                .put("parent", new Struct(parentSchema)
+                        .put("child", new Struct(childSchema).put("k2", "123")));
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, rootSchema, root, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        final Struct out = (Struct) transformedRecord.key();
+        assertEquals(123, out.get("k1"));
+        final Struct other = assertInstanceOf(Struct.class, out.get("other"));
+        final Struct parent = (Struct) other.get("parent");
+        final Struct child = (Struct) parent.get("child");
+        assertEquals("123", child.get("k2"));
+    }
+
+    @Test
+    @DisplayName("V1: dotted hoisted path is treated as a single literal field name")
+    void v1DottedHoistedIsLiteral() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("field", "other");
+        configs.put("hoisted", "a.b.c");
+        // V1 is the default
+        xform.configure(configs);
+
+        final Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        value.put("a.b.c", 42);
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, value, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        assertEquals(Map.of("k1", 123, "other", Map.of("a.b.c", 42)), transformedRecord.key());
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: result and inner wrapper Maps are mutable")
+    @SuppressWarnings("unchecked")
+    void hoistedSchemalessResultIsMutable() {
+        xform.configure(v2("other", "parent.k2"));
+
+        final Map<String, Object> parent = new LinkedHashMap<>();
+        parent.put("k2", "NY");
+        final Map<String, Object> value = new LinkedHashMap<>();
+        value.put("k1", 123);
+        value.put("parent", parent);
+
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, value, null, null, 0);
+        final SinkRecord transformedRecord = xform.apply(sinkRecord);
+
+        Map<String, Object> out = (Map<String, Object>) transformedRecord.key();
+        out.put("extra", "value");
+        Map<String, Object> outParent = (Map<String, Object>) out.get("parent");
+        Map<String, Object> wrapper = (Map<String, Object>) outParent.get("other");
+        wrapper.put("added", 1);
+
+        assertEquals("NY", wrapper.get("k2"));
+        assertEquals(1, wrapper.get("added"));
+        assertEquals("value", out.get("extra"));
+        assertEquals(123, out.get("k1"));
+    }
+
+    @Test
+    @DisplayName("With schema: unknown hoisted path throws")
+    void unknownHoistedPathWithSchemaThrows() {
+        xform.configure(v2("other", "does.not.exist"));
+
+        final Schema rootSchema = SchemaBuilder.struct().field("k1", Schema.INT32_SCHEMA).build();
+        final Struct root = new Struct(rootSchema).put("k1", 123);
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, rootSchema, root, null, null, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> xform.apply(sinkRecord));
+    }
+
+    @Test
+    @DisplayName("Schemaless: unknown hoisted path throws")
+    void unknownHoistedPathSchemalessThrows() {
+        xform.configure(v2("other", "does.not.exist"));
+
+        final Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        final SinkRecord sinkRecord = new SinkRecord("test", 0, null, value, null, null, 0);
+
+        assertThrows(IllegalArgumentException.class, () -> xform.apply(sinkRecord));
+    }
 }


### PR DESCRIPTION
Adds support for for nested structures to the `HoistField` transformer.

[KIP-821: Connect Transforms support for nested structures](https://cwiki.apache.org/confluence/display/KAFKA/KIP-821%3A+Connect+Transforms+support+for+nested+structures) was approved back in 2023, but support for this feature has been added only to the `ExtractField` transformer so far.
