### PR TITLE
KAFKA-19790: Parse space-delimited OAuth scope claim strings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -225,7 +224,7 @@ public class BrokerJwtValidator implements JwtValidator {
         if (scopeRaw instanceof String) {
             String scopeRawString = (String) scopeRaw;
             scopeRawCollection = scopeRawString.trim().isEmpty()
-                ? Collections.singletonList(scopeRawString)
+                ? List.of()
                 : OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim(scopeRawString);
         } else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.security.oauthbearer;
 
 import org.apache.kafka.common.annotation.InterfaceAudience;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerScopeClaimUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ClaimValidationUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableVerificationKeyResolver;
@@ -221,7 +222,7 @@ public class BrokerJwtValidator implements JwtValidator {
         Collection<String> scopeRawCollection;
 
         if (scopeRaw instanceof String)
-            scopeRawCollection = List.of((String) scopeRaw);
+            scopeRawCollection = OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim((String) scopeRaw);
         else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;
         else

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -221,9 +222,12 @@ public class BrokerJwtValidator implements JwtValidator {
         Object scopeRaw = getClaim(() -> claims.getClaimValue(scopeClaimName), scopeClaimName);
         Collection<String> scopeRawCollection;
 
-        if (scopeRaw instanceof String)
-            scopeRawCollection = OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim((String) scopeRaw);
-        else if (scopeRaw instanceof Collection)
+        if (scopeRaw instanceof String) {
+            String scopeRawString = (String) scopeRaw;
+            scopeRawCollection = scopeRawString.trim().isEmpty()
+                ? Collections.singletonList(scopeRawString)
+                : OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim(scopeRawString);
+        } else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;
         else
             scopeRawCollection = Set.of();

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,9 +109,12 @@ public class ClientJwtValidator implements JwtValidator {
         Object scopeRaw = getClaim(payload, scopeClaimName);
         Collection<String> scopeRawCollection;
 
-        if (scopeRaw instanceof String)
-            scopeRawCollection = OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim((String) scopeRaw);
-        else if (scopeRaw instanceof Collection)
+        if (scopeRaw instanceof String) {
+            String scopeRawString = (String) scopeRaw;
+            scopeRawCollection = scopeRawString.trim().isEmpty()
+                ? Collections.singletonList(scopeRawString)
+                : OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim(scopeRawString);
+        } else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;
         else
             scopeRawCollection = Set.of();

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,7 +111,7 @@ public class ClientJwtValidator implements JwtValidator {
         if (scopeRaw instanceof String) {
             String scopeRawString = (String) scopeRaw;
             scopeRawCollection = scopeRawString.trim().isEmpty()
-                ? Collections.singletonList(scopeRawString)
+                ? List.of()
                 : OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim(scopeRawString);
         } else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidator.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.security.oauthbearer;
 
 import org.apache.kafka.common.annotation.InterfaceAudience;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerScopeClaimUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ClaimValidationUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
@@ -108,7 +109,7 @@ public class ClientJwtValidator implements JwtValidator {
         Collection<String> scopeRawCollection;
 
         if (scopeRaw instanceof String)
-            scopeRawCollection = List.of((String) scopeRaw);
+            scopeRawCollection = OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim((String) scopeRaw);
         else if (scopeRaw instanceof Collection)
             scopeRawCollection = (Collection<String>) scopeRaw;
         else

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtils.java
@@ -31,7 +31,7 @@ public final class OAuthBearerScopeClaimUtils {
     public static List<String> parseSpaceDelimitedScopeClaim(String scopeClaim) {
         String trimmedScopeClaim = scopeClaim.trim();
         if (trimmedScopeClaim.isEmpty())
-            return List.of(scopeClaim);
+            return List.of();
 
         return Arrays.asList(trimmedScopeClaim.split(" +"));
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer.internals;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class OAuthBearerScopeClaimUtils {
+
+    private OAuthBearerScopeClaimUtils() {
+    }
+
+    /**
+     * Splits string-valued OAuth scope claims into RFC 6749 space-delimited scope tokens.
+     */
+    public static List<String> parseSpaceDelimitedScopeClaim(String scopeClaim) {
+        String trimmedScopeClaim = scopeClaim.trim();
+        if (trimmedScopeClaim.isEmpty())
+            return List.of(scopeClaim);
+
+        return Arrays.asList(trimmedScopeClaim.split(" +"));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJws.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJws.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerScopeClaimUtils;
 import org.apache.kafka.common.utils.Utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -345,10 +346,9 @@ public class OAuthBearerUnsecuredJws implements OAuthBearerToken {
         if (isClaimType(scopeClaimName, String.class)) {
             String scopeClaimValue = claim(scopeClaimName, String.class);
             if (Utils.isBlank(scopeClaimValue))
-                return Set.of();
-            else {
-                return Set.of(scopeClaimValue.trim());
-            }
+                return Collections.emptySet();
+            else
+                return Collections.unmodifiableSet(new HashSet<>(OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim(scopeClaimValue)));
         }
         List<?> scopeClaimValue = claim(scopeClaimName, List.class);
         if (scopeClaimValue == null || scopeClaimValue.isEmpty())

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
@@ -314,11 +314,10 @@ public class BrokerJwtValidatorTest extends JwtValidatorTest {
     }
 
     @Test
-    public void testBlankSpaceDelimitedStringScopesRejected() {
-        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
-            () -> validateTokenWithScope("   "));
+    public void testBlankSpaceDelimitedStringScopesProduceEmptySet() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("   ");
 
-        assertErrorMessageContains(exception.getMessage(), "scope value must not contain only whitespace");
+        assertEquals(Set.of(), token.scope());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER;
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
@@ -283,6 +284,50 @@ public class BrokerJwtValidatorTest extends JwtValidatorTest {
                 SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE);
     }
 
+    @Test
+    public void testSpaceDelimitedStringScopesProcessedAccordingToRfc8693() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("email profile phone address");
+
+        assertEquals(Set.of("email", "profile", "phone", "address"), token.scope());
+    }
+
+    @Test
+    public void testSpaceDelimitedStringScopesTrimmedAndCollapsed() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("   email   profile   phone   ");
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
+    @Test
+    public void testSpaceDelimitedStringScopesProcessedWithConfiguredScopeClaimName() throws Exception {
+        OAuthBearerToken token = validateTokenWithCustomScopeClaimName("scp", "email profile phone");
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
+    @Test
+    public void testDuplicateSpaceDelimitedStringScopesRejected() {
+        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
+            () -> validateTokenWithScope("email profile email"));
+
+        assertErrorMessageContains(exception.getMessage(), "scope value must not contain duplicates");
+    }
+
+    @Test
+    public void testBlankSpaceDelimitedStringScopesRejected() {
+        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
+            () -> validateTokenWithScope("   "));
+
+        assertErrorMessageContains(exception.getMessage(), "scope value must not contain only whitespace");
+    }
+
+    @Test
+    public void testCollectionScopesStillProcessed() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope(List.of("email", "profile", "phone"));
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
     private void testEncryptionAlgorithm(PublicJsonWebKey jwk, String alg) throws Exception {
         AccessTokenBuilder builder = new AccessTokenBuilder().jwk(jwk).alg(alg)
                 .addCustomClaim("iss", EXPECTED_ISSUER).audience(EXPECTED_AUDIENCE);
@@ -298,6 +343,45 @@ public class BrokerJwtValidatorTest extends JwtValidatorTest {
         assertEquals(builder.issuedAtSeconds() * 1000, token.startTimeMs());
         assertEquals(builder.expirationSeconds() * 1000, token.lifetimeMs());
         assertEquals(1, token.scope().size());
+    }
+
+    private OAuthBearerToken validateTokenWithScope(Object scope) throws Exception {
+        PublicJsonWebKey jwk = createRsaJwk();
+        AccessTokenBuilder tokenBuilder = new AccessTokenBuilder()
+            .jwk(jwk)
+            .alg(AlgorithmIdentifiers.RSA_USING_SHA256)
+            .addCustomClaim("iss", EXPECTED_ISSUER)
+            .audience(EXPECTED_AUDIENCE)
+            .scope(scope);
+        JwtValidator validator = createJwtValidator(tokenBuilder);
+        validator.configure(getSaslConfigs(Map.of(
+            SASL_OAUTHBEARER_EXPECTED_ISSUER, EXPECTED_ISSUER,
+            SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, List.of(EXPECTED_AUDIENCE))),
+            OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+
+        return validator.validate(tokenBuilder.build());
+    }
+
+    private OAuthBearerToken validateTokenWithCustomScopeClaimName(String scopeClaimName, String scope) throws Exception {
+        PublicJsonWebKey jwk = createRsaJwk();
+        AccessTokenBuilder tokenBuilder = new AccessTokenBuilder()
+            .jwk(jwk)
+            .alg(AlgorithmIdentifiers.RSA_USING_SHA256)
+            .addCustomClaim("iss", EXPECTED_ISSUER)
+            .audience(EXPECTED_AUDIENCE)
+            .scope("engineering")
+            .addCustomClaim(scopeClaimName, scope);
+        JwtValidator validator = createJwtValidator(tokenBuilder);
+        validator.configure(
+            getSaslConfigs(Map.of(
+                SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, scopeClaimName,
+                SASL_OAUTHBEARER_EXPECTED_ISSUER, EXPECTED_ISSUER,
+                SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, List.of(EXPECTED_AUDIENCE))),
+            OAUTHBEARER_MECHANISM,
+            getJaasConfigEntries()
+        );
+
+        return validator.validate(tokenBuilder.build());
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
@@ -285,7 +285,7 @@ public class BrokerJwtValidatorTest extends JwtValidatorTest {
     }
 
     @Test
-    public void testSpaceDelimitedStringScopesProcessedAccordingToRfc8693() throws Exception {
+    public void testSpaceDelimitedStringScopesProcessedAccordingToRfc6749() throws Exception {
         OAuthBearerToken token = validateTokenWithScope("email profile phone address");
 
         assertEquals(Set.of("email", "profile", "phone", "address"), token.scope());

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
@@ -61,7 +61,7 @@ public class ClientJwtValidatorTest extends JwtValidatorTest {
     }
 
     @Test
-    void testSpaceDelimitedStringScopesProcessedAccordingToRfc8693() throws Exception {
+    void testSpaceDelimitedStringScopesProcessedAccordingToRfc6749() throws Exception {
         OAuthBearerToken token = validateTokenWithScope("email profile phone address");
 
         assertEquals(Set.of("email", "profile", "phone", "address"), token.scope());

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
@@ -17,15 +17,19 @@
 
 package org.apache.kafka.common.security.oauthbearer;
 
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenBuilder;
 import org.apache.kafka.common.utils.Utils;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
+import java.util.List;
+import java.util.Set;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClientJwtValidatorTest extends JwtValidatorTest {
@@ -54,5 +58,102 @@ public class ClientJwtValidatorTest extends JwtValidatorTest {
                 "Valid, URL-safe base 64-encoded JWT should be decodable"
             );
         }
+    }
+
+    @Test
+    void testSpaceDelimitedStringScopesProcessedAccordingToRfc8693() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("email profile phone address");
+
+        assertEquals(Set.of("email", "profile", "phone", "address"), token.scope());
+    }
+
+    @Test
+    void testSpaceDelimitedStringScopesTrimmedAndCollapsed() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("   email   profile   phone   ");
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
+    @Test
+    void testSpaceDelimitedStringScopesProcessedWithConfiguredScopeClaimName() throws Exception {
+        OAuthBearerToken token = validateTokenWithCustomScopeClaimName("scp", "email profile phone");
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
+    @Test
+    void testDuplicateSpaceDelimitedStringScopesRejected() {
+        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
+            () -> validateTokenWithScope("email profile email"));
+
+        assertErrorMessageContains(exception.getMessage(), "scope value must not contain duplicates");
+    }
+
+    @Test
+    void testBlankSpaceDelimitedStringScopesRejected() {
+        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
+            () -> validateTokenWithScope("   "));
+
+        assertErrorMessageContains(exception.getMessage(), "scope value must not contain only whitespace");
+    }
+
+    @Test
+    void testCollectionScopesStillProcessed() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope(List.of("email", "profile", "phone"));
+
+        assertEquals(Set.of("email", "profile", "phone"), token.scope());
+    }
+
+    private OAuthBearerToken validateTokenWithScope(Object scope) throws Exception {
+        JwtValidator validator = createJwtValidator();
+        validator.configure(getSaslConfigs(), OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+
+        return validator.validate(createJwtWithScope(scope));
+    }
+
+    private OAuthBearerToken validateTokenWithCustomScopeClaimName(String scopeClaimName, Object scope) throws Exception {
+        JwtValidator validator = createJwtValidator();
+        validator.configure(
+            getSaslConfigs(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, scopeClaimName),
+            OAUTHBEARER_MECHANISM,
+            getJaasConfigEntries()
+        );
+
+        return validator.validate(createJwtWithScopeClaimName(scopeClaimName, scope));
+    }
+
+    private String createJwtWithScope(Object scope) {
+        return createJwtWithScopeClaimName("scope", scope);
+    }
+
+    private String createJwtWithScopeClaimName(String scopeClaimName, Object scope) {
+        String defaultScopeJson = "scope".equals(scopeClaimName) ? "" : "\"scope\":\"engineering\",";
+        return createJwt(
+            "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
+            String.format(
+                "{\"sub\":\"jdoe\",\"exp\":60,\"iat\":0,%s\"%s\":%s}",
+                defaultScopeJson,
+                scopeClaimName,
+                scopeJson(scope)
+            ),
+            "dummysignature"
+        );
+    }
+
+    private String scopeJson(Object scope) {
+        if (scope instanceof String)
+            return "\"" + escapeJson((String) scope) + "\"";
+
+        @SuppressWarnings("unchecked")
+        List<String> scopes = (List<String>) scope;
+        return scopes.stream()
+            .map(scopeValue -> "\"" + escapeJson(scopeValue) + "\"")
+            .reduce((left, right) -> left + "," + right)
+            .map(scopeValues -> "[" + scopeValues + "]")
+            .orElse("[]");
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/ClientJwtValidatorTest.java
@@ -90,11 +90,10 @@ public class ClientJwtValidatorTest extends JwtValidatorTest {
     }
 
     @Test
-    void testBlankSpaceDelimitedStringScopesRejected() {
-        JwtValidatorException exception = assertThrows(JwtValidatorException.class,
-            () -> validateTokenWithScope("   "));
+    void testBlankSpaceDelimitedStringScopesProduceEmptySet() throws Exception {
+        OAuthBearerToken token = validateTokenWithScope("   ");
 
-        assertErrorMessageContains(exception.getMessage(), "scope value must not contain only whitespace");
+        assertEquals(Set.of(), token.scope());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtilsTest.java
@@ -50,7 +50,7 @@ public class OAuthBearerScopeClaimUtilsTest {
     }
 
     @Test
-    public void testParseSpaceDelimitedScopeClaimPreservesBlankClaimForCallerValidation() {
-        assertEquals(List.of("   "), OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("   "));
+    public void testParseSpaceDelimitedScopeClaimReturnsEmptyListForBlankClaim() {
+        assertEquals(List.of(), OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("   "));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerScopeClaimUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.oauthbearer.internals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OAuthBearerScopeClaimUtilsTest {
+
+    @Test
+    public void testParseSpaceDelimitedScopeClaimSplitsScopeClaim() {
+        assertEquals(List.of("email", "profile", "phone"),
+            OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("email profile phone"));
+    }
+
+    @Test
+    public void testParseSpaceDelimitedScopeClaimPreservesSingleScope() {
+        assertEquals(List.of("email"),
+            OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("email"));
+    }
+
+    @Test
+    public void testParseSpaceDelimitedScopeClaimTrimsClaimBeforeSplitting() {
+        assertEquals(List.of("email", "profile", "phone"),
+            OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("  email   profile   phone  "));
+    }
+
+    @Test
+    public void testParseSpaceDelimitedScopeClaimDoesNotEmitEmptyScopeItems() {
+        assertEquals(List.of("email", "profile", "phone"),
+            OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("email  profile     phone"));
+    }
+
+    @Test
+    public void testParseSpaceDelimitedScopeClaimPreservesBlankClaimForCallerValidation() {
+        assertEquals(List.of("   "), OAuthBearerScopeClaimUtils.parseSpaceDelimitedScopeClaim("   "));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
@@ -22,8 +22,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Base64.Encoder;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,6 +85,75 @@ public class OAuthBearerUnsecuredJwsTest {
     }
 
     @Test
+    public void validStringScopeCompactSerialization() {
+        String subject = "foo";
+        long issuedAt = 100;
+        long expirationTime = issuedAt + 60 * 60;
+        String scope = "email profile phone address";
+        String validCompactSerialization = compactSerializationWithStringScope(subject, issuedAt, expirationTime, scope);
+        OAuthBearerUnsecuredJws jws = new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+
+        assertEquals(scope, jws.claims().get("scope"));
+        assertEquals(Set.of("email", "profile", "phone", "address"), jws.scope());
+    }
+
+    @Test
+    public void validStringScopeCompactSerializationWithExtraSpaces() {
+        String subject = "foo";
+        long issuedAt = 100;
+        long expirationTime = issuedAt + 60 * 60;
+        String validCompactSerialization = compactSerializationWithStringScope(
+            subject,
+            issuedAt,
+            expirationTime,
+            "   email   profile   phone   "
+        );
+        OAuthBearerUnsecuredJws jws = new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+
+        assertEquals(Set.of("email", "profile", "phone"), jws.scope());
+    }
+
+    @Test
+    public void validStringScopeCompactSerializationWithCustomScopeClaimName() {
+        String subject = "foo";
+        long issuedAt = 100;
+        long expirationTime = issuedAt + 60 * 60;
+        String validCompactSerialization = compactSerializationWithStringScope(
+            subject,
+            issuedAt,
+            expirationTime,
+            "scp",
+            "email profile phone"
+        );
+        OAuthBearerUnsecuredJws jws = new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scp");
+
+        assertEquals("scp", jws.scopeClaimName());
+        assertEquals(Set.of("email", "profile", "phone"), jws.scope());
+    }
+
+    @Test
+    public void validStringScopeCompactSerializationReturnsUnmodifiableScope() {
+        String subject = "foo";
+        long issuedAt = 100;
+        long expirationTime = issuedAt + 60 * 60;
+        String validCompactSerialization = compactSerializationWithStringScope(subject, issuedAt, expirationTime, "email profile");
+        OAuthBearerUnsecuredJws jws = new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+
+        assertThrows(UnsupportedOperationException.class, () -> jws.scope().add("phone"));
+    }
+
+    @Test
+    public void blankStringScopeCompactSerialization() {
+        String subject = "foo";
+        long issuedAt = 100;
+        long expirationTime = issuedAt + 60 * 60;
+        String validCompactSerialization = compactSerializationWithStringScope(subject, issuedAt, expirationTime, "   ");
+        OAuthBearerUnsecuredJws jws = new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+
+        assertEquals(Collections.emptySet(), jws.scope());
+    }
+
+    @Test
     public void missingPrincipal() {
         String subject = null;
         long issuedAt = 100;
@@ -105,6 +176,24 @@ public class OAuthBearerUnsecuredJwsTest {
     }
 
     private static String compactSerialization(String subject, Long issuedAt, Long expirationTime, List<String> scope) {
+        return compactSerializationFromScopeJson(subject, issuedAt, expirationTime, scope != null ? scopeJson(scope) : null);
+    }
+
+    private static String compactSerializationWithStringScope(String subject, Long issuedAt, Long expirationTime, String scope) {
+        return compactSerializationWithStringScope(subject, issuedAt, expirationTime, "scope", scope);
+    }
+
+    private static String compactSerializationWithStringScope(
+        String subject,
+        Long issuedAt,
+        Long expirationTime,
+        String scopeClaimName,
+        String scope
+    ) {
+        return compactSerializationFromScopeJson(subject, issuedAt, expirationTime, scope != null ? stringScopeJson(scopeClaimName, scope) : null);
+    }
+
+    private static String compactSerializationFromScopeJson(String subject, Long issuedAt, Long expirationTime, String scopeJson) {
         Encoder encoder = Base64.getUrlEncoder().withoutPadding();
         String algorithm = "none";
         String headerJson = "{\"alg\":\"" + algorithm + "\"}";
@@ -112,7 +201,6 @@ public class OAuthBearerUnsecuredJwsTest {
         String subjectJson = subject != null ? "\"sub\":\"" + subject + "\"" : null;
         String issuedAtJson = issuedAt != null ? "\"iat\":" + issuedAt : null;
         String expirationTimeJson = expirationTime != null ? "\"exp\":" + expirationTime : null;
-        String scopeJson = scope != null ? scopeJson(scope) : null;
         String claimsJson = claimsJson(subjectJson, issuedAtJson, expirationTimeJson, scopeJson);
         String encodedClaims = encoder.encodeToString(claimsJson.getBytes(StandardCharsets.UTF_8));
         return encodedHeader + "." + encodedClaims + ".";
@@ -142,6 +230,14 @@ public class OAuthBearerUnsecuredJwsTest {
         }
         scopeJsonBuilder.append(']');
         return scopeJsonBuilder.toString();
+    }
+
+    private static String stringScopeJson(String scope) {
+        return stringScopeJson("scope", scope);
+    }
+
+    private static String stringScopeJson(String scopeClaimName, String scope) {
+        return "\"" + escape(scopeClaimName) + "\":\"" + escape(scope) + "\"";
     }
 
     private static void appendCommaJsonText(StringBuilder sb, String claimName, Number claimValue) {


### PR DESCRIPTION
### Summary
- Parse string-valued OAuth scope claims as space-delimited scope tokens
in broker and client JWT validators.
- Reuse the same parsing for unsecured JWS string scope claims.
- Treat whitespace-only string scope claims as an empty scope set rather
than emitting a blank scope token.
- Preserve existing behavior for collection-valued scope claims.

### Motivation
OAuth scope values are commonly represented as a space-delimited string
such as `email profile phone`. Previously, the secured validators
wrapped a string-valued scope claim as a single collection item, so
Kafka treated that example as one scope instead of three. This patch
normalizes only string-valued scope claims before the existing
validation path.

A blank string contains no RFC 6749 scope-token. The validators now
normalize it to an empty set, consistent with the parser and unsecured
JWS path.

### Testing
- `./gradlew :clients:unitTest --tests
org.apache.kafka.common.security.oauthbearer.BrokerJwtValidatorTest
--tests
org.apache.kafka.common.security.oauthbearer.ClientJwtValidatorTest
--tests
org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJwsTest
--tests
org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerScopeClaimUtilsTest
--no-build-cache --console=plain`
- `./gradlew :clients:checkstyleMain :clients:checkstyleTest
:clients:spotbugsMain --no-build-cache --console=plain`
- `git diff --check`
- `./gradlew :clients:unitTest`

Reviewers: Kirk True <kirk.true@gmail.com>, Evan Zhou
 <ezhou@confluent.io>
