### PR TITLE
MINOR: Fix typo in TransactionContext javadoc

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/TransactionContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/TransactionContext.java
@@ -43,7 +43,7 @@ public interface TransactionContext {
     /**
      * Requests a transaction abort after the next batch of records from {@link SourceTask#poll()}. All of
      * the records in that transaction will be discarded and will not appear in a committed transaction.
-     * However, offsets for that transaction will still be committed so than the records in that transaction
+     * However, offsets for that transaction will still be committed so that the records in that transaction
      * are not reprocessed. If the data should instead be reprocessed, the task should not invoke this method
      * and should instead throw an exception.
      */


### PR DESCRIPTION
## Summary
Fix a small typo in the javadoc for
`TransactionContext#abortTransaction()`:
`committed so than the records` → `committed so that the records`.

The parallel docstring for `abortTransaction(SourceRecord)` a few lines
below already uses the correct phrasing, so this looks like a copy/paste
slip that was missed.

## Why
Docs-only correction picked up while reading the Connect source API. No
functional or API change.

## Testing
None required — javadoc comment text only, no code path is affected.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
