### PR TITLE
KAFKA-20587: Wait for global store topic partitions in test setup

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -151,7 +151,7 @@ public class KafkaStreamsTelemetryIntegrationTest {
         cluster.createTopic(outputTopicOnePartition, 1, 1);
         cluster.createTopic(globalStoreTopic, 2, 1);
 
-        // KAFKA-20587: createTopic only waits until the topic name appears in listTopics(), not until
+        // createTopic only waits until the topic name appears in listTopics(), not until
         // partition metadata has fully propagated. The GlobalStreamThread fails fast if partitionsFor()
         // returns empty during initialization, so wait until partitions are visible before starting Streams.
         try (final Admin admin = cluster.createAdminClient()) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KafkaStreamsTelemetryIntegrationTest.java
@@ -150,6 +150,20 @@ public class KafkaStreamsTelemetryIntegrationTest {
         cluster.createTopic(inputTopicOnePartition, 1, 1);
         cluster.createTopic(outputTopicOnePartition, 1, 1);
         cluster.createTopic(globalStoreTopic, 2, 1);
+
+        // KAFKA-20587: createTopic only waits until the topic name appears in listTopics(), not until
+        // partition metadata has fully propagated. The GlobalStreamThread fails fast if partitionsFor()
+        // returns empty during initialization, so wait until partitions are visible before starting Streams.
+        try (final Admin admin = cluster.createAdminClient()) {
+            waitForCondition(
+                () -> admin.describeTopics(Collections.singleton(globalStoreTopic))
+                    .allTopicNames().get()
+                    .get(globalStoreTopic)
+                    .partitions().size() == 2,
+                30_000,
+                "Global store topic partitions were not available"
+            );
+        }
     }
 
     @AfterAll


### PR DESCRIPTION
## Summary

`KafkaStreamsTelemetryIntegrationTest.shouldPushGlobalThreadMetricsToBroker`
is flaky because `EmbeddedKafkaCluster.createTopic` only waits until the
topic name appears in `listTopics()`, not until partition metadata has
fully propagated. The `GlobalStreamThread` then calls `partitionsFor()`
during initialization and fails fast when the broker returns an empty
partition list:
wait in BeforeEach until describeTopics reports the expected partition
count for the global store source topic before starting Kafka Streams.

Reviewers: @muralibasani @mjsax, Sushant Mahajan <smahajan@confluent.io>, Murali Basani <muralidhar.basani@aiven.io>
