### PR TITLE
KAFKA-8073: Fix flaky BaseQuotaTest.testThrottledProducerConsumer

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.quota.ClientQuotaAlteration
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.test.api.Flaky
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig
 import org.apache.kafka.server.config.{QuotaConfig, ServerConfigs}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
@@ -91,7 +90,6 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
     quotaTestClients = createQuotaTestClients(topic1, leaderNode)
   }
 
-  @Flaky("KAFKA-8073")
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testThrottledProducerConsumer(groupProtocol: String): Unit = {
@@ -198,6 +196,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 
 object QuotaTestClients {
   val DefaultEntity: String = null
+  // Large enough to exceed the default producer byte-rate quota (8000 B/s) in a tight send loop.
+  val ProducePayloadSizeBytes: Int = 2048
 
   def metricValue(metric: Metric): Double = metric.metricValue().asInstanceOf[Double]
 }
@@ -219,13 +219,14 @@ abstract class QuotaTestClients(topic: String,
   def produceUntilThrottled(maxRecords: Int, waitForRequestCompletion: Boolean = true): Int = {
     var numProduced = 0
     var throttled = false
-    val metric = throttleMetric(QuotaType.PRODUCE, producerClientId)
+    val payload = new Array[Byte](QuotaTestClients.ProducePayloadSizeBytes)
     do {
-      val payload = numProduced.toString.getBytes
       val future = producer.send(new ProducerRecord[Array[Byte], Array[Byte]](topic, null, null, payload),
         new ErrorLoggingCallback(topic, null, null, true))
       numProduced += 1
       do {
+        // Re-read the metric since it is registered lazily on the broker.
+        val metric = throttleMetric(QuotaType.PRODUCE, producerClientId)
         throttled = metric != null && metricValue(metric) > 0
       } while (!future.isDone && (!throttled || waitForRequestCompletion))
     } while (numProduced < maxRecords && !throttled)
@@ -261,11 +262,15 @@ abstract class QuotaTestClients(topic: String,
 
   private def verifyThrottleTimeRequestChannelMetric(apiKey: ApiKeys, metricNameSuffix: String,
                                                      clientId: String, expectThrottle: Boolean): Unit = {
-    val throttleTimeMs = brokerRequestMetricsThrottleTimeMs(apiKey, metricNameSuffix)
-    if (expectThrottle)
-      assertTrue(throttleTimeMs > 0, s"Client with id=$clientId should have been throttled, $throttleTimeMs")
-    else
+    if (expectThrottle) {
+      TestUtils.waitUntilTrue(
+        () => brokerRequestMetricsThrottleTimeMs(apiKey, metricNameSuffix) > 0,
+        s"Client with id=$clientId should have been throttled in RequestChannel metrics"
+      )
+    } else {
+      val throttleTimeMs = brokerRequestMetricsThrottleTimeMs(apiKey, metricNameSuffix)
       assertEquals(0.0, throttleTimeMs, 0.0, s"Client with id=$clientId should not have been throttled")
+    }
   }
 
   def verifyProduceThrottle(expectThrottle: Boolean, verifyClientMetric: Boolean = true,

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -94,7 +94,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   @MethodSource(Array("getTestGroupProtocolParametersAll"))
   def testThrottledProducerConsumer(groupProtocol: String): Unit = {
     val numRecords = 1000
-    val produced = quotaTestClients.produceUntilThrottled(numRecords)
+    val produced = quotaTestClients.produceUntilThrottled(
+      numRecords, payloadSizeBytes = QuotaTestClients.ProducePayloadSizeBytes)
     quotaTestClients.verifyProduceThrottle(expectThrottle = true)
 
     // Consumer should read in a bursty manner and get throttled immediately
@@ -216,11 +217,14 @@ abstract class QuotaTestClients(topic: String,
   protected def userPrincipal: KafkaPrincipal
   protected def quotaMetricTags(clientId: String): Map[String, String]
 
-  def produceUntilThrottled(maxRecords: Int, waitForRequestCompletion: Boolean = true): Int = {
+  def produceUntilThrottled(maxRecords: Int,
+                            waitForRequestCompletion: Boolean = true,
+                            payloadSizeBytes: Int = 0): Int = {
     var numProduced = 0
     var throttled = false
-    val payload = new Array[Byte](QuotaTestClients.ProducePayloadSizeBytes)
     do {
+      val payload = if (payloadSizeBytes > 0) new Array[Byte](payloadSizeBytes)
+                    else numProduced.toString.getBytes
       val future = producer.send(new ProducerRecord[Array[Byte], Array[Byte]](topic, null, null, payload),
         new ErrorLoggingCallback(topic, null, null, true))
       numProduced += 1


### PR DESCRIPTION
Ref: https://issues.apache.org/jira/browse/KAFKA-8073

## Causes
1. `produceUntilThrottled` sent tiny payloads, so on slow hosts the
   1000 sends could stay under the 8000 B/s producer quota and never
   trigger a throttle.
2. The broker `throttle-time` metric was cached once before the send
   loop, so the lazily-registered sensor could be missed.
3. `verifyThrottleTimeRequestChannelMetric` asserted on the broker
   `ThrottleTimeMs` histogram immediately, before the broker had
   recorded the value.

## Changes
- Use a fixed 2 KB payload in `produceUntilThrottled` so the quota is
  reliably exceeded.
- Re-read the broker throttle-time metric inside the send loop.
- Poll the RequestChannel `ThrottleTimeMs` via `TestUtils.waitUntilTrue`.
