### PR TITLE
KAFKA-19193: throw ConfigException if rack is empty in rack-aware mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.TimestampType;
@@ -1240,7 +1241,7 @@ public class RecordAccumulator {
             this.rack = rack;
 
             if (rackAware && Utils.isBlank(rack)) {
-                throw new IllegalArgumentException("client.rack must be provided if partitioner.rack.aware is enabled");
+                throw new ConfigException("client.rack must be provided if partitioner.rack.aware is enabled");
             }
         }
 


### PR DESCRIPTION
As a follow-up to comments in https://github.com/apache/kafka/pull/19850

Reviewers: Viktor Somogyi-Vass <viktorsomogyi@gmail.com>
