### PR TITLE
MINOR: Fix Streams query result Javadocs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/QueryResult.java
@@ -147,7 +147,7 @@ public interface QueryResult<R> {
      * Returns the result of executing the query on one partition. The result type is determined by
      * the query. Note: queries may choose to return {@code null} for a successful query, so {@link
      * #isSuccess()} and {@link #isFailure()} must be used to determine whether the query
-     * was successful of failed on this partition.
+     * was successful or failed on this partition.
      *
      * @throws IllegalArgumentException if this is not a successful query.
      */

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/FailedQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/FailedQueryResult.java
@@ -77,7 +77,7 @@ public final class FailedQueryResult<R>
      * Returns the result of executing the query on one partition. The result type is determined by
      * the query. Note: queries may choose to return {@code null} for a successful query, so {@link
      * this#isSuccess()} and {@link this#isFailure()} must be used to determine whether the query
-     * was successful of failed on this partition.
+     * was successful or failed on this partition.
      *
      * @throws IllegalArgumentException if this is not a successful query.
      */

--- a/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/internals/SucceededQueryResult.java
@@ -92,7 +92,7 @@ public final class SucceededQueryResult<R>
      * Returns the result of executing the query on one partition. The result type is determined by
      * the query. Note: queries may choose to return {@code null} for a successful query, so {@link
      * this#isSuccess()} and {@link this#isFailure()} must be used to determine whether the query
-     * was successful of failed on this partition.
+     * was successful or failed on this partition.
      *
      * @throws IllegalArgumentException if this is not a successful query.
      */


### PR DESCRIPTION
## What changed

Fixed a small typo in three Kafka Streams query result Javadocs, changing "successful of failed" to "successful or failed".

## Why

The existing wording is grammatically incorrect in public Streams query result documentation.

## How tested

- Ran `rg -n "was successful of failed|was successful or failed" streams/src/main/java/org/apache/kafka/streams/query -S`
- Ran `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :streams:javadoc --no-daemon`

I confirm this contribution is my original work and I license it to the project under the project open source license.