### PR TITLE
KAFKA-20589 : Adding new streams config for restore path to handle memory issues

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -764,6 +764,13 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
 
+    /** {@code restore.buffered.records.per.partition} */
+    @SuppressWarnings("WeakerAccess")
+    public static final String RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG = "restore.buffered.records.per.partition";
+    private static final String RESTORE_BUFFERED_RECORDS_PER_PARTITION_DOC = "Maximum number of records to buffer per partition during state-store restoration. "
+        + "Bounds the memory used by the restore consumer's per-partition buffer in <code>StoreChangelogReader</code>. "
+        + "Distinct from <code>buffered.records.per.partition</code>, which bounds the main processing queue and does not affect the restore path.";
+
     /** {@code retry.backoff.ms} */
     @SuppressWarnings("WeakerAccess")
     public static final String RETRY_BACKOFF_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
@@ -1056,6 +1063,12 @@ public class StreamsConfig extends AbstractConfig {
                     -1,
                     Importance.MEDIUM,
                     REPLICATION_FACTOR_DOC)
+            .define(RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG,
+                    Type.INT,
+                    10_000,
+                    atLeast(1),
+                    Importance.LOW,
+                    RESTORE_BUFFERED_RECORDS_PER_PARTITION_DOC)
             .define(SECURITY_PROTOCOL_CONFIG,
                     Type.STRING,
                     CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -226,6 +226,9 @@ public class StoreChangelogReader implements ChangelogReader {
     private long lastUpdateOffsetTime;
     private final StandbyUpdateListener standbyUpdateListener;
 
+    // pauses fetching when a partition's buffer hits this size, to bound restore memory
+    private final int restoreMaxBufferedRecordsPerPartition;
+
     public StoreChangelogReader(final Time time,
                                 final StreamsConfig config,
                                 final LogContext logContext,
@@ -246,6 +249,8 @@ public class StoreChangelogReader implements ChangelogReader {
         this.updateOffsetIntervalMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) == Long.MAX_VALUE ?
             DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
         this.lastUpdateOffsetTime = 0L;
+        this.restoreMaxBufferedRecordsPerPartition =
+            config.getInt(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG);
 
         this.changelogs = new HashMap<>();
     }
@@ -537,21 +542,23 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     private boolean shouldResume(final Map<TaskId, Task> tasks, final TopicPartition partition, final TaskType taskType) {
-        final ProcessorStateManager manager = changelogs.get(partition).stateManager;
+        final ChangelogMetadata metadata = changelogs.get(partition);
+        final ProcessorStateManager manager = metadata.stateManager;
         final TaskId taskId = manager.taskId();
         final Task task = tasks.get(taskId);
         if (manager.taskType() == taskType) {
-            return task != null;
+            return task != null && metadata.bufferedRecords.size() < restoreMaxBufferedRecordsPerPartition;
         }
         return false;
     }
 
     private boolean shouldPause(final Map<TaskId, Task> tasks, final TopicPartition partition, final TaskType taskType) {
-        final ProcessorStateManager manager = changelogs.get(partition).stateManager;
+        final ChangelogMetadata metadata = changelogs.get(partition);
+        final ProcessorStateManager manager = metadata.stateManager;
         final TaskId taskId = manager.taskId();
         final Task task = tasks.get(taskId);
         if (manager.taskType() == taskType) {
-            return task == null;
+            return task == null || metadata.bufferedRecords.size() >= restoreMaxBufferedRecordsPerPartition;
         }
         return false;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -1586,8 +1586,9 @@ public class StoreChangelogReaderTest {
         when(storeMetadata.offset()).thenReturn(3L);
         when(storeMetadata.endOffset()).thenReturn(20L);
 
+        final int restoreBufferedRecordsPerPartition = 3;
         final Properties properties = new Properties();
-        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, 3);
+        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, restoreBufferedRecordsPerPartition);
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         final StreamsConfig cappedConfig =
             new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
@@ -1603,19 +1604,19 @@ public class StoreChangelogReaderTest {
         assertEquals(Collections.emptySet(), consumer.paused());
 
         // committed offset is 7, so offsets >=7 stay buffered
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 5L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 6L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 8L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 9L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 10L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 11L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 5L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 6L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 7L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 8L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 9L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 10L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 11L, "key".getBytes(), "value".getBytes()));
 
         // first tick fills the buffer, second tick sees it full and pauses
         changelogReader.restore(mockTasks);
         changelogReader.restore(mockTasks);
 
-        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= 3);
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= restoreBufferedRecordsPerPartition);
         assertEquals(Collections.singleton(tp), consumer.paused());
     }
 
@@ -1634,8 +1635,9 @@ public class StoreChangelogReaderTest {
         when(storeMetadata.endOffset()).thenReturn(20L);
 
         final long now = time.milliseconds();
+        final int restoreBufferedRecordsPerPartition = 3;
         final Properties properties = new Properties();
-        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, 3);
+        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, restoreBufferedRecordsPerPartition);
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         final StreamsConfig cappedConfig =
             new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
@@ -1648,18 +1650,18 @@ public class StoreChangelogReaderTest {
         changelogReader.register(tp, standbyStateManager);
 
         changelogReader.restore(mockTasks);
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 5L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 6L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 8L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 9L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 10L, "key".getBytes(), "value".getBytes()));
-        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 11L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 5L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 6L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 7L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 8L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 9L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 10L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, tp.partition(), 11L, "key".getBytes(), "value".getBytes()));
 
         // fill the buffer past the cap and confirm the pause
         changelogReader.restore(mockTasks);
         changelogReader.restore(mockTasks);
-        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= 3);
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= restoreBufferedRecordsPerPartition);
         assertEquals(Collections.singleton(tp), consumer.paused());
 
         // bump the committed offset so the buffered records can drain
@@ -1670,7 +1672,7 @@ public class StoreChangelogReaderTest {
         changelogReader.restore(mockTasks);
         changelogReader.restore(mockTasks);
 
-        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() < 3);
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() < restoreBufferedRecordsPerPartition);
         assertEquals(Collections.emptySet(), consumer.paused());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
@@ -1560,6 +1561,115 @@ public class StoreChangelogReaderTest {
         reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
 
         assertEquals(0L, consumer.position(tp), "Non-windowed store should seek to beginning, not by timestamp");
+    }
+
+    @Test
+    public void shouldRejectInvalidRestoreBufferedRecordsPerPartition() {
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, 0);
+        assertThrows(ConfigException.class,
+            () -> new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties)));
+    }
+
+    @Test
+    public void shouldPausePartitionWhenRestoreBufferCapIsReached() {
+        // standby with a committed-offset limit lets records pile up past the limit
+        setupStandbyStateManager();
+        setupStoreMetadata();
+        setupStore();
+        @SuppressWarnings("unchecked")
+        final Map<TaskId, Task> mockTasks = mock(Map.class);
+        when(mockTasks.get(null)).thenReturn(mock(Task.class));
+        when(mockTasks.containsKey(null)).thenReturn(true);
+        when(standbyStateManager.changelogAsSource(tp)).thenReturn(true);
+        when(storeMetadata.offset()).thenReturn(3L);
+        when(storeMetadata.endOffset()).thenReturn(20L);
+
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, 3);
+        properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        final StreamsConfig cappedConfig =
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, cappedConfig, logContext, adminClient, consumer, callback, standbyListener);
+        changelogReader.transitToUpdateStandby();
+
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+        adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 7L));
+        changelogReader.register(tp, standbyStateManager);
+
+        changelogReader.restore(mockTasks);
+        assertEquals(Collections.emptySet(), consumer.paused());
+
+        // committed offset is 7, so offsets >=7 stay buffered
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 5L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 6L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 8L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 9L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 10L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 11L, "key".getBytes(), "value".getBytes()));
+
+        // first tick fills the buffer, second tick sees it full and pauses
+        changelogReader.restore(mockTasks);
+        changelogReader.restore(mockTasks);
+
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= 3);
+        assertEquals(Collections.singleton(tp), consumer.paused());
+    }
+
+    @Test
+    public void shouldResumePartitionOnceBufferDrainsBelowCap() {
+        setupStandbyStateManager();
+        setupStoreMetadata();
+        setupStore();
+        @SuppressWarnings("unchecked")
+        final Map<TaskId, Task> mockTasks = mock(Map.class);
+        when(mockTasks.get(null)).thenReturn(mock(Task.class));
+        when(mockTasks.containsKey(null)).thenReturn(true);
+        when(standbyStateManager.changelogAsSource(tp)).thenReturn(true);
+        when(storeMetadata.offset()).thenReturn(3L);
+        when(storeMetadata.endOffset()).thenReturn(20L);
+
+        final long now = time.milliseconds();
+        final Properties properties = new Properties();
+        properties.put(StreamsConfig.RESTORE_BUFFERED_RECORDS_PER_PARTITION_CONFIG, 3);
+        properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        final StreamsConfig cappedConfig =
+            new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader", properties));
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, cappedConfig, logContext, adminClient, consumer, callback, standbyListener);
+        changelogReader.transitToUpdateStandby();
+
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+        adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 7L));
+        changelogReader.register(tp, standbyStateManager);
+
+        changelogReader.restore(mockTasks);
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 5L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 6L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 7L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 8L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 9L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 10L, "key".getBytes(), "value".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(topicName, 0, 11L, "key".getBytes(), "value".getBytes()));
+
+        // fill the buffer past the cap and confirm the pause
+        changelogReader.restore(mockTasks);
+        changelogReader.restore(mockTasks);
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() >= 3);
+        assertEquals(Collections.singleton(tp), consumer.paused());
+
+        // bump the committed offset so the buffered records can drain
+        adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 20L));
+        time.setCurrentTimeMs(now + 101L);
+        // refresh limit, drain, then resume
+        changelogReader.restore(mockTasks);
+        changelogReader.restore(mockTasks);
+        changelogReader.restore(mockTasks);
+
+        assertTrue(changelogReader.changelogMetadata(tp).bufferedRecords().size() < 3);
+        assertEquals(Collections.emptySet(), consumer.paused());
     }
 
     private void assignPartition(final long messages,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -1577,6 +1577,7 @@ public class StoreChangelogReaderTest {
         setupStandbyStateManager();
         setupStoreMetadata();
         setupStore();
+        // standby fixture has a null taskId, so the predicate looks up tasks.get(null)
         @SuppressWarnings("unchecked")
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         when(mockTasks.get(null)).thenReturn(mock(Task.class));
@@ -1623,6 +1624,7 @@ public class StoreChangelogReaderTest {
         setupStandbyStateManager();
         setupStoreMetadata();
         setupStore();
+        // standby fixture has a null taskId, so the predicate looks up tasks.get(null)
         @SuppressWarnings("unchecked")
         final Map<TaskId, Task> mockTasks = mock(Map.class);
         when(mockTasks.get(null)).thenReturn(mock(Task.class));


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-20589

[Kip-1325](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1325%3A+Add+restore.buffered.records.per.partition+to+cap+Kafka+Streams+state-restore+memory)

Add restore.buffered.records.per.partition config and enforce cap in StoreChangelogReader
