### PR TITLE
KAFKA-20530: Log cluster.id at startup phase

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -55,6 +55,8 @@ class KafkaRaftServer(
   private val (metaPropsEnsemble, bootstrapMetadata) =
     KafkaRaftServer.initializeLogDirs(config, this.logger.underlying, this.logIdent)
 
+  info(s"Loaded cluster id ${metaPropsEnsemble.clusterId().get()} from meta.properties")
+
   private val metrics = Server.initializeMetrics(
     config,
     time,


### PR DESCRIPTION
Adds an INFO log line in `KafkaRaftServer` right after `meta.properties` is loaded, recording the `cluster.id`. As requested in [KAFKA-20530](https://issues.apache.org/jira/browse/KAFKA-20530), this lets operators troubleshoot `INCONSISTENT_CLUSTER_ID` errors directly from server logs without dumping `meta.properties` manually.

Example output:

```
[KafkaRaftServer nodeId=0] Loaded cluster id <UUID> from meta.properties (kafka.server.KafkaRaftServer)
```

Verified locally with `./gradlew core:compileScala`, `./gradlew core:test --tests "kafka.server.KafkaRaftServerTest"`, and the lint trio (`checkstyleMain`, `spotbugsMain`, `spotlessCheck`).