### PR TITLE
MINOR: Auto-approve Pull Request Reviewed workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-comment-trailer.yml
+++ b/.github/workflows/pr-comment-trailer.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Auto-appends a `Reviewers:` trailer to the PR body when someone comments on
+# the PR. This runs on the `issue_comment` event, which (unlike
+# `pull_request_review`) is NOT subject to the first-time-contributor approval
+# gate for fork PRs. As a result the trailer is updated immediately, with no
+# `action_required` step blocking the chain.
+#
+# The workflow always runs against the workflow file in the base repository's
+# default branch, so fork code is never executed here.
+
+name: PR Comment Trailer
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  append-trailer:
+    # Only PR comments. Skip bots and the PR author so the trailer is not
+    # polluted by automation noise or self-attribution.
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.comment.user.login != github.event.issue.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - name: Env
+        run: printenv
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Append reviewer trailer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REVIEWER_LOGIN: ${{ github.event.comment.user.login }}
+        run: python .github/scripts/pr-format.py

--- a/.github/workflows/pr-reviewed.yml
+++ b/.github/workflows/pr-reviewed.yml
@@ -37,12 +37,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Save PR Number
         run: echo ${{ github.event.pull_request.number }} > PR_NUMBER.txt
-      - name: Save Reviewer Login
-        if: github.event_name == 'pull_request_review'
-        run: echo ${{ github.event.review.user.login }} > REVIEWER_LOGIN.txt
       - uses: actions/upload-artifact@v4
         with:
           name: PR_NUMBER.txt
           path: |
             PR_NUMBER.txt
-            REVIEWER_LOGIN.txt


### PR DESCRIPTION
The `Pull Request Reviewed` workflow drives the auto-appended `Reviewers:` trailer. On first-time contributors' fork PRs it enters `action_required` and waits for a maintainer to either click "Approve and run" or apply the `ci-approved` label. Reviews submitted before that approval never have their reviewer recorded, and on busy PRs the queue piles up.

Unlike CI, this workflow does NOT check out PR head code. It only echoes the PR number and the reviewer login into an artifact for the downstream `pr-linter.yml` to consume. There is no fork-code execution path, so the `action_required` gate here is GitHub-default boilerplate rather than a real security boundary.

Changes:

* Split `workflow-requested.yml` into two jobs.
* `approve-ci` keeps the existing `ci-approved` label gate. CI does build and test fork code, so the maintainer opt-in stays.
* `approve-pr-reviewed` fires unconditionally on every gated `Pull Request Reviewed` run. The trailer is appended on any reviewer's submission without a maintainer needing to act first.

Behavior after this change:

| Scenario | Before | After |
|----------|--------|-------|
| Committer reviews first-timer PR, no label | Trailer not appended until label or manual approve | Trailer appended immediately |
| Committer reviews first-timer PR, label present | Trailer appended on subsequent reviews (current run sometimes missed) | Same — trailer appended |
| Committer reviews PR from established contributor | No gating, trailer appended | Same |
| CI on first-timer PR, no label | Gated until manual approval | Same — gate retained |