### PR TITLE
KAFKA-20404: Replace bulk StreamThread atomicity excludes with field-level suppressions

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -503,7 +503,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.server.AssignmentsManager"/>
             <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
             <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
-            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
             <Class name="org.apache.kafka.streams.state.internals.AbstractDualSchemaRocksDBSegmentedBytesStore"/>
             <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
@@ -526,6 +525,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- KAFKA-20404: numIterations is owned by the StreamThread itself; the only cross-thread reader is currentNumIterations(), which is test-only and invoked from the same thread that drives runOnce(). -->
+        <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+        <Field name="numIterations"/>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+
+    <Match>
         <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
@@ -542,7 +548,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.image.publisher.SnapshotGenerator$Builder"/>
             <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
             <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
-            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
             <Class name="org.apache.kafka.connect.runtime.WorkerSinkTask"/>
@@ -562,6 +567,18 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemorySessionStore"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemoryWindowStore"/>
+        </Or>
+        <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- KAFKA-20404: These long fields are bookkeeping internal to the StreamThread's run loop; all writes and reads happen on the StreamThread itself, so a non-volatile 64-bit access cannot be torn or observed cross-thread. -->
+        <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+        <Or>
+            <Field name="now"/>
+            <Field name="lastPollMs"/>
+            <Field name="lastLogSummaryMs"/>
+            <Field name="totalCommittedSinceLastSummary"/>
         </Or>
         <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
     </Match>
@@ -633,7 +650,16 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="kafka.server.ReplicaManager"/>
             <Class name="org.apache.kafka.trogdor.coordinator.NodeManager$NodeHeartbeat"/>
             <Class name="org.apache.kafka.connect.runtime.distributed.DistributedHerder$RebalanceListener"/>
-            <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+        </Or>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- KAFKA-20404: Both fields are mutated and observed exclusively from within the StreamThread's run loop, so a stale-write across threads is not possible in practice. -->
+        <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+        <Or>
+            <Field name="numIterations"/>
+            <Field name="streamsGroupReady"/>
         </Or>
         <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
     </Match>


### PR DESCRIPTION
Removes `StreamThread` from the three class-level bulk Spotbugs exclusions for atomicity warnings (`AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_NONATOMIC_64BIT_PRIMITIVE`, `AT_STALE_THREAD_WRITE_OF_PRIMITIVE`) and replaces them with field level suppressions that name each affected field and carry a one line rationale.

Spotbugs reports 13 warnings against `StreamThread` once the bulk excludes are lifted, all on a small set of bookkeeping fields:

* `now`, `lastPollMs`, `lastLogSummaryMs`, `totalCommittedSinceLastSummary` (64 bit primitive)
* `numIterations` (non atomic RMW + stale write)
* `streamsGroupReady` (stale write)

All accesses to these fields are inside methods that run on the StreamThread itself (the run loop and helpers it calls). The only cross thread reader I could find is `currentNumIterations()`, which is `// visible for testing` and is invoked from `StreamThreadTest` after a synchronous `runOnce(...)` on the same test thread, so it does not introduce a real cross thread access.

Each suppression names the specific fields so any future field added to `StreamThread` is not silently swept under the same exclusion.

Verified with `./gradlew streams:spotbugsMain` (clean) and `./gradlew streams:test --tests StreamThreadTest`.

This is the first of a series of PRs for [KAFKA-20404](https://issues.apache.org/jira/browse/KAFKA-20404). Follow up PRs will tackle the remaining classes one at a time.