### PR TITLE
KAFKA-20394: Close stale broker connections when host or resolved IP changes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -174,6 +174,33 @@ final class ClusterConnectionStates {
     }
 
     /**
+     * Returns true if the connection for the given node is stale relative to the supplied host:
+     * either the cached host differs, or its resolved addresses no longer include the bound IP.
+     *
+     * @param id the id of the node
+     * @param currentHost the latest known host for the node (e.g. from metadata)
+     * @throws UnknownHostException if re-resolution fails
+     */
+    public boolean isConnectionStale(String id, String currentHost) throws UnknownHostException {
+        NodeConnectionState state = nodeState.get(id);
+        if (state == null || state.lastAttemptedAddress == null) {
+            return false;
+        }
+        if (!state.host.equals(currentHost)) {
+            log.info("Cached host {} for node {} differs from current host {}",
+                    state.host, id, currentHost);
+            return true;
+        }
+        List<InetAddress> resolved = ClientUtils.resolve(currentHost, hostResolver);
+        boolean stale = !resolved.contains(state.lastAttemptedAddress);
+        if (stale) {
+            log.info("Bound address {} for node {} is no longer in the resolved set for host {}: {}",
+                    state.lastAttemptedAddress, id, currentHost, resolved);
+        }
+        return stale;
+    }
+
+    /**
      * Enter the disconnected state for the given node.
      * @param id the connection we have disconnected
      * @param now the current time in ms

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -54,6 +54,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -1076,6 +1077,29 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
+     * Close any TCP channel whose bound IP no longer matches the latest host from metadata.
+     * Detects IP changes that TCP keepalive misses — e.g. a broker pod rescheduled with a new
+     * IP, or an IP reassigned across brokers (KAFKA-20394).
+     */
+    private void maybeCloseStaleConnections() {
+        for (Node node : metadataUpdater.fetchNodes()) {
+            String nodeId = node.idString();
+            if (!connectionStates.isConnected(nodeId)) {
+                continue;
+            }
+            try {
+                if (connectionStates.isConnectionStale(nodeId, node.host())) {
+                    log.info("Closing stale connection to node {} (host {})", nodeId, node.host());
+                    disconnect(nodeId);
+                }
+            } catch (UnknownHostException e) {
+                log.debug("Could not re-resolve host {} for node {}; leaving existing connection in place",
+                        node.host(), nodeId, e);
+            }
+        }
+    }
+
+    /**
      * Record any newly completed connections
      */
     private void handleConnections() {
@@ -1304,6 +1328,7 @@ public class NetworkClient implements KafkaClient {
                 this.metadata.failedUpdate(now);
             } else {
                 this.metadata.update(inProgress.requestVersion, response, inProgress.isPartialUpdate, now);
+                maybeCloseStaleConnections();
                 metadataAttemptStartMs = Optional.empty();
             }
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -329,6 +329,34 @@ public class ClusterConnectionStatesTest {
     }
 
     @Test
+    public void testIsConnectionStaleWhenHostChanges() throws UnknownHostException {
+        setupMultipleIPs();
+        connectionStates.connecting(nodeId1, time.milliseconds(), hostTwoIps);
+        connectionStates.currentAddress(nodeId1);
+
+        assertTrue(connectionStates.isConnectionStale(nodeId1, "different.host"));
+    }
+
+    @Test
+    public void testIsConnectionStaleWhenDnsResolutionChanges() throws UnknownHostException {
+        setupMultipleIPs();
+        connectionStates.connecting(nodeId1, time.milliseconds(), hostTwoIps);
+        connectionStates.currentAddress(nodeId1);
+
+        multipleIPHostResolver.changeAddresses();
+        assertTrue(connectionStates.isConnectionStale(nodeId1, hostTwoIps));
+    }
+
+    @Test
+    public void testIsConnectionStaleReturnsFalseWhenAddressUnchanged() throws UnknownHostException {
+        setupMultipleIPs();
+        connectionStates.connecting(nodeId1, time.milliseconds(), hostTwoIps);
+        connectionStates.currentAddress(nodeId1);
+
+        assertFalse(connectionStates.isConnectionStale(nodeId1, hostTwoIps));
+    }
+
+    @Test
     public void testIsPreparingConnection() {
         assertFalse(connectionStates.isPreparingConnection(nodeId1));
         connectionStates.connecting(nodeId1, time.milliseconds(), "localhost");

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -1191,6 +1191,56 @@ public class NetworkClientTest {
     }
 
     @Test
+    public void testStaleConnectionClosedWhenHostnameChanges() {
+        AddressChangeHostResolver mockHostResolver = new AddressChangeHostResolver(
+                initialAddresses.toArray(new InetAddress[0]), initialAddresses.toArray(new InetAddress[0]));
+        MockSelector mockSelector = new MockSelector(this.time);
+
+        ClientTelemetrySender mockClientTelemetrySender = mock(ClientTelemetrySender.class);
+        when(mockClientTelemetrySender.timeToNextUpdate(anyLong())).thenReturn(Long.MAX_VALUE);
+
+        int refreshBackoffMs = 50;
+        // Seed: node 0 reported at host-a
+        Node initialNode = new Node(0, "host-a", 1969);
+        MetadataResponse seedResponse = RequestTestUtils.metadataResponse(
+                Collections.singletonList(initialNode), "kafka-cluster", 0, Collections.emptyList());
+        Metadata metadata = new Metadata(refreshBackoffMs, refreshBackoffMs, 5000, new LogContext(), new ClusterResourceListeners());
+        metadata.updateWithCurrentRequestVersion(seedResponse, false, time.milliseconds());
+        Node targetNode = metadata.fetch().nodes().get(0);
+
+        NetworkClient client = new NetworkClient(null, metadata, mockSelector, "mock", Integer.MAX_VALUE,
+                reconnectBackoffMsTest, reconnectBackoffMaxMsTest, 64 * 1024, 64 * 1024,
+                defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest,
+                time, false, new ApiVersions(), null, new LogContext(), mockHostResolver, mockClientTelemetrySender,
+                Long.MAX_VALUE, MetadataRecoveryStrategy.NONE);
+
+        // Establish connection — ClusterConnectionStates caches host="host-a" for node 0
+        awaitReady(client, targetNode);
+        assertTrue(client.isReady(targetNode, time.milliseconds()));
+
+        // Simulate metadata reporting the same broker id under a different hostname
+        Node renamedNode = new Node(0, "host-b", 1969);
+        MetadataResponse updatedResponse = RequestTestUtils.metadataResponse(
+                Collections.singletonList(renamedNode), "kafka-cluster", 0, Collections.emptyList());
+
+        // Trigger a metadata refresh — request goes out on the next poll
+        metadata.requestUpdate(true);
+        time.sleep(refreshBackoffMs);
+        client.poll(0, time.milliseconds());
+
+        // Reflect the request header back into the updated response and deliver it
+        ByteBuffer requestBuffer = mockSelector.completedSendBuffers().get(0).buffer();
+        RequestHeader header = parseHeader(requestBuffer);
+        ByteBuffer responseBuffer = RequestTestUtils.serializeResponseWithHeader(
+                updatedResponse, header.apiVersion(), header.correlationId());
+        mockSelector.delayedReceive(new DelayedReceive(targetNode.idString(), new NetworkReceive(targetNode.idString(), responseBuffer)));
+
+        // Response processing closes the stale channel via maybeCloseStaleConnections
+        client.poll(0, time.milliseconds());
+        assertFalse(client.isReady(targetNode, time.milliseconds()));
+    }
+
+    @Test
     public void testFailedConnectionToFirstAddress() {
         AddressChangeHostResolver mockHostResolver = new AddressChangeHostResolver(
                 initialAddresses.toArray(new InetAddress[0]), newAddresses.toArray(new InetAddress[0]));


### PR DESCRIPTION
When a broker's advertised host changes (e.g. a Kafka pod is rescheduled with a new hostname), 
`NetworkClient` keeps using the channel bound to the old host. TCP keepalive can mask this, silently routing requests to another broker that now owns the old address. The same occurs when only the resolved IP changes.

After a successful metadata update, close any connection whose cached host differs from the latest metadata, 
or whose bound IP is no longer in the resolved set for that host.

Unit tests cover host-change and IP-change cases, and verify the channel is closed after the next metadata update.