### PR TITLE
MINOR: Add missing GROUP_ID_NOT_FOUND in {Consumer,Share,Streams}GroupHeartbeatResponse schema

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json
@@ -25,6 +25,7 @@
   // - COORDINATOR_NOT_AVAILABLE (version 0+)
   // - COORDINATOR_LOAD_IN_PROGRESS (version 0+)
   // - INVALID_REQUEST (version 0+)
+  // - GROUP_ID_NOT_FOUND (version 0+)
   // - UNKNOWN_MEMBER_ID (version 0+)
   // - FENCED_MEMBER_EPOCH (version 0+)
   // - UNSUPPORTED_ASSIGNOR (version 0+)

--- a/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/ShareGroupHeartbeatResponse.json
@@ -24,13 +24,14 @@
   "flexibleVersions": "0+",
   // Supported errors:
   // - GROUP_AUTHORIZATION_FAILED (version 0+)
-  // - TOPIC_AUTHORIZATION_FAILED (version 1+)
   // - NOT_COORDINATOR (version 0+)
   // - COORDINATOR_NOT_AVAILABLE (version 0+)
   // - COORDINATOR_LOAD_IN_PROGRESS (version 0+)
+  // - GROUP_ID_NOT_FOUND (version 0+)
   // - UNKNOWN_MEMBER_ID (version 0+)
   // - GROUP_MAX_SIZE_REACHED (version 0+)
   // - INVALID_REQUEST (version 0+)
+  // - TOPIC_AUTHORIZATION_FAILED (version 1+)
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatResponse.json
@@ -26,6 +26,7 @@
   // - COORDINATOR_NOT_AVAILABLE (version 0+)
   // - COORDINATOR_LOAD_IN_PROGRESS (version 0+)
   // - INVALID_REQUEST (version 0+)
+  // - GROUP_ID_NOT_FOUND (version 0+)
   // - UNKNOWN_MEMBER_ID (version 0+)
   // - FENCED_MEMBER_EPOCH (version 0+)
   // - UNRELEASED_INSTANCE_ID (version 0+)


### PR DESCRIPTION
Add missing GROUP_ID_NOT_FOUND in
{Consumer,Share,Streams}GroupHeartbeatResponse schema.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
