### PR TITLE
KAFKA-20072 Make Uuid no-dash behavior opt-in

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -71,9 +71,24 @@ public class Uuid implements Comparable<Uuid> {
     /**
      * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
      * <p>
-     * This will not generate a UUID equal to 0, 1, or one whose string representation contains a dash ("-").
+     * This will not generate a UUID equal to 0, 1, or one whose string representation starts with a dash ("-").
      */
     public static Uuid randomUuid() {
+        Uuid uuid = unsafeRandomUuid();
+        while (RESERVED.contains(uuid) || uuid.toString().startsWith("-")) {
+            uuid = unsafeRandomUuid();
+        }
+        return uuid;
+    }
+
+    /**
+     * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
+     * <p>
+     * This will not generate a UUID equal to 0, 1, or one whose string representation contains a dash ("-").
+     * Note that this will result in 30% rejected UUIDs, and so should not be used in performance sensitive
+     * code paths.
+     */
+    public static Uuid randomUuidNoDashes() {
         Uuid uuid = unsafeRandomUuid();
         while (RESERVED.contains(uuid) || uuid.toString().contains("-")) {
             uuid = unsafeRandomUuid();

--- a/clients/src/test/java/org/apache/kafka/common/UuidTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/UuidTest.java
@@ -83,6 +83,15 @@ public class UuidTest {
 
         assertNotEquals(Uuid.ZERO_UUID, randomID);
         assertNotEquals(Uuid.METADATA_TOPIC_ID, randomID);
+        assertFalse(randomID.toString().startsWith("-"));
+    }
+
+    @RepeatedTest(value = 100, name = RepeatedTest.LONG_DISPLAY_NAME)
+    public void testRandomUuidNoDash() {
+        Uuid randomID = Uuid.randomUuidNoDashes();
+
+        assertNotEquals(Uuid.ZERO_UUID, randomID);
+        assertNotEquals(Uuid.METADATA_TOPIC_ID, randomID);
         assertFalse(randomID.toString().contains("-"));
     }
 

--- a/docs/design/protocol.md
+++ b/docs/design/protocol.md
@@ -218,11 +218,11 @@ A final question is why we don't use a system like Protocol Buffers or Thrift to
 
 ## Recommendations for 3rd‑party Clients: Member ID Format
 
-When a Kafka client participates in group protocols (e.g., `ConsumerGroupHeartbeat` RPC), it must generate a **member ID** to identify itself to the broker. While the protocol does not strictly enforce the format of this ID, we strongly recommend the following:
+When a Kafka client participates in group protocols (e.g., `ConsumerGroupHeartbeat` RPC), it must generate a **member ID** to identify itself to the broker. While the protocol does not strictly enforce the format of this ID, we recommend the following:
 
 1. **Use a base64‑encoded UUID** as the member ID.
 2. **Encode the UUID using URL‑safe base64** (without `+` or `/` characters).
-3. **Omit hyphens** — the resulting string should be a continuous sequence of alphanumeric characters (e.g., `abc123def456`).
+3. **Omit leading hyphens** — the resulting string should not include a leading hyphen
 
 **Example**  
 A standard UUID (`00000000-0000-0000-0000-000000000000`) should be transformed into a URL‑safe base64 string like: `YzYxNjQ4OTItZDE1Mi00Y2E4LWIyNzUtYmIwMzAwMDAwMDAw`

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -815,7 +815,7 @@ public class ReplicationControlManager {
                 numPartitions, e.throttleTimeMs());
             return ApiError.fromThrowable(e);
         }
-        Uuid topicId = Uuid.randomUuid();
+        Uuid topicId = Uuid.randomUuidNoDashes();
         CreatableTopicResult result = new CreatableTopicResult().
             setName(topic.name()).
             setTopicId(topicId).


### PR DESCRIPTION
Instead of changing `Uuid#randomUuid` to always have the new behavior
introduced in #21313, this patch moves the new logic into a separate
`randomUuidNoDashes` method.

Since Uuid is a utility class, it is used widely throughout the broker
and client (possibly even applications). In most cases, the presence of
a dash is inconsequential. The new behavior, which comes with a small
performance hit, should not affect these callers. The introduction of a
new Uuid factory makes the new behavior opt-in.

One caller is updated to use the new factory which is where the
controller allocates topic IDs. This matches the intention of the
original Jira.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
