### PR TITLE
KAFKA-20638: Use Locale.ROOT in ConsumerGroupCommand.toLowerCase()

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -164,7 +164,7 @@ public class ConsumerGroupCommand {
     @SuppressWarnings("Regexp")
     static Set<GroupType> consumerGroupTypesFromString(String input) {
         Set<GroupType> validTypes = Set.of(GroupType.CLASSIC, GroupType.CONSUMER);
-        Set<GroupType> parsedTypes = Stream.of(input.toLowerCase().split(",")).map(s -> GroupType.parse(s.trim())).collect(Collectors.toSet());
+        Set<GroupType> parsedTypes = Stream.of(input.toLowerCase(java.util.Locale.ROOT).split(",")).map(s -> GroupType.parse(s.trim())).collect(Collectors.toSet());
         if (!validTypes.containsAll(parsedTypes)) {
             throw new IllegalArgumentException("Invalid types list '" + input + "'. Valid types are: " +
                 String.join(", ", validTypes.stream().map(GroupType::toString).collect(Collectors.toSet())));


### PR DESCRIPTION
Fixes a checkstyle violation by explicitly passing
`java.util.Locale.ROOT` to `toLowerCase()` inside
`ConsumerGroupCommand.consumerGroupTypesFromString()`.

This ensures consistent behavior across different server locales.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
