### PR TITLE
KAFKA-20404: Replace bulk StreamsPartitionAssignor atomicity exclude with field-level suppressions

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -597,7 +597,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.server.AssignmentsManager"/>
             <Class name="org.apache.kafka.connect.file.FileStreamSourceTask"/>
             <Class name="org.apache.kafka.streams.processor.internals.InternalTopologyBuilder"/>
-            <Class name="org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamsProducer"/>
             <Class name="org.apache.kafka.streams.processor.internals.TaskManager"/>
             <Class name="org.apache.kafka.streams.state.internals.AbstractRocksDBSegmentedBytesStore"/>
@@ -634,6 +633,16 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
             <Class name="org.apache.kafka.trogdor.coordinator.NodeManager$NodeHeartbeat"/>
             <Class name="org.apache.kafka.connect.runtime.distributed.DistributedHerder$RebalanceListener"/>
             <Class name="org.apache.kafka.streams.processor.internals.StreamThread"/>
+        </Or>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+
+    <Match>
+        <!-- KAFKA-20404: Both fields are accessed only from ConsumerPartitionAssignor callbacks (configure, subscriptionUserData, onAssignment) that the KafkaConsumer invokes from poll(); poll() in turn is driven by the StreamThread, so the read-modify-write happens on a single thread. -->
+        <Class name="org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor"/>
+        <Or>
+            <Field name="uniqueField"/>
+            <Field name="usedSubscriptionMetadataVersion"/>
         </Or>
         <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
     </Match>


### PR DESCRIPTION
## Background
[KAFKA-20404](https://issues.apache.org/jira/browse/KAFKA-20404) tracks replacing the bulk SpotBugs atomicity excludes (introduced when SpotBugs was upgraded from 4.8.6 to 4.9.4) with per-field investigations. This PR handles `StreamsPartitionAssignor`, the fourth class in the series after `StreamThread` (#22320), `DefaultStateUpdater` (#22333), and `TaskManager` (#22340).

## Investigation
After removing `StreamsPartitionAssignor` from the single bulk `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` block it appeared in (trunk line 600), SpotBugs reports two fields with warnings:

- `uniqueField` at `StreamsPartitionAssignor.java:232`, flagged at line 266 (`configure(Map)`) and line 288 (`subscriptionUserData(Set)`).
- `usedSubscriptionMetadataVersion` at `StreamsPartitionAssignor.java:223`, flagged at line 1432 and line 1447 (both inside `maybeUpdateSubscriptionVersion(int, int)`).

Walking the call sites:
- `configure`, `subscriptionUserData`, and `onAssignment` are all `ConsumerPartitionAssignor` / `Configurable` interface methods. The Kafka consumer invokes them from inside `poll()` (e.g. `ConsumerCoordinator.java:311` calls `assignor.subscriptionUserData(...)`, line 370 calls `assignor.onAssignment(...)`).
- `maybeUpdateSubscriptionVersion` is `protected` and only called from `maybeScheduleFollowupRebalance` (line 1544), which is itself reached from `onAssignment`.
- The package-private `uniqueField()` getter is only invoked by `StreamsPartitionAssignorTest`.

`KafkaConsumer.poll()` is driven by the `StreamThread`, so both fields are thread-confined and the SpotBugs warnings are false positives.

## Changes
- Remove `StreamsPartitionAssignor` from the bulk `<Or>` block.
- Add a single targeted `<Match>` block scoped to the class with an `<Or>` over both fields, with a rationale comment.

## Verification
- `:streams:spotbugsMain --rerun-tasks` clean.
- `:streams:spotbugsTest` / `:streams:checkstyleMain` / `:streams:checkstyleTest` clean.
- `:streams:test --tests "*StreamsPartitionAssignor*"` all green.