### PR TITLE
MINOR: remove stale zk comment

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -562,7 +562,6 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         // We want to remote topicId map and stopPartition on RLMM for deleteLocalLog or stopRLMM partitions because
         // in both case, they all mean the topic will not be held in this broker anymore.
-        // NOTE: In ZK mode, this#stopPartitions method is called when Replica state changes to Offline and ReplicaDeletionStarted
         Set<TopicIdPartition> pendingActionsPartitions = stopPartitions.stream()
                 .filter(sp -> (sp.stopRemoteLogMetadataManager || sp.deleteLocalLog) && topicIdByPartitionMap.containsKey(sp.topicPartition))
                 .map(sp -> new TopicIdPartition(topicIdByPartitionMap.get(sp.topicPartition), sp.topicPartition))

--- a/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
+++ b/storage/src/test/java/org/apache/kafka/tiered/storage/integration/DeleteSegmentsDueToLogStartOffsetBreachTest.java
@@ -96,7 +96,6 @@ public final class DeleteSegmentsDueToLogStartOffsetBreachTest {
                 .expectDeletionInRemoteStorage(broker0, topicA, p0, DELETE_SEGMENT, 1)
                 .deleteRecords(topicA, p0, beforeOffset)
                 // expect that the leader epoch checkpoint is updated
-                // Comment out this line if it's FLAKY since the leader-epoch is not deterministic in ZK mode.
                 .expectLeaderEpochCheckpoint(broker0, topicA, p0, beginEpoch, startOffset)
                 // consume from the offset-3 of the topic to read data from local and remote storage
                 .expectFetchFromTieredStorage(broker0, topicA, p0, 1)


### PR DESCRIPTION
Remove stale ZK comments in RemoteLogManager and
DeleteSegmentsDueToLogStartOffsetBreachTest.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>
