### PR TITLE
KAFKA-20497: Add readOnly(IsolationLevel) to ChangeLogging stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serializer;
@@ -26,6 +27,7 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 
 import java.util.List;
 
@@ -62,6 +64,11 @@ public class ChangeLoggingKeyValueBytesStore
     @Override
     public long approximateNumEntries() {
         return wrapped().approximateNumEntries();
+    }
+
+    @Override
+    public ReadOnlyKeyValueStore<Bytes, byte[]> readOnly(final IsolationLevel isolationLevel) {
+        return wrapped().readOnly(isolationLevel);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -23,6 +24,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.SessionStore;
 
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
@@ -45,6 +47,11 @@ public class ChangeLoggingSessionBytesStore
     public void init(final StateStoreContext stateStoreContext, final StateStore root) {
         internalContext = asInternalProcessorContext(stateStoreContext);
         super.init(stateStoreContext, root);
+    }
+
+    @Override
+    public ReadOnlySessionStore<Bytes, byte[]> readOnly(final IsolationLevel isolationLevel) {
+        return wrapped().readOnly(isolationLevel);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -23,6 +24,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
@@ -65,6 +67,11 @@ class ChangeLoggingWindowBytesStore
     public byte[] fetch(final Bytes key,
                         final long timestamp) {
         return wrapped().fetch(key, timestamp);
+    }
+
+    @Override
+    public ReadOnlyWindowStore<Bytes, byte[]> readOnly(final IsolationLevel isolationLevel) {
+        return wrapped().readOnly(isolationLevel);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
@@ -61,6 +62,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.Mockito.mock;
@@ -262,6 +264,18 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), is(notNullValue()));
         assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), hasEntry(0, 100L));
 
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyUncommittedToInner() {
+        assertThat(store.readOnly(IsolationLevel.READ_UNCOMMITTED),
+            sameInstance(inner.readOnly(IsolationLevel.READ_UNCOMMITTED)));
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyCommittedToInner() {
+        assertThat(store.readOnly(IsolationLevel.READ_COMMITTED),
+            sameInstance(inner.readOnly(IsolationLevel.READ_COMMITTED)));
     }
 
     private StreamsConfig streamsConfigMock() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -24,6 +25,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.SessionStore;
 
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +41,8 @@ import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,6 +55,8 @@ public class ChangeLoggingSessionBytesStoreTest {
     private SessionStore<Bytes, byte[]> inner;
     @Mock
     private ProcessorContextImpl context;
+    @Mock
+    private ReadOnlySessionStore<Bytes, byte[]> view;
 
     private ChangeLoggingSessionBytesStore store;
     private final byte[] value1 = {0};
@@ -188,5 +194,17 @@ public class ChangeLoggingSessionBytesStoreTest {
         store.close();
 
         verify(inner).close();
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyUncommittedToInner() {
+        when(inner.readOnly(IsolationLevel.READ_UNCOMMITTED)).thenReturn(view);
+        assertThat(store.readOnly(IsolationLevel.READ_UNCOMMITTED), sameInstance(view));
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyCommittedToInner() {
+        when(inner.readOnly(IsolationLevel.READ_COMMITTED)).thenReturn(view);
+        assertThat(store.readOnly(IsolationLevel.READ_COMMITTED), sameInstance(view));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -24,6 +25,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
@@ -38,6 +40,8 @@ import org.mockito.quality.Strictness;
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +57,8 @@ public class ChangeLoggingWindowBytesStoreTest {
     private WindowStore<Bytes, byte[]> inner;
     @Mock
     private ProcessorContextImpl context;
+    @Mock
+    private ReadOnlyWindowStore<Bytes, byte[]> view;
     private ChangeLoggingWindowBytesStore store;
 
     private static final Position POSITION = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 1L)))));
@@ -122,6 +128,18 @@ public class ChangeLoggingWindowBytesStoreTest {
         try (final KeyValueIterator<Windowed<Bytes>, byte[]> unused =  store.backwardFetch(bytesKey, bytesKey, ofEpochMilli(0), ofEpochMilli(1))) {
             verify(inner).backwardFetch(bytesKey, bytesKey, 0, 1);
         }
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyUncommittedToInner() {
+        when(inner.readOnly(IsolationLevel.READ_UNCOMMITTED)).thenReturn(view);
+        assertThat(store.readOnly(IsolationLevel.READ_UNCOMMITTED), sameInstance(view));
+    }
+
+    @Test
+    public void shouldDelegateReadOnlyCommittedToInner() {
+        when(inner.readOnly(IsolationLevel.READ_COMMITTED)).thenReturn(view);
+        assertThat(store.readOnly(IsolationLevel.READ_COMMITTED), sameInstance(view));
     }
 
     @Test


### PR DESCRIPTION
The ChangeLogging wrappers have no cache of their own — they simply
intercept  writes to emit changelog records and delegate reads straight
through. There is  no uncommitted state held at this layer, so the
isolation semantics belong  entirely to the inner store. Pure delegation
to wrapped().readOnly(level) is  therefore the only sensible
implementation.

KAFKA-20497

Reviewers: Murali Basani  <muralidhar.basani@aiven.io>, Bill Bejeck
 <bbejeck@apache.org>
