### PR TITLE
MINOR: Reduce close delay in testFailureToFenceEpoch

### DIFF
--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/TransactionsTestHelper.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/TransactionsTestHelper.java
@@ -923,7 +923,9 @@ public class TransactionsTestHelper {
         long producerId;
         int initialProducerEpoch;
 
-        try (var producer1 = createTransactionalProducer(clusterInstance, "transactional-producer")) {
+        // Use a shorter request timeout to bound the graceful close delay when the fencing probe leaves producer1 in an empty transaction.
+        try (var producer1 = createTransactionalProducer(
+                clusterInstance, "transactional-producer", 60000, 60000, 120000, 1000)) {
             producer1.initTransactions();
 
             producer1.beginTransaction();


### PR DESCRIPTION
Reduce the request timeout for the producer used by testFailureToFenceEpoch so graceful close does not wait on the default 30s timeout after the fencing probe leaves the producer in an empty transaction.

Tested by running testFailureToFenceEpochWithTV1 and testFailureToFenceEpochWithTV2.