### PR TITLE
KAFKA-20539 Prevent Hot Data Loss on Partition Expansion for Latest Policy (1/N)

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json
@@ -19,7 +19,8 @@
   "listeners": ["broker"],
   "name": "ConsumerGroupHeartbeatRequest",
   // Version 1 adds SubscribedTopicRegex (KIP-848), and requires the consumer to generate their own Member ID (KIP-1082)
-  "validVersions": "0-1",
+  // Version 2 is bumped to pair with the response, which adds the tagged NewPartitions field (KIP-1327).
+  "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",

--- a/clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json
@@ -17,7 +17,8 @@
   "apiKey": 68,
   "type": "response",
   "name": "ConsumerGroupHeartbeatResponse",
-  "validVersions": "0-1",
+  // Version 2 adds the tagged NewPartitions field to the assignment (KIP-1327).
+  "validVersions": "0-2",
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
@@ -57,7 +58,10 @@
       { "name": "TopicId", "type": "uuid", "versions": "0+",
         "about": "The topic ID." },
       { "name": "Partitions", "type": "[]int32", "versions": "0+",
-        "about": "The partitions." }
+        "about": "The partitions." },
+      { "name": "NewPartitions", "type": "[]int32",
+        "versions": "2+", "taggedVersions": "2+", "tag": 0, "ignorable": true,
+        "about": "Subset of partition indices in Partitions that the group coordinator classified as newly expanded (partition.creationTime > group.creationTime). For each partition index listed here that has no committed offset, the consumer applies auto.offset.reset.new.partitions; for any other partition without a committed offset, it applies the base auto.offset.reset. Absent (or empty) on older brokers; consumers then apply auto.offset.reset uniformly." }
     ]}
   ]
 }

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetadataImage.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorMetadataImage.java
@@ -44,6 +44,12 @@ public interface CoordinatorMetadataImage {
     boolean isEmpty();
 
     /**
+     * @param featureName The finalized feature name (e.g. "group.version").
+     * @return The finalized feature level for the given feature, or 0 if the feature is not finalized.
+     */
+    short finalizedFeatureLevel(String featureName);
+
+    /**
      * Metadata about a particular topic
      */
     interface TopicMetadata {
@@ -54,6 +60,13 @@ public interface CoordinatorMetadataImage {
         int partitionCount();
 
         List<String> partitionRacks(int partitionId);
+
+        /**
+         * @param partitionId The partition id.
+         * @return The time in milliseconds when the partition was created, or -1 if unknown
+         *         (e.g. the partition predates KIP-1327 or does not exist).
+         */
+        long partitionCreationTimeMs(int partitionId);
     }
 
     private static CoordinatorMetadataImage emptyImage() {
@@ -92,6 +105,11 @@ public interface CoordinatorMetadataImage {
             @Override
             public boolean isEmpty() {
                 return true;
+            }
+
+            @Override
+            public short finalizedFeatureLevel(String featureName) {
+                return 0;
             }
         };
     }

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRecordSerde.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRecordSerde.java
@@ -101,8 +101,9 @@ public abstract class CoordinatorRecordSerde implements Serializer<CoordinatorRe
         try {
             message.read(new ByteBufferAccessor(buffer), version);
         } catch (RuntimeException ex) {
+            String cause = ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName();
             throw new RuntimeException(String.format("Could not read record with version %d from %s's buffer due to: %s.",
-                version, name, ex.getMessage()), ex);
+                version, name, cause), ex);
         }
     }
 

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KRaftCoordinatorMetadataImage.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/KRaftCoordinatorMetadataImage.java
@@ -96,6 +96,11 @@ public class KRaftCoordinatorMetadataImage implements CoordinatorMetadataImage {
     }
 
     @Override
+    public short finalizedFeatureLevel(String featureName) {
+        return metadataImage.features().finalizedVersions().getOrDefault(featureName, (short) 0);
+    }
+
+    @Override
     public String toString() {
         return metadataImage.toString();
     }
@@ -151,6 +156,12 @@ public class KRaftCoordinatorMetadataImage implements CoordinatorMetadataImage {
             } else {
                 return List.of();
             }
+        }
+
+        @Override
+        public long partitionCreationTimeMs(int partition) {
+            PartitionRegistration partitionRegistration = topicImage.partitions().get(partition);
+            return partitionRegistration != null ? partitionRegistration.creationTimeMs : -1L;
         }
     }
 }

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/KRaftCoordinatorMetadataImageTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/KRaftCoordinatorMetadataImageTest.java
@@ -110,6 +110,57 @@ class KRaftCoordinatorMetadataImageTest {
     }
 
     @Test
+    public void testFinalizedFeatureLevel() {
+        MetadataImage metadataImage = new MetadataImageBuilder()
+            .addFeature("group.version", (short) 2)
+            .build();
+
+        KRaftCoordinatorMetadataImage image = new KRaftCoordinatorMetadataImage(metadataImage);
+
+        // Finalized feature returns its level.
+        assertEquals((short) 2, image.finalizedFeatureLevel("group.version"));
+        // A feature that is not finalized returns 0.
+        assertEquals((short) 0, image.finalizedFeatureLevel("does.not.exist"));
+    }
+
+    @Test
+    public void testPartitionCreationTimeMs() {
+        Uuid topicWithTimeId = Uuid.randomUuid();
+        String topicWithTime = "topic-with-time";
+        Uuid topicWithoutTimeId = Uuid.randomUuid();
+        String topicWithoutTime = "topic-without-time";
+
+        MetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(topicWithTimeId, topicWithTime, 2, 4242L)
+            .addTopic(topicWithoutTimeId, topicWithoutTime, 2)
+            .build();
+
+        KRaftCoordinatorMetadataImage image = new KRaftCoordinatorMetadataImage(metadataImage);
+
+        image.topicMetadata(topicWithTime).ifPresentOrElse(
+            topicMetadata -> {
+                // The recorded creation time is returned for existing partitions.
+                assertEquals(4242L, topicMetadata.partitionCreationTimeMs(0));
+                assertEquals(4242L, topicMetadata.partitionCreationTimeMs(1));
+                // A partition that does not exist returns -1.
+                assertEquals(-1L, topicMetadata.partitionCreationTimeMs(5));
+            },
+            () -> fail("Expected topic metadata for " + topicWithTime)
+        );
+
+        image.topicMetadata(topicWithoutTime).ifPresentOrElse(
+            // Partitions created without a creation time (e.g. predating KIP-1327) return -1.
+            topicMetadata -> assertEquals(-1L, topicMetadata.partitionCreationTimeMs(0)),
+            () -> fail("Expected topic metadata for " + topicWithoutTime)
+        );
+    }
+
+    @Test
+    public void testEmptyImageFinalizedFeatureLevel() {
+        assertEquals((short) 0, CoordinatorMetadataImage.EMPTY.finalizedFeatureLevel("group.version"));
+    }
+
+    @Test
     public void testEqualsAndHashcode() {
         Uuid topicId = Uuid.randomUuid();
         String topicName = "test-topic";

--- a/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
+++ b/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.common.runtime;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
@@ -54,6 +55,32 @@ public class MetadataImageBuilder {
                 .setPartitionId(i)
                 .setReplicas(List.of(i % 4, (i + 1) % 4)));
         }
+        return this;
+    }
+
+    public MetadataImageBuilder addTopic(
+        Uuid topicId,
+        String topicName,
+        int numPartitions,
+        long partitionCreationTimeMs
+    ) {
+        delta.replay(new TopicRecord().setTopicId(topicId).setName(topicName));
+        for (int i = 0; i < numPartitions; i++) {
+            delta.replay(new PartitionRecord()
+                .setTopicId(topicId)
+                .setPartitionId(i)
+                .setReplicas(List.of(i % 4, (i + 1) % 4))
+                .setCreationTimeMs(partitionCreationTimeMs));
+        }
+        return this;
+    }
+
+    /**
+     * Finalizes a feature (e.g. group.version) at the given level so that callers can exercise
+     * feature-gated coordinator behavior.
+     */
+    public MetadataImageBuilder addFeature(String featureName, short featureLevel) {
+        delta.replay(new FeatureLevelRecord().setName(featureName).setFeatureLevel(featureLevel));
         return this;
     }
 

--- a/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
+++ b/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
@@ -75,10 +75,6 @@ public class MetadataImageBuilder {
         return this;
     }
 
-    /**
-     * Finalizes a feature (e.g. group.version) at the given level so that callers can exercise
-     * feature-gated coordinator behavior.
-     */
     public MetadataImageBuilder addFeature(String featureName, short featureLevel) {
         delta.replay(new FeatureLevelRecord().setName(featureName).setFeatureLevel(featureLevel));
         return this;

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -72,7 +72,7 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       assertEquals(TransactionVersion.TV_2.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(TransactionVersion.FEATURE_NAME).maxVersion())
 
       assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).minVersion())
-      assertEquals(GroupVersion.GV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).maxVersion())
+      assertEquals(GroupVersion.GV_2.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(GroupVersion.FEATURE_NAME).maxVersion())
 
       assertEquals(0, apiVersionsResponse.data().supportedFeatures().find(EligibleLeaderReplicasVersion.FEATURE_NAME).minVersion())
       assertEquals(EligibleLeaderReplicasVersion.ELRV_1.featureLevel(), apiVersionsResponse.data().supportedFeatures().find(EligibleLeaderReplicasVersion.FEATURE_NAME).maxVersion())

--- a/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerGroupHeartbeatRequestTest.scala
@@ -138,7 +138,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
     val expectedAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
       .setTopicPartitions(List(new ConsumerGroupHeartbeatResponseData.TopicPartitions()
         .setTopicId(topicId)
-        .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
+        .setPartitions(List[Integer](0, 1, 2).asJava)
+        .setNewPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
     // Heartbeats until the partitions are assigned.
     consumerGroupHeartbeatResponse = null
@@ -218,7 +219,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
       var expectedAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
         .setTopicPartitions(List(new ConsumerGroupHeartbeatResponseData.TopicPartitions()
           .setTopicId(topicId)
-          .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
+          .setPartitions(List[Integer](0, 1, 2).asJava)
+          .setNewPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
       // Heartbeats until the partitions are assigned.
       consumerGroupHeartbeatResponse = null
@@ -421,7 +423,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
     val expectedAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
       .setTopicPartitions(List(new ConsumerGroupHeartbeatResponseData.TopicPartitions()
         .setTopicId(topicId)
-        .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
+        .setPartitions(List[Integer](0, 1, 2).asJava)
+        .setNewPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
     // Heartbeats until the partitions are assigned.
     consumerGroupHeartbeatResponse = null
@@ -532,7 +535,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
     val expectedAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
       .setTopicPartitions(List(new ConsumerGroupHeartbeatResponseData.TopicPartitions()
         .setTopicId(topicId)
-        .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
+        .setPartitions(List[Integer](0, 1, 2).asJava)
+        .setNewPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
     // Heartbeats until the partitions are assigned.
     consumerGroupHeartbeatResponse = null
@@ -743,7 +747,8 @@ class ConsumerGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupC
     val expectedAssignment = new ConsumerGroupHeartbeatResponseData.Assignment()
       .setTopicPartitions(List(new ConsumerGroupHeartbeatResponseData.TopicPartitions()
         .setTopicId(topicId)
-        .setPartitions(List[Integer](0, 1, 2).asJava)).asJava)
+        .setPartitions(List[Integer](0, 1, 2).asJava)
+        .setNewPartitions(List[Integer](0, 1, 2).asJava)).asJava)
 
     // Wait until partitions are assigned and member epoch advances.
     TestUtils.waitUntilTrue(() => {

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1524,8 +1524,12 @@ public final class MessageDataGenerator implements MessageClassGenerator {
                         target.sourceVariable())));
             } else if (field.type().isArray()) {
                 cond.ifShouldNotBeNull(() -> {
+                    // Prefix the temporary copy with an underscore so it can never shadow a
+                    // sibling field. Field names are camelCase and never start with an
+                    // underscore, so e.g. a field named "newPartitions" no longer collides
+                    // with the temp generated for a sibling "partitions" field.
                     String newArrayName =
-                        String.format("new%s", field.capitalizedCamelCaseName());
+                        String.format("_new%s", field.capitalizedCamelCaseName());
                     String type = field.concreteJavaType(headerGenerator, structRegistry);
                     buffer.printf("%s %s = new %s(%s.size());%n",
                         type, newArrayName, type, target.sourceVariable());
@@ -1538,8 +1542,7 @@ public final class MessageDataGenerator implements MessageClassGenerator {
                         String.format("%s.add(%s)", newArrayName, input)));
                     buffer.decrementIndent();
                     buffer.printf("}%n");
-                    buffer.printf("%s;%n", target.assignmentStatement(
-                        String.format("new%s", field.capitalizedCamelCaseName())));
+                    buffer.printf("%s;%n", target.assignmentStatement(newArrayName));
                 });
             } else {
                 throw new RuntimeException("Unhandled field type " + field.type());

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpers.java
@@ -139,17 +139,19 @@ public class GroupCoordinatorRecordHelpers {
     }
 
     /**
-     * Creates a ConsumerGroupMetadata record.
+     * Creates a ConsumerGroupMetadataValue record with creation time.
      *
-     * @param groupId       The consumer group id.
-     * @param newGroupEpoch The consumer group epoch.
-     * @param metadataHash  The consumer group metadata hash.
+     * @param groupId        The consumer group id.
+     * @param newGroupEpoch  The consumer group epoch.
+     * @param metadataHash   The consumer group metadata hash.
+     * @param creationTimeMs The creation time of the group in milliseconds, or -1 if unknown.
      * @return The record.
      */
     public static CoordinatorRecord newConsumerGroupEpochRecord(
         String groupId,
         int newGroupEpoch,
-        long metadataHash
+        long metadataHash,
+        long creationTimeMs
     ) {
         return CoordinatorRecord.record(
             new ConsumerGroupMetadataKey()
@@ -157,7 +159,8 @@ public class GroupCoordinatorRecordHelpers {
             new ApiMessageAndVersion(
                 new ConsumerGroupMetadataValue()
                     .setEpoch(newGroupEpoch)
-                    .setMetadataHash(metadataHash),
+                    .setMetadataHash(metadataHash)
+                    .setCreationTimeMs(creationTimeMs),
                 (short) 0
             )
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -72,7 +72,6 @@ import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.SchemaException;
-import org.apache.kafka.common.requests.ConsumerGroupHeartbeatResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.ShareGroupHeartbeatRequest;
 import org.apache.kafka.common.requests.ShareGroupHeartbeatResponse;
@@ -168,6 +167,7 @@ import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
 import org.apache.kafka.coordinator.group.streams.topics.TopicConfigurationException;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.authorizer.Authorizer;
+import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.share.persister.DeleteShareGroupStateParameters;
 import org.apache.kafka.server.share.persister.GroupTopicPartitionData;
 import org.apache.kafka.server.share.persister.InitializeShareGroupStateParameters;
@@ -870,10 +870,10 @@ public class GroupMetadataManager {
         }
 
         if (group == null) {
-            return new ConsumerGroup(logContext, snapshotRegistry, groupId);
+            return new ConsumerGroup(logContext, snapshotRegistry, groupId, groupCreationTimeMsForNewGroup());
         } else if (createIfNotExists && maybeDeleteEmptyClassicGroup(group, records)) {
             log.info("[GroupId {}] Converted the empty classic group to a consumer group.", groupId);
-            return new ConsumerGroup(logContext, snapshotRegistry, groupId);
+            return new ConsumerGroup(logContext, snapshotRegistry, groupId, groupCreationTimeMsForNewGroup());
         } else {
             if (group.type() == CONSUMER) {
                 return (ConsumerGroup) group;
@@ -1037,7 +1037,9 @@ public class GroupMetadataManager {
         }
 
         if (group == null) {
-            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
+            // -1L placeholder; the real timestamp is filled in from the persisted
+            // ConsumerGroupMetadataValue.CreationTimeMs when the metadata record is replayed.
+            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId, -1L);
             groups.put(groupId, consumerGroup);
             return consumerGroup;
         } else if (group.type() == CONSUMER) {
@@ -1047,7 +1049,7 @@ public class GroupMetadataManager {
             // offsets if no group existed. Simple classic groups are not backed by any records
             // in the __consumer_offsets topic hence we can safely replace it here. Without this,
             // replaying consumer group records after offset commit records would not work.
-            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
+            ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId, -1L);
             groups.put(groupId, consumerGroup);
             return consumerGroup;
         } else {
@@ -1470,6 +1472,7 @@ public class GroupMetadataManager {
                     "Please refer to the documentation or switch to a default assignor before re-attempting the upgrade.", classicGroup.groupId())
             );
         }
+        consumerGroup.setCreationTimeMs(groupCreationTimeMsForNewGroup());
         consumerGroup.createConsumerGroupRecords(records);
 
         // Create the session timeouts for the new members. If the conversion fails, the group will remain a
@@ -2623,10 +2626,111 @@ public class GroupMetadataManager {
         // 2. The member's assignment has been updated.
         boolean isFullRequest = rebalanceTimeoutMs != -1 && (subscribedTopicNames != null || subscribedTopicRegex != null) && ownedTopicPartitions != null;
         if (memberEpoch == 0 || isFullRequest || ConsumerGroupMember.hasAssignedPartitionsChanged(member, updatedMember)) {
-            response.setAssignment(ConsumerGroupHeartbeatResponse.createAssignment(updatedMember.assignedPartitions()));
+            response.setAssignment(createResponseAssignment(group, updatedMember));
         }
 
         return new CoordinatorResult<>(records, response);
+    }
+
+    /**
+     * @return The creation timestamp to stamp on a newly created consumer group, or -1 if
+     *         partition-expansion classification (KIP-1327) is not enabled on the cluster.
+     *         When the feature is disabled the coordinator does not record the creation time,
+     *         keeping the behavior consistent across coordinator replicas during a rolling upgrade.
+     */
+    private long groupCreationTimeMsForNewGroup() {
+        return isNewPartitionsClassificationEnabled() ? time.milliseconds() : -1L;
+    }
+
+    /**
+     * @return Whether the cluster's group.version enables partition-expansion classification (GV_2+, KIP-1327).
+     */
+    private boolean isNewPartitionsClassificationEnabled() {
+        return metadataImage.finalizedFeatureLevel(GroupVersion.FEATURE_NAME) >= GroupVersion.GV_2.featureLevel();
+    }
+
+    /**
+     * Builds the heartbeat response assignment for a member. When partition-expansion
+     * classification is enabled (KIP-1327), the per-topic NewPartitions list is populated with
+     * the subset of assigned partitions whose creation time postdates the group's creation time.
+     *
+     * @param group  The consumer group.
+     * @param member The member whose assignment is returned.
+     * @return The assignment to set on the heartbeat response.
+     */
+    private ConsumerGroupHeartbeatResponseData.Assignment createResponseAssignment(
+        ConsumerGroup group,
+        ConsumerGroupMember member
+    ) {
+        boolean classify = isNewPartitionsClassificationEnabled();
+        long groupCreationTimeMs = group.creationTimeMs();
+
+        List<ConsumerGroupHeartbeatResponseData.TopicPartitions> topicPartitions =
+            new ArrayList<>(member.assignedPartitions().size());
+        for (Map.Entry<Uuid, Map<Integer, Integer>> entry : member.assignedPartitions().entrySet()) {
+            Uuid topicId = entry.getKey();
+            List<Integer> partitions = new ArrayList<>(entry.getValue().keySet());
+            ConsumerGroupHeartbeatResponseData.TopicPartitions topicPartition =
+                new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                    .setTopicId(topicId)
+                    .setPartitions(partitions);
+            if (classify) {
+                List<Integer> newPartitions = computeNewPartitions(topicId, partitions, groupCreationTimeMs);
+                if (!newPartitions.isEmpty()) {
+                    topicPartition.setNewPartitions(newPartitions);
+                }
+            }
+            topicPartitions.add(topicPartition);
+        }
+
+        return new ConsumerGroupHeartbeatResponseData.Assignment().setTopicPartitions(topicPartitions);
+    }
+
+    /**
+     * Computes the subset of the given partitions classified as newly expanded (KIP-1327), i.e.
+     * partitions whose creation time postdates the group's creation time.
+     *
+     * @param topicId             The topic id.
+     * @param partitions          The assigned partitions of the topic.
+     * @param groupCreationTimeMs The group's creation time, or -1 if unknown.
+     * @return The newly expanded partition indices (possibly empty).
+     */
+    private List<Integer> computeNewPartitions(
+        Uuid topicId,
+        List<Integer> partitions,
+        long groupCreationTimeMs
+    ) {
+        Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadata = metadataImage.topicMetadata(topicId);
+        if (topicMetadata.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> newPartitions = new ArrayList<>();
+        for (int partition : partitions) {
+            if (isNewPartition(groupCreationTimeMs, topicMetadata.get().partitionCreationTimeMs(partition))) {
+                newPartitions.add(partition);
+            }
+        }
+        return newPartitions;
+    }
+
+    /**
+     * Classifies a partition as newly expanded or pre-existing using the conservative rules of
+     * KIP-1327. An unknown partition creation time (-1) is treated as pre-existing; an unknown
+     * group creation time (-1) is treated as -infinity, so any partition with a known creation
+     * time is classified as new.
+     *
+     * @param groupCreationTimeMs     The group's creation time, or -1 if unknown.
+     * @param partitionCreationTimeMs The partition's creation time, or -1 if unknown.
+     * @return Whether the partition is newly expanded.
+     */
+    private static boolean isNewPartition(long groupCreationTimeMs, long partitionCreationTimeMs) {
+        if (partitionCreationTimeMs < 0) {
+            return false;
+        }
+        if (groupCreationTimeMs < 0) {
+            return true;
+        }
+        return partitionCreationTimeMs > groupCreationTimeMs;
     }
 
     /**
@@ -3715,7 +3819,7 @@ public class GroupMetadataManager {
 
             if (bumpGroupEpoch) {
                 int groupEpoch = group.groupEpoch() + 1;
-                records.add(newConsumerGroupEpochRecord(groupId, groupEpoch, groupMetadataHash));
+                records.add(newConsumerGroupEpochRecord(groupId, groupEpoch, groupMetadataHash, group.creationTimeMs()));
                 log.info("[GroupId {}] Bumped group epoch to {} with metadata hash {}.", groupId, groupEpoch, groupMetadataHash);
                 metrics.record(CONSUMER_GROUP_REBALANCES_SENSOR_NAME);
                 group.setMetadataRefreshDeadline(
@@ -4054,7 +4158,7 @@ public class GroupMetadataManager {
 
         if (bumpGroupEpoch) {
             groupEpoch += 1;
-            records.add(newConsumerGroupEpochRecord(groupId, groupEpoch, groupMetadataHash));
+            records.add(newConsumerGroupEpochRecord(groupId, groupEpoch, groupMetadataHash, group.creationTimeMs()));
             log.info("[GroupId {}] Bumped group epoch to {} with metadata hash {}.", groupId, groupEpoch, groupMetadataHash);
             metrics.record(CONSUMER_GROUP_REBALANCES_SENSOR_NAME);
         }
@@ -4700,7 +4804,7 @@ public class GroupMetadataManager {
 
             // We bump the group epoch.
             int groupEpoch = group.groupEpoch() + 1;
-            records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch, groupMetadataHash));
+            records.add(newConsumerGroupEpochRecord(group.groupId(), groupEpoch, groupMetadataHash, group.creationTimeMs()));
             log.info("[GroupId {}] Bumped group epoch to {} with metadata hash {}.", group.groupId(), groupEpoch, groupMetadataHash);
 
             // If all members are being fenced, the group becomes empty so
@@ -5778,6 +5882,7 @@ public class GroupMetadataManager {
             ConsumerGroup consumerGroup = getOrMaybeCreatePersistedConsumerGroup(groupId, true);
             consumerGroup.setGroupEpoch(value.epoch());
             consumerGroup.setMetadataHash(value.metadataHash());
+            consumerGroup.setCreationTimeMs(value.creationTimeMs());
         } else {
             ConsumerGroup consumerGroup;
             try {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2646,7 +2646,9 @@ public class GroupMetadataManager {
      * @return Whether the cluster's group.version enables partition-expansion classification (GV_2+, KIP-1327).
      */
     private boolean isNewPartitionsClassificationEnabled() {
-        return metadataImage.finalizedFeatureLevel(GroupVersion.FEATURE_NAME) >= GroupVersion.GV_2.featureLevel();
+        return GroupVersion.fromFeatureLevel(
+            metadataImage.finalizedFeatureLevel(GroupVersion.FEATURE_NAME)
+        ).isNewPartitionsClassificationSupported();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroup.java
@@ -48,6 +48,7 @@ import org.apache.kafka.coordinator.group.modern.SubscriptionCount;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
+import org.apache.kafka.timeline.TimelineLong;
 import org.apache.kafka.timeline.TimelineObject;
 
 import org.slf4j.Logger;
@@ -156,10 +157,17 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
 
     private final TimelineObject<Boolean> hasSubscriptionMetadataRecord;
 
+    /**
+     * The creation time of this consumer group in milliseconds since epoch.
+     * Set once at group creation, never updated. -1 if unknown (pre-upgrade groups).
+     */
+    private final TimelineLong creationTimeMs;
+
     public ConsumerGroup(
         LogContext logContext,
         SnapshotRegistry snapshotRegistry,
-        String groupId
+        String groupId,
+        long creationTimeMs
     ) {
         super(snapshotRegistry, groupId);
         this.log = logContext.logger(ConsumerGroup.class);
@@ -172,6 +180,33 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         this.subscribedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.resolvedRegularExpressions = new TimelineHashMap<>(snapshotRegistry, 0);
         this.hasSubscriptionMetadataRecord = new TimelineObject<>(snapshotRegistry, false);
+        this.creationTimeMs = new TimelineLong(snapshotRegistry);
+        this.creationTimeMs.set(creationTimeMs);
+    }
+
+    /**
+     * @return The creation time of this consumer group in milliseconds since epoch, or -1 if unknown.
+     */
+    public long creationTimeMs() {
+        return creationTimeMs.get();
+    }
+
+    /**
+     * @return The creation time of this consumer group at the given committed offset, or -1 if unknown.
+     */
+    public long creationTimeMs(long committedOffset) {
+        return creationTimeMs.get(committedOffset);
+    }
+
+    /**
+     * Sets the creation time of this consumer group.
+     *
+     * @param creationTimeMs The creation time in milliseconds since epoch.
+     */
+    public void setCreationTimeMs(long creationTimeMs) {
+        if (this.creationTimeMs.get() == -1L) {
+            this.creationTimeMs.set(creationTimeMs);
+        }
     }
 
     /**
@@ -1218,7 +1253,8 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
         CoordinatorMetadataImage metadataImage
     ) {
         String groupId = classicGroup.groupId();
-        ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId);
+        // -1L placeholder; the caller stamps the real timestamp via setCreationTimeMs after upgrade.
+        ConsumerGroup consumerGroup = new ConsumerGroup(logContext, snapshotRegistry, groupId, -1L);
         consumerGroup.setGroupEpoch(classicGroup.generationId());
         consumerGroup.setTargetAssignmentMetadata(classicGroup.generationId(), 0L);
 
@@ -1292,7 +1328,7 @@ public class ConsumerGroup extends ModernGroup<ConsumerGroupMember> {
             records.add(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId(), consumerGroupMember))
         );
 
-        records.add(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId(), groupEpoch(), metadataHash()));
+        records.add(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId(), groupEpoch(), metadataHash(), creationTimeMs()));
 
         members().forEach((consumerGroupMemberId, consumerGroupMember) ->
             records.add(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(

--- a/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataValue.json
+++ b/group-coordinator/src/main/resources/common/message/ConsumerGroupMetadataValue.json
@@ -28,6 +28,11 @@
     // It indicates that the group should be rebalanced.
     { "name": "MetadataHash", "versions": "0+", "type": "int64",
       "default": 0, "taggedVersions": "0+", "tag": 0,
-      "about": "The hash of all topics in the group." }
+      "about": "The hash of all topics in the group." },
+    // The CreationTimeMs is added in 4.3 (KIP-1327). It records when the
+    // consumer group was first created. Set once, never updated afterward.
+    { "name": "CreationTimeMs", "versions": "0+", "type": "int64",
+      "default": "-1", "taggedVersions": "0+", "tag": 1,
+      "about": "The time in milliseconds when this consumer group was first created. -1 if unknown." }
   ]
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorRecordHelpersTest.java
@@ -180,7 +180,8 @@ public class GroupCoordinatorRecordHelpersTest {
         assertEquals(expectedRecord, newConsumerGroupEpochRecord(
             "group-id",
             10,
-            10
+            10,
+            -1L
         ));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -1483,8 +1483,8 @@ public class GroupCoordinatorShardTest {
 
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
 
-        ConsumerGroup group1 = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id");
-        ConsumerGroup group2 = new ConsumerGroup(new LogContext(), snapshotRegistry, "other-group-id");
+        ConsumerGroup group1 = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id", -1L);
+        ConsumerGroup group2 = new ConsumerGroup(new LogContext(), snapshotRegistry, "other-group-id", -1L);
 
         when(groupMetadataManager.groupIds()).thenReturn(Set.of("group-id", "other-group-id"));
         when(groupMetadataManager.group("group-id")).thenReturn(group1);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -156,6 +156,7 @@ import org.apache.kafka.server.authorizer.Action;
 import org.apache.kafka.server.authorizer.AuthorizationResult;
 import org.apache.kafka.server.authorizer.Authorizer;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.share.persister.DeleteShareGroupStateParameters;
 import org.apache.kafka.server.share.persister.InitializeShareGroupStateParameters;
 import org.apache.kafka.server.share.persister.PartitionIdData;
@@ -437,7 +438,7 @@ public class GroupMetadataManagerTest {
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, 0, -1L));
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 1, 2, 3)
@@ -529,7 +530,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1, 2)
         )));
@@ -603,7 +604,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 101, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1)
         )));
@@ -673,7 +674,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1, 2)
         )));
@@ -744,7 +745,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1, 2)
         )));
@@ -831,7 +832,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 101, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1)
         )));
@@ -935,7 +936,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member2));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1, 2)
         )));
@@ -1026,7 +1027,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 101, computeGroupHash(Map.of(
             fooTopicName, fooTopicHash
-        ))));
+        )), -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 0, 1)
         )));
@@ -1297,7 +1298,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
                 mkTopicAssignment(barTopicId, 0, 1, 2)
@@ -1307,6 +1308,75 @@ public class GroupMetadataManagerTest {
         );
 
         assertRecordsEquals(expectedRecords, result.records());
+    }
+
+    @Test
+    public void testConsumerGroupHeartbeatComputesNewPartitions() {
+        // KIP-1327: when group.version is GV_2, the coordinator classifies partitions whose
+        // creation time postdates the group's creation time as newly expanded and reports them
+        // in the per-topic NewPartitions side channel of the heartbeat assignment.
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+        Uuid barTopicId = Uuid.randomUuid();
+        String barTopicName = "bar";
+
+        // The test context's clock starts at 1000, so the group is created at 1000.
+        // foo's partitions are created after the group (2000) -> newly expanded.
+        // bar's partitions are created before the group (500) -> pre-existing.
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addFeature(GroupVersion.FEATURE_NAME, GroupVersion.GV_2.featureLevel())
+            .addTopic(fooTopicId, fooTopicName, 6, 2000L)
+            .addTopic(barTopicId, barTopicName, 3, 500L)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
+            .withMetadataImage(metadataImage)
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Map.of(memberId, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
+                mkTopicAssignment(barTopicId, 0, 1, 2)
+            )))
+        ));
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(List.of("foo", "bar"))
+                .setTopicPartitions(List.of()));
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(2)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(List.of(0, 1, 2, 3, 4, 5))
+                            .setNewPartitions(List.of(0, 1, 2, 3, 4, 5)),
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(barTopicId)
+                            .setPartitions(List.of(0, 1, 2))
+                    ))),
+            result.response()
+        );
+
+        // The group creation time is recorded when group.version is GV_2.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+        assertEquals(context.time.milliseconds(), group.creationTimeMs());
     }
 
     @Test
@@ -1377,7 +1447,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember),
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
             )),
@@ -1407,7 +1477,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0),
+            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0, -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 3, 0L)
         );
         assertRecordsEquals(expectedRecords, result.records());
@@ -1504,7 +1574,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash,
                 barTopicName, barTopicHash
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5),
                 mkTopicAssignment(barTopicId, 0, 1, 2)
@@ -1600,7 +1670,7 @@ public class GroupMetadataManagerTest {
         List<CoordinatorRecord> expectedRecords = List.of(
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, newMetadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, context.time.milliseconds()),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember)
         );
@@ -1693,7 +1763,7 @@ public class GroupMetadataManagerTest {
             .build();
 
         List<CoordinatorRecord> expectedRecords = List.of(
-            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0),
+            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, Map.of()),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, context.time.milliseconds()),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember)
@@ -1783,7 +1853,7 @@ public class GroupMetadataManagerTest {
         List<CoordinatorRecord> expectedRecords = List.of(
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, new KRaftCoordinatorMetadataImage(metadataImage))
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupSubscriptionMetadataTombstoneRecord(groupId),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, context.time.milliseconds()),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember)
@@ -1905,7 +1975,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedRecordsEquals(
             List.of(
                 List.of(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember3)),
-                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash)),
+                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash, -1L)),
                 List.of(
                     GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
                         mkTopicAssignment(fooTopicId, 0, 1),
@@ -2021,7 +2091,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash,
                 barTopicName, barTopicHash
-            )))
+            )), -1L)
         );
 
         assertRecordsEquals(expectedRecords, result.records());
@@ -2145,7 +2215,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedRecordsEquals(
             List.of(
                 List.of(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember3)),
-                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash)),
+                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash, -1L)),
                 List.of(
                     GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
                         mkTopicAssignment(fooTopicId, 0, 1),
@@ -2526,7 +2596,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash,
                 barTopicName, barTopicHash
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, member2RejoinId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 3, 4, 5),
                 mkTopicAssignment(barTopicId, 0, 1, 2)
@@ -2908,7 +2978,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash,
                 barTopicName, barTopicHash
-            )))
+            )), -1L)
         );
 
         assertRecordsEquals(expectedRecords, result.records());
@@ -3104,7 +3174,7 @@ public class GroupMetadataManagerTest {
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, member));
 
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 100, 0, -1L));
 
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
             mkTopicAssignment(fooTopicId, 1, 2, 3)
@@ -4097,7 +4167,7 @@ public class GroupMetadataManagerTest {
             .build()));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
             fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-        ))));
+        )), -1L));
 
         assertEquals(ConsumerGroup.ConsumerGroupState.ASSIGNING, context.consumerGroupState(groupId));
 
@@ -4259,7 +4329,7 @@ public class GroupMetadataManagerTest {
         List<CoordinatorRecord> expectedRecords = List.of(
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
             )),
@@ -4388,7 +4458,7 @@ public class GroupMetadataManagerTest {
         List<CoordinatorRecord> expectedRecords = List.of(
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, mkAssignment(
                 mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
             )),
@@ -4739,7 +4809,7 @@ public class GroupMetadataManagerTest {
                         GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
                         GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0),
+                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0, -1L),
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 3, 0L)
                     )
                 )
@@ -4805,7 +4875,7 @@ public class GroupMetadataManagerTest {
                             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
                             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
                             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-                            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0),
+                            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L),
                             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, 0L)
                         )
                     )
@@ -5012,7 +5082,7 @@ public class GroupMetadataManagerTest {
                         GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord(groupId, memberId),
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId),
                         GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0),
+                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, 0, -1L),
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 3, 0L)
                     )
                 )
@@ -5293,7 +5363,7 @@ public class GroupMetadataManagerTest {
                         GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId1),
                         GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 4, computeGroupHash(Map.of(
                             fooTopicName, computeTopicHash(fooTopicName, new KRaftCoordinatorMetadataImage(metadataImage))
-                        )))
+                        )), -1L)
                     )
                 )
             )),
@@ -10488,7 +10558,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(consumerGroupId, new ConsumerGroupMember.Builder(memberId1)
             .setSubscribedTopicNames(List.of(fooTopicName))
             .build()));
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, 11, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, 11, 0, -1L));
 
         // Test list group response without a group state or group type filter.
         Map<String, ListGroupsResponseData.ListedGroup> actualAllGroupMap =
@@ -10717,7 +10787,7 @@ public class GroupMetadataManagerTest {
         ConsumerGroupMember.Builder memberBuilder1 = new ConsumerGroupMember.Builder(memberId1)
             .setSubscribedTopicNames(List.of(topicName));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(consumerGroupId, memberBuilder1.build()));
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, epoch + 1, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, epoch + 1, 0, -1L));
 
         Map<Uuid, Set<Integer>> assignmentMap = Map.of(topicId, Set.of());
 
@@ -10726,7 +10796,7 @@ public class GroupMetadataManagerTest {
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(consumerGroupId, memberId2, assignmentMap));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(consumerGroupId, epoch + 1, 12345L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(consumerGroupId, memberBuilder2.build()));
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, epoch + 2, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(consumerGroupId, epoch + 2, 0, -1L));
 
         List<ConsumerGroupDescribeResponseData.DescribedGroup> actual = context.groupMetadataManager.consumerGroupDescribe(List.of(consumerGroupId), context.lastCommittedOffset);
         ConsumerGroupDescribeResponseData.DescribedGroup describedGroup = new ConsumerGroupDescribeResponseData.DescribedGroup()
@@ -12030,7 +12100,7 @@ public class GroupMetadataManagerTest {
             List.of(
                 GroupCoordinatorRecordHelpers.newGroupMetadataTombstoneRecord(classicGroupId),
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(classicGroupId, expectedMember),
-                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(classicGroupId, 2, 0),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(classicGroupId, 2, 0, -1L),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(classicGroupId, memberId, Map.of()),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(classicGroupId, 2, context.time.milliseconds()),
                 GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(classicGroupId, expectedMember)
@@ -12197,7 +12267,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 0, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, toAssignmentWithoutEpochs(expectedMember1.assignedPartitions())),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 0, 0),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember1),
@@ -12209,7 +12279,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 1, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId2, assignor.targetPartitions(memberId2)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, assignor.targetPartitions(memberId1)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 1, context.time.milliseconds()),
@@ -12412,7 +12482,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 0, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, toAssignmentWithoutEpochs(expectedMember1.assignedPartitions())),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId2, toAssignmentWithoutEpochs(expectedMember2.assignedPartitions())),
 
@@ -12428,7 +12498,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 1, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, assignor.targetPartitions(memberId1)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId3, assignor.targetPartitions(memberId3)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 1, context.time.milliseconds()),
@@ -12827,7 +12897,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedClassicMember),
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, group.generationId(), computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, toAssignmentWithoutEpochs(expectedClassicMember.assignedPartitions())),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, group.generationId(), 0),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedClassicMember),
@@ -12953,7 +13023,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 1, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, toAssignmentWithoutEpochs(expectedMember1.assignedPartitions())),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 1, 0),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember1),
@@ -12965,7 +13035,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId2, Map.of()),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 2, context.time.milliseconds()),
 
@@ -13337,7 +13407,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 1, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, toAssignmentWithoutEpochs(expectedMember1.assignedPartitions())),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId2, toAssignmentWithoutEpochs(expectedMember2.assignedPartitions())),
 
@@ -13353,7 +13423,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                 barTopicName, computeTopicHash(barTopicName, metadataImage)
-            ))),
+            )), -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, assignor.targetPartitions(memberId1)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId3, assignor.targetPartitions(memberId3)),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 2, context.time.milliseconds()),
@@ -14245,7 +14315,7 @@ public class GroupMetadataManagerTest {
                 List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash
-                ))))
+                )), -1L))
             );
         } else {
             memberUpdateRecords = List.of(
@@ -14822,7 +14892,7 @@ public class GroupMetadataManagerTest {
                     List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                         fooTopicName, fooTopicHash,
                         barTopicName, barTopicHash
-                    )))),
+                    )), -1L)),
 
                     List.of(
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId, assignor.targetPartitions(memberId)),
@@ -14985,7 +15055,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash,
                 barTopicName, barTopicHash
-            ))),
+            )), -1L),
 
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, newMemberId, Map.of()),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, context.time.milliseconds()),
@@ -15248,7 +15318,7 @@ public class GroupMetadataManagerTest {
         assertUnorderedRecordsEquals(
             List.of(
                 List.of(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember)),
-                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash)),
+                List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash, -1L)),
                 List.of(
                     GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
                         mkTopicAssignment(fooTopicId, 0),
@@ -15483,7 +15553,7 @@ public class GroupMetadataManagerTest {
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash,
                     zarTopicName, zarTopicHash
-                )))),
+                )), -1L)),
 
                 List.of(
                     GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
@@ -15724,7 +15794,7 @@ public class GroupMetadataManagerTest {
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash,
                     zarTopicName, zarTopicHash
-                )))),
+                )), -1L)),
 
                 List.of(
                     GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
@@ -16802,7 +16872,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
 
                 // The group epoch is bumped.
-                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, 0L)
             ),
             timeout.result().records()
@@ -16869,7 +16939,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId),
 
                 // The group epoch is bumped.
-                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0),
+                GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, 0L)
             ),
             timeout.result().records()
@@ -17080,7 +17150,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId3)
             ),
             // Bump the group epoch.
-            List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0)),
+            List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L)),
             List.of(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, 0L))
         );
         assertUnorderedRecordsEquals(expectedRecords, leaveResult.records());
@@ -17193,7 +17263,7 @@ public class GroupMetadataManagerTest {
             // Bump the group epoch.
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, fooTopicHash
-            )))
+            )), -1L)
         );
         assertEquals(expectedRecords, leaveResult.records());
     }
@@ -22701,7 +22771,7 @@ public class GroupMetadataManagerTest {
 
         // The group still exists but the member is already gone. Replaying the
         // ConsumerGroupMemberMetadata tombstone should be a no-op.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0, -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord("foo", "m1"));
         assertThrows(UnknownMemberIdException.class, () -> context.groupMetadataManager.consumerGroup("foo").getOrMaybeCreateMember("m1", false));
 
@@ -22717,7 +22787,7 @@ public class GroupMetadataManagerTest {
             .build();
 
         // The group is created if it does not exist.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0, -1L));
         assertEquals(10, context.groupMetadataManager.consumerGroup("foo").groupEpoch());
     }
 
@@ -22863,7 +22933,7 @@ public class GroupMetadataManagerTest {
 
         // The group still exists but the member is already gone. Replaying the
         // ConsumerGroupCurrentMemberAssignment tombstone should be a no-op.
-        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0));
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord("foo", 10, 0, -1L));
         context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentTombstoneRecord("foo", "m1"));
         assertThrows(UnknownMemberIdException.class, () -> context.groupMetadataManager.consumerGroup("foo").getOrMaybeCreateMember("m1", false));
 
@@ -24147,7 +24217,7 @@ public class GroupMetadataManagerTest {
                             )
                         ),
                         // The group epoch is bumped.
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash)
+                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, groupMetadataHash, -1L)
                     ))
                 )
             ),
@@ -24258,7 +24328,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                     fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                     barTopicName, computeTopicHash(barTopicName, metadataImage)
-                )))
+                )), -1L)
             ),
             task.result().records()
         );
@@ -24488,7 +24558,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                     fooTopicName, computeTopicHash(fooTopicName, metadataImage),
                     barTopicName, computeTopicHash(barTopicName, metadataImage)
-                )))
+                )), -1L)
             ),
             task.result().records()
         );
@@ -24630,7 +24700,7 @@ public class GroupMetadataManagerTest {
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash,
                     foooTopicName, computeTopicHash(foooTopicName, new KRaftCoordinatorMetadataImage(newImage))
-                ))))
+                )), -1L))
             ),
             task.result().records()
         );
@@ -24708,7 +24778,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember1),
             // previous expression is deleted
             GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone(groupId, "foo*"),
-            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0),
+            GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, 0, -1L),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, Map.of()),
             GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 11, context.time.milliseconds()),
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember1)
@@ -24853,7 +24923,7 @@ public class GroupMetadataManagerTest {
             // The group epoch is bumped.
             List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-            )))),
+            )), -1L)),
             // The target assignment is updated.
             List.of(
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, expectedMember1.memberId(), Map.of()),
@@ -24997,7 +25067,7 @@ public class GroupMetadataManagerTest {
             // The group epoch is bumped.
             List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-            )))),
+            )), -1L)),
             // The target assignment is updated.
             List.of(
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, expectedMember1.memberId(), Map.of()),
@@ -25148,7 +25218,7 @@ public class GroupMetadataManagerTest {
                         ),
                         GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                             fooTopicName, fooTopicHash
-                        )))
+                        )), -1L)
                     ))
                 )
             ),
@@ -25230,7 +25300,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 12, computeGroupHash(Map.of(
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash
-                )))
+                )), -1L)
             ),
             context.processTasks().get(0).result().records()
         );
@@ -25371,7 +25441,7 @@ public class GroupMetadataManagerTest {
                         ),
                         GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                             fooTopicName, fooTopicHash
-                        )))
+                        )), -1L)
                     ))
                 )
             ),
@@ -25455,7 +25525,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 12, computeGroupHash(Map.of(
                     fooTopicName, fooTopicHash,
                     barTopicName, barTopicHash
-                )))
+                )), -1L)
             ),
             context.processTasks().get(0).result().records()
         );
@@ -25613,7 +25683,7 @@ public class GroupMetadataManagerTest {
                 // The group epoch is bumped.
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                     fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-                )))
+                )), -1L)
             ),
             task.result().records()
         );
@@ -25762,7 +25832,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone(groupId, "foo*"),
             GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                 barTopicName, barTopicHash
-            )))
+            )), -1L)
         );
 
         assertRecordsEquals(expectedRecords, result.records());
@@ -25781,7 +25851,7 @@ public class GroupMetadataManagerTest {
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(groupId, memberId2),
                         GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionTombstoneRecord(groupId, memberId2),
                         GroupCoordinatorRecordHelpers.newConsumerGroupRegularExpressionTombstone(groupId, "bar*"),
-                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 12, 0),
+                        GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 12, 0, -1L),
                         GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(groupId, 12, 0L)
                     )
                 )
@@ -25938,7 +26008,7 @@ public class GroupMetadataManagerTest {
                 // Bumped epoch.
                 List.of(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 11, computeGroupHash(Map.of(
                     barTopicName, barTopicHash
-                ))))
+                )), -1L))
             ),
             result.records()
         );
@@ -28224,7 +28294,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember1),
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, computeGroupHash(Map.of(
                     fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-                ))),
+                )), -1L),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(groupId, memberId1, mkAssignment(
                     mkTopicAssignment(fooTopicId, 0, 1, 2, 3, 4, 5)
                 )),
@@ -28283,7 +28353,7 @@ public class GroupMetadataManagerTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupMemberSubscriptionRecord(groupId, expectedMember2),
                 GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 3, computeGroupHash(Map.of(
                     fooTopicName, computeTopicHash(fooTopicName, metadataImage)
-                ))),
+                )), -1L),
                 GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember2)
             ),
             result2.records()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1420,7 +1420,7 @@ public class GroupMetadataManagerTest {
         assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
-                .setMemberEpoch(1)
+                .setMemberEpoch(2)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
                     .setTopicPartitions(List.of(
@@ -1477,7 +1477,7 @@ public class GroupMetadataManagerTest {
         assertResponseEquals(
             new ConsumerGroupHeartbeatResponseData()
                 .setMemberId(memberId)
-                .setMemberEpoch(1)
+                .setMemberEpoch(2)
                 .setHeartbeatIntervalMs(5000)
                 .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
                     .setTopicPartitions(List.of(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1380,6 +1380,136 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testConsumerGroupHeartbeatDoesNotComputeNewPartitionsWhenFeatureDisabled() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        // No GV_2 feature is added, so classification is disabled. foo's partitions are created
+        // after the group would have been (2000 > the clock's start of 1000).
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 3, 2000L)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
+            .withMetadataImage(metadataImage)
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Map.of(memberId, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2)
+            )))
+        ));
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(List.of("foo"))
+                .setTopicPartitions(List.of()));
+
+        // The assignment has no NewPartitions side channel set.
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(1)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(List.of(0, 1, 2))
+                    ))),
+            result.response()
+        );
+
+        // The creation time is not recorded when the feature is disabled.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+        assertEquals(-1L, group.creationTimeMs());
+    }
+
+    @Test
+    public void testConsumerGroupHeartbeatTreatsPartitionsWithoutCreationTimeAsPreExisting() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        // foo is added without a partition creation time, so its partitions report -1.
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addFeature(GroupVersion.FEATURE_NAME, GroupVersion.GV_2.featureLevel())
+            .addTopic(fooTopicId, fooTopicName, 3)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+
+        MockPartitionAssignor assignor = new MockPartitionAssignor("range");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(assignor))
+            .withMetadataImage(metadataImage)
+            .build();
+
+        assignor.prepareGroupAssignment(new GroupAssignment(
+            Map.of(memberId, new MemberAssignmentImpl(mkAssignment(
+                mkTopicAssignment(fooTopicId, 0, 1, 2)
+            )))
+        ));
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result = context.consumerGroupHeartbeat(
+            new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setServerAssignor("range")
+                .setRebalanceTimeoutMs(5000)
+                .setSubscribedTopicNames(List.of("foo"))
+                .setTopicPartitions(List.of()));
+
+        // No partition is classified as new because their creation time is unknown.
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(1)
+                .setHeartbeatIntervalMs(5000)
+                .setAssignment(new ConsumerGroupHeartbeatResponseData.Assignment()
+                    .setTopicPartitions(List.of(
+                        new ConsumerGroupHeartbeatResponseData.TopicPartitions()
+                            .setTopicId(fooTopicId)
+                            .setPartitions(List.of(0, 1, 2))
+                    ))),
+            result.response()
+        );
+
+        // The creation time is still recorded because the feature is enabled.
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+        assertEquals(context.time.milliseconds(), group.creationTimeMs());
+    }
+
+    @Test
+    public void testConsumerGroupCreationTimeMsIsRestoredOnReplay() {
+        String groupId = "fooup";
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder().build();
+
+        // The metadata record carries the group's creation time.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 1, 0, 12345L));
+        ConsumerGroup group = context.groupMetadataManager.consumerGroup(groupId);
+        assertEquals(12345L, group.creationTimeMs());
+
+        // Replaying a later epoch record (which carries the same creation time in production) does
+        // not overwrite the value, even if the field were to differ.
+        context.replay(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, 2, 0, 99999L));
+        assertEquals(12345L, group.creationTimeMs());
+    }
+
+    @Test
     public void testTopicHashIsRemoveFromCacheIfNoGroupSubscribesIt() {
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -1312,12 +1312,8 @@ public class GroupMetadataManagerTest {
 
     @Test
     public void testConsumerGroupHeartbeatComputesNewPartitions() {
-        // KIP-1327: when group.version is GV_2, the coordinator classifies partitions whose
-        // creation time postdates the group's creation time as newly expanded and reports them
-        // in the per-topic NewPartitions side channel of the heartbeat assignment.
         String groupId = "fooup";
         String memberId = Uuid.randomUuid().toString();
-
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
         Uuid barTopicId = Uuid.randomUuid();
@@ -1383,7 +1379,6 @@ public class GroupMetadataManagerTest {
     public void testConsumerGroupHeartbeatDoesNotComputeNewPartitionsWhenFeatureDisabled() {
         String groupId = "fooup";
         String memberId = Uuid.randomUuid().toString();
-
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/classic/ClassicGroupTest.java
@@ -1414,7 +1414,8 @@ public class ClassicGroupTest {
         ConsumerGroup consumerGroup = new ConsumerGroup(
             logContext,
             new SnapshotRegistry(logContext),
-            groupId
+            groupId,
+            -1L
         );
         consumerGroup.setGroupEpoch(10);
         consumerGroup.setTargetAssignmentMetadata(10, time.milliseconds());
@@ -1567,7 +1568,8 @@ public class ClassicGroupTest {
         ConsumerGroup consumerGroup = new ConsumerGroup(
             logContext,
             new SnapshotRegistry(logContext),
-            groupId
+            groupId,
+            -1L
         );
         consumerGroup.setGroupEpoch(10);
         consumerGroup.setTargetAssignmentMetadata(10, time.milliseconds());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupBuilder.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupBuilder.java
@@ -92,7 +92,7 @@ public class ConsumerGroupBuilder {
         );
 
         // Add group epoch record.
-        records.add(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, groupEpoch, metadataHash));
+        records.add(GroupCoordinatorRecordHelpers.newConsumerGroupEpochRecord(groupId, groupEpoch, metadataHash, -1L));
 
         // Add target assignment records.
         assignments.forEach((memberId, assignment) ->

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -96,7 +96,8 @@ public class ConsumerGroupTest {
         return new ConsumerGroup(
             new LogContext(),
             snapshotRegistry,
-            groupId
+            groupId,
+            -1L
         );
     }
 
@@ -728,7 +729,7 @@ public class ConsumerGroupTest {
     @Test
     public void testUpdateInvertedAssignment() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup consumerGroup = new ConsumerGroup(new LogContext(), snapshotRegistry, "test-group");
+        ConsumerGroup consumerGroup = new ConsumerGroup(new LogContext(), snapshotRegistry, "test-group", -1L);
         Uuid topicId = Uuid.randomUuid();
         String memberId1 = "member1";
         String memberId2 = "member2";
@@ -1108,7 +1109,7 @@ public class ConsumerGroupTest {
     @Test
     public void testAsListedGroup() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo", -1L);
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY.toString(), group.stateAsString(0));
         group.updateMember(new ConsumerGroupMember.Builder("member1")
@@ -1124,9 +1125,10 @@ public class ConsumerGroupTest {
     public void testValidateOffsetFetch() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         ConsumerGroup group = new ConsumerGroup(
-            new LogContext(), 
+            new LogContext(),
             snapshotRegistry,
-            "group-foo"
+            "group-foo",
+            -1L
         );
 
         // Simulate a call from the admin client without member id and member epoch.
@@ -1185,7 +1187,7 @@ public class ConsumerGroupTest {
         long commitTimestamp = 20000L;
         long offsetsRetentionMs = 10000L;
         OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(15000L, OptionalInt.empty(), "", commitTimestamp, OptionalLong.empty(), Uuid.ZERO_UUID);
-        ConsumerGroup group = new ConsumerGroup(new LogContext(), new SnapshotRegistry(new LogContext()), "group-id");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), new SnapshotRegistry(new LogContext()), "group-id", -1L);
 
         Optional<OffsetExpirationCondition> offsetExpirationCondition = group.offsetExpirationCondition();
         assertTrue(offsetExpirationCondition.isPresent());
@@ -1222,7 +1224,7 @@ public class ConsumerGroupTest {
     @Test
     public void testAsDescribedGroup() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id-1");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id-1", -1L);
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertEquals(ConsumerGroup.ConsumerGroupState.EMPTY.toString(), group.stateAsString(0));
 
@@ -1264,7 +1266,7 @@ public class ConsumerGroupTest {
     @Test
     public void testIsInStatesCaseInsensitive() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo");
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo", -1L);
         snapshotRegistry.idempotentCreateSnapshot(0);
         assertTrue(group.isInStates(Set.of("empty"), 0));
         assertFalse(group.isInStates(Set.of("Empty"), 0));
@@ -1503,9 +1505,10 @@ public class ConsumerGroupTest {
         );
 
         ConsumerGroup expectedConsumerGroup = new ConsumerGroup(
-            new LogContext(), 
+            new LogContext(),
             new SnapshotRegistry(logContext),
-            groupId
+            groupId,
+            -1L
         );
         expectedConsumerGroup.setGroupEpoch(10);
         expectedConsumerGroup.setTargetAssignmentMetadata(10, 0L);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1222,6 +1222,42 @@ public class ConsumerGroupTest {
     }
 
     @Test
+    public void testCreationTimeMsIsWriteOnce() {
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+
+        // A group created with a known creation time keeps it...
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo", 1000L);
+        assertEquals(1000L, group.creationTimeMs());
+        // ...and a subsequent set is ignored because the value is already set (write-once).
+        group.setCreationTimeMs(2000L);
+        assertEquals(1000L, group.creationTimeMs());
+
+        // A group created with the -1 placeholder (the replay path) accepts the first value...
+        ConsumerGroup persisted = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-bar", -1L);
+        assertEquals(-1L, persisted.creationTimeMs());
+        persisted.setCreationTimeMs(1000L);
+        assertEquals(1000L, persisted.creationTimeMs());
+        // ...but ignores later values, so replaying the same field again is idempotent.
+        persisted.setCreationTimeMs(5000L);
+        assertEquals(1000L, persisted.creationTimeMs());
+    }
+
+    @Test
+    public void testCreationTimeMsIsSnapshotted() {
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+        ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-foo", -1L);
+        snapshotRegistry.idempotentCreateSnapshot(0);
+
+        group.setCreationTimeMs(1000L);
+        snapshotRegistry.idempotentCreateSnapshot(1);
+
+        // The value is read per committed offset from the timeline.
+        assertEquals(-1L, group.creationTimeMs(0));
+        assertEquals(1000L, group.creationTimeMs(1));
+        assertEquals(1000L, group.creationTimeMs());
+    }
+
+    @Test
     public void testAsDescribedGroup() {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         ConsumerGroup group = new ConsumerGroup(new LogContext(), snapshotRegistry, "group-id-1", -1L);

--- a/group-coordinator/src/testFixtures/java/org/apache/kafka/coordinator/group/Assertions.java
+++ b/group-coordinator/src/testFixtures/java/org/apache/kafka/coordinator/group/Assertions.java
@@ -196,7 +196,10 @@ public class Assertions {
         Consumer<ConsumerGroupHeartbeatResponseData> normalize = message -> {
             if (message.assignment() != null) {
                 message.assignment().topicPartitions().sort(Comparator.comparing(ConsumerGroupHeartbeatResponseData.TopicPartitions::topicId));
-                message.assignment().topicPartitions().forEach(topic -> topic.partitions().sort(Integer::compareTo));
+                message.assignment().topicPartitions().forEach(topic -> {
+                    topic.partitions().sort(Integer::compareTo);
+                    topic.newPartitions().sort(Integer::compareTo);
+                });
             }
         };
 

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1604,6 +1604,7 @@ public final class QuorumController implements Controller {
             setClusterControl(clusterControl).
             setCreateTopicPolicy(createTopicPolicy).
             setFeatureControl(featureControl).
+            setTime(time).
             build();
         this.scramControlManager = new ScramControlManager.Builder().
             setLogContext(logContext).

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -78,6 +78,7 @@ import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AlterPartitionRequest;
 import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
@@ -162,6 +163,7 @@ public class ReplicationControlManager {
         private ClusterControlManager clusterControl = null;
         private Optional<CreateTopicPolicy> createTopicPolicy = Optional.empty();
         private FeatureControlManager featureControl = null;
+        private Time time = Time.SYSTEM;
 
         Builder setSnapshotRegistry(SnapshotRegistry snapshotRegistry) {
             this.snapshotRegistry = snapshotRegistry;
@@ -208,6 +210,11 @@ public class ReplicationControlManager {
             return this;
         }
 
+        public Builder setTime(Time time) {
+            this.time = time;
+            return this;
+        }
+
         ReplicationControlManager build() {
             if (configurationControl == null) {
                 throw new IllegalStateException("Configuration control must be set before building");
@@ -227,7 +234,8 @@ public class ReplicationControlManager {
                 configurationControl,
                 clusterControl,
                 createTopicPolicy,
-                featureControl);
+                featureControl,
+                time);
         }
     }
 
@@ -321,6 +329,11 @@ public class ReplicationControlManager {
     private final FeatureControlManager featureControl;
 
     /**
+     * The clock used to obtain current timestamps.
+     */
+    private final Time time;
+
+    /**
      * Maps topic names to topic UUIDs.
      */
     private final TimelineHashMap<String, Uuid> topicsByName;
@@ -387,7 +400,8 @@ public class ReplicationControlManager {
         ConfigurationControlManager configurationControl,
         ClusterControlManager clusterControl,
         Optional<CreateTopicPolicy> createTopicPolicy,
-        FeatureControlManager featureControl
+        FeatureControlManager featureControl,
+        Time time
     ) {
         this.snapshotRegistry = snapshotRegistry;
         this.log = logContext.logger(ReplicationControlManager.class);
@@ -398,6 +412,7 @@ public class ReplicationControlManager {
         this.createTopicPolicy = createTopicPolicy;
         this.featureControl = featureControl;
         this.clusterControl = clusterControl;
+        this.time = time;
         this.topicsByName = new TimelineHashMap<>(snapshotRegistry, 0);
         this.topicsWithCollisionChars = new TimelineHashMap<>(snapshotRegistry, 0);
         this.topics = new TimelineHashMap<>(snapshotRegistry, 0);
@@ -748,7 +763,7 @@ public class ReplicationControlManager {
                 }
                 newParts.put(
                     assignment.partitionIndex(),
-                    buildPartitionRegistration(partitionAssignment, isr)
+                    buildPartitionRegistration(partitionAssignment, isr, time.milliseconds())
                 );
             }
             for (int i = 0; i < newParts.size(); i++) {
@@ -795,7 +810,7 @@ public class ReplicationControlManager {
                     }
                     newParts.put(
                         partitionId,
-                        buildPartitionRegistration(partitionAssignment, isr)
+                        buildPartitionRegistration(partitionAssignment, isr, time.milliseconds())
                     );
                 }
             } catch (InvalidReplicationFactorException e) {
@@ -852,14 +867,16 @@ public class ReplicationControlManager {
             PartitionRegistration info = partEntry.getValue();
             records.add(info.toRecord(topicId, partitionIndex, new ImageWriterOptions.Builder(featureControl.metadataVersionOrThrow()).
                 setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled()).
+                setPartitionCreationTimestampSupported(featureControl.metadataVersionOrThrow().isPartitionCreationTimestampSupported()).
                 build()));
         }
         return ApiError.NONE;
     }
 
-    private static PartitionRegistration buildPartitionRegistration(
+    private PartitionRegistration buildPartitionRegistration(
         PartitionAssignment partitionAssignment,
-        List<Integer> isr
+        List<Integer> isr,
+        long creationTimeMs
     ) {
         return new PartitionRegistration.Builder().
             setReplicas(Replicas.toArray(partitionAssignment.replicas())).
@@ -869,6 +886,7 @@ public class ReplicationControlManager {
             setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).
             setPartitionEpoch(0).
+            setCreationTimeMs(creationTimeMs).
             build();
     }
 
@@ -1991,9 +2009,10 @@ public class ReplicationControlManager {
                     "Unable to replicate the partition " + replicationFactor +
                         " time(s): All brokers are currently fenced or in controlled shutdown.");
             }
-            records.add(buildPartitionRegistration(partitionAssignment, isr)
+            records.add(buildPartitionRegistration(partitionAssignment, isr, time.milliseconds())
                 .toRecord(topicId, partitionId, new ImageWriterOptions.Builder(featureControl.metadataVersionOrThrow()).
                         setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled()).
+                        setPartitionCreationTimestampSupported(featureControl.metadataVersionOrThrow().isPartitionCreationTimestampSupported()).
                         build()));
             partitionId++;
         }

--- a/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
+++ b/metadata/src/main/java/org/apache/kafka/image/loader/MetadataLoader.java
@@ -317,6 +317,7 @@ public class MetadataLoader implements RaftClient.Listener<ApiMessageAndVersion>
         ImageReWriter writer = new ImageReWriter(delta);
         image.write(writer, new ImageWriterOptions.Builder(image.features().metadataVersionOrThrow()).
                 setEligibleLeaderReplicasEnabled(image.features().isElrEnabled()).
+                setPartitionCreationTimestampSupported(image.features().metadataVersionOrThrow().isPartitionCreationTimestampSupported()).
                 build());
         // ImageReWriter#close invokes finishSnapshot, so we don't need to invoke it here.
         SnapshotManifest manifest = new SnapshotManifest(

--- a/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
+++ b/metadata/src/main/java/org/apache/kafka/image/publisher/SnapshotEmitter.java
@@ -148,6 +148,7 @@ public class SnapshotEmitter implements SnapshotGenerator.Emitter {
         try {
             image.write(writer, new ImageWriterOptions.Builder(image.features().metadataVersionOrThrow()).
                     setEligibleLeaderReplicasEnabled(image.features().isElrEnabled()).
+                    setPartitionCreationTimestampSupported(image.features().metadataVersionOrThrow().isPartitionCreationTimestampSupported()).
                     build());
             writer.close(true);
             metrics.setLatestSnapshotGeneratedTimeMs(time.milliseconds());

--- a/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriterOptions.java
+++ b/metadata/src/main/java/org/apache/kafka/image/writer/ImageWriterOptions.java
@@ -33,6 +33,7 @@ public final class ImageWriterOptions {
             throw e;
         };
         private boolean isEligibleLeaderReplicasEnabled = false;
+        private boolean isPartitionCreationTimestampSupported = false;
 
         public Builder(MetadataVersion metadataVersion) {
             this.metadataVersion = metadataVersion;
@@ -41,6 +42,7 @@ public final class ImageWriterOptions {
         public Builder(MetadataImage image) {
             this.metadataVersion = image.features().metadataVersionOrThrow();
             this.isEligibleLeaderReplicasEnabled = image.features().isElrEnabled();
+            this.isPartitionCreationTimestampSupported = image.features().metadataVersionOrThrow().isPartitionCreationTimestampSupported();
         }
 
         public Builder setMetadataVersion(MetadataVersion metadataVersion) {
@@ -53,6 +55,11 @@ public final class ImageWriterOptions {
             return this;
         }
 
+        public Builder setPartitionCreationTimestampSupported(boolean isPartitionCreationTimestampSupported) {
+            this.isPartitionCreationTimestampSupported = isPartitionCreationTimestampSupported;
+            return this;
+        }
+
         public MetadataVersion metadataVersion() {
             return metadataVersion;
         }
@@ -61,28 +68,35 @@ public final class ImageWriterOptions {
             return isEligibleLeaderReplicasEnabled;
         }
 
+        public boolean isPartitionCreationTimestampSupported() {
+            return isPartitionCreationTimestampSupported;
+        }
+
         public Builder setLossHandler(Consumer<UnwritableMetadataException> lossHandler) {
             this.lossHandler = lossHandler;
             return this;
         }
 
         public ImageWriterOptions build() {
-            return new ImageWriterOptions(metadataVersion, lossHandler, isEligibleLeaderReplicasEnabled);
+            return new ImageWriterOptions(metadataVersion, lossHandler, isEligibleLeaderReplicasEnabled, isPartitionCreationTimestampSupported);
         }
     }
 
     private final MetadataVersion metadataVersion;
     private final Consumer<UnwritableMetadataException> lossHandler;
     private final boolean isEligibleLeaderReplicasEnabled;
+    private final boolean isPartitionCreationTimestampSupported;
 
     private ImageWriterOptions(
         MetadataVersion metadataVersion,
         Consumer<UnwritableMetadataException> lossHandler,
-        boolean isEligibleLeaderReplicasEnabled
+        boolean isEligibleLeaderReplicasEnabled,
+        boolean isPartitionCreationTimestampSupported
     ) {
         this.metadataVersion = metadataVersion;
         this.lossHandler = lossHandler;
         this.isEligibleLeaderReplicasEnabled = isEligibleLeaderReplicasEnabled;
+        this.isPartitionCreationTimestampSupported = isPartitionCreationTimestampSupported;
     }
 
     public MetadataVersion metadataVersion() {
@@ -90,6 +104,10 @@ public final class ImageWriterOptions {
     }
     public boolean isEligibleLeaderReplicasEnabled() {
         return isEligibleLeaderReplicasEnabled;
+    }
+
+    public boolean isPartitionCreationTimestampSupported() {
+        return isPartitionCreationTimestampSupported;
     }
 
     public void handleLoss(String loss) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -51,6 +51,7 @@ public class PartitionRegistration {
         private LeaderRecoveryState leaderRecoveryState;
         private Integer leaderEpoch;
         private Integer partitionEpoch;
+        private long creationTimeMs = -1L;
 
         public Builder setReplicas(int[] replicas) {
             this.replicas = replicas;
@@ -107,6 +108,11 @@ public class PartitionRegistration {
             return this;
         }
 
+        public Builder setCreationTimeMs(long creationTimeMs) {
+            this.creationTimeMs = creationTimeMs;
+            return this;
+        }
+
         public PartitionRegistration build() {
             if (replicas == null) {
                 throw new IllegalStateException("You must set replicas.");
@@ -145,7 +151,8 @@ public class PartitionRegistration {
                 leaderEpoch,
                 partitionEpoch,
                 elr,
-                lastKnownElr
+                lastKnownElr,
+                creationTimeMs
             );
         }
     }
@@ -161,6 +168,7 @@ public class PartitionRegistration {
     public final LeaderRecoveryState leaderRecoveryState;
     public final int leaderEpoch;
     public final int partitionEpoch;
+    public final long creationTimeMs;
 
     public static boolean electionWasUnclean(byte leaderRecoveryState) {
         return leaderRecoveryState == LeaderRecoveryState.RECOVERING.value();
@@ -210,12 +218,14 @@ public class PartitionRegistration {
             record.leaderEpoch(),
             record.partitionEpoch(),
             Replicas.toArray(record.eligibleLeaderReplicas()),
-            Replicas.toArray(record.lastKnownElr()));
+            Replicas.toArray(record.lastKnownElr()),
+            record.creationTimeMs());
     }
 
     private PartitionRegistration(int[] replicas, Uuid[] directories, int[] isr, int[] removingReplicas,
                                   int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
-                                  int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr) {
+                                  int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr,
+                                  long creationTimeMs) {
         Objects.requireNonNull(directories);
         if (directories.length > 0 && directories.length != replicas.length) {
             throw new IllegalArgumentException("The lengths for replicas and directories do not match.");
@@ -229,6 +239,7 @@ public class PartitionRegistration {
         this.leaderRecoveryState = leaderRecoveryState;
         this.leaderEpoch = leaderEpoch;
         this.partitionEpoch = partitionEpoch;
+        this.creationTimeMs = creationTimeMs;
 
         // We could parse a lower version record without elr/lastKnownElr.
         this.elr = elr == null ? new int[0] : elr;
@@ -273,7 +284,8 @@ public class PartitionRegistration {
             newLeaderEpoch,
             partitionEpoch + 1,
             newElr,
-            newLastKnownElr);
+            newLastKnownElr,
+            this.creationTimeMs);
     }
 
     public String diff(PartitionRegistration prev) {
@@ -339,6 +351,11 @@ public class PartitionRegistration {
         if (partitionEpoch != prev.partitionEpoch) {
             builder.append(prefix).append("partitionEpoch: ").
                 append(prev.partitionEpoch).append(" -> ").append(partitionEpoch);
+            prefix = ", ";
+        }
+        if (creationTimeMs != prev.creationTimeMs) {
+            builder.append(prefix).append("creationTimeMs: ").
+                append(prev.creationTimeMs).append(" -> ").append(creationTimeMs);
         }
         return builder.toString();
     }
@@ -390,6 +407,9 @@ public class PartitionRegistration {
             if (elr.length > 0) record.setEligibleLeaderReplicas(Replicas.toList(elr));
             if (lastKnownElr.length > 0) record.setLastKnownElr(Replicas.toList(lastKnownElr));
         }
+        if (options.isPartitionCreationTimestampSupported()) {
+            record.setCreationTimeMs(creationTimeMs);
+        }
 
         if (options.metadataVersion() == null) {
             options.handleLoss("the metadata version");
@@ -412,7 +432,8 @@ public class PartitionRegistration {
     public int hashCode() {
         return Objects.hash(Arrays.hashCode(replicas), Arrays.hashCode(isr), Arrays.hashCode(removingReplicas),
             Arrays.hashCode(directories), Arrays.hashCode(elr), Arrays.hashCode(lastKnownElr),
-            Arrays.hashCode(addingReplicas), leader, leaderRecoveryState, leaderEpoch, partitionEpoch);
+            Arrays.hashCode(addingReplicas), leader, leaderRecoveryState, leaderEpoch, partitionEpoch,
+            creationTimeMs);
     }
 
     @Override
@@ -428,7 +449,8 @@ public class PartitionRegistration {
             leader == other.leader &&
             leaderRecoveryState == other.leaderRecoveryState &&
             leaderEpoch == other.leaderEpoch &&
-            partitionEpoch == other.partitionEpoch;
+            partitionEpoch == other.partitionEpoch &&
+            creationTimeMs == other.creationTimeMs;
     }
 
     @Override
@@ -444,6 +466,7 @@ public class PartitionRegistration {
                 ", leaderRecoveryState=" + leaderRecoveryState +
                 ", leaderEpoch=" + leaderEpoch +
                 ", partitionEpoch=" + partitionEpoch +
+                ", creationTimeMs=" + creationTimeMs +
                 ")";
     }
 }

--- a/metadata/src/main/resources/common/metadata/PartitionRecord.json
+++ b/metadata/src/main/resources/common/metadata/PartitionRecord.json
@@ -19,6 +19,7 @@
   "name": "PartitionRecord",
   // Version 1 adds Directories for KIP-858
   // Version 2 implements Eligible Leader Replicas and LastKnownElr as described in KIP-966.
+  // Tagged field CreationTimeMs added for KIP-1327 (partition creation timestamp).
   "validVersions": "0-2",
   "flexibleVersions": "0+",
   "fields": [
@@ -49,6 +50,10 @@
       "about": "The eligible leader replicas of this partition." },
     { "name": "LastKnownElr", "type": "[]int32", "default": "null", "entityType": "brokerId",
       "versions": "2+", "nullableVersions": "2+", "taggedVersions": "2+", "tag": 2,
-      "about": "The last known eligible leader replicas of this partition." }
+      "about": "The last known eligible leader replicas of this partition." },
+    // Version 0+ tagged field (tag 3): CreationTimeMs for KIP-1327.
+    { "name": "CreationTimeMs", "type": "int64", "versions": "0+",
+      "taggedVersions": "0+", "tag": 3, "default": "-1",
+      "about": "The time in milliseconds when this partition was first created. Set once at creation, never updated. -1 if unknown." }
   ]
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -275,6 +275,7 @@ public class ReplicationControlManagerTest {
                 setClusterControl(clusterControl).
                 setCreateTopicPolicy(createTopicPolicy).
                 setFeatureControl(featureControl).
+                setTime(time).
                 build();
             clusterControl.activate();
         }
@@ -670,7 +671,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00002DIRAAAA"),
                     Uuid.fromString("TESTBROKER00000DIRAAAA")
             }).
-            setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
+            setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).setCreationTimeMs(ctx.time.milliseconds()).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result3.records().get(0).message()).topicId(), 0));
         ControllerResult<CreateTopicsResponseData> result4 =
@@ -744,7 +745,7 @@ public class ReplicationControlManagerTest {
                 setLeader(0).
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
-                setPartitionEpoch(0).build(),
+                setPartitionEpoch(0).setCreationTimeMs(ctx.time.milliseconds()).build(),
             replicationControl.getPartition(
                 ((TopicRecord) result.records().get(0).message()).topicId(), 0));
     }
@@ -1781,6 +1782,7 @@ public class ReplicationControlManagerTest {
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
                 setPartitionEpoch(0).
+                setCreationTimeMs(ctx.time.milliseconds()).
                 build(),
             replicationControl.getPartition(
                 ((TopicRecord) result.records().get(0).message()).topicId(), 1));
@@ -2108,6 +2110,7 @@ public class ReplicationControlManagerTest {
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
                 setPartitionEpoch(1).
+                setCreationTimeMs(ctx.time.milliseconds()).
                 build(),
             replication.getPartition(fooId, 0));
 
@@ -2251,6 +2254,7 @@ public class ReplicationControlManagerTest {
                 setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
                 setLeaderEpoch(0).
                 setPartitionEpoch(0).
+                setCreationTimeMs(ctx.time.milliseconds()).
                 build(),
             replication.getPartition(fooId, 0));
 
@@ -2309,7 +2313,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00003DIRAAAA"),
                     Uuid.fromString("TESTBROKER00004DIRAAAA")
             }).
-            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).build(), replication.getPartition(fooId, 0));
+            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(1).setCreationTimeMs(ctx.time.milliseconds()).build(), replication.getPartition(fooId, 0));
         ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
             replication.alterPartitionReassignments(
                 new AlterPartitionReassignmentsRequestData().setTopics(List.of(
@@ -2345,7 +2349,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00002DIRAAAA"),
                     Uuid.fromString("TESTBROKER00004DIRAAAA")
             }).
-            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).build(), replication.getPartition(fooId, 0));
+            setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(2).setCreationTimeMs(ctx.time.milliseconds()).build(), replication.getPartition(fooId, 0));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 0}).setIsr(new int[] {0, 1, 2}).
             setDirectories(new Uuid[] {
                     Uuid.fromString("TESTBROKER00001DIRAAAA"),
@@ -2353,7 +2357,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00003DIRAAAA"),
                     Uuid.fromString("TESTBROKER00000DIRAAAA")
             }).
-            setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(fooId, 1));
+            setLeader(0).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).setCreationTimeMs(ctx.time.milliseconds()).build(), replication.getPartition(fooId, 1));
         assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 3, 4, 0}).setIsr(new int[] {4, 2}).
             setDirectories(new Uuid[] {
                     Uuid.fromString("TESTBROKER00001DIRAAAA"),
@@ -2362,7 +2366,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00004DIRAAAA"),
                     Uuid.fromString("TESTBROKER00000DIRAAAA")
             }).
-            setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).build(), replication.getPartition(barId, 0));
+            setAddingReplicas(new int[] {0, 1}).setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(2).setCreationTimeMs(ctx.time.milliseconds()).build(), replication.getPartition(barId, 0));
         ListPartitionReassignmentsResponseData currentReassigning =
             new ListPartitionReassignmentsResponseData().setErrorMessage(null).
                 setTopics(List.of(new OngoingTopicReassignment().
@@ -2431,7 +2435,7 @@ public class ReplicationControlManagerTest {
                     Uuid.fromString("TESTBROKER00003DIRAAAA"),
                     Uuid.fromString("TESTBROKER00004DIRAAAA")
             }).
-            setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(3).build(), replication.getPartition(barId, 0));
+            setLeader(4).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(1).setPartitionEpoch(3).setCreationTimeMs(ctx.time.milliseconds()).build(), replication.getPartition(barId, 0));
     }
 
     @Test
@@ -2457,7 +2461,7 @@ public class ReplicationControlManagerTest {
                         Uuid.fromString("TESTBROKER00004DIRAAAA"),
                         Uuid.fromString("TESTBROKER00005DIRAAAA")
                 }).
-                setIsr(new int[] {2}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
+                setIsr(new int[] {2}).setLeader(2).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).setCreationTimeMs(ctx.time.milliseconds()).build(),
             ctx.replicationControl.getPartition(fooId, 1));
     }
 
@@ -3524,5 +3528,43 @@ public class ReplicationControlManagerTest {
         int partitionEpoch = ctx.replicationControl.getPartition(fooId, 0).partitionEpoch;
         ctx.replay(List.of(new ApiMessageAndVersion(new ClearElrRecord(), CLEAR_ELR_RECORD.highestSupportedVersion())));
         assertEquals(partitionEpoch, ctx.replicationControl.getPartition(fooId, 0).partitionEpoch);
+    }
+
+    @Test
+    public void testCreateTopicSetsCreationTimeMs() {
+        long expectedCreationTimeMs = 12345L;
+        MockTime mockTime = new MockTime(0, expectedCreationTimeMs, 0);
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+            .setMockTime(mockTime)
+            .build();
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        CreatableTopicResult result = ctx.createTestTopic("foo", new int[][]{{0, 1, 2}});
+        PartitionRegistration partition = ctx.replicationControl.getPartition(result.topicId(), 0);
+        assertNotNull(partition);
+        assertEquals(expectedCreationTimeMs, partition.creationTimeMs);
+    }
+
+    @Test
+    public void testCreatePartitionsSetsCreationTimeMs() {
+        long topicCreationTimeMs = 1000L;
+        long partitionCreationTimeMs = 9000L;
+        MockTime mockTime = new MockTime(0, topicCreationTimeMs, 0);
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+            .setMockTime(mockTime)
+            .build();
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        CreatableTopicResult result = ctx.createTestTopic("foo", 1, (short) 3, (short) 0);
+        Uuid topicId = result.topicId();
+        assertEquals(topicCreationTimeMs, ctx.replicationControl.getPartition(topicId, 0).creationTimeMs);
+
+        mockTime.sleep(partitionCreationTimeMs - topicCreationTimeMs);
+        ctx.createPartitions(2, "foo", new int[][]{{1, 2, 0}}, (short) 0);
+        PartitionRegistration newPartition = ctx.replicationControl.getPartition(topicId, 1);
+        assertNotNull(newPartition);
+        assertEquals(partitionCreationTimeMs, newPartition.creationTimeMs);
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/node/TopicImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/TopicImageNodeTest.java
@@ -83,7 +83,7 @@ public class TopicImageNodeTest {
         assertEquals("PartitionRegistration(replicas=[2, 3, 4], " +
                 "directories=[AAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAA], " +
                 "isr=[2, 3], removingReplicas=[], addingReplicas=[], elr=[], lastKnownElr=[], leader=2, " +
-                "leaderRecoveryState=RECOVERED, leaderEpoch=1, partitionEpoch=345)", stringifier.toString());
+                "leaderRecoveryState=RECOVERED, leaderEpoch=1, partitionEpoch=345, creationTimeMs=-1)", stringifier.toString());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
@@ -18,14 +18,21 @@
 package org.apache.kafka.image.publisher;
 
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.image.FakeSnapshotWriter;
+import org.apache.kafka.image.MetadataDelta;
+import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataImageTest;
+import org.apache.kafka.image.MetadataProvenance;
+import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.raft.RaftClient;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.KRaftVersion;
+import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.snapshot.SnapshotWriter;
 
@@ -174,5 +181,59 @@ public class SnapshotEmitterTest {
         // Second call to emit does nothing because we already have a snapshot at that offset and epoch.
         emitter.maybeEmit(MetadataImageTest.IMAGE1);
         assertEquals(1, mockRaftClient.writers.size());
+    }
+
+    @Test
+    public void testEmitPreservesPartitionCreationTimeMs() {
+        MockRaftClient mockRaftClient = new MockRaftClient();
+        MockTime time = new MockTime(0, 10000L, 20000L);
+        SnapshotEmitter emitter = new SnapshotEmitter.Builder().
+            setTime(time).
+            setBatchSize(2).
+            setRaftClient(mockRaftClient).
+            build();
+
+        // Build a MetadataImage with a partition that has a non-default creationTimeMs.
+        long expectedCreationTimeMs = 5000L;
+        Uuid topicId = Uuid.randomUuid();
+        MetadataDelta delta = new MetadataDelta.Builder().setImage(MetadataImage.EMPTY).build();
+        delta.replay(new org.apache.kafka.common.metadata.FeatureLevelRecord()
+            .setName(MetadataVersion.FEATURE_NAME)
+            .setFeatureLevel(MetadataVersion.IBP_4_4_IV1.featureLevel()));
+        delta.replay(new org.apache.kafka.common.metadata.TopicRecord()
+            .setName("test-topic")
+            .setTopicId(topicId));
+        delta.replay(new org.apache.kafka.common.metadata.PartitionRecord()
+            .setTopicId(topicId)
+            .setPartitionId(0)
+            .setReplicas(List.of(0))
+            .setIsr(List.of(0))
+            .setLeader(0)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value())
+            .setCreationTimeMs(expectedCreationTimeMs));
+        MetadataImage image = delta.apply(new MetadataProvenance(100, 4, 2000, true));
+
+        emitter.maybeEmit(image);
+
+        FakeSnapshotWriter writer = mockRaftClient.writers.get(image.provenance().snapshotId());
+        assertNotNull(writer);
+        assertTrue(writer.isFrozen());
+
+        // Find the PartitionRecord in the written batches and verify creationTimeMs is preserved.
+        boolean foundPartitionRecord = false;
+        for (List<ApiMessageAndVersion> batch : writer.batches()) {
+            for (ApiMessageAndVersion record : batch) {
+                if (record.message() instanceof PartitionRecord partitionRecord) {
+                    if (partitionRecord.topicId().equals(topicId)) {
+                        assertEquals(expectedCreationTimeMs, partitionRecord.creationTimeMs(),
+                            "PartitionRecord should preserve creationTimeMs in snapshot");
+                        foundPartitionRecord = true;
+                    }
+                }
+            }
+        }
+        assertTrue(foundPartitionRecord, "Should have found a PartitionRecord in the snapshot");
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/image/writer/ImageWriterOptionsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/writer/ImageWriterOptionsTest.java
@@ -83,6 +83,17 @@ public class ImageWriterOptionsTest {
         assertFalse(options.isEligibleLeaderReplicasEnabled());
     }
 
+    @Test
+    public void testSetPartitionCreationTimestampSupported() {
+        MetadataVersion version = MetadataVersion.MINIMUM_VERSION;
+        ImageWriterOptions options = new ImageWriterOptions.Builder(version)
+            .setPartitionCreationTimestampSupported(true).build();
+        assertTrue(options.isPartitionCreationTimestampSupported());
+
+        options = new ImageWriterOptions.Builder(version).build();
+        assertFalse(options.isPartitionCreationTimestampSupported());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testConstructionWithImage(boolean isElrEnabled) {

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -397,4 +397,97 @@ public class PartitionRegistrationTest {
         PartitionRegistration registration = new PartitionRegistration(record);
         assertArrayEquals(new Uuid[]{DirectoryId.MIGRATING, DirectoryId.MIGRATING}, registration.directories);
     }
+
+    @Test
+    public void testCreationTimeMsPreservedInMerge() {
+        PartitionRegistration reg = new PartitionRegistration.Builder()
+            .setReplicas(new int[]{1, 2, 3})
+            .setDirectories(DirectoryId.unassignedArray(3))
+            .setIsr(new int[]{1})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setCreationTimeMs(1000L)
+            .build();
+
+        PartitionChangeRecord change = new PartitionChangeRecord()
+            .setLeader(2)
+            .setIsr(List.of(2));
+        PartitionRegistration merged = reg.merge(change);
+
+        assertEquals(1000L, merged.creationTimeMs);
+    }
+
+    @Test
+    public void testCreationTimeMsInToRecord_Supported() {
+        PartitionRegistration reg = new PartitionRegistration.Builder()
+            .setReplicas(new int[]{1})
+            .setDirectories(DirectoryId.unassignedArray(1))
+            .setIsr(new int[]{1})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setCreationTimeMs(5000L)
+            .build();
+
+        Uuid topicId = Uuid.randomUuid();
+        ImageWriterOptions options = new ImageWriterOptions.Builder(MetadataVersion.IBP_4_4_IV1)
+            .setPartitionCreationTimestampSupported(true)
+            .build();
+        ApiMessageAndVersion record = reg.toRecord(topicId, 0, options);
+        PartitionRecord partitionRecord = (PartitionRecord) record.message();
+
+        assertEquals(5000L, partitionRecord.creationTimeMs());
+    }
+
+    @Test
+    public void testCreationTimeMsInToRecord_NotSupported() {
+        PartitionRegistration reg = new PartitionRegistration.Builder()
+            .setReplicas(new int[]{1})
+            .setDirectories(DirectoryId.unassignedArray(1))
+            .setIsr(new int[]{1})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setCreationTimeMs(5000L)
+            .build();
+
+        Uuid topicId = Uuid.randomUuid();
+        ImageWriterOptions options = new ImageWriterOptions.Builder(MetadataVersion.IBP_4_0_IV1).build();
+        ApiMessageAndVersion record = reg.toRecord(topicId, 0, options);
+        PartitionRecord partitionRecord = (PartitionRecord) record.message();
+
+        assertEquals(-1L, partitionRecord.creationTimeMs());
+    }
+
+    @Test
+    public void testCreationTimeMsInEqualsAndDiff() {
+        PartitionRegistration reg1 = new PartitionRegistration.Builder()
+            .setReplicas(new int[]{1})
+            .setDirectories(DirectoryId.unassignedArray(1))
+            .setIsr(new int[]{1})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setCreationTimeMs(1000L)
+            .build();
+
+        PartitionRegistration reg2 = new PartitionRegistration.Builder()
+            .setReplicas(new int[]{1})
+            .setDirectories(DirectoryId.unassignedArray(1))
+            .setIsr(new int[]{1})
+            .setLeader(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+            .setLeaderEpoch(0)
+            .setPartitionEpoch(0)
+            .setCreationTimeMs(2000L)
+            .build();
+
+        assertNotEquals(reg1, reg2);
+        assertTrue(reg2.diff(reg1).contains("creationTimeMs:"));
+    }
 }

--- a/server-common/src/main/java/org/apache/kafka/server/common/GroupVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/GroupVersion.java
@@ -27,8 +27,6 @@ public enum GroupVersion implements FeatureVersion {
     GV_1(1, MetadataVersion.IBP_4_0_IV0, Map.of()),
 
     // Version 2 enables partition-expansion classification for consumer groups (KIP-1327).
-    // It depends on metadata.version IBP_4_4_IV1 so that partition.creationTime is available
-    // in the metadata image when the coordinator computes NewPartitions.
     GV_2(2, MetadataVersion.IBP_4_4_IV1, Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_4_IV1.featureLevel()));
 
     public static final String FEATURE_NAME = "group.version";

--- a/server-common/src/main/java/org/apache/kafka/server/common/GroupVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/GroupVersion.java
@@ -24,7 +24,12 @@ public enum GroupVersion implements FeatureVersion {
     GV_0(0, MetadataVersion.MINIMUM_VERSION, Map.of()),
 
     // Version 1 enables the consumer rebalance protocol (KIP-848).
-    GV_1(1, MetadataVersion.IBP_4_0_IV0, Map.of());
+    GV_1(1, MetadataVersion.IBP_4_0_IV0, Map.of()),
+
+    // Version 2 enables partition-expansion classification for consumer groups (KIP-1327).
+    // It depends on metadata.version IBP_4_4_IV1 so that partition.creationTime is available
+    // in the metadata image when the coordinator computes NewPartitions.
+    GV_2(2, MetadataVersion.IBP_4_4_IV1, Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_4_IV1.featureLevel()));
 
     public static final String FEATURE_NAME = "group.version";
 
@@ -68,12 +73,18 @@ public enum GroupVersion implements FeatureVersion {
         return featureLevel >= GV_1.featureLevel;
     }
 
+    public boolean isNewPartitionsClassificationSupported() {
+        return featureLevel >= GV_2.featureLevel;
+    }
+
     public static GroupVersion fromFeatureLevel(short version) {
         switch (version) {
             case 0:
                 return GV_0;
             case 1:
                 return GV_1;
+            case 2:
+                return GV_2;
             default:
                 throw new RuntimeException("Unknown group feature level: " + (int) version);
         }

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -133,7 +133,10 @@ public enum MetadataVersion {
 
     // IBP_4_4_IV0 enables dead-letter queue support for share groups (KIP-1191). When this version
     // is finalized, so will the DLQ support.
-    IBP_4_4_IV0(31, "4.4", "IV0", false);
+    IBP_4_4_IV0(31, "4.4", "IV0", false),
+
+    // IBP_4_4_IV1 records partition creation timestamps in PartitionRecord (KIP-1327).
+    IBP_4_4_IV1(32, "4.4", "IV1", true);
 
 
     // NOTES when adding a new version:
@@ -219,6 +222,10 @@ public enum MetadataVersion {
 
     public boolean isCordonedLogDirsSupported() {
         return this.isAtLeast(MetadataVersion.IBP_4_3_IV0);
+    }
+
+    public boolean isPartitionCreationTimestampSupported() {
+        return this.isAtLeast(IBP_4_4_IV1);
     }
 
     public short registerBrokerRecordVersion() {

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -37,6 +37,7 @@ import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV2;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_3_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_4_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -231,6 +232,12 @@ class MetadataVersionTest {
     @Test
     public void assertLatestIsNotProduction() {
         assertFalse(MetadataVersion.latestTesting().isProduction());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testIsPartitionCreationTimestampSupported(MetadataVersion metadataVersion) {
+        assertEquals(metadataVersion.isAtLeast(IBP_4_4_IV1), metadataVersion.isPartitionCreationTimestampSupported());
     }
 
     @ParameterizedTest

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
@@ -52,7 +52,7 @@ public @interface ClusterTest {
     String brokerListener() default DEFAULT_BROKER_LISTENER_NAME;
     SecurityProtocol controllerSecurityProtocol() default SecurityProtocol.PLAINTEXT;
     String controllerListener() default DEFAULT_CONTROLLER_LISTENER_NAME;
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_4_IV0;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_4_IV1;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};

--- a/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
@@ -951,8 +951,10 @@ public class DumpLogSegmentsTest {
             Optional.empty()
         );
 
-        // Any parsing error is swallowed and reported.
-        assertParseResult(
+        // Any parsing error is swallowed and reported. The exact failure message depends on
+        // which read path the random mismatched bytes happen to hit (e.g. readArray vs.
+        // readLong of a newly added tagged field), so only assert on the stable prefix.
+        assertParseResultKeyStartsWith(
             parser.parse(serializedRecord(
                 new ConsumerGroupMetadataKey().setGroupId("group"),
                 new ApiMessageAndVersion(
@@ -960,8 +962,7 @@ public class DumpLogSegmentsTest {
                     (short) 0
                 )
             )),
-            Optional.of("Error at offset 0, skipping. Could not read record with version 0 from value's buffer due to: " +
-                "Error reading byte array of 536870911 byte(s): only 1 byte(s) available."),
+            "Error at offset 0, skipping. Could not read record with version 0 from value's buffer due to: ",
             Optional.empty()
         );
     }
@@ -1422,6 +1423,17 @@ public class DumpLogSegmentsTest {
         Optional<String> expectedValue
     ) {
         assertEquals(expectedKey, result.key());
+        assertEquals(expectedValue, result.value());
+    }
+
+    private void assertParseResultKeyStartsWith(
+        DumpLogSegments.ParseResult<String, String> result,
+        String expectedKeyPrefix,
+        Optional<String> expectedValue
+    ) {
+        assertTrue(result.key().isPresent(), "Expected a key but got empty");
+        assertTrue(result.key().get().startsWith(expectedKeyPrefix),
+            "Expected key to start with: " + expectedKeyPrefix + " but was: " + result.key().get());
         assertEquals(expectedValue, result.value());
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -59,7 +59,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(0))
         );
         assertFeatureOutput(
-                "group.version", "0", "1", "0",
+                "group.version", "0", "2", "0",
                 outputWithoutEpoch(features.get(1))
         );
         assertFeatureOutput(
@@ -98,7 +98,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(0))
         );
         assertFeatureOutput(
-                "group.version", "0", "1", "0",
+                "group.version", "0", "2", "0",
                 outputWithoutEpoch(features.get(1))
         );
         assertFeatureOutput(
@@ -154,7 +154,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(0))
         );
         assertFeatureOutput(
-                "group.version", "0", "1", "0",
+                "group.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(1))
         );
         assertFeatureOutput(
@@ -247,7 +247,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(0))
         );
         assertFeatureOutput(
-                "group.version", "0", "1", "0",
+                "group.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(1))
         );
         assertFeatureOutput(


### PR DESCRIPTION
  Records two creation timestamps (partition + consumer group) once at
creation, exposes them via RPC. Default `-1` = unknown.

  #### Partition creation timestamp

  - `PartitionRecord`: tagged field `CreationTimeMs` (tag 3).    -
`ReplicationControlManager`: stamps it on partition create / expand.
- `PartitionRegistration` + `KRaftMetadataCache`: propagate to RPC.    -
`MetadataResponse` v14: tagged `CreationTimeMs` on partition.    -
`DescribeTopicPartitionsResponse` v1: tagged `CreationTimeMs` on
partition.    - `TopicPartitionInfo.creationTimeMs(): OptionalLong`.
- New `MetadataVersion IBP_4_4_IV1` gates stamping; image writer drops
the field for older MVs.

  #### Consumer group creation timestamp

  - `ConsumerGroupMetadataValue`: tagged field `CreationTimeMs` (tag 1),
persisted in `__consumer_offsets`, write-once.    - `ConsumerGroup`:
stores it in a `TimelineLong`.    - `ConsumerGroupHeartbeatResponse` v2:
`GroupCreationTimeMs`.    - `ConsumerGroupDescribeResponse` v2:
`GroupCreationTimeMs`.

  ### Out of scope

  - Client-side reset (`auto.offset.reset.max.age.ms` etc.).    -
Tooling (`kafka-topics.sh`, `kafka-consumer-groups.sh`) display.

KIP:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-1327%3A+Prevent+Hot+Data+Loss+on+Partition+Expansion+for+Latest+Policy
