### PR TITLE
KAFKA-19584: add SecurityManager shim support to native image

### DIFF
--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -641,6 +641,13 @@
   "name":"java.rmi.server.UID"
 },
 {
+  "name":"java.security.AccessControlContext"
+},
+{
+  "name":"java.security.AccessController",
+  "methods":[{"name":"doPrivileged","parameterTypes":["java.security.PrivilegedAction"] }, {"name":"getContext","parameterTypes":[] }]
+},
+{
   "name":"java.security.AlgorithmParametersSpi"
 },
 {
@@ -794,6 +801,10 @@
 {
   "name":"javax.management.remote.rmi.RMIServerImpl_Stub",
   "methods":[{"name":"<init>","parameterTypes":["java.rmi.server.RemoteRef"] }]
+},
+{
+  "name":"javax.security.auth.Subject",
+  "methods":[{"name":"callAs","parameterTypes":["javax.security.auth.Subject","java.util.concurrent.Callable"] }, {"name":"current","parameterTypes":[] }, {"name":"doAs","parameterTypes":["javax.security.auth.Subject","java.security.PrivilegedExceptionAction"] }, {"name":"getSubject","parameterTypes":["java.security.AccessControlContext"] }]
 },
 {
   "name":"javax.security.auth.x500.X500Principal",


### PR DESCRIPTION
KAFKA-17078 introduced a shim for SecurityManager to handle the removal
of SecurityManager from JDK 23.

This shim relies on reflection to load `legacy` and `modern` classes at
runtime. Unfortunately, the native image's reachability metadata was not
updated to account for this reflective access.

This change fixes the regression and updates reflect-config.json
appropriately.

Reviewers: Jose Ignacio Gil Jaldo <naranja82@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
