### PR TITLE
KAFKA-20602: Bound DLQ topic creation, fix log level and restore interrupt in DeadLetterQueueReporter

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -42,6 +42,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Write the original consumed record into a dead letter queue. The dead letter queue is a Kafka topic located
@@ -79,15 +81,22 @@ public class DeadLetterQueueReporter implements ErrorReporter<ConsumerRecord<byt
                                                          SinkConnectorConfig sinkConfig, Map<String, Object> producerProps,
                                                          ErrorHandlingMetrics errorHandlingMetrics) {
         String topic = sinkConfig.dlqTopicName();
+        long timeoutMs = TimeUnit.SECONDS.toMillis(30);
 
         try (Admin admin = Admin.create(adminProps)) {
-            if (!admin.listTopics().names().get().contains(topic)) {
-                log.error("Topic {} doesn't exist. Will attempt to create topic.", topic);
-                NewTopic schemaTopicRequest = new NewTopic(topic, DLQ_NUM_DESIRED_PARTITIONS, sinkConfig.dlqTopicReplicationFactor());
-                admin.createTopics(Set.of(schemaTopicRequest)).all().get();
+            if (!admin.listTopics().names().get(timeoutMs, TimeUnit.MILLISECONDS).contains(topic)) {
+                log.info("Topic {} does not exist; creating it with {} partitions and replication factor {}",
+                        topic, DLQ_NUM_DESIRED_PARTITIONS, sinkConfig.dlqTopicReplicationFactor());
+                NewTopic schemaTopicRequest = new NewTopic(topic, DLQ_NUM_DESIRED_PARTITIONS,
+                        sinkConfig.dlqTopicReplicationFactor());
+                admin.createTopics(Set.of(schemaTopicRequest)).all().get(timeoutMs, TimeUnit.MILLISECONDS);
             }
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new ConnectException("Could not initialize dead letter queue with topic=" + topic, e);
+        } catch (TimeoutException e) {
+            throw new ConnectException(
+                    "Timed out waiting for DLQ topic '" + topic + "' to be verified or created", e);
         } catch (ExecutionException e) {
             if (!(e.getCause() instanceof TopicExistsException)) {
                 throw new ConnectException("Could not initialize dead letter queue with topic=" + topic, e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -16,36 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.errors;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.runtime.ConnectMetrics;
-import org.apache.kafka.connect.runtime.ConnectorConfig;
-import org.apache.kafka.connect.runtime.MockConnectMetrics;
-import org.apache.kafka.connect.runtime.SinkConnectorConfig;
-import org.apache.kafka.connect.runtime.isolation.Plugins;
-import org.apache.kafka.connect.sink.SinkTask;
-import org.apache.kafka.connect.transforms.Transformation;
-import org.apache.kafka.connect.util.ConnectorTaskId;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_CONNECTOR_NAME;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXCEPTION;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXCEPTION_MESSAGE;
@@ -59,14 +29,57 @@ import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ER
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.utils.LogCaptureAppender;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.runtime.ConnectMetrics;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.MockConnectMetrics;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -98,6 +111,96 @@ public class ErrorReporterTest {
     public void tearDown() {
         if (metrics != null) {
             metrics.stop();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void createAndSetupTimesOutWhenBrokerUnreachable() throws Exception {
+        Admin admin = mock(Admin.class);
+        ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+        KafkaFuture<Set<String>> namesFuture = mock(KafkaFuture.class);
+
+        when(admin.listTopics()).thenReturn(listTopicsResult);
+        when(listTopicsResult.names()).thenReturn(namesFuture);
+        when(namesFuture.get(anyLong(), any())).thenThrow(new TimeoutException("simulated unreachable broker"));
+
+        SinkConnectorConfig sinkConfig = config(Map.of(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
+
+        try (MockedStatic<Admin> adminStatic = mockStatic(Admin.class)) {
+            adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
+
+            ConnectException e = assertThrows(ConnectException.class, () ->
+                    DeadLetterQueueReporter.createAndSetup(Map.of(), TASK_ID, sinkConfig, Map.of(), errorHandlingMetrics));
+            assertTrue(e.getMessage().contains("Timed out waiting for DLQ topic"));
+        }
+
+        verify(admin).close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void createAndSetupRestoresInterruptOnInterruptedException() throws Exception {
+        Admin admin = mock(Admin.class);
+        ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+        KafkaFuture<Set<String>> namesFuture = mock(KafkaFuture.class);
+        when(admin.listTopics()).thenReturn(listTopicsResult);
+        when(listTopicsResult.names()).thenReturn(namesFuture);
+        when(namesFuture.get(anyLong(), any())).thenThrow(new InterruptedException("simulated interrupt"));
+
+        SinkConnectorConfig sinkConfig = config(Map.of(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
+
+        AtomicBoolean interruptRestored = new AtomicBoolean(false);
+        // Run on a dedicated thread so the restored interrupt flag does not leak into other tests.
+        Thread thread = new Thread(() -> {
+            try (MockedStatic<Admin> adminStatic = mockStatic(Admin.class)) {
+                adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
+                assertThrows(ConnectException.class, () ->
+                        DeadLetterQueueReporter.createAndSetup(Map.of(), TASK_ID, sinkConfig, Map.of(), errorHandlingMetrics));
+                interruptRestored.set(Thread.currentThread().isInterrupted());
+            }
+        });
+        thread.start();
+        thread.join();
+
+        assertTrue(interruptRestored.get(),
+                "interrupt flag should be restored before re-throwing as ConnectException");
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void firstTimeDlqTopicCreationLogsAtInfoNotError() throws Exception {
+        Admin admin = mock(Admin.class);
+        ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+        KafkaFuture<Set<String>> namesFuture = mock(KafkaFuture.class);
+        CreateTopicsResult createTopicsResult = mock(CreateTopicsResult.class);
+        KafkaFuture<Void> createFuture = mock(KafkaFuture.class);
+
+        when(admin.listTopics()).thenReturn(listTopicsResult);
+        when(listTopicsResult.names()).thenReturn(namesFuture);
+
+        when(namesFuture.get(anyLong(), any())).thenReturn(Set.of());
+        when(admin.createTopics(any())).thenReturn(createTopicsResult);
+        when(createTopicsResult.all()).thenReturn(createFuture);
+        when(createFuture.get(anyLong(), any())).thenReturn(null);
+
+        SinkConnectorConfig sinkConfig = config(Map.of(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
+
+        try (LogCaptureAppender logCaptureAppender = LogCaptureAppender.createAndRegister(DeadLetterQueueReporter.class);
+             MockedStatic<Admin> adminStatic = mockStatic(Admin.class);
+             MockedConstruction<KafkaProducer> ignored = mockConstruction(KafkaProducer.class)) {
+
+            adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
+
+            DeadLetterQueueReporter reporter = DeadLetterQueueReporter.createAndSetup(
+                    Map.of(), TASK_ID, sinkConfig, Map.of(), errorHandlingMetrics);
+            assertNotNull(reporter);
+
+            assertTrue(logCaptureAppender.getMessages("ERROR").isEmpty(),
+                    "first-time DLQ topic creation should not log at ERROR");
+            assertTrue(logCaptureAppender.getMessages("INFO").stream()
+                            .anyMatch(msg -> msg.contains(DLQ_TOPIC) && msg.contains("does not exist")),
+                    "first-time DLQ topic creation should log at INFO");
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -116,7 +116,7 @@ public class ErrorReporterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void createAndSetupTimesOutWhenBrokerUnreachable() throws Exception {
+    void createAndSetupTimesOutWhenBrokerUnreachable() throws Exception {
         Admin admin = mock(Admin.class);
         ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
         KafkaFuture<Set<String>> namesFuture = mock(KafkaFuture.class);
@@ -126,12 +126,14 @@ public class ErrorReporterTest {
         when(namesFuture.get(anyLong(), any())).thenThrow(new TimeoutException("simulated unreachable broker"));
 
         SinkConnectorConfig sinkConfig = config(Map.of(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
+        Map<String, Object> adminProps = Map.of();
+        Map<String, Object> producerProps = Map.of();
 
         try (MockedStatic<Admin> adminStatic = mockStatic(Admin.class)) {
             adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
 
             ConnectException e = assertThrows(ConnectException.class, () ->
-                    DeadLetterQueueReporter.createAndSetup(Map.of(), TASK_ID, sinkConfig, Map.of(), errorHandlingMetrics));
+                    DeadLetterQueueReporter.createAndSetup(adminProps, TASK_ID, sinkConfig, producerProps, errorHandlingMetrics));
             assertTrue(e.getMessage().contains("Timed out waiting for DLQ topic"));
         }
 
@@ -140,10 +142,11 @@ public class ErrorReporterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void createAndSetupRestoresInterruptOnInterruptedException() throws Exception {
+    void createAndSetupRestoresInterruptOnInterruptedException() throws Exception {
         Admin admin = mock(Admin.class);
         ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
         KafkaFuture<Set<String>> namesFuture = mock(KafkaFuture.class);
+
         when(admin.listTopics()).thenReturn(listTopicsResult);
         when(listTopicsResult.names()).thenReturn(namesFuture);
         when(namesFuture.get(anyLong(), any())).thenThrow(new InterruptedException("simulated interrupt"));
@@ -151,20 +154,28 @@ public class ErrorReporterTest {
         SinkConnectorConfig sinkConfig = config(Map.of(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC));
 
         AtomicBoolean interruptRestored = new AtomicBoolean(false);
-        // Run on a dedicated thread so the restored interrupt flag does not leak into other tests.
-        Thread thread = new Thread(() -> {
-            try (MockedStatic<Admin> adminStatic = mockStatic(Admin.class)) {
-                adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
-                assertThrows(ConnectException.class, () ->
-                        DeadLetterQueueReporter.createAndSetup(Map.of(), TASK_ID, sinkConfig, Map.of(), errorHandlingMetrics));
-                interruptRestored.set(Thread.currentThread().isInterrupted());
-            }
-        });
-        thread.start();
+
+        Thread thread = getThread(admin, sinkConfig, interruptRestored);
         thread.join();
 
         assertTrue(interruptRestored.get(),
                 "interrupt flag should be restored before re-throwing as ConnectException");
+    }
+
+    private Thread getThread(Admin admin, SinkConnectorConfig sinkConfig, AtomicBoolean interruptRestored) {
+        Map<String, Object> adminProps = Map.of();
+        Map<String, Object> producerProps = Map.of();
+        Thread thread = new Thread(() -> {
+            try (MockedStatic<Admin> adminStatic = mockStatic(Admin.class)) {
+                adminStatic.when(() -> Admin.create(anyMap())).thenReturn(admin);
+                assertThrows(ConnectException.class, () ->
+                        DeadLetterQueueReporter.createAndSetup(adminProps, TASK_ID, sinkConfig, producerProps, errorHandlingMetrics));
+                interruptRestored.set(Thread.currentThread().isInterrupted());
+            }
+        });
+
+        thread.start();
+        return thread;
     }
 
     @Test


### PR DESCRIPTION
`DeadLetterQueueReporter.createAndSetup` verifies/creates the dead letter queue topic during sink task startup. The current implementation has three issues:

1. Indefinite hang on broker outage. Both `admin.listTopics().names().get()` and `admin.createTopics(...).all().get()` are unbounded blocking calls. When the broker is unreachable, each call blocks until the AdminClient's internal `default.api.timeout.ms` elapses (default 60s). Because tasks are started serially, a worker with N DLQ-enabled connectors can stall for up to N x 60s on a cold-broker scenario (DR failover, outage recovery), which surfaces to operators as "all connectors stuck Initializing".

2. Wrong log level. The expected "topic does not exist yet" case on first startup was logged at ERROR, even though the very next line creates the topic. This produces spurious ERROR alerts on every first start of a connector with DLQ enabled.

3. Interrupt status not restored. The `InterruptedException` handler threw a `ConnectException` without calling `Thread.currentThread().interrupt()`, clearing the interrupt signal for any upstream blocking call.

Changes:

- Bound both admin calls with `get(30, TimeUnit.SECONDS)` so startup fails fast on an unreachable broker regardless of the AdminClient's configured api timeout, and add a `catch (TimeoutException)` that surfaces a clear `ConnectException`.
- Downgrade the "topic does not exist" message from ERROR to INFO and include the partition count and replication factor.
- Restore the thread interrupt flag before re-throwing on `InterruptedException`.

The 30s timeout is hardcoded rather than exposed as a new config to avoid a KIP; it covers the overwhelming majority of clusters and can be revisited if a user reports needing longer.

Testing strategy:

Added three unit tests to `ErrorReporterTest`. `createAndSetup` constructs its own `Admin` and `KafkaProducer` internally, so the tests use `mockStatic(Admin.class)` to inject a mock admin (and `mockConstruction` for
the producer), then stub the returned `KafkaFuture.get(timeout, unit)` to drive each path:

- `createAndSetupTimesOutWhenBrokerUnreachable` - stubs a `TimeoutException` and asserts a `ConnectException` is thrown and the admin client is closed. Done with a mocked timeout rather than a real unreachable broker so the test is deterministic and does not wait the full 30s.
- `createAndSetupRestoresInterruptOnInterruptedException` - stubs an `InterruptedException`, runs on a dedicated thread (so the restored interrupt flag does not leak into other tests), and asserts the flag is set after the `ConnectException` propagates.
- `firstTimeDlqTopicCreationLogsAtInfoNotError` - uses `LogCaptureAppender` to assert the first-time creation path logs at INFO and not ERROR.

No new integration or system tests: the change is a localized fix to an existing code path with no new public surface or cross-component behavior.