### PR TITLE
KAFKA-20409: Don't expose internal group configs unless they are user-defined

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -344,6 +344,15 @@ public final class GroupConfig extends AbstractConfig {
     );
 
     /**
+     * Returns {@code true} if the given config name is defined as internal in {@link #CONFIG_DEF}.
+     * Returns {@code false} for unknown names or non-internal configs.
+     */
+    public static boolean isInternal(String configName) {
+        ConfigDef.ConfigKey configKey = CONFIG_DEF.configKeys().get(configName);
+        return configKey != null && configKey.internalConfig;
+    }
+
+    /**
      * Returns the broker-level synonym config name for the given group config name,
      * or {@code Optional.empty()} if no broker-level synonym exists.
      */

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -634,8 +634,14 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
 
     public Map<String, Object> extractGroupConfigMap() {
         Map<String, Object> defaults = new HashMap<>();
-        GroupConfig.ALL_GROUP_CONFIG_SYNONYMS.forEach((groupConfigName, brokerConfigName) ->
-            brokerConfigName.ifPresent(name -> defaults.put(groupConfigName, get(name)))
+        Map<String, Object> brokerOriginals = originals();
+        GroupConfig.configNames().forEach(groupConfigName ->
+            GroupConfig.brokerSynonym(groupConfigName).ifPresent(brokerConfigName -> {
+                // Skip internal configs unless they are explicitly configured via the broker synonym.
+                if (!GroupConfig.isInternal(groupConfigName) || brokerOriginals.containsKey(brokerConfigName)) {
+                    defaults.put(groupConfigName, get(brokerConfigName));
+                }
+            })
         );
         return defaults;
     }

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -632,6 +632,13 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         return millis < 0 ? Long.valueOf(-1) : millis;
     }
 
+    /**
+     * Returns a map of group config names to their broker-level synonym values, used as
+     * defaults when building a {@link GroupConfig} for {@code DescribeConfigs}.
+     * Internal group configs are excluded unless their broker synonym was explicitly configured.
+     *
+     * @return a map of group config names to their corresponding broker-level values
+     */
     public Map<String, Object> extractGroupConfigMap() {
         Map<String, Object> defaults = new HashMap<>();
         Map<String, Object> brokerOriginals = originals();

--- a/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
@@ -67,29 +67,29 @@ public class AbstractKafkaConfigTest {
     }
 
     @Test
-    public void testInternalConfigWithDefaultSynonymIsSkipped() {
-        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(), true);
+    public void testExtractGroupConfigMapExcludesInternalConfigWithUnconfiguredBrokerSynonym() {
+        Map<String, Object> config = extractGroupConfigMap(Map.of(), true);
 
         assertFalse(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
     }
 
     @Test
-    public void testInternalConfigWithSetSynonymIsIncluded() {
-        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, "override-value"), true);
+    public void testExtractGroupConfigMapIncludesInternalConfigWithConfiguredBrokerSynonym() {
+        Map<String, Object> config = extractGroupConfigMap(Map.of(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, "override-value"), true);
 
         assertTrue(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
         assertEquals("override-value", config.get(TEST_INTERNAL_GROUP_CONFIG));
     }
 
     @Test
-    public void testNonInternalConfigIsIncluded() {
-        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(), false);
+    public void testExtractGroupConfigMapIncludesNonInternalConfig() {
+        Map<String, Object> config = extractGroupConfigMap(Map.of(), false);
 
         assertTrue(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
         assertEquals("default-value", config.get(TEST_INTERNAL_GROUP_CONFIG));
     }
 
-    private static Map<String, Object> mockInternalGroupConfigMap(Map<String, Object> overrides, boolean isInternal) {
+    private static Map<String, Object> extractGroupConfigMap(Map<String, Object> brokerProps, boolean isInternal) {
         try (MockedStatic<GroupConfig> mocked = mockStatic(GroupConfig.class, Mockito.CALLS_REAL_METHODS)) {
 
             // mock group config
@@ -101,7 +101,7 @@ public class AbstractKafkaConfigTest {
             ConfigDef configDef = new ConfigDef().define(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, ConfigDef.Type.STRING,
                 "default-value", ConfigDef.Importance.LOW, "test broker synonym");
 
-            AbstractKafkaConfig kafkaConfig = new AbstractKafkaConfig(configDef, new HashMap<>(overrides), Map.of(), false) {
+            AbstractKafkaConfig kafkaConfig = new AbstractKafkaConfig(configDef, new HashMap<>(brokerProps), Map.of(), false) {
                 @Override
                 public void addReconfigurable(Reconfigurable reconfigurable) { }
 

--- a/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
@@ -16,17 +16,30 @@
  */
 package org.apache.kafka.server.config;
 
+import org.apache.kafka.common.Reconfigurable;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.coordinator.group.GroupConfig;
 import org.apache.kafka.raft.KRaftConfigs;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 
 public class AbstractKafkaConfigTest {
+
+    private static final String TEST_INTERNAL_GROUP_CONFIG = "group.test.internal.config";
+    private static final String TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM = "group.test.internal.config.broker.synonym";
 
     @Test
     public void testPopulateSynonymsOnEmptyMap() {
@@ -51,5 +64,52 @@ public class AbstractKafkaConfigTest {
         expectedOutput.put(ServerConfigs.BROKER_ID_CONFIG, "4");
         expectedOutput.put(KRaftConfigs.NODE_ID_CONFIG, "4");
         assertEquals(expectedOutput, AbstractKafkaConfig.populateSynonyms(input));
+    }
+
+    @Test
+    public void testInternalConfigWithDefaultSynonymIsSkipped() {
+        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(), true);
+
+        assertFalse(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
+    }
+
+    @Test
+    public void testInternalConfigWithSetSynonymIsIncluded() {
+        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, "override-value"), true);
+
+        assertTrue(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
+        assertEquals("override-value", config.get(TEST_INTERNAL_GROUP_CONFIG));
+    }
+
+    @Test
+    public void testNonInternalConfigIsIncluded() {
+        Map<String, Object> config = mockInternalGroupConfigMap(Map.of(), false);
+
+        assertTrue(config.containsKey(TEST_INTERNAL_GROUP_CONFIG));
+        assertEquals("default-value", config.get(TEST_INTERNAL_GROUP_CONFIG));
+    }
+
+    private static Map<String, Object> mockInternalGroupConfigMap(Map<String, Object> overrides, boolean isInternal) {
+        try (MockedStatic<GroupConfig> mocked = mockStatic(GroupConfig.class, Mockito.CALLS_REAL_METHODS)) {
+
+            // mock group config
+            mocked.when(GroupConfig::configNames).thenReturn(Set.of(TEST_INTERNAL_GROUP_CONFIG));
+            mocked.when(() -> GroupConfig.brokerSynonym(TEST_INTERNAL_GROUP_CONFIG)).thenReturn(Optional.of(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM));
+            mocked.when(() -> GroupConfig.isInternal(TEST_INTERNAL_GROUP_CONFIG)).thenReturn(isInternal);
+
+            // mock broker synonym config
+            ConfigDef configDef = new ConfigDef().define(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, ConfigDef.Type.STRING,
+                "default-value", ConfigDef.Importance.LOW, "test broker synonym");
+
+            AbstractKafkaConfig kafkaConfig = new AbstractKafkaConfig(configDef, new HashMap<>(overrides), Map.of(), false) {
+                @Override
+                public void addReconfigurable(Reconfigurable reconfigurable) { }
+
+                @Override
+                public void removeReconfigurable(Reconfigurable reconfigurable) { }
+            };
+
+            return kafkaConfig.extractGroupConfigMap();
+        }
     }
 }


### PR DESCRIPTION
Previously, `internal group configs` with a `broker-level synonym` were
always included in the group config map, exposing them even when the
user had never explicitly set them. This change skips such configs
unless the user has configured them either via the broker synonym or
directly at the group level.

Reviewers: Sean Quah <squah@confluent.io>
