### PR TITLE
KAFKA-20597: Fix prefixScan overflow handling in in-memory state stores

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/internals/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/internals/ByteUtils.java
@@ -67,6 +67,21 @@ public final class ByteUtils {
     }
 
     /**
+     * Increment the underlying byte array by adding 1 without throwing on overflow.
+     *
+     * @param input - The byte array to increment
+     * @return A new copy of the incremented byte array, or {@code null} if incrementing causes the
+     *         underlying input byte array to overflow
+     */
+    public static Bytes incrementWithoutOverflow(final Bytes input) {
+        try {
+            return increment(input);
+        } catch (final IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    /**
      * A byte array comparator based on lexicographic ordering.
      */
     public static final ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -427,7 +427,7 @@ public class CachingKeyValueStore
         validateStoreOpen();
         final KeyValueIterator<Bytes, byte[]> storeIterator = wrapped().prefixScan(prefix, prefixKeySerializer);
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = internalContext.cache().range(cacheName, from, to, false);
         return new MergedSortedCacheKeyValueBytesStoreIterator(cacheIterator, storeIterator, true);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import static org.apache.kafka.streams.state.internals.RocksDBStore.incrementWithoutOverflow;
+import static org.apache.kafka.common.utils.internals.ByteUtils.incrementWithoutOverflow;
 
 /**
  * A generic implementation of {@link RocksDBStore.ColumnFamilyAccessor} that supports dual-column-family

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -174,9 +174,12 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     public synchronized <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
 
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
-        return new InMemoryKeyValueIterator(map.subMap(from, true, to, false).keySet(), true);
+        return new InMemoryKeyValueIterator(
+            to == null ? map.tailMap(from, true).keySet() : map.subMap(from, true, to, false).keySet(),
+            true
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
@@ -44,7 +44,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.streams.state.internals.RocksDBStore.incrementWithoutOverflow;
+import static org.apache.kafka.common.utils.internals.ByteUtils.incrementWithoutOverflow;
 
 /**
  * This "logical segment" is a segment which shares its underlying physical store with other

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -90,13 +90,16 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
     public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
 
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
         final TreeMap<Bytes, byte[]> treeMap = toTreeMap();
 
         return new DelegatingPeekingKeyValueIterator<>(
             name(),
-            new MemoryNavigableLRUCache.CacheIterator(treeMap.subMap(from, true, to, false).keySet().iterator(), treeMap)
+            new MemoryNavigableLRUCache.CacheIterator(
+                (to == null ? treeMap.tailMap(from, true) : treeMap.subMap(from, true, to, false)).keySet().iterator(),
+                treeMap
+            )
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -1143,7 +1143,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor, final Bytes prefix) {
-            final Bytes to = incrementWithoutOverflow(prefix);
+            final Bytes to = ByteUtils.incrementWithoutOverflow(prefix);
             return accessor.prefixScan(columnFamily, name, prefix, to);
         }
 
@@ -1197,21 +1197,5 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     @Override
     public Position getPosition() {
         return position;
-    }
-
-    /**
-     * Same as {@link ByteUtils#increment(Bytes)} but {@code null} is returned instead of throwing
-     * {@code IndexOutOfBoundsException} in the event of overflow.
-     *
-     * @param input bytes to increment
-     * @return A new copy of the incremented byte array, or {@code null} if incrementing would
-     *         result in overflow.
-     */
-    static Bytes incrementWithoutOverflow(final Bytes input) {
-        try {
-            return ByteUtils.increment(input);
-        } catch (final IndexOutOfBoundsException e) {
-            return null;
-        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
@@ -454,6 +455,31 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         assertEquals(2, numberOfKeysReturned);
         assertEquals(Arrays.asList("abcd", "abcdd"), keys);
         assertEquals(Arrays.asList("2", "1"), values);
+    }
+
+    @Test
+    public void shouldPrefixScanPrefixWithNoUpperBound() {
+        final Serializer<byte[]> serializer = (topic, data) -> data;
+
+        store.put(Bytes.wrap(new byte[] {(byte) 0xFE}), new byte[] {0});
+        store.put(Bytes.wrap(new byte[] {(byte) 0xFF}), new byte[] {1});
+        store.put(Bytes.wrap(new byte[] {(byte) 0xFF, 0x00}), new byte[] {2});
+
+        final List<Bytes> keys = new ArrayList<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator =
+                store.prefixScan(new byte[] {(byte) 0xFF}, serializer)) {
+            while (iterator.hasNext()) {
+                keys.add(iterator.next().key);
+            }
+        }
+
+        assertEquals(
+            Arrays.asList(
+                Bytes.wrap(new byte[] {(byte) 0xFF}),
+                Bytes.wrap(new byte[] {(byte) 0xFF, 0x00})
+            ),
+            keys
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -447,4 +448,28 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
         return Bytes.wrap(key.getBytes());
     }
 
+    @Test
+    public void shouldPrefixScanPrefixWithNoUpperBound() {
+        final Serializer<byte[]> serializer = (topic, data) -> data;
+
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFE}), new byte[] {0});
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFF}), new byte[] {1});
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFF, 0x00}), new byte[] {2});
+
+        final List<Bytes> keys = new ArrayList<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator =
+                byteStore.prefixScan(new byte[] {(byte) 0xFF}, serializer)) {
+            while (iterator.hasNext()) {
+                keys.add(iterator.next().key);
+            }
+        }
+
+        assertEquals(
+            Arrays.asList(
+                Bytes.wrap(new byte[] {(byte) 0xFF}),
+                Bytes.wrap(new byte[] {(byte) 0xFF, 0x00})
+            ),
+            keys
+        );
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -17,14 +17,18 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -161,5 +165,31 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
         // and there are no other entries ...
         assertEquals(10, driver.sizeOf(store));
+    }
+
+    @Test
+    public void shouldPrefixScanPrefixWithNoUpperBound() {
+        final Serializer<byte[]> serializer = (topic, data) -> data;
+        final MemoryNavigableLRUCache byteStore = new MemoryNavigableLRUCache("byte-store", 10);
+
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFE}), new byte[] {0});
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFF}), new byte[] {1});
+        byteStore.put(Bytes.wrap(new byte[] {(byte) 0xFF, 0x00}), new byte[] {2});
+
+        final List<Bytes> keys = new ArrayList<>();
+        try (final KeyValueIterator<Bytes, byte[]> iterator =
+                 byteStore.prefixScan(new byte[] {(byte) 0xFF}, serializer)) {
+            while (iterator.hasNext()) {
+                keys.add(iterator.next().key);
+            }
+        }
+
+        assertEquals(
+            Arrays.asList(
+                Bytes.wrap(new byte[] {(byte) 0xFF}),
+                Bytes.wrap(new byte[] {(byte) 0xFF, 0x00})
+            ),
+            keys
+        );
     }
 }


### PR DESCRIPTION
prefixScan currently behaves inconsistently across state store
implementations when the prefix has no lexicographically larger upper
bound.

For example, given the following keys:

- FF
- FF 00
- FF 10
- FE

Calling `prefixScan(FF)` should return:

- FF
- FF 00
- FF 10

`RocksDBStore` already handles this case correctly by treating the upper
bound as unbounded when incrementing the prefix overflows.

However, `InMemoryKeyValueStore`, `MemoryNavigableLRUCache`, and
`CachingKeyValueStore` directly call `ByteUtils.increment(...)`, which
throws `IndexOutOfBoundsException` for prefixes such as `0xFF`.

This causes `prefixScan` to fail before iteration begins for in-memory
state store implementations.

This PR centralizes overflow-safe increment handling in
`ByteUtils.incrementWithoutOverflow(...)` and updates the affected state
stores to use the shared implementation when handling prefixes without
an upper bound.

Regression tests named `shouldPrefixScanPrefixWithNoUpperBound` have
been added for each of `InMemoryKeyValueStore`, `CachingKeyValueStore`,
and `MemoryNavigableLRUCache` to reproduce the failure for the prefix
`0xFF`.

### Testing

```bash
./gradlew spotlessApply
./gradlew :streams:test \
  --tests
org.apache.kafka.streams.state.internals.InMemoryKeyValueStoreTest.shouldPrefixScanPrefixWithNoUpperBound
\
  --tests
org.apache.kafka.streams.state.internals.CachingInMemoryKeyValueStoreTest.shouldPrefixScanPrefixWithNoUpperBound
\
  --tests
org.apache.kafka.streams.state.internals.InMemoryLRUCacheStoreTest.shouldPrefixScanPrefixWithNoUpperBound
./gradlew :streams:checkstyleTest
```
Before the fix, my regression test failed with
`IndexOutOfBoundsException`. After the fix, the test passes
successfully.

Reviewers: Sanskar
 Jhajharia[sjhajharia@confluent.io](mailto:sjhajharia@confluent.io),
 Chia-Ping Tsai  [chia7712@gmail.com](mailto:chia7712@gmail.com)
