### PR TITLE
KAFKA-20145: Avoid redundant partial HB acks from network-thread reconcile

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -806,8 +806,14 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
      *    are missing from the target assignment.
      *
      * @param canCommit Controls whether reconciliation can proceed when auto-commit is enabled.
-     *                  Set to true only when the current offset positions are safe to commit.
-     *                  If false and auto-commit enabled, the reconciliation will be skipped.
+     *                  {@code true} when invoked from the consumer poll path (offsets are ready to
+     *                  commit before rebalance); {@code false} from the network I/O poll only.
+     *                  If false and auto-commit enabled, full reconciliation that needs a commit
+     *                  is skipped.
+     *                  When false, the member will also not take the partial-reconciliation path that
+     *                  only acknowledges a resolvable subset equal to the current assignment; that
+     *                  path is reserved for attempts from the application poll ({@code true}) so the
+     *                  network poll loop does not emit redundant heartbeats.
      */
     public void maybeReconcile(boolean canCommit) {
         if (state != MemberState.RECONCILING) {
@@ -831,6 +837,13 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
         final LocalAssignment resolvedAssignment = new LocalAssignment(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
         if (!currentAssignment.isNone() && resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
+            if (!canCommit) {
+                log.trace("Deferring partial acknowledgement while topic ids are unresolved; resolvable " +
+                    "fragment equals current assignment {}. Will retry when reconciliation runs during " +
+                    "consumer.poll().",
+                    resolvedAssignment.partitions);
+                return;
+            }
             log.debug("There are unresolved partitions, and the resolvable fragment of the target assignment {} is equal to the current " +
                 "assignment. Bumping the local epoch of the assignment and acknowledging the partially resolved assignment",
                 resolvedAssignment.partitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractMembershipManager.java
@@ -805,15 +805,12 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
      *  - There are topics that haven't been added to the current assignment yet, but all their topic IDs
      *    are missing from the target assignment.
      *
-     * @param canCommit Controls whether reconciliation can proceed when auto-commit is enabled.
-     *                  {@code true} when invoked from the consumer poll path (offsets are ready to
-     *                  commit before rebalance); {@code false} from the network I/O poll only.
-     *                  If false and auto-commit enabled, full reconciliation that needs a commit
-     *                  is skipped.
-     *                  When false, the member will also not take the partial-reconciliation path that
-     *                  only acknowledges a resolvable subset equal to the current assignment; that
-     *                  path is reserved for attempts from the application poll ({@code true}) so the
-     *                  network poll loop does not emit redundant heartbeats.
+     * @param canCommit Controls whether reconciliation can proceed when auto-commit is enabled or
+     *                  there are partitions to revoke. Auto-commit and partition revocation can only
+     *                  be triggered on reconciliations initiated within a call to {@code consumer.poll()}.
+     *                  Set to {@code true} when invoked from the consumer poll path (offsets are safe to
+     *                  commit before rebalance); {@code false} from the background thread poll. If
+     *                  {@code false} and either condition applies, the reconciliation will be skipped.
      */
     public void maybeReconcile(boolean canCommit) {
         if (state != MemberState.RECONCILING) {
@@ -837,11 +834,7 @@ public abstract class AbstractMembershipManager<R extends AbstractResponse> impl
         final LocalAssignment resolvedAssignment = new LocalAssignment(currentTargetAssignment.localEpoch, assignedTopicIdPartitions);
 
         if (!currentAssignment.isNone() && resolvedAssignment.partitions.equals(currentAssignment.partitions)) {
-            if (!canCommit) {
-                log.trace("Deferring partial acknowledgement while topic ids are unresolved; resolvable " +
-                    "fragment equals current assignment {}. Will retry when reconciliation runs during " +
-                    "consumer.poll().",
-                    resolvedAssignment.partitions);
+            if (currentAssignment.localEpoch == resolvedAssignment.localEpoch) {
                 return;
             }
             log.debug("There are unresolved partitions, and the resolvable fragment of the target assignment {} is equal to the current " +

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
@@ -824,8 +824,6 @@ public class ConsumerMembershipManagerTest {
         membershipManager.onHeartbeatSuccess(createConsumerGroupHeartbeatResponse(assignment1, membershipManager.memberId()));
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         membershipManager.maybeReconcile(false);
-        assertEquals(MemberState.RECONCILING, membershipManager.state());
-        membershipManager.maybeReconcile(true);
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(Collections.singletonMap(topic1, mkSortedSet(0)), membershipManager.currentAssignment().partitions);
@@ -966,8 +964,10 @@ public class ConsumerMembershipManagerTest {
 
     /**
      * When the resolvable subset of the target equals the current assignment but some topic ids
-     * remain unresolved, partial acknowledgement must not be driven solely by the network
-     * poll path ({@code maybeReconcile(false)}), to avoid redundant heartbeats.
+     * remain unresolved, the partial acknowledgement must fire exactly once per target epoch -
+     * regardless of which thread invokes maybeReconcile. The first attempt (background or
+     * foreground) acks the resolvable fragment; subsequent attempts must stay in RECONCILING
+     * to avoid emitting redundant heartbeats.
      */
     @Test
     public void testPartialAckNotRepeatedOnBackgroundReconcileWhenMetadataMissing() {
@@ -988,18 +988,22 @@ public class ConsumerMembershipManagerTest {
         Map<Uuid, SortedSet<Integer>> newAssignment = Map.of(topicId1, mkSortedSet(0), topicId2, mkSortedSet(0));
         receiveAssignment(newAssignment, membershipManager);
 
-        for (int i = 0; i < 5; i++) {
-            membershipManager.maybeReconcile(false);
-            assertEquals(MemberState.RECONCILING, membershipManager.state());
-            assertNotEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
-        }
-
-        membershipManager.maybeReconcile(true);
+        // First reconcile from the background thread acks the resolvable fragment, no need to wait for consumer.poll.
+        membershipManager.maybeReconcile(false);
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
 
         membershipManager.onHeartbeatRequestGenerated();
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());
+
+        // Until a new target arrives or new metadata resolves topicId2, further reconciles from either
+        // thread must stay in RECONCILING - no redundant acks.
+        for (int i = 0; i < 5; i++) {
+            membershipManager.maybeReconcile(false);
+            assertEquals(MemberState.RECONCILING, membershipManager.state());
+            membershipManager.maybeReconcile(true);
+            assertEquals(MemberState.RECONCILING, membershipManager.state());
+        }
     }
 
     // Tests the case where topic metadata is not available at the time of the assignment,
@@ -1032,9 +1036,6 @@ public class ConsumerMembershipManagerTest {
 
         receiveAssignment(newAssignment, membershipManager);
         membershipManager.maybeReconcile(false);
-        assertEquals(MemberState.RECONCILING, membershipManager.state());
-
-        membershipManager.maybeReconcile(true);
         // No full reconciliation triggered, but assignment needs to be acknowledged.
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         assertTrue(membershipManager.shouldHeartbeatNow());
@@ -1044,7 +1045,7 @@ public class ConsumerMembershipManagerTest {
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());
-        verify(metadata, times(2)).requestUpdate(anyBoolean());
+        verify(metadata).requestUpdate(anyBoolean());
         clearInvocations(membershipManager, commitRequestManager);
 
         // Metadata discovered for topic2. Should trigger reconciliation to complete the assignment,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMembershipManagerTest.java
@@ -824,6 +824,8 @@ public class ConsumerMembershipManagerTest {
         membershipManager.onHeartbeatSuccess(createConsumerGroupHeartbeatResponse(assignment1, membershipManager.memberId()));
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         membershipManager.maybeReconcile(false);
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
+        membershipManager.maybeReconcile(true);
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(Collections.singletonMap(topic1, mkSortedSet(0)), membershipManager.currentAssignment().partitions);
@@ -962,6 +964,44 @@ public class ConsumerMembershipManagerTest {
         verifyReconciliationTriggeredAndCompleted(membershipManager, Arrays.asList(topicId1Partition0, topicId2Partition0));
     }
 
+    /**
+     * When the resolvable subset of the target equals the current assignment but some topic ids
+     * remain unresolved, partial acknowledgement must not be driven solely by the network
+     * poll path ({@code maybeReconcile(false)}), to avoid redundant heartbeats.
+     */
+    @Test
+    public void testPartialAckNotRepeatedOnBackgroundReconcileWhenMetadataMissing() {
+        Uuid topicId1 = Uuid.randomUuid();
+        String topic1 = "topic1";
+        final TopicIdPartition topicId1Partition0 = new TopicIdPartition(topicId1, new TopicPartition(topic1, 0));
+
+        Uuid topicId2 = Uuid.randomUuid();
+
+        ConsumerMembershipManager membershipManager =
+            mockMemberSuccessfullyReceivesAndAcksAssignment(topicId1, topic1, Collections.singletonList(0));
+
+        membershipManager.onHeartbeatRequestGenerated();
+        assertEquals(MemberState.STABLE, membershipManager.state());
+        when(subscriptionState.assignedPartitions()).thenReturn(getTopicPartitions(Collections.singleton(topicId1Partition0)));
+        clearInvocations(membershipManager, subscriptionState);
+
+        Map<Uuid, SortedSet<Integer>> newAssignment = Map.of(topicId1, mkSortedSet(0), topicId2, mkSortedSet(0));
+        receiveAssignment(newAssignment, membershipManager);
+
+        for (int i = 0; i < 5; i++) {
+            membershipManager.maybeReconcile(false);
+            assertEquals(MemberState.RECONCILING, membershipManager.state());
+            assertNotEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+        }
+
+        membershipManager.maybeReconcile(true);
+        assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
+
+        membershipManager.onHeartbeatRequestGenerated();
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
+        assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());
+    }
+
     // Tests the case where topic metadata is not available at the time of the assignment,
     // but is made available later.
     @Test
@@ -992,7 +1032,9 @@ public class ConsumerMembershipManagerTest {
 
         receiveAssignment(newAssignment, membershipManager);
         membershipManager.maybeReconcile(false);
+        assertEquals(MemberState.RECONCILING, membershipManager.state());
 
+        membershipManager.maybeReconcile(true);
         // No full reconciliation triggered, but assignment needs to be acknowledged.
         assertEquals(MemberState.ACKNOWLEDGING, membershipManager.state());
         assertTrue(membershipManager.shouldHeartbeatNow());
@@ -1002,7 +1044,7 @@ public class ConsumerMembershipManagerTest {
         verifyReconciliationNotTriggered(membershipManager);
         assertEquals(MemberState.RECONCILING, membershipManager.state());
         assertEquals(Collections.singleton(topicId2), membershipManager.topicsAwaitingReconciliation());
-        verify(metadata).requestUpdate(anyBoolean());
+        verify(metadata, times(2)).requestUpdate(anyBoolean());
         clearInvocations(membershipManager, commitRequestManager);
 
         // Metadata discovered for topic2. Should trigger reconciliation to complete the assignment,


### PR DESCRIPTION
We were partial-acking the same assignment over and over because
maybeReconcile(false) runs on every network poll. If some topic IDs
still could not be resolved but the rest matched what we already had,
we’d flip to ACKNOWLEDGING each time for no real change.

Now we only take that partial-ack shortcut when maybeReconcile(true)
runs (the normal consumer poll() path). Background poll can still
reconcile when it’s safe, but it won’t keep acking the same partial
snapshot.

Tests updated + a small regression test for the “many
maybeReconcile(false) in a row” case.

Reviewer @lianetm

Reviewers: Lianet Magrans <lmagrans@confluent.io>
