### PR TITLE
KAFKA-20404: Replace bulk TaskManager atomicity exclude with a field-level suppression

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -599,7 +599,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.streams.processor.internals.InternalTopologyBuilder"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
-            <Class name="org.apache.kafka.streams.processor.internals.TaskManager"/>
             <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
             <Class name="org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer"/>
             <Class name="org.apache.kafka.streams.state.internals.RocksDBStore"/>
@@ -635,6 +634,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.connect.runtime.distributed.DistributedHerder$RebalanceListener"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
         </Or>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- KAFKA-20404: rebalanceInProgress is written from the ConsumerRebalanceListener callbacks (handleRebalanceStart / handleRebalanceComplete) and read from StreamThread.runLoop and TaskManager's commit paths; all of these run on the StreamThread, so a stale cross-thread write cannot occur. -->
+        <Class name="org.apache.kafka.streams.processor.internals.TaskManager"/>
+        <Field name="rebalanceInProgress"/>
         <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
     </Match>
 


### PR DESCRIPTION
## Background
[KAFKA-20404](https://issues.apache.org/jira/browse/KAFKA-20404) tracks replacing the bulk SpotBugs atomicity excludes (introduced when SpotBugs was upgraded from 4.8.6 to 4.9.4) with per-field investigations. This PR handles `TaskManager`, the third class in the series after `StreamThread` (#22320) and `DefaultStateUpdater` (#22333).

## Investigation
After removing `TaskManager` from the single bulk `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` block it appeared in (trunk line 602), SpotBugs reports exactly one field with warnings:

- `rebalanceInProgress` at `TaskManager.java:102`, flagged at line 191 (`handleRebalanceStart`) and line 208 (`handleRebalanceComplete`).

Walking the call sites:
- Writes (`handleRebalanceStart` / `handleRebalanceComplete`) are invoked from `StreamsPartitionAssignor` and `DefaultStreamsRebalanceListener` — both are `ConsumerRebalanceListener` callbacks fired from inside `KafkaConsumer.poll()`, which is driven by the `StreamThread`.
- Reads via the `rebalanceInProgress()` getter happen at `StreamThread.runLoop` (lines 938 and 962).
- Direct field reads at `TaskManager.java:1883` (`maybeCommitActiveTasksPerUserRequested`) and `TaskManager.java:1897` (`commitTasksAndMaybeUpdateCommittableOffsets`) are reached only from `TaskManager.commit(...)` / `StreamThread.runOnce*`, which also run on the `StreamThread`.

So `rebalanceInProgress` is thread-confined to the `StreamThread`, and the SpotBugs warning is a false positive.

## Changes
- Remove `TaskManager` from the bulk `<Or>` block.
- Add a targeted `<Match>` block scoped to the class plus the `rebalanceInProgress` field, with a rationale comment explaining the thread-confinement.

## Verification
- `:streams:spotbugsMain --rerun-tasks` clean.
- `:streams:spotbugsTest` / `:streams:checkstyleMain` / `:streams:checkstyleTest` clean.
- `:streams:test --tests "*TaskManager*"` all green.