### PR TITLE
KAFKA-19536: Respect grace period for out-of-order stream joins

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -174,9 +174,9 @@ abstract class KStreamKStreamJoin<K, VLeft, VRight, VOut, VThis, VOther> impleme
                     //
                     // See KStreamKStreamLeftJoinTest.testLowerWindowBound() tests
                     //
-                    // This condition below allows us to process the out-of-order records without the need
-                    // to hold it in the temporary outer store
-                    if (outerJoinStore.isEmpty() || timeTo < sharedTimeTracker.streamTime) {
+                    // This condition allows us to process out-of-order records whose grace period has
+                    // expired without holding them in the temporary outer store.
+                    if (outerJoinStore.isEmpty() || timeTo + joinGraceMs < sharedTimeTracker.streamTime) {
                         context().forward(record.withValue(joiner.apply(record.key(), record.value(), null)));
                     } else {
                         sharedTimeTracker.updatedMinTime(inputRecordTimestamp);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -895,6 +895,51 @@ public class KStreamKStreamLeftJoinTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    public void testOutOfOrderRecordWithinGracePeriod(final boolean withHeaders) {
+        setDslStoreFormat(withHeaders);
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<Integer, String> stream1;
+        final KStream<Integer, String> stream2;
+        final KStream<Integer, String> joined;
+        final MockApiProcessorSupplier<Integer, String, Void, Void> supplier = new MockApiProcessorSupplier<>();
+        stream1 = builder.stream(topic1, consumed);
+        stream2 = builder.stream(topic2, consumed);
+
+        joined = stream1.leftJoin(
+            stream2,
+            MockValueJoiner.TOSTRING_JOINER,
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100L), ofMillis(10L)),
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
+        joined.process(supplier);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), PROPS)) {
+            final TestInputTopic<Integer, String> inputTopic1 =
+                driver.createInputTopic(topic1, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+            final TestInputTopic<Integer, String> inputTopic2 =
+                driver.createInputTopic(topic2, new IntegerSerializer(), new StringSerializer(), Instant.ofEpochMilli(0L), Duration.ZERO);
+            final MockApiProcessor<Integer, String, Void, Void> processor = supplier.theCapturedProcessor();
+
+            inputTopic2.pipeInput(1, "advance", 105L);
+            processor.checkAndClearProcessResult();
+
+            // The left record's window ends at 100, but the grace period keeps it open until 110.
+            inputTopic1.pipeInput(0, "A0", 0L);
+            processor.checkAndClearProcessResult();
+
+            inputTopic2.pipeInput(0, "a0", 50L);
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+a0", 50L)
+            );
+
+            inputTopic2.pipeInput(2, "later", 500L);
+            processor.checkAndClearProcessResult();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
     public void testWindowing(final boolean withHeaders) {
         setDslStoreFormat(withHeaders);
         final StreamsBuilder builder = new StreamsBuilder();


### PR DESCRIPTION
KStream-KStream left joins currently emit an out-of-order left record as `left+null` as soon as the join window end is behind stream time, even if the configured grace period has not elapsed. That can produce an unmatched result and a later matched result for the same left record.

This changes the immediate emission check to wait until `windowEnd + grace` is behind stream time. Records that are still within grace stay in the outer join store, so a matching right-side record can still produce the join result.

I added a regression test that advances stream time past the window end but still inside grace, verifies the left record is not emitted as unmatched, then sends a matching right record.

No documentation update is included because this fixes the implementation to match the existing `JoinWindows` grace-period behavior and does not add or change any public API, configuration, or protocol.

Tests:
- `./gradlew :streams:test --tests org.apache.kafka.streams.kstream.internals.KStreamKStreamLeftJoinTest.testOutOfOrderRecordWithinGracePeriod --no-build-cache --rerun-tasks`
- `./gradlew :streams:test --tests org.apache.kafka.streams.kstream.internals.KStreamKStreamLeftJoinTest --tests org.apache.kafka.streams.kstream.internals.KStreamKStreamOuterJoinTest --tests org.apache.kafka.streams.kstream.internals.KStreamKStreamJoinTest --no-build-cache --rerun-tasks`
- `./gradlew :streams:check --no-build-cache --rerun-tasks`

This contribution is my original work, and I license the work to the project under the project's open source license.