### PR TITLE
KAFKA-20586: Fix flaky LeaderElectionCommandTest.testPreferredReplicaElection

### DIFF
--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
@@ -49,36 +49,69 @@ public final class AdminUtils {
             }
 
             public void checkLeader() {
-                try {
-                    TopicDescription topicDescription = admin.describeTopics(List.of(topic))
-                            .allTopicNames().get().get(topic);
-
-                    Optional<Integer> leader = topicDescription.partitions().stream()
-                            .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
-                            .findFirst()
-                            .flatMap(partitionInfo -> Optional.ofNullable(partitionInfo.leader()))
-                            .map(node -> {
-                                int leaderId = node.id();
-                                return leaderId == Node.noNode().id() ? null : leaderId;
-                            });
-
-                    leader.ifPresent(integer -> this.leader = integer);
-                } catch (ExecutionException e) {
-                    Throwable cause = e.getCause();
-                    boolean isTransient = cause instanceof UnknownTopicOrPartitionException
-                            || cause instanceof LeaderNotAvailableException;
-                    if (!isTransient) {
-                        throw new RuntimeException(e);
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
+                fetchPartitionLeader(admin, topic, partitionNumber).ifPresent(integer -> this.leader = integer);
             }
         };
 
         TestUtils.waitForCondition(condition, timeoutMs, "Timing out after %d ms since a leader was not elected for partition %s-%d".formatted(timeoutMs, topic, partitionNumber));
 
         return condition.leader;
+    }
+
+    /**
+     * Fetch the partition leader or wait until the expected leader is observed using the provided admin client.
+     */
+    public static int fetchOrWaitForExpectedLeader(Admin admin,
+                                                   String topic,
+                                                   int partitionNumber,
+                                                   int expectedLeaderId,
+                                                   long timeoutMs) throws InterruptedException {
+        var condition = new Supplier<Boolean>() {
+            int leader = Node.noNode().id();
+
+            @Override
+            public Boolean get() {
+                checkLeader();
+                return this.leader == expectedLeaderId;
+            }
+
+            public void checkLeader() {
+                fetchPartitionLeader(admin, topic, partitionNumber).ifPresent(integer -> this.leader = integer);
+            }
+        };
+
+        TestUtils.waitForCondition(condition, timeoutMs,
+            () -> "Timing out after %d ms waiting for partition %s-%d leader to become %d, last observed=%d"
+                .formatted(timeoutMs, topic, partitionNumber, expectedLeaderId, condition.leader));
+
+        return condition.leader;
+    }
+
+    private static Optional<Integer> fetchPartitionLeader(Admin admin, String topic, int partitionNumber) {
+        try {
+            TopicDescription topicDescription = admin.describeTopics(List.of(topic))
+                .allTopicNames().get().get(topic);
+
+            return topicDescription.partitions().stream()
+                .filter(partitionInfo -> partitionInfo.partition() == partitionNumber)
+                .findFirst()
+                .flatMap(partitionInfo -> Optional.ofNullable(partitionInfo.leader()))
+                .map(node -> {
+                    int leaderId = node.id();
+                    return leaderId == Node.noNode().id() ? null : leaderId;
+                });
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            boolean isTransient = cause instanceof UnknownTopicOrPartitionException
+                || cause instanceof LeaderNotAvailableException;
+            if (!isTransient) {
+                throw new RuntimeException(e);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        return Optional.empty();
     }
 }

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/AdminUtils.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 public final class AdminUtils {
@@ -39,50 +40,45 @@ public final class AdminUtils {
                                            String topic,
                                            int partitionNumber,
                                            long timeoutMs) throws InterruptedException {
-
-        var condition = new Supplier<Boolean>() {
-            int leader = Node.noNode().id();
-            @Override
-            public Boolean get() {
-                checkLeader();
-                return this.leader != Node.noNode().id();
-            }
-
-            public void checkLeader() {
-                fetchPartitionLeader(admin, topic, partitionNumber).ifPresent(integer -> this.leader = integer);
-            }
-        };
-
-        TestUtils.waitForCondition(condition, timeoutMs, "Timing out after %d ms since a leader was not elected for partition %s-%d".formatted(timeoutMs, topic, partitionNumber));
-
-        return condition.leader;
+        return waitForLeader(admin, topic, partitionNumber,
+            id -> id != Node.noNode().id(),
+            timeoutMs,
+            "Timing out after %d ms since a leader was not elected for partition %s-%d"
+                .formatted(timeoutMs, topic, partitionNumber));
     }
 
     /**
-     * Fetch the partition leader or wait until the expected leader is observed using the provided admin client.
+     * Wait until the expected leader is observed for the given partition using the provided admin client.
      */
-    public static int fetchOrWaitForExpectedLeader(Admin admin,
-                                                   String topic,
-                                                   int partitionNumber,
-                                                   int expectedLeaderId,
-                                                   long timeoutMs) throws InterruptedException {
+    public static void waitForExpectedLeader(Admin admin,
+                                             String topic,
+                                             int partitionNumber,
+                                             int expectedLeaderId,
+                                             long timeoutMs) throws InterruptedException {
+        waitForLeader(admin, topic, partitionNumber,
+            id -> id == expectedLeaderId,
+            timeoutMs,
+            "Timing out after %d ms waiting for partition %s-%d leader to become %d"
+                .formatted(timeoutMs, topic, partitionNumber, expectedLeaderId));
+    }
+
+    private static int waitForLeader(Admin admin,
+                                     String topic,
+                                     int partitionNumber,
+                                     IntPredicate leaderMatches,
+                                     long timeoutMs,
+                                     String timeoutMessage) throws InterruptedException {
         var condition = new Supplier<Boolean>() {
             int leader = Node.noNode().id();
 
             @Override
             public Boolean get() {
-                checkLeader();
-                return this.leader == expectedLeaderId;
-            }
-
-            public void checkLeader() {
-                fetchPartitionLeader(admin, topic, partitionNumber).ifPresent(integer -> this.leader = integer);
+                fetchPartitionLeader(admin, topic, partitionNumber).ifPresent(id -> this.leader = id);
+                return leaderMatches.test(this.leader);
             }
         };
 
-        TestUtils.waitForCondition(condition, timeoutMs,
-            () -> "Timing out after %d ms waiting for partition %s-%d leader to become %d, last observed=%d"
-                .formatted(timeoutMs, topic, partitionNumber, expectedLeaderId, condition.leader));
+        TestUtils.waitForCondition(condition, timeoutMs, () -> "%s, last observed=%d".formatted(timeoutMessage, condition.leader));
 
         return condition.leader;
     }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -83,5 +84,53 @@ public class AdminUtilsTest {
         assertThrows(AssertionError.class, () ->
                         AdminUtils.fetchOrWaitForLeader(admin, topic, partition, 1),
                 "Timing out after 1 ms since a leader was not elected for partition test-topic-0");
+    }
+
+    @Test
+    void testFetchOrWaitForExpectedLeader() throws Exception {
+        String topic = "test-topic";
+        int partition = 0;
+        int expectedLeader = 1;
+        Admin admin = mock(Admin.class);
+        when(admin.describeTopics(anyCollection())).thenAnswer(new Answer<Object>() {
+            boolean called = false;
+
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                if (called) {
+                    return resultWithLeader(new Node(expectedLeader, "", 0));
+                } else {
+                    called = true;
+                    return resultWithLeader(new Node(2, "", 0));
+                }
+            }
+
+            DescribeTopicsResult resultWithLeader(Node leader) {
+                TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(partition, leader, List.of(), List.of());
+                return AdminClientTestUtils.describeTopicsResult(topic,
+                    new TopicDescription(topic, false, List.of(topicPartitionInfo)));
+            }
+        });
+
+        int result = AdminUtils.fetchOrWaitForExpectedLeader(admin, topic, partition, expectedLeader, 1000);
+
+        assertEquals(expectedLeader, result);
+    }
+
+    @Test
+    void testFetchOrWaitForExpectedLeaderTimesOut() {
+        String topic = "test-topic";
+        int partition = 0;
+        TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(partition, new Node(2, "", 0), List.of(), List.of());
+        DescribeTopicsResult describeResult = AdminClientTestUtils.describeTopicsResult(topic,
+            new TopicDescription(topic, false, List.of(topicPartitionInfo)));
+        Admin admin = mock(Admin.class);
+        when(admin.describeTopics(anyCollection())).thenReturn(describeResult);
+
+        AssertionError error = assertThrows(AssertionError.class, () ->
+            AdminUtils.fetchOrWaitForExpectedLeader(admin, topic, partition, 1, 1));
+        assertTrue(error.getCause().getMessage().contains(
+            "Timing out after 1 ms waiting for partition test-topic-0 leader to become 1, last observed=2"),
+            error.getCause().getMessage());
     }
 }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/AdminUtilsTest.java
@@ -87,7 +87,7 @@ public class AdminUtilsTest {
     }
 
     @Test
-    void testFetchOrWaitForExpectedLeader() throws Exception {
+    void testWaitForExpectedLeader() throws Exception {
         String topic = "test-topic";
         int partition = 0;
         int expectedLeader = 1;
@@ -112,13 +112,11 @@ public class AdminUtilsTest {
             }
         });
 
-        int result = AdminUtils.fetchOrWaitForExpectedLeader(admin, topic, partition, expectedLeader, 1000);
-
-        assertEquals(expectedLeader, result);
+        AdminUtils.waitForExpectedLeader(admin, topic, partition, expectedLeader, 1000);
     }
 
     @Test
-    void testFetchOrWaitForExpectedLeaderTimesOut() {
+    void testWaitForExpectedLeaderTimesOut() {
         String topic = "test-topic";
         int partition = 0;
         TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(partition, new Node(2, "", 0), List.of(), List.of());
@@ -128,7 +126,7 @@ public class AdminUtilsTest {
         when(admin.describeTopics(anyCollection())).thenReturn(describeResult);
 
         AssertionError error = assertThrows(AssertionError.class, () ->
-            AdminUtils.fetchOrWaitForExpectedLeader(admin, topic, partition, 1, 1));
+            AdminUtils.waitForExpectedLeader(admin, topic, partition, 1, 1));
         assertTrue(error.getCause().getMessage().contains(
             "Timing out after 1 ms waiting for partition test-topic-0 leader to become 1, last observed=2"),
             error.getCause().getMessage());

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -447,7 +447,7 @@ public class LeaderElectionCommandTest {
     }
 
     private void assertLeader(Admin client, TopicPartition topicPartition, int expectedLeader) throws Exception {
-        int leader = AdminUtils.fetchOrWaitForLeader(client, topicPartition.topic(), topicPartition.partition(), 30000);
+        int leader = AdminUtils.fetchOrWaitForExpectedLeader(client, topicPartition.topic(), topicPartition.partition(), expectedLeader, 30000);
         assertEquals(expectedLeader, leader);
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/LeaderElectionCommandTest.java
@@ -447,8 +447,7 @@ public class LeaderElectionCommandTest {
     }
 
     private void assertLeader(Admin client, TopicPartition topicPartition, int expectedLeader) throws Exception {
-        int leader = AdminUtils.fetchOrWaitForExpectedLeader(client, topicPartition.topic(), topicPartition.partition(), expectedLeader, 30000);
-        assertEquals(expectedLeader, leader);
+        AdminUtils.waitForExpectedLeader(client, topicPartition.topic(), topicPartition.partition(), expectedLeader, 30000);
     }
 
     private void assertNoLeader(Admin client, TopicPartition topicPartition) throws InterruptedException {


### PR DESCRIPTION
`LeaderElectionCommand` success only indicates the `controller` has
written the metadata change, but brokers may not have synced the
corresponding update yet.

The previous helper `fetchOrWaitForLeader` only waited for any leader
(not the expected one), so assertions could still observe stale leader
state and become flaky.

This change adds `waitForExpectedLeader` to poll until the expected
leader is observed, eliminating the race in the test path.
