### PR TITLE
KAFKA-20600: Move AuthHelper.scala to server module.

### DIFF
--- a/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
+++ b/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java
@@ -17,7 +17,6 @@
 
 package kafka.server.handlers;
 
-import kafka.server.AuthHelper;
 import kafka.server.KafkaConfig;
 
 import org.apache.kafka.common.Uuid;
@@ -31,6 +30,7 @@ import org.apache.kafka.common.requests.DescribeTopicPartitionsRequest;
 import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.metadata.MetadataCache;
 import org.apache.kafka.network.Request;
+import org.apache.kafka.security.authorizer.JAuthHelper;
 
 import java.util.HashSet;
 import java.util.List;
@@ -42,12 +42,12 @@ import static org.apache.kafka.common.resource.ResourceType.TOPIC;
 
 public class DescribeTopicPartitionsRequestHandler {
     MetadataCache metadataCache;
-    AuthHelper authHelper;
+    JAuthHelper authHelper;
     KafkaConfig config;
 
     public DescribeTopicPartitionsRequestHandler(
         MetadataCache metadataCache,
-        AuthHelper authHelper,
+        JAuthHelper authHelper,
         KafkaConfig config
     ) {
         this.metadataCache = metadataCache;

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.network.Request
-import org.apache.kafka.security.authorizer.AuthorizerUtils
+import org.apache.kafka.security.authorizer.{AuthorizerUtils, JAuthHelper}
 import org.apache.kafka.server.ProcessRole
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.purgatory.DelayedFuturePurgatory
@@ -46,7 +46,7 @@ import scala.jdk.OptionConverters.RichOptional
 /**
  * Logic to handle ACL requests.
  */
-class AclApis(authHelper: AuthHelper,
+class AclApis(authHelper: JAuthHelper,
               authorizerPlugin: Option[Plugin[Authorizer]],
               requestHelper: RequestHandlerHelper,
               role: ProcessRole,

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -33,6 +33,7 @@ import org.apache.kafka.common.resource.ResourceType.{CLUSTER, GROUP, TOPIC}
 import org.apache.kafka.coordinator.group.GroupConfig
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.network.Request
+import org.apache.kafka.security.authorizer.JAuthHelper
 import org.apache.kafka.server.ConfigHelperUtils.createResponseConfig
 import org.apache.kafka.server.config.{DynamicBrokerConfig, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.logger.LoggingController
@@ -47,7 +48,7 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
 
   def handleDescribeConfigsRequest(
     request: Request,
-    authHelper: AuthHelper
+    authHelper: JAuthHelper
   ): DescribeConfigsResponseData = {
     val describeConfigsRequest = request.body(classOf[DescribeConfigsRequest])
     val (authorizedResources, unauthorizedResources) = describeConfigsRequest.data.resources.asScala.partition { resource =>

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -55,12 +55,14 @@ import org.apache.kafka.metadata.{BrokerHeartbeatReply, BrokerRegistrationReply,
 import org.apache.kafka.network.Request
 import org.apache.kafka.raft.RaftManager
 import org.apache.kafka.security.DelegationTokenManager
+import org.apache.kafka.security.authorizer.JAuthHelper
 import org.apache.kafka.server.{ApiVersionManager, ProcessRole}
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.{ApiMessageAndVersion, RequestLocal}
 import org.apache.kafka.server.quota.ControllerMutationQuota
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 
 
 /**
@@ -81,7 +83,7 @@ class ControllerApis(
 ) extends ApiRequestHandler with Logging {
 
   this.logIdent = s"[ControllerApis nodeId=${config.nodeId}] "
-  val authHelper = new AuthHelper(authorizerPlugin)
+  val authHelper = new JAuthHelper(authorizerPlugin.toJava)
   val configHelper = new ConfigHelper(metadataCache, config, metadataCache)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)
   val runtimeLoggerManager = new RuntimeLoggerManager(config.nodeId, logger.underlying)
@@ -204,9 +206,9 @@ class ControllerApis(
     val future = deleteTopics(context,
       deleteTopicsRequest.data,
       request.context.apiVersion,
-      authHelper.authorize(request.context, DELETE, CLUSTER, CLUSTER_NAME, logIfDenied = false),
-      names => authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, names)(n => n),
-      names => authHelper.filterByAuthorized(request.context, DELETE, TOPIC, names)(n => n))
+      authHelper.authorize(request.context, DELETE, CLUSTER, CLUSTER_NAME, true, false, 1),
+      names => authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, names.asJava, (n: String) => n).asScala.toSet,
+      names => authHelper.filterByAuthorized(request.context, DELETE, TOPIC, names.asJava, (n: String) => n).asScala.toSet)
     future.handle[Unit] { (results, exception) =>
       val response = if (exception != null) {
         deleteTopicsRequest.getErrorResponse(exception)
@@ -367,10 +369,10 @@ class ControllerApis(
       controllerMutationQuotaRecorderFor(controllerMutationQuota))
     val future = createTopics(context,
         createTopicsRequest.data,
-        authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false),
-        names => authHelper.filterByAuthorized(request.context, CREATE, TOPIC, names)(identity),
+        authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, true, false, 1),
+        names => authHelper.filterByAuthorized(request.context, CREATE, TOPIC, names.asJava, (n: String) => n).asScala.toSet,
         names => authHelper.filterByAuthorized(request.context, DESCRIBE_CONFIGS, TOPIC,
-            names, logIfDenied = false)(identity),
+            names.asJava, true, false, (n: String) => n).asScala.toSet,
         request.isForwarded)
     future.handle[Unit] { (result, exception) =>
       val response = if (exception != null) {
@@ -795,7 +797,7 @@ class ControllerApis(
 
   private def handleCreatePartitions(request: Request): CompletableFuture[Unit] = {
     def filterAlterAuthorizedTopics(topics: Iterable[String]): Set[String] = {
-      authHelper.filterByAuthorized(request.context, ALTER, TOPIC, topics)(n => n)
+      authHelper.filterByAuthorized(request.context, ALTER, TOPIC, topics.asJava, (n:String) => n).asScala.toSet
     }
     val createPartitionsRequest = request.body(classOf[CreatePartitionsRequest])
     val controllerMutationQuota = quotas.controllerMutation.newQuotaFor(request.session, request.header, 3)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -38,6 +38,7 @@ import org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.Delet
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.message.MetadataResponseData.{MetadataResponsePartition, MetadataResponseTopic}
+import org.apache.kafka.common.message.OffsetDeleteRequestData.OffsetDeleteRequestTopic
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEndOffset, OffsetForLeaderTopicResult, OffsetForLeaderTopicResultCollection}
 import org.apache.kafka.common.message._
@@ -63,6 +64,8 @@ import org.apache.kafka.coordinator.share.ShareCoordinator
 import org.apache.kafka.metadata.{ConfigRepository, MetadataCache}
 import org.apache.kafka.network.Request
 import org.apache.kafka.security.DelegationTokenManager
+import org.apache.kafka.security.authorizer.JAuthHelper
+import org.apache.kafka.security.authorizer.JAuthHelper.PartitionedSeq
 import org.apache.kafka.server.{ApiVersionManager, ClientMetricsManager, FetchManager, ProcessRole}
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.common.{GroupVersion, RequestLocal, ShareVersion, StreamsVersion, TransactionVersion}
@@ -84,6 +87,7 @@ import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 import scala.jdk.javaapi.OptionConverters
 
 /**
@@ -117,7 +121,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   type ProduceResponseStats = Map[TopicIdPartition, RecordValidationStats]
   this.logIdent = "[KafkaApi-%d] ".format(brokerId)
   val configHelper = new ConfigHelper(metadataCache, config, configRepository)
-  val authHelper = new AuthHelper(authorizerPlugin)
+  val authHelper = new JAuthHelper(authorizerPlugin.toJava)
   val requestHelper = new RequestHandlerHelper(requestChannel, quotas, time)
   val aclApis = new AclApis(authHelper, authorizerPlugin, requestHelper, ProcessRole.BrokerRole, config)
   val configManager = new ConfigAdminManager(brokerId, config, configRepository)
@@ -295,8 +299,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         request.context,
         READ,
         TOPIC,
-        offsetCommitRequest.data.topics.asScala
-      )(_.name)
+        offsetCommitRequest.data.topics,
+        (n: OffsetCommitRequestData.OffsetCommitRequestTopic) => n.name()
+      )
 
       val responseBuilder = OffsetCommitResponse.newBuilder(useTopicIds)
       val authorizedTopicsRequest = new mutable.ArrayBuffer[OffsetCommitRequestData.OffsetCommitRequestTopic]()
@@ -427,8 +432,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
     }
     // cache the result to avoid redundant authorization calls
-    val authorizedTopics = authHelper.filterByAuthorized(request.context, WRITE, TOPIC, topicIdToPartitionData)(_._1.topic)
-
+    val authorizedTopics = authHelper.filterByAuthorized(request.context, WRITE, TOPIC, topicIdToPartitionData.asJava,
+      (e: (TopicIdPartition, ProduceRequestData.PartitionProduceData)) => e._1.topic).asScala.toSet
     topicIdToPartitionData.foreach { case (topicIdPartition, partition) =>
       // This caller assumes the type is MemoryRecords and that is true on current serialization
       // We cast the type to avoid causing big change to code base.
@@ -607,7 +612,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         else
           partitionDatas += topicIdPartition -> partitionData
       }
-      val authorizedTopics = authHelper.filterByAuthorized(request.context, READ, TOPIC, partitionDatas)(_._1.topicPartition.topic)
+      val authorizedTopics = authHelper.filterByAuthorized(request.context, READ, TOPIC,
+        partitionDatas.asJava, (e: (TopicIdPartition, FetchRequest.PartitionData)) => e._1.topicPartition.topic).asScala.toSet
       partitionDatas.foreach { case (topicIdPartition, data) =>
         if (!authorizedTopics.contains(topicIdPartition.topic))
           erroneous += topicIdPartition -> FetchResponse.partitionResponse(topicIdPartition, Errors.TOPIC_AUTHORIZATION_FAILED)
@@ -791,8 +797,10 @@ class KafkaApis(val requestChannel: RequestChannel,
         .setOffset(ListOffsetsResponse.UNKNOWN_OFFSET)
     }
 
-    val (authorizedRequestInfo, unauthorizedRequestInfo) = authHelper.partitionSeqByAuthorized(request.context,
-        DESCRIBE, TOPIC, offsetRequest.topics.asScala.toSeq)(_.name)
+    val result = authHelper.partitionSeqByAuthorized(request.context, DESCRIBE, TOPIC, offsetRequest.topics,
+      (n: ListOffsetsRequestData.ListOffsetsTopic) => n.name)
+    val authorizedRequestInfo = result.authorizedPartition.asScala.toList
+    val unauthorizedRequestInfo = result.unauthorizedPartition.asScala.toList
 
     val unauthorizedResponseStatus = unauthorizedRequestInfo.map(topic =>
       new ListOffsetsTopicResponse()
@@ -910,16 +918,16 @@ class KafkaApis(val requestChannel: RequestChannel,
       metadataRequest.topics.asScala.toSet
 
     val authorizedForDescribeTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-      topics, logIfDenied = !metadataRequest.isAllTopics)(identity)
+      topics.asJava, true, !metadataRequest.isAllTopics, (n:String) => n).asScala.toSet
     var (authorizedTopics, unauthorizedForDescribeTopics) = topics.partition(authorizedForDescribeTopics.contains)
     var unauthorizedForCreateTopics = Set[String]()
 
     if (authorizedTopics.nonEmpty) {
       val nonExistingTopics = authorizedTopics.filterNot(metadataCache.contains)
       if (metadataRequest.allowAutoTopicCreation && config.autoCreateTopicsEnable && nonExistingTopics.nonEmpty) {
-        if (!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
+        if (!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, true, false, 1)) {
           val authorizedForCreateTopics = authHelper.filterByAuthorized(request.context, CREATE, TOPIC,
-            nonExistingTopics)(identity)
+            nonExistingTopics.asJava, (n: String) => n).asScala.toSet
           unauthorizedForCreateTopics = nonExistingTopics.diff(authorizedForCreateTopics)
           authorizedTopics = authorizedTopics.diff(unauthorizedForCreateTopics)
         }
@@ -1076,8 +1084,9 @@ class KafkaApis(val requestChannel: RequestChannel,
           requestContext,
           DESCRIBE,
           TOPIC,
-          groupFetchResponse.topics.asScala
-        )(_.name)
+          groupFetchResponse.topics,
+          (n: OffsetFetchResponseData.OffsetFetchResponseTopics) => n.name()
+        )
 
         val topics = new mutable.ArrayBuffer[OffsetFetchResponseData.OffsetFetchResponseTopics]
         groupFetchResponse.topics.forEach { topic =>
@@ -1123,8 +1132,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       requestContext,
       DESCRIBE,
       TOPIC,
-      groupFetchRequest.topics.asScala
-    )(_.name)
+      groupFetchRequest.topics,
+      (n: OffsetFetchRequestData.OffsetFetchRequestTopics) => n.name
+    )
 
     val authorizedTopics = new mutable.ArrayBuffer[OffsetFetchRequestData.OffsetFetchRequestTopics]
     val errorTopics = new mutable.ArrayBuffer[OffsetFetchResponseData.OffsetFetchResponseTopics]
@@ -1348,7 +1358,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def handleListGroupsRequest(request: Request): CompletableFuture[Unit] = {
     val listGroupsRequest = request.body(classOf[ListGroupsRequest])
-    val hasClusterDescribe = authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, logIfDenied = false)
+    val hasClusterDescribe = authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME, true, false, 1)
 
     groupCoordinator.listGroups(
       request.context,
@@ -1363,7 +1373,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         } else {
           // Otherwise, only groups with described group are returned.
           val authorizedGroups = response.groups.asScala.filter { group =>
-            authHelper.authorize(request.context, DESCRIBE, GROUP, group.groupId, logIfDenied = false)
+            authHelper.authorize(request.context, DESCRIBE, GROUP, group.groupId, true, false, 1)
           }
           new ListGroupsResponse(response.setGroups(authorizedGroups.asJava))
         }
@@ -1431,12 +1441,13 @@ class KafkaApis(val requestChannel: RequestChannel,
     val deleteGroupsRequest = request.body(classOf[DeleteGroupsRequest])
     val groups = deleteGroupsRequest.data.groupsNames.asScala.distinct
 
-    val (authorizedGroups, unauthorizedGroups) =
-      authHelper.partitionSeqByAuthorized(request.context, DELETE, GROUP, groups)(identity)
+    val result = authHelper.partitionSeqByAuthorized(request.context, DELETE, GROUP, groups.asJava, (n: String) => n)
+    val authorizedGroups = result.authorizedPartition.asScala.toList
+    val unauthorizedGroups = result.unauthorizedPartition.asScala.toList
 
     groupCoordinator.deleteGroups(
       request.context,
-      authorizedGroups.toList.asJava,
+      authorizedGroups.asJava,
       requestLocal.bufferSupplier
     ).handle[Unit] { (results, exception) =>
       val response = new DeleteGroupsResponseData()
@@ -1542,7 +1553,8 @@ class KafkaApis(val requestChannel: RequestChannel,
     val authorizedForDeleteTopicOffsets = mutable.Map[TopicPartition, Long]()
 
     val topics = deleteRecordsRequest.data.topics.asScala
-    val authorizedTopics = authHelper.filterByAuthorized(request.context, DELETE, TOPIC, topics)(_.name)
+    val authorizedTopics = authHelper.filterByAuthorized(request.context, DELETE, TOPIC, topics.asJava,
+      (n: DeleteRecordsRequestData.DeleteRecordsTopic) => n.name())
     val deleteTopicPartitions = topics.flatMap { deleteTopic =>
       deleteTopic.partitions.asScala.map { deletePartition =>
         new TopicPartition(deleteTopic.name, deletePartition.partitionIndex) -> deletePartition.offset
@@ -1612,7 +1624,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestHelper.sendErrorResponseMaybeThrottle(request, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED.exception)
         return
       }
-    } else if (!authHelper.authorize(request.context, IDEMPOTENT_WRITE, CLUSTER, CLUSTER_NAME, true, false)
+    } else if (!authHelper.authorize(request.context, IDEMPOTENT_WRITE, CLUSTER, CLUSTER_NAME, true, false, 1)
         && !authHelper.authorizeByResourceType(request.context, AclOperation.WRITE, ResourceType.TOPIC)) {
       requestHelper.sendErrorResponseMaybeThrottle(request, Errors.CLUSTER_AUTHORIZATION_FAILED.exception)
       return
@@ -1710,7 +1722,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleWriteTxnMarkersRequest(request: Request, requestLocal: RequestLocal): Unit = {
     // We are checking for AlterCluster permissions first. If it is not present, we are authorizing cluster operation
     // The latter will throw an exception if it is denied.
-    if (!authHelper.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
+    if (!authHelper.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME, true, false, 1)) {
       authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     }
     val writeTxnMarkersRequest = request.body(classOf[WriteTxnMarkersRequest])
@@ -1911,7 +1923,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         // Only request versions less than 4 need write authorization since they come from clients.
         val authorizedTopics =
           if (version < 4)
-            authHelper.filterByAuthorized(request.context, WRITE, TOPIC, partitionsToAdd.filterNot(tp => Topic.isInternal(tp.topic)))(_.topic)
+            authHelper.filterByAuthorized(request.context, WRITE, TOPIC, partitionsToAdd.filterNot(tp => Topic.isInternal(tp.topic)).asJava,
+              (n: TopicPartition) => n.topic()).asScala.toSet
           else
             partitionsToAdd.map(_.topic).toSet
         for (topicPartition <- partitionsToAdd) {
@@ -2064,8 +2077,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         request.context,
         READ,
         TOPIC,
-        txnOffsetCommitRequest.data.topics.asScala
-      )(_.name)
+        txnOffsetCommitRequest.data.topics,
+        (n: TxnOffsetCommitRequestData.TxnOffsetCommitRequestTopic) => n.name()
+      )
 
       val responseBuilder = TxnOffsetCommitResponse.newBuilder(useTopicIds)
       val authorizedTopicCommittedOffsets = new mutable.ArrayBuffer[TxnOffsetCommitRequestData.TxnOffsetCommitRequestTopic]()
@@ -2154,10 +2168,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     // The OffsetsForLeaderEpoch API was initially only used for inter-broker communication and required
     // cluster permission. With KIP-320, the consumer now also uses this API to check for log truncation
     // following a leader change, so we also allow topic describe permission.
-    val (authorizedTopics, unauthorizedTopics) =
-      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME, logIfDenied = false))
-        (topics, Seq.empty[OffsetForLeaderTopic])
-      else authHelper.partitionSeqByAuthorized(request.context, DESCRIBE, TOPIC, topics)(_.topic)
+    val result =
+      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME, true, false, 1))
+        new PartitionedSeq[OffsetForLeaderTopic](topics.asJava, java.util.List.of())
+      else authHelper.partitionSeqByAuthorized(request.context, DESCRIBE, TOPIC, topics.asJava,
+          (n: OffsetForLeaderTopic) => n.topic())
+
+    val authorizedTopics = result.authorizedPartition.asScala.toList
+    val unauthorizedTopics = result.unauthorizedPartition.asScala.toList
 
     val endOffsetsForAuthorizedPartitions = replicaManager.lastOffsetForLeaderEpoch(authorizedTopics)
     val endOffsetsForUnauthorizedPartitions = unauthorizedTopics.map { offsetForLeaderTopic =>
@@ -2401,8 +2419,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         request.context,
         READ,
         TOPIC,
-        offsetDeleteRequest.data.topics.asScala
-      )(_.name)
+        offsetDeleteRequest.data.topics,
+        (n: OffsetDeleteRequestTopic) => n.name()
+      )
 
       val responseBuilder = new OffsetDeleteResponse.Builder
       val authorizedTopicPartitions = new OffsetDeleteRequestData.OffsetDeleteRequestTopicCollection()
@@ -2644,7 +2663,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // Clients are not allowed to see topics that are not authorized for Describe.
         val subscribedTopicSet = consumerGroupHeartbeatRequest.data.subscribedTopicNames.asScala.toSet
         val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-          subscribedTopicSet)(identity)
+          subscribedTopicSet.asJava, (n: String) => n)
         if (authorizedTopics.size < subscribedTopicSet.size) {
           val responseData = new ConsumerGroupHeartbeatResponseData()
             .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
@@ -2726,7 +2745,7 @@ class KafkaApis(val requestChannel: RequestChannel,
               .collect(Collectors.toSet[String])
               .asScala
             val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-              topicsToCheck)(identity)
+              topicsToCheck.asJava, (n: String) => n)
             val updatedGroups = response.groups.stream().map { group =>
               val hasUnauthorizedTopic = group.members.stream()
                 .flatMap(member => util.stream.Stream.of(member.assignment, member.targetAssignment))
@@ -2807,7 +2826,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
 
         if (requiredTopics.nonEmpty) {
-          val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, requiredTopics)(identity)
+          val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, requiredTopics.asJava, (n: String) => n)
           if (authorizedTopics.size < requiredTopics.size) {
             val responseData = new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
             requestHelper.sendMaybeThrottle(request, new StreamsGroupHeartbeatResponse(responseData))
@@ -2828,8 +2847,8 @@ class KafkaApis(val requestChannel: RequestChannel,
           if (topicsToCreate.nonEmpty) {
 
             val createTopicUnauthorized =
-              if(!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false))
-                authHelper.partitionSeqByAuthorized(request.context, CREATE, TOPIC, topicsToCreate.keys.toSeq)(identity[String])._2
+              if(!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, true, false, 1))
+                authHelper.partitionSeqByAuthorized(request.context, CREATE, TOPIC, topicsToCreate.keys.toList.asJava, (n: String) => n).unauthorizedPartition.asScala.toSet
               else Set.empty
 
             if (createTopicUnauthorized.nonEmpty) {
@@ -2957,7 +2976,7 @@ class KafkaApis(val requestChannel: RequestChannel,
               .asScala
 
             val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-              topicsToCheck)(identity)
+              topicsToCheck.asJava, (n: String) => n)
 
               val updatedGroups = response.groups.stream.map { group =>
                 val hasUnauthorizedTopic = if (group.topology == null) false else
@@ -3089,7 +3108,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // Clients are not allowed to see topics that are not authorized for Describe.
         val subscribedTopicSet = shareGroupHeartbeatRequest.data.subscribedTopicNames.asScala.toSet
         val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-          subscribedTopicSet)(identity)
+          subscribedTopicSet.asJava, (n: String) => n)
         if (authorizedTopics.size < subscribedTopicSet.size) {
           val responseData = new ShareGroupHeartbeatResponseData()
             .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
@@ -3169,7 +3188,7 @@ class KafkaApis(val requestChannel: RequestChannel,
               .collect(Collectors.toSet[String])
               .asScala
             val authorizedTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
-              topicsToCheck)(identity)
+              topicsToCheck.asJava, (n: String) => n)
             val updatedGroups = response.groups.stream().map { group =>
               val hasUnauthorizedTopic = group.members.stream()
                 .flatMap(member => member.assignment.topicPartitions.stream)
@@ -3303,8 +3322,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       request.context,
       READ,
       TOPIC,
-      topicIdPartitionSeq
-    )(_.topicPartition.topic)
+      topicIdPartitionSeq.asJava,
+      (n: TopicIdPartition) => n.topicPartition().topic()
+    ).asScala.toSet
 
     // Variable to store the topic partition wise result of piggybacked acknowledgements.
     var acknowledgeResult: CompletableFuture[Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]] =
@@ -3628,8 +3648,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       request.context,
       READ,
       TOPIC,
-      topicIdPartitionSeq
-    )(_.topicPartition.topic)
+      topicIdPartitionSeq.asJava,
+      (n: TopicIdPartition) => n.topicPartition().topic()
+    ).asScala.toSet
 
     val erroneous = mutable.Map[TopicIdPartition, ShareAcknowledgeResponseData.PartitionData]()
     val acknowledgementDataFromRequest = getAcknowledgeBatchesFromShareAcknowledgeRequest(shareAcknowledgeRequest, topicIdNames, erroneous)
@@ -3828,13 +3849,14 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setErrorMessage(error.message)
       } else {
         // Clients are not allowed to see offsets for topics that are not authorized for Describe.
-        val (authorizedOffsets, _) = authHelper.partitionSeqByAuthorized(
+        val result = authHelper.partitionSeqByAuthorized(
           requestContext,
           DESCRIBE,
           TOPIC,
-          groupDescribeOffsetsResponse.topics.asScala
-        )(_.topicName)
-        groupDescribeOffsetsResponse.setTopics(authorizedOffsets.asJava)
+          groupDescribeOffsetsResponse.topics,
+          (n: DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseTopic) => n.topicName()
+        )
+        groupDescribeOffsetsResponse.setTopics(result.authorizedPartition)
       }
     }
   }
@@ -3843,18 +3865,21 @@ class KafkaApis(val requestChannel: RequestChannel,
     groupDescribeOffsetsRequest: DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup
   ): CompletableFuture[DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup] = {
     // Clients are not allowed to see offsets for topics that are not authorized for Describe.
-    val (authorizedTopics, unauthorizedTopics) = authHelper.partitionSeqByAuthorized(
+    val result = authHelper.partitionSeqByAuthorized(
       requestContext,
       DESCRIBE,
       TOPIC,
-      groupDescribeOffsetsRequest.topics.asScala
-    )(_.topicName)
+      groupDescribeOffsetsRequest.topics,
+      (n: DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestTopic) => n.topicName()
+    )
+    val authorizedTopics = result.authorizedPartition
+    val unauthorizedTopics = result.unauthorizedPartition.asScala.toList
 
     groupCoordinator.describeShareGroupOffsets(
       requestContext,
       new DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup()
         .setGroupId(groupDescribeOffsetsRequest.groupId)
-        .setTopics(authorizedTopics.asJava)
+        .setTopics(authorizedTopics)
     ).handle[DescribeShareGroupOffsetsResponseData.DescribeShareGroupOffsetsResponseGroup] { (groupDescribeOffsetsResponse, exception) =>
       if (exception != null) {
         val error = Errors.forException(exception)

--- a/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
+++ b/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
@@ -17,7 +17,6 @@
 
 package kafka.server.handlers;
 
-import kafka.server.AuthHelper;
 import kafka.server.KafkaConfig;
 import kafka.utils.TestUtils;
 
@@ -62,6 +61,7 @@ import org.apache.kafka.network.SocketServerConfigs;
 import org.apache.kafka.network.metrics.RequestChannelMetrics;
 import org.apache.kafka.raft.KRaftConfigs;
 import org.apache.kafka.raft.QuorumConfig;
+import org.apache.kafka.security.authorizer.JAuthHelper;
 import org.apache.kafka.server.authorizer.Action;
 import org.apache.kafka.server.authorizer.AuthorizationResult;
 import org.apache.kafka.server.authorizer.Authorizer;
@@ -192,7 +192,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
         KRaftMetadataCache metadataCache = new KRaftMetadataCache(0, () -> KRaftVersion.KRAFT_VERSION_1);
         updateKraftMetadataCache(metadataCache, records);
         DescribeTopicPartitionsRequestHandler handler =
-            new DescribeTopicPartitionsRequestHandler(metadataCache, new AuthHelper(scala.Option.apply(authorizerPlugin)), createKafkaDefaultConfig());
+            new DescribeTopicPartitionsRequestHandler(metadataCache, new JAuthHelper(Optional.of(authorizerPlugin)), createKafkaDefaultConfig());
 
         // 3.1 Basic test
         DescribeTopicPartitionsRequest describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(
@@ -390,7 +390,7 @@ class DescribeTopicPartitionsRequestHandlerTest {
         KRaftMetadataCache metadataCache = new KRaftMetadataCache(0, () -> KRaftVersion.KRAFT_VERSION_1);
         updateKraftMetadataCache(metadataCache, records);
         DescribeTopicPartitionsRequestHandler handler =
-            new DescribeTopicPartitionsRequestHandler(metadataCache, new AuthHelper(scala.Option.apply(authorizerPlugin)), createKafkaDefaultConfig());
+            new DescribeTopicPartitionsRequestHandler(metadataCache, new JAuthHelper(Optional.of(authorizerPlugin)), createKafkaDefaultConfig());
 
         // 3.1 With cursor point to the first one
         DescribeTopicPartitionsRequest describeTopicPartitionsRequest = new DescribeTopicPartitionsRequest(new DescribeTopicPartitionsRequestData()

--- a/server/src/main/java/org/apache/kafka/security/authorizer/JAuthHelper.java
+++ b/server/src/main/java/org/apache/kafka/security/authorizer/JAuthHelper.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.security.authorizer;
+
+import org.apache.kafka.clients.admin.EndpointType;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.internals.Plugin;
+import org.apache.kafka.common.message.DescribeClusterResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.DescribeClusterRequest;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.Resource;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.network.Request;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.authorizer.Authorizer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class JAuthHelper {
+    private final Optional<Plugin<Authorizer>> authorizerOpt;
+
+    public JAuthHelper(Optional<Plugin<Authorizer>> authorizer) {
+        this.authorizerOpt = authorizer;
+    }
+
+    public boolean authorize(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        String resourceName,
+        boolean logIfAllowed,
+        boolean logIfDenied,
+        int refCount
+    ) {
+        return authorizerOpt.map(plugin -> {
+            ResourcePattern resource = new ResourcePattern(resourceType, resourceName, PatternType.LITERAL);
+            List<Action> actions = List.of(new Action(operation, resource, refCount, logIfAllowed, logIfDenied));
+            return plugin.get().authorize(requestContext, actions).get(0) == AuthorizationResult.ALLOWED;
+        }).orElse(true);
+    }
+
+    public boolean authorize(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        String resourceName
+    ) {
+        return authorize(requestContext, operation, resourceType, resourceName, true, true, 1);
+    }
+
+    public void authorizeClusterOperation(
+        Request request,
+        AclOperation operation
+    ) {
+        if (!authorize(request.context(), operation, ResourceType.CLUSTER, Resource.CLUSTER_NAME, true, true, 1)) {
+            throw new ClusterAuthorizationException(String.format("Request %s needs %s permission.", request, operation));
+        }
+    }
+
+    public int authorizedOperations(
+        Request request,
+        Resource resource
+    ) {
+        List<AclOperation> supportedOps = AclEntry.supportedOperations(resource.resourceType()).stream().toList();
+        if (authorizerOpt.isPresent()) {
+            ResourcePattern resourcePattern = new ResourcePattern(resource.resourceType(), resource.name(), PatternType.LITERAL);
+            List<Action> actions = supportedOps.stream()
+                .map(op -> new Action(op, resourcePattern, 1, false, false))
+                .toList();
+            List<AuthorizationResult> authorizationResults = authorizerOpt.get().get().authorize(request.context(), actions);
+            Set<Byte> finalSupportedOperations = new HashSet<>();
+            int size = Math.min(supportedOps.size(), authorizationResults.size());
+            for (int index = 0; index < size; index++) {
+                if (authorizationResults.get(index) == AuthorizationResult.ALLOWED) {
+                    finalSupportedOperations.add(supportedOps.get(index).code());
+                }
+            }
+            return Utils.to32BitField(finalSupportedOperations);
+        }
+        return Utils.to32BitField(supportedOps.stream().map(AclOperation::code).collect(Collectors.toSet()));
+    }
+
+    public boolean authorizeByResourceType(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType
+    ) {
+        return authorizerOpt.map(plugin -> plugin.get().authorizeByResourceType(requestContext, operation, resourceType) == AuthorizationResult.ALLOWED)
+            .orElse(true);
+    }
+
+    public record PartitionedSeq<T>(
+        List<T> authorizedPartition,
+        List<T> unauthorizedPartition
+    ) {
+    }
+
+    public <T> PartitionedSeq<T> partitionSeqByAuthorized(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        List<T> resources,
+        boolean logIfAllowed,
+        boolean logIfDenied,
+        Function<T, String> resourceName
+    ) {
+        return authorizerOpt.map(plugin -> {
+            Set<String> authorizedResourceNames = filterByAuthorized(requestContext, operation, resourceType,
+                resources, logIfAllowed, logIfDenied, resourceName);
+            Map<Boolean, List<T>> partitioned = resources.stream()
+                .collect(Collectors.partitioningBy(r -> authorizedResourceNames.contains(resourceName.apply(r))));
+            return new PartitionedSeq<>(partitioned.get(true), partitioned.get(false));
+        }).orElse(new PartitionedSeq<>(resources, List.of()));
+    }
+
+    public <T> PartitionedSeq<T> partitionSeqByAuthorized(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        List<T> resources,
+        Function<T, String> resourceName
+    ) {
+        return partitionSeqByAuthorized(requestContext, operation, resourceType, resources, true, true, resourceName);
+    }
+
+    public <T> Set<String> filterByAuthorized(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        Iterable<T> resources,
+        boolean logIfAllowed,
+        boolean logIfDenied,
+        Function<T, String> resourceName
+    ) {
+        return authorizerOpt.map(plugin -> {
+            Map<String, Integer> resourceNameToCount = new TreeMap<>();
+            for (T resource : resources) {
+                resourceNameToCount.compute(resourceName.apply(resource), (k, v) -> v == null ? 1 : v + 1);
+            }
+
+            List<Action> actions = new ArrayList<>(resourceNameToCount.size());
+            List<String> resourceNames = new ArrayList<>();
+            resourceNameToCount.forEach((rName, count) -> {
+                ResourcePattern resource = new ResourcePattern(resourceType, rName, PatternType.LITERAL);
+                actions.add(new Action(operation, resource, count, logIfAllowed, logIfDenied));
+                resourceNames.add(rName);
+            });
+
+            List<AuthorizationResult> authorizationResults = plugin.get().authorize(requestContext, actions);
+            Set<String> finalResourceNames = new HashSet<>();
+            for (int i = 0; i < resourceNames.size(); i++) {
+                if (authorizationResults.get(i) == AuthorizationResult.ALLOWED) {
+                    finalResourceNames.add(resourceNames.get(i));
+                }
+            }
+            return finalResourceNames;
+        }).orElseGet(() -> {
+            Set<String> finalResourceNames = new HashSet<>();
+            for (T resource : resources) {
+                finalResourceNames.add(resourceName.apply(resource));
+            }
+            return finalResourceNames;
+        });
+    }
+
+    public <T> Set<String> filterByAuthorized(
+        RequestContext requestContext,
+        AclOperation operation,
+        ResourceType resourceType,
+        Iterable<T> resources,
+        Function<T, String> resourceName
+    ) {
+        return filterByAuthorized(requestContext, operation, resourceType, resources, true, true, resourceName);
+    }
+
+    public DescribeClusterResponseData computeDescribeClusterResponse(
+        Request request,
+        EndpointType expectedEndpointType,
+        String clusterId,
+        Supplier<DescribeClusterResponseData.DescribeClusterBrokerCollection> getNodes,
+        Supplier<Integer> getControllerId
+    ) {
+        DescribeClusterRequest describeClusterRequest = request.body(DescribeClusterRequest.class);
+        EndpointType requestEndpointType = EndpointType.fromId(describeClusterRequest.data().endpointType());
+
+        if (requestEndpointType.equals(EndpointType.UNKNOWN)) {
+            return new DescribeClusterResponseData()
+                .setErrorCode(request.header().data().requestApiVersion() == 0 ? Errors.INVALID_REQUEST.code() : Errors.UNSUPPORTED_ENDPOINT_TYPE.code())
+                .setErrorMessage("Unsupported endpoint type " + (int) describeClusterRequest.data().endpointType());
+        } else if (!expectedEndpointType.equals(requestEndpointType)) {
+            return new DescribeClusterResponseData()
+                .setErrorCode(request.header().data().requestApiVersion() == 0 ? Errors.INVALID_REQUEST.code() : Errors.MISMATCHED_ENDPOINT_TYPE.code())
+                .setErrorMessage("The request was sent to an endpoint of type " + expectedEndpointType +
+                    ", but we wanted an endpoint of type " + requestEndpointType);
+        }
+
+        var clusterAuthorizedOperations = Integer.MIN_VALUE;    // Default value in the schema
+
+        // get cluster authorized operations
+        if (describeClusterRequest.data().includeClusterAuthorizedOperations()) {
+            if (authorize(request.context(), AclOperation.DESCRIBE, ResourceType.CLUSTER, Resource.CLUSTER_NAME, true, true, 1))
+                clusterAuthorizedOperations = authorizedOperations(request, Resource.CLUSTER);
+            else
+                clusterAuthorizedOperations = 0;
+        }
+
+        // get the node list and the controller ID.
+        DescribeClusterResponseData.DescribeClusterBrokerCollection nodes = getNodes.get();
+        int controllerId = getControllerId.get();
+
+        // If the provided controller ID is not in the node list, return -1 instead
+        // to avoid confusing the client. This could happen in a case where we know
+        // the controller ID, but we don't yet have KIP-919 information about that
+        // controller.
+        int effectiveControllerId = nodes.find(controllerId) == null ? -1 : controllerId;
+        return new DescribeClusterResponseData().
+            setClusterId(clusterId).
+            setControllerId(effectiveControllerId).
+            setClusterAuthorizedOperations(clusterAuthorizedOperations).
+            setBrokers(nodes).
+            setEndpointType(expectedEndpointType.id());
+    }
+}

--- a/server/src/test/java/org/apache/kafka/security/authorizer/JAuthHelperTest.java
+++ b/server/src/test/java/org/apache/kafka/security/authorizer/JAuthHelperTest.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.security.authorizer;
+
+import org.apache.kafka.clients.admin.EndpointType;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.internals.Plugin;
+import org.apache.kafka.common.message.DescribeClusterRequestData;
+import org.apache.kafka.common.message.DescribeClusterResponseData;
+import org.apache.kafka.common.message.DescribeClusterResponseData.DescribeClusterBrokerCollection;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.DescribeClusterRequest;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.network.Request;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.authorizer.Authorizer;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JAuthHelperTest {
+
+    private static final String CLIENT_ID = "";
+
+    private static Request newMockDescribeClusterRequest(
+        DescribeClusterRequestData data,
+        int requestVersion
+    ) throws UnknownHostException {
+        RequestContext requestContext = new RequestContext(
+            new RequestHeader(ApiKeys.DESCRIBE_CLUSTER, (short) requestVersion, "", 0),
+            "",
+            InetAddress.getLocalHost(),
+            KafkaPrincipal.ANONYMOUS,
+            new ListenerName("PLAINTEXT"),
+            SecurityProtocol.PLAINTEXT,
+            ClientInformation.EMPTY,
+            false);
+        Request request = mock(Request.class);
+        when(request.body(DescribeClusterRequest.class)).thenReturn(
+            new DescribeClusterRequest(data, (short) requestVersion));
+        when(request.context()).thenReturn(requestContext);
+        when(request.header()).thenReturn(requestContext.header);
+        return request;
+    }
+
+    @Test
+    public void testAuthorize() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+
+        AclOperation operation = AclOperation.WRITE;
+        ResourceType resourceType = ResourceType.TOPIC;
+        String resourceName = "topic-1";
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.PRODUCE, ApiKeys.PRODUCE.latestVersion(), CLIENT_ID, 0);
+        RequestContext requestContext = new RequestContext(requestHeader, "1", InetAddress.getLocalHost(),
+            KafkaPrincipal.ANONYMOUS, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+
+        List<Action> expectedActions = List.of(
+            new Action(operation, new ResourcePattern(resourceType, resourceName, PatternType.LITERAL),
+                1, true, true)
+        );
+
+        when(authorizer.authorize(requestContext, expectedActions))
+            .thenReturn(List.of(AuthorizationResult.ALLOWED));
+
+        boolean result = new JAuthHelper(Optional.of(authorizerPlugin)).authorize(
+            requestContext, operation, resourceType, resourceName);
+
+        verify(authorizer).authorize(requestContext, expectedActions);
+
+        assertEquals(true, result);
+    }
+
+    @Test
+    public void testFilterByAuthorized() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+
+        AclOperation operation = AclOperation.WRITE;
+        ResourceType resourceType = ResourceType.TOPIC;
+        String resourceName1 = "topic-1";
+        String resourceName2 = "topic-2";
+        String resourceName3 = "topic-3";
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.PRODUCE, ApiKeys.PRODUCE.latestVersion(),
+            CLIENT_ID, 0);
+        RequestContext requestContext = new RequestContext(requestHeader, "1", InetAddress.getLocalHost(),
+            KafkaPrincipal.ANONYMOUS, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+
+        List<Action> expectedActions = List.of(
+            new Action(operation, new ResourcePattern(resourceType, resourceName1, PatternType.LITERAL),
+                2, true, true),
+            new Action(operation, new ResourcePattern(resourceType, resourceName2, PatternType.LITERAL),
+                1, true, true),
+            new Action(operation, new ResourcePattern(resourceType, resourceName3, PatternType.LITERAL),
+                1, true, true)
+        );
+
+        when(authorizer.authorize(
+            eq(requestContext), argThat(actions -> actions != null && actions.containsAll(expectedActions))
+        )).thenAnswer(invocation -> {
+            List<Action> actions = invocation.getArgument(1);
+            return actions.stream().map(action -> {
+                if (Set.of(resourceName1, resourceName3).contains(action.resourcePattern().name()))
+                    return AuthorizationResult.ALLOWED;
+                else
+                    return AuthorizationResult.DENIED;
+            }).collect(Collectors.toList());
+        });
+
+        Set<String> result = new JAuthHelper(Optional.of(authorizerPlugin)).filterByAuthorized(
+            requestContext,
+            operation,
+            resourceType,
+            // Duplicate resource names should not trigger multiple calls to authorize
+            List.of(resourceName1, resourceName2, resourceName1, resourceName3),
+            true,
+            true,
+            Function.identity()
+        );
+
+        verify(authorizer).authorize(
+            eq(requestContext), argThat(actions -> actions != null && actions.containsAll(expectedActions))
+        );
+
+        assertEquals(Set.of(resourceName1, resourceName3), result);
+    }
+
+    @Test
+    public void testFilterByAuthorizedWithEmptyResources() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.PRODUCE, ApiKeys.PRODUCE.latestVersion(), CLIENT_ID, 0);
+        RequestContext requestContext = new RequestContext(requestHeader, "1", InetAddress.getLocalHost(),
+            KafkaPrincipal.ANONYMOUS, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+
+        // Mock returns a non-empty list even for empty actions — simulating a poorly-behaved mock/authorizer.
+        when(authorizer.authorize(any(RequestContext.class), any()))
+            .thenReturn(List.of(AuthorizationResult.ALLOWED));
+
+        Set<String> result = new JAuthHelper(Optional.of(authorizerPlugin)).filterByAuthorized(
+            requestContext,
+            AclOperation.WRITE,
+            ResourceType.TOPIC,
+            Collections.emptyList(),
+            Function.identity()
+        );
+
+        assertEquals(Set.of(), result);
+    }
+
+    @Test
+    public void testAuthorizedOperationsWithMismatchedAuthorizerResults() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.DESCRIBE_CLUSTER, (short) 1, CLIENT_ID, 0);
+        RequestContext requestContext = new RequestContext(requestHeader, "1", InetAddress.getLocalHost(),
+            KafkaPrincipal.ANONYMOUS, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+            SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+        Request request = mock(Request.class);
+        when(request.context()).thenReturn(requestContext);
+
+        // Mock returns an empty list regardless of how many actions are sent.
+        when(authorizer.authorize(any(RequestContext.class), any()))
+            .thenReturn(Collections.emptyList());
+
+        org.apache.kafka.common.resource.Resource resource =
+            new org.apache.kafka.common.resource.Resource(ResourceType.TOPIC, "test-topic");
+
+        int result = new JAuthHelper(Optional.of(authorizerPlugin)).authorizedOperations(request, resource);
+
+        // No operations should be authorized since the authorizer returned an empty list.
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseV1WithUnknownEndpointType() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType((byte) 123), 1);
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.BROKER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            DescribeClusterBrokerCollection::new,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setErrorCode(Errors.UNSUPPORTED_ENDPOINT_TYPE.code())
+            .setErrorMessage("Unsupported endpoint type 123"), responseData);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseV0WithUnknownEndpointType() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType((byte) 123), 0);
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.BROKER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            DescribeClusterBrokerCollection::new,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setErrorCode(Errors.INVALID_REQUEST.code())
+            .setErrorMessage("Unsupported endpoint type 123"), responseData);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseV1WithUnexpectedEndpointType() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType(EndpointType.BROKER.id()), 1);
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.CONTROLLER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            DescribeClusterBrokerCollection::new,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setErrorCode(Errors.MISMATCHED_ENDPOINT_TYPE.code())
+            .setErrorMessage("The request was sent to an endpoint of type CONTROLLER, but we wanted an endpoint of type BROKER"), responseData);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseV0WithUnexpectedEndpointType() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType(EndpointType.BROKER.id()), 0);
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.CONTROLLER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            DescribeClusterBrokerCollection::new,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setErrorCode(Errors.INVALID_REQUEST.code())
+            .setErrorMessage("The request was sent to an endpoint of type CONTROLLER, but we wanted an endpoint of type BROKER"), responseData);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseWhereControllerIsNotFound() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType(EndpointType.CONTROLLER.id()), 1);
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.CONTROLLER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            DescribeClusterBrokerCollection::new,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setClusterId("ltCWoi9wRhmHSQCIgAznEg")
+            .setControllerId(-1)
+            .setClusterAuthorizedOperations(Integer.MIN_VALUE)
+            .setEndpointType((byte) 2), responseData);
+    }
+
+    @Test
+    public void testComputeDescribeClusterResponseSuccess() throws UnknownHostException {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        JAuthHelper authHelper = new JAuthHelper(Optional.of(authorizerPlugin));
+        Request request = newMockDescribeClusterRequest(
+            new DescribeClusterRequestData().setEndpointType(EndpointType.CONTROLLER.id()), 1);
+        DescribeClusterBrokerCollection nodes = new DescribeClusterBrokerCollection(
+            Arrays.asList(
+                new DescribeClusterResponseData.DescribeClusterBroker().setBrokerId(1)));
+        DescribeClusterResponseData responseData = authHelper.computeDescribeClusterResponse(request,
+            EndpointType.CONTROLLER,
+            "ltCWoi9wRhmHSQCIgAznEg",
+            () -> nodes,
+            () -> 1);
+        assertEquals(new DescribeClusterResponseData()
+            .setClusterId("ltCWoi9wRhmHSQCIgAznEg")
+            .setControllerId(1)
+            .setClusterAuthorizedOperations(Integer.MIN_VALUE)
+            .setBrokers(nodes)
+            .setEndpointType((byte) 2), responseData);
+    }
+}


### PR DESCRIPTION
* Move `AuthHelper.scala` to `server` module.
* The new class is named `JAuthHelper.java` for now and will be renamed
post successful reviews and the original `AuthHelper.scala` removed.
* Tests have been added in `JAuthHelper.java`.
* Existing code has been updated especially `KafkaApis.scala`.
