### PR TITLE
MINOR: Note that formatted storage directories are not forward-compatible

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -336,7 +336,9 @@ object StorageTool extends Logging {
     formatParser.addArgument("--release-version", "-r")
       .action(store())
       .help(s"The release version to use for the initial feature settings. The minimum is " +
-        s"${MetadataVersion.MINIMUM_VERSION}; the default is ${MetadataVersion.LATEST_PRODUCTION}")
+        s"${MetadataVersion.MINIMUM_VERSION}; the default is ${MetadataVersion.LATEST_PRODUCTION}. " +
+        s"Note: formatted directories are not forward-compatible — the broker version must be greater " +
+        s"than or equal to the kafka-storage tool that formatted the directory, regardless of this setting.")
 
     formatParser.addArgument("--feature", "-f")
       .help("The setting to use for a specific feature, in feature=level format. For example: `kraft.version=1`.")

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -33,7 +33,8 @@ type: docs
 ### Notable changes in 4.4.0
 
   * The `ClientQuotaCallback#updateClusterMetadata` method is deprecated and will be removed in Kafka 5.0. Custom implementations of `ClientQuotaCallback` no longer need to override this method, as a default no-op implementation is now provided. For further details, please refer to [KIP-1200](https://cwiki.apache.org/confluence/x/axBJFg).
-  * The in-memory keystores (used for PEM certificates) now use the default type provided by `KeyStore.getDefaultType()` instead of the hardcoded PKCS12 type.   
+  * The in-memory keystores (used for PEM certificates) now use the default type provided by `KeyStore.getDefaultType()` instead of the hardcoded PKCS12 type.
+  * Storage directories formatted by the `kafka-storage` tool are no longer forward-compatible. A Kafka broker must be the same version as, or newer than, the `kafka-storage` tool that formatted its directory, regardless of the `--release-version` chosen at format time. For further details, please refer to [KIP-1170](https://cwiki.apache.org/confluence/x/ZYoEFQ).
 
 ## Upgrading to 4.3.0
 


### PR DESCRIPTION
Follow-up to #20707, which unified bootstrap metadata into the KRaft
zero checkpoint. As a side effect, a directory produced by a newer
`kafka-storage` tool can no longer be started by an older Kafka broker —
even if `--release-version` was set to an older version at format time.
The flag only chooses the initial feature levels; the on-disk checkpoint
layout itself is dictated by the tool's own code version.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
