### PR TITLE
Add explicit least-privilege permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -21,6 +21,11 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  contents: read
+  statuses: write
+
 run-name: Build Scans for ${{ github.event.workflow_run.display_title}}
 
 # This workflow runs after the completion of the CI workflow triggered on a "pull_request" event.

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -36,6 +36,9 @@ on:
         type: string
         default: '17'
 
+permissions:
+  contents: read
+
 jobs:
   deflake:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -28,6 +28,9 @@ on:
         description: Kafka url to be used to build the docker image
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_official_image_build_and_test.yml
+++ b/.github/workflows/docker_official_image_build_and_test.yml
@@ -27,6 +27,9 @@ on:
         description: Kafka version for the docker official image. This should be >=3.7.0
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_promote.yml
+++ b/.github/workflows/docker_promote.yml
@@ -25,6 +25,9 @@ on:
         description: Docker image name of the promoted image (Example:- apache/kafka:3.8.0 (OR) apache/kafka-native:3.8.0)
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   promote:
     if: github.repository == 'apache/kafka'

--- a/.github/workflows/docker_rc_release.yml
+++ b/.github/workflows/docker_rc_release.yml
@@ -31,6 +31,9 @@ on:
         description: Kafka url to be used to build the docker image
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release:
     if: github.repository == 'apache/kafka'

--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -19,6 +19,10 @@ on:
     # This job will run at 3:30 UTC daily
     - cron: '30 3 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   scan_jvm:
     if: github.repository == 'apache/kafka'

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -20,6 +20,11 @@ on:
     types:
       - labeled
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   approve-workflow-run:
     name: Approve CI

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -21,6 +21,11 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  contents: read
+  statuses: write
+
 jobs:
   lint-pr:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pr-reviewed.yml
+++ b/.github/workflows/pr-reviewed.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - trunk
 
+permissions:
+  contents: read
+
 jobs:
   save-pr-number:
     name: Save PR Number

--- a/.github/workflows/prepare_docker_official_image_source.yml
+++ b/.github/workflows/prepare_docker_official_image_source.yml
@@ -26,6 +26,9 @@ on:
       kafka_version:
         description: Kafka version for the docker official image. This should be >=3.7.0
         required: true
+
+permissions:
+  contents: read
         
 jobs:
   build:

--- a/.github/workflows/workflow-requested.yml
+++ b/.github/workflows/workflow-requested.yml
@@ -21,6 +21,11 @@ on:
     types:
       - requested
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 run-name: Workflow Requested for ${{ github.event.workflow_run.display_title}}
 
 jobs:


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to 12 workflows that previously relied on default token scopes.
- Set read-only permissions (`contents: read`) for build/test and Docker workflows.
- Add narrowly scoped write permissions only where workflow behavior requires them:
  - `actions: write` for workflow run approval automation
  - `statuses: write` for commit status update workflows

## Why
This hardens `GITHUB_TOKEN` usage by making required scopes explicit and minimizing privilege per workflow.

## Notes
- `ci.yml` is intentionally excluded in this PR because it invokes the reusable `build.yml` workflow, which includes a trunk-only `update-test-catalog` job that requires `contents: write`.