### PR TITLE
KAFKA-14276: Clarify java doc for ProcessorAPI init method and stateStore.approximateNumEntries()

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/FixedKeyProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/FixedKeyProcessor.java
@@ -40,6 +40,12 @@ public interface FixedKeyProcessor<KIn, VIn, VOut> {
      * The provided {@link FixedKeyProcessorContext context} can be used to access topology and record metadata, to
      * {@link FixedKeyProcessorContext#schedule(Duration, PunctuationType, Punctuator) schedule} a method to be
      * {@link Punctuator#punctuate(long) called periodically} and to access attached {@link StateStore}s.
+     * <p>
+     * State stores attached to this processor are fully restored from their changelog topics before {@code init()} is called.
+     * However, for stores that report approximate sizes (notably the default RocksDB-backed stores), size estimates such as
+     * {@link org.apache.kafka.streams.state.ReadOnlyKeyValueStore#approximateNumEntries()} may not yet reflect post-compaction
+     * counts at this point and can include duplicate writes and tombstones replayed during restoration; see that method's
+     * Javadoc for details.
      *
      * @param context the context; may not be null
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/Processor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/Processor.java
@@ -41,6 +41,12 @@ public interface Processor<KIn, VIn, KOut, VOut> {
      * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
      * {@link ProcessorContext#schedule(Duration, PunctuationType, Punctuator) schedule} a method to be
      * {@link Punctuator#punctuate(long) called periodically} and to access attached {@link StateStore}s.
+     * <p>
+     * State stores attached to this processor are fully restored from their changelog topics before {@code init()} is called.
+     * However, for stores that report approximate sizes (notably the default RocksDB-backed stores), size estimates such as
+     * {@link org.apache.kafka.streams.state.ReadOnlyKeyValueStore#approximateNumEntries()} may not yet reflect post-compaction
+     * counts at this point and can include duplicate writes and tombstones replayed during restoration; see that method's
+     * Javadoc for details.
      *
      * @param context the context; may not be null
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -129,6 +129,17 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * <p>
      * The count is not guaranteed to be exact in order to accommodate stores
      * where an exact count is expensive to calculate.
+     * <p>
+     * The accuracy of the estimate depends on the backing store. In particular,
+     * stores backed by an LSM-tree (such as the default RocksDB-based stores) may
+     * report a count that includes duplicate writes and tombstones produced when
+     * the store is restored from its changelog topic, until the backing store
+     * compacts those records away. As a result, this method can return a value
+     * substantially larger than the number of live, unique keys, especially
+     * shortly after task initialization (for example, when called from
+     * {@link org.apache.kafka.streams.processor.api.Processor#init}).
+     * Callers that need an exact live-key count should iterate the store via
+     * {@link #all()} (or its variants) and count entries.
      *
      * @return an approximate count of key-value mappings in the store.
      * @throws InvalidStateStoreException if the store is not initialized

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -714,6 +714,19 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
      * property to get an approximate count. The returned size also includes
      * a count of dirty keys in the store's in-memory cache, which may lead to some
      * double-counting of entries and inflate the estimate.
+     * <p>
+     * The <code>rocksdb.estimate-num-keys</code> property reflects the raw LSM-tree
+     * state (memtable plus SSTables) prior to background compaction. Repeated
+     * writes to the same key and tombstones (null-value writes) each count toward
+     * the estimate until RocksDB compacts them away. Consequently, immediately
+     * after the store has been restored from its changelog topic (for example,
+     * inside the first invocations of
+     * {@link org.apache.kafka.streams.processor.api.Processor#init} or
+     * {@link org.apache.kafka.streams.processor.api.Processor#process}), this
+     * estimate is typically inflated by every duplicate update and tombstone
+     * replayed during restoration. The estimate converges toward the live-key
+     * count as background compaction proceeds; iterating the store via
+     * {@link #all()} is the only way to obtain an exact count.
      *
      * @return an approximate count of key-value mappings in the store.
      */


### PR DESCRIPTION
Clarifies in Javadoc that `KeyValueStore.approximateNumEntries()` may
return a count substantially larger than the number of live keys
iteration would yield, particularly when called from  `Processor.init()`
immediately after restoration.

Reviewers: Matthias J. Sax <matthias@confluent.io>
