### PR TITLE
MINOR: Add hearbeat interval override to PerformanceServiceTest

### DIFF
--- a/tests/kafkatest/sanity_checks/test_performance_services.py
+++ b/tests/kafkatest/sanity_checks/test_performance_services.py
@@ -40,9 +40,18 @@ class PerformanceServiceTest(Test):
         number of messages. The actual stats here are pretty meaningless since the number of messages is quite small.
         """
         version = KafkaVersion(version)
+        server_overrides = [
+            ["group.share.min.heartbeat.interval.ms", "1500"],
+            ["group.share.heartbeat.interval.ms", "1500"],
+        ]
         self.kafka = KafkaService(
-            self.test_context, 1,
-            None, topics={self.topic: {'partitions': 1, 'replication-factor': 1}}, version=DEV_BRANCH)
+            self.test_context,
+            1,
+            None,
+            topics={self.topic: {'partitions': 1, 'replication-factor': 1}},
+            version=DEV_BRANCH,
+            server_prop_overrides=server_overrides
+        )
         self.kafka.start()
 
         # check basic run of producer performance


### PR DESCRIPTION
Sometimes the system test `PerformanceServiceTest` could fail with 0
records consumed by share consumer because the perf test command times
out in 10 seconds (default) and the partition assignment might not have
happened for the share member. This is because assignment does not
happen until share partitions are initialized in the share coordinator
which is dynamically loaded when the FindCoordinator request is sent.
The share group state topic too is created by auto topic manager and is
not present in a cold start cluster.  Decreasing the share goup
heartbeat interval solves the issue as more heartbeats get sent in the
10 second interval. Default heartbeat interval is 5 seconds so test
could
time out before getting an assignment.

Reviewers: Andrew Schofield <aschofield@confluent.io>
