### PR TITLE
MINOR: Move LoggingController log level resolution test to server

### DIFF
--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -17,13 +17,11 @@
 
 package kafka.utils
 
-import org.apache.kafka.server.logger.LoggingController
 import java.lang.management.ManagementFactory
 
 import javax.management.ObjectName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
-import org.slf4j.LoggerFactory
 
 class LoggingTest extends Logging {
 
@@ -59,23 +57,5 @@ class LoggingTest extends Logging {
     val logging = new TestLogging
 
     assertEquals(logging.getClass.getName, logging.log.underlying.getName)
-  }
-
-  @Test
-  def testLoggerLevelIsResolved(): Unit = {
-    val controller = new LoggingController()
-    val previousLevel = controller.getLogLevel("kafka")
-    try {
-      controller.setLogLevel("kafka", "TRACE")
-      // Do some logging so that the Logger is created within the hierarchy
-      // (until loggers are used only loggers in the config file exist)
-      LoggerFactory.getLogger("kafka.utils.Log4jControllerTest").trace("test")
-      assertEquals("TRACE", controller.getLogLevel("kafka"))
-      assertEquals("TRACE", controller.getLogLevel("kafka.utils.Log4jControllerTest"))
-      assertTrue(controller.getLoggers.contains("kafka=TRACE"))
-      assertTrue(controller.getLoggers.contains("kafka.utils.Log4jControllerTest=TRACE"))
-    } finally {
-      controller.setLogLevel("kafka", previousLevel)
-    }
   }
 }

--- a/server/src/test/java/org/apache/kafka/server/logger/LoggingControllerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/logger/LoggingControllerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.logger;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoggingControllerTest {
+
+    @Test
+    public void testLoggerLevelIsResolved() {
+        LoggingController controller = new LoggingController();
+        String loggerName = "org.apache.kafka";
+        String childLoggerName = "org.apache.kafka.server.logger.LoggingControllerTest";
+        String previousLevel = controller.getLogLevel(loggerName);
+        try {
+            controller.setLogLevel(loggerName, "TRACE");
+            // Do some logging so that the Logger is created within the hierarchy
+            // (until loggers are used only loggers in the config file exist).
+            LoggerFactory.getLogger(childLoggerName).trace("test");
+            assertEquals("TRACE", controller.getLogLevel(loggerName));
+            assertEquals("TRACE", controller.getLogLevel(childLoggerName));
+            assertTrue(controller.getLoggers().contains(loggerName + "=TRACE"));
+            assertTrue(controller.getLoggers().contains(childLoggerName + "=TRACE"));
+        } finally {
+            controller.setLogLevel(loggerName, previousLevel);
+        }
+    }
+}


### PR DESCRIPTION
`LoggingController` now lives in the `server` module, but its direct log
level resolution test was still under `core`. This PR moves that test to
`server` and rewrites it in Java.

Reviewers: Russole <850905junior@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
