### PR TITLE
MINOR: Add 4.3.0 to docker_scan workflow

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # This is an array of supported tags. Make sure this array only contains the supported tags
-        supported_image_tag: ['latest', '3.9.2', '4.0.2', '4.1.2', '4.2.0']
+        supported_image_tag: ['latest', '3.9.2', '4.0.2', '4.1.2', '4.2.0', '4.3.0']
     steps:
       - name: Run CVE scan
         uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb # v1.0.1


### PR DESCRIPTION
I promoted both the jvm and native Docker images for 4.3.0, so adding
the new version to docker_scan

Reviewers: PoAn Yang <payang@apache.org>, Murali Basani
 <muralidhar.basani@aiven.io>
