### PR TITLE
MINOR: Publish kafka-clients test-fixtures artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -413,7 +413,14 @@ subprojects {
           }
 
           afterEvaluate {
-            ["srcJar", "javadocJar", "scaladocJar", "testJar", "testSrcJar"].forEach { taskName ->
+            // testFixturesJar is automatically included by components.java when the java-test-fixtures
+            // plugin is applied, so it should only be added explicitly when publishing the shadow
+            // component (which does not include the test-fixtures variant).
+            def artifactTaskNames = ["srcJar", "javadocJar", "scaladocJar", "testJar", "testSrcJar"]
+            if (shouldPublishWithShadow) {
+              artifactTaskNames += "testFixturesJar"
+            }
+            artifactTaskNames.forEach { taskName ->
               def task = tasks.findByName(taskName)
               if (task != null)
                 artifact task


### PR DESCRIPTION
See https://github.com/apache/kafka/pull/22201#issuecomment-4437144149 . This change add `testFixturesJar` to the published artifacts.