### PR TITLE
KAFKA-20404: Replace bulk DefaultStateUpdater atomicity excludes with field-level suppressions

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -502,7 +502,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.storage.internals.log.AbstractIndex"/>
             <Class name="org.apache.kafka.server.AssignmentsManager"/>
             <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
-            <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
             <Class name="org.apache.kafka.streams.state.internals.AbstractDualSchemaRocksDBSegmentedBytesStore"/>
@@ -526,6 +525,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- KAFKA-20404: totalCheckpointLatency is accumulated in measureCheckpointLatency and reset in recordMetrics; both methods only run inside StateUpdaterThread.runOnce, so the read-modify-write is thread-confined. -->
+        <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
+        <Field name="totalCheckpointLatency"/>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+
+    <Match>
         <!-- New warning type added when we upgraded from spotbugs 4.8.6 to 4.9.4.
         These are possibly real bugs, and have not been evaluated, they were just bulk excluded to unblock upgrading Spotbugs.
          -->
@@ -541,7 +547,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.image.publisher.SnapshotGenerator"/>
             <Class name="org.apache.kafka.image.publisher.SnapshotGenerator$Builder"/>
             <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
-            <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
@@ -563,6 +568,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.streams.state.internals.InMemorySessionStore"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemoryWindowStore"/>
         </Or>
+        <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- KAFKA-20404: totalCheckpointLatency is a 64-bit counter mutated and read only on the StateUpdaterThread (see measureCheckpointLatency and recordMetrics), so a torn read across threads cannot occur. -->
+        <Class name="org.apache.kafka.streams.processor.internals.DefaultStateUpdater$StateUpdaterThread"/>
+        <Field name="totalCheckpointLatency"/>
         <Bug pattern="AT_NONATOMIC_64BIT_PRIMITIVE"/>
     </Match>
 


### PR DESCRIPTION
## Background
[KAFKA-20404](https://issues.apache.org/jira/browse/KAFKA-20404) tracks replacing the bulk SpotBugs atomicity excludes (introduced when SpotBugs was upgraded from 4.8.6 to 4.9.4) with per-field investigations. This PR handles `DefaultStateUpdater$StateUpdaterThread`, the second class in the series after `StreamThread` (#22320).

## Investigation
After removing `DefaultStateUpdater$StateUpdaterThread` from the two bulk excludes it appeared in (`AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` at line 505 and `AT_NONATOMIC_64BIT_PRIMITIVE` at line 544 on trunk), SpotBugs reports exactly one field with warnings:

- `totalCheckpointLatency` at `DefaultStateUpdater.java:100`, flagged at line 732 (`measureCheckpointLatency`) and line 750 (`recordMetrics`).

Walking the call sites:
- `measureCheckpointLatency` is `private` and only called from within `StateUpdaterThread`: `restoreTasks`, `pauseTasks`, `resumeTasks`, `removeUpdatingTask`, `maybeCheckpointTasks`.
- `recordMetrics` is `private` and only called from `StateUpdaterThread.runOnce` (line 213).
- All callers run on the `StateUpdaterThread` itself (the inner class extends `Thread`).

So `totalCheckpointLatency` is thread-confined and the SpotBugs warnings are false positives.

## Changes
- Remove `DefaultStateUpdater$StateUpdaterThread` from the two bulk `<Or>` blocks.
- Add two targeted `<Match>` blocks scoped to the class plus the `totalCheckpointLatency` field, each with a rationale comment explaining the thread-confinement, one per bug pattern.

## Verification
- `:streams:spotbugsMain --rerun-tasks` clean.
- `:streams:checkstyleMain` / `:streams:checkstyleTest` / `:streams:spotbugsTest` clean.
- `:streams:test --tests "*DefaultStateUpdater*"` all green.