### PR TITLE
KAFKA-9479: Print describe --state header once for multiple groups

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -509,6 +509,10 @@ public class ConsumerGroupCommand {
             }).sorted().collect(Collectors.joining(";"));
         }
 
+        private static String formatCoordinator(Node coordinator) {
+            return coordinator.host() + ":" + coordinator.port() + "  (" + coordinator.idString() + ")";
+        }
+
         private void printStates(Map<String, GroupInformation> states, boolean verbose) {
             List<GroupInformation> printableStates = new ArrayList<>();
             states.forEach((groupId, state) -> {
@@ -524,7 +528,7 @@ public class ConsumerGroupCommand {
             int coordinatorColLen = 25;
             int groupColLen = 15;
             for (GroupInformation state : printableStates) {
-                String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
+                String coordinator = formatCoordinator(state.coordinator());
                 coordinatorColLen = Math.max(coordinatorColLen, coordinator.length());
                 groupColLen = Math.max(groupColLen, state.group().length());
             }
@@ -540,7 +544,7 @@ public class ConsumerGroupCommand {
             }
 
             for (GroupInformation state : printableStates) {
-                String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
+                String coordinator = formatCoordinator(state.coordinator());
                 String assignmentStrategy = state.assignmentStrategy().isEmpty() ? MISSING_COLUMN_VALUE : state.assignmentStrategy();
                 if (verbose) {
                     System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(),

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -510,28 +510,47 @@ public class ConsumerGroupCommand {
         }
 
         private void printStates(Map<String, GroupInformation> states, boolean verbose) {
+            List<GroupInformation> printableStates = new ArrayList<>();
             states.forEach((groupId, state) -> {
                 if (shouldPrintMemberState(groupId, Optional.of(state.groupState()), Optional.of(1))) {
-                    String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
-                    int coordinatorColLen = Math.max(25, coordinator.length());
-                    int groupColLen = Math.max(15, state.group().length());
-
-                    String assignmentStrategy = state.assignmentStrategy().isEmpty() ? MISSING_COLUMN_VALUE : state.assignmentStrategy();
-
-                    if (verbose) {
-                        String format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %-15s %-25s %s";
-                        System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE",
-                            "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS");
-                        System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(),
-                            state.groupEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.targetAssignmentEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.numMembers());
-                    } else {
-                        String format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %s";
-                        System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS");
-                        System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(), state.numMembers());
-                    }
-                    System.out.println();
+                    printableStates.add(state);
                 }
             });
+
+            if (printableStates.isEmpty()) {
+                return;
+            }
+
+            int coordinatorColLen = 25;
+            int groupColLen = 15;
+            for (GroupInformation state : printableStates) {
+                String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
+                coordinatorColLen = Math.max(coordinatorColLen, coordinator.length());
+                groupColLen = Math.max(groupColLen, state.group().length());
+            }
+
+            String format;
+            if (verbose) {
+                format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %-15s %-25s %s";
+                System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE",
+                    "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS");
+            } else {
+                format = "\n%" + -groupColLen + "s %" + -coordinatorColLen + "s %-20s %-20s %s";
+                System.out.printf(format, "GROUP", "COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS");
+            }
+
+            for (GroupInformation state : printableStates) {
+                String coordinator = state.coordinator().host() + ":" + state.coordinator().port() + "  (" + state.coordinator().idString() + ")";
+                String assignmentStrategy = state.assignmentStrategy().isEmpty() ? MISSING_COLUMN_VALUE : state.assignmentStrategy();
+                if (verbose) {
+                    System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(),
+                        state.groupEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE),
+                        state.targetAssignmentEpoch().map(Object::toString).orElse(MISSING_COLUMN_VALUE), state.numMembers());
+                } else {
+                    System.out.printf(format, state.group(), coordinator, assignmentStrategy, state.groupState(), state.numMembers());
+                }
+                System.out.println();
+            }
         }
 
         void describeGroups() throws Exception {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
@@ -380,9 +380,10 @@ public class DescribeConsumerGroupTest {
                     protocolConsumerGroupExecutors.add(consumerGroupClosable(groupProtocol, group, topic, Map.of()));
                 }
 
-                int expectedNumLines = DESCRIBE_TYPES.size() * 2;
-
                 for (List<String> describeType : DESCRIBE_TYPES) {
+                    int expectedNumLines = describeType.contains("--state")
+                        ? DESCRIBE_TYPES.size() + 1
+                        : DESCRIBE_TYPES.size() * 2;
                     List<String> cgcArgs = new ArrayList<>(List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--describe"));
                     cgcArgs.addAll(groups);
                     cgcArgs.addAll(describeType);
@@ -420,8 +421,10 @@ public class DescribeConsumerGroupTest {
                     groups.add(group);
                     protocolConsumerGroupExecutors.add(consumerGroupClosable(groupProtocol, group, topic, Map.of()));
                 }
-                int expectedNumLines = DESCRIBE_TYPES.size() * 2;
                 for (List<String> describeType : DESCRIBE_TYPES) {
+                    int expectedNumLines = describeType.contains("--state")
+                        ? DESCRIBE_TYPES.size() + 1
+                        : DESCRIBE_TYPES.size() * 2;
                     List<String> cgcArgs = new ArrayList<>(List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--describe", "--all-groups"));
                     cgcArgs.addAll(describeType);
                     try (ConsumerGroupCommand.ConsumerGroupService service = consumerGroupService(cgcArgs.toArray(new String[0]))) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
@@ -449,6 +449,35 @@ public class DescribeConsumerGroupTest {
     }
 
     @ClusterTest
+    public void testDescribeStatePrintsHeaderOnceForMultipleGroups(ClusterInstance clusterInstance) throws Exception {
+        this.clusterInstance = clusterInstance;
+        for (GroupProtocol groupProtocol : clusterInstance.supportedGroupProtocols()) {
+            String topic = TOPIC_PREFIX + groupProtocol.name() + ".header-once";
+            createTopic(topic);
+            String group1 = GROUP_PREFIX + groupProtocol.name() + ".header-once.g1";
+            String group2 = GROUP_PREFIX + groupProtocol.name() + ".header-once.g2";
+            try (AutoCloseable executor1 = consumerGroupClosable(groupProtocol, group1, topic, Map.of());
+                 AutoCloseable executor2 = consumerGroupClosable(groupProtocol, group2, topic, Map.of())) {
+                String[] cgcArgs = new String[]{
+                    "--bootstrap-server", clusterInstance.bootstrapServers(),
+                    "--describe", "--all-groups", "--state"
+                };
+                try (ConsumerGroupCommand.ConsumerGroupService service = consumerGroupService(cgcArgs)) {
+                    TestUtils.waitForCondition(() -> {
+                        Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
+                        return res.getValue().isEmpty() &&
+                            countStateHeaderLines(res.getKey(), false) == 1 &&
+                            countStateDataLines(res.getKey()) >= 2;
+                    }, "Expected a single state header and at least two data rows for --all-groups --state.");
+                }
+            } finally {
+                deleteConsumerGroups(List.of(group1, group2));
+                deleteTopic(topic);
+            }
+        }
+    }
+
+    @ClusterTest
     public void testDescribeOffsetsOfExistingGroup(ClusterInstance clusterInstance) throws Exception {
         this.clusterInstance = clusterInstance;
         for (GroupProtocol groupProtocol: clusterInstance.supportedGroupProtocols()) {
@@ -1299,6 +1328,21 @@ public class DescribeConsumerGroupTest {
             List.of("GROUP", "COORDINATOR", "(ID)", "ASSIGNMENT-STRATEGY", "STATE", "GROUP-EPOCH", "TARGET-ASSIGNMENT-EPOCH", "#MEMBERS") :
             List.of("GROUP", "COORDINATOR", "(ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS");
         return Arrays.stream(output.trim().split("\\s+")).toList().equals(expectedKeys);
+    }
+
+    private long countStateHeaderLines(String output, boolean verbose) {
+        return Arrays.stream(output.split("\n"))
+            .filter(line -> !line.isBlank())
+            .filter(line -> checkStateArgsHeaderOutput(line, verbose))
+            .count();
+    }
+
+    private long countStateDataLines(String output) {
+        return Arrays.stream(output.split("\n"))
+            .filter(line -> !line.isBlank())
+            .filter(line -> !checkStateArgsHeaderOutput(line, false))
+            .filter(this::checkStateArgsOutput)
+            .count();
     }
 
     private void sendRecords(String topic, int partition, int recordsCount) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
@@ -460,15 +460,19 @@ public class DescribeConsumerGroupTest {
                  AutoCloseable executor2 = consumerGroupClosable(groupProtocol, group2, topic, Map.of())) {
                 String[] cgcArgs = new String[]{
                     "--bootstrap-server", clusterInstance.bootstrapServers(),
-                    "--describe", "--all-groups", "--state"
+                    "--describe", "--group", group1, "--group", group2, "--state"
                 };
                 try (ConsumerGroupCommand.ConsumerGroupService service = consumerGroupService(cgcArgs)) {
                     TestUtils.waitForCondition(() -> {
                         Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
-                        return res.getValue().isEmpty() &&
-                            countStateHeaderLines(res.getKey(), false) == 1 &&
-                            countStateDataLines(res.getKey()) >= 2;
-                    }, "Expected a single state header and at least two data rows for --all-groups --state.");
+                        if (!res.getValue().isEmpty()) {
+                            return false;
+                        }
+                        long nonBlankLines = Arrays.stream(res.getKey().split("\n"))
+                            .filter(line -> !line.isBlank())
+                            .count();
+                        return countStateHeaderLines(res.getKey(), false) == 1 && nonBlankLines == 3;
+                    }, "Expected a single state header and two data rows for multiple --group --state.");
                 }
             } finally {
                 deleteConsumerGroups(List.of(group1, group2));
@@ -1334,14 +1338,6 @@ public class DescribeConsumerGroupTest {
         return Arrays.stream(output.split("\n"))
             .filter(line -> !line.isBlank())
             .filter(line -> checkStateArgsHeaderOutput(line, verbose))
-            .count();
-    }
-
-    private long countStateDataLines(String output) {
-        return Arrays.stream(output.split("\n"))
-            .filter(line -> !line.isBlank())
-            .filter(line -> !checkStateArgsHeaderOutput(line, false))
-            .filter(this::checkStateArgsOutput)
             .count();
     }
 


### PR DESCRIPTION
When describing multiple consumer groups with --state (including
--all-groups), compute column widths across all groups and print the
header once.
