### PR TITLE
MINOR: Provide default no-op implementations for addReconfigurable and removeReconfigurable in AbstractKafkaConfig

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -349,20 +349,24 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
      * <p>
      * This method exists to support migration from kafka.server.KafkaConfig (Scala/core) to AbstractKafkaConfig (Java/server).
      * When migrating code, replace KafkaConfig references with AbstractKafkaConfig.
+     * Subclasses should override this method to integrate with their dynamic configuration mechanism;
+     * the default implementation is a no-op.
      *
      * @param reconfigurable the component to register for configuration updates
      */
-    public abstract void addReconfigurable(Reconfigurable reconfigurable);
+    public void addReconfigurable(Reconfigurable reconfigurable) { }
 
     /**
      * Unregisters a component from dynamic reconfiguration notifications.
      * <p>
      * This method exists to support migration from kafka.server.KafkaConfig (Scala/core) to AbstractKafkaConfig (Java/server).
      * When migrating code, replace KafkaConfig references with AbstractKafkaConfig.
+     * Subclasses should override this method to integrate with their dynamic configuration mechanism;
+     * the default implementation is a no-op.
      *
      * @param reconfigurable the component to unregister
      */
-    public abstract void removeReconfigurable(Reconfigurable reconfigurable);
+    public void removeReconfigurable(Reconfigurable reconfigurable) { }
 
     /**
      * Determines whether a config entry might be sensitive based on its type.

--- a/server/src/test/java/org/apache/kafka/server/DefaultAutoTopicCreationManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/DefaultAutoTopicCreationManagerTest.java
@@ -100,14 +100,7 @@ public class DefaultAutoTopicCreationManagerTest {
         props.setProperty(ServerLogConfigs.NUM_PARTITIONS_CONFIG, "1");
         props.setProperty(ReplicationConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG, "1");
 
-        config = new AbstractKafkaConfig(AbstractKafkaConfig.CONFIG_DEF, props, Map.of(), false) {
-            @Override
-            public void addReconfigurable(org.apache.kafka.common.Reconfigurable reconfigurable) {
-            }
-            @Override
-            public void removeReconfigurable(org.apache.kafka.common.Reconfigurable reconfigurable) {
-            }
-        };
+        config = new AbstractKafkaConfig(AbstractKafkaConfig.CONFIG_DEF, props, Map.of(), false) { };
         topicCreator.reset();
     }
 

--- a/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/AbstractKafkaConfigTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.server.config;
 
-import org.apache.kafka.common.Reconfigurable;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.coordinator.group.GroupConfig;
 import org.apache.kafka.raft.KRaftConfigs;
@@ -101,13 +100,7 @@ public class AbstractKafkaConfigTest {
             ConfigDef configDef = new ConfigDef().define(TEST_INTERNAL_GROUP_CONFIG_BROKER_SYNONYM, ConfigDef.Type.STRING,
                 "default-value", ConfigDef.Importance.LOW, "test broker synonym");
 
-            AbstractKafkaConfig kafkaConfig = new AbstractKafkaConfig(configDef, new HashMap<>(brokerProps), Map.of(), false) {
-                @Override
-                public void addReconfigurable(Reconfigurable reconfigurable) { }
-
-                @Override
-                public void removeReconfigurable(Reconfigurable reconfigurable) { }
-            };
+            AbstractKafkaConfig kafkaConfig = new AbstractKafkaConfig(configDef, new HashMap<>(brokerProps), Map.of(), false) { };
 
             return kafkaConfig.extractGroupConfigMap();
         }

--- a/server/src/test/java/org/apache/kafka/server/transaction/AddPartitionsToTxnManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/transaction/AddPartitionsToTxnManagerTest.java
@@ -90,17 +90,7 @@ public class AddPartitionsToTxnManagerTest {
                 KRaftConfigs.NODE_ID_CONFIG, "1",
                 KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER"),
             Map.of(),
-            false) {
-        @Override
-        public void addReconfigurable(org.apache.kafka.common.Reconfigurable reconfigurable) {
-            // No-op for test
-        }
-
-        @Override
-        public void removeReconfigurable(org.apache.kafka.common.Reconfigurable reconfigurable) {
-            // No-op for test
-        }
-    };
+            false) { };
     private final AddPartitionsToTxnManager addPartitionsToTxnManager =
             new AddPartitionsToTxnManager(config, networkClient, metadataCache, partitionFor, time);
 


### PR DESCRIPTION
Ref: https://github.com/apache/kafka/pull/22302#discussion_r3281352410.
Convert `addReconfigurable` and `removeReconfigurable` from abstract to
default no-op methods so tests no longer need to supply dummy overrides.

Reviewers: Ken Huang <s7133700@gmail.com>, Murali Basani
 <muralidhar.basani@aiven.io>, Chia-Ping Tsai <chia7712@gmail.com>
