### PR TITLE
MINOR: Add 4.3.0 to system tests

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -109,6 +109,7 @@ versions += [
   kafka_40: "4.0.1",
   kafka_41: "4.1.2",
   kafka_42: "4.2.0",
+  kafka_43: "4.3.0",
   log4j2: "2.25.4",
   // When updating lz4 make sure the compression levels in org.apache.kafka.common.record.internal.CompressionType are still valid
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/internal/CompressionType.java#L73-L74
@@ -219,6 +220,8 @@ libs += [
   kafkaStreams_39: "org.apache.kafka:kafka-streams:$versions.kafka_39",
   kafkaStreams_40: "org.apache.kafka:kafka-streams:$versions.kafka_40",
   kafkaStreams_41: "org.apache.kafka:kafka-streams:$versions.kafka_41",
+  kafkaStreams_42: "org.apache.kafka:kafka-streams:$versions.kafka_42",
+  kafkaStreams_43: "org.apache.kafka:kafka-streams:$versions.kafka_43",
   log4j1Bridge2Api: "org.apache.logging.log4j:log4j-1.2-api:$versions.log4j2",
   log4j2Api: "org.apache.logging.log4j:log4j-api:$versions.log4j2",
   log4j2Core: "org.apache.logging.log4j:log4j-core:$versions.log4j2",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -97,6 +97,7 @@ RUN mkdir -p "/opt/kafka-3.9.2" && chmod a+rw /opt/kafka-3.9.2 && curl -s "$KAFK
 RUN mkdir -p "/opt/kafka-4.0.1" && chmod a+rw /opt/kafka-4.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.13-4.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-4.0.1"
 RUN mkdir -p "/opt/kafka-4.1.2" && chmod a+rw /opt/kafka-4.1.2 && curl -s "$KAFKA_MIRROR/kafka_2.13-4.1.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-4.1.2"
 RUN mkdir -p "/opt/kafka-4.2.0" && chmod a+rw /opt/kafka-4.2.0 && curl -s "$KAFKA_MIRROR/kafka_2.13-4.2.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-4.2.0"
+RUN mkdir -p "/opt/kafka-4.3.0" && chmod a+rw /opt/kafka-4.3.0 && curl -s "$KAFKA_MIRROR/kafka_2.13-4.3.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-4.3.0"
 
 
 # Streams test dependencies
@@ -121,6 +122,7 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.2-test.jar" -o /opt/kafka-3.9.2/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.0.1-test.jar" -o /opt/kafka-4.0.1/libs/kafka-streams-4.0.1-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.1.2-test.jar" -o /opt/kafka-4.1.2/libs/kafka-streams-4.1.2-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.2.0-test.jar" -o /opt/kafka-4.2.0/libs/kafka-streams-4.2.0-test.jar
+RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.3.0-test.jar" -o /opt/kafka-4.3.0/libs/kafka-streams-4.3.0-test.jar
 
 # To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper 
 # client from version 3.4.x to 3.5.7 in Kafka versions 2.1.1, 2.2.2, and 2.3.1, as the older Zookeeper 

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -252,3 +252,7 @@ LATEST_4_1 = V_4_1_2
 # 4.2.x version
 V_4_2_0 = KafkaVersion("4.2.0")
 LATEST_4_2 = V_4_2_0
+
+# 4.3.x version
+V_4_3_0 = KafkaVersion("4.3.0")
+LATEST_4_3 = V_4_3_0

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -180,6 +180,8 @@ get_kafka 4.1.2 2.13
 chmod a+rw /opt/kafka-4.1.2
 get_kafka 4.2.0 2.13
 chmod a+rw /opt/kafka-4.2.0
+get_kafka 4.3.0 2.13
+chmod a+rw /opt/kafka-4.3.0
 
 # To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper
 # client from version 3.4.x to 3.5.7 in Kafka versions 2.1.1, 2.2.2, and 2.3.1, as the older Zookeeper


### PR DESCRIPTION
Adding 4.3.0 to the system tests as per the post release instructions:
https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=34840886#ReleaseProcess-Afterrelease

I'll follow up with 2 other PRs for the core and streams system tests
updates.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
