### PR TITLE
MINOR: Fix delegation token docs typo

### DIFF
--- a/docs/security/authentication-using-sasl.md
+++ b/docs/security/authentication-using-sasl.md
@@ -810,7 +810,7 @@ Tokens can also be cancelled explicitly. If a token is not renewed by the tokenâ
 
 #### Creating Delegation Tokens
 
-Tokens can be created by using Admin APIs or using `kafka-delegation-tokens.sh` script. Delegation token requests (create/renew/expire/describe) should be issued only on SASL or SSL authenticated channels. Tokens can not be requests if the initial authentication is done through delegation token. A token can be created by the user for that user or others as well by specifying the `--owner-principal` parameter. Owner/Renewers can renew or expire tokens. Owner/renewers can always describe their own tokens. To describe other tokens, a DESCRIBE_TOKEN permission needs to be added on the User resource representing the owner of the token. `kafka-delegation-tokens.sh` script examples are given below.
+Tokens can be created by using Admin APIs or using `kafka-delegation-tokens.sh` script. Delegation token requests (create/renew/expire/describe) should be issued only on SASL or SSL authenticated channels. Tokens cannot be requested if the initial authentication is done through delegation token. A token can be created by the user for that user or others as well by specifying the `--owner-principal` parameter. Owners/renewers can renew or expire tokens. Owner/renewers can always describe their own tokens. To describe other tokens, a DESCRIBE_TOKEN permission needs to be added on the User resource representing the owner of the token. `kafka-delegation-tokens.sh` script examples are given below.
 
 Create a delegation token: 
 


### PR DESCRIPTION
## What changed

Fixed a typo in the SASL delegation token documentation, changing
"Tokens can not be requests" to "Tokens cannot be requested".

## Why

The existing sentence is grammatically incorrect in the user-facing
security documentation.

## How tested

- Ran `rg -n "Tokens can not be requests|Tokens cannot be requested"
docs/security/authentication-using-sasl.md`
- Ran `git diff --check -- docs/security/authentication-using-sasl.md`

This is a documentation-only change, so no unit tests were run.

I confirm this contribution is my original work and I license it to the
project under the project open source license.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
