### PR TITLE
KAFKA-18948 Move DynamicLogConfig to server module

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -25,7 +25,7 @@ import kafka.network.DataPlaneAcceptor
 import kafka.raft.KafkaRaftManager
 import kafka.server.DynamicBrokerConfig._
 import kafka.utils.Logging
-import org.apache.kafka.common.{Endpoint, Reconfigurable, Uuid}
+import org.apache.kafka.common.{Endpoint, Reconfigurable}
 import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource, SslConfigs}
 import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType}
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
@@ -38,17 +38,15 @@ import org.apache.kafka.common.utils.internals.ConfigUtils
 import org.apache.kafka.network.SocketServer
 import org.apache.kafka.raft.{KRaftConfigs, KafkaRaftClient}
 import org.apache.kafka.server.{DynamicThreadPool, ProcessRole}
-import org.apache.kafka.server.common.{ApiMessageAndVersion, DirectoryEventHandler}
-import org.apache.kafka.server.config.{BrokerReconfigurable => JBrokerReconfigurable, DynamicConfig, DynamicProducerStateManagerConfig, ServerConfigs, ServerLogConfigs, DynamicBrokerConfig => JDynamicBrokerConfig}
+import org.apache.kafka.server.common.ApiMessageAndVersion
+import org.apache.kafka.server.config.{BrokerReconfigurable => JBrokerReconfigurable, DynamicConfig, DynamicLogConfig, DynamicProducerStateManagerConfig, ServerConfigs, DynamicBrokerConfig => JDynamicBrokerConfig}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.{ClientTelemetryExporterPlugin, MetricConfigs}
 import org.apache.kafka.server.quota.QuotaFactory
 import org.apache.kafka.server.telemetry.{ClientTelemetry, ClientTelemetryExporterProvider}
 import org.apache.kafka.server.util.LockUtils.{inReadLock, inWriteLock}
 import org.apache.kafka.snapshot.RecordsSnapshotReader
-import org.apache.kafka.storage.internals.log.{LogConfig, LogManager}
 
-import java.util.stream.Collectors
 import scala.util.Using
 import scala.collection._
 import scala.jdk.CollectionConverters._
@@ -536,113 +534,6 @@ trait BrokerReconfigurable {
   def validateReconfiguration(newConfig: KafkaConfig): Unit
 
   def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit
-}
-
-class DynamicLogConfig(logManager: LogManager, directoryEventHandler: DirectoryEventHandler) extends BrokerReconfigurable with Logging {
-
-  override def reconfigurableConfigs: util.Set[String] = {
-    JDynamicBrokerConfig.DynamicLogConfig.RECONFIGURABLE_CONFIGS
-  }
-
-  override def validateReconfiguration(newConfig: KafkaConfig): Unit = {
-    // For update of topic config overrides, only config names and types are validated
-    // Names and types have already been validated. For consistency with topic config
-    // validation, no additional validation is performed.
-
-    def validateLogLocalRetentionMs(): Unit = {
-      val logRetentionMs = newConfig.logRetentionTimeMillis
-      val logLocalRetentionMs: java.lang.Long = newConfig.remoteLogManagerConfig.logLocalRetentionMs
-      if (logRetentionMs != -1L && logLocalRetentionMs != -2L) {
-        if (logLocalRetentionMs == -1L) {
-          throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
-            s"Value must not be -1 as ${ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG} value is set as $logRetentionMs.")
-        }
-        if (logLocalRetentionMs > logRetentionMs) {
-          throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
-            s"Value must not be more than ${ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG} property value: $logRetentionMs")
-        }
-      }
-    }
-
-    def validateLogLocalRetentionBytes(): Unit = {
-      val logRetentionBytes = newConfig.logRetentionBytes
-      val logLocalRetentionBytes: java.lang.Long = newConfig.remoteLogManagerConfig.logLocalRetentionBytes
-      if (logRetentionBytes > -1 && logLocalRetentionBytes != -2) {
-        if (logLocalRetentionBytes == -1) {
-          throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
-            s"Value must not be -1 as ${ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG} value is set as $logRetentionBytes.")
-        }
-        if (logLocalRetentionBytes > logRetentionBytes) {
-          throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
-            s"Value must not be more than ${ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG} property value: $logRetentionBytes")
-        }
-      }
-    }
-
-    def validateLogRemoteCopyLagMs(): Unit = {
-      val logRetentionMs: Long = newConfig.logRetentionTimeMillis
-      val logLocalRetentionMs = newConfig.remoteLogManagerConfig.logLocalRetentionMs
-      val effectiveLocalRetentionMs = if (logLocalRetentionMs == -2L) logRetentionMs else logLocalRetentionMs
-      val logRemoteCopyLagMs = newConfig.remoteLogManagerConfig.logRemoteCopyLagMs
-      if (logRemoteCopyLagMs > 0L && effectiveLocalRetentionMs >= 0L && logRemoteCopyLagMs > effectiveLocalRetentionMs) {
-        throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP, logRemoteCopyLagMs,
-          s"Value must not exceed ${RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP} (effective value: $effectiveLocalRetentionMs)")
-      }
-    }
-
-    def validateLogRemoteCopyLagBytes(): Unit = {
-      val logRetentionBytes: Long = newConfig.logRetentionBytes
-      val logLocalRetentionBytes = newConfig.remoteLogManagerConfig.logLocalRetentionBytes
-      val effectiveLocalRetentionBytes = if (logLocalRetentionBytes == -2L) logRetentionBytes else logLocalRetentionBytes
-      val logRemoteCopyLagBytes = newConfig.remoteLogManagerConfig.logRemoteCopyLagBytes
-      if (logRemoteCopyLagBytes > 0L && effectiveLocalRetentionBytes >= 0L && logRemoteCopyLagBytes > effectiveLocalRetentionBytes) {
-        throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP, logRemoteCopyLagBytes,
-          s"Value must not exceed ${RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP} (effective value: $effectiveLocalRetentionBytes)")
-      }
-    }
-
-    def validateCordonedLogDirs(): Unit = {
-      val logDirs = newConfig.logDirs()
-      val cordonedLogDirs = newConfig.cordonedLogDirs()
-      cordonedLogDirs.asScala.foreach(dir =>
-        if (!logDirs.contains(dir)) {
-          throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs, s"Invalid entry in ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG}: $dir. " +
-            s"All cordoned log dirs must be entries of ${ServerLogConfigs.LOG_DIRS_CONFIG} or ${ServerLogConfigs.LOG_DIR_CONFIG}.")
-        }
-      )
-    }
-
-    validateLogLocalRetentionMs()
-    validateLogLocalRetentionBytes()
-    validateLogRemoteCopyLagMs()
-    validateLogRemoteCopyLagBytes()
-    validateCordonedLogDirs()
-  }
-
-  private def updateLogsConfig(newBrokerDefaults: Map[String, Object]): Unit = {
-    logManager.brokerConfigUpdated()
-    logManager.allLogs.forEach { log =>
-      val props = mutable.Map.empty[Any, Any]
-      props ++= newBrokerDefaults
-      props ++= log.config.originals.asScala.filter { case (k, _) =>
-        log.config.overriddenConfigs.contains(k)
-      }
-
-      val logConfig = new LogConfig(props.asJava, log.config.overriddenConfigs)
-      log.updateConfig(logConfig)
-    }
-  }
-
-  override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {
-    val newBrokerDefaults = new util.HashMap[String, Object](newConfig.extractLogConfigMap)
-    logManager.reconfigureDefaultLogConfig(new LogConfig(newBrokerDefaults))
-    updateLogsConfig(newBrokerDefaults.asScala)
-
-    logManager.updateCordonedLogDirs(util.Set.copyOf(newConfig.cordonedLogDirs))
-    directoryEventHandler.handleCordoned(newConfig.cordonedLogDirs.stream
-      .flatMap[Uuid](dir => logManager.directoryId(dir).stream)
-      .collect(Collectors.toSet[Uuid]))
-  }
 }
 
 class ControllerDynamicThreadPool(controller: ControllerServer) extends BrokerReconfigurable {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -23,7 +23,7 @@ import java.util.Properties
 import kafka.utils.Logging
 import kafka.utils.Implicits._
 import org.apache.kafka.common.{Endpoint, Reconfigurable}
-import org.apache.kafka.common.config.{ConfigDef, ConfigException, TopicConfig}
+import org.apache.kafka.common.config.{ConfigDef, ConfigException}
 import org.apache.kafka.common.config.ConfigDef.ConfigKey
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.internals.Plugin
@@ -599,42 +599,4 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
       s"${BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG} must implement KafkaPrincipalSerde")
   }
 
-  /**
-   * Copy the subset of properties that are relevant to Logs. The individual properties
-   * are listed here since the names are slightly different in each Config class...
-   */
-  def extractLogConfigMap: java.util.Map[String, Object] = {
-    val logProps = new java.util.HashMap[String, Object]()
-    logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, logSegmentBytes)
-    logProps.put(TopicConfig.SEGMENT_MS_CONFIG, logRollTimeMillis)
-    logProps.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, logRollTimeJitterMillis)
-    logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, logIndexSizeMaxBytes)
-    logProps.put(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, logFlushIntervalMessages)
-    logProps.put(TopicConfig.FLUSH_MS_CONFIG, logFlushIntervalMs)
-    logProps.put(TopicConfig.RETENTION_BYTES_CONFIG, logRetentionBytes)
-    logProps.put(TopicConfig.RETENTION_MS_CONFIG, logRetentionTimeMillis: java.lang.Long)
-    logProps.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, messageMaxBytes)
-    logProps.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, logIndexIntervalBytes)
-    logProps.put(TopicConfig.DELETE_RETENTION_MS_CONFIG, logCleanerDeleteRetentionMs)
-    logProps.put(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, logCleanerMinCompactionLagMs)
-    logProps.put(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, logCleanerMaxCompactionLagMs)
-    logProps.put(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, logDeleteDelayMs)
-    logProps.put(TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_CONFIG, logCleanerMinCleanRatio)
-    logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, logCleanupPolicy)
-    logProps.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minInSyncReplicas)
-    logProps.put(TopicConfig.COMPRESSION_TYPE_CONFIG, compressionType)
-    logProps.put(TopicConfig.COMPRESSION_GZIP_LEVEL_CONFIG, gzipCompressionLevel)
-    logProps.put(TopicConfig.COMPRESSION_LZ4_LEVEL_CONFIG, lz4CompressionLevel)
-    logProps.put(TopicConfig.COMPRESSION_ZSTD_LEVEL_CONFIG, zstdCompressionLevel)
-    logProps.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, uncleanLeaderElectionEnable)
-    logProps.put(TopicConfig.PREALLOCATE_CONFIG, logPreAllocateEnable)
-    logProps.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, logMessageTimestampType.name)
-    logProps.put(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG, logMessageTimestampBeforeMaxMs: java.lang.Long)
-    logProps.put(TopicConfig.MESSAGE_TIMESTAMP_AFTER_MAX_MS_CONFIG, logMessageTimestampAfterMaxMs: java.lang.Long)
-    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, remoteLogManagerConfig.logLocalRetentionMs: java.lang.Long)
-    logProps.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, remoteLogManagerConfig.logLocalRetentionBytes: java.lang.Long)
-    logProps.put(TopicConfig.REMOTE_COPY_LAG_MS_CONFIG, remoteLogManagerConfig.logRemoteCopyLagMs: java.lang.Long)
-    logProps.put(TopicConfig.REMOTE_COPY_LAG_BYTES_CONFIG, remoteLogManagerConfig.logRemoteCopyLagBytes: java.lang.Long)
-    logProps
-  }
 }

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -37,7 +37,7 @@ import org.apache.kafka.network.{SocketServerConfigs, SocketServer => JSocketSer
 import org.apache.kafka.server.DynamicThreadPool
 import org.apache.kafka.server.authorizer._
 import org.apache.kafka.server.common.DirectoryEventHandler
-import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs}
+import org.apache.kafka.server.config.{DynamicLogConfig, ReplicationConfigs, ServerConfigs, ServerLogConfigs}
 import org.apache.kafka.server.log.remote.storage.{RemoteLogManager, RemoteLogManagerConfig}
 import org.apache.kafka.server.metrics.{ClientTelemetryExporterPlugin, KafkaYammerMetrics, MetricConfigs}
 import org.apache.kafka.server.quota.QuotaFactory

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.ListenerName;
@@ -649,6 +650,45 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         }
 
         return millis < 0 ? Long.valueOf(-1) : millis;
+    }
+
+    /**
+     * Copy the subset of properties that are relevant to logs. The individual properties
+     * are listed here since the names are slightly different in each config class.
+     */
+    public Map<String, Object> extractLogConfigMap() {
+        Map<String, Object> logProps = new HashMap<>();
+        logProps.put(TopicConfig.SEGMENT_BYTES_CONFIG, logSegmentBytes());
+        logProps.put(TopicConfig.SEGMENT_MS_CONFIG, logRollTimeMillis());
+        logProps.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, logRollTimeJitterMillis());
+        logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, logIndexSizeMaxBytes());
+        logProps.put(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, logFlushIntervalMessages());
+        logProps.put(TopicConfig.FLUSH_MS_CONFIG, logFlushIntervalMs());
+        logProps.put(TopicConfig.RETENTION_BYTES_CONFIG, logRetentionBytes());
+        logProps.put(TopicConfig.RETENTION_MS_CONFIG, logRetentionTimeMillis());
+        logProps.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, getInt(ServerConfigs.MESSAGE_MAX_BYTES_CONFIG));
+        logProps.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, logIndexIntervalBytes());
+        logProps.put(TopicConfig.DELETE_RETENTION_MS_CONFIG, logCleanerDeleteRetentionMs());
+        logProps.put(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG, logCleanerMinCompactionLagMs());
+        logProps.put(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, logCleanerMaxCompactionLagMs());
+        logProps.put(TopicConfig.FILE_DELETE_DELAY_MS_CONFIG, logDeleteDelayMs());
+        logProps.put(TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_CONFIG, logCleanerMinCleanRatio());
+        logProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, logCleanupPolicy());
+        logProps.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minInSyncReplicas());
+        logProps.put(TopicConfig.COMPRESSION_TYPE_CONFIG, getString(ServerConfigs.COMPRESSION_TYPE_CONFIG));
+        logProps.put(TopicConfig.COMPRESSION_GZIP_LEVEL_CONFIG, getInt(ServerConfigs.COMPRESSION_GZIP_LEVEL_CONFIG));
+        logProps.put(TopicConfig.COMPRESSION_LZ4_LEVEL_CONFIG, getInt(ServerConfigs.COMPRESSION_LZ4_LEVEL_CONFIG));
+        logProps.put(TopicConfig.COMPRESSION_ZSTD_LEVEL_CONFIG, getInt(ServerConfigs.COMPRESSION_ZSTD_LEVEL_CONFIG));
+        logProps.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, getBoolean(ReplicationConfigs.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG));
+        logProps.put(TopicConfig.PREALLOCATE_CONFIG, logPreAllocateEnable());
+        logProps.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, logMessageTimestampType().name);
+        logProps.put(TopicConfig.MESSAGE_TIMESTAMP_BEFORE_MAX_MS_CONFIG, logMessageTimestampBeforeMaxMs());
+        logProps.put(TopicConfig.MESSAGE_TIMESTAMP_AFTER_MAX_MS_CONFIG, logMessageTimestampAfterMaxMs());
+        logProps.put(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP));
+        logProps.put(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP));
+        logProps.put(TopicConfig.REMOTE_COPY_LAG_MS_CONFIG, getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP));
+        logProps.put(TopicConfig.REMOTE_COPY_LAG_BYTES_CONFIG, getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP));
+        return logProps;
     }
 
     /**

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicBrokerConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicBrokerConfig.java
@@ -200,19 +200,6 @@ public class DynamicBrokerConfig {
         );
     }
 
-    public static class DynamicLogConfig {
-        /**
-         * The broker configurations pertaining to logs that are reconfigurable. This set contains
-         * the names you would use when setting a static or dynamic broker configuration (not topic
-         * configuration).
-         */
-        public static final Set<String> RECONFIGURABLE_CONFIGS = Stream.of(
-                ServerTopicConfigSynonyms.TOPIC_CONFIG_SYNONYMS.values(),
-                Set.of(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toUnmodifiableSet());
-    }
-
     public static class DynamicListenerConfig {
         /**
          * The set of configurations which the DynamicListenerConfig object listens for. Many of

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -147,9 +147,11 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         logManager.brokerConfigUpdated();
         for (UnifiedLog unifiedLog : logManager.allLogs()) {
             Map<String, Object> props = new HashMap<>(newBrokerDefaults);
-            unifiedLog.config().originals().entrySet().stream()
-                .filter(entry -> unifiedLog.config().overriddenConfigs.contains(entry.getKey()))
-                .forEach(entry -> props.put(entry.getKey(), entry.getValue()));
+            unifiedLog.config().originals().forEach((key, value) -> {
+                if (unifiedLog.config().overriddenConfigs.contains(key)) {
+                    props.put(key, value);
+                }
+            });
             unifiedLog.updateConfig(new LogConfig(props, unifiedLog.config().overriddenConfigs));
         }
     }

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -79,10 +79,10 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     private void validateLogLocalRetentionMs(AbstractKafkaConfig config) {
         long logRetentionMs = config.logRetentionTimeMillis();
         long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
-        if (logRetentionMs != -1L && logLocalRetentionMs != -2L) {
-            if (logLocalRetentionMs == -1L) {
+        if (logRetentionMs != LogConfig.NO_RETENTION_LIMIT && logLocalRetentionMs != LogConfig.DEFAULT_LOCAL_RETENTION_MS) {
+            if (logLocalRetentionMs == LogConfig.NO_RETENTION_LIMIT) {
                 throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
-                    "Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG + " value is set as " + logRetentionMs + ".");
+                    "Value must not be " + LogConfig.NO_RETENTION_LIMIT + " as " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG + " value is set as " + logRetentionMs + ".");
             }
             if (logLocalRetentionMs > logRetentionMs) {
                 throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
@@ -94,10 +94,10 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     private void validateLogLocalRetentionBytes(AbstractKafkaConfig config) {
         long logRetentionBytes = config.logRetentionBytes();
         long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
-        if (logRetentionBytes > -1L && logLocalRetentionBytes != -2L) {
-            if (logLocalRetentionBytes == -1L) {
+        if (logRetentionBytes > LogConfig.NO_RETENTION_LIMIT && logLocalRetentionBytes != LogConfig.DEFAULT_LOCAL_RETENTION_BYTES) {
+            if (logLocalRetentionBytes == LogConfig.NO_RETENTION_LIMIT) {
                 throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
-                    "Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG + " value is set as " + logRetentionBytes + ".");
+                    "Value must not be " + LogConfig.NO_RETENTION_LIMIT + " as " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG + " value is set as " + logRetentionBytes + ".");
             }
             if (logLocalRetentionBytes > logRetentionBytes) {
                 throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
@@ -109,7 +109,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     private void validateLogRemoteCopyLagMs(AbstractKafkaConfig config) {
         long logRetentionMs = config.logRetentionTimeMillis();
         long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
-        long effectiveLocalRetentionMs = logLocalRetentionMs == -2L ? logRetentionMs : logLocalRetentionMs;
+        long effectiveLocalRetentionMs = logLocalRetentionMs == LogConfig.DEFAULT_LOCAL_RETENTION_MS ? logRetentionMs : logLocalRetentionMs;
         long logRemoteCopyLagMs = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP);
         if (logRemoteCopyLagMs > 0L && effectiveLocalRetentionMs >= 0L && logRemoteCopyLagMs > effectiveLocalRetentionMs) {
             throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP, logRemoteCopyLagMs,
@@ -121,7 +121,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     private void validateLogRemoteCopyLagBytes(AbstractKafkaConfig config) {
         long logRetentionBytes = config.logRetentionBytes();
         long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
-        long effectiveLocalRetentionBytes = logLocalRetentionBytes == -2L ? logRetentionBytes : logLocalRetentionBytes;
+        long effectiveLocalRetentionBytes = logLocalRetentionBytes == LogConfig.DEFAULT_LOCAL_RETENTION_BYTES ? logRetentionBytes : logLocalRetentionBytes;
         long logRemoteCopyLagBytes = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP);
         if (logRemoteCopyLagBytes > 0L && effectiveLocalRetentionBytes >= 0L && logRemoteCopyLagBytes > effectiveLocalRetentionBytes) {
             throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP, logRemoteCopyLagBytes,

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.config.BrokerReconfigurable;
+import org.apache.kafka.server.common.DirectoryEventHandler;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.storage.internals.log.LogConfig;
+import org.apache.kafka.storage.internals.log.LogManager;
+import org.apache.kafka.storage.internals.log.UnifiedLog;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DynamicLogConfig implements BrokerReconfigurable {
+    /**
+     * The broker configurations pertaining to logs that are reconfigurable. This set contains
+     * the names you would use when setting a static or dynamic broker configuration (not topic
+     * configuration).
+     */
+    public static final Set<String> RECONFIGURABLE_CONFIGS = Stream.of(
+            ServerTopicConfigSynonyms.TOPIC_CONFIG_SYNONYMS.values(),
+            Set.of(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toUnmodifiableSet());
+
+    private final LogManager logManager;
+    private final DirectoryEventHandler directoryEventHandler;
+
+    public DynamicLogConfig(LogManager logManager, DirectoryEventHandler directoryEventHandler) {
+        this.logManager = logManager;
+        this.directoryEventHandler = directoryEventHandler;
+    }
+
+    @Override
+    public Set<String> reconfigurableConfigs() {
+        return RECONFIGURABLE_CONFIGS;
+    }
+
+    @Override
+    public void validateReconfiguration(AbstractConfig newConfig) {
+        AbstractKafkaConfig kafkaConfig = requireKafkaConfig(newConfig);
+        validateLogLocalRetentionMs(kafkaConfig);
+        validateLogLocalRetentionBytes(kafkaConfig);
+        validateLogRemoteCopyLagMs(kafkaConfig);
+        validateLogRemoteCopyLagBytes(kafkaConfig);
+        validateCordonedLogDirs(kafkaConfig);
+    }
+
+    private AbstractKafkaConfig requireKafkaConfig(AbstractConfig config) {
+        if (!(config instanceof AbstractKafkaConfig kafkaConfig)) {
+            throw new IllegalArgumentException("DynamicLogConfig requires AbstractKafkaConfig, got " +
+                config.getClass().getName());
+        }
+        return kafkaConfig;
+    }
+
+    private void validateLogLocalRetentionMs(AbstractKafkaConfig config) {
+        long logRetentionMs = config.logRetentionTimeMillis();
+        long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
+        if (logRetentionMs != -1L && logLocalRetentionMs != -2L) {
+            if (logLocalRetentionMs == -1L) {
+                throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
+                    "Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG + " value is set as " + logRetentionMs + ".");
+            }
+            if (logLocalRetentionMs > logRetentionMs) {
+                throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, logLocalRetentionMs,
+                    "Value must not be more than " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG + " property value: " + logRetentionMs);
+            }
+        }
+    }
+
+    private void validateLogLocalRetentionBytes(AbstractKafkaConfig config) {
+        long logRetentionBytes = config.logRetentionBytes();
+        long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
+        if (logRetentionBytes > -1L && logLocalRetentionBytes != -2L) {
+            if (logLocalRetentionBytes == -1L) {
+                throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
+                    "Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG + " value is set as " + logRetentionBytes + ".");
+            }
+            if (logLocalRetentionBytes > logRetentionBytes) {
+                throw new ConfigException(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, logLocalRetentionBytes,
+                    "Value must not be more than " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG + " property value: " + logRetentionBytes);
+            }
+        }
+    }
+
+    private void validateLogRemoteCopyLagMs(AbstractKafkaConfig config) {
+        long logRetentionMs = config.logRetentionTimeMillis();
+        long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
+        long effectiveLocalRetentionMs = logLocalRetentionMs == -2L ? logRetentionMs : logLocalRetentionMs;
+        long logRemoteCopyLagMs = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP);
+        if (logRemoteCopyLagMs > 0L && effectiveLocalRetentionMs >= 0L && logRemoteCopyLagMs > effectiveLocalRetentionMs) {
+            throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP, logRemoteCopyLagMs,
+                "Value must not exceed " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP +
+                    " (effective value: " + effectiveLocalRetentionMs + ")");
+        }
+    }
+
+    private void validateLogRemoteCopyLagBytes(AbstractKafkaConfig config) {
+        long logRetentionBytes = config.logRetentionBytes();
+        long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
+        long effectiveLocalRetentionBytes = logLocalRetentionBytes == -2L ? logRetentionBytes : logLocalRetentionBytes;
+        long logRemoteCopyLagBytes = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP);
+        if (logRemoteCopyLagBytes > 0L && effectiveLocalRetentionBytes >= 0L && logRemoteCopyLagBytes > effectiveLocalRetentionBytes) {
+            throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP, logRemoteCopyLagBytes,
+                "Value must not exceed " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP +
+                    " (effective value: " + effectiveLocalRetentionBytes + ")");
+        }
+    }
+
+    private void validateCordonedLogDirs(AbstractKafkaConfig config) {
+        List<String> cordonedLogDirs = config.cordonedLogDirs();
+        List<String> logDirs = config.logDirs();
+        for (String dir : cordonedLogDirs) {
+            if (!logDirs.contains(dir)) {
+                throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs,
+                    "Invalid entry in " + ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG + ": " + dir + ". " +
+                        "All cordoned log dirs must be entries of " + ServerLogConfigs.LOG_DIRS_CONFIG + " or " +
+                        ServerLogConfigs.LOG_DIR_CONFIG + ".");
+            }
+        }
+    }
+
+    private void updateLogsConfig(Map<String, Object> newBrokerDefaults) {
+        logManager.brokerConfigUpdated();
+        for (UnifiedLog unifiedLog : logManager.allLogs()) {
+            Map<String, Object> props = new HashMap<>(newBrokerDefaults);
+            unifiedLog.config().originals().entrySet().stream()
+                .filter(entry -> unifiedLog.config().overriddenConfigs.contains(entry.getKey()))
+                .forEach(entry -> props.put(entry.getKey(), entry.getValue()));
+            unifiedLog.updateConfig(new LogConfig(props, unifiedLog.config().overriddenConfigs));
+        }
+    }
+
+    @Override
+    public void reconfigure(AbstractConfig oldConfig, AbstractConfig newConfig) {
+        AbstractKafkaConfig kafkaConfig = requireKafkaConfig(newConfig);
+        Map<String, Object> newBrokerDefaults = new HashMap<>(kafkaConfig.extractLogConfigMap());
+        logManager.reconfigureDefaultLogConfig(new LogConfig(newBrokerDefaults));
+        updateLogsConfig(newBrokerDefaults);
+
+        logManager.updateCordonedLogDirs(Set.copyOf(kafkaConfig.cordonedLogDirs()));
+        directoryEventHandler.handleCordoned(kafkaConfig.cordonedLogDirs().stream()
+            .flatMap(dir -> logManager.directoryId(dir).stream())
+            .collect(Collectors.toSet()));
+    }
+
+    @Override
+    public String toString() {
+        return "DynamicLogConfig";
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -155,7 +155,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         logManager.updateCordonedLogDirs(Set.copyOf(newConfig.cordonedLogDirs()));
         directoryEventHandler.handleCordoned(newConfig.cordonedLogDirs().stream()
             .flatMap(dir -> logManager.directoryId(dir).stream())
-            .collect(Collectors.toSet()));
+            .collect(Collectors.toUnmodifiableSet()));
     }
 
     @Override

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -100,7 +100,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
         long effectiveLocalRetentionMs = logLocalRetentionMs == LogConfig.DEFAULT_LOCAL_RETENTION_MS ? logRetentionMs : logLocalRetentionMs;
         long logRemoteCopyLagMs = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP);
-        if (logRemoteCopyLagMs > 0L && effectiveLocalRetentionMs >= 0L && logRemoteCopyLagMs > effectiveLocalRetentionMs) {
+        if (effectiveLocalRetentionMs >= 0L && logRemoteCopyLagMs > effectiveLocalRetentionMs) {
             throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_MS_PROP, logRemoteCopyLagMs,
                 "Value must not exceed " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP +
                     " (effective value: " + effectiveLocalRetentionMs + ")");
@@ -112,7 +112,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
         long effectiveLocalRetentionBytes = logLocalRetentionBytes == LogConfig.DEFAULT_LOCAL_RETENTION_BYTES ? logRetentionBytes : logLocalRetentionBytes;
         long logRemoteCopyLagBytes = config.getLong(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP);
-        if (logRemoteCopyLagBytes > 0L && effectiveLocalRetentionBytes >= 0L && logRemoteCopyLagBytes > effectiveLocalRetentionBytes) {
+        if (effectiveLocalRetentionBytes >= 0L && logRemoteCopyLagBytes > effectiveLocalRetentionBytes) {
             throw new ConfigException(RemoteLogManagerConfig.LOG_REMOTE_COPY_LAG_BYTES_PROP, logRemoteCopyLagBytes,
                 "Value must not exceed " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP +
                     " (effective value: " + effectiveLocalRetentionBytes + ")");

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -16,9 +16,7 @@
  */
 package org.apache.kafka.server.config;
 
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.config.BrokerReconfigurable;
 import org.apache.kafka.server.common.DirectoryEventHandler;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.apache.kafka.storage.internals.log.LogConfig;
@@ -59,21 +57,12 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     }
 
     @Override
-    public void validateReconfiguration(AbstractConfig newConfig) {
-        AbstractKafkaConfig kafkaConfig = requireKafkaConfig(newConfig);
-        validateLogLocalRetentionMs(kafkaConfig);
-        validateLogLocalRetentionBytes(kafkaConfig);
-        validateLogRemoteCopyLagMs(kafkaConfig);
-        validateLogRemoteCopyLagBytes(kafkaConfig);
-        validateCordonedLogDirs(kafkaConfig);
-    }
-
-    private AbstractKafkaConfig requireKafkaConfig(AbstractConfig config) {
-        if (!(config instanceof AbstractKafkaConfig kafkaConfig)) {
-            throw new IllegalArgumentException("DynamicLogConfig requires AbstractKafkaConfig, got " +
-                config.getClass().getName());
-        }
-        return kafkaConfig;
+    public void validateReconfiguration(AbstractKafkaConfig newConfig) {
+        validateLogLocalRetentionMs(newConfig);
+        validateLogLocalRetentionBytes(newConfig);
+        validateLogRemoteCopyLagMs(newConfig);
+        validateLogRemoteCopyLagBytes(newConfig);
+        validateCordonedLogDirs(newConfig);
     }
 
     private void validateLogLocalRetentionMs(AbstractKafkaConfig config) {
@@ -157,14 +146,13 @@ public class DynamicLogConfig implements BrokerReconfigurable {
     }
 
     @Override
-    public void reconfigure(AbstractConfig oldConfig, AbstractConfig newConfig) {
-        AbstractKafkaConfig kafkaConfig = requireKafkaConfig(newConfig);
-        Map<String, Object> newBrokerDefaults = new HashMap<>(kafkaConfig.extractLogConfigMap());
+    public void reconfigure(AbstractKafkaConfig oldConfig, AbstractKafkaConfig newConfig) {
+        Map<String, Object> newBrokerDefaults = new HashMap<>(newConfig.extractLogConfigMap());
         logManager.reconfigureDefaultLogConfig(new LogConfig(newBrokerDefaults));
         updateLogsConfig(newBrokerDefaults);
 
-        logManager.updateCordonedLogDirs(Set.copyOf(kafkaConfig.cordonedLogDirs()));
-        directoryEventHandler.handleCordoned(kafkaConfig.cordonedLogDirs().stream()
+        logManager.updateCordonedLogDirs(Set.copyOf(newConfig.cordonedLogDirs()));
+        directoryEventHandler.handleCordoned(newConfig.cordonedLogDirs().stream()
             .flatMap(dir -> logManager.directoryId(dir).stream())
             .collect(Collectors.toSet()));
     }

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -65,7 +65,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         validateCordonedLogDirs(newConfig);
     }
 
-    private void validateLogLocalRetentionMs(AbstractKafkaConfig config) {
+    private static void validateLogLocalRetentionMs(AbstractKafkaConfig config) {
         long logRetentionMs = config.logRetentionTimeMillis();
         long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
         if (logRetentionMs != LogConfig.NO_RETENTION_LIMIT && logLocalRetentionMs != LogConfig.DEFAULT_LOCAL_RETENTION_MS) {
@@ -80,7 +80,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         }
     }
 
-    private void validateLogLocalRetentionBytes(AbstractKafkaConfig config) {
+    private static void validateLogLocalRetentionBytes(AbstractKafkaConfig config) {
         long logRetentionBytes = config.logRetentionBytes();
         long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
         if (logRetentionBytes > LogConfig.NO_RETENTION_LIMIT && logLocalRetentionBytes != LogConfig.DEFAULT_LOCAL_RETENTION_BYTES) {
@@ -95,7 +95,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         }
     }
 
-    private void validateLogRemoteCopyLagMs(AbstractKafkaConfig config) {
+    private static void validateLogRemoteCopyLagMs(AbstractKafkaConfig config) {
         long logRetentionMs = config.logRetentionTimeMillis();
         long logLocalRetentionMs = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP);
         long effectiveLocalRetentionMs = logLocalRetentionMs == LogConfig.DEFAULT_LOCAL_RETENTION_MS ? logRetentionMs : logLocalRetentionMs;
@@ -107,7 +107,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         }
     }
 
-    private void validateLogRemoteCopyLagBytes(AbstractKafkaConfig config) {
+    private static void validateLogRemoteCopyLagBytes(AbstractKafkaConfig config) {
         long logRetentionBytes = config.logRetentionBytes();
         long logLocalRetentionBytes = config.getLong(RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP);
         long effectiveLocalRetentionBytes = logLocalRetentionBytes == LogConfig.DEFAULT_LOCAL_RETENTION_BYTES ? logRetentionBytes : logLocalRetentionBytes;

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -148,7 +148,7 @@ public class DynamicLogConfig implements BrokerReconfigurable {
 
     @Override
     public void reconfigure(AbstractKafkaConfig oldConfig, AbstractKafkaConfig newConfig) {
-        Map<String, Object> newBrokerDefaults = new HashMap<>(newConfig.extractLogConfigMap());
+        Map<String, Object> newBrokerDefaults = newConfig.extractLogConfigMap();
         logManager.reconfigureDefaultLogConfig(new LogConfig(newBrokerDefaults));
         updateLogsConfig(newBrokerDefaults);
 

--- a/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/DynamicLogConfig.java
@@ -119,16 +119,17 @@ public class DynamicLogConfig implements BrokerReconfigurable {
         }
     }
 
-    private void validateCordonedLogDirs(AbstractKafkaConfig config) {
+    private static void validateCordonedLogDirs(AbstractKafkaConfig config) {
         List<String> cordonedLogDirs = config.cordonedLogDirs();
         List<String> logDirs = config.logDirs();
-        for (String dir : cordonedLogDirs) {
-            if (!logDirs.contains(dir)) {
-                throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs,
-                    "Invalid entry in " + ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG + ": " + dir + ". " +
-                        "All cordoned log dirs must be entries of " + ServerLogConfigs.LOG_DIRS_CONFIG + " or " +
-                        ServerLogConfigs.LOG_DIR_CONFIG + ".");
-            }
+        List<String> invalidDirs = cordonedLogDirs.stream()
+            .filter(dir -> !logDirs.contains(dir))
+            .toList();
+        if (!invalidDirs.isEmpty()) {
+            throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs,
+                "Invalid entries in " + ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG + ": " + invalidDirs + ". " +
+                    "All cordoned log dirs must be entries of " + ServerLogConfigs.LOG_DIRS_CONFIG + " or " +
+                    ServerLogConfigs.LOG_DIR_CONFIG + ".");
         }
     }
 

--- a/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.config;
+
+import org.apache.kafka.common.Reconfigurable;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.raft.KRaftConfigs;
+import org.apache.kafka.server.common.DirectoryEventHandler;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.storage.internals.log.LogManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class DynamicLogConfigTest {
+
+    private final DynamicLogConfig dynamicLogConfig = new DynamicLogConfig(
+        mock(LogManager.class),
+        mock(DirectoryEventHandler.class)
+    );
+
+    @Test
+    public void testValidateLogLocalRetentionMs() {
+        assertInvalidConfig(
+            Map.of(
+                ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG, "1000",
+                RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "-1"
+            ),
+            "Invalid value -1 for configuration " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP +
+                ": Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG +
+                " value is set as 1000."
+        );
+
+        assertInvalidConfig(
+            Map.of(
+                ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG, "1000",
+                RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP, "1001"
+            ),
+            "Invalid value 1001 for configuration " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_MS_PROP +
+                ": Value must not be more than " + ServerLogConfigs.LOG_RETENTION_TIME_MILLIS_CONFIG +
+                " property value: 1000"
+        );
+    }
+
+    @Test
+    public void testValidateLogLocalRetentionBytes() {
+        assertInvalidConfig(
+            Map.of(
+                ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG, "1000",
+                RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "-1"
+            ),
+            "Invalid value -1 for configuration " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP +
+                ": Value must not be -1 as " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG +
+                " value is set as 1000."
+        );
+
+        assertInvalidConfig(
+            Map.of(
+                ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG, "1000",
+                RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP, "1001"
+            ),
+            "Invalid value 1001 for configuration " + RemoteLogManagerConfig.LOG_LOCAL_RETENTION_BYTES_PROP +
+                ": Value must not be more than " + ServerLogConfigs.LOG_RETENTION_BYTES_CONFIG +
+                " property value: 1000"
+        );
+    }
+
+    private void assertInvalidConfig(Map<String, Object> overrides, String expectedMessage) {
+        ConfigException exception = assertThrows(
+            ConfigException.class,
+            () -> dynamicLogConfig.validateReconfiguration(kafkaConfig(overrides))
+        );
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    private static AbstractKafkaConfig kafkaConfig(Map<String, Object> overrides) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(KRaftConfigs.PROCESS_ROLES_CONFIG, "broker");
+        props.put(KRaftConfigs.NODE_ID_CONFIG, "1");
+        props.put(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER");
+        props.putAll(overrides);
+        return new AbstractKafkaConfig(AbstractKafkaConfig.CONFIG_DEF, props, Map.of(), false) {
+            @Override
+            public void addReconfigurable(Reconfigurable reconfigurable) {
+            }
+
+            @Override
+            public void removeReconfigurable(Reconfigurable reconfigurable) {
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.server.config;
 
-import org.apache.kafka.common.Reconfigurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.raft.KRaftConfigs;
 import org.apache.kafka.server.common.DirectoryEventHandler;
@@ -113,14 +112,6 @@ public class DynamicLogConfigTest {
         props.put(KRaftConfigs.NODE_ID_CONFIG, "1");
         props.put(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER");
         props.putAll(overrides);
-        return new AbstractKafkaConfig(AbstractKafkaConfig.CONFIG_DEF, props, Map.of(), false) {
-            @Override
-            public void addReconfigurable(Reconfigurable reconfigurable) {
-            }
-
-            @Override
-            public void removeReconfigurable(Reconfigurable reconfigurable) {
-            }
-        };
+        return new AbstractKafkaConfig(AbstractKafkaConfig.CONFIG_DEF, props, Map.of(), false) { };
     }
 }

--- a/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
+++ b/server/src/test/java/org/apache/kafka/server/config/DynamicLogConfigTest.java
@@ -85,6 +85,20 @@ public class DynamicLogConfigTest {
         );
     }
 
+    @Test
+    public void testValidateCordonedLogDirsReportsAllInvalidEntries() {
+        assertInvalidConfig(
+            Map.of(
+                ServerLogConfigs.LOG_DIRS_CONFIG, "/tmp/kafka-1,/tmp/kafka-2",
+                ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, "/tmp/bad-1,/tmp/bad-2"
+            ),
+            "Invalid value [/tmp/bad-1, /tmp/bad-2] for configuration " + ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG +
+                ": Invalid entries in " + ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG + ": [/tmp/bad-1, /tmp/bad-2]. " +
+                "All cordoned log dirs must be entries of " + ServerLogConfigs.LOG_DIRS_CONFIG + " or " +
+                ServerLogConfigs.LOG_DIR_CONFIG + "."
+        );
+    }
+
     private void assertInvalidConfig(Map<String, Object> overrides, String expectedMessage) {
         ConfigException exception = assertThrows(
             ConfigException.class,

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -262,8 +262,8 @@ public class LogConfig extends AbstractConfig {
     public final Set<String> overriddenConfigs;
 
     /*
-     * Important note: Any configuration parameter that is passed along from KafkaConfig to LogConfig
-     * should also be in `KafkaConfig#extractLogConfigMap`.
+     * Important note: Any configuration parameter that is passed along from AbstractKafkaConfig to
+     * LogConfig should also be in `AbstractKafkaConfig#extractLogConfigMap`.
      */
     private final int segmentSize;
     private final Integer internalSegmentSize;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -141,6 +141,7 @@ public class LogConfig extends AbstractConfig {
     public static final boolean DEFAULT_REMOTE_STORAGE_ENABLE = false;
     public static final boolean DEFAULT_REMOTE_LOG_COPY_DISABLE = false;
     public static final boolean DEFAULT_REMOTE_LOG_DELETE_ON_DISABLE = false;
+    public static final long NO_RETENTION_LIMIT = -1L; // It indicates no retention limit
     public static final long DEFAULT_LOCAL_RETENTION_BYTES = -2; // It indicates the value to be derived from RetentionBytes
     public static final long DEFAULT_LOCAL_RETENTION_MS = -2; // It indicates the value to be derived from RetentionMs
 
@@ -204,7 +205,7 @@ public class LogConfig extends AbstractConfig {
                 // can be negative. See kafka.log.LogManager.cleanupSegmentsToMaintainSize
                 .define(TopicConfig.RETENTION_BYTES_CONFIG, LONG, ServerLogConfigs.LOG_RETENTION_BYTES_DEFAULT, MEDIUM, TopicConfig.RETENTION_BYTES_DOC)
                 // can be negative. See kafka.log.LogManager.cleanupExpiredSegments
-                .define(TopicConfig.RETENTION_MS_CONFIG, LONG, DEFAULT_RETENTION_MS, atLeast(-1), MEDIUM,
+                .define(TopicConfig.RETENTION_MS_CONFIG, LONG, DEFAULT_RETENTION_MS, atLeast(NO_RETENTION_LIMIT), MEDIUM,
                         TopicConfig.RETENTION_MS_DOC)
                 .define(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, INT, ServerLogConfigs.MAX_MESSAGE_BYTES_DEFAULT, atLeast(0), MEDIUM,
                         TopicConfig.MAX_MESSAGE_BYTES_DOC)
@@ -594,10 +595,10 @@ public class LogConfig extends AbstractConfig {
     private static void validateRemoteStorageRetentionSize(Map<String, ?> props) {
         Long retentionBytes = (Long) props.get(TopicConfig.RETENTION_BYTES_CONFIG);
         Long localRetentionBytes = (Long) props.get(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG);
-        if (retentionBytes > -1 && localRetentionBytes != -2) {
-            if (localRetentionBytes == -1) {
-                String message = String.format("Value must not be -1 as %s value is set as %d.",
-                        TopicConfig.RETENTION_BYTES_CONFIG, retentionBytes);
+        if (retentionBytes > NO_RETENTION_LIMIT && localRetentionBytes != DEFAULT_LOCAL_RETENTION_BYTES) {
+            if (localRetentionBytes == NO_RETENTION_LIMIT) {
+                String message = String.format("Value must not be %d as %s value is set as %d.",
+                        NO_RETENTION_LIMIT, TopicConfig.RETENTION_BYTES_CONFIG, retentionBytes);
                 throw new ConfigException(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG, localRetentionBytes, message);
             }
             if (localRetentionBytes > retentionBytes) {
@@ -611,10 +612,10 @@ public class LogConfig extends AbstractConfig {
     private static void validateRemoteStorageRetentionTime(Map<String, ?> props) {
         Long retentionMs = (Long) props.get(TopicConfig.RETENTION_MS_CONFIG);
         Long localRetentionMs = (Long) props.get(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG);
-        if (retentionMs != -1 && localRetentionMs != -2) {
-            if (localRetentionMs == -1) {
-                String message = String.format("Value must not be -1 as %s value is set as %d.",
-                        TopicConfig.RETENTION_MS_CONFIG, retentionMs);
+        if (retentionMs != NO_RETENTION_LIMIT && localRetentionMs != DEFAULT_LOCAL_RETENTION_MS) {
+            if (localRetentionMs == NO_RETENTION_LIMIT) {
+                String message = String.format("Value must not be %d as %s value is set as %d.",
+                        NO_RETENTION_LIMIT, TopicConfig.RETENTION_MS_CONFIG, retentionMs);
                 throw new ConfigException(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG, localRetentionMs, message);
             }
             if (localRetentionMs > retentionMs) {
@@ -629,7 +630,7 @@ public class LogConfig extends AbstractConfig {
         Long retentionMs = (Long) props.get(TopicConfig.RETENTION_MS_CONFIG);
         Long localRetentionMs = (Long) props.get(TopicConfig.LOCAL_LOG_RETENTION_MS_CONFIG);
         Long remoteCopyLagMs = (Long) props.get(TopicConfig.REMOTE_COPY_LAG_MS_CONFIG);
-        long effectiveLocalRetentionMs = localRetentionMs == -2 ? retentionMs : localRetentionMs;
+        long effectiveLocalRetentionMs = localRetentionMs == DEFAULT_LOCAL_RETENTION_MS ? retentionMs : localRetentionMs;
         if (remoteCopyLagMs > 0 && effectiveLocalRetentionMs >= 0
                 && remoteCopyLagMs > effectiveLocalRetentionMs) {
             String message = String.format("Value must not exceed %s (effective value: %d)",
@@ -642,7 +643,7 @@ public class LogConfig extends AbstractConfig {
         Long retentionBytes = (Long) props.get(TopicConfig.RETENTION_BYTES_CONFIG);
         Long localRetentionBytes = (Long) props.get(TopicConfig.LOCAL_LOG_RETENTION_BYTES_CONFIG);
         Long remoteCopyLagBytes = (Long) props.get(TopicConfig.REMOTE_COPY_LAG_BYTES_CONFIG);
-        long effectiveLocalRetentionBytes = localRetentionBytes == -2 ? retentionBytes : localRetentionBytes;
+        long effectiveLocalRetentionBytes = localRetentionBytes == DEFAULT_LOCAL_RETENTION_BYTES ? retentionBytes : localRetentionBytes;
         if (remoteCopyLagBytes > 0 && effectiveLocalRetentionBytes >= 0
                 && remoteCopyLagBytes > effectiveLocalRetentionBytes) {
             String message = String.format("Value must not exceed %s (effective value: %d)",


### PR DESCRIPTION
## Summary

Move `DynamicLogConfig` from `core` to the `server` module as a Java
`BrokerReconfigurable`.

This also moves `extractLogConfigMap` to `AbstractKafkaConfig`, so log
reconfiguration no longer depends directly on
`kafka.server.KafkaConfig`.

## Testing

- `./gradlew :core:test --tests kafka.server.DynamicBrokerConfigTest`

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
