### PR TITLE
MINOR: Write bootstrap checkpoint only to metadata directories

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -445,11 +445,12 @@ public class Formatter {
                     build());
             }
             copier.setPreWriteHandler((writeLogDir, __, ____) -> {
+                DirectoryType directoryType = directoryTypes.get(writeLogDir);
                 printStream.printf("Formatting %s %s with %s %s.%n",
-                    directoryTypes.get(writeLogDir).description(), writeLogDir,
+                    directoryType.description(), writeLogDir,
                     MetadataVersion.FEATURE_NAME, releaseVersion);
                 Files.createDirectories(Paths.get(writeLogDir));
-                if (writeBootstrapSnapshot) {
+                if (writeBootstrapSnapshot && directoryType.isMetadataDirectory()) {
                     writeBoostrapSnapshot(writeLogDir,
                         bootstrapMetadata,
                         initialControllers,
@@ -480,9 +481,8 @@ public class Formatter {
             };
         }
 
-        boolean isDynamicMetadataDirectory() {
-            return this == DYNAMIC_METADATA_NON_VOTER_DIRECTORY ||
-                this == DYNAMIC_METADATA_VOTER_DIRECTORY;
+        boolean isMetadataDirectory() {
+            return this != LOG_DIRECTORY;
         }
 
         static DirectoryType calculate(

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -118,6 +118,12 @@ public class FormatterTest {
         }
     }
 
+    private static File clusterMetadataDir(String directory) {
+        return new File(directory, String.format("%s-%d",
+            CLUSTER_METADATA_TOPIC_PARTITION.topic(),
+            CLUSTER_METADATA_TOPIC_PARTITION.partition()));
+    }
+
     static class FormatterContext {
         final Formatter formatter;
         final ByteArrayOutputStream stream;
@@ -155,15 +161,25 @@ public class FormatterTest {
     }
 
     @Test
+    public void testWritesBootstrapSnapshotOnlyToMetadataDirectory() throws Exception {
+        try (TestEnv testEnv = new TestEnv(3)) {
+            testEnv.newFormatter().formatter.run();
+            assertTrue(clusterMetadataDir(testEnv.directory(0)).exists());
+            assertFalse(clusterMetadataDir(testEnv.directory(1)).exists());
+            assertFalse(clusterMetadataDir(testEnv.directory(2)).exists());
+
+            BootstrapMetadata bootstrapMetadata = BootstrapTestUtils.readBootstrapMetadata(testEnv.directory(0));
+            assertEquals(MetadataVersion.latestProduction(), bootstrapMetadata.metadataVersion());
+        }
+    }
+
+    @Test
     public void testSkipsBootstrapSnapshotWhenDisabled() throws Exception {
         try (TestEnv testEnv = new TestEnv(1)) {
             FormatterContext context = testEnv.newFormatter();
             context.formatter.setWriteBootstrapSnapshot(false);
             context.formatter.run();
-            File clusterMetadataDir = new File(testEnv.directory(0), String.format("%s-%d",
-                CLUSTER_METADATA_TOPIC_PARTITION.topic(),
-                CLUSTER_METADATA_TOPIC_PARTITION.partition()));
-            assertFalse(clusterMetadataDir.exists());
+            assertFalse(clusterMetadataDir(testEnv.directory(0)).exists());
         }
     }
 


### PR DESCRIPTION
This patch ensures the storage formatter writes the `bootstrap
checkpoint` only to metadata directories, avoiding unexpected
`__cluster_metadata-0` directories in pure data log directories when
formatting multiple directories in KRaft mode.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
