### PR TITLE
MINOR: Remove redundant start calls from persister and dlq mgr.

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -165,7 +165,6 @@ public class PersisterStateManager {
     public void start() {
         if (isStarted.compareAndSet(false, true)) {
             this.sender.start();
-            isStarted.set(true);
         }
     }
 

--- a/server/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQStateManager.java
+++ b/server/src/main/java/org/apache/kafka/server/share/dlq/ShareGroupDLQStateManager.java
@@ -125,7 +125,6 @@ public class ShareGroupDLQStateManager {
         if (isStarted.compareAndSet(false, true)) {
             log.info("Starting ShareGroupDLQStateManager");
             this.sender.start();
-            isStarted.set(true);
         }
     }
 


### PR DESCRIPTION
* The `start` method in both `PersisterStateManager` and
`ShareGroupDLQStateManager` currently makes redundant call to  set
`isStarted` atomic boolean despite being already done in the
`compareAndSet` method. Hence, removing those.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
