### PR TITLE
KAFKA-20566: Improve logging in share coordinator

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -777,7 +777,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic/TopicPartition not found in metadata image.");
+            log.error("Topic or partition not found in metadata image when writing: {}:null-{}.", topicId, partitionId);
             return Optional.of(getWriteErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 
@@ -825,7 +825,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic/TopicPartition not found in metadata image.");
+            log.error("Topic or partition not found in metadata image when reading: {}:null-{}.", topicId, partitionId);
             return Optional.of(ReadShareGroupStateResponse.toErrorResponseData(topicId, partitionId, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
         }
 
@@ -859,7 +859,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic/TopicPartition not found in metadata image.");
+            log.error("Topic or partition not found in metadata image when reading summary: {}:null-{}.", topicId, partitionId);
             return Optional.of(ReadShareGroupStateSummaryResponse.toErrorResponseData(topicId, partitionId, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
         }
 
@@ -891,7 +891,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic/TopicPartition not found in metadata image.");
+            log.error("Topic or partition not found in metadata image when deleting: {}:null-{}.", topicId, partitionId);
             return Optional.of(getDeleteErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 
@@ -929,7 +929,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic/TopicPartition not found in metadata image.");
+            log.error("Topic or partition not found in metadata image when initializing: {}:null-{}.", topicId, partitionId);
             return Optional.of(getInitializeErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -777,7 +777,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic or partition not found in metadata image when writing: {}:null-{}.", topicId, partitionId);
+            log.error("Topic or partition not found in metadata image when writing: {}:{}-{}.", topicId,
+                topicMetadataOp.map(CoordinatorMetadataImage.TopicMetadata::name).orElse("null"), partitionId);
             return Optional.of(getWriteErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 
@@ -825,7 +826,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic or partition not found in metadata image when reading: {}:null-{}.", topicId, partitionId);
+            log.error("Topic or partition not found in metadata image when reading: {}:{}-{}.", topicId,
+                topicMetadataOp.map(CoordinatorMetadataImage.TopicMetadata::name).orElse("null"), partitionId);
             return Optional.of(ReadShareGroupStateResponse.toErrorResponseData(topicId, partitionId, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
         }
 
@@ -859,7 +861,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic or partition not found in metadata image when reading summary: {}:null-{}.", topicId, partitionId);
+            log.error("Topic or partition not found in metadata image when reading summary: {}:{}-{}.", topicId,
+                topicMetadataOp.map(CoordinatorMetadataImage.TopicMetadata::name).orElse("null"), partitionId);
             return Optional.of(ReadShareGroupStateSummaryResponse.toErrorResponseData(topicId, partitionId, Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
         }
 
@@ -891,7 +894,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic or partition not found in metadata image when deleting: {}:null-{}.", topicId, partitionId);
+            log.error("Topic or partition not found in metadata image when deleting: {}:{}-{}.", topicId,
+                topicMetadataOp.map(CoordinatorMetadataImage.TopicMetadata::name).orElse("null"), partitionId);
             return Optional.of(getDeleteErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 
@@ -929,7 +933,8 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         Optional<CoordinatorMetadataImage.TopicMetadata> topicMetadataOp = metadataImage.topicMetadata(topicId);
         if (topicMetadataOp.isEmpty() ||
             topicMetadataOp.get().partitionCount() <= partitionId) {
-            log.error("Topic or partition not found in metadata image when initializing: {}:null-{}.", topicId, partitionId);
+            log.error("Topic or partition not found in metadata image when initializing: {}:{}-{}.", topicId,
+                topicMetadataOp.map(CoordinatorMetadataImage.TopicMetadata::name).orElse("null"), partitionId);
             return Optional.of(getInitializeErrorCoordinatorResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, topicId, partitionId));
         }
 


### PR DESCRIPTION
This PR just improves the logging for situations in which the metadata
image in the share coordinator does not contain an expected topic ID. We
see this log line in some situations but because there are 5 instances
with identical text, it's not possible to tell from the log alone which
one is responsible.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Sushant Mahajan
 <smahajan@confluent.io>, PoAn Yang <payang@apache.org>
