### PR TITLE
KAFKA-20640: Consumer group should reject classic member joins when migration policy is disabled

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
@@ -422,7 +422,7 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
 
     val rejectedResponse = new JoinGroupResponseData()
       .setProtocolName(null)
-      .setErrorCode(Errors.GROUP_ID_NOT_FOUND.code)
+      .setErrorCode(Errors.INCONSISTENT_GROUP_PROTOCOL.code)
 
     // A new dynamic member is rejected.
     assertEquals(

--- a/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
@@ -395,7 +395,7 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
       new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, value = "disabled")
     )
   )
-  def testDowngradeWithDisabledMigrationPolicy(): Unit = {
+  def testClassicMemberJoinToConsumerGroupWithDisabledMigrationPolicy(): Unit = {
     // Creates the __consumer_offsets topics because it won't be created automatically
     // in this test because it does not use FindCoordinator API.
     createOffsetsTopic()
@@ -409,22 +409,17 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
     val groupId = "grp"
 
     // Consumer member 1 joins the group.
-    val (memberId1, _) = joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
+    joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
 
-    // Classic member 2 joins the group.
-    val joinGroupResponseData = sendJoinRequest(
-      groupId = groupId
-    )
-    sendJoinRequest(
-      groupId = groupId,
-      memberId = joinGroupResponseData.memberId,
-      metadata = metadata(List.empty)
-    )
-
-    // Try to downgrade the group by leaving member 1.
-    leaveGroupWithNewProtocol(
-      groupId = groupId,
-      memberId = memberId1
+    // A classic member tries to join the consumer group and is rejected.
+    assertEquals(
+      new JoinGroupResponseData()
+        .setProtocolName(null)
+        .setErrorCode(Errors.GROUP_ID_NOT_FOUND.code),
+      sendJoinRequest(
+        groupId = groupId,
+        metadata = metadata(List.empty)
+      )
     )
 
     // The group is still a consumer group.
@@ -433,7 +428,68 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
         new ListGroupsResponseData.ListedGroup()
           .setGroupId(groupId)
           .setProtocolType("consumer")
-          .setGroupState(ConsumerGroupState.ASSIGNING.toString)
+          .setGroupState(ConsumerGroupState.STABLE.toString)
+          .setGroupType(Group.GroupType.CONSUMER.toString)
+      ),
+      listGroups(
+        statesFilter = List.empty,
+        typesFilter = List(Group.GroupType.CONSUMER.toString)
+      )
+    )
+  }
+
+  @ClusterTest(
+    serverProperties = Array(
+      new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, value = "disabled")
+    )
+  )
+  def testStaticMemberReplacementWithClassicMemberWithDisabledMigrationPolicy(): Unit = {
+    // Creates the __consumer_offsets topics because it won't be created automatically
+    // in this test because it does not use FindCoordinator API.
+    createOffsetsTopic()
+
+    // Create the topic.
+    createTopic(
+      topic = "foo",
+      numPartitions = 3
+    )
+
+    val groupId = "grp"
+    val instanceId = "instance-id"
+
+    // A static member using the consumer protocol joins the group.
+    consumerGroupHeartbeat(
+      groupId = groupId,
+      memberId = Uuid.randomUuid.toString,
+      instanceId = instanceId,
+      rebalanceTimeoutMs = 5 * 60 * 1000,
+      subscribedTopicNames = List("foo"),
+      topicPartitions = List.empty,
+      expectedError = Errors.NONE
+    )
+
+    // A classic member replaces the static member using the same instance id.
+    val joinGroupResponseData = sendJoinRequest(
+      groupId = groupId,
+      groupInstanceId = instanceId,
+      metadata = metadata(List.empty)
+    )
+    assertEquals(
+      new JoinGroupResponseData()
+        .setGenerationId(2)
+        .setProtocolType("consumer")
+        .setProtocolName("consumer-range")
+        .setMemberId(joinGroupResponseData.memberId),
+      joinGroupResponseData
+    )
+
+    // The group is still a consumer group.
+    assertEquals(
+      List(
+        new ListGroupsResponseData.ListedGroup()
+          .setGroupId(groupId)
+          .setProtocolType("consumer")
+          .setGroupState(ConsumerGroupState.STABLE.toString)
           .setGroupType(Group.GroupType.CONSUMER.toString)
       ),
       listGroups(

--- a/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ConsumerProtocolMigrationTest.scala
@@ -407,54 +407,6 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
     )
 
     val groupId = "grp"
-
-    // Consumer member 1 joins the group.
-    joinConsumerGroupWithNewProtocol(groupId, Uuid.randomUuid.toString)
-
-    // A classic member tries to join the consumer group and is rejected.
-    assertEquals(
-      new JoinGroupResponseData()
-        .setProtocolName(null)
-        .setErrorCode(Errors.GROUP_ID_NOT_FOUND.code),
-      sendJoinRequest(
-        groupId = groupId,
-        metadata = metadata(List.empty)
-      )
-    )
-
-    // The group is still a consumer group.
-    assertEquals(
-      List(
-        new ListGroupsResponseData.ListedGroup()
-          .setGroupId(groupId)
-          .setProtocolType("consumer")
-          .setGroupState(ConsumerGroupState.STABLE.toString)
-          .setGroupType(Group.GroupType.CONSUMER.toString)
-      ),
-      listGroups(
-        statesFilter = List.empty,
-        typesFilter = List(Group.GroupType.CONSUMER.toString)
-      )
-    )
-  }
-
-  @ClusterTest(
-    serverProperties = Array(
-      new ClusterConfigProperty(key = GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, value = "disabled")
-    )
-  )
-  def testStaticMemberReplacementWithClassicMemberWithDisabledMigrationPolicy(): Unit = {
-    // Creates the __consumer_offsets topics because it won't be created automatically
-    // in this test because it does not use FindCoordinator API.
-    createOffsetsTopic()
-
-    // Create the topic.
-    createTopic(
-      topic = "foo",
-      numPartitions = 3
-    )
-
-    val groupId = "grp"
     val instanceId = "instance-id"
 
     // A static member using the consumer protocol joins the group.
@@ -468,19 +420,37 @@ class ConsumerProtocolMigrationTest(cluster: ClusterInstance) extends GroupCoord
       expectedError = Errors.NONE
     )
 
-    // A classic member replaces the static member using the same instance id.
-    val joinGroupResponseData = sendJoinRequest(
-      groupId = groupId,
-      groupInstanceId = instanceId,
-      metadata = metadata(List.empty)
-    )
+    val rejectedResponse = new JoinGroupResponseData()
+      .setProtocolName(null)
+      .setErrorCode(Errors.GROUP_ID_NOT_FOUND.code)
+
+    // A new dynamic member is rejected.
     assertEquals(
-      new JoinGroupResponseData()
-        .setGenerationId(2)
-        .setProtocolType("consumer")
-        .setProtocolName("consumer-range")
-        .setMemberId(joinGroupResponseData.memberId),
-      joinGroupResponseData
+      rejectedResponse,
+      sendJoinRequest(
+        groupId = groupId,
+        metadata = metadata(List.empty)
+      )
+    )
+
+    // A new static member with a different instance id is rejected.
+    assertEquals(
+      rejectedResponse,
+      sendJoinRequest(
+        groupId = groupId,
+        groupInstanceId = "another-instance-id",
+        metadata = metadata(List.empty)
+      )
+    )
+
+    // A static member reusing the existing instance id is also rejected.
+    assertEquals(
+      rejectedResponse,
+      sendJoinRequest(
+        groupId = groupId,
+        groupInstanceId = instanceId,
+        metadata = metadata(List.empty)
+      )
     )
 
     // The group is still a consumer group.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ConsumerGroupMigrationPolicy.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/ConsumerGroupMigrationPolicy.java
@@ -33,7 +33,7 @@ public enum ConsumerGroupMigrationPolicy {
     /** Only downgrade is enabled.*/
     DOWNGRADE("downgrade", false, true),
 
-    /** Neither upgrade nor downgrade is enabled.*/
+    /** Neither upgrade nor downgrade is enabled; a classic member cannot join or rejoin a consumer group.*/
     DISABLED("disabled", false, false);
 
     private final String name;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -231,7 +231,10 @@ public class GroupCoordinatorConfig {
         ConsumerGroupMigrationPolicy.BIDIRECTIONAL + ": both upgrade from classic group to consumer group and downgrade from consumer group to classic group are enabled, " +
         ConsumerGroupMigrationPolicy.UPGRADE + ": only upgrade from classic group to consumer group is enabled, " +
         ConsumerGroupMigrationPolicy.DOWNGRADE + ": only downgrade from consumer group to classic group is enabled, " +
-        ConsumerGroupMigrationPolicy.DISABLED + ": neither upgrade nor downgrade is enabled.";
+        ConsumerGroupMigrationPolicy.DISABLED + ": neither upgrade nor downgrade is enabled. " +
+        "In this mode a member using the classic protocol is not allowed to join or rejoin a non-empty consumer group; " +
+        "if a group is already mixed (for example because this policy was changed), its classic-protocol members are " +
+        "rejected when they next attempt to rejoin.";
 
     public static final String CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_CONFIG = "group.consumer.assignment.interval.ms";
     public static final String CONSUMER_GROUP_ASSIGNMENT_INTERVAL_MS_DOC = "The interval between assignment updates for a consumer group.";

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1395,6 +1395,26 @@ public class GroupMetadataManager {
     }
 
     /**
+     * Validates whether a new classic member is allowed to join the consumer group.
+     *
+     * @param consumerGroup       The consumer group the classic member wants to join.
+     * @param isNewMemberJoining  Whether the joining classic member is not yet a member of the group.
+     * @throws GroupIdNotFoundException if a new classic member cannot join the consumer group.
+     */
+    private void throwIfClassicMemberCannotJoinConsumerGroup(
+        ConsumerGroup consumerGroup,
+        boolean isNewMemberJoining
+    ) {
+        if (isNewMemberJoining && config.consumerGroupMigrationPolicy() == ConsumerGroupMigrationPolicy.DISABLED) {
+            log.info("Cannot join the consumer group {} with the classic protocol because the group migration is disabled.",
+                consumerGroup.groupId());
+            throw new GroupIdNotFoundException(
+                String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", consumerGroup.groupId())
+            );
+        }
+    }
+
+    /**
      * Creates a ConsumerGroup corresponding to the given classic group.
      *
      * @param classicGroup  The ClassicGroup to convert.
@@ -2497,6 +2517,13 @@ public class GroupMetadataManager {
 
         throwIfConsumerGroupIsFull(group, memberId);
         throwIfClassicProtocolIsNotSupported(group, memberId, request.protocolType(), protocols);
+
+        // Under the disabled migration policy, a new classic member is not allowed.
+        // Members that are already in the group may still rejoin.
+        boolean isNewMemberJoining = instanceId == null
+            ? !group.hasMember(memberId)
+            : group.staticMember(instanceId) == null;
+        throwIfClassicMemberCannotJoinConsumerGroup(group, isNewMemberJoining);
 
         if (JoinGroupRequest.requiresKnownMemberId(request, context.requestVersion())) {
             // A dynamic member requiring a member id joins the group. Send back a response to call for another

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1399,13 +1399,13 @@ public class GroupMetadataManager {
      * migration policy is disabled, no classic member may join or rejoin the consumer group.
      *
      * @param consumerGroup The consumer group the classic member wants to join.
-     * @throws GroupIdNotFoundException if the classic member cannot join the consumer group.
+     * @throws InconsistentGroupProtocolException if the classic member cannot join the consumer group.
      */
     private void throwIfClassicMemberCannotJoinConsumerGroup(ConsumerGroup consumerGroup) {
         if (config.consumerGroupMigrationPolicy() == ConsumerGroupMigrationPolicy.DISABLED) {
             log.info("Cannot join the consumer group {} with the classic protocol because the group migration is disabled.",
                 consumerGroup.groupId());
-            throw new GroupIdNotFoundException(
+            throw Errors.INCONSISTENT_GROUP_PROTOCOL.exception(
                 String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", consumerGroup.groupId())
             );
         }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1396,24 +1396,33 @@ public class GroupMetadataManager {
 
     /**
      * Validates whether a new classic member is allowed to join the consumer group.
-     * If the migration policy is disabled, the join request will be rejected, unless
-     * the classic member is static and it replaces an existing consumer member in
-     * the consumer group.
+     * If the migration policy is disabled, the join request will be rejected even if
+     * it's a new static member trying to replace an existing member with the same
+     * instance id.
      *
      * @param consumerGroup The consumer group the classic member wants to join.
      * @param memberId      The joining member id (used to identify a dynamic member).
      * @param instanceId    The joining member instance id, or null for a dynamic member.
-     * @throws GroupIdNotFoundException if a new classic member cannot join the consumer group.
+     * @throws GroupIdNotFoundException if the classic member cannot join the consumer group.
      */
     private void throwIfClassicMemberCannotJoinConsumerGroup(
         ConsumerGroup consumerGroup,
         String memberId,
         String instanceId
     ) {
-        boolean isNewMemberJoining = instanceId == null
-            ? !consumerGroup.hasMember(memberId)
-            : consumerGroup.staticMember(instanceId) == null;
-        if (isNewMemberJoining && config.consumerGroupMigrationPolicy() == ConsumerGroupMigrationPolicy.DISABLED) {
+        if (config.consumerGroupMigrationPolicy() != ConsumerGroupMigrationPolicy.DISABLED) {
+            return;
+        }
+
+        boolean cannotJoin;
+        if (instanceId == null) {
+            cannotJoin = !consumerGroup.hasMember(memberId);
+        } else {
+            // A new instance id or the replacement of a consumer member is rejected.
+            ConsumerGroupMember existingMember = consumerGroup.staticMember(instanceId);
+            cannotJoin = existingMember == null || !existingMember.useClassicProtocol();
+        }
+        if (cannotJoin) {
             log.info("Cannot join the consumer group {} with the classic protocol because the group migration is disabled.",
                 consumerGroup.groupId());
             throw new GroupIdNotFoundException(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1395,34 +1395,14 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Validates whether a new classic member is allowed to join the consumer group.
-     * If the migration policy is disabled, the join request will be rejected even if
-     * it's a new static member trying to replace an existing member with the same
-     * instance id.
+     * Validates whether a classic member is allowed to join or rejoin the consumer group. When the
+     * migration policy is disabled, no classic member may join or rejoin the consumer group.
      *
      * @param consumerGroup The consumer group the classic member wants to join.
-     * @param memberId      The joining member id (used to identify a dynamic member).
-     * @param instanceId    The joining member instance id, or null for a dynamic member.
      * @throws GroupIdNotFoundException if the classic member cannot join the consumer group.
      */
-    private void throwIfClassicMemberCannotJoinConsumerGroup(
-        ConsumerGroup consumerGroup,
-        String memberId,
-        String instanceId
-    ) {
-        if (config.consumerGroupMigrationPolicy() != ConsumerGroupMigrationPolicy.DISABLED) {
-            return;
-        }
-
-        boolean cannotJoin;
-        if (instanceId == null) {
-            cannotJoin = !consumerGroup.hasMember(memberId);
-        } else {
-            // A new instance id or the replacement of a consumer member is rejected.
-            ConsumerGroupMember existingMember = consumerGroup.staticMember(instanceId);
-            cannotJoin = existingMember == null || !existingMember.useClassicProtocol();
-        }
-        if (cannotJoin) {
+    private void throwIfClassicMemberCannotJoinConsumerGroup(ConsumerGroup consumerGroup) {
+        if (config.consumerGroupMigrationPolicy() == ConsumerGroupMigrationPolicy.DISABLED) {
             log.info("Cannot join the consumer group {} with the classic protocol because the group migration is disabled.",
                 consumerGroup.groupId());
             throw new GroupIdNotFoundException(
@@ -2521,6 +2501,8 @@ public class GroupMetadataManager {
         JoinGroupRequestData request,
         CompletableFuture<JoinGroupResponseData> responseFuture
     ) throws ApiException {
+        throwIfClassicMemberCannotJoinConsumerGroup(group);
+
         final long currentTimeMs = time.milliseconds();
         final List<CoordinatorRecord> records = new ArrayList<>();
         final String groupId = request.groupId();
@@ -2534,8 +2516,6 @@ public class GroupMetadataManager {
 
         throwIfConsumerGroupIsFull(group, memberId);
         throwIfClassicProtocolIsNotSupported(group, memberId, request.protocolType(), protocols);
-
-        throwIfClassicMemberCannotJoinConsumerGroup(group, memberId, instanceId);
 
         if (JoinGroupRequest.requiresKnownMemberId(request, context.requestVersion())) {
             // A dynamic member requiring a member id joins the group. Send back a response to call for another

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1396,15 +1396,23 @@ public class GroupMetadataManager {
 
     /**
      * Validates whether a new classic member is allowed to join the consumer group.
+     * If the migration policy is disabled, the join request will be rejected, unless
+     * the classic member is static and it replaces an existing consumer member in
+     * the consumer group.
      *
-     * @param consumerGroup       The consumer group the classic member wants to join.
-     * @param isNewMemberJoining  Whether the joining classic member is not yet a member of the group.
+     * @param consumerGroup The consumer group the classic member wants to join.
+     * @param memberId      The joining member id (used to identify a dynamic member).
+     * @param instanceId    The joining member instance id, or null for a dynamic member.
      * @throws GroupIdNotFoundException if a new classic member cannot join the consumer group.
      */
     private void throwIfClassicMemberCannotJoinConsumerGroup(
         ConsumerGroup consumerGroup,
-        boolean isNewMemberJoining
+        String memberId,
+        String instanceId
     ) {
+        boolean isNewMemberJoining = instanceId == null
+            ? !consumerGroup.hasMember(memberId)
+            : consumerGroup.staticMember(instanceId) == null;
         if (isNewMemberJoining && config.consumerGroupMigrationPolicy() == ConsumerGroupMigrationPolicy.DISABLED) {
             log.info("Cannot join the consumer group {} with the classic protocol because the group migration is disabled.",
                 consumerGroup.groupId());
@@ -2518,12 +2526,7 @@ public class GroupMetadataManager {
         throwIfConsumerGroupIsFull(group, memberId);
         throwIfClassicProtocolIsNotSupported(group, memberId, request.protocolType(), protocols);
 
-        // Under the disabled migration policy, a new classic member is not allowed.
-        // Members that are already in the group may still rejoin.
-        boolean isNewMemberJoining = instanceId == null
-            ? !group.hasMember(memberId)
-            : group.staticMember(instanceId) == null;
-        throwIfClassicMemberCannotJoinConsumerGroup(group, isNewMemberJoining);
+        throwIfClassicMemberCannotJoinConsumerGroup(group, memberId, instanceId);
 
         if (JoinGroupRequest.requiresKnownMemberId(request, context.requestVersion())) {
             // A dynamic member requiring a member id joins the group. Send back a response to call for another

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14236,44 +14236,25 @@ public class GroupMetadataManagerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled(boolean isStatic) {
+    public void testRejoiningClassicMemberFailsWhenMigrationDisabled(boolean isStatic) {
         String groupId = "group-id";
-        Uuid fooTopicId = Uuid.randomUuid();
-        String fooTopicName = "foo";
-
-        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
-            .addTopic(fooTopicId, fooTopicName, 2)
-            .addRacks()
-            .buildCoordinatorMetadataImage();
-
         String memberId = Uuid.randomUuid().toString();
         String instanceId = "instance-id";
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
-            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(new NoOpPartitionAssignor()))
-            .withMetadataImage(metadataImage)
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(new ConsumerGroupMember.Builder(memberId)
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
-                    .setRebalanceTimeoutMs(500)
-                    .setSubscribedTopicNames(List.of(fooTopicName))
-                    .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
-                        mkTopicAssignment(fooTopicId, 0, 1)), 10))
                     .setInstanceId(isStatic ? instanceId : null)
                     .setClassicMemberMetadata(
                         new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                            .setSessionTimeoutMs(500)
+                            .setSessionTimeoutMs(5000)
                             .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
                                 GroupMetadataManagerTestContext.toProtocols("range"))))
-                    .build())
-                .withAssignment(memberId, mkAssignment(mkTopicAssignment(fooTopicId, 0, 1)))
-                .withAssignmentEpoch(10)
-                .withMetadataHash(computeGroupHash(Map.of(
-                    fooTopicName, computeTopicHash(fooTopicName, metadataImage)))))
+                    .build()))
             .build();
-        context.groupMetadataManager.consumerGroup(groupId).setMetadataRefreshDeadline(Long.MAX_VALUE, 10);
 
         JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
             .withGroupId(groupId)
@@ -14282,8 +14263,12 @@ public class GroupMetadataManagerTest {
             .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
 
-        // The existing classic member is allowed to rejoin even though migration is disabled.
-        assertDoesNotThrow(() -> context.sendClassicGroupJoin(request, isStatic));
+        // Even an existing classic member cannot rejoin when migration is disabled.
+        Exception ex = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(request, isStatic));
+        assertEquals(
+            String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
+            ex.getMessage()
+        );
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14233,7 +14233,7 @@ public class GroupMetadataManagerTest {
             .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
         assertEquals(errorMessage,
-            assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(newMemberRequest, isStatic)).getMessage());
+            assertThrows(InconsistentGroupProtocolException.class, () -> context.sendClassicGroupJoin(newMemberRequest, isStatic)).getMessage());
 
         // The existing classic member cannot rejoin.
         JoinGroupRequestData rejoinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
@@ -14243,7 +14243,7 @@ public class GroupMetadataManagerTest {
             .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
         assertEquals(errorMessage,
-            assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(rejoinRequest, isStatic)).getMessage());
+            assertThrows(InconsistentGroupProtocolException.class, () -> context.sendClassicGroupJoin(rejoinRequest, isStatic)).getMessage());
 
         if (isStatic) {
             // A classic member cannot replace an existing consumer-protocol static member.
@@ -14254,7 +14254,7 @@ public class GroupMetadataManagerTest {
                 .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
                 .build();
             assertEquals(errorMessage,
-                assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(replaceRequest, true)).getMessage());
+                assertThrows(InconsistentGroupProtocolException.class, () -> context.sendClassicGroupJoin(replaceRequest, true)).getMessage());
         }
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14189,86 +14189,73 @@ public class GroupMetadataManagerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testJoiningConsumerGroupWithClassicProtocolFailsIfMigrationDisabled(boolean isStatic) {
+    public void testClassicMemberJoinToConsumerGroupWithDisabledMigrationPolicy(boolean isStatic) {
         String groupId = "group-id";
-        String memberId = Uuid.randomUuid().toString();
-        String instanceId = "instance-id";
+        String classicMemberId = Uuid.randomUuid().toString();
+        String classicInstanceId = "classic-instance-id";
+        String consumerMemberId = Uuid.randomUuid().toString();
+        String consumerInstanceId = "consumer-instance-id";
+        String errorMessage = String.format(
+            "Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId);
+
+        // The group already contains a classic member. For the static case it also contains a
+        // consumer-protocol static member that a classic member could try to replace.
+        ConsumerGroupBuilder groupBuilder = new ConsumerGroupBuilder(groupId, 10)
+            .withMember(new ConsumerGroupMember.Builder(classicMemberId)
+                .setState(MemberState.STABLE)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(10)
+                .setInstanceId(isStatic ? classicInstanceId : null)
+                .setClassicMemberMetadata(
+                    new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                        .setSessionTimeoutMs(5000)
+                        .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                            GroupMetadataManagerTestContext.toProtocols("range"))))
+                .build());
+        if (isStatic) {
+            groupBuilder.withMember(new ConsumerGroupMember.Builder(consumerMemberId)
+                .setState(MemberState.STABLE)
+                .setMemberEpoch(10)
+                .setPreviousMemberEpoch(10)
+                .setInstanceId(consumerInstanceId)
+                .build());
+        }
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
-            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                .withMember(new ConsumerGroupMember.Builder(memberId)
-                    .setState(MemberState.STABLE)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(10)
-                    .setInstanceId(isStatic ? instanceId : null)
-                    .build()))
+            .withConsumerGroup(groupBuilder)
             .build();
 
-        JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+        // A new classic member cannot join
+        JoinGroupRequestData newMemberRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
             .withGroupId(groupId)
             .withMemberId(UNKNOWN_MEMBER_ID)
             .withGroupInstanceId(isStatic ? "new-instance-id" : null)
-            .withDefaultProtocolTypeAndProtocols()
+            .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
+        assertEquals(errorMessage,
+            assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(newMemberRequest, isStatic)).getMessage());
 
-        Exception ex = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(request, isStatic));
-        assertEquals(
-            String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
-            ex.getMessage()
-        );
+        // The existing classic member cannot rejoin.
+        JoinGroupRequestData rejoinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withMemberId(isStatic ? UNKNOWN_MEMBER_ID : classicMemberId)
+            .withGroupInstanceId(isStatic ? classicInstanceId : null)
+            .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
+            .build();
+        assertEquals(errorMessage,
+            assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(rejoinRequest, isStatic)).getMessage());
 
         if (isStatic) {
-            // A classic member reusing the existing instance id is also rejected.
+            // A classic member cannot replace an existing consumer-protocol static member.
             JoinGroupRequestData replaceRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
                 .withGroupId(groupId)
                 .withMemberId(UNKNOWN_MEMBER_ID)
-                .withGroupInstanceId(instanceId)
-                .withDefaultProtocolTypeAndProtocols()
+                .withGroupInstanceId(consumerInstanceId)
+                .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
                 .build();
-
-            Exception replaceEx = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(replaceRequest, true));
-            assertEquals(
-                String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
-                replaceEx.getMessage()
-            );
+            assertEquals(errorMessage,
+                assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(replaceRequest, true)).getMessage());
         }
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testRejoiningClassicMemberFailsWhenMigrationDisabled(boolean isStatic) {
-        String groupId = "group-id";
-        String memberId = Uuid.randomUuid().toString();
-        String instanceId = "instance-id";
-        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
-            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
-                .withMember(new ConsumerGroupMember.Builder(memberId)
-                    .setState(MemberState.STABLE)
-                    .setMemberEpoch(10)
-                    .setPreviousMemberEpoch(10)
-                    .setInstanceId(isStatic ? instanceId : null)
-                    .setClassicMemberMetadata(
-                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
-                            .setSessionTimeoutMs(5000)
-                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
-                                GroupMetadataManagerTestContext.toProtocols("range"))))
-                    .build()))
-            .build();
-
-        JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
-            .withGroupId(groupId)
-            .withMemberId(isStatic ? UNKNOWN_MEMBER_ID : memberId)
-            .withGroupInstanceId(isStatic ? instanceId : null)
-            .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
-            .build();
-
-        // Even an existing classic member cannot rejoin when migration is disabled.
-        Exception ex = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(request, isStatic));
-        assertEquals(
-            String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
-            ex.getMessage()
-        );
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14192,6 +14192,7 @@ public class GroupMetadataManagerTest {
     public void testJoiningConsumerGroupWithClassicProtocolFailsIfMigrationDisabled(boolean isStatic) {
         String groupId = "group-id";
         String memberId = Uuid.randomUuid().toString();
+        String instanceId = "instance-id";
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
@@ -14199,6 +14200,7 @@ public class GroupMetadataManagerTest {
                     .setState(MemberState.STABLE)
                     .setMemberEpoch(10)
                     .setPreviousMemberEpoch(10)
+                    .setInstanceId(isStatic ? instanceId : null)
                     .build()))
             .build();
 
@@ -14214,10 +14216,27 @@ public class GroupMetadataManagerTest {
             String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
             ex.getMessage()
         );
+
+        if (isStatic) {
+            // A classic member reusing the existing instance id is also rejected.
+            JoinGroupRequestData replaceRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+                .withGroupId(groupId)
+                .withMemberId(UNKNOWN_MEMBER_ID)
+                .withGroupInstanceId(instanceId)
+                .withDefaultProtocolTypeAndProtocols()
+                .build();
+
+            Exception replaceEx = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(replaceRequest, true));
+            assertEquals(
+                String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
+                replaceEx.getMessage()
+            );
+        }
     }
 
-    @Test
-    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled(boolean isStatic) {
         String groupId = "group-id";
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
@@ -14228,6 +14247,7 @@ public class GroupMetadataManagerTest {
             .buildCoordinatorMetadataImage();
 
         String memberId = Uuid.randomUuid().toString();
+        String instanceId = "instance-id";
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(new NoOpPartitionAssignor()))
@@ -14241,6 +14261,7 @@ public class GroupMetadataManagerTest {
                     .setSubscribedTopicNames(List.of(fooTopicName))
                     .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
                         mkTopicAssignment(fooTopicId, 0, 1)), 10))
+                    .setInstanceId(isStatic ? instanceId : null)
                     .setClassicMemberMetadata(
                         new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
                             .setSessionTimeoutMs(500)
@@ -14256,12 +14277,13 @@ public class GroupMetadataManagerTest {
 
         JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
             .withGroupId(groupId)
-            .withMemberId(memberId)
+            .withMemberId(isStatic ? UNKNOWN_MEMBER_ID : memberId)
+            .withGroupInstanceId(isStatic ? instanceId : null)
             .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
 
-        // The existing classic member is allowed to rejoin even though migration is disabled
-        assertDoesNotThrow(() -> context.sendClassicGroupJoin(request));
+        // The existing classic member is allowed to rejoin even though migration is disabled.
+        assertDoesNotThrow(() -> context.sendClassicGroupJoin(request, isStatic));
     }
 
     @Test
@@ -14572,7 +14594,7 @@ public class GroupMetadataManagerTest {
         String memberId = Uuid.randomUuid().toString();
         String instanceId = "instance-id";
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
-            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.UPGRADE.toString())
             .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(new NoOpPartitionAssignor()))
             .withMetadataImage(metadataImage)
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14187,6 +14187,86 @@ public class GroupMetadataManagerTest {
         assertThrows(InconsistentGroupProtocolException.class, () -> context.sendClassicGroupJoin(requestWithInvalidProtocolType));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testJoiningConsumerGroupWithClassicProtocolFailsIfMigrationDisabled(boolean isStatic) {
+        String groupId = "group-id";
+        String memberId = Uuid.randomUuid().toString();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId)
+                    .setState(MemberState.STABLE)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .build()))
+            .build();
+
+        JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withGroupInstanceId(isStatic ? "new-instance-id" : null)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        Exception ex = assertThrows(GroupIdNotFoundException.class, () -> context.sendClassicGroupJoin(request, isStatic));
+        assertEquals(
+            String.format("Cannot join the consumer group %s with the classic protocol because the group migration is disabled.", groupId),
+            ex.getMessage()
+        );
+    }
+
+    @Test
+    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled() throws Exception {
+        String groupId = "group-id";
+        Uuid fooTopicId = Uuid.randomUuid();
+        String fooTopicName = "foo";
+
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(fooTopicId, fooTopicName, 2)
+            .addRacks()
+            .buildCoordinatorMetadataImage();
+
+        String memberId = Uuid.randomUuid().toString();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_MIGRATION_POLICY_CONFIG, ConsumerGroupMigrationPolicy.DISABLED.toString())
+            .withConfig(GroupCoordinatorConfig.CONSUMER_GROUP_ASSIGNORS_CONFIG, List.of(new NoOpPartitionAssignor()))
+            .withMetadataImage(metadataImage)
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(new ConsumerGroupMember.Builder(memberId)
+                    .setState(MemberState.STABLE)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .setRebalanceTimeoutMs(500)
+                    .setSubscribedTopicNames(List.of(fooTopicName))
+                    .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1)), 10))
+                    .setClassicMemberMetadata(
+                        new ConsumerGroupMemberMetadataValue.ClassicMemberMetadata()
+                            .setSessionTimeoutMs(500)
+                            .setSupportedProtocols(ConsumerGroupMember.classicProtocolListFromJoinRequestProtocolCollection(
+                                GroupMetadataManagerTestContext.toProtocols("range"))))
+                    .build())
+                .withAssignment(memberId, mkAssignment(mkTopicAssignment(fooTopicId, 0, 1)))
+                .withAssignmentEpoch(10)
+                .withMetadataHash(computeGroupHash(Map.of(
+                    fooTopicName, computeTopicHash(fooTopicName, metadataImage)))))
+            .build();
+        context.groupMetadataManager.consumerGroup(groupId).setMetadataRefreshDeadline(Long.MAX_VALUE, 10);
+
+        JoinGroupRequestData request = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId(groupId)
+            .withMemberId(memberId)
+            .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
+            .build();
+
+        GroupMetadataManagerTestContext.JoinResult joinResult = context.sendClassicGroupJoin(request);
+        joinResult.appendFuture.complete(null);
+        assertTrue(joinResult.joinFuture.isDone());
+        assertEquals(memberId, joinResult.joinFuture.get().memberId());
+        assertEquals(Errors.NONE.code(), joinResult.joinFuture.get().errorCode());
+    }
+
     @Test
     public void testJoiningConsumerGroupWithNewDynamicMember() throws Exception {
         String groupId = "group-id";

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -14217,7 +14217,7 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
-    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled() throws Exception {
+    public void testRejoiningClassicMemberIsAllowedWhenMigrationDisabled() {
         String groupId = "group-id";
         Uuid fooTopicId = Uuid.randomUuid();
         String fooTopicName = "foo";
@@ -14260,11 +14260,8 @@ public class GroupMetadataManagerTest {
             .withProtocols(GroupMetadataManagerTestContext.toProtocols("range"))
             .build();
 
-        GroupMetadataManagerTestContext.JoinResult joinResult = context.sendClassicGroupJoin(request);
-        joinResult.appendFuture.complete(null);
-        assertTrue(joinResult.joinFuture.isDone());
-        assertEquals(memberId, joinResult.joinFuture.get().memberId());
-        assertEquals(Errors.NONE.code(), joinResult.joinFuture.get().errorCode());
+        // The existing classic member is allowed to rejoin even though migration is disabled
+        assertDoesNotThrow(() -> context.sendClassicGroupJoin(request));
     }
 
     @Test


### PR DESCRIPTION
When group.consumer.migration.policy=disabled, a new classic-protocol
member is still admitted into an existing consumer group. Because the
policy permits neither an online upgrade nor an online downgrade, the
group can never converge back to a single protocol — it stays
permanently mixed.

This is inconsistent with the other direction. With disabled, a new
consumer-protocol member joining a classic group is refused, because the
upgrade it would require is turned off. A new classic member joining a
consumer group should be refused for the same reason: the downgrade it
would imply is also turned off. Under disabled the intent is that no
migration happens and groups stay single-protocol, so a new classic
member joining a consumer group should be rejected, mirroring the
consumer-into-classic case that is already rejected today.

This applies to disabled only. Under upgrade, classic members already in
the group during an in-progress upgrade must still be able to rejoin
after a transient fence, and under downgrade, new classic members are
the mechanism of the downgrade rollout, so neither policy should reject
them.

This patch rejects the new or any rejoining classic member if it tries
to join a consumer  group when the policy is disabled.

Reviewers: David Jacot <david.jacot@gmail.com>
