### PR TITLE
MINOR: Re-read PRODUCE throttle metric each iteration in produceUntilThrottled

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -220,13 +220,14 @@ abstract class QuotaTestClients(topic: String,
   def produceUntilThrottled(maxRecords: Int, waitForRequestCompletion: Boolean = true): Int = {
     var numProduced = 0
     var throttled = false
-    val metric = throttleMetric(QuotaType.PRODUCE, producerClientId)
     do {
       val payload = numProduced.toString.getBytes
       val future = producer.send(new ProducerRecord[Array[Byte], Array[Byte]](topic, null, null, payload),
         new ErrorLoggingCallback(topic, null, null, true))
       numProduced += 1
       do {
+        // Re-read the metric since it is registered lazily on the broker.
+        val metric = throttleMetric(QuotaType.PRODUCE, producerClientId)
         throttled = metric != null && metricValue(metric) > 0
       } while (!future.isDone && (!throttled || waitForRequestCompletion))
     } while (numProduced < maxRecords && !throttled)


### PR DESCRIPTION

While reviewing the PR #22329, I noticed that produceUntilThrottled caches the produce throttle metric reference before entering the polling loop.
Since the broker registers the throttle metric lazily, the metric may not yet exist when the helper first reads it. In that case, the cached reference remains null for the lifetime of the method, preventing the helper from observing throttling even after the broker later records the metric.

Reviewer - @muralibasani 

