### PR TITLE
MINOR: Added Compression.wrapForInput method for ByteBufferInputStream.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/compress/Compression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/Compression.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.compress;
 
 import org.apache.kafka.common.record.internal.CompressionType;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
 
@@ -54,6 +55,19 @@ public interface Compression {
      * performance impact.
      */
     InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier);
+
+    /**
+     * Wrap bufferStream with an InputStream that will decompress data with this Compression.
+     *
+     * @param bufferStream The {@link ByteBufferInputStream} instance holding the data to decompress.
+     * @param messageVersion The record format version to use.
+     * @param decompressionBufferSupplier The supplier of ByteBuffer(s) used for decompression if supported.
+     * For small record batches, allocating a potentially large buffer (64 KB for LZ4)
+     * will dominate the cost of decompressing and iterating over the records in the
+     * batch. As such, a supplier that reuses buffers will have a significant
+     * performance impact.
+     */
+    InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier);
 
     /**
      * Recommended size of buffer for storing decompressed output.

--- a/clients/src/main/java/org/apache/kafka/common/compress/GzipCompression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/GzipCompression.java
@@ -59,6 +59,11 @@ public class GzipCompression implements Compression {
 
     @Override
     public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
+        return wrapForInput(new ByteBufferInputStream(buffer), messageVersion, decompressionBufferSupplier);
+    }
+
+    @Override
+    public InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
         try {
             // Set input buffer (compressed) to 8 KB (GZIPInputStream uses 0.5 KB by default) to ensure reasonable
             // performance in cases where the caller reads a small number of bytes (potentially a single byte).
@@ -67,7 +72,7 @@ public class GzipCompression implements Compression {
             //
             // ChunkedBytesStream is used to wrap the GZIPInputStream because the default implementation of
             // GZIPInputStream does not use an intermediate buffer for decompression in chunks.
-            return new ChunkedBytesStream(new GZIPInputStream(new ByteBufferInputStream(buffer), 8 * 1024),
+            return new ChunkedBytesStream(new GZIPInputStream(bufferStream, 8 * 1024),
                                           decompressionBufferSupplier,
                                           decompressionOutputSize(),
                                           false);

--- a/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockInputStream.java
@@ -65,9 +65,11 @@ public final class Lz4BlockInputStream extends InputStream {
         BROKEN_LZ4_EXCEPTION = exception;
     }
 
-    private final ByteBuffer in;
+    private final InputStream inStream;
     private final boolean ignoreFlagDescriptorChecksum;
     private final BufferSupplier bufferSupplier;
+    // Per-block staging buffer. Holds one block plus its optional 4-byte checksum.
+    private final ByteBuffer staging;
     private final ByteBuffer decompressionBuffer;
     // `flg` and `maxBlockSize` are effectively final, they are initialised in the `readHeader` method that is only
     // invoked from the constructor
@@ -80,130 +82,134 @@ public final class Lz4BlockInputStream extends InputStream {
     private boolean finished;
 
     /**
-     * Create a new {@link InputStream} that will decompress data using the LZ4 algorithm.
-     *
-     * @param in The byte buffer to decompress
+     * @param in The input stream supplying LZ4-compressed bytes
      * @param ignoreFlagDescriptorChecksum for compatibility with old kafka clients, ignore incorrect HC byte
-     * @throws IOException
      */
-    public Lz4BlockInputStream(ByteBuffer in, BufferSupplier bufferSupplier, boolean ignoreFlagDescriptorChecksum) throws IOException {
+    public Lz4BlockInputStream(InputStream in, BufferSupplier bufferSupplier, boolean ignoreFlagDescriptorChecksum) throws IOException {
         if (BROKEN_LZ4_EXCEPTION != null) {
             throw BROKEN_LZ4_EXCEPTION;
         }
+        this.inStream = in;
         this.ignoreFlagDescriptorChecksum = ignoreFlagDescriptorChecksum;
-        this.in = in.duplicate().order(ByteOrder.LITTLE_ENDIAN);
         this.bufferSupplier = bufferSupplier;
         readHeader();
-        decompressionBuffer = bufferSupplier.get(maxBlockSize);
-        finished = false;
+        this.staging = bufferSupplier.get(maxBlockSize + 4).order(ByteOrder.LITTLE_ENDIAN);
+        this.decompressionBuffer = bufferSupplier.get(maxBlockSize);
+        this.finished = false;
     }
 
     /**
-     * Check whether KafkaLZ4BlockInputStream is configured to ignore the
-     * Frame Descriptor checksum, which is useful for compatibility with
-     * old client implementations that use incorrect checksum calculations.
+     * Check whether this stream is configured to ignore the Frame Descriptor checksum, which is useful for
+     * compatibility with old client implementations that use incorrect checksum calculations.
      */
     public boolean ignoreFlagDescriptorChecksum() {
         return this.ignoreFlagDescriptorChecksum;
     }
 
     /**
-     * Reads the magic number and frame descriptor from input buffer.
-     *
-     * @throws IOException
+     * Reads magic and frame descriptor from {@code inStream} into a 15-byte temporary array — the maximum
+     * possible header size (4 magic + 1 FLG + 1 BD + 8 optional content size + 1 HC).
      */
     private void readHeader() throws IOException {
-        // read first 6 bytes into buffer to check magic and FLG/BD descriptor flags
-        if (in.remaining() < 6) {
-            throw new IOException(PREMATURE_EOS);
-        }
-
-        if (MAGIC != in.getInt()) {
+        byte[] hdr = new byte[15];
+        // Need 6 bytes to know whether the content-size field is present
+        readFully(hdr, 0, 6);
+        int magic = ByteBuffer.wrap(hdr, 0, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        if (magic != MAGIC) {
             throw new IOException(NOT_SUPPORTED);
         }
-        // mark start of data to checksum
-        in.mark();
+        flg = FLG.fromByte(hdr[4]);
+        maxBlockSize = BD.fromByte(hdr[5]).getBlockMaximumSize();
 
-        flg = FLG.fromByte(in.get());
-        maxBlockSize = BD.fromByte(in.get()).getBlockMaximumSize();
-
+        int descLen;
         if (flg.isContentSizeSet()) {
-            if (in.remaining() < 8) {
-                throw new IOException(PREMATURE_EOS);
-            }
-            in.position(in.position() + 8);
+            // 8 content-size bytes + 1 HC byte
+            readFully(hdr, 6, 9);
+            descLen = 10;
+        } else {
+            // just the HC byte
+            readFully(hdr, 6, 1);
+            descLen = 2;
         }
 
-        // Final byte of Frame Descriptor is HC checksum
-
-        // Old implementations produced incorrect HC checksums
         if (ignoreFlagDescriptorChecksum) {
-            in.position(in.position() + 1);
             return;
         }
-
-        int len = in.position() - in.reset().position();
-
-        int hash = CHECKSUM.hash(in, in.position(), len, 0);
-        in.position(in.position() + len);
-        if (in.get() != (byte) ((hash >> 8) & 0xFF)) {
+        int hash = CHECKSUM.hash(hdr, 4, descLen, 0);
+        if (hdr[4 + descLen] != (byte) ((hash >> 8) & 0xFF)) {
             throw new IOException(DESCRIPTOR_HASH_MISMATCH);
         }
     }
 
     /**
-     * Decompresses (if necessary) buffered data, optionally computes and validates a XXHash32 checksum, and writes the
-     * result to a buffer.
-     *
-     * @throws IOException
+     * Decodes the next block, populating {@link #decompressedBuffer} (or sets {@link #finished} on end-mark).
      */
     private void readBlock() throws IOException {
-        if (in.remaining() < 4) {
-            throw new IOException(PREMATURE_EOS);
-        }
-
-        int blockSize = in.getInt();
-        boolean compressed = (blockSize & LZ4_FRAME_INCOMPRESSIBLE_MASK) == 0;
-        blockSize &= ~LZ4_FRAME_INCOMPRESSIBLE_MASK;
+        int rawBlockSize = readFrameInt();
+        boolean compressed = (rawBlockSize & LZ4_FRAME_INCOMPRESSIBLE_MASK) == 0;
+        int blockSize = rawBlockSize & ~LZ4_FRAME_INCOMPRESSIBLE_MASK;
 
         // Check for EndMark
         if (blockSize == 0) {
             finished = true;
-            if (flg.isContentChecksumSet())
-                in.getInt(); // TODO: verify this content checksum
+            if (flg.isContentChecksumSet()) {
+                readFrameInt(); // TODO: verify this content checksum
+            }
             return;
-        } else if (blockSize > maxBlockSize) {
+        }
+        if (blockSize > maxBlockSize) {
             throw new IOException(String.format("Block size %d exceeded max: %d", blockSize, maxBlockSize));
         }
 
-        if (in.remaining() < blockSize) {
-            throw new IOException(PREMATURE_EOS);
-        }
+        fillStaging(blockSize);
 
         if (compressed) {
             try {
-                final int bufferSize = DECOMPRESSOR.decompress(in, in.position(), blockSize, decompressionBuffer, 0,
-                    maxBlockSize);
+                int sz = DECOMPRESSOR.decompress(staging, 0, blockSize, decompressionBuffer, 0, maxBlockSize);
                 decompressionBuffer.position(0);
-                decompressionBuffer.limit(bufferSize);
+                decompressionBuffer.limit(sz);
                 decompressedBuffer = decompressionBuffer;
             } catch (LZ4Exception e) {
                 throw new IOException(e);
             }
         } else {
-            decompressedBuffer = in.slice();
-            decompressedBuffer.limit(blockSize);
+            // Copy into decompressionBuffer because `staging` is reused for the next block, which would corrupt a slice.
+            decompressionBuffer.clear();
+            decompressionBuffer.put(staging.array(), staging.arrayOffset(), blockSize);
+            decompressionBuffer.flip();
+            decompressedBuffer = decompressionBuffer;
         }
 
-        // verify checksum
+        // Hash before the next readFrameInt overwrites staging.
         if (flg.isBlockChecksumSet()) {
-            int hash = CHECKSUM.hash(in, in.position(), blockSize, 0);
-            in.position(in.position() + blockSize);
-            if (hash != in.getInt()) {
+            int computedHash = CHECKSUM.hash(staging, 0, blockSize, 0);
+            if (computedHash != readFrameInt()) {
                 throw new IOException(BLOCK_HASH_MISMATCH);
             }
-        } else {
-            in.position(in.position() + blockSize);
+        }
+    }
+
+    private int readFrameInt() throws IOException {
+        fillStaging(4);
+        return staging.getInt(0);
+    }
+
+    // Refill the staging buffer with exactly `count` bytes from the input stream. On return, staging is in
+    // read mode: position=0, limit=count.
+    private void fillStaging(int count) throws IOException {
+        readFully(staging.array(), staging.arrayOffset(), count);
+        staging.position(0);
+        staging.limit(count);
+    }
+
+    private void readFully(byte[] dst, int off, int len) throws IOException {
+        int read = 0;
+        while (read < len) {
+            int n = inStream.read(dst, off + read, len - read);
+            if (n < 0) {
+                throw new IOException(PREMATURE_EOS);
+            }
+            read += n;
         }
     }
 
@@ -218,7 +224,6 @@ public final class Lz4BlockInputStream extends InputStream {
         if (finished) {
             return -1;
         }
-
         return decompressedBuffer.get() & 0xFF;
     }
 
@@ -235,7 +240,6 @@ public final class Lz4BlockInputStream extends InputStream {
             return -1;
         }
         len = Math.min(len, available());
-
         decompressedBuffer.get(b, off, len);
         return len;
     }
@@ -263,7 +267,12 @@ public final class Lz4BlockInputStream extends InputStream {
 
     @Override
     public void close() {
-        bufferSupplier.release(decompressionBuffer);
+        if (staging != null) {
+            bufferSupplier.release(staging);
+        }
+        if (decompressionBuffer != null) {
+            bufferSupplier.release(decompressionBuffer);
+        }
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/compress/Lz4Compression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/Lz4Compression.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.compress;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.record.internal.CompressionType;
 import org.apache.kafka.common.record.internal.RecordBatch;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
 import org.apache.kafka.common.utils.internals.ChunkedBytesStream;
@@ -54,9 +55,14 @@ public class Lz4Compression implements Compression {
 
     @Override
     public InputStream wrapForInput(ByteBuffer inputBuffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
+        return wrapForInput(new ByteBufferInputStream(inputBuffer), messageVersion, decompressionBufferSupplier);
+    }
+
+    @Override
+    public InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
         try {
             return new ChunkedBytesStream(
-                    new Lz4BlockInputStream(inputBuffer, decompressionBufferSupplier, messageVersion == RecordBatch.MAGIC_VALUE_V0),
+                    new Lz4BlockInputStream(bufferStream, decompressionBufferSupplier, messageVersion == RecordBatch.MAGIC_VALUE_V0),
                     decompressionBufferSupplier, decompressionOutputSize(), true);
         } catch (Throwable e) {
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/compress/NoCompression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/NoCompression.java
@@ -44,6 +44,11 @@ public class NoCompression implements Compression {
         return new ByteBufferInputStream(buffer);
     }
 
+    @Override
+    public InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
+        return bufferStream;
+    }
+
     public static class Builder implements Compression.Builder<NoCompression> {
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/compress/SnappyCompression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/SnappyCompression.java
@@ -51,10 +51,15 @@ public class SnappyCompression implements Compression {
 
     @Override
     public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
+        return wrapForInput(new ByteBufferInputStream(buffer), messageVersion, decompressionBufferSupplier);
+    }
+
+    @Override
+    public InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
         // SnappyInputStream uses default implementation of InputStream for skip. Default implementation of
         // SnappyInputStream allocates a new skip buffer every time, hence, we prefer our own implementation.
         try {
-            return new ChunkedBytesStream(new SnappyInputStream(new ByteBufferInputStream(buffer)),
+            return new ChunkedBytesStream(new SnappyInputStream(bufferStream),
                                           decompressionBufferSupplier,
                                           decompressionOutputSize(),
                                           false);

--- a/clients/src/main/java/org/apache/kafka/common/compress/ZstdCompression.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/ZstdCompression.java
@@ -64,8 +64,13 @@ public class ZstdCompression implements Compression {
 
     @Override
     public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
+        return wrapForInput(new ByteBufferInputStream(buffer), messageVersion, decompressionBufferSupplier);
+    }
+
+    @Override
+    public InputStream wrapForInput(ByteBufferInputStream bufferStream, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
         try {
-            return new ChunkedBytesStream(wrapForZstdInput(buffer, decompressionBufferSupplier),
+            return new ChunkedBytesStream(wrapForZstdInput(bufferStream, decompressionBufferSupplier),
                     decompressionBufferSupplier,
                     decompressionOutputSize(),
                     false);
@@ -76,6 +81,10 @@ public class ZstdCompression implements Compression {
 
     // visible for testing
     public static ZstdInputStreamNoFinalizer wrapForZstdInput(ByteBuffer buffer, BufferSupplier decompressionBufferSupplier) throws IOException {
+        return wrapForZstdInput(new ByteBufferInputStream(buffer), decompressionBufferSupplier);
+    }
+
+    public static ZstdInputStreamNoFinalizer wrapForZstdInput(ByteBufferInputStream bufferStream, BufferSupplier decompressionBufferSupplier) throws IOException {
         // We use our own BufferSupplier instead of com.github.luben.zstd.RecyclingBufferPool since our
         // implementation doesn't require locking or soft references. The buffer allocated by this buffer pool is
         // used by zstd-jni for 1\ reading compressed data from input stream into a buffer before passing it over JNI
@@ -94,7 +103,7 @@ public class ZstdCompression implements Compression {
         // Ideally, data from ZstdInputStreamNoFinalizer should be read in a bulk because every call to
         // `ZstdInputStreamNoFinalizer#read()` is a JNI call. The caller is expected to
         // balance the tradeoff between reading large amount of data vs. making multiple JNI calls.
-        return new ZstdInputStreamNoFinalizer(new ByteBufferInputStream(buffer), bufferPool);
+        return new ZstdInputStreamNoFinalizer(bufferStream, bufferPool);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/compress/Lz4CompressionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/compress/Lz4CompressionTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.compress;
 
 import org.apache.kafka.common.record.internal.RecordBatch;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
 import org.apache.kafka.common.utils.internals.ChunkedBytesStream;
@@ -209,7 +210,7 @@ public class Lz4CompressionTest {
     }
 
     private Lz4BlockInputStream makeInputStream(ByteBuffer buffer, boolean ignoreFlagDescriptorChecksum) throws IOException {
-        return new Lz4BlockInputStream(buffer, BufferSupplier.create(), ignoreFlagDescriptorChecksum);
+        return new Lz4BlockInputStream(new ByteBufferInputStream(buffer), BufferSupplier.create(), ignoreFlagDescriptorChecksum);
     }
 
     @ParameterizedTest

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/DefaultRecordBatchTest.java
@@ -488,12 +488,18 @@ public class DefaultRecordBatchTest {
             Arguments.of(CompressionType.SNAPPY, 1, smallRecordValue),
             Arguments.of(CompressionType.SNAPPY, 1, largeRecordValue),
             /*
+             * 1 allocation per batch (i.e. per iterator instance) for ChunkedBytesStream's output buffer
+             * 1 allocation per batch (i.e. per iterator instance) for Lz4BlockInputStream's per-block staging buffer
+             * 1 allocation per batch (i.e. per iterator instance) for Lz4BlockInputStream's decompression buffer
+             * = 3 buffer allocations
+             */
+            Arguments.of(CompressionType.LZ4, 3, smallRecordValue),
+            Arguments.of(CompressionType.LZ4, 3, largeRecordValue),
+            /*
              * 1 allocation per batch (i.e. per iterator instance) for buffer holding compressed data
              * 1 allocation per batch (i.e. per iterator instance) for buffer holding uncompressed data
              * = 2 buffer allocations
              */
-            Arguments.of(CompressionType.LZ4, 2, smallRecordValue),
-            Arguments.of(CompressionType.LZ4, 2, largeRecordValue),
             Arguments.of(CompressionType.ZSTD, 2, smallRecordValue),
             Arguments.of(CompressionType.ZSTD, 2, largeRecordValue)
         );


### PR DESCRIPTION
Updated the implementation of Lz4BlockInputStream to correctly work with input streams.

Increasing the extensibility of the class for future([KIP-1332](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1332%3A+Dynamic+memory+allocation+for+the+Kafka+producer)) changes.