### PR TITLE
MINOR: Correcting reviewers script for names

### DIFF
--- a/committer-tools/reviewers.py
+++ b/committer-tools/reviewers.py
@@ -84,7 +84,11 @@ if __name__ == "__main__":
     lines = stream.readlines()
     all_reviewers = defaultdict(int)
     for line in lines:
-        stripped = line.strip().lstrip("Reviewers: ").lstrip("Author: ")
+        stripped = line.strip()
+        if stripped.startswith("Reviewers: "):
+            stripped = stripped[len("Reviewers: "):]
+        elif stripped.startswith("Author: "):
+            stripped = stripped[len("Author: "):]
         reviewers = stripped.split(",")
         for reviewer in reviewers:
             all_reviewers[reviewer.strip()] += 1


### PR DESCRIPTION
The reviewers.py script incorrectly parses reviewer names that start
with characters appearing in "Author:" or "Reviewers:", leading to
truncated names.

### Issue

stripped = line.strip().lstrip("Reviewers: ").lstrip("Author: ")

The Problem: lstrip(string) does not remove a prefix string. Instead, it
removes any characters from that character set from the left side of the
string.

### Fix

Replace the buggy lstrip() calls with proper prefix removal. Two options
available:

Option 1: Using removeprefix() (Python 3.9+)
```
stripped = line.strip().removeprefix("Reviewers:
").removeprefix("Author: ")
```
Requires Python 3.9+

Option 2: Using startswith() (Python 3.0+)

Used option 2 as the script currently supports Python 3+

Example Issue:
When searching for "Apoorv", the script showed:
- poorv Mittal apoorvmittal10@gmail.com ❌ - Missing the "A"
- Apoorv Mittal apoorvmittal10@gmail.com ✅ - Correct

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ming-Yen Chung
 <mingyen066@gmail.com>
