### PR TITLE
KAFKA-20545: Fix flaky MirrorConnectorsIntegrationSSLTest testConnectorMetrics* tests

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -1036,7 +1036,6 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     private void testConnectorMetrics(String format, Supplier<Boolean> assertions) throws InterruptedException, ExecutionException {
-        CollectAllMetricsReporter.METRICS.clear();
         // one way replication from primary to backup
         mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
         if (format != null) {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -287,6 +287,8 @@ public class MirrorConnectorsIntegrationBaseTest {
             } finally {
                 Exit.resetExitProcedure();
                 Exit.resetHaltProcedure();
+                // Shared by all CollectAllMetricsReporter instances; avoid cross-test accumulation.
+                CollectAllMetricsReporter.METRICS.clear();
             }
         }
     }
@@ -1034,6 +1036,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     private void testConnectorMetrics(String format, Supplier<Boolean> assertions) throws InterruptedException, ExecutionException {
+        CollectAllMetricsReporter.METRICS.clear();
         // one way replication from primary to backup
         mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
         if (format != null) {
@@ -1627,6 +1630,11 @@ public class MirrorConnectorsIntegrationBaseTest {
         @Override
         public void metricChange(KafkaMetric metric) {
             METRICS.put(metric.metricName(), metric);
+        }
+
+        @Override
+        public void metricRemoval(KafkaMetric metric) {
+            METRICS.remove(metric.metricName());
         }
     }
 }


### PR DESCRIPTION
Clear the static `CollectAllMetricsReporter.METRICS` map in `@AfterEach`
and at the start of `testConnectorMetrics` so metric counts are not
polluted by prior tests in the same JVM.

Fixes flaky failures where `assertMetrics` never reached the expected
156 source / 4 checkpoint metrics and `waitForCondition` timed out with
"Unable to find the MirrorMaker metrics".

Reviewers: Mickael Maison <mickael.maison@gmail.com>, Murali Basani
 <muralidhar.basani@aiven.io>
