### PR TITLE
MINOR: fix doc for CVE-2026-41115

### DIFF
--- a/docs/security/authorization-and-acls.md
+++ b/docs/security/authorization-and-acls.md
@@ -2252,7 +2252,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 


### PR DESCRIPTION
Fix documentation for CVE-2026-41115, to use `DESCRIBE` permission on
`GROUP` resource for `CONSUMER_GROUP_DESCRIBE (69)` API.

Reviewers: David Jacot <david.jacot@gmail.com>
