### PR TITLE
KAFKA-20605 upgrade gradle action to enable the CI

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -42,7 +42,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       env:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
       with:


### PR DESCRIPTION
5.0.0 was removed by
https://github.com/apache/infrastructure-actions/commit/9ef334e76e7ff0298931d114ec2ac2517c77306c

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
