### PR TITLE
MINOR: Assert queryable state range results

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -812,6 +812,10 @@ public class QueryableStateIntegrationTest {
                 new KeyValue<>(keys[3], "5"),
                 new KeyValue<>(keys[4], "2"))
         );
+        final List<KeyValue<String, Long>> expectedRangeResult = List.of(
+                new KeyValue<>(keys[0], 1L),
+                new KeyValue<>(keys[4], 2L)
+        );
 
         IntegrationTestUtils.produceKeyValuesSynchronously(
             streamOne,
@@ -843,11 +847,13 @@ public class QueryableStateIntegrationTest {
             assertEquals(Long.valueOf(batchEntry.value), myMapStore.get(batchEntry.key));
         }
 
+        int index = 0;
         try (final KeyValueIterator<String, Long> range = myMapStore.range("hello", "kafka")) {
             while (range.hasNext()) {
-                System.out.println(range.next());
+                assertEquals(expectedRangeResult.get(index++), range.next());
             }
         }
+        assertEquals(expectedRangeResult.size(), index);
     }
 
     @Test
@@ -902,6 +908,7 @@ public class QueryableStateIntegrationTest {
                 assertEquals(expectedPrefixScanResult.get(index++), range.next());
             }
         }
+        assertEquals(expectedPrefixScanResult.size(), index);
     }
 
     @Test


### PR DESCRIPTION
### Summary

This PR improves `QueryableStateIntegrationTest` by replacing an unasserted range-query loop with deterministic assertions.

Previously, `shouldBeAbleToQueryMapValuesState()` iterated over `myMapStore.range("hello", "kafka")` and printed the returned records using `System.out.println`, but did not verify the range-query result.

This change:
- asserts the expected range-query records
- verifies that the expected number of records was returned
- adds a similar result-count assertion to the nearby prefix-scan test

### Testing

```bash
./gradlew streams:integration-tests:test \
  --tests org.apache.kafka.streams.integration.QueryableStateIntegrationTest.shouldBeAbleToQueryMapValuesState \
  --rerun-tasks

./gradlew streams:integration-tests:test \
  --tests org.apache.kafka.streams.integration.QueryableStateIntegrationTest.shouldBeAbleToQueryKeysWithGivenPrefix \
  --rerun-tasks