### PR TITLE
MINOR: Remove unused Response.onComplete method

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -44,18 +44,13 @@ object RequestChannel extends Logging {
     def processor: Int = request.processor
 
     def responseLog: Option[JsonNode] = None
-
-    def onComplete: Option[Send => Unit] = None
   }
 
   /** responseLogValue should only be defined if request logging is enabled */
   class SendResponse(request: Request,
                      val responseSend: Send,
-                     val responseLogValue: Option[JsonNode],
-                     val onCompleteCallback: Option[Send => Unit]) extends Response(request) {
+                     val responseLogValue: Option[JsonNode]) extends Response(request) {
     override def responseLog: Option[JsonNode] = responseLogValue
-
-    override def onComplete: Option[Send => Unit] = onCompleteCallback
 
     override def toString: String =
       s"Response(type=Send, request=$request, send=$responseSend, asString=$responseLogValue)"
@@ -135,15 +130,13 @@ class RequestChannel(val queueSize: Int,
 
   def sendResponse(
     request: Request,
-    response: AbstractResponse,
-    onComplete: Option[Send => Unit]
+    response: AbstractResponse
   ): Unit = {
     updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala)
     sendResponse(new RequestChannel.SendResponse(
       request,
       request.buildResponseSend(response),
-      request.responseNode(response).toScala,
-      onComplete
+      request.responseNode(response).toScala
     ))
   }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1068,10 +1068,6 @@ private[kafka] class Processor(
         val response = inflightResponses.remove(send.destinationId).getOrElse {
           throw new IllegalStateException(s"Send for ${send.destinationId} completed, but not in `inflightResponses`")
         }
-
-        // Invoke send completion callback, and then update request metrics since there might be some
-        // request metrics got updated during callback
-        response.onComplete.foreach(onComplete => onComplete(send))
         updateRequestMetrics(response)
 
         // Try unmuting the channel. If there was no quota violation and the channel has not been throttled,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -523,7 +523,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           requestHelper.sendNoOpResponseExemptThrottle(request)
         }
       } else {
-        requestChannel.sendResponse(request, new ProduceResponse(mergedResponseStatus.asJava, maxThrottleTimeMs, nodeEndpoints.values.toList.asJava), None)
+        requestChannel.sendResponse(request, new ProduceResponse(mergedResponseStatus.asJava, maxThrottleTimeMs, nodeEndpoints.values.toList.asJava))
       }
     }
 
@@ -724,7 +724,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
         recordBytesOutMetric(fetchResponse)
         // Send the response immediately.
-        requestChannel.sendResponse(request, fetchResponse, None)
+        requestChannel.sendResponse(request, fetchResponse)
       }
     }
 
@@ -3428,7 +3428,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (exception != null) {
         requestHelper.sendMaybeThrottle(request, shareFetchRequest.getErrorResponse(AbstractResponse.DEFAULT_THROTTLE_TIME, exception))
       } else {
-        requestChannel.sendResponse(request, result, None)
+        requestChannel.sendResponse(request, result)
       }
     }
   }

--- a/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
+++ b/core/src/main/scala/kafka/server/RequestHandlerHelper.scala
@@ -20,7 +20,6 @@ package kafka.server
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.QuotaManagers
 import org.apache.kafka.common.errors.ClusterAuthorizationException
-import org.apache.kafka.common.network.Send
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.network.Request
@@ -62,7 +61,7 @@ class RequestHandlerHelper(
     if (response == null)
       requestChannel.closeConnection(request, requestBody.errorCounts(error))
     else
-      requestChannel.sendResponse(request, response, None)
+      requestChannel.sendResponse(request, response)
   }
 
   def sendForwardedResponse(request: Request,
@@ -74,7 +73,7 @@ class RequestHandlerHelper(
     val appliedThrottleTimeMs = math.max(controllerThrottleTimeMs, requestThrottleTimeMs)
     throttle(quotas.request, request, appliedThrottleTimeMs)
     response.maybeSetThrottleTimeMs(appliedThrottleTimeMs)
-    requestChannel.sendResponse(request, response, None)
+    requestChannel.sendResponse(request, response)
   }
 
   // Throttle the channel if the request quota is enabled but has been violated. Regardless of throttling, send the
@@ -88,7 +87,7 @@ class RequestHandlerHelper(
     if (!request.isForwarded)
       throttle(quotas.request, request, throttleTimeMs)
     response.maybeSetThrottleTimeMs(throttleTimeMs)
-    requestChannel.sendResponse(request, response, None)
+    requestChannel.sendResponse(request, response)
   }
 
   def sendResponseMaybeThrottle(request: Request,
@@ -97,7 +96,7 @@ class RequestHandlerHelper(
     // Only throttle non-forwarded requests
     if (!request.isForwarded)
       throttle(quotas.request, request, throttleTimeMs)
-    requestChannel.sendResponse(request, createResponse(throttleTimeMs), None)
+    requestChannel.sendResponse(request, createResponse(throttleTimeMs))
   }
 
   def sendErrorResponseMaybeThrottle(request: Request, error: Throwable): Unit = {
@@ -138,14 +137,13 @@ class RequestHandlerHelper(
     }
 
     response.maybeSetThrottleTimeMs(maxThrottleTimeMs)
-    requestChannel.sendResponse(request, response, None)
+    requestChannel.sendResponse(request, response)
   }
 
   def sendResponseExemptThrottle(request: Request,
-                                 response: AbstractResponse,
-                                 onComplete: Option[Send => Unit] = None): Unit = {
+                                 response: AbstractResponse): Unit = {
     quotas.request.maybeRecordExempt(request)
-    requestChannel.sendResponse(request, response, onComplete)
+    requestChannel.sendResponse(request, response)
   }
 
   private def sendErrorResponseExemptThrottle(request: Request, error: Throwable): Unit = {

--- a/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
@@ -58,7 +58,7 @@ class TestRaftRequestHandler(
         error(s"Unexpected error handling request ${request.requestDesc(true)} " +
           s"with context ${request.context}", e)
         val errorResponse = request.body(classOf[AbstractRequest]).getErrorResponse(e)
-        requestChannel.sendResponse(request, errorResponse, None)
+        requestChannel.sendResponse(request, errorResponse)
     } finally {
       // The local completion time may be set while processing the request. Only record it if it's unset.
       if (request.apiLocalCompleteTimeNanos < 0)
@@ -67,7 +67,7 @@ class TestRaftRequestHandler(
   }
 
   private def handleApiVersions(request: Request): Unit = {
-    requestChannel.sendResponse(request, apiVersionManager.apiVersionResponse(0, request.header.apiVersion() < 4), None)
+    requestChannel.sendResponse(request, apiVersionManager.apiVersionResponse(0, request.header.apiVersion() < 4))
   }
 
   private def handleVote(request: Request): Unit = {
@@ -109,7 +109,7 @@ class TestRaftRequestHandler(
       } else {
         buildResponse(response)
       }
-      requestChannel.sendResponse(request, res, None)
+      requestChannel.sendResponse(request, res)
     })
   }
 

--- a/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
@@ -71,7 +71,7 @@ class RequestConvertToJsonTest {
     val req = request(alterIsrRequest)
     val send = new NetworkSend(req.context.connectionId, alterIsrRequest.toSend(req.header))
     val headerLog = RequestConvertToJson.requestHeaderNode(req.header)
-    val res = new RequestChannel.SendResponse(req, send, Some(headerLog), None)
+    val res = new RequestChannel.SendResponse(req, send, Some(headerLog))
 
     val totalTimeMs = 1
     val requestQueueTimeMs = 2

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -164,7 +164,7 @@ class SocketServerTest {
     val byteBuffer = request.body(classOf[AbstractRequest]).serializeWithHeader(request.header)
     val send = new NetworkSend(request.context.connectionId, ByteBufferSend.sizePrefixed(byteBuffer))
     val headerLog = RequestConvertToJson.requestHeaderNode(request.header)
-    channel.sendResponse(new RequestChannel.SendResponse(request, send, Some(headerLog), None))
+    channel.sendResponse(new RequestChannel.SendResponse(request, send, Some(headerLog)))
   }
 
   def processRequestNoOpResponse(channel: RequestChannel, request: Request): Unit = {
@@ -652,7 +652,7 @@ class SocketServerTest {
     val headerLog = RequestConvertToJson.requestHeaderNode(request.header)
     val response =
       if (!noOpResponse)
-        new RequestChannel.SendResponse(request, send, Some(headerLog), None)
+        new RequestChannel.SendResponse(request, send, Some(headerLog))
       else
         new RequestChannel.NoOpResponse(request)
     server.dataPlaneRequestChannel.sendResponse(response)
@@ -1104,7 +1104,7 @@ class SocketServerTest {
       val send = new NetworkSend(request.context.connectionId, ByteBufferSend.sizePrefixed(ByteBuffer.allocate(responseBufferSize)))
       val headerLog = new ObjectNode(JsonNodeFactory.instance)
       headerLog.set("response", new TextNode("someResponse"))
-      channel.sendResponse(new RequestChannel.SendResponse(request, send, Some(headerLog), None))
+      channel.sendResponse(new RequestChannel.SendResponse(request, send, Some(headerLog)))
 
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -359,8 +359,7 @@ class ControllerApisTest {
       ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None))
+      capturedResponse.capture())
     assertNotNull(capturedResponse.getValue)
     val response = capturedResponse.getValue.asInstanceOf[AlterConfigsResponse]
     assertEquals(Set(
@@ -458,8 +457,7 @@ class ControllerApisTest {
     controllerApis.handle(request, RequestLocal.withThreadConfinedCaching)
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None))
+      capturedResponse.capture())
 
     assertNotNull(capturedResponse.getValue)
 
@@ -518,8 +516,7 @@ class ControllerApisTest {
       ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None))
+      capturedResponse.capture())
     assertNotNull(capturedResponse.getValue)
     val response = capturedResponse.getValue.asInstanceOf[IncrementalAlterConfigsResponse]
     assertEquals(Set(new AlterConfigsResourceResponse().
@@ -633,8 +630,7 @@ class ControllerApisTest {
       ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None))
+      capturedResponse.capture())
     assertNotNull(capturedResponse.getValue)
     val response = capturedResponse.getValue.asInstanceOf[IncrementalAlterConfigsResponse]
     assertEquals(Set(
@@ -1249,8 +1245,7 @@ class ControllerApisTest {
       ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(req),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
 
     capturedResponse.getValue match {
@@ -1271,7 +1266,7 @@ class ControllerApisTest {
     val responseFuture = new CompletableFuture[ApiMessage]()
     val errorResponseFuture = new AtomicReference[AbstractResponse]()
     when(raftManager.handleRequest(any(), any(), any(), any())).thenReturn(responseFuture)
-    when(requestChannel.sendResponse(any(), any(), any())).thenAnswer { _ =>
+    when(requestChannel.sendResponse(any(), any())).thenAnswer { _ =>
       // Simulate an encoding failure in the initial fetch response
       throw new UnsupportedVersionException("Something went wrong")
     }.thenAnswer { invocation =>

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1026,8 +1026,7 @@ class KafkaApisTest extends Logging {
           kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
           verify(requestChannel).sendResponse(
             ArgumentMatchers.eq(request),
-            capturedResponse.capture(),
-            any()
+            capturedResponse.capture()
           )
           val response = capturedResponse.getValue.asInstanceOf[MetadataResponse]
           assertEquals(1, response.topicMetadata.size)
@@ -1740,8 +1739,7 @@ class KafkaApisTest extends Logging {
 
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
     val response = capturedResponse.getValue
 
@@ -1811,8 +1809,7 @@ class KafkaApisTest extends Logging {
 
         verify(requestChannel).sendResponse(
           ArgumentMatchers.eq(request),
-          capturedResponse.capture(),
-          ArgumentMatchers.eq(None)
+          capturedResponse.capture()
         )
         val response = capturedResponse.getValue
 
@@ -1874,8 +1871,7 @@ class KafkaApisTest extends Logging {
 
         verify(requestChannel).sendResponse(
           ArgumentMatchers.eq(request),
-          capturedResponse.capture(),
-          ArgumentMatchers.eq(None)
+          capturedResponse.capture()
         )
         val response = capturedResponse.getValue
 
@@ -1933,8 +1929,7 @@ class KafkaApisTest extends Logging {
 
         verify(requestChannel).sendResponse(
           ArgumentMatchers.eq(request),
-          capturedResponse.capture(),
-          ArgumentMatchers.eq(None)
+          capturedResponse.capture()
         )
         val response = capturedResponse.getValue
 
@@ -1995,8 +1990,7 @@ class KafkaApisTest extends Logging {
 
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
 
     assertEquals(Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED.code, capturedResponse.getValue.data.errorCode)
@@ -2070,8 +2064,7 @@ class KafkaApisTest extends Logging {
     val capturedResponse = ArgumentCaptor.forClass(classOf[InitProducerIdResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
 
     assertEquals(Errors.NONE.code, capturedResponse.getValue.data.errorCode)
@@ -2326,8 +2319,7 @@ class KafkaApisTest extends Logging {
 
         verify(requestChannel).sendResponse(
           ArgumentMatchers.eq(request),
-          capturedResponse.capture(),
-          ArgumentMatchers.eq(None)
+          capturedResponse.capture()
         )
         val response = capturedResponse.getValue
 
@@ -3131,8 +3123,7 @@ class KafkaApisTest extends Logging {
 
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
     val markersResponse = capturedResponse.getValue
     assertEquals(expectedErrors, markersResponse.errorsByProducerId.get(1L))
@@ -3167,8 +3158,7 @@ class KafkaApisTest extends Logging {
 
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
     val markersResponse = capturedResponse.getValue
     assertEquals(2, markersResponse.errorsByProducerId.size())
@@ -3206,8 +3196,7 @@ class KafkaApisTest extends Logging {
     kafkaApis.handleWriteTxnMarkersRequest(request, requestLocal)
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      ArgumentMatchers.eq(None)
+      capturedResponse.capture()
     )
 
     val markersResponse = capturedResponse.getValue
@@ -8651,7 +8640,7 @@ class KafkaApisTest extends Logging {
     )).thenReturn(future)
 
     var response: JoinGroupResponse = null
-    when(requestChannel.sendResponse(any(), any(), any())).thenAnswer { _ =>
+    when(requestChannel.sendResponse(any(), any())).thenAnswer { _ =>
       throw new Exception("Something went wrong")
     }.thenAnswer { invocation =>
       response = invocation.getArgument(1, classOf[JoinGroupResponse])
@@ -10319,8 +10308,7 @@ class KafkaApisTest extends Logging {
     val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      any()
+      capturedResponse.capture()
     )
     val response = capturedResponse.getValue
     val readable = MessageUtil.toByteBufferAccessor(
@@ -10340,8 +10328,7 @@ class KafkaApisTest extends Logging {
     val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
-      capturedResponse.capture(),
-      any()
+      capturedResponse.capture()
     )
     val response = capturedResponse.getValue
     val readable = MessageUtil.toByteBufferAccessor(
@@ -10353,8 +10340,7 @@ class KafkaApisTest extends Logging {
     val sendResponse = new RequestChannel.SendResponse(
       request,
       request.buildResponseSend(response),
-      request.responseNode(response).toScala,
-      None
+      request.responseNode(response).toScala
     )
     request.updateRequestMetrics(time.milliseconds(), sendResponse.responseLog.toJava)
 


### PR DESCRIPTION
As far as I can tell, all callers set `onCompleteCallback` to `None` in
the `SendResponse` constructor, so the callback is never set. So let's
remove it.

I stumble on that while working on
https://issues.apache.org/jira/browse/KAFKA-20451. I figured it made
more sense to first remove that while the logic is in Scala, and then
I'll open a PR for KAFKA-20451 so it's a clean translation.

Reviewers: PoAn Yang <payang@apache.org>
