### PR TITLE
MINOR: Remove unnecessary null check in DefaultStatePersister#stop

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/DefaultStatePersister.java
@@ -69,9 +69,7 @@ public class DefaultStatePersister implements Persister {
     @Override
     public void stop() {
         try {
-            if (stateManager != null) {
-                stateManager.stop();
-            }
+            stateManager.stop();
         } catch (Exception e) {
             log.error("Unable to stop state manager", e);
         }


### PR DESCRIPTION
The `stateManager` field is `final` and assigned in both constructors of
`DefaultStatePersister`, so the `if (stateManager != null)` guard in
`stop()` can never evaluate to false.

  No behavior change; existing tests in `DefaultStatePersisterTest`
remain    sufficient.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
