### PR TITLE
docs: Document actual ProducerRecord default partitioner strategy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -28,7 +28,9 @@ import java.util.Objects;
  * <p>
  * If a valid partition number is specified that partition will be used when sending the record. If no partition is
  * specified but a key is present a partition will be chosen using a hash of the key. If neither key nor partition is
- * present a partition will be assigned in a round-robin fashion. Note that partition numbers are 0-indexed.
+ * present a partition will be assigned utilizing the {@link org.apache.kafka.clients.producer.Partitioner}
+ * configured via {@link org.apache.kafka.clients.producer.ProducerConfig#PARTITIONER_CLASS_CONFIG} or its default
+ * behavior. Note that partition numbers are 0-indexed.
  * <p>
  * The record also has an associated timestamp. If the user did not provide a timestamp, the producer will stamp the
  * record with its current time. The timestamp eventually used by Kafka depends on the timestamp type configured for


### PR DESCRIPTION
Since Kafka 2.4, the default partitioning strategy when producing records has been a Sticky strategy that allows for batch + linger configurations; and with recent evolutions around adaptive partitioning and rack awareness. References to round robin as the default are incorrect and misleading.