### PR TITLE
KAFKA-19193: trace-log rack-specific load stats in rack-aware mode

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BuiltInPartitioner.java
@@ -334,8 +334,19 @@ public class BuiltInPartitioner {
         // Invert and fold the queue size, so that they become separator values in the CFT.
         invertAndFoldQueueSizeArray(queueSizes, maxSizePlus1, length);
 
-        log.trace("Partition load stats for topic {}: CFT={}, IDs={}, length={}",
-                topic, queueSizes, partitionIds, length);
+        if (log.isTraceEnabled()) {
+            if (rackAware) {
+                assert partitionLoadStatsInThisRack != null;
+                log.trace(
+                    "Partition load stats for topic {}: CFT={}, IDs={}, length={}; in producer rack: CFT={}, IDs={}, length={}",
+                    topic,
+                    queueSizes, partitionIds, length,
+                    partitionLoadStatsInThisRack.cumulativeFrequencyTable, partitionLoadStatsInThisRack.partitionIds, partitionLoadStatsInThisRack.length);
+            } else {
+                log.trace("Partition load stats for topic {}: CFT={}, IDs={}, length={}",
+                    topic, queueSizes, partitionIds, length);
+            }
+        }
         partitionLoadStatsHolder = new PartitionLoadStatsHolder(
             new PartitionLoadStats(queueSizes, partitionIds, length),
             partitionLoadStatsInThisRack


### PR DESCRIPTION
As a follow-up to comments in https://github.com/apache/kafka/pull/19850

Reviewers: Viktor Somogyi-Vass <viktorsomogyi@gmail.com>
