### PR TITLE
KAFKA-20532: Defensive trimming of min.insync.replicas in controller and kafka-topics to tolerate whitespace-contaminated configs

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2427,7 +2427,7 @@ public class ReplicationControlManager {
     // Visible to test.
     int getTopicEffectiveMinIsr(String topicName) {
         String minIsrConfig = configurationControl.getTopicConfig(topicName, MIN_IN_SYNC_REPLICAS_CONFIG).value();
-        int currentMinIsr = Integer.parseInt(minIsrConfig);
+        int currentMinIsr = Integer.parseInt(minIsrConfig.trim());
         Uuid topicId = topicsByName.get(topicName);
         int replicationFactor = topics.get(topicId).parts.get(0).replicas.length;
         return Math.min(currentMinIsr, replicationFactor);

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1203,6 +1203,65 @@ public class ReplicationControlManagerTest {
         assertEquals(3, replicationControl.getTopicEffectiveMinIsr("foo"));
     }
 
+    // KAFKA-20532: regression tests — getTopicEffectiveMinIsr must tolerate whitespace-padded
+    // min.insync.replicas values that bypass ConfigDef trimming and are stored raw.
+    @Test
+    public void testGetTopicEffectiveMinIsr_LeadingWhitespace() {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setIsElrEnabled(true).build();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+        ctx.createTestTopic("foo", new int[][]{new int[]{0, 1, 2}});
+
+        // Simulate a whitespace-contaminated value reaching the metadata store (e.g. via ZK
+        // migration or a client that exploits the validate-trim/store-raw mismatch).
+        ctx.alterTopicConfig("foo", TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, " 2");
+
+        // Must not throw NumberFormatException and must return the correct integer value.
+        assertEquals(2, replicationControl.getTopicEffectiveMinIsr("foo"));
+    }
+
+    @Test
+    public void testGetTopicEffectiveMinIsr_TrailingWhitespace() {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setIsElrEnabled(true).build();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+        ctx.createTestTopic("foo", new int[][]{new int[]{0, 1, 2}});
+
+        ctx.alterTopicConfig("foo", TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2 ");
+
+        assertEquals(2, replicationControl.getTopicEffectiveMinIsr("foo"));
+    }
+
+    @Test
+    public void testGetTopicEffectiveMinIsr_BothSidesWhitespace() {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setIsElrEnabled(true).build();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+        ctx.createTestTopic("foo", new int[][]{new int[]{0, 1, 2}});
+
+        ctx.alterTopicConfig("foo", TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, " 2 ");
+
+        assertEquals(2, replicationControl.getTopicEffectiveMinIsr("foo"));
+    }
+
+    @Test
+    public void testGetTopicEffectiveMinIsr_WhitespaceCappedByReplicationFactor() {
+        // Verify that the replication-factor cap still applies correctly after trimming.
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setIsElrEnabled(true).build();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+        ctx.createTestTopic("foo", new int[][]{new int[]{0, 1, 2}});
+
+        // Whitespace-padded value that exceeds replication factor (3) — should be capped at 3.
+        ctx.alterTopicConfig("foo", TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, " 5");
+
+        assertEquals(3, replicationControl.getTopicEffectiveMinIsr("foo"));
+    }
+
     @Test
     public void testEligibleLeaderReplicas_CleanElection() {
         ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()

--- a/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicCommand.java
@@ -312,7 +312,7 @@ public abstract class TopicCommand {
         }
 
         int minIsrCount() {
-            return Integer.parseInt(config.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value());
+            return Integer.parseInt(config.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value().trim());
         }
 
         boolean isUnderReplicated() {

--- a/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicCommandTest.java
@@ -126,6 +126,53 @@ public class TopicCommandTest {
         assertFalse(partitionDescription.isUnderReplicated());
     }
 
+    // KAFKA-20532: regression tests — minIsrCount() must tolerate whitespace-padded
+    // min.insync.replicas values stored raw in the metadata store.
+    @Test
+    public void testMinIsrCount_LeadingWhitespace() {
+        Config config = new Config(List.of(
+            new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, " 2")
+        ));
+        TopicCommand.PartitionDescription pd = new TopicCommand.PartitionDescription(
+            "test-topic",
+            new TopicPartitionInfo(0, new Node(0, "localhost", 9090),
+                List.of(new Node(0, "localhost", 9090)), List.of(new Node(0, "localhost", 9090))),
+            config,
+            null
+        );
+        assertEquals(2, pd.minIsrCount());
+    }
+
+    @Test
+    public void testMinIsrCount_TrailingWhitespace() {
+        Config config = new Config(List.of(
+            new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2 ")
+        ));
+        TopicCommand.PartitionDescription pd = new TopicCommand.PartitionDescription(
+            "test-topic",
+            new TopicPartitionInfo(0, new Node(0, "localhost", 9090),
+                List.of(new Node(0, "localhost", 9090)), List.of(new Node(0, "localhost", 9090))),
+            config,
+            null
+        );
+        assertEquals(2, pd.minIsrCount());
+    }
+
+    @Test
+    public void testMinIsrCount_BothSidesWhitespace() {
+        Config config = new Config(List.of(
+            new ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, " 2 ")
+        ));
+        TopicCommand.PartitionDescription pd = new TopicCommand.PartitionDescription(
+            "test-topic",
+            new TopicPartitionInfo(0, new Node(0, "localhost", 9090),
+                List.of(new Node(0, "localhost", 9090)), List.of(new Node(0, "localhost", 9090))),
+            config,
+            null
+        );
+        assertEquals(2, pd.minIsrCount());
+    }
+
     @Test
     public void testAlterWithUnspecifiedPartitionCount() {
         String[] options = new String[] {" --bootstrap-server", bootstrapServer, "--alter", "--topic", topicName};


### PR DESCRIPTION
Summary :
Whitespace-contaminated min.insync.replicas values silently accepted at write time cause a controller failover loop and full cluster unavailability with no operator-visible warning, because the --describe observability path trims whitespace before displaying the value.

Impact
A topic config min.insync.replicas stored with leading or trailing whitespace (e.g. " 2") causes the KRaft controller to enter a continuous failover loop, making the cluster unavailable. The crash is triggered on every alterPartition event (e.g. any replica
restart), so recovery is not spontaneous. Critically, kafka-topics.sh --describe silently strips the whitespace before displaying the value, so the corrupted config is invisible to operators. There is no log warning, no alert, and no way to detect the problem via the standard Admin API observability path. An operator can stare at a failing cluster and see only
clean config values.

More Details in JIRA : https://issues.apache.org/jira/browse/KAFKA-20532

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
