### PR TITLE
MINOR: Prevent this leak while DefaultStatePersister construction.

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -24,6 +24,7 @@ import kafka.network.SocketServer
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata._
 import kafka.server.share.{ShareCoordinatorMetadataCacheHelperImpl, SharePartitionManager}
+import org.apache.kafka.clients.KafkaClient
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.internals.Plugin
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -53,7 +54,7 @@ import org.apache.kafka.server.log.remote.metadata.storage.BrokerReadyCallback
 import org.apache.kafka.server.log.remote.storage.{RemoteLogManager, RemoteLogManagerConfig}
 import org.apache.kafka.server.metrics.{ClientTelemetryExporterPlugin, KafkaYammerMetrics}
 import org.apache.kafka.server.network.{EndpointReadyFutures, KafkaAuthorizerServerInfo}
-import org.apache.kafka.server.share.persister.{DefaultStatePersister, NoOpStatePersister, Persister, PersisterStateManager}
+import org.apache.kafka.server.share.persister.{DefaultStatePersister, NoOpStatePersister, Persister, ShareCoordinatorMetadataCacheHelper}
 import org.apache.kafka.server.share.session.ShareSessionCache
 import org.apache.kafka.server.util.timer.{SystemTimer, SystemTimerReaper, Timer}
 import org.apache.kafka.server.util.{Deadline, FutureUtils, KafkaScheduler, NetworkPartitionMetadataClient, PartitionMetadataClient}
@@ -725,13 +726,13 @@ class BrokerServer(
     if (config.shareGroupConfig.shareGroupPersisterClassName.nonEmpty) {
       val klass = Utils.loadClass(config.shareGroupConfig.shareGroupPersisterClassName, classOf[Object]).asInstanceOf[Class[Persister]]
       if (klass.getName.equals(classOf[DefaultStatePersister].getName)) {
-        klass.getDeclaredMethod("instance", classOf[PersisterStateManager])
-          .invoke(null, new PersisterStateManager(
+        klass.getDeclaredMethod("instance", classOf[KafkaClient], classOf[ShareCoordinatorMetadataCacheHelper], classOf[Time], classOf[Timer])
+          .invoke(null,
             NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
             new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager),
             Time.SYSTEM,
             shareGroupTimer
-          )).asInstanceOf[Persister]
+          ).asInstanceOf[Persister]
       } else if (klass.getName.equals(classOf[NoOpStatePersister].getName)) {
         info("Using no-op persister")
         new NoOpStatePersister()

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -724,17 +724,14 @@ class BrokerServer(
   private def createShareStatePersister(): Persister = {
     if (config.shareGroupConfig.shareGroupPersisterClassName.nonEmpty) {
       val klass = Utils.loadClass(config.shareGroupConfig.shareGroupPersisterClassName, classOf[Object]).asInstanceOf[Class[Persister]]
-
       if (klass.getName.equals(classOf[DefaultStatePersister].getName)) {
-        klass.getConstructor(classOf[PersisterStateManager])
-          .newInstance(
-            new PersisterStateManager(
-              NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
-              new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager),
-              Time.SYSTEM,
-              shareGroupTimer
-            )
-          )
+        klass.getDeclaredMethod("instance", classOf[PersisterStateManager])
+          .invoke(null, new PersisterStateManager(
+            NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
+            new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager),
+            Time.SYSTEM,
+            shareGroupTimer
+          )).asInstanceOf[Persister]
       } else if (klass.getName.equals(classOf[NoOpStatePersister].getName)) {
         info("Using no-op persister")
         new NoOpStatePersister()

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -24,7 +24,6 @@ import kafka.network.SocketServer
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata._
 import kafka.server.share.{ShareCoordinatorMetadataCacheHelperImpl, SharePartitionManager}
-import org.apache.kafka.clients.KafkaClient
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.internals.Plugin
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -54,7 +53,7 @@ import org.apache.kafka.server.log.remote.metadata.storage.BrokerReadyCallback
 import org.apache.kafka.server.log.remote.storage.{RemoteLogManager, RemoteLogManagerConfig}
 import org.apache.kafka.server.metrics.{ClientTelemetryExporterPlugin, KafkaYammerMetrics}
 import org.apache.kafka.server.network.{EndpointReadyFutures, KafkaAuthorizerServerInfo}
-import org.apache.kafka.server.share.persister.{DefaultStatePersister, NoOpStatePersister, Persister, ShareCoordinatorMetadataCacheHelper}
+import org.apache.kafka.server.share.persister.{DefaultStatePersister, NoOpStatePersister, Persister}
 import org.apache.kafka.server.share.session.ShareSessionCache
 import org.apache.kafka.server.util.timer.{SystemTimer, SystemTimerReaper, Timer}
 import org.apache.kafka.server.util.{Deadline, FutureUtils, KafkaScheduler, NetworkPartitionMetadataClient, PartitionMetadataClient}
@@ -726,13 +725,12 @@ class BrokerServer(
     if (config.shareGroupConfig.shareGroupPersisterClassName.nonEmpty) {
       val klass = Utils.loadClass(config.shareGroupConfig.shareGroupPersisterClassName, classOf[Object]).asInstanceOf[Class[Persister]]
       if (klass.getName.equals(classOf[DefaultStatePersister].getName)) {
-        klass.getDeclaredMethod("instance", classOf[KafkaClient], classOf[ShareCoordinatorMetadataCacheHelper], classOf[Time], classOf[Timer])
-          .invoke(null,
-            NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
-            new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager),
-            Time.SYSTEM,
-            shareGroupTimer
-          ).asInstanceOf[Persister]
+        DefaultStatePersister.instance(
+          NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
+          new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager),
+          Time.SYSTEM,
+          shareGroupTimer
+        )
       } else if (klass.getName.equals(classOf[NoOpStatePersister].getName)) {
         info("Using no-op persister")
         new NoOpStatePersister()

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.server.share.persister;
 
+import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DeleteShareGroupStateResponse;
@@ -24,6 +25,8 @@ import org.apache.kafka.common.requests.InitializeShareGroupStateResponse;
 import org.apache.kafka.common.requests.ReadShareGroupStateResponse;
 import org.apache.kafka.common.requests.ReadShareGroupStateSummaryResponse;
 import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.util.timer.Timer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,12 +48,24 @@ public class DefaultStatePersister implements Persister {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultStatePersister.class);
 
-    public static DefaultStatePersister instance(PersisterStateManager stateManager) {
+    public static DefaultStatePersister instance(KafkaClient client, ShareCoordinatorMetadataCacheHelper cacheHelper, Time time, Timer timer) {
+        DefaultStatePersister instance = new DefaultStatePersister(client, cacheHelper, time, timer);
+        instance.start();
+        return instance;
+    }
+
+    // Visibility for tests
+    static DefaultStatePersister instance(PersisterStateManager stateManager) {
         DefaultStatePersister instance = new DefaultStatePersister(stateManager);
         instance.start();
         return instance;
     }
 
+    private DefaultStatePersister(KafkaClient client, ShareCoordinatorMetadataCacheHelper cacheHelper, Time time, Timer timer) {
+        this.stateManager = new PersisterStateManager(client, cacheHelper, time, timer);
+    }
+
+    // For testing purpose only
     private DefaultStatePersister(PersisterStateManager stateManager) {
         this.stateManager = stateManager;
     }

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -45,8 +45,17 @@ public class DefaultStatePersister implements Persister {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultStatePersister.class);
 
-    public DefaultStatePersister(PersisterStateManager stateManager) {
+    public static DefaultStatePersister instance(PersisterStateManager stateManager) {
+        DefaultStatePersister instance = new DefaultStatePersister(stateManager);
+        instance.start();
+        return instance;
+    }
+
+    private DefaultStatePersister(PersisterStateManager stateManager) {
         this.stateManager = stateManager;
+    }
+
+    private void start() {
         this.stateManager.start();
     }
 

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public class DefaultStatePersister implements Persister {
     private final PersisterStateManager stateManager;
-
     private static final Logger log = LoggerFactory.getLogger(DefaultStatePersister.class);
 
     public static DefaultStatePersister instance(KafkaClient client, ShareCoordinatorMetadataCacheHelper cacheHelper, Time time, Timer timer) {
@@ -55,19 +54,12 @@ public class DefaultStatePersister implements Persister {
     }
 
     // Visibility for tests
-    static DefaultStatePersister instance(PersisterStateManager stateManager) {
-        DefaultStatePersister instance = new DefaultStatePersister(stateManager);
-        instance.start();
-        return instance;
+    DefaultStatePersister(PersisterStateManager stateManager) {
+        this.stateManager = stateManager;
     }
 
     private DefaultStatePersister(KafkaClient client, ShareCoordinatorMetadataCacheHelper cacheHelper, Time time, Timer timer) {
         this.stateManager = new PersisterStateManager(client, cacheHelper, time, timer);
-    }
-
-    // For testing purpose only
-    private DefaultStatePersister(PersisterStateManager stateManager) {
-        this.stateManager = stateManager;
     }
 
     private void start() {

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -106,8 +106,7 @@ class DefaultStatePersisterTest {
         }
 
         public DefaultStatePersister build() {
-            PersisterStateManager persisterStateManager = new PersisterStateManager(client, cacheHelper, time, timer);
-            return DefaultStatePersister.instance(persisterStateManager);
+            return DefaultStatePersister.instance(client, cacheHelper, time, timer);
         }
     }
 

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -107,7 +107,7 @@ class DefaultStatePersisterTest {
 
         public DefaultStatePersister build() {
             PersisterStateManager persisterStateManager = new PersisterStateManager(client, cacheHelper, time, timer);
-            return new DefaultStatePersister(persisterStateManager);
+            return DefaultStatePersister.instance(persisterStateManager);
         }
     }
 
@@ -200,7 +200,7 @@ class DefaultStatePersisterTest {
                 .setGroupId(groupId)
                 .setTopicsData(List.of(new TopicData<>(topicId,
                     List.of(PartitionFactory.newPartitionStateBatchData(
-                        incorrectPartition, 1, 0, 0,  0, null))))).build()).build());
+                        incorrectPartition, 1, 0, 0, 0, null))))).build()).build());
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
         assertFutureThrows(IllegalArgumentException.class, result);
@@ -1243,7 +1243,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         WriteShareGroupStateResult results = dsp.writeResponsesToResult(futureMap);
 
@@ -1290,7 +1290,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         WriteShareGroupStateResult results = dsp.writeResponsesToResult(futureMap);
 
@@ -1350,7 +1350,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         ReadShareGroupStateResult results = dsp.readResponsesToResult(futureMap);
 
@@ -1400,7 +1400,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         ReadShareGroupStateResult results = dsp.readResponsesToResult(futureMap);
 
@@ -1461,7 +1461,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         ReadShareGroupStateSummaryResult results = dsp.readSummaryResponsesToResult(futureMap);
 
@@ -1512,7 +1512,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         ReadShareGroupStateSummaryResult results = dsp.readSummaryResponsesToResult(futureMap);
 
@@ -1569,7 +1569,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         DeleteShareGroupStateResult results = dsp.deleteResponsesToResult(futureMap);
 
@@ -1612,7 +1612,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         DeleteShareGroupStateResult results = dsp.deleteResponsesToResult(futureMap);
 
@@ -1663,7 +1663,7 @@ class DefaultStatePersisterTest {
         ));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         InitializeShareGroupStateResult results = dsp.initializeResponsesToResult(futureMap);
 
@@ -1707,7 +1707,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
 
         InitializeShareGroupStateResult results = dsp.initializeResponsesToResult(futureMap);
 
@@ -1734,7 +1734,7 @@ class DefaultStatePersisterTest {
     @Test
     public void testDefaultPersisterClose() {
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = new DefaultStatePersister(psm);
+        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
         try {
             verify(psm, times(0)).stop();
 

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/DefaultStatePersisterTest.java
@@ -1242,7 +1242,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         WriteShareGroupStateResult results = dsp.writeResponsesToResult(futureMap);
 
@@ -1289,7 +1289,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         WriteShareGroupStateResult results = dsp.writeResponsesToResult(futureMap);
 
@@ -1349,7 +1349,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         ReadShareGroupStateResult results = dsp.readResponsesToResult(futureMap);
 
@@ -1399,7 +1399,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         ReadShareGroupStateResult results = dsp.readResponsesToResult(futureMap);
 
@@ -1460,7 +1460,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         ReadShareGroupStateSummaryResult results = dsp.readSummaryResponsesToResult(futureMap);
 
@@ -1511,7 +1511,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         ReadShareGroupStateSummaryResult results = dsp.readSummaryResponsesToResult(futureMap);
 
@@ -1568,7 +1568,7 @@ class DefaultStatePersisterTest {
             );
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         DeleteShareGroupStateResult results = dsp.deleteResponsesToResult(futureMap);
 
@@ -1611,7 +1611,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         DeleteShareGroupStateResult results = dsp.deleteResponsesToResult(futureMap);
 
@@ -1662,7 +1662,7 @@ class DefaultStatePersisterTest {
         ));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         InitializeShareGroupStateResult results = dsp.initializeResponsesToResult(futureMap);
 
@@ -1706,7 +1706,7 @@ class DefaultStatePersisterTest {
             .put(tp2.partition(), CompletableFuture.failedFuture(new Exception("scary stuff")));
 
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
 
         InitializeShareGroupStateResult results = dsp.initializeResponsesToResult(futureMap);
 
@@ -1733,7 +1733,7 @@ class DefaultStatePersisterTest {
     @Test
     public void testDefaultPersisterClose() {
         PersisterStateManager psm = mock(PersisterStateManager.class);
-        DefaultStatePersister dsp = DefaultStatePersister.instance(psm);
+        DefaultStatePersister dsp = new DefaultStatePersister(psm);
         try {
             verify(psm, times(0)).stop();
 


### PR DESCRIPTION
* Currently `DefaultStatePersister` instantiates `PersisterStateManager`
in its constructor. This implies that the `this` creation is not yet
complete and initializing another component.
* To remedy this the public API constructor is replaced with static
factory method.
* Tests and `BrokerServer` code has been updated to reflect the change.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
