### PR TITLE
KAFKA-20617: add validation for cluster-id in Formatter

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -246,7 +246,8 @@ public class Formatter {
     /**
      * Validates the correctness of the given cluster id. A valid cluster id is a base64, urlencoded, no padding
      * representation of a {@link Uuid}. These checks do not validate the absence of <code>-</code> character as
-     * {@link Uuid#randomUuid()} avoids them only for convenience reasons.
+     * {@link Uuid#randomUuid()} avoids them only for convenience reasons and such a validation would break
+     * compatibility when attempting to format using an old cluster id.
      */
     private void validateClusterId(String clusterId) {
         if (clusterId == null) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -243,17 +243,19 @@ public class Formatter {
         return bootstrapMetadata;
     }
 
-    public void run() throws Exception {
-        if (nodeId < 0) {
-            throw new RuntimeException("You must specify a valid non-negative node ID.");
-        }
+    /**
+     * Validates the correctness of the given cluster id. A valid cluster id is a base64, urlencoded, no padding
+     * representation of a {@link Uuid}. These checks do not validate the absence of <code>-</code> character as
+     * {@link Uuid#randomUuid()} avoids them only for convenience reasons.
+     */
+    private void validateClusterId(String clusterId) {
         if (clusterId == null) {
             throw new FormatterException("You must specify the cluster id.");
         }
+        if (clusterId.contains("=")) {
+            throw new FormatterException("The specified cluster id, " + clusterId + " is invalid: contains padding");
+        }
         try {
-            if (clusterId.contains("=")) {
-                throw new FormatterException("The specified cluster id, " + clusterId + " contains padding and is invalid");
-            }
             Uuid uuid = Uuid.fromString(clusterId);
             if (Uuid.RESERVED.contains(uuid)) {
                 throw new FormatterException("The specified cluster id, " + clusterId + " is reserved");
@@ -261,6 +263,13 @@ public class Formatter {
         } catch (IllegalArgumentException e) {
             throw new FormatterException("The specified cluster id, " + clusterId + " is invalid", e);
         }
+    }
+
+    public void run() throws Exception {
+        if (nodeId < 0) {
+            throw new RuntimeException("You must specify a valid non-negative node ID.");
+        }
+        validateClusterId(clusterId);
         if (directories.isEmpty()) {
             throw new FormatterException("You must specify at least one directory to format");
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -250,6 +250,17 @@ public class Formatter {
         if (clusterId == null) {
             throw new FormatterException("You must specify the cluster id.");
         }
+        try {
+            if (clusterId.contains("=")) {
+                throw new FormatterException("The specified cluster id, " + clusterId + " contains padding and is invalid");
+            }
+            Uuid uuid = Uuid.fromString(clusterId);
+            if (Uuid.RESERVED.contains(uuid)) {
+                throw new FormatterException("The specified cluster id, " + clusterId + " is reserved");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new FormatterException("The specified cluster id, " + clusterId + " is invalid", e);
+        }
         if (directories.isEmpty()) {
             throw new FormatterException("You must specify at least one directory to format");
         }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -608,4 +608,18 @@ public class FormatterTest {
             assertNotNull(logDirProps1);
         }
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unrvTtQISjar0JUWGU/8Pg", "igNUVIdeSPO5JCZYFhOh7Q==", "AAAAAAAAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAAAAAAAQ"})
+    public void testFormatWithInvalidClusterId(String clusterId) throws Exception {
+        try (TestEnv testEnv = new TestEnv(2)) {
+            FormatterContext formatter1 = testEnv.newFormatter();
+            formatter1.formatter.setClusterId(clusterId);
+            String expectedPrefix = "The specified cluster id, " + clusterId;
+            assertEquals(expectedPrefix,
+                    assertThrows(FormatterException.class,
+                            formatter1.formatter::run).
+                            getMessage().substring(0, expectedPrefix.length()));
+        }
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -622,4 +622,14 @@ public class FormatterTest {
                             getMessage().substring(0, expectedPrefix.length()));
         }
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"iIygKoNNSpGzNeAEr_QW7w", "-w_KF-snTmuEnKPqZ0RDzA", "dZMgZA7nTLqZTdzb0zbvSQ", "hxqHyN2OSSmPajVhm_DR-Q"})
+    public void testFormatWithValidClusterId(String clusterId) throws Exception {
+        try (TestEnv testEnv = new TestEnv(2)) {
+            FormatterContext formatter1 = testEnv.newFormatter();
+            formatter1.formatter.setClusterId(clusterId);
+            formatter1.formatter.run();
+        }
+    }
 }

--- a/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ReconfigurableQuorumIntegrationTest.java
@@ -255,7 +255,7 @@ public class ReconfigurableQuorumIntegrationTest {
     @Test
     public void testRemoveAndAddVoterWithValidClusterId() throws Exception {
         final var nodes = new TestKitNodes.Builder()
-            .setClusterId("test-cluster")
+            .setClusterId("5EqhrOPYSkaSsXk4RYkNow")
             .setNumBrokerNodes(1)
             .setNumControllerNodes(3)
             .build();
@@ -285,7 +285,7 @@ public class ReconfigurableQuorumIntegrationTest {
                 admin.removeRaftVoter(
                     3000,
                     dirId,
-                    new RemoveRaftVoterOptions().setClusterId(Optional.of("test-cluster"))
+                    new RemoveRaftVoterOptions().setClusterId(Optional.of("5EqhrOPYSkaSsXk4RYkNow"))
                 ).all().get();
                 retryOnExceptionWithTimeout(30_000, 10, () -> {
                     Map<Integer, Uuid> voters = findVoterDirs(admin);
@@ -297,7 +297,7 @@ public class ReconfigurableQuorumIntegrationTest {
 
                 retryOnExceptionWithTimeout(30_000, 1_000, () ->
                     admin.addRaftVoter(3000, dirId, Set.of(new RaftVoterEndpoint("CONTROLLER", "localhost", port)),
-                        new AddRaftVoterOptions().setClusterId(Optional.of("test-cluster"))).all().get());
+                        new AddRaftVoterOptions().setClusterId(Optional.of("5EqhrOPYSkaSsXk4RYkNow"))).all().get());
             }
         }
     }
@@ -305,7 +305,7 @@ public class ReconfigurableQuorumIntegrationTest {
     @Test
     public void testRemoveAndAddVoterWithInconsistentClusterId() throws Exception {
         final var nodes = new TestKitNodes.Builder()
-            .setClusterId("test-cluster")
+            .setClusterId("5EqhrOPYSkaSsXk4RYkNow")
             .setNumBrokerNodes(1)
             .setNumControllerNodes(3)
             .build();
@@ -326,7 +326,7 @@ public class ReconfigurableQuorumIntegrationTest {
                 var removeFuture = admin.removeRaftVoter(
                     3000,
                     dirId,
-                    new RemoveRaftVoterOptions().setClusterId(Optional.of("inconsistent"))
+                    new RemoveRaftVoterOptions().setClusterId(Optional.of("wXyMD5v8SeGIHHxZEdmSLA"))
                 ).all();
                 assertFutureThrows(InconsistentClusterIdException.class, removeFuture);
 
@@ -334,7 +334,7 @@ public class ReconfigurableQuorumIntegrationTest {
                     3000,
                     dirId,
                     Set.of(new RaftVoterEndpoint("CONTROLLER", "localhost", port(admin, 3000))),
-                    new AddRaftVoterOptions().setClusterId(Optional.of("inconsistent"))
+                    new AddRaftVoterOptions().setClusterId(Optional.of("wXyMD5v8SeGIHHxZEdmSLA"))
                 ).all();
                 assertFutureThrows(InconsistentClusterIdException.class, addFuture);
             }


### PR DESCRIPTION
This change adds validation for Uuids in Formatter which is used by
`kafka-storage.sh` which allows users to fail fast before they
inadvertently end up using an invalid cluster-id.

Reviewers: Federico Valeri <fedevaleri@gmail.com>, Luke Chen
 <showuon@gmail.com>
