### PR TITLE
KAFKA-14227 Support for nested structures: MaskField

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MaskField.java
@@ -19,11 +19,12 @@ package org.apache.kafka.connect.transforms;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
+import org.apache.kafka.connect.transforms.field.SingleFieldPath;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.math.BigDecimal;
@@ -31,11 +32,10 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
@@ -52,15 +52,16 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
     private static final String REPLACEMENT_CONFIG = "replacement";
     private static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "replace.null.with.default";
 
-    public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, 
-                    ConfigDef.ValidList.anyNonDuplicateValues(false, false),
-                    ConfigDef.Importance.HIGH, "Names of fields to mask.")
-            .define(REPLACEMENT_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
-                    ConfigDef.Importance.LOW, "Custom value replacement, that will be applied to all"
-                            + " 'fields' values (numeric or non-empty string values only).")
-            .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
-                    "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used.");
+    public static final ConfigDef CONFIG_DEF = FieldSyntaxVersion.appendConfigTo(
+            new ConfigDef()
+                    .define(FIELDS_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE,
+                            ConfigDef.ValidList.anyNonDuplicateValues(false, false),
+                            ConfigDef.Importance.HIGH, "Names of fields to mask.")
+                    .define(REPLACEMENT_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
+                            ConfigDef.Importance.LOW, "Custom value replacement, that will be applied to all"
+                                    + " 'fields' values (numeric or non-empty string values only).")
+                    .define(REPLACE_NULL_WITH_DEFAULT_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                            "Whether to replace fields that have a default value and that are null to the default value. When set to true, the default value is used, otherwise null is used."));
 
     private static final String PURPOSE = "mask fields";
 
@@ -89,7 +90,7 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         Map.entry(String.class, "")
     );
 
-    private Set<String> maskedFields;
+    private List<SingleFieldPath> maskedFieldPaths;
     private String replacement;
     private boolean replaceNullWithDefault;
 
@@ -101,7 +102,10 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-        maskedFields = new HashSet<>(config.getList(FIELDS_CONFIG));
+        final FieldSyntaxVersion fieldSyntaxVersion = FieldSyntaxVersion.fromConfig(config);
+        maskedFieldPaths = config.getList(FIELDS_CONFIG).stream()
+                .map(field -> new SingleFieldPath(field, fieldSyntaxVersion))
+                .collect(Collectors.toList());
         replacement = config.getString(REPLACEMENT_CONFIG);
         replaceNullWithDefault = config.getBoolean(REPLACE_NULL_WITH_DEFAULT_CONFIG);
     }
@@ -115,30 +119,24 @@ public abstract class MaskField<R extends ConnectRecord<R>> implements Transform
         }
     }
 
+    @SuppressWarnings("unchecked")
     private R applySchemaless(R record) {
         final Map<String, Object> value = requireMap(operatingValue(record), PURPOSE);
         final HashMap<String, Object> updatedValue = new HashMap<>(value);
-        for (String field : maskedFields) {
-            updatedValue.put(field, masked(value.get(field)));
+        for (SingleFieldPath fieldPath : maskedFieldPaths) {
+            fieldPath.setValue(updatedValue, masked(fieldPath.valueFrom(updatedValue)));
         }
         return newRecord(record, updatedValue);
     }
 
     private R applyWithSchema(R record) {
         final Struct value = requireStruct(operatingValue(record), PURPOSE);
-        final Struct updatedValue = new Struct(value.schema());
-        for (Field field : value.schema().fields()) {
-            final Object origFieldValue = getFieldValue(value, field);
-            updatedValue.put(field, maskedFields.contains(field.name()) ? masked(origFieldValue) : origFieldValue);
+        Struct updatedValue = value;
+        for (SingleFieldPath fieldPath : maskedFieldPaths) {
+            Object origValue = fieldPath.valueFrom(updatedValue, replaceNullWithDefault);
+            updatedValue = fieldPath.withValue(updatedValue, masked(origValue), replaceNullWithDefault);
         }
         return newRecord(record, updatedValue);
-    }
-
-    private Object getFieldValue(Struct value, Field field) {
-        if (replaceNullWithDefault) {
-            return value.get(field);
-        }
-        return value.getWithoutDefault(field.name());
     }
 
     private Object masked(Object value) {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/field/SingleFieldPath.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -205,6 +206,55 @@ public class SingleFieldPath {
             if (current == null) return null;
         }
         return current.get(lastStep());
+    }
+
+    /**
+     * Set a value at the current path within a schemaless {@code Map<String, Object>}.
+     * Intermediate maps along the path are defensively copied to avoid mutating the original.
+     */
+    @SuppressWarnings("unchecked")
+    public void setValue(Map<String, Object> map, Object newValue) {
+        Map<String, Object> current = map;
+        for (String step : stepsWithoutLast()) {
+            Map<String, Object> nested = requireMapOrNull(current.get(step), "nested field access");
+            if (nested == null) return;
+            Map<String, Object> copy = new HashMap<>(nested);
+            current.put(step, copy);
+            current = copy;
+        }
+        current.put(lastStep(), newValue);
+    }
+
+    /**
+     * Return a copy of the given Struct with the value at this path replaced.
+     * The schema is preserved; only the value at the target path is changed.
+     */
+    public Struct withValue(Struct struct, Object newValue, boolean replaceNullWithDefault) {
+        return rebuildWithValue(struct, 0, newValue, replaceNullWithDefault);
+    }
+
+    private Struct rebuildWithValue(Struct source, int stepIndex, Object newValue, boolean replaceNullWithDefault) {
+        Schema schema = source.schema();
+        Struct result = new Struct(schema);
+        String targetFieldName = steps.get(stepIndex);
+        boolean isLeaf = stepIndex == lastStepIndex();
+
+        for (Field field : schema.fields()) {
+            Object fieldValue = replaceNullWithDefault ? source.get(field) : source.getWithoutDefault(field.name());
+            if (field.name().equals(targetFieldName)) {
+                if (isLeaf) {
+                    result.put(field, newValue);
+                } else {
+                    Struct child = requireStructOrNull(fieldValue, "nested field access");
+                    result.put(field, child != null
+                        ? rebuildWithValue(child, stepIndex + 1, newValue, replaceNullWithDefault)
+                        : null);
+                }
+            } else {
+                result.put(field, fieldValue);
+            }
+        }
+        return result;
     }
 
     // For testing

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MaskFieldTest.java
@@ -27,7 +27,9 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.field.FieldSyntaxVersion;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -272,5 +274,252 @@ public class MaskFieldTest {
     public void testMaskFieldReturnsVersionFromAppInfoParser() {
         final MaskField<SinkRecord> xform = new MaskField.Value<>();
         assertEquals(AppInfoParser.getVersion(), xform.version());
+    }
+
+    // --- V2 nested field tests ---
+
+    private static MaskField<SinkRecord> transformV2(List<String> fields, String replacement) {
+        final MaskField<SinkRecord> xform = new MaskField.Value<>();
+        Map<String, Object> props = new HashMap<>();
+        props.put("fields", fields);
+        props.put("replacement", replacement);
+        props.put("replace.null.with.default", false);
+        props.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xform.configure(props);
+        return xform;
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: masks nested field in Map")
+    public void testV2SchemalessNestedMask() {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("secret", "password123");
+        inner.put("visible", "hello");
+        Map<String, Object> value = new HashMap<>();
+        value.put("outer", inner);
+        value.put("top", "keep");
+
+        SinkRecord record = record(null, value);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) transformV2(
+                List.of("outer.secret"), null).apply(record).value();
+
+        assertEquals("keep", result.get("top"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultInner = (Map<String, Object>) result.get("outer");
+        assertEquals("", resultInner.get("secret"));
+        assertEquals("hello", resultInner.get("visible"));
+    }
+
+    @Test
+    @DisplayName("V2 with schema: masks nested field in Struct")
+    public void testV2WithSchemaNestedMask() {
+        Schema innerSchema = SchemaBuilder.struct()
+                .field("secret", Schema.STRING_SCHEMA)
+                .field("visible", Schema.STRING_SCHEMA)
+                .build();
+        Schema outerSchema = SchemaBuilder.struct()
+                .field("outer", innerSchema)
+                .field("top", Schema.STRING_SCHEMA)
+                .build();
+        Struct innerStruct = new Struct(innerSchema)
+                .put("secret", "password123")
+                .put("visible", "hello");
+        Struct outerStruct = new Struct(outerSchema)
+                .put("outer", innerStruct)
+                .put("top", "keep");
+
+        SinkRecord record = record(outerSchema, outerStruct);
+        Struct result = (Struct) transformV2(List.of("outer.secret"), null).apply(record).value();
+
+        assertEquals("keep", result.get("top"));
+        Struct resultInner = (Struct) result.get("outer");
+        assertEquals("", resultInner.get("secret"));
+        assertEquals("hello", resultInner.get("visible"));
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: masks deeply nested field (three levels)")
+    public void testV2SchemalessDeepNestedMask() {
+        Map<String, Object> c = new HashMap<>();
+        c.put("target", 42);
+        c.put("keep", 99);
+        Map<String, Object> b = new HashMap<>();
+        b.put("c", c);
+        Map<String, Object> a = new HashMap<>();
+        a.put("b", b);
+        Map<String, Object> value = new HashMap<>();
+        value.put("a", a);
+
+        SinkRecord record = record(null, value);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) transformV2(
+                List.of("a.b.c.target"), null).apply(record).value();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> ra = (Map<String, Object>) result.get("a");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> rb = (Map<String, Object>) ra.get("b");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> rc = (Map<String, Object>) rb.get("c");
+        assertEquals(0, rc.get("target"));
+        assertEquals(99, rc.get("keep"));
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: masks multiple nested fields")
+    public void testV2SchemalessMultipleNestedMasks() {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("a", "secret1");
+        inner.put("b", "secret2");
+        inner.put("c", "visible");
+        Map<String, Object> value = new HashMap<>();
+        value.put("nested", inner);
+
+        SinkRecord record = record(null, value);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) transformV2(
+                List.of("nested.a", "nested.b"), null).apply(record).value();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultInner = (Map<String, Object>) result.get("nested");
+        assertEquals("", resultInner.get("a"));
+        assertEquals("", resultInner.get("b"));
+        assertEquals("visible", resultInner.get("c"));
+    }
+
+    @Test
+    @DisplayName("V2 with schema: custom replacement on nested field")
+    public void testV2WithSchemaNestedCustomReplacement() {
+        Schema innerSchema = SchemaBuilder.struct()
+                .field("amount", Schema.INT32_SCHEMA)
+                .build();
+        Schema outerSchema = SchemaBuilder.struct()
+                .field("payment", innerSchema)
+                .build();
+        Struct innerStruct = new Struct(innerSchema).put("amount", 500);
+        Struct outerStruct = new Struct(outerSchema).put("payment", innerStruct);
+
+        SinkRecord record = record(outerSchema, outerStruct);
+        Struct result = (Struct) transformV2(List.of("payment.amount"), "0").apply(record).value();
+
+        Struct payment = (Struct) result.get("payment");
+        assertEquals(0, payment.get("amount"));
+    }
+
+    @Test
+    @DisplayName("V1 backward compat: dotted field name is treated as a literal")
+    public void testV1BackwardCompatDottedFieldName() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("outer.inner", "secret");
+        value.put("visible", "hello");
+
+        SinkRecord record = record(null, value);
+        // V1 (default) — "outer.inner" is a literal single key
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) transform(
+                List.of("outer.inner"), null).apply(record).value();
+
+        assertEquals("", result.get("outer.inner"));
+        assertEquals("hello", result.get("visible"));
+    }
+
+    @Test
+    @DisplayName("V2 escaping: backtick-wrapped dotted field masks a literal key")
+    public void testV2BacktickEscapedFieldIsLiteral() {
+        Schema schema = SchemaBuilder.struct()
+                .field("outer.inner", Schema.STRING_SCHEMA)
+                .field("visible", Schema.STRING_SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("outer.inner", "secret")
+                .put("visible", "hello");
+
+        final MaskField<SinkRecord> xform = new MaskField.Value<>();
+        Map<String, Object> props = new HashMap<>();
+        props.put("fields", List.of("`outer.inner`"));
+        props.put("replacement", null);
+        props.put("replace.null.with.default", false);
+        props.put(FieldSyntaxVersion.FIELD_SYNTAX_VERSION_CONFIG, FieldSyntaxVersion.V2.name());
+        xform.configure(props);
+
+        Struct result = (Struct) xform.apply(record(schema, struct)).value();
+
+        assertEquals("", result.get("outer.inner"));
+        assertEquals("hello", result.get("visible"));
+    }
+
+    @Test
+    @DisplayName("V2 with schema: masks multiple fields at different nesting levels")
+    public void testV2WithSchemaMultipleNestedMasks() {
+        Schema innerSchema = SchemaBuilder.struct()
+                .field("secret", Schema.STRING_SCHEMA)
+                .field("visible", Schema.STRING_SCHEMA)
+                .build();
+        Schema outerSchema = SchemaBuilder.struct()
+                .field("nested", innerSchema)
+                .field("topSecret", Schema.INT32_SCHEMA)
+                .field("topVisible", Schema.STRING_SCHEMA)
+                .build();
+        Struct innerStruct = new Struct(innerSchema)
+                .put("secret", "password")
+                .put("visible", "hello");
+        Struct outerStruct = new Struct(outerSchema)
+                .put("nested", innerStruct)
+                .put("topSecret", 42)
+                .put("topVisible", "keep");
+
+        SinkRecord record = record(outerSchema, outerStruct);
+        Struct result = (Struct) transformV2(
+                List.of("nested.secret", "topSecret"), null).apply(record).value();
+
+        assertEquals("keep", result.get("topVisible"));
+        assertEquals(0, result.get("topSecret"));
+        Struct resultInner = (Struct) result.get("nested");
+        assertEquals("", resultInner.get("secret"));
+        assertEquals("hello", resultInner.get("visible"));
+    }
+
+    @Test
+    @DisplayName("V2 schemaless: backtick-escaped dotted parent name with nested child (`parent.child`.k2)")
+    public void testV2SchemalessBacktickEscapedNestedParent() {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("k2", "123");
+        Map<String, Object> value = new HashMap<>();
+        value.put("k1", 123);
+        value.put("parent.child", inner);
+
+        SinkRecord record = record(null, value);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) transformV2(
+                List.of("`parent.child`.k2"), null).apply(record).value();
+
+        assertEquals(123, result.get("k1"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resultInner = (Map<String, Object>) result.get("parent.child");
+        assertEquals("", resultInner.get("k2"));
+    }
+
+    @Test
+    @DisplayName("V2 with schema: backtick-escaped dotted parent name with nested child (`parent.child`.k2)")
+    public void testV2WithSchemaBacktickEscapedNestedParent() {
+        Schema innerSchema = SchemaBuilder.struct()
+                .field("k2", Schema.STRING_SCHEMA)
+                .build();
+        Schema outerSchema = SchemaBuilder.struct()
+                .field("k1", Schema.INT32_SCHEMA)
+                .field("parent.child", innerSchema)
+                .build();
+        Struct innerStruct = new Struct(innerSchema).put("k2", "123");
+        Struct outerStruct = new Struct(outerSchema)
+                .put("k1", 123)
+                .put("parent.child", innerStruct);
+
+        SinkRecord record = record(outerSchema, outerStruct);
+        Struct result = (Struct) transformV2(List.of("`parent.child`.k2"), null).apply(record).value();
+
+        assertEquals(123, result.get("k1"));
+        Struct resultInner = (Struct) result.get("parent.child");
+        assertEquals("", resultInner.get("k2"));
     }
 }


### PR DESCRIPTION
Adds support for for nested structures to the `MaskField` transformer.

See also https://github.com/apache/kafka/pull/22237 and https://github.com/apache/kafka/pull/22235 