### PR TITLE
KAFKA-20652: a couple of java-doc typo fixing

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
@@ -154,7 +154,7 @@ public class JoinWindows extends Windows<Window> {
      * @param timeDifference join window interval
      * @return a new JoinWindows object with the window definition with and grace period (default to 24 hours minus {@code timeDifference})
      * @throws IllegalArgumentException if {@code timeDifference} is negative or can't be represented as {@code long milliseconds}
-     * @deprecated Since 3.0. Use {@link #ofTimeDifferenceWithNoGrace(Duration)}} instead.
+     * @deprecated Since 3.0. Use {@link #ofTimeDifferenceWithNoGrace(Duration)} instead.
      */
     @Deprecated
     public static JoinWindows of(final Duration timeDifference) throws IllegalArgumentException {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
@@ -114,7 +114,7 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
 
     /**
      * Create a Produced instance with provided valueSerde.
-     * @param valueSerde    Serde to use for serializing the key
+     * @param valueSerde    Serde to use for serializing the value
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with valueSerde

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -183,7 +183,7 @@ public interface ReadOnlyWindowStore<K, V> {
     }
 
     /**
-     * Gets all the key-value pairs that belong to the windows within in the given time range.
+     * Gets all the key-value pairs that belong to the windows within the given time range.
      *
      * @param timeFrom the beginning of the time slot from which to search (inclusive), where iteration starts.
      * @param timeTo   the end of the time slot from which to search (inclusive), where iteration ends.
@@ -195,7 +195,7 @@ public interface ReadOnlyWindowStore<K, V> {
     KeyValueIterator<Windowed<K>, V> fetchAll(Instant timeFrom, Instant timeTo) throws IllegalArgumentException;
 
     /**
-     * Gets all the key-value pairs that belong to the windows within in the given time range in backward order
+     * Gets all the key-value pairs that belong to the windows within the given time range in backward order
      * with respect to time (from end to beginning of time).
      *
      * @param timeFrom the beginning of the time slot from which to search (inclusive), where iteration ends.

--- a/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
@@ -162,7 +162,7 @@ public interface WindowStore<K, V> extends StateStore, ReadOnlyWindowStore<K, V>
     }
 
     /**
-     * Gets all the key-value pairs that belong to the windows within in the given time range.
+     * Gets all the key-value pairs that belong to the windows within the given time range.
      *
      * @param timeFrom the beginning of the time slot from which to search (inclusive)
      * @param timeTo   the end of the time slot from which to search (inclusive)

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedBytesStore.java
@@ -89,7 +89,7 @@ public interface SegmentedBytesStore extends StateStore {
     KeyValueIterator<Bytes, byte[]> backwardAll();
 
     /**
-     * Gets all the key-value pairs that belong to the windows within in the given time range.
+     * Gets all the key-value pairs that belong to the windows within the given time range.
      *
      * @param from the beginning of the time slot from which to search (inclusive)
      * @param to   the end of the time slot from which to search (inclusive)


### PR DESCRIPTION
fix: correct javadoc typos

- Produced.java:117: fix @param description for valueSerde (was 'key',
should be 'value')
- WindowStore, ReadOnlyWindowStore, SegmentedBytesStore: fix 'within in'
→ 'within the' (4 occurrences)
- JoinWindows.java:157: remove stray closing brace in {@link} tag

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
