### PR TITLE
KAFKA-4320: Clarify log compaction configuration docs

### DIFF
--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -436,13 +436,13 @@ Log compaction is handled by the log cleaner, a pool of background threads that 
 
 ### Configuring The Log Cleaner
 
-The log cleaner is enabled by default. This will start the pool of cleaner threads. To enable log cleaning on a particular topic, add the log-specific property 
+The log cleaner is enabled by default, which starts the pool of cleaner threads. Compaction runs only for topics whose cleanup policy includes `compact`. To make compaction the broker default for topics that do not set their own cleanup policy, add the following broker configuration to `server.properties`:
 
 ```properties
 log.cleanup.policy=compact
 ```
 
-The `log.cleanup.policy` property is a broker configuration setting defined in the broker's `server.properties` file; it affects all of the topics in the cluster that do not have a configuration override in place as documented [here](/documentation.html#brokerconfigs). The log cleaner can be configured to retain a minimum amount of the uncompacted "head" of the log. This is enabled by setting the compaction time lag. 
+To enable compaction for an individual topic, set the topic configuration `cleanup.policy=compact` when creating or altering the topic. Topic-level configuration overrides the broker default, as documented [here](/documentation.html#topicconfigs). The log cleaner can be configured to retain a minimum amount of the uncompacted "head" of the log. This is enabled by setting the compaction time lag.
 
 ```properties
 log.cleaner.min.compaction.lag.ms


### PR DESCRIPTION
Clarifies the log compaction docs by distinguishing between the log
cleaner being enabled and compaction being applied only to topics whose
cleanup policy includes `compact`. It also calls out the topic-level
`cleanup.policy=compact` override separately from the broker-level
`log.cleanup.policy=compact` default.

This contribution is my original work and I license the work to the
project under the project's open source license.

Testing:
- `./gradlew siteDocsTar`

Reviewers: Mickael Maison <mickael.maison@gmail.com>, Sushant Mahajan
 <smahajan@confluent.io>
