### PR TITLE
KAFKA-20033: make the __remote_log_metadata topic compact

### DIFF
--- a/bin/kafka-remote-log-metadata-migration.sh
+++ b/bin/kafka-remote-log-metadata-migration.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.RemoteLogMetadataMigrationTool "$@"

--- a/docs/operations/remote-log-metadata-topic-compaction.md
+++ b/docs/operations/remote-log-metadata-topic-compaction.md
@@ -1,0 +1,154 @@
+# Remote Log Metadata Topic Compaction Feature
+
+## Overview
+
+This feature enables safe compaction of the `__remote_log_metadata` topic through a three-version upgrade path controlled by `remote.log.metadata.version`.
+
+**Note**: The upgrade path is only required for **existing clusters** that already have the `__remote_log_metadata` topic. New clusters automatically use version 2.
+
+## Message Format
+
+### Old Format (Version 0)
+- Key: `null`
+- Value: Serialized `RemoteLogMetadata`
+- Cannot be compacted (null keys are deleted during compaction)
+
+### New Format (Version 1+)
+- Key: `topicId:topicName:partition:endOffset:brokerLeaderEpoch` or `topicId:topicName:partition:endOffset:brokerLeaderEpoch:UPDATE`
+- Value: Serialized `RemoteLogMetadata`
+- Base record key: `topicId:topicName:partition:endOffset:brokerLeaderEpoch`
+- Update record key: `topicId:topicName:partition:endOffset:brokerLeaderEpoch:UPDATE`
+
+## Upgrade Path
+
+### Why Three Versions?
+
+Kafka's log cleaner immediately deletes null-key messages during compaction. Existing clusters may have millions of null-key messages in `__remote_log_metadata`. Direct upgrade to compact-only policy would cause immediate data loss.
+
+The three-version approach:
+1. **Version 0**: Current state (delete-only, may contain null-key messages)
+2. **Version 1**: Transition state (compact+delete, allows null-key messages to expire via retention while preventing compaction)
+3. **Version 2**: Final state (compact-only, all messages have keys)
+
+### Version 0 (Default)
+- Topic: `cleanup.policy=delete` or not yet created
+- Messages: May have null keys
+- Behavior: No compaction, messages expire via retention
+
+### Version 1 (Transition)
+- Topic: `cleanup.policy=compact,delete`
+- Configuration:
+  - `retention.ms`: User-specified, it's recommended to set to be longer than the maximum retention time across all topics that have remote storage enabled
+  - `min.compaction.lag.ms`: Same as retention.ms
+- Messages: New messages have keys, old messages expire via retention
+- Purpose: Allow null-key messages to expire via retention BEFORE log cleaner begins compacting
+
+### Version 2 (Final)
+- Topic: `cleanup.policy=compact`
+- Configuration: Uses broker defaults (retention.ms and min.compaction.lag.ms overrides removed)
+- Messages: All messages have keys, retained indefinitely via compaction
+
+## Cluster Scenarios
+
+### Scenario 1: New Cluster (Fresh Install)
+```bash
+kafka-storage.sh format -t <cluster-id> -c server.properties
+kafka-server-start.sh server.properties
+```
+- `remote.log.metadata.version` automatically set to 2 (LATEST_PRODUCTION)
+- Topic created with `cleanup.policy=compact`
+- All messages have keys from the start
+- **No migration required**
+
+### Scenario 2: Existing Cluster with Tiered Storage Already Enabled
+Cluster already has `__remote_log_metadata` topic with potential null-key messages.
+
+**Upgrade Path** (0 → 1 → 2):
+
+**Step 1: Upgrade to Version 1**
+```bash
+kafka-remote-log-metadata-migration.sh \
+  --bootstrap-server localhost:9092 \
+  --upgrade-to-v1 \
+  --retention-ms 1209600000  # 14 days
+```
+Result:
+- Topic config: `cleanup.policy=compact,delete`, `retention.ms=1209600000`, `min.compaction.lag.ms=1209600000`
+- Feature: `remote.log.metadata.version=1`
+- New messages have keys, old null-key messages will expire via retention
+
+**Step 2: Wait for Retention Period**
+- Wait at least 14 days (or your specified retention period)
+- Allows all null-key messages to expire naturally
+- Log cleaner won't compact yet (blocked by min.compaction.lag.ms)
+
+**Step 3: Validate and Upgrade to Version 2**
+```bash
+kafka-remote-log-metadata-migration.sh \
+  --bootstrap-server localhost:9092 \
+  --check \
+  --upgrade-to-v2
+```
+Result:
+- Tool displays retention reminder and checks if enough time has passed
+- Scans topic for null-key messages
+- Records last null-key message timestamp and suggests retry time if validation fails
+- If validation passes:
+  - Feature: `remote.log.metadata.version=2`
+  - Topic config: `cleanup.policy=compact` (min.compaction.lag.ms and retention.ms overrides removed)
+
+**Force Upgrade (Not Recommended)**:
+```bash
+kafka-remote-log-metadata-migration.sh \
+  --bootstrap-server localhost:9092 \
+  --check \
+  --upgrade-to-v2 \
+  --force
+```
+Use `--force` to upgrade even if null-key messages exist. **Warning**: Null-key messages will be lost during compaction,
+this might lead to data loss.
+
+### Scenario 3: Existing Cluster Enabling Tiered Storage for First Time
+```bash
+# Edit server.properties to enable the remote storage
+remote.log.storage.system.enable=true
+
+# Restart broker to run the remote storage functionality and topic will be created with compact cleanup policy
+kafka-server-start.sh server.properties
+
+# Manually upgrade feature
+kafka-features.sh upgrade --feature remote.log.metadata.version=2
+```
+- Feature version starts at 0 (not automatically upgraded)
+- Topic will be created with correct configurations on first use
+- The feature value needs to be upgraded to 2 manually while no change will be applied to the topic.
+
+
+## Migration Tool
+
+### Commands
+
+**Upgrade to Version 1**:
+```bash
+kafka-remote-log-metadata-migration.sh \
+  --bootstrap-server localhost:9092 \
+  --upgrade-to-v1 \
+  --retention-ms 1209600000
+```
+
+**Validate and Upgrade to Version 2**:
+```bash
+kafka-remote-log-metadata-migration.sh \
+  --bootstrap-server localhost:9092 \
+  --check \
+  --upgrade-to-v2
+```
+
+### Safety Features
+- Validates current version before upgrade
+- Scans entire topic for null-key messages
+- Records last null-key message timestamp
+- Calculates message age and suggests retry time
+- Displays retention period reminder before validation
+- Only upgrades if no null-key messages found (unless `--force` is used)
+- `--force` flag available to bypass validation (use with caution)

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -64,6 +64,7 @@ import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION
 import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
 import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
 import static org.apache.kafka.controller.QuorumController.MAX_RECORDS_PER_USER_OP;
+import static org.apache.kafka.server.common.RemoteLogMetadataVersion.REMOTE_LOG_METADATA_TOPIC_NAME;
 import static org.apache.kafka.server.config.ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG;
 
 
@@ -756,17 +757,36 @@ public class ConfigurationControlManager {
         int currentClaimEpoch
     ) {
         ControllerResult<ApiError> result = featureControl.updateFeatures(updates, upgradeTypes, validateOnly, currentClaimEpoch);
-        if (result.response().isSuccess() &&
-            !validateOnly &&
-            updates.getOrDefault(EligibleLeaderReplicasVersion.FEATURE_NAME, (short) 0) > 0
-        ) {
-            List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
-            String logMessage = maybeGenerateElrSafetyRecords(records);
-            if (!logMessage.isEmpty()) {
-                log.info("{}", logMessage);
+        if (result.response().isSuccess() && !validateOnly) {
+            List<ApiMessageAndVersion> additionalRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+
+            // Handle ELR safety records for EligibleLeaderReplicasVersion
+            if (updates.getOrDefault(EligibleLeaderReplicasVersion.FEATURE_NAME, (short) 0) > 0) {
+                String logMessage = maybeGenerateElrSafetyRecords(additionalRecords);
+                if (!logMessage.isEmpty()) {
+                    log.info("{}", logMessage);
+                }
+                additionalRecords.addAll(result.records());
+                return ControllerResult.atomicOf(additionalRecords, ApiError.NONE);
             }
-            records.addAll(result.records());
-            return ControllerResult.atomicOf(records, ApiError.NONE);
+
+            // Handle remote log metadata topic compaction for RemoteLogMetadataVersion
+            short remoteLogMetadataVersion = updates.getOrDefault(org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME, (short) 0);
+
+            if (remoteLogMetadataVersion >= 2) {
+                // Upgrading to version 2: change to compact-only and remove overrides
+                // Note: Users should run RemoteLogMetadataMigrationTool --check before upgrading
+                logValidationReminder();
+                additionalRecords.addAll(maybeGenerateRemoteLogMetadataTopicV2ConfigRecords());
+            } else if (remoteLogMetadataVersion >= 1) {
+                // Upgrading to version 1: enable compaction
+                additionalRecords.addAll(maybeGenerateRemoteLogMetadataTopicV1ConfigRecords());
+            }
+
+            if (!additionalRecords.isEmpty()) {
+                additionalRecords.addAll(result.records());
+                return ControllerResult.atomicOf(additionalRecords, ApiError.NONE);
+            }
         }
         return result;
     }
@@ -808,5 +828,156 @@ public class ConfigurationControlManager {
     // Visible to test
     TimelineHashSet<Integer> brokersWithConfigs() {
         return brokersWithConfigs;
+    }
+
+    /**
+     * Generates ConfigRecords to update the __remote_log_metadata topic to use compaction and deletion
+     * cleanup policy.
+     * This is called when the remote.log.metadata.version feature is being upgraded to level 1 or higher.
+     *
+     * Note: retention.ms and min.compaction.lag.ms are configured by the migration script,
+     * not by this method. This method only updates the cleanup.policy to enable compaction.
+     *
+     * @return List of ConfigRecords if updates are needed, empty list otherwise
+     */
+    List<ApiMessageAndVersion> maybeGenerateRemoteLogMetadataTopicV1ConfigRecords() {
+        String topicName = REMOTE_LOG_METADATA_TOPIC_NAME;
+        ConfigResource topicResource = new ConfigResource(Type.TOPIC, topicName);
+
+        // Check if topic configuration exists
+        TimelineHashMap<String, String> configs = configData.get(topicResource);
+        if (configs == null) {
+            log.info("Topic {} does not exist yet. It will be created with appropriate config when needed.", topicName);
+            return List.of();
+        }
+
+        // Check current configuration
+        String currentPolicy = configs.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+
+        // Target configuration for version 1: compact,delete policy
+        // Note: retention.ms, min.compaction.lag.ms, and segment.ms should be set via migration script
+        String targetCleanupPolicy = TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE;
+
+        boolean needsCleanupPolicyUpdate = currentPolicy == null ||
+            !(currentPolicy.contains(TopicConfig.CLEANUP_POLICY_COMPACT) &&
+              currentPolicy.contains(TopicConfig.CLEANUP_POLICY_DELETE));
+
+        if (!needsCleanupPolicyUpdate) {
+            log.info("Topic {} already has correct cleanup.policy configuration: {}",
+                topicName, currentPolicy);
+            return List.of();
+        }
+
+        log.info("Updating topic {} cleanup.policy configuration. Current: '{}', Target: '{}'",
+                 topicName, currentPolicy, targetCleanupPolicy);
+
+        // Create ConfigRecord for cleanup.policy update
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        ConfigRecord cleanupPolicyRecord = new ConfigRecord()
+            .setResourceType(Type.TOPIC.id())
+            .setResourceName(topicName)
+            .setName(TopicConfig.CLEANUP_POLICY_CONFIG)
+            .setValue(targetCleanupPolicy);
+        records.add(new ApiMessageAndVersion(cleanupPolicyRecord, (short) 0));
+
+        return records;
+    }
+
+    /**
+     * Generates ConfigRecords to update the __remote_log_metadata topic configuration for version 2.
+     * This is called when the remote.log.metadata.version feature is being upgraded from level 1 to level 2.
+     *
+     * Version 2 changes:
+     * 1. Changes cleanup.policy to "compact" (removes "delete") - topic becomes compact-only
+     * 2. Sets retention.ms to -1 (infinite retention) - compact-only topics should not delete based on time
+     * 3. Removes min.compaction.lag.ms override - uses broker default for immediate compaction eligibility
+     *
+     * In version 1, the topic used "compact,delete" policy with retention.ms and min.compaction.lag.ms
+     * (configured by migration script) to safely handle the migration from old-format (null-key) messages.
+     * Version 2 transitions to compact-only policy since all messages now have proper keys.
+     *
+     * This should only be called after validating that no null-key messages remain in the topic,
+     * as those messages cannot be compacted and would cause issues in a compact-only topic.
+     *
+     * @return List of ConfigRecords if updates are needed, empty list otherwise
+     */
+    List<ApiMessageAndVersion> maybeGenerateRemoteLogMetadataTopicV2ConfigRecords() {
+        String topicName = REMOTE_LOG_METADATA_TOPIC_NAME;
+        ConfigResource topicResource = new ConfigResource(Type.TOPIC, topicName);
+
+        // Check if topic configuration exists
+        TimelineHashMap<String, String> configs = configData.get(topicResource);
+        if (configs == null) {
+            log.info("Topic {} does not exist yet. It will be created with appropriate config when needed.", topicName);
+            return List.of();
+        }
+
+        // Check current configuration
+        String currentCleanupPolicy = configs.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+        String currentMinCompactionLagMs = configs.get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG);
+        String currentRetentionMs = configs.get(TopicConfig.RETENTION_MS_CONFIG);
+
+        // Target configuration for version 2: compact-only with infinite retention
+        String targetCleanupPolicy = TopicConfig.CLEANUP_POLICY_COMPACT;
+        String targetRetentionMs = String.valueOf(-1L); // -1 means infinite retention
+
+        boolean needsCleanupPolicyUpdate = !targetCleanupPolicy.equals(currentCleanupPolicy);
+        boolean needsRetentionMsUpdate = !targetRetentionMs.equals(currentRetentionMs);
+        boolean needsMinCompactionLagRemoval = currentMinCompactionLagMs != null;
+
+        if (!needsCleanupPolicyUpdate && !needsRetentionMsUpdate && !needsMinCompactionLagRemoval) {
+            log.info("Topic {} already has correct version 2 configuration (cleanup.policy=compact, retention.ms=-1, min.compaction.lag.ms unset).", topicName);
+            return List.of();
+        }
+
+        log.info("Updating topic {} configuration for version 2. Current: cleanup.policy='{}', retention.ms='{}', min.compaction.lag.ms='{}'. " +
+                 "Target: cleanup.policy='{}', retention.ms='{}', min.compaction.lag.ms unset",
+                 topicName, currentCleanupPolicy, currentRetentionMs, currentMinCompactionLagMs,
+                 targetCleanupPolicy, targetRetentionMs);
+
+        // Create ConfigRecords for the updates needed
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+
+        if (needsCleanupPolicyUpdate) {
+            ConfigRecord cleanupPolicyRecord = new ConfigRecord()
+                .setResourceType(Type.TOPIC.id())
+                .setResourceName(topicName)
+                .setName(TopicConfig.CLEANUP_POLICY_CONFIG)
+                .setValue(targetCleanupPolicy);
+            records.add(new ApiMessageAndVersion(cleanupPolicyRecord, (short) 0));
+        }
+
+        if (needsRetentionMsUpdate) {
+            ConfigRecord retentionMsRecord = new ConfigRecord()
+                .setResourceType(Type.TOPIC.id())
+                .setResourceName(topicName)
+                .setName(TopicConfig.RETENTION_MS_CONFIG)
+                .setValue(targetRetentionMs);
+            records.add(new ApiMessageAndVersion(retentionMsRecord, (short) 0));
+        }
+
+        if (needsMinCompactionLagRemoval) {
+            // Setting value to null removes the config override, uses broker default
+            ConfigRecord minCompactionLagRecord = new ConfigRecord()
+                .setResourceType(Type.TOPIC.id())
+                .setResourceName(topicName)
+                .setName(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG)
+                .setValue(null);
+            records.add(new ApiMessageAndVersion(minCompactionLagRecord, (short) 0));
+        }
+
+        return records;
+    }
+
+    /**
+     * Logs a reminder to validate the __remote_log_metadata topic before upgrading to version 2.
+     *
+     * Note: Actual validation is enforced by requiring users to pass the --validated flag
+     * when running kafka-features.sh upgrade command. This method just logs informational message.
+     */
+    void logValidationReminder() {
+        log.info("Upgrading to remote.log.metadata.version=2. " +
+                 "Ensure you have run 'kafka-remote-log-metadata-migration.sh --check' " +
+                 "to verify no null-key messages exist in __remote_log_metadata topic.");
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.server.common.Feature;
 import org.apache.kafka.server.common.GroupVersion;
 import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.MetadataVersion;
+import org.apache.kafka.server.common.RemoteLogMetadataVersion;
 import org.apache.kafka.server.common.ShareVersion;
 import org.apache.kafka.server.common.StreamsVersion;
 import org.apache.kafka.server.common.TestFeatureVersion;
@@ -394,6 +395,9 @@ public class FormatterTest {
                 setName(GroupVersion.FEATURE_NAME).
                 setFeatureLevel(GroupVersion.GV_1.featureLevel()), (short) 0));
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(RemoteLogMetadataVersion.FEATURE_NAME).
+                setFeatureLevel(RemoteLogMetadataVersion.RLS_V1.featureLevel()), (short) 0));
+            expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(ShareVersion.FEATURE_NAME).
                 setFeatureLevel(ShareVersion.SV_1.featureLevel()), (short) 0));
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
@@ -419,7 +423,7 @@ public class FormatterTest {
             formatter1.formatter.setFeatureLevel("nonexistent.feature", (short) 1);
             assertEquals("Unsupported feature: nonexistent.feature. Supported features " +
                     "are: eligible.leader.replicas.version, group.version, kraft.version, " +
-                    "share.version, streams.version, test.feature.version, transaction.version",
+                    "remote.log.metadata.version, share.version, streams.version, test.feature.version, transaction.version",
                 assertThrows(FormatterException.class,
                     formatter1.formatter::run).
                         getMessage());

--- a/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/Feature.java
@@ -48,6 +48,7 @@ public enum Feature {
     ELIGIBLE_LEADER_REPLICAS_VERSION(EligibleLeaderReplicasVersion.FEATURE_NAME, EligibleLeaderReplicasVersion.values(), EligibleLeaderReplicasVersion.LATEST_PRODUCTION),
     SHARE_VERSION(ShareVersion.FEATURE_NAME, ShareVersion.values(), ShareVersion.LATEST_PRODUCTION),
     STREAMS_VERSION(StreamsVersion.FEATURE_NAME, StreamsVersion.values(), StreamsVersion.LATEST_PRODUCTION),
+    REMOTE_LOG_METADATA_VERSION(RemoteLogMetadataVersion.FEATURE_NAME, RemoteLogMetadataVersion.values(), RemoteLogMetadataVersion.LATEST_PRODUCTION),
 
     /**
      * Features defined only for unit tests and are not used in production.

--- a/server-common/src/main/java/org/apache/kafka/server/common/RemoteLogMetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/RemoteLogMetadataVersion.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.common;
+
+import java.util.Map;
+
+/**
+ * Remote log metadata feature version controls the cleanup policy for the __remote_log_metadata topic.
+ *
+ * <p>Note: Starting from the version that introduces keys (when this feature is added), all remote log
+ * metadata messages are produced with keys regardless of the feature level. The feature level only
+ * controls whether the topic uses compaction cleanup policy.</p>
+ *
+ * <ul>
+ *   <li>Version 0: Topic uses delete cleanup policy. New code still writes keys for forward compatibility.</li>
+ *   <li>Version 1: Topic uses compact,delete cleanup policy. Migration script configures retention.ms and min.compaction.lag.ms
+ *       to safely expire old null-key messages while enabling compaction for new keyed messages.</li>
+ *   <li>Version 2: Topic uses compact-only cleanup policy with infinite retention (retention.ms=-1).
+ *       Removes min.compaction.lag.ms override. Requires validation that no null-key messages remain.</li>
+ * </ul>
+ */
+public enum RemoteLogMetadataVersion implements FeatureVersion {
+
+    /**
+     * Version 0: Original implementation.
+     * - Topic uses delete cleanup policy
+     * - Messages are produced with keys (for forward compatibility)
+     * - Compatible with clusters that have not yet enabled compaction
+     */
+    RLS_V0(0, MetadataVersion.IBP_3_5_IV0, Map.of()),
+
+    /**
+     * Version 1: Compaction enabled.
+     * - Controller updates topic to use compact,delete cleanup policy
+     * - Migration script sets retention.ms and min.compaction.lag.ms (should be set to the same as or longer than
+     * the current retention hours of the __remote_log_metadata topic)
+     *   to safely expire old null-key messages while enabling compaction for new keyed messages
+     * - All new messages are produced with keys
+     * - Enables space savings through log compaction while maintaining backward compatibility
+     */
+    RLS_V1(1, MetadataVersion.IBP_4_4_IV0, Map.of()),
+
+    /**
+     * Version 2: Compact-only mode.
+     * - Controller changes cleanup.policy to compact-only (removes "delete")
+     * - Controller sets retention.ms to -1 (infinite retention)
+     * - Controller removes min.compaction.lag.ms override (uses broker default)
+     * - Requires validation that no null-key messages remain before upgrade
+     * - Enables more aggressive compaction for optimal storage efficiency
+     */
+    RLS_V2(2, MetadataVersion.IBP_4_4_IV0, Map.of());
+
+    public static final String FEATURE_NAME = "remote.log.metadata.version";
+    public static final String REMOTE_LOG_METADATA_TOPIC_NAME = "__remote_log_metadata";
+
+    public static final RemoteLogMetadataVersion LATEST_PRODUCTION = RLS_V2;
+
+    private final short featureLevel;
+    private final MetadataVersion bootstrapMetadataVersion;
+    private final Map<String, Short> dependencies;
+
+    RemoteLogMetadataVersion(
+        int featureLevel,
+        MetadataVersion bootstrapMetadataVersion,
+        Map<String, Short> dependencies
+    ) {
+        this.featureLevel = (short) featureLevel;
+        this.bootstrapMetadataVersion = bootstrapMetadataVersion;
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public short featureLevel() {
+        return featureLevel;
+    }
+
+    @Override
+    public String featureName() {
+        return FEATURE_NAME;
+    }
+
+    @Override
+    public MetadataVersion bootstrapMetadataVersion() {
+        return bootstrapMetadataVersion;
+    }
+
+    @Override
+    public Map<String, Short> dependencies() {
+        return dependencies;
+    }
+
+    /**
+     * Converts a feature level to its corresponding enum value.
+     *
+     * @param version the feature level
+     * @return the corresponding RemoteLogMetadataVersion
+     * @throws RuntimeException if the version is unknown
+     */
+    public static RemoteLogMetadataVersion fromFeatureLevel(short version) {
+        switch (version) {
+            case 0:
+                return RLS_V0;
+            case 1:
+                return RLS_V1;
+            case 2:
+                return RLS_V2;
+            default:
+                throw new RuntimeException("Unknown remote log metadata feature level: " + (int) version);
+        }
+    }
+}

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadata.java
@@ -34,9 +34,23 @@ public abstract class RemoteLogMetadata {
      */
     private final long eventTimestampMs;
 
-    protected RemoteLogMetadata(int brokerId, long eventTimestampMs) {
+    /**
+     * The leader epoch of the broker (partition leader epoch) at the time this metadata is being published.
+     * This represents the current leader epoch of the partition, not the leader epochs within a segment.
+     */
+    private final int brokerLeaderEpoch;
+
+    /**
+     * The end offset of the log segment or partition. This is deterministic when the broker decides to
+     * upload/update/delete the segment or partition.
+     */
+    private final long endOffset;
+
+    protected RemoteLogMetadata(int brokerId, long eventTimestampMs, int brokerLeaderEpoch, long endOffset) {
         this.brokerId = brokerId;
         this.eventTimestampMs = eventTimestampMs;
+        this.brokerLeaderEpoch = brokerLeaderEpoch;
+        this.endOffset = endOffset;
     }
 
     /**
@@ -54,7 +68,31 @@ public abstract class RemoteLogMetadata {
     }
 
     /**
+     * @return The current leader epoch of the partition when this metadata is being published.
+     */
+    public int brokerLeaderEpoch() {
+        return brokerLeaderEpoch;
+    }
+
+    /**
+     * @return The end offset of the log segment or partition.
+     */
+    public long endOffset() {
+        return endOffset;
+    }
+
+    public String metadataKey() {
+        TopicIdPartition tip = this.topicIdPartition();
+        return tip.topicId() + ":" +
+                tip.topic() + ":" +
+                tip.partition() + ":" +
+                this.endOffset() + ":" +
+                this.brokerLeaderEpoch();
+    }
+
+    /**
      * @return TopicIdPartition for which this event is generated.
      */
     public abstract TopicIdPartition topicIdPartition();
+
 }

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -81,6 +81,27 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
      */
     private final boolean txnIdxEmpty;
 
+
+    //for test only
+    public RemoteLogSegmentMetadata(RemoteLogSegmentId remoteLogSegmentId,
+                                    long startOffset,
+                                    long endOffset,
+                                    long maxTimestampMs,
+                                    int brokerId,
+                                    long eventTimestampMs,
+                                    int segmentSizeInBytes,
+                                    Map<Integer, Long> segmentLeaderEpochs) {
+        this(remoteLogSegmentId,
+                startOffset,
+                endOffset,
+                maxTimestampMs,
+                brokerId,
+                eventTimestampMs, segmentSizeInBytes,
+                Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_STARTED,
+                segmentLeaderEpochs, -1);
+    }
+
     /**
      * Creates an instance with the given metadata of remote log segment.
      * <p>
@@ -107,9 +128,10 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
                                     int segmentSizeInBytes,
                                     Optional<CustomMetadata> customMetadata,
                                     RemoteLogSegmentState state,
-                                    Map<Integer, Long> segmentLeaderEpochs) {
+                                    Map<Integer, Long> segmentLeaderEpochs,
+                                    int brokerLeaderEpoch) {
         this(remoteLogSegmentId, startOffset, endOffset, maxTimestampMs, brokerId, eventTimestampMs, segmentSizeInBytes,
-                customMetadata, state, segmentLeaderEpochs, false);
+                customMetadata, state, segmentLeaderEpochs, false, brokerLeaderEpoch);
     }
 
     /**
@@ -140,8 +162,9 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
                                     Optional<CustomMetadata> customMetadata,
                                     RemoteLogSegmentState state,
                                     Map<Integer, Long> segmentLeaderEpochs,
-                                    boolean txnIdxEmpty) {
-        super(brokerId, eventTimestampMs);
+                                    boolean txnIdxEmpty,
+                                    int brokerLeaderEpoch)  {
+        super(brokerId, eventTimestampMs, brokerLeaderEpoch, endOffset);
         this.remoteLogSegmentId = Objects.requireNonNull(remoteLogSegmentId, "remoteLogSegmentId can not be null");
         this.state = Objects.requireNonNull(state, "state can not be null");
 
@@ -189,7 +212,8 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
                                     int brokerId,
                                     long eventTimestampMs,
                                     int segmentSizeInBytes,
-                                    Map<Integer, Long> segmentLeaderEpochs) {
+                                    Map<Integer, Long> segmentLeaderEpochs,
+                                    int brokerLeaderEpoch) {
         this(remoteLogSegmentId,
                 startOffset,
                 endOffset,
@@ -198,7 +222,8 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
                 eventTimestampMs, segmentSizeInBytes,
                 Optional.empty(),
                 RemoteLogSegmentState.COPY_SEGMENT_STARTED,
-                segmentLeaderEpochs);
+                segmentLeaderEpochs,
+                brokerLeaderEpoch);
     }
 
     /**
@@ -225,9 +250,11 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
                                     long eventTimestampMs,
                                     int segmentSizeInBytes,
                                     Map<Integer, Long> segmentLeaderEpochs,
-                                    boolean txnIdxEmpty) {
+                                    boolean txnIdxEmpty,
+                                    int brokerLeaderEpoch) {
         this(remoteLogSegmentId, startOffset, endOffset, maxTimestampMs, brokerId, eventTimestampMs, segmentSizeInBytes,
-                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, segmentLeaderEpochs, txnIdxEmpty);
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, segmentLeaderEpochs, txnIdxEmpty,
+                brokerLeaderEpoch);
     }
 
     /**
@@ -314,7 +341,8 @@ public class RemoteLogSegmentMetadata extends RemoteLogMetadata {
 
         return new RemoteLogSegmentMetadata(remoteLogSegmentId, startOffset,
                 endOffset, maxTimestampMs, rlsmUpdate.brokerId(), rlsmUpdate.eventTimestampMs(),
-                segmentSizeInBytes, rlsmUpdate.customMetadata(), rlsmUpdate.state(), segmentLeaderEpochs, txnIdxEmpty);
+                segmentSizeInBytes, rlsmUpdate.customMetadata(), rlsmUpdate.state(), segmentLeaderEpochs, txnIdxEmpty,
+                brokerLeaderEpoch());
     }
 
     @Override

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
@@ -54,12 +54,13 @@ public class RemoteLogSegmentMetadataUpdate extends RemoteLogMetadata {
     public RemoteLogSegmentMetadataUpdate(RemoteLogSegmentId remoteLogSegmentId, long eventTimestampMs,
                                           Optional<CustomMetadata> customMetadata,
                                           RemoteLogSegmentState state,
-                                          int brokerId) {
-        super(brokerId, eventTimestampMs);
+                                          int brokerId, int brokerLeaderEpoch, long endOffset) {
+        super(brokerId, eventTimestampMs, brokerLeaderEpoch, endOffset);
         this.remoteLogSegmentId = Objects.requireNonNull(remoteLogSegmentId, "remoteLogSegmentId can not be null");
         this.customMetadata = Objects.requireNonNull(customMetadata, "customMetadata can not be null");
         this.state = Objects.requireNonNull(state, "state can not be null");
     }
+
 
     /**
      * @return Universally unique id of this remote log segment.

--- a/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemotePartitionDeleteMetadata.java
+++ b/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemotePartitionDeleteMetadata.java
@@ -40,8 +40,8 @@ public class RemotePartitionDeleteMetadata extends RemoteLogMetadata {
     public RemotePartitionDeleteMetadata(TopicIdPartition topicIdPartition,
                                          RemotePartitionDeleteState state,
                                          long eventTimestampMs,
-                                         int brokerId) {
-        super(brokerId, eventTimestampMs);
+                                         int brokerId, int brokerLeaderEpoch, long endOffset) {
+        super(brokerId, eventTimestampMs, brokerLeaderEpoch, endOffset);
         this.topicIdPartition = Objects.requireNonNull(topicIdPartition);
         this.state = Objects.requireNonNull(state);
     }

--- a/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataTest.java
+++ b/storage/api/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentMetadataTest.java
@@ -52,16 +52,17 @@ class RemoteLogSegmentMetadataTest {
                 segmentLeaderEpochs);
 
         CustomMetadata customMetadata = new CustomMetadata(new byte[]{0, 1, 2, 3});
+        int brokerLeaderEpoch = 0;
         RemoteLogSegmentMetadataUpdate segmentMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
                 segmentId, timestampFinished, Optional.of(customMetadata), RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                brokerIdFinished);
+                brokerIdFinished, brokerLeaderEpoch, endOffset);
         RemoteLogSegmentMetadata updatedMetadata = segmentMetadata.createWithUpdates(segmentMetadataUpdate);
 
         RemoteLogSegmentMetadata expectedUpdatedMetadata = new RemoteLogSegmentMetadata(
                 segmentId, startOffset, endOffset,
                 maxTimestamp, brokerIdFinished, timestampFinished, segmentSize, Optional.of(customMetadata),
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                segmentLeaderEpochs
+                segmentLeaderEpochs, brokerLeaderEpoch
         );
         assertEquals(expectedUpdatedMetadata, updatedMetadata);
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/TopicPartitionLog.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/TopicPartitionLog.java
@@ -37,4 +37,6 @@ public interface TopicPartitionLog {
      * @return The log of the partition or empty
      */
     Optional<UnifiedLog> unifiedLog();
+
+    int getLeaderEpoch();
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.Time;
@@ -164,6 +165,43 @@ class ConsumerTask implements Runnable, Closeable {
     }
 
     private void processConsumerRecord(ConsumerRecord<byte[], byte[]> record) {
+        // Tombstone messages (value == null) are used for compaction hints.
+        // We need to process them to clean up the endOffsetToSegments index.
+        if (record.value() == null) {
+            log.debug("Processing tombstone message at offset {} partition {}", record.offset(), record.partition());
+            readOffsetsByMetadataPartition.put(record.partition(), record.offset());
+
+            // Parse the tombstone key to extract metadata and trigger cleanup
+            if (record.key() != null) {
+                String key = new String(record.key(), java.nio.charset.StandardCharsets.UTF_8);
+                // Remove the :UPDATE suffix if present
+                final String baseKey = key.endsWith(":UPDATE")
+                        ? key.substring(0, key.length() - ":UPDATE".length())
+                        : key;
+
+                // Parse the 5-part key: {topicId}:{topicName}:{partition}:{endOffset}:{brokerLeaderEpoch}
+                String[] parts = baseKey.split(":", 5);
+                if (parts.length == 5) {
+                    try {
+                        Uuid topicId = Uuid.fromString(parts[0]);
+                        String topicName = parts[1];
+                        int partition = Integer.parseInt(parts[2]);
+                        long endOffset = Long.parseLong(parts[3]);
+                        int brokerLeaderEpoch = Integer.parseInt(parts[4]);
+
+                        // Trigger the tombstone event handler to clean up the index
+                        remotePartitionMetadataEventHandler.handleTombstoneEvent(
+                                topicId, topicName, partition, endOffset, brokerLeaderEpoch);
+                    } catch (Exception e) {
+                        log.warn("Failed to parse tombstone key: {}", key, e);
+                    }
+                } else {
+                    log.warn("Skipping tombstone with unexpected key format: {}", key);
+                }
+            }
+            return;
+        }
+
         final RemoteLogMetadata remoteLogMetadata = serde.deserialize(record.value());
         if (shouldProcess(remoteLogMetadata, record.offset())) {
             remotePartitionMetadataEventHandler.handleRemoteLogMetadata(remoteLogMetadata);
@@ -372,7 +410,6 @@ class ConsumerTask implements Runnable, Closeable {
                     .stream()
                     .collect(Collectors.toMap(Map.Entry::getKey,
                         e -> new StartAndEndOffsetHolder(startOffsets.get(e.getKey()), e.getValue())));
-
             }
             hasLastOffsetsFetchFailed = false;
         } catch (final RetriableException ex) {

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ProducerManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ProducerManager.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX;
 
 /**
  * This class is responsible for publishing messages into the remote log metadata topic partitions.
@@ -41,9 +44,10 @@ public class ProducerManager implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(ProducerManager.class);
 
     private final RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
-    private final KafkaProducer<byte[], byte[]> producer;
+    private final KafkaProducer<String, byte[]> producer;
     private final RemoteLogMetadataTopicPartitioner topicPartitioner;
     private final TopicBasedRemoteLogMetadataManagerConfig rlmmConfig;
+
 
     public ProducerManager(TopicBasedRemoteLogMetadataManagerConfig rlmmConfig,
                            RemoteLogMetadataTopicPartitioner rlmmTopicPartitioner) {
@@ -63,12 +67,12 @@ public class ProducerManager implements Closeable {
         CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
 
         TopicIdPartition topicIdPartition = remoteLogMetadata.topicIdPartition();
-        int metadataPartitionNum = topicPartitioner.metadataPartition(topicIdPartition);
+        int metadataPartitionNumber = topicPartitioner.metadataPartition(topicIdPartition);
         log.debug("Publishing metadata message of partition:[{}] into metadata topic partition:[{}] with payload: [{}]",
-                  topicIdPartition, metadataPartitionNum, remoteLogMetadata);
-        if (metadataPartitionNum >= rlmmConfig.metadataTopicPartitionsCount()) {
+                  topicIdPartition, metadataPartitionNumber, remoteLogMetadata);
+        if (metadataPartitionNumber >= rlmmConfig.metadataTopicPartitionsCount()) {
             // This should never occur as long as metadata partitions always remain the same.
-            throw new KafkaException("Chosen partition no " + metadataPartitionNum +
+            throw new KafkaException("Chosen partition no " + metadataPartitionNumber +
                                              " must be less than the partition count: " + rlmmConfig.metadataTopicPartitionsCount());
         }
 
@@ -80,11 +84,56 @@ public class ProducerManager implements Closeable {
                     future.complete(metadata);
                 }
             };
-            producer.send(new ProducerRecord<>(rlmmConfig.remoteLogMetadataTopicName(), metadataPartitionNum, null,
-                                               serde.serialize(remoteLogMetadata)), callback);
+            if (remoteLogMetadata instanceof RemoteLogSegmentMetadata) {
+                producer.send(new ProducerRecord<>(rlmmConfig.remoteLogMetadataTopicName(), metadataPartitionNumber,
+                        remoteLogMetadata.metadataKey(), serde.serialize(remoteLogMetadata)), callback);
+            } else {
+                producer.send(new ProducerRecord<>(rlmmConfig.remoteLogMetadataTopicName(), metadataPartitionNumber,
+                        remoteLogMetadata.metadataKey() + REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX,
+                        serde.serialize(remoteLogMetadata)), callback);
+            }
+
         } catch (Exception ex) {
             future.completeExceptionally(ex);
         }
+
+        return future;
+    }
+
+    /**
+     * Publishes a tombstone (null value) for the given metadata key.
+     * This is used to delete records from the compacted metadata topic.
+     *
+     * @param topicIdPartition the topic partition
+     * @param metadataKey the key to tombstone
+     * @return a CompletableFuture containing the record metadata
+     */
+    public CompletableFuture<RecordMetadata> publishTombstone(
+            TopicIdPartition topicIdPartition,
+            String metadataKey) {
+
+        log.debug("Publishing tombstone for key: {} to topic: {} partition: {}",
+                metadataKey, topicIdPartition.topic(), topicIdPartition.partition());
+
+        CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+        int metadataPartitionNumber = topicPartitioner.metadataPartition(topicIdPartition);
+
+        // Send tombstone (null value) to the topic
+        producer.send(
+                new ProducerRecord<>(
+                        rlmmConfig.remoteLogMetadataTopicName(),
+                        metadataPartitionNumber,
+                        metadataKey,
+                        null
+                ),
+                (metadata, exception) -> {
+                    if (exception != null) {
+                        future.completeExceptionally(exception);
+                    } else {
+                        future.complete(metadata);
+                    }
+                }
+        );
 
         return future;
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
@@ -25,14 +25,18 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -107,6 +111,10 @@ public class RemoteLogMetadataCache {
     // https://issues.apache.org/jira/browse/KAFKA-12641
     protected final ConcurrentMap<Integer, RemoteLogLeaderEpochState> leaderEpochEntries = new ConcurrentHashMap<>();
 
+    // a map from the endoffset to the RemoteLogSegmentKey
+    private final ConcurrentSkipListMap<Long, ConcurrentMap<Integer, Set<String>>> endOffsetToSegments
+            = new ConcurrentSkipListMap<>();
+
     private final CountDownLatch initializedLatch = new CountDownLatch(1);
 
     void markInitialized() {
@@ -154,6 +162,56 @@ public class RemoteLogMetadataCache {
             }
         }
         return txnIdxEmpty ? Optional.empty() : metadataOpt;
+    }
+
+    /**
+     * Returns all segments with the given end offset and broker leader epoch less than or equal to the specified epoch.
+     * This is used to find all metadata records that need to be tombstoned when deleting a segment.
+     *
+     * <p>When using a compacted metadata topic with keys like "topicId:partition:endOffset:brokerLeaderEpoch",
+     * we need to tombstone all historical entries for the same endOffset that have a lower or equal broker leader epoch.
+     * This ensures that after compaction, only the tombstone markers remain for deleted segments.</p>
+     *
+     * @param endOffset the end offset to match
+     * @param maxBrokerLeaderEpoch the maximum broker leader epoch to include (inclusive)
+     * @return iterator of all segments matching the criteria, sorted by broker leader epoch (ascending)
+     */
+    public List<String> listRemoteLogSegmentKeysByEndOffset(long endOffset, int maxBrokerLeaderEpoch) {
+        List<String> matchingSegments = new ArrayList<>();
+
+
+        // iterate over lower entries
+        endOffsetToSegments.headMap(endOffset, true).forEach((offset, epochMap) -> {
+            epochMap.forEach((brokerLeaderEpoch, segmentKeys) -> {
+                // only include entries where brokerLeaderEpoch <= maxBrokerLeaderEpoch
+                if (brokerLeaderEpoch <= maxBrokerLeaderEpoch) {
+                    matchingSegments.addAll(segmentKeys);
+                }
+            });
+        });
+        return matchingSegments;
+    }
+
+    /**
+     * Removes a metadata key from the endOffsetToSegments index.
+     * If the brokerLeaderEpoch set becomes empty after removal, it is also removed.
+     * If the endOffset map becomes empty after removal, it is also removed.
+     *
+     * @param endOffset the end offset
+     * @param brokerLeaderEpoch the broker leader epoch
+     * @param metadataKey the metadata key to remove from the index
+     */
+    public void removeFromEndOffsetIndex(long endOffset, int brokerLeaderEpoch, String metadataKey) {
+        ConcurrentMap<Integer, Set<String>> epochMap = endOffsetToSegments.get(endOffset);
+        if (epochMap != null) {
+            Set<String> keySet = epochMap.get(brokerLeaderEpoch);
+            if (keySet != null) {
+                keySet.remove(metadataKey);
+                // Clean up empty collections
+                epochMap.computeIfPresent(brokerLeaderEpoch, (k, v) -> v.isEmpty() ? null : v);
+                endOffsetToSegments.computeIfPresent(endOffset, (k, v) -> v.isEmpty() ? null : v);
+            }
+        }
     }
 
     private RemoteLogSegmentMetadata getSegmentMetadata(int leaderEpoch, long offset) {
@@ -338,6 +396,20 @@ public class RemoteLogMetadataCache {
             leaderEpochEntries.computeIfAbsent(epoch, leaderEpoch -> new RemoteLogLeaderEpochState())
                     .handleSegmentWithCopySegmentStartedState(remoteLogSegmentId);
         }
+
+        long endOffset = remoteLogSegmentMetadata.endOffset();
+        int brokerLeaderEpoch = remoteLogSegmentMetadata.brokerLeaderEpoch();
+
+        // Only add to endOffsetToSegments index if brokerLeaderEpoch is valid (not -1)
+        // Old version messages have brokerLeaderEpoch=-1 and null keys, which should not be indexed
+        if (brokerLeaderEpoch != -1) {
+            ConcurrentMap<Integer, Set<String>> epochMap =
+                    endOffsetToSegments.computeIfAbsent(endOffset, k -> new ConcurrentHashMap<>());
+
+            epochMap.computeIfAbsent(brokerLeaderEpoch, k -> ConcurrentHashMap.newKeySet())
+                    .add(remoteLogSegmentMetadata.metadataKey());
+        }
+
         idToSegmentMetadata.put(remoteLogSegmentId, remoteLogSegmentMetadata);
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentMetadataSnapshot.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentMetadataSnapshot.java
@@ -99,6 +99,38 @@ public class RemoteLogSegmentMetadataSnapshot extends RemoteLogMetadata {
      * @param customMetadata      Custom metadata.
      * @param state               State of the respective segment of remoteLogSegmentId.
      * @param segmentLeaderEpochs leader epochs occurred within this segment.
+     */
+    public RemoteLogSegmentMetadataSnapshot(Uuid segmentId,
+                                            long startOffset,
+                                            long endOffset,
+                                            long maxTimestampMs,
+                                            int brokerId,
+                                            long eventTimestampMs,
+                                            int segmentSizeInBytes,
+                                            Optional<CustomMetadata> customMetadata,
+                                            RemoteLogSegmentState state,
+                                            Map<Integer, Long> segmentLeaderEpochs,
+                                            int brokerLeaderEpoch) {
+        this(segmentId, startOffset, endOffset, maxTimestampMs, brokerId, eventTimestampMs, segmentSizeInBytes,
+                customMetadata, state, segmentLeaderEpochs, false, brokerLeaderEpoch);
+    }
+
+    /**
+     * Creates an instance with the given metadata of remote log segment.
+     * <p>
+     * {@code segmentLeaderEpochs} can not be empty. If all the records in this segment belong to the same leader epoch
+     * then it should have an entry with epoch mapping to start-offset of this segment.
+     *
+     * @param segmentId           Universally unique remote log segment id.
+     * @param startOffset         Start offset of this segment (inclusive).
+     * @param endOffset           End offset of this segment (inclusive).
+     * @param maxTimestampMs      Maximum timestamp in milliseconds in this segment.
+     * @param brokerId            Broker id from which this event is generated.
+     * @param eventTimestampMs    Epoch time in milliseconds at which the remote log segment is copied to the remote tier storage.
+     * @param segmentSizeInBytes  Size of this segment in bytes.
+     * @param customMetadata      Custom metadata.
+     * @param state               State of the respective segment of remoteLogSegmentId.
+     * @param segmentLeaderEpochs leader epochs occurred within this segment.
      * @param txnIdxEmpty         true if the transaction index is empty, false otherwise.
      */
     public RemoteLogSegmentMetadataSnapshot(Uuid segmentId,
@@ -111,8 +143,9 @@ public class RemoteLogSegmentMetadataSnapshot extends RemoteLogMetadata {
                                             Optional<CustomMetadata> customMetadata,
                                             RemoteLogSegmentState state,
                                             Map<Integer, Long> segmentLeaderEpochs,
-                                            boolean txnIdxEmpty) {
-        super(brokerId, eventTimestampMs);
+                                            boolean txnIdxEmpty,
+                                            int brokerLeaderEpoch) {
+        super(brokerId, eventTimestampMs, brokerLeaderEpoch, endOffset);
         this.segmentId = Objects.requireNonNull(segmentId, "remoteLogSegmentId can not be null");
         this.state = Objects.requireNonNull(state, "state can not be null");
 
@@ -132,8 +165,9 @@ public class RemoteLogSegmentMetadataSnapshot extends RemoteLogMetadata {
 
     public static RemoteLogSegmentMetadataSnapshot create(RemoteLogSegmentMetadata metadata) {
         return new RemoteLogSegmentMetadataSnapshot(metadata.remoteLogSegmentId().id(), metadata.startOffset(), metadata.endOffset(),
-                                                    metadata.maxTimestampMs(), metadata.brokerId(), metadata.eventTimestampMs(),
-                                                    metadata.segmentSizeInBytes(), metadata.customMetadata(), metadata.state(), metadata.segmentLeaderEpochs(), metadata.isTxnIdxEmpty()
+                metadata.maxTimestampMs(), metadata.brokerId(), metadata.eventTimestampMs(),
+                metadata.segmentSizeInBytes(), metadata.customMetadata(), metadata.state(), metadata.segmentLeaderEpochs(),
+                metadata.isTxnIdxEmpty(), metadata.brokerLeaderEpoch()
         );
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataEventHandler.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataEventHandler.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadataUpdate;
@@ -49,4 +50,16 @@ public abstract class RemotePartitionMetadataEventHandler {
     public abstract boolean isInitialized(TopicIdPartition partition);
 
     public abstract void maybeLoadPartition(TopicIdPartition partition);
+
+    /**
+     * Handle a tombstone event for a remote log segment.
+     * This is called when a tombstone message is consumed from the metadata topic.
+     *
+     * @param topicId the topic UUID
+     * @param topicName the topic name
+     * @param partition the partition number
+     * @param endOffset the end offset of the segment
+     * @param brokerLeaderEpoch the broker leader epoch
+     */
+    public abstract void handleTombstoneEvent(Uuid topicId, String topicName, int partition, long endOffset, int brokerLeaderEpoch);
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
@@ -31,7 +32,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,7 +53,15 @@ public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHa
     private Map<TopicIdPartition, RemoteLogMetadataCache> idToRemoteLogMetadataCache =
             new ConcurrentHashMap<>();
 
-    public RemotePartitionMetadataStore() {
+    public Iterator<String> listRemoteLogSegmentKeysByEndOffset(TopicIdPartition topicIdPartition, long endOffset, int maxLeaderEpoch) {
+        List<String> metadataKeys = new ArrayList<>();
+        try {
+            metadataKeys = getRemoteLogMetadataCache(topicIdPartition).listRemoteLogSegmentKeysByEndOffset(endOffset, maxLeaderEpoch);
+        } catch (RemoteResourceNotFoundException e) {
+            log.error("Failed to list all the keys those are no greater than the endOffset and maxLeadeerEpoch");
+        }
+        return metadataKeys.iterator();
+
     }
 
     @Override
@@ -180,5 +191,22 @@ public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHa
     public boolean isInitialized(TopicIdPartition topicIdPartition) {
         RemoteLogMetadataCache metadataCache = idToRemoteLogMetadataCache.get(topicIdPartition);
         return metadataCache != null && metadataCache.isInitialized();
+    }
+
+    @Override
+    public void handleTombstoneEvent(Uuid topicId, String topicName, int partition, long endOffset, int brokerLeaderEpoch) {
+        // Construct TopicIdPartition from the parsed tombstone key
+        TopicIdPartition topicIdPartition = new TopicIdPartition(topicId, partition, topicName);
+
+        // Try to remove from the endOffsetToSegments index
+        try {
+            String metadataKey = topicId + ":" + topicName + ":" + partition + ":" + endOffset + ":" + brokerLeaderEpoch;
+            getRemoteLogMetadataCache(topicIdPartition).removeFromEndOffsetIndex(endOffset, brokerLeaderEpoch, metadataKey);
+            log.debug("Removed metadata key {} from endOffsetToSegments index for partition {} due to tombstone",
+                      metadataKey, topicIdPartition);
+        } catch (RemoteResourceNotFoundException e) {
+            // Partition not assigned to this broker or cache not initialized, skip
+            log.warn("Skipping tombstone cleanup for partition {}: {}", topicIdPartition, e.getMessage());
+        }
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -61,6 +61,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX;
+
 /**
  * This is the {@link RemoteLogMetadataManager} implementation with storage as an internal topic with name
  * {@link TopicBasedRemoteLogMetadataManagerConfig#REMOTE_LOG_METADATA_TOPIC_NAME}.
@@ -129,8 +131,88 @@ public class TopicBasedRemoteLogMetadataManager implements BrokerReadyCallback, 
                 throw new IllegalArgumentException("Given remoteLogSegmentMetadataUpdate should not have the state as: "
                         + RemoteLogSegmentState.COPY_SEGMENT_STARTED);
             }
+
+            if (metadataUpdate.state() == RemoteLogSegmentState.DELETE_SEGMENT_FINISHED) {
+                return tombstoneSegmentMetadata(metadataUpdate.remoteLogSegmentId().topicIdPartition(), metadataUpdate);
+            }
             return storeRemoteLogMetadata(metadataUpdate);
         });
+    }
+
+    /**
+     * Tombstones segment metadata by publishing DELETE_SEGMENT_FINISHED and sending tombstones for historical records.
+     *
+     * The DELETE_SEGMENT_FINISHED event is critical and must be delivered successfully. However, tombstone messages
+     * are sent on a best-effort basis (fire-and-forget) as they are optimization hints for compaction, not critical
+     * state updates. The segment is considered deleted once DELETE_SEGMENT_FINISHED is published, regardless of
+     * whether tombstones succeed.
+     *
+     * @param topicIdPartition the topic partition
+     * @param segmentMetadataUpdate the DELETE_SEGMENT_FINISHED update
+     * @return CompletableFuture that completes when DELETE_SEGMENT_FINISHED is successfully published
+     */
+    private CompletableFuture<Void> tombstoneSegmentMetadata(TopicIdPartition topicIdPartition, RemoteLogSegmentMetadataUpdate segmentMetadataUpdate)
+            throws RemoteStorageException {
+        Objects.requireNonNull(segmentMetadataUpdate, "segmentMetadataUpdate can not be null");
+
+        lock.readLock().lock();
+        try {
+            ensureInitializedAndNotClosed();
+
+            // 1. Publish DELETE_SEGMENT_FINISHED - this is the critical operation
+            CompletableFuture<Void> deleteFinishedFuture = storeRemoteLogMetadata(segmentMetadataUpdate);
+
+            // 2. Send tombstones on a best-effort basis (fire-and-forget)
+            // These are optimization hints for compaction and don't affect correctness.
+            // Index cleanup will happen when the tombstones are consumed by ConsumerTask.
+            try {
+                Iterator<String> toBeTombstonedKeys = remotePartitionMetadataStore.listRemoteLogSegmentKeysByEndOffset(
+                        topicIdPartition, segmentMetadataUpdate.endOffset(), segmentMetadataUpdate.brokerLeaderEpoch());
+
+                while (toBeTombstonedKeys.hasNext()) {
+                    String metadataKey = toBeTombstonedKeys.next();
+
+                    // Fire-and-forget: send tombstones but don't wait for completion
+                    // First tombstone the update key, then tombstone the metadata key
+                    producerManager.publishTombstone(topicIdPartition, metadataKey + REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX)
+                            .whenComplete((metadata, exception) -> {
+                                if (exception != null) {
+                                    log.warn("Failed to publish tombstone for key: {}{}. This is non-critical and " +
+                                            "will be retried in the future. Error: {}", metadataKey, REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX, exception.getMessage());
+                                } else {
+                                    log.debug("Successfully published tombstone for key: {}{}", metadataKey, REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX);
+
+                                    // After update key tombstone succeeds, tombstone the metadata key
+                                    producerManager.publishTombstone(topicIdPartition, metadataKey)
+                                            .whenComplete((metadata2, exception2) -> {
+                                                if (exception2 != null) {
+                                                    log.warn("Failed to publish tombstone for key: {}. This is non-critical and " +
+                                                            "will be retried in the future. Error: {}", metadataKey, exception2.getMessage());
+                                                } else {
+                                                    log.debug("Successfully published tombstone for key: {}", metadataKey);
+                                                }
+                                            });
+                                }
+                            });
+                }
+            } catch (Exception e) {
+                // Log but don't fail the operation - tombstones are best-effort
+                log.warn("Failed to query or publish tombstones for segment with endOffset: {}. " +
+                        "This is non-critical. Error: {}", segmentMetadataUpdate.endOffset(), e.getMessage());
+            }
+
+            // 3. Return the DELETE_SEGMENT_FINISHED future - operation succeeds when this completes
+            return deleteFinishedFuture;
+
+        } catch (KafkaException e) {
+            if (e instanceof RetriableException) {
+                throw e;
+            } else {
+                throw new RemoteStorageException(e);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
@@ -432,9 +514,16 @@ public class TopicBasedRemoteLogMetadataManager implements BrokerReadyCallback, 
     private NewTopic newRemoteLogMetadataTopic(TopicBasedRemoteLogMetadataManagerConfig rlmmConfig) {
         Map<String, String> topicConfigs = new HashMap<>();
         topicConfigs.put(TopicConfig.RETENTION_MS_CONFIG, Long.toString(rlmmConfig.metadataTopicRetentionMs()));
-        topicConfigs.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
         topicConfigs.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false");
         topicConfigs.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, Short.toString(rlmmConfig.metadataTopicMinIsr()));
+
+        // Always use compaction for new topic creation.
+        // For new clusters, remote.log.metadata.version will be at the latest (V1) by default.
+        // For existing clusters, the topic already exists so this code path is not used.
+        // When existing clusters upgrade the feature to V1, the controller will update the
+        // existing topic's cleanup policy to compact.
+        topicConfigs.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+
         return new NewTopic(rlmmConfig.remoteLogMetadataTopicName(),
                             rlmmConfig.metadataTopicPartitionsCount(),
                             rlmmConfig.metadataTopicReplicationFactor()).configs(topicConfigs);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +60,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_MAX_TIMEOUT_MS = 2 * 60 * 1000L;
     public static final long DEFAULT_REMOTE_LOG_METADATA_INITIALIZATION_RETRY_INTERVAL_MS = 100L;
 
+    public static final String REMOTE_LOG_METADATA_UPDATE_KEY_SUFFIX = ":UPDATE";
     public static final String REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor of remote log metadata topic.";
     public static final String REMOTE_LOG_METADATA_TOPIC_PARTITIONS_DOC = "The number of partitions for remote log metadata topic.";
     public static final String REMOTE_LOG_METADATA_TOPIC_RETENTION_MS_DOC = "Retention of remote log metadata topic in milliseconds. " +
@@ -85,6 +87,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final String LOG_DIR = "log.dir";
 
     private static final String REMOTE_LOG_METADATA_CLIENT_PREFIX = "__remote_log_metadata_client";
+
 
     private static final ConfigDef CONFIG = new ConfigDef();
     static {
@@ -240,8 +243,8 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         props.put(ProducerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "_producer");
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         return Collections.unmodifiableMap(props);
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataSnapshotTransform.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataSnapshotTransform.java
@@ -73,7 +73,8 @@ public class RemoteLogSegmentMetadataSnapshotTransform implements RemoteLogMetad
                                                     customMetadata,
                                                     RemoteLogSegmentState.forId(record.remoteLogSegmentState()),
                                                     segmentLeaderEpochs,
-                                                    record.txnIndexEmpty());
+                                                    record.txnIndexEmpty(),
+                                                    record.brokerLeaderEpoch());
     }
 
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataTransform.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataTransform.java
@@ -44,7 +44,8 @@ public class RemoteLogSegmentMetadataTransform implements RemoteLogMetadataTrans
                 .setSegmentSizeInBytes(segmentMetadata.segmentSizeInBytes())
                 .setSegmentLeaderEpochs(createSegmentLeaderEpochsEntry(segmentMetadata))
                 .setRemoteLogSegmentState(segmentMetadata.state().id())
-                .setTxnIndexEmpty(segmentMetadata.isTxnIdxEmpty());
+                .setTxnIndexEmpty(segmentMetadata.isTxnIdxEmpty())
+                .setBrokerLeaderEpoch(segmentMetadata.brokerLeaderEpoch());
         segmentMetadata.customMetadata().ifPresent(md -> record.setCustomMetadata(md.value()));
 
         return new ApiMessageAndVersion(record, record.highestSupportedVersion());
@@ -83,12 +84,14 @@ public class RemoteLogSegmentMetadataTransform implements RemoteLogMetadataTrans
                 new RemoteLogSegmentMetadata(remoteLogSegmentId, record.startOffset(), record.endOffset(),
                                              record.maxTimestampMs(), record.brokerId(),
                                              record.eventTimestampMs(), record.segmentSizeInBytes(),
-                                             segmentLeaderEpochs, record.txnIndexEmpty());
+                                             segmentLeaderEpochs, record.txnIndexEmpty(), record.brokerLeaderEpoch());
         RemoteLogSegmentMetadataUpdate rlsmUpdate
                 = new RemoteLogSegmentMetadataUpdate(remoteLogSegmentId, record.eventTimestampMs(),
                                                      customMetadata,
                                                      RemoteLogSegmentState.forId(record.remoteLogSegmentState()),
-                                                     record.brokerId());
+                                                     record.brokerId(),
+                                                     record.brokerLeaderEpoch(),
+                                                     record.endOffset());
 
         return remoteLogSegmentMetadata.createWithUpdates(rlsmUpdate);
     }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataUpdateTransform.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataUpdateTransform.java
@@ -48,7 +48,8 @@ public class RemoteLogSegmentMetadataUpdateTransform implements RemoteLogMetadat
 
         Optional<CustomMetadata> customMetadata = Optional.ofNullable(record.customMetadata()).map(CustomMetadata::new);
         return new RemoteLogSegmentMetadataUpdate(new RemoteLogSegmentId(topicIdPartition, entry.id()),
-                record.eventTimestampMs(), customMetadata, RemoteLogSegmentState.forId(record.remoteLogSegmentState()), record.brokerId());
+                record.eventTimestampMs(), customMetadata, RemoteLogSegmentState.forId(record.remoteLogSegmentState()),
+                record.brokerId(), record.brokerLeaderEpoch(), record.endOffset());
     }
 
     private RemoteLogSegmentMetadataUpdateRecord.RemoteLogSegmentIdEntry createRemoteLogSegmentIdEntry(RemoteLogSegmentMetadataUpdate data) {

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemotePartitionDeleteMetadataTransform.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemotePartitionDeleteMetadataTransform.java
@@ -49,6 +49,6 @@ public final class RemotePartitionDeleteMetadataTransform implements RemoteLogMe
 
         return new RemotePartitionDeleteMetadata(topicIdPartition,
                 RemotePartitionDeleteState.forId(record.remotePartitionDeleteState()),
-                record.eventTimestampMs(), record.brokerId());
+                record.eventTimestampMs(), record.brokerId(), record.brokerLeaderEpoch(), record.endOffset());
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -196,6 +196,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     private final Timer remoteReadTimer;
 
     private boolean closed = false;
+    private final ConcurrentMap<TopicIdPartition, Integer> topicIdPartitionToLeaderEpochMap = new ConcurrentHashMap<>();
 
     private volatile DelayedOperationPurgatory<DelayedRemoteListOffsets> delayedRemoteListOffsetsPurgatory;
 
@@ -471,6 +472,10 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         LOGGER.debug("Received leadership changes for leaders: {} and followers: {}", partitionsBecomeLeader, partitionsBecomeFollower);
 
         Map<TopicIdPartition, Boolean> leaderPartitions = filterPartitions(partitionsBecomeLeader)
+                .peek(p -> {
+                    TopicIdPartition tip = new TopicIdPartition(topicIds.get(p.topicPartition().topic()), p.topicPartition());
+                    topicIdPartitionToLeaderEpochMap.put(tip, p.getLeaderEpoch());
+                })
                 .collect(Collectors.toMap(p -> new TopicIdPartition(topicIds.get(p.topicPartition().topic()), p.topicPartition()),
                         p -> p.unifiedLog().isPresent() ? p.unifiedLog().get().config().remoteLogCopyDisable() : false));
 
@@ -546,6 +551,11 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
                     removeRemoteTopicPartitionMetrics(tpId);
 
+                    // Clean up leader epoch mapping after all tasks are cancelled
+                    // This is safe because no background tasks will access this entry anymore
+                    topicIdPartitionToLeaderEpochMap.remove(tpId);
+                    LOGGER.debug("Removed leader epoch mapping for partition: {}", tpId);
+
                     if (stopPartition.deleteRemoteLog) {
                         LOGGER.info("Deleting the remote log segments task for partition: {}", tpId);
                         deleteRemoteLogPartition(tpId);
@@ -577,10 +587,16 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         List<RemoteLogSegmentMetadata> metadataList = new ArrayList<>();
         remoteLogMetadataManagerPlugin.get().listRemoteLogSegments(partition).forEachRemaining(metadataList::add);
 
+        // Get the broker leader epoch once for all segments in this partition
+        // This requires the partition to have been properly initialized via onLeadershipChange
+        int brokerLeaderEpoch = getBrokerLeaderEpochForPublish(partition,
+                "deleteRemoteLogPartition for partition " + partition);
+
         List<RemoteLogSegmentMetadataUpdate> deleteSegmentStartedEvents = metadataList.stream()
                 .map(metadata ->
                         new RemoteLogSegmentMetadataUpdate(metadata.remoteLogSegmentId(), time.milliseconds(),
-                                metadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId))
+                                metadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId,
+                                brokerLeaderEpoch, metadata.endOffset()))
                 .collect(Collectors.toList());
         publishEvents(deleteSegmentStartedEvents).get();
 
@@ -595,7 +611,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         List<RemoteLogSegmentMetadataUpdate> deleteSegmentFinishedEvents = metadataList.stream()
                 .map(metadata ->
                         new RemoteLogSegmentMetadataUpdate(metadata.remoteLogSegmentId(), time.milliseconds(),
-                                metadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId))
+                                metadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId,
+                                brokerLeaderEpoch, metadata.endOffset()))
                 .collect(Collectors.toList());
         publishEvents(deleteSegmentFinishedEvents).get();
     }
@@ -1036,9 +1053,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             epochEntries.forEach(entry -> segmentLeaderEpochs.put(entry.epoch(), entry.startOffset()));
 
             boolean isTxnIdxEmpty = segment.txnIndex().isEmpty();
+            // For copy operations, the partition must be properly initialized as leader via onLeadershipChange
+            int brokerLeaderEpoch = getBrokerLeaderEpochForPublish(topicIdPartition,
+                    "copyLogSegment COPY_SEGMENT_STARTED for segment " + segmentId);
             RemoteLogSegmentMetadata copySegmentStartedRlsm = new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), endOffset,
                     segment.largestTimestamp(), brokerId, time.milliseconds(), segment.log().sizeInBytes(),
-                    segmentLeaderEpochs, isTxnIdxEmpty);
+                    segmentLeaderEpochs, isTxnIdxEmpty, brokerLeaderEpoch);
 
             remoteLogMetadataManagerPlugin.get().addRemoteLogSegmentMetadata(copySegmentStartedRlsm).get();
 
@@ -1066,8 +1086,10 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 throw e;
             }
 
+            // Reuse the same broker leader epoch for the COPY_SEGMENT_FINISHED event
             RemoteLogSegmentMetadataUpdate copySegmentFinishedRlsm = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                    customMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId);
+                    customMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId,
+                    brokerLeaderEpoch, endOffset);
 
             if (customMetadata.isPresent()) {
                 long customMetadataSize = customMetadata.get().value().length;
@@ -1618,18 +1640,57 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
     }
 
+    /**
+     * Get the current broker's leader epoch for the given partition. This method requires that the partition
+     * has been registered in the map via onLeadershipChange. If the partition is not found, it indicates
+     * a programming error where the partition was not properly initialized.
+     *
+     * @param topicIdPartition the partition to look up
+     * @param context additional context for error logging (e.g., segment ID, operation)
+     * @return the broker leader epoch to use for publishing metadata events
+     * @throws IllegalStateException if the partition is not found in the map
+     */
+    private int getBrokerLeaderEpochForPublish(TopicIdPartition topicIdPartition, String context) {
+        Integer currentBrokerLeaderEpoch = topicIdPartitionToLeaderEpochMap.get(topicIdPartition);
+        if (currentBrokerLeaderEpoch == null) {
+            throw new IllegalStateException("Partition " + topicIdPartition + " not found in topicIdPartitionToLeaderEpochMap. " +
+                    "This indicates the partition was not properly initialized via onLeadershipChange. Context: " + context);
+        }
+        return currentBrokerLeaderEpoch;
+    }
+
+    /**
+     * Get the current broker's leader epoch for the given partition based on segment metadata.
+     *
+     * @param topicIdPartition the partition to look up
+     * @param segmentMetadata the segment metadata for error context
+     * @return the broker leader epoch to use for publishing metadata events
+     * @throws IllegalStateException if the partition is not found in the map
+     */
+    private int getBrokerLeaderEpochForPublish(TopicIdPartition topicIdPartition, RemoteLogSegmentMetadata segmentMetadata) {
+        return getBrokerLeaderEpochForPublish(topicIdPartition, "Segment: " + segmentMetadata.remoteLogSegmentId());
+    }
+
+    // Visible for testing
+    void setLeaderEpochForPartition(TopicIdPartition topicIdPartition, int leaderEpoch) {
+        topicIdPartitionToLeaderEpochMap.put(topicIdPartition, leaderEpoch);
+    }
+
     private boolean deleteRemoteLogSegment(
         RemoteLogSegmentMetadata segmentMetadata,
         Predicate<RemoteLogSegmentMetadata> predicate
     ) throws RemoteStorageException, ExecutionException, InterruptedException {
         if (predicate.test(segmentMetadata)) {
             LOGGER.debug("Deleting remote log segment {}", segmentMetadata.remoteLogSegmentId());
-            String topic = segmentMetadata.topicIdPartition().topic();
+            TopicIdPartition topicIdPartition = segmentMetadata.topicIdPartition();
+            String topic = topicIdPartition.topic();
+            int brokerLeaderEpoch = getBrokerLeaderEpochForPublish(topicIdPartition, segmentMetadata);
 
             // Publish delete segment started event.
             remoteLogMetadataManagerPlugin.get().updateRemoteLogSegmentMetadata(
                 new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId)).get();
+                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId,
+                        brokerLeaderEpoch, segmentMetadata.endOffset())).get();
 
             brokerTopicStats.topicStats(topic).remoteDeleteRequestRate().mark();
             brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().mark();
@@ -1648,7 +1709,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             // Publish delete segment finished event.
             remoteLogMetadataManagerPlugin.get().updateRemoteLogSegmentMetadata(
                 new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
-                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId)).get();
+                    segmentMetadata.customMetadata(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId,
+                        brokerLeaderEpoch, segmentMetadata.endOffset())).get();
             LOGGER.debug("Deleted remote log segment {}", segmentMetadata.remoteLogSegmentId());
             return true;
         }

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataRecord.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 0,
   "type": "metadata",
   "name": "RemoteLogSegmentMetadataRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -137,6 +137,15 @@
       "about": "Flag to indicate if the transaction index is empty.",
       "taggedVersions": "0+",
       "tag": 0
+    },
+    {
+      "name": "BrokerLeaderEpoch",
+      "type": "int32",
+      "versions": "1+",
+      "taggedVersions": "1+",
+      "tag": 1,
+      "default": "-1",
+      "about": "The leader epoch of the broker (partition leader epoch) at the time this segment is being uploaded."
     }
   ]
 }

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataSnapshotRecord.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataSnapshotRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 3,
   "type": "metadata",
   "name": "RemoteLogSegmentMetadataSnapshotRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -103,6 +103,15 @@
       "about": "Flag to indicate if the transaction index is empty.",
       "taggedVersions": "0+",
       "tag": 0
+    },
+    {
+      "name": "BrokerLeaderEpoch",
+      "type": "int32",
+      "versions": "1+",
+      "taggedVersions": "1+",
+      "tag": 1,
+      "default": "-1",
+      "about": "The leader epoch of the broker (partition leader epoch) at the time this segment is being uploaded."
     }
   ]
 }

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataUpdateRecord.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataUpdateRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 1,
   "type": "metadata",
   "name": "RemoteLogSegmentMetadataUpdateRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -85,6 +85,24 @@
       "type": "int8",
       "versions": "0+",
       "about": "State identifier of the remote log segment, which is RemoteLogSegmentState.id()."
+    },
+    {
+      "name": "BrokerLeaderEpoch",
+      "type": "int32",
+      "versions": "1+",
+      "default": "-1",
+      "about": "The leader epoch of the broker (partition leader epoch) at the time this update is being published.",
+      "taggedVersions": "1+",
+      "tag": 0
+    },
+    {
+      "name": "EndOffset",
+      "type": "int64",
+      "versions": "1+",
+      "default": "-1",
+      "about": "End offset of the segment being updated.",
+      "taggedVersions": "1+",
+      "tag": 1
     }
   ]
 }

--- a/storage/src/main/resources/message/RemotePartitionDeleteMetadataRecord.json
+++ b/storage/src/main/resources/message/RemotePartitionDeleteMetadataRecord.json
@@ -17,7 +17,7 @@
   "apiKey": 2,
   "type": "metadata",
   "name": "RemotePartitionDeleteMetadataRecord",
-  "validVersions": "0",
+  "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [
     {
@@ -63,6 +63,24 @@
       "type": "int8",
       "versions": "0+",
       "about": "Deletion state identifier of the remote partition, which is RemotePartitionDeleteState.id()."
+    },
+    {
+      "name": "BrokerLeaderEpoch",
+      "type": "int32",
+      "versions": "1+",
+      "default": "-1",
+      "about": "The leader epoch of the broker (partition leader epoch) at the time this update is being published.",
+      "taggedVersions": "1+",
+      "tag": 0
+    },
+    {
+      "name": "EndOffset",
+      "type": "int64",
+      "versions": "1+",
+      "default": "-1",
+      "about": "End offset of the segment being updated.",
+      "taggedVersions": "1+",
+      "tag": 1
     }
   ]
 }

--- a/storage/src/test/java/org/apache/kafka/admin/RemoteTopicCrudTest.java
+++ b/storage/src/test/java/org/apache/kafka/admin/RemoteTopicCrudTest.java
@@ -651,7 +651,8 @@ class RemoteTopicCrudTest {
                     SEGMENT_SIZE,
                     Optional.empty(),
                     RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                    segmentLeaderEpochs
+                    segmentLeaderEpochs,
+                    0
                 );
                 segmentMetadataList.add(metadata);
             }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTaskTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTaskTest.java
@@ -475,5 +475,10 @@ public class ConsumerTaskTest {
         public void maybeLoadPartition(TopicIdPartition partition) {
             isPartitionLoaded.put(partition, true);
         }
+
+        @Override
+        public void handleTombstoneEvent(Uuid topicId, String topicName, int partition, long endOffset, int brokerLeaderEpoch) {
+            // No-op for test
+        }
     }
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCacheTest.java
@@ -63,10 +63,10 @@ public class RemoteLogMetadataCacheTest {
             if (state != RemoteLogSegmentState.COPY_SEGMENT_STARTED) {
                 RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
                 RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, 0, 100L,
-                        -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(0, 0L));
+                        -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(0, 0L), 0);
                 RemoteLogSegmentMetadata updatedMetadata = segmentMetadata.createWithUpdates(
                         new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(), Optional.empty(),
-                                state, brokerId1));
+                                state, brokerId1, 0, 100L));
                 assertThrows(IllegalArgumentException.class, () -> cache.addCopyInProgressSegment(updatedMetadata));
             }
         }
@@ -83,7 +83,7 @@ public class RemoteLogMetadataCacheTest {
             if (state != RemoteLogSegmentState.COPY_SEGMENT_STARTED) {
                 RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
                 RemoteLogSegmentMetadataUpdate updatedMetadata = new RemoteLogSegmentMetadataUpdate(
-                        segmentId, time.milliseconds(), Optional.empty(), state, brokerId1);
+                        segmentId, time.milliseconds(), Optional.empty(), state, brokerId1, 0, 100L);
                 try {
                     cache.updateRemoteLogSegmentMetadata(updatedMetadata);
                     if (isInitialized) {
@@ -105,47 +105,47 @@ public class RemoteLogMetadataCacheTest {
         long offset = 10L;
         RemoteLogSegmentId segmentId = new RemoteLogSegmentId(tpId0, Uuid.randomUuid());
         RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, offset, 100L,
-                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, offset));
+                -1L, brokerId0, time.milliseconds(), segmentSize, Map.of(leaderEpoch, offset), 0);
         cache.addCopyInProgressSegment(segmentMetadata);
 
         // invalid-transition-1. COPY_SEGMENT_STARTED -> DELETE_SEGMENT_FINISHED
         RemoteLogSegmentMetadataUpdate updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_STARTED, leaderEpoch);
 
         // valid-transition-2: COPY_SEGMENT_STARTED -> COPY_SEGMENT_FINISHED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
 
         // invalid-transition-3: COPY_SEGMENT_FINISHED -> DELETE_SEGMENT_FINISHED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
 
         // invalid-transition-4: COPY_SEGMENT_FINISHED -> COPY_SEGMENT_STARTED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpoch);
 
         // valid-transition-5: COPY_SEGMENT_FINISHED -> DELETE_SEGMENT_STARTED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
 
         // invalid-transition-6: DELETE_SEGMENT_STARTED -> COPY_SEGMENT_FINISHED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
 
         // invalid-transition-7: DELETE_SEGMENT_STARTED -> COPY_SEGMENT_STARTED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_STARTED, leaderEpoch);
 
         // valid-transition-8: DELETE_SEGMENT_STARTED -> DELETE_SEGMENT_FINISHED
         updatedMetadata = new RemoteLogSegmentMetadataUpdate(segmentId, time.milliseconds(),
-                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1);
+                Optional.empty(), RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId1, 0, 100L);
         updateAndVerifyCacheContents(updatedMetadata, RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, leaderEpoch);
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataFormatterTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataFormatterTest.java
@@ -53,7 +53,7 @@ public class RemoteLogMetadataFormatterTest {
         Optional<CustomMetadata> customMetadata = Optional.of(new CustomMetadata(new byte[10]));
         RemoteLogSegmentMetadata remoteLogMetadata = new RemoteLogSegmentMetadata(
                 remoteLogSegmentId, 0L, 100L, -1L, 1, 123L, 1024, customMetadata, COPY_SEGMENT_STARTED,
-                segLeaderEpochs, true);
+                segLeaderEpochs, true, 0);
 
         byte[] metadataBytes = new RemoteLogMetadataSerde().serialize(remoteLogMetadata);
         ConsumerRecord<byte[], byte[]> metadataRecord = new ConsumerRecord<>(

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSerdeTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataSerdeTest.java
@@ -70,19 +70,19 @@ public class RemoteLogMetadataSerdeTest {
         segLeaderEpochs.put(1, 20L);
         segLeaderEpochs.put(2, 80L);
         RemoteLogSegmentId remoteLogSegmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
-        return new RemoteLogSegmentMetadata(remoteLogSegmentId, 0L, 100L, -1L, 1, 
+        return new RemoteLogSegmentMetadata(remoteLogSegmentId, 0L, 100L, -1L, 1,
                 time.milliseconds(), 1024, Optional.of(new CustomMetadata(new byte[] {0, 1, 2, 3})),
-                COPY_SEGMENT_STARTED, segLeaderEpochs);
+                COPY_SEGMENT_STARTED, segLeaderEpochs, 0);
     }
 
     private RemoteLogSegmentMetadataUpdate createRemoteLogSegmentMetadataUpdate() {
         RemoteLogSegmentId remoteLogSegmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
         return new RemoteLogSegmentMetadataUpdate(remoteLogSegmentId, time.milliseconds(),
-                Optional.of(new CustomMetadata(new byte[] {0, 1, 2, 3})), COPY_SEGMENT_FINISHED, 2);
+                Optional.of(new CustomMetadata(new byte[] {0, 1, 2, 3})), COPY_SEGMENT_FINISHED, 2, 0, 100L);
     }
 
     private RemotePartitionDeleteMetadata createRemotePartitionDeleteMetadata() {
-        return new RemotePartitionDeleteMetadata(TP0, DELETE_PARTITION_MARKED, time.milliseconds(), 0);
+        return new RemotePartitionDeleteMetadata(TP0, DELETE_PARTITION_MARKED, time.milliseconds(), 0, 0, 0L);
     }
 
     private void doTestRemoteLogMetadataSerde(RemoteLogMetadata remoteLogMetadata) {
@@ -107,7 +107,7 @@ public class RemoteLogMetadataSerdeTest {
 
     private static class InvalidRemoteLogMetadata extends RemoteLogMetadata {
         public InvalidRemoteLogMetadata(int brokerId, long eventTimestampMs) {
-            super(brokerId, eventTimestampMs);
+            super(brokerId, eventTimestampMs, 0, 0L);
         }
 
         @Override

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataTransformTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataTransformTest.java
@@ -58,7 +58,7 @@ public class RemoteLogMetadataTransformTest {
         RemoteLogSegmentMetadataUpdateTransform metadataUpdateTransform = new RemoteLogSegmentMetadataUpdateTransform();
         RemoteLogSegmentMetadataUpdate metadataUpdate = new RemoteLogSegmentMetadataUpdate(
                 new RemoteLogSegmentId(TP0, Uuid.randomUuid()), time.milliseconds(),
-                Optional.of(new CustomMetadata(new byte[]{0, 1, 2, 3})), COPY_SEGMENT_FINISHED, 1);
+                Optional.of(new CustomMetadata(new byte[]{0, 1, 2, 3})), COPY_SEGMENT_FINISHED, 1, 0, 100L);
         ApiMessageAndVersion apiMessageAndVersion = metadataUpdateTransform.toApiMessageAndVersion(metadataUpdate);
         RemoteLogSegmentMetadataUpdate metadataUpdateFromRecord =
                 metadataUpdateTransform.fromApiMessageAndVersion(apiMessageAndVersion);
@@ -68,14 +68,14 @@ public class RemoteLogMetadataTransformTest {
     private RemoteLogSegmentMetadata createRemoteLogSegmentMetadata() {
         RemoteLogSegmentId remoteLogSegmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
         return new RemoteLogSegmentMetadata(remoteLogSegmentId, 0L, 100L, -1L, 1,
-                time.milliseconds(), 1024, Map.of(0, 0L));
+                time.milliseconds(), 1024, Map.of(0, 0L), 0);
     }
 
     @Test
     public void testRemoteLogPartitionMetadataTransform() {
         RemotePartitionDeleteMetadataTransform transform = new RemotePartitionDeleteMetadataTransform();
         RemotePartitionDeleteMetadata partitionDeleteMetadata
-                = new RemotePartitionDeleteMetadata(TP0, DELETE_PARTITION_STARTED, time.milliseconds(), 1);
+                = new RemotePartitionDeleteMetadata(TP0, DELETE_PARTITION_STARTED, time.milliseconds(), 1, 0, 0L);
         ApiMessageAndVersion apiMessageAndVersion = transform.toApiMessageAndVersion(partitionDeleteMetadata);
         RemotePartitionDeleteMetadata partitionDeleteMetadataFromRecord =
                 transform.fromApiMessageAndVersion(apiMessageAndVersion);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -87,7 +87,7 @@ public class RemoteLogSegmentLifecycleTest {
             leaderEpochSegment0.put(2, 80L);
             RemoteLogSegmentId segmentId0 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
             RemoteLogSegmentMetadata metadataSegment0 = new RemoteLogSegmentMetadata(segmentId0, 0L,
-                    100L, -1L, brokerId0, time.milliseconds(), segSize, leaderEpochSegment0);
+                    100L, -1L, brokerId0, time.milliseconds(), segSize, leaderEpochSegment0, 0);
             metadataManager.addRemoteLogSegmentMetadata(metadataSegment0).get();
             verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadata(metadataSegment0);
 
@@ -102,7 +102,7 @@ public class RemoteLogSegmentLifecycleTest {
 
             RemoteLogSegmentMetadataUpdate metadataUpdateSegment0 = new RemoteLogSegmentMetadataUpdate(
                     segmentId0, time.milliseconds(), Optional.empty(),
-                    COPY_SEGMENT_FINISHED, brokerId1);
+                    COPY_SEGMENT_FINISHED, brokerId1, 0, 100L);
             metadataManager.updateRemoteLogSegmentMetadata(metadataUpdateSegment0).get();
             verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadataUpdate(metadataUpdateSegment0);
             metadataSegment0 = metadataSegment0.createWithUpdates(metadataUpdateSegment0);
@@ -172,7 +172,7 @@ public class RemoteLogSegmentLifecycleTest {
             // It should not be available when we search for that segment.
             RemoteLogSegmentMetadataUpdate metadataDeleteStartedSegment0 =
                     new RemoteLogSegmentMetadataUpdate(metadataSegment0.remoteLogSegmentId(), time.milliseconds(),
-                            Optional.empty(), DELETE_SEGMENT_STARTED, brokerId1);
+                            Optional.empty(), DELETE_SEGMENT_STARTED, brokerId1, 0, metadataSegment0.endOffset());
             metadataManager.updateRemoteLogSegmentMetadata(metadataDeleteStartedSegment0).get();
             assertFalse(metadataManager.remoteLogSegmentMetadata(topicIdPartition, 0, 10).isPresent());
 
@@ -180,7 +180,7 @@ public class RemoteLogSegmentLifecycleTest {
             // It should not be available when we search for that segment.
             RemoteLogSegmentMetadataUpdate metadataDeleteFinishedSegment0 =
                     new RemoteLogSegmentMetadataUpdate(metadataSegment0.remoteLogSegmentId(), time.milliseconds(),
-                            Optional.empty(), DELETE_SEGMENT_FINISHED, brokerId1);
+                            Optional.empty(), DELETE_SEGMENT_FINISHED, brokerId1, 0, metadataSegment0.endOffset());
             metadataManager.updateRemoteLogSegmentMetadata(metadataDeleteFinishedSegment0).get();
             assertFalse(metadataManager.remoteLogSegmentMetadata(topicIdPartition, 0, 10).isPresent());
 
@@ -216,12 +216,12 @@ public class RemoteLogSegmentLifecycleTest {
             throws RemoteStorageException, ExecutionException, InterruptedException {
         RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
         RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, startOffset, endOffset,
-                -1L, brokerId0, time.milliseconds(), segSize, segmentLeaderEpochs);
+                -1L, brokerId0, time.milliseconds(), segSize, segmentLeaderEpochs, 0);
         metadataManager.addRemoteLogSegmentMetadata(segmentMetadata).get();
         verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadata(segmentMetadata);
 
         RemoteLogSegmentMetadataUpdate segMetadataUpdate = new RemoteLogSegmentMetadataUpdate(segmentId,
-                time.milliseconds(), Optional.empty(), state, brokerId1);
+                time.milliseconds(), Optional.empty(), state, brokerId1, 0, endOffset);
         metadataManager.updateRemoteLogSegmentMetadata(segMetadataUpdate).get();
         verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadataUpdate(segMetadataUpdate);
         return segmentMetadata.createWithUpdates(segMetadataUpdate);
@@ -251,7 +251,7 @@ public class RemoteLogSegmentLifecycleTest {
             // segments.
             RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
             RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(segmentId, 0L, 50L,
-                    -1L, brokerId0, time.milliseconds(), segSize, Map.of(0, 0L));
+                    -1L, brokerId0, time.milliseconds(), segSize, Map.of(0, 0L), 0);
             metadataManager.addRemoteLogSegmentMetadata(segmentMetadata).get();
             verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadata(segmentMetadata);
 
@@ -315,7 +315,7 @@ public class RemoteLogSegmentLifecycleTest {
 
             RemoteLogSegmentMetadataUpdate segmentMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
                     segmentMetadata.remoteLogSegmentId(), time.milliseconds(), Optional.empty(),
-                    DELETE_SEGMENT_FINISHED, brokerId1);
+                    DELETE_SEGMENT_FINISHED, brokerId1, 0, segmentMetadata.endOffset());
             metadataManager.updateRemoteLogSegmentMetadata(segmentMetadataUpdate).get();
             verify(spyRemotePartitionMetadataStore).handleRemoteLogSegmentMetadataUpdate(segmentMetadataUpdate);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataSnapshotTransformTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataSnapshotTransformTest.java
@@ -44,7 +44,8 @@ class RemoteLogSegmentMetadataSnapshotTransformTest {
                 customMetadata,
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
                 segmentLeaderEpochs,
-                isTxnIdxEmpty
+                isTxnIdxEmpty,
+                0
         );
 
         RemoteLogSegmentMetadataSnapshotTransform transform = new RemoteLogSegmentMetadataSnapshotTransform();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataTransformTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataTransformTest.java
@@ -45,7 +45,8 @@ class RemoteLogSegmentMetadataTransformTest {
                 0L, 100L, -1L, 0, 0, 1234,
                 customMetadata,
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                segmentLeaderEpochs
+                segmentLeaderEpochs,
+                0
         );
 
         RemoteLogSegmentMetadataTransform transform = new RemoteLogSegmentMetadataTransform();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataUpdateTransformTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/serialization/RemoteLogSegmentMetadataUpdateTransformTest.java
@@ -45,7 +45,9 @@ class RemoteLogSegmentMetadataUpdateTransformTest {
                 123L,
                 customMetadata,
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                1
+                1,
+                0,
+                100L
         );
 
         RemoteLogSegmentMetadataUpdateTransform transform = new RemoteLogSegmentMetadataUpdateTransform();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -235,6 +235,16 @@ public class RemoteLogManagerTest {
         config = configs(props);
         brokerTopicStats = new BrokerTopicStats(config.isRemoteStorageSystemEnabled());
 
+        // Configure mockLog with necessary mocks for background tasks
+        when(mockLog.parentDir()).thenReturn("test-dir");
+        when(mockLog.config()).thenReturn(new LogConfig(new Properties()));
+        // Create a minimal LeaderEpochFileCache for mockLog
+        LeaderEpochCheckpointFile defaultCheckpoint = new LeaderEpochCheckpointFile(TestUtils.tempFile(), new LogDirFailureChannel(1));
+        defaultCheckpoint.write(Collections.singletonList(new EpochEntry(0, 0L)));
+        LeaderEpochFileCache defaultCache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), defaultCheckpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(defaultCache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+
         remoteLogManager = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
                 tp -> Optional.of(mockLog),
                 (topicPartition, offset) -> currentLogStartOffset.set(offset),
@@ -550,6 +560,9 @@ public class RemoteLogManagerTest {
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteCopyBytesRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteCopyRequestRate().count());
 
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         task.copyLogSegmentsToRemote(mockLog);
 
@@ -658,6 +671,9 @@ public class RemoteLogManagerTest {
                 .thenReturn(Optional.of(customMetadata));
         when(rlmCopyQuotaManager.getThrottleTimeMs()).thenReturn(quotaAvailableThrottleTime);
 
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, customMetadataSizeLimit);
         task.copyLogSegmentsToRemote(mockLog);
 
@@ -667,7 +683,7 @@ public class RemoteLogManagerTest {
         // Check we attempt to delete the segment data providing the custom metadata back.
         RemoteLogSegmentMetadataUpdate expectedMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
                 remoteLogSegmentMetadataArg.getValue().remoteLogSegmentId(), time.milliseconds(),
-                Optional.of(customMetadata), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId);
+                Optional.of(customMetadata), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId, 0, remoteLogSegmentMetadataArg.getValue().endOffset());
         RemoteLogSegmentMetadata expectedDeleteMetadata = remoteLogSegmentMetadataArg.getValue().createWithUpdates(expectedMetadataUpdate);
         verify(remoteStorageManager, times(1)).deleteLogSegmentData(eq(expectedDeleteMetadata));
 
@@ -751,6 +767,10 @@ public class RemoteLogManagerTest {
         // throw exception when copyLogSegmentData
         when(remoteStorageManager.copyLogSegmentData(any(RemoteLogSegmentMetadata.class), any(LogSegmentData.class)))
                 .thenThrow(new RemoteStorageException("test"));
+
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         task.copyLogSegmentsToRemote(mockLog);
 
@@ -838,6 +858,10 @@ public class RemoteLogManagerTest {
         // throw retriable exception when copyLogSegmentData
         when(remoteStorageManager.copyLogSegmentData(any(RemoteLogSegmentMetadata.class), any(LogSegmentData.class)))
             .thenThrow(new RetriableRemoteStorageException("test-retriable"));
+
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         assertThrows(RetriableRemoteStorageException.class, () -> task.copyLogSegmentsToRemote(mockLog));
 
@@ -1307,6 +1331,10 @@ public class RemoteLogManagerTest {
         // Verify aggregate metrics
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteCopyRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteCopyRequestRate().count());
+
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         task.copyLogSegmentsToRemote(mockLog);
 
@@ -1514,7 +1542,7 @@ public class RemoteLogManagerTest {
                     Map<Integer, Long> leaderEpochs = new TreeMap<>();
                     leaderEpochs.put(leaderEpoch, offset);
                     RemoteLogSegmentMetadata metadata = new RemoteLogSegmentMetadata(segmentId,
-                            offset, offset + 100, time.milliseconds(), 0, time.milliseconds(), 1024, leaderEpochs, true);
+                            offset, offset + 100, time.milliseconds(), 0, time.milliseconds(), 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpochs, 0);
                     return Optional.of(metadata);
                 });
 
@@ -1546,7 +1574,7 @@ public class RemoteLogManagerTest {
                         Map<Integer, Long> leaderEpochs = new TreeMap<>();
                         leaderEpochs.put(leaderEpoch, offset);
                         RemoteLogSegmentMetadata metadata = new RemoteLogSegmentMetadata(segmentId,
-                                offset, offset + 100, time.milliseconds(), 0, time.milliseconds(), 1024, leaderEpochs, true);
+                                offset, offset + 100, time.milliseconds(), 0, time.milliseconds(), 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, leaderEpochs, 0);
                         metadataOpt = Optional.of(metadata);
                     }
                     return metadataOpt;
@@ -1752,12 +1780,12 @@ public class RemoteLogManagerTest {
 
         long timestamp = time.milliseconds();
         RemoteLogSegmentMetadata metadata0 = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(tpId, Uuid.randomUuid()),
-                0, 99, timestamp, brokerId, timestamp, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, truncateAndGetLeaderEpochs(epochEntries, 0L, 99L));
+                0, 99, timestamp, brokerId, timestamp, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, truncateAndGetLeaderEpochs(epochEntries, 0L, 99L), 0);
         RemoteLogSegmentMetadata metadata1 = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(tpId, Uuid.randomUuid()),
-                100, 199, timestamp + 1, brokerId, timestamp + 1, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, truncateAndGetLeaderEpochs(epochEntries, 100L, 199L));
+                100, 199, timestamp + 1, brokerId, timestamp + 1, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_FINISHED, truncateAndGetLeaderEpochs(epochEntries, 100L, 199L), 0);
         // Note that the metadata2 is in COPY_SEGMENT_STARTED state
         RemoteLogSegmentMetadata metadata2 = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(tpId, Uuid.randomUuid()),
-                100, 299, timestamp + 2, brokerId, timestamp + 2, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, truncateAndGetLeaderEpochs(epochEntries, 200L, 299L));
+                100, 299, timestamp + 2, brokerId, timestamp + 2, 1024, Optional.empty(), RemoteLogSegmentState.COPY_SEGMENT_STARTED, truncateAndGetLeaderEpochs(epochEntries, 200L, 299L), 0);
 
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(tpId), anyInt()))
             .thenAnswer(ans -> {
@@ -1904,7 +1932,7 @@ public class RemoteLogManagerTest {
                 100000L,
                 1000,
                 Optional.empty(),
-                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, segmentEpochs);
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, segmentEpochs, 0);
     }
 
     @Test
@@ -2452,6 +2480,10 @@ public class RemoteLogManagerTest {
         when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any()))
                 .thenReturn(dummyFuture);
 
+        // First, make both partitions leaders so they are added to topicIdPartitionToLeaderEpochMap
+        remoteLogManager.onLeadershipChange(Set.of(mockPartition(leaderTopicIdPartition), mockPartition(followerTopicIdPartition)),
+                Set.of(), topicIds);
+        // Then, convert followerTopicIdPartition to follower (but keep its leader epoch in the map)
         remoteLogManager.onLeadershipChange(Set.of(mockPartition(leaderTopicIdPartition)),
                 Set.of(mockPartition(followerTopicIdPartition)), topicIds);
         assertNotNull(remoteLogManager.leaderCopyTask(leaderTopicIdPartition));
@@ -2487,9 +2519,9 @@ public class RemoteLogManagerTest {
         int segmentSize = 1024;
         List<RemoteLogSegmentMetadata> segmentMetadataList = List.of(
                 new RemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
-                        500, 539, timestamp, brokerId, timestamp, segmentSize, truncateAndGetLeaderEpochs(epochEntries, 500L, 539L)),
+                        500, 539, timestamp, brokerId, timestamp, segmentSize, truncateAndGetLeaderEpochs(epochEntries, 500L, 539L), 0),
                 new RemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
-                        540, 700, timestamp, brokerId, timestamp, segmentSize, truncateAndGetLeaderEpochs(epochEntries, 540L, 700L))
+                        540, 700, timestamp, brokerId, timestamp, segmentSize, truncateAndGetLeaderEpochs(epochEntries, 540L, 700L), 0)
                 );
         when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
                 .thenAnswer(invocation -> {
@@ -2706,6 +2738,11 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(logProps);
         when(mockLog.config()).thenReturn(mockLogConfig);
 
+        // Initialize topicIdPartitionToLeaderEpochMap by calling onLeadershipChange
+        TopicPartitionLog mockLeaderPartition = mockPartition(leaderTopicIdPartition);
+        Map<String, Uuid> topicIds = Collections.singletonMap(leaderTopicIdPartition.topic(), leaderTopicIdPartition.topicId());
+        remoteLogManager.onLeadershipChange(Set.of(mockLeaderPartition), Set.of(), topicIds);
+
         RemoteLogManager.RLMCopyTask copyTask = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
         Thread copyThread  = new Thread(() -> {
             try {
@@ -2779,7 +2816,7 @@ public class RemoteLogManagerTest {
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
 
-
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         if (expectDeletion) {
             advanceTimeToMakeSegmentDeletable();
@@ -2830,7 +2867,7 @@ public class RemoteLogManagerTest {
         RemoteLogSegmentMetadata metadata2 = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(leaderTopicIdPartition, Uuid.randomUuid()),
                 metadata1.startOffset(), metadata1.endOffset() + 5, metadata1.maxTimestampMs(),
                 metadata1.brokerId() + 1, metadata1.eventTimestampMs(), metadata1.segmentSizeInBytes() + 128,
-                metadata1.customMetadata(), metadata1.state(), metadata1.segmentLeaderEpochs());
+                metadata1.customMetadata(), metadata1.state(), metadata1.segmentLeaderEpochs(), metadata1.brokerLeaderEpoch());
 
         // When there are overlapping/duplicate segments, the RemoteLogMetadataManager#listRemoteLogSegments
         // returns the segments in order of (valid ++ unreferenced) segments:
@@ -2856,6 +2893,7 @@ public class RemoteLogManagerTest {
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
 
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         advanceTimeToMakeSegmentDeletable();
         task.cleanupExpiredRemoteLogSegments();
@@ -2909,6 +2947,7 @@ public class RemoteLogManagerTest {
             return Optional.empty();
         }).when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
 
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
 
         verifyRemoteDeleteMetrics(0L, 0L);
@@ -2981,6 +3020,7 @@ public class RemoteLogManagerTest {
         doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
 
         // RUN 1
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         task.cleanupExpiredRemoteLogSegments();
         verify(remoteStorageManager, times(2)).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
@@ -3012,6 +3052,7 @@ public class RemoteLogManagerTest {
 
     @Test
     public void testDeleteRetentionMsBeingCancelledBeforeSecondDelete() throws RemoteStorageException, ExecutionException, InterruptedException {
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask leaderTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
 
         when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
@@ -3052,6 +3093,7 @@ public class RemoteLogManagerTest {
         verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
 
         // test that the 2nd log segment will be deleted by the new leader
+        remoteLogManager.setLeaderEpochForPartition(followerTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask newLeaderTask = remoteLogManager.new RLMExpirationTask(followerTopicIdPartition);
 
         Iterator<RemoteLogSegmentMetadata> firstIterator = metadataList.iterator();
@@ -3083,6 +3125,7 @@ public class RemoteLogManagerTest {
         LogConfig mockLogConfig = new LogConfig(Map.of("retention.ms", time.milliseconds() + 24 * 30 * 60 * 60 * 1000L));
         when(mockLog.config()).thenReturn(mockLogConfig);
 
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask leaderTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
 
         when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
@@ -3140,6 +3183,7 @@ public class RemoteLogManagerTest {
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
 
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         doThrow(new RemoteStorageException("Failed to delete segment")).when(remoteStorageManager).deleteLogSegmentData(any());
         advanceTimeToMakeSegmentDeletable();
@@ -3196,6 +3240,7 @@ public class RemoteLogManagerTest {
         assertEquals(0, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
 
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         doThrow(new RetriableRemoteStorageException("Failed to delete segment with retriable exception")).when(remoteStorageManager).deleteLogSegmentData(any());
         advanceTimeToMakeSegmentDeletable();
@@ -3330,6 +3375,7 @@ public class RemoteLogManagerTest {
                 });
         when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
                 .thenAnswer(answer -> CompletableFuture.runAsync(() -> { }));
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
         RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
         task.cleanupExpiredRemoteLogSegments();
 
@@ -3361,6 +3407,7 @@ public class RemoteLogManagerTest {
                 return remoteLogMetadataManager;
             }
         }) {
+            remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
             RemoteLogManager.RLMExpirationTask task = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
 
             when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
@@ -3446,7 +3493,8 @@ public class RemoteLogManagerTest {
                     segmentSize,
                     Optional.empty(),
                     state,
-                    segmentLeaderEpochs
+                    segmentLeaderEpochs,
+                    0
             );
             segmentMetadataList.add(metadata);
         }
@@ -3469,7 +3517,8 @@ public class RemoteLogManagerTest {
                 segmentSize,
                 Optional.empty(),
                 state,
-                truncateAndGetLeaderEpochs(epochEntries, startOffset, endOffset));
+                truncateAndGetLeaderEpochs(epochEntries, startOffset, endOffset),
+                0);
     }
 
     private Map<Integer, Long> truncateAndGetLeaderEpochs(List<EpochEntry> entries,
@@ -3791,11 +3840,16 @@ public class RemoteLogManagerTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testCopyQuota(boolean quotaExceeded) throws Exception {
-        RemoteLogManager.RLMCopyTask task = setupRLMTask(quotaExceeded);
+        setupRLMTask(quotaExceeded);
+
+        // Initialize topicIdPartitionToLeaderEpochMap using the helper method
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
+
+        final RemoteLogManager.RLMCopyTask testTask = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
 
         if (quotaExceeded) {
             // Verify that the copy operation times out, since no segments can be copied due to quota being exceeded
-            assertThrows(AssertionFailedError.class, () -> assertTimeoutPreemptively(Duration.ofMillis(200), () -> task.copyLogSegmentsToRemote(mockLog)));
+            assertThrows(AssertionFailedError.class, () -> assertTimeoutPreemptively(Duration.ofMillis(200), () -> testTask.copyLogSegmentsToRemote(mockLog)));
 
             Map<org.apache.kafka.common.MetricName, KafkaMetric> allMetrics = metrics.metrics();
             KafkaMetric avgMetric = allMetrics.get(metrics.metricName("remote-copy-throttle-time-avg", "RemoteLogManager"));
@@ -3810,7 +3864,7 @@ public class RemoteLogManagerTest {
             assertEquals(-1L, capture.getValue());
         } else {
             // Verify the copy operation completes within the timeout, since it does not need to wait for quota availability
-            assertTimeoutPreemptively(Duration.ofMillis(1000), () -> task.copyLogSegmentsToRemote(mockLog));
+            assertTimeoutPreemptively(Duration.ofMillis(1000), () -> testTask.copyLogSegmentsToRemote(mockLog));
 
             // Verify quota check was performed
             verify(rlmCopyQuotaManager, times(1)).getThrottleTimeMs();
@@ -3866,7 +3920,7 @@ public class RemoteLogManagerTest {
         LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
         when(mockLog.leaderEpochCache()).thenReturn(cache);
         when(mockLog.parentDir()).thenReturn("dir1");
-        when(remoteLogMetadataManager.highestOffsetForEpoch(any(TopicIdPartition.class), anyInt())).thenReturn(Optional.of(0L));
+        when(remoteLogMetadataManager.highestOffsetForEpoch(any(TopicIdPartition.class), anyInt())).thenReturn(Optional.of(-1L));
 
         // create 2 log segments, with 0 and 150 as log start offset
         LogSegment oldSegment = mock(LogSegment.class);
@@ -3984,6 +4038,9 @@ public class RemoteLogManagerTest {
         // After the first call, getThrottleTimeMs should return non-zero throttle time
         when(rlmCopyQuotaManager.getThrottleTimeMs()).thenReturn(0L, 1000L);
         doNothing().when(rlmCopyQuotaManager).record(anyInt());
+
+        // Initialize topicIdPartitionToLeaderEpochMap
+        remoteLogManager.setLeaderEpochForPartition(leaderTopicIdPartition, 0);
 
         RemoteLogManager.RLMCopyTask task = remoteLogManager.new RLMCopyTask(leaderTopicIdPartition, 128);
 
@@ -4289,6 +4346,22 @@ public class RemoteLogManagerTest {
         when(log.remoteLogEnabled()).thenReturn(true);
         when(partition.unifiedLog()).thenReturn(Optional.of(log));
         when(log.config()).thenReturn(new LogConfig(new Properties()));
+        when(partition.getLeaderEpoch()).thenReturn(0); // Mock leader epoch for map initialization
+
+        // Mock additional log properties needed by background tasks
+        when(log.topicPartition()).thenReturn(tp);
+        when(log.parentDir()).thenReturn("test-dir");
+
+        // Create a minimal LeaderEpochFileCache for background tasks
+        try {
+            LeaderEpochCheckpointFile checkpoint = new LeaderEpochCheckpointFile(TestUtils.tempFile(), new LogDirFailureChannel(1));
+            checkpoint.write(Collections.singletonList(new EpochEntry(0, 0L)));
+            LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+            when(log.leaderEpochCache()).thenReturn(cache);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
         return partition;
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataDeserializationTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataDeserializationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.storage;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit test to verify that consumer deserialization logic works regardless of key format.
+ * This validates that new code can handle both old format (null key) and new format (with key).
+ */
+public class RemoteLogMetadataDeserializationTest {
+    private static final String METADATA_TOPIC = "__remote_log_metadata";
+    private static final int SEG_SIZE = 1048576;
+    private final Time time = Time.SYSTEM;
+
+    /**
+     * Test that consumer logic can deserialize messages regardless of key format.
+     * This test verifies that the deserialization depends only on the value field.
+     */
+    @Test
+    public void testConsumerCanDeserializeMessagesWithAnyKeyFormat() {
+        TopicIdPartition topicIdPartition = new TopicIdPartition(
+                Uuid.randomUuid(),
+                new TopicPartition("test-key-format", 0)
+        );
+
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        long endOffset = 500L;
+        int brokerLeaderEpoch = 1;
+
+        RemoteLogSegmentMetadata metadata = new RemoteLogSegmentMetadata(
+                segmentId,
+                0L,
+                endOffset,
+                -1L,
+                0,
+                time.milliseconds(),
+                SEG_SIZE,
+                Collections.singletonMap(0, 0L),
+                brokerLeaderEpoch
+        );
+
+        RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
+        byte[] serializedValue = serde.serialize(metadata);
+
+        // Test 1: Simulate old format (null key)
+        ConsumerRecord<byte[], byte[]> oldFormatRecord = new ConsumerRecord<>(
+                METADATA_TOPIC,
+                0,
+                100L,
+                null,  // Old format: null key
+                serializedValue
+        );
+
+        RemoteLogMetadata deserializedOld = assertDoesNotThrow(() -> serde.deserialize(oldFormatRecord.value()),
+                "Should be able to deserialize message with null key");
+        assertNotNull(deserializedOld);
+        assertEquals(segmentId, ((RemoteLogSegmentMetadata) deserializedOld).remoteLogSegmentId());
+        assertNull(oldFormatRecord.key(), "Old format should have null key");
+
+        // Test 2: Simulate new format (with key)
+        String newFormatKey = metadata.metadataKey();
+        ConsumerRecord<byte[], byte[]> newFormatRecord = new ConsumerRecord<>(
+                METADATA_TOPIC,
+                0,
+                101L,
+                newFormatKey.getBytes(),  // New format: has key
+                serializedValue
+        );
+
+        RemoteLogMetadata deserializedNew = assertDoesNotThrow(() -> serde.deserialize(newFormatRecord.value()),
+                "Should be able to deserialize message with key");
+        assertNotNull(deserializedNew);
+        assertEquals(segmentId, ((RemoteLogSegmentMetadata) deserializedNew).remoteLogSegmentId());
+        assertNotNull(newFormatRecord.key(), "New format should have key");
+        assertEquals(newFormatKey, new String(newFormatRecord.key()));
+
+        // Test 3: Verify both deserializations produce the same metadata
+        assertEquals(
+                ((RemoteLogSegmentMetadata) deserializedOld).remoteLogSegmentId(),
+                ((RemoteLogSegmentMetadata) deserializedNew).remoteLogSegmentId(),
+                "Deserialized metadata should be the same regardless of key format"
+        );
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
@@ -70,7 +70,7 @@ public class RemoteLogMetadataManagerTest {
             Map<Integer, Long> segmentLeaderEpochs = Map.of(0, 101L);
             RemoteLogSegmentId segmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
             RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(
-                    segmentId, 101L, 200L, -1L, BROKER_ID_0, time.milliseconds(), SEG_SIZE, segmentLeaderEpochs);
+                    segmentId, 101L, 200L, -1L, BROKER_ID_0, time.milliseconds(), SEG_SIZE, segmentLeaderEpochs, 0);
             // Wait until the segment is added successfully.
             assertDoesNotThrow(() -> remoteLogMetadataManager.addRemoteLogSegmentMetadata(segmentMetadata).get());
 
@@ -79,7 +79,7 @@ public class RemoteLogMetadataManagerTest {
 
             // 2.Move that segment to COPY_SEGMENT_FINISHED state and this segment should be available.
             RemoteLogSegmentMetadataUpdate segmentMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
-                    segmentId, time.milliseconds(), Optional.empty(), COPY_SEGMENT_FINISHED, BROKER_ID_1);
+                    segmentId, time.milliseconds(), Optional.empty(), COPY_SEGMENT_FINISHED, BROKER_ID_1, 0, 200L);
             // Wait until the segment is updated successfully.
             assertDoesNotThrow(() -> remoteLogMetadataManager.updateRemoteLogSegmentMetadata(segmentMetadataUpdate).get());
             RemoteLogSegmentMetadata expectedSegmentMetadata = segmentMetadata.createWithUpdates(segmentMetadataUpdate);
@@ -109,12 +109,12 @@ public class RemoteLogMetadataManagerTest {
             segmentLeaderEpochs.put(3, 80L);
             RemoteLogSegmentId segmentId = new RemoteLogSegmentId(TP0, Uuid.randomUuid());
             RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(
-                    segmentId, 0L, 100L, -1L, BROKER_ID_0, time.milliseconds(), SEG_SIZE, segmentLeaderEpochs);
+                    segmentId, 0L, 100L, -1L, BROKER_ID_0, time.milliseconds(), SEG_SIZE, segmentLeaderEpochs, 0);
             // Wait until the segment is added successfully.
             assertDoesNotThrow(() -> remoteLogMetadataManager.addRemoteLogSegmentMetadata(segmentMetadata).get());
 
             RemoteLogSegmentMetadataUpdate segmentMetadataUpdate = new RemoteLogSegmentMetadataUpdate(
-                    segmentId, time.milliseconds(), Optional.empty(), COPY_SEGMENT_FINISHED, BROKER_ID_1);
+                    segmentId, time.milliseconds(), Optional.empty(), COPY_SEGMENT_FINISHED, BROKER_ID_1, 0, 100L);
             // Wait until the segment is updated successfully.
             assertDoesNotThrow(() -> remoteLogMetadataManager.updateRemoteLogSegmentMetadata(segmentMetadataUpdate).get());
 
@@ -153,6 +153,6 @@ public class RemoteLogMetadataManagerTest {
     }
 
     private RemotePartitionDeleteMetadata createRemotePartitionDeleteMetadata(RemotePartitionDeleteState state) {
-        return new RemotePartitionDeleteMetadata(TP0, state, time.milliseconds(), BROKER_ID_0);
+        return new RemotePartitionDeleteMetadata(TP0, state, time.milliseconds(), BROKER_ID_0, 0, 100L);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataOldFormatCompatibilityTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataOldFormatCompatibilityTest.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.storage;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.log.remote.metadata.storage.RemoteLogMetadataManagerTestUtils;
+import org.apache.kafka.server.log.remote.metadata.storage.RemoteLogMetadataTopicPartitioner;
+import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
+import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
+
+import org.junit.jupiter.api.AfterEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test to verify backward compatibility: new code can handle old message format (messages without keys).
+ *
+ * Background:
+ * - Old code (before commit b92795741b) wrote messages with null keys
+ * - New code writes messages with keys in format: "topicId:partition:endOffset:brokerLeaderEpoch"
+ * - Consumer (ConsumerTask) only reads the value field, not the key
+ * - Therefore, new code can read old messages without keys
+ *
+ * Upgrade strategy:
+ * - Existing clusters: topic starts with delete policy, old messages (null keys) exist
+ * - After upgrade: new messages written with keys
+ * - Old messages expire via time-based retention (24h default)
+ * - After retention period: topic can be safely changed to compacted policy
+ */
+@ClusterTestDefaults(brokers = 3)
+public class RemoteLogMetadataOldFormatCompatibilityTest {
+    private static final Logger log = LoggerFactory.getLogger(RemoteLogMetadataOldFormatCompatibilityTest.class);
+    private static final String METADATA_TOPIC = "__remote_log_metadata";
+    private static final int SEG_SIZE = 1048576;
+
+    private final ClusterInstance clusterInstance;
+    private final Time time = Time.SYSTEM;
+    private TopicBasedRemoteLogMetadataManager remoteLogMetadataManager;
+
+    RemoteLogMetadataOldFormatCompatibilityTest(ClusterInstance clusterInstance) {
+        this.clusterInstance = clusterInstance;
+    }
+
+    private TopicBasedRemoteLogMetadataManager createManager() {
+        if (remoteLogMetadataManager == null) {
+            remoteLogMetadataManager = RemoteLogMetadataManagerTestUtils.builder()
+                    .bootstrapServers(clusterInstance.bootstrapServers())
+                    .build();
+        }
+        return remoteLogMetadataManager;
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        if (remoteLogMetadataManager != null) {
+            remoteLogMetadataManager.close();
+        }
+    }
+
+    /**
+     * Test upgrade scenario: topic starts with delete policy (old messages with null keys),
+     * then new messages with keys are written, and finally topic is changed to compacted.
+     */
+    @ClusterTest
+    public void testUpgradeScenarioWithMixedMessageFormats() throws Exception {
+        TopicIdPartition topicIdPartition = new TopicIdPartition(
+                Uuid.randomUuid(),
+                new TopicPartition("test-upgrade-scenario", 0)
+        );
+        int brokerLeaderEpoch = 1;
+
+        initializeOldCluster(topicIdPartition);
+        SegmentIds segmentIds = writeOldFormatMessages(topicIdPartition, brokerLeaderEpoch);
+        TopicBasedRemoteLogMetadataManager rlmm2 = upgradeToNewCode(topicIdPartition);
+        reEmitStatesWithKeys(topicIdPartition, rlmm2, segmentIds, brokerLeaderEpoch);
+        writeNewFormatMessages(topicIdPartition, rlmm2, brokerLeaderEpoch);
+        changeTopicToCompactedAndVerify(topicIdPartition, rlmm2, brokerLeaderEpoch);
+        log.info("✅ Test passed! Upgrade scenario with mixed message formats works correctly.");
+    }
+
+    private TopicBasedRemoteLogMetadataManager initializeOldCluster(TopicIdPartition topicIdPartition) throws Exception {
+        log.info("Step 1: Initializing RLMM with delete policy...");
+        TopicBasedRemoteLogMetadataManager rlmm = createManager();
+        rlmm.onPartitionLeadershipChanges(Collections.singleton(topicIdPartition), Collections.emptySet());
+        waitForInitialization(rlmm, topicIdPartition);
+        changeTopicToDeletePolicy();
+        rlmm.close();
+        remoteLogMetadataManager = null;
+        Thread.sleep(2000);
+        return rlmm;
+    }
+
+    private SegmentIds writeOldFormatMessages(TopicIdPartition topicIdPartition, int brokerLeaderEpoch) throws Exception {
+        log.info("Step 2: Writing old format messages (null key)...");
+        RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        long endOffset1 = 500L;
+        long endOffset2 = 1000L;
+
+        writeMessageWithNullKey(topicIdPartition, new RemoteLogSegmentMetadata(
+                segmentId1, 0L, endOffset1, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 0L), brokerLeaderEpoch));
+
+        writeMessageWithNullKey(topicIdPartition, new RemoteLogSegmentMetadata(
+                segmentId2, 501L, endOffset2, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 501L), brokerLeaderEpoch));
+
+        writeUpdateWithNullKey(topicIdPartition, new RemoteLogSegmentMetadataUpdate(
+                segmentId2, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, 0, brokerLeaderEpoch, endOffset2));
+
+        writeUpdateWithNullKey(topicIdPartition, new RemoteLogSegmentMetadataUpdate(
+                segmentId2, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_STARTED, 0, brokerLeaderEpoch, endOffset2));
+
+        Thread.sleep(2000);
+        return new SegmentIds(segmentId1, segmentId2, endOffset1, endOffset2);
+    }
+
+    private TopicBasedRemoteLogMetadataManager upgradeToNewCode(TopicIdPartition topicIdPartition) throws Exception {
+        log.info("Step 3: Upgrading to new code...");
+        TopicBasedRemoteLogMetadataManager rlmm2 = createManager();
+        rlmm2.onPartitionLeadershipChanges(Collections.singleton(topicIdPartition), Collections.emptySet());
+        waitForInitialization(rlmm2, topicIdPartition);
+        Thread.sleep(3000);
+        return rlmm2;
+    }
+
+    private void reEmitStatesWithKeys(TopicIdPartition topicIdPartition, TopicBasedRemoteLogMetadataManager rlmm2,
+                                      SegmentIds segmentIds, int brokerLeaderEpoch) throws Exception {
+        log.info("Step 4: New broker re-emitting states with keys...");
+        assertDoesNotThrow(() -> rlmm2.addRemoteLogSegmentMetadata(new RemoteLogSegmentMetadata(
+                segmentIds.segmentId1, 0L, segmentIds.endOffset1, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 0L), brokerLeaderEpoch)).get());
+
+        Thread.sleep(1000);
+        assertDoesNotThrow(() -> rlmm2.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentIds.segmentId1, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, 0, brokerLeaderEpoch, segmentIds.endOffset1)).get());
+
+        Thread.sleep(1000);
+        Optional<RemoteLogSegmentMetadata> retrieved = rlmm2.remoteLogSegmentMetadata(topicIdPartition, 0, 250);
+        assertTrue(retrieved.isPresent());
+        assertEquals(segmentIds.segmentId1, retrieved.get().remoteLogSegmentId());
+
+        assertDoesNotThrow(() -> rlmm2.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentIds.segmentId2, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_STARTED, 0, brokerLeaderEpoch, segmentIds.endOffset2)).get());
+
+        Thread.sleep(1000);
+        assertDoesNotThrow(() -> rlmm2.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentIds.segmentId2, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, 0, brokerLeaderEpoch, segmentIds.endOffset2)).get());
+    }
+
+    private void writeNewFormatMessages(TopicIdPartition topicIdPartition, TopicBasedRemoteLogMetadataManager rlmm2,
+                                       int brokerLeaderEpoch) throws Exception {
+        log.info("Step 5: Writing new format messages...");
+        RemoteLogSegmentId newSegmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        long newEndOffset = 1500L;
+
+        assertDoesNotThrow(() -> rlmm2.addRemoteLogSegmentMetadata(new RemoteLogSegmentMetadata(
+                newSegmentId, 1001L, newEndOffset, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 1001L), brokerLeaderEpoch)).get());
+
+        assertDoesNotThrow(() -> rlmm2.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                newSegmentId, time.milliseconds(), Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, 0, brokerLeaderEpoch, newEndOffset)).get());
+
+        Thread.sleep(1000);
+    }
+
+    private void changeTopicToCompactedAndVerify(TopicIdPartition topicIdPartition,
+                                                 TopicBasedRemoteLogMetadataManager rlmm2,
+                                                 int brokerLeaderEpoch) throws Exception {
+        log.info("Step 6: Changing to compacted policy and verifying...");
+        changeTopicToCompactedPolicy();
+
+        RemoteLogSegmentId thirdSegmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        assertDoesNotThrow(() -> rlmm2.addRemoteLogSegmentMetadata(new RemoteLogSegmentMetadata(
+                thirdSegmentId, 1501L, 2500L, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 1501L), brokerLeaderEpoch)).get());
+    }
+
+    private static class SegmentIds {
+        final RemoteLogSegmentId segmentId1;
+        final RemoteLogSegmentId segmentId2;
+        final long endOffset1;
+        final long endOffset2;
+
+        SegmentIds(RemoteLogSegmentId segmentId1, RemoteLogSegmentId segmentId2, long endOffset1, long endOffset2) {
+            this.segmentId1 = segmentId1;
+            this.segmentId2 = segmentId2;
+            this.endOffset1 = endOffset1;
+            this.endOffset2 = endOffset2;
+        }
+    }
+
+    private void writeMessageWithNullKey(TopicIdPartition topicIdPartition,
+                                         RemoteLogSegmentMetadata metadata) throws Exception {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props)) {
+            RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
+            byte[] value = serde.serialize(metadata);
+
+            RemoteLogMetadataTopicPartitioner partitioner = new RemoteLogMetadataTopicPartitioner(3);
+            int metadataPartition = partitioner.metadataPartition(topicIdPartition);
+
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                    METADATA_TOPIC,
+                    metadataPartition,
+                    null,  // Old format: null key
+                    value
+            );
+
+            producer.send(record).get();
+            producer.flush();
+        }
+    }
+
+    private void writeUpdateWithNullKey(TopicIdPartition topicIdPartition,
+                                        RemoteLogSegmentMetadataUpdate update) throws Exception {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props)) {
+            RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
+            byte[] value = serde.serialize(update);
+
+            RemoteLogMetadataTopicPartitioner partitioner = new RemoteLogMetadataTopicPartitioner(3);
+            int metadataPartition = partitioner.metadataPartition(topicIdPartition);
+
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                    METADATA_TOPIC,
+                    metadataPartition,
+                    null,  // Old format: null key
+                    value
+            );
+
+            producer.send(record).get();
+            producer.flush();
+        }
+    }
+
+    private void changeTopicToDeletePolicy() throws Exception {
+        try (Admin admin = Admin.create(Collections.singletonMap(
+                "bootstrap.servers", clusterInstance.bootstrapServers()))) {
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, METADATA_TOPIC);
+
+            Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
+            configs.put(resource, Collections.singletonList(
+                    new AlterConfigOp(
+                            new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
+                            AlterConfigOp.OpType.SET
+                    )
+            ));
+
+            admin.incrementalAlterConfigs(configs).all().get();
+            Thread.sleep(2000); // Wait for config change to propagate
+        }
+    }
+
+    private void changeTopicToCompactedPolicy() throws Exception {
+        try (Admin admin = Admin.create(Collections.singletonMap(
+                "bootstrap.servers", clusterInstance.bootstrapServers()))) {
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, METADATA_TOPIC);
+
+            Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
+            configs.put(resource, Collections.singletonList(
+                    new AlterConfigOp(
+                            new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+                            AlterConfigOp.OpType.SET
+                    )
+            ));
+
+            admin.incrementalAlterConfigs(configs).all().get();
+            Thread.sleep(2000); // Wait for config change to propagate
+        }
+    }
+
+    private void waitForInitialization(TopicBasedRemoteLogMetadataManager rlmm,
+                                       TopicIdPartition topicIdPartition) throws InterruptedException {
+        int maxWaitMs = 30000;
+        int waitedMs = 0;
+        while (!rlmm.isReady(topicIdPartition) && waitedMs < maxWaitMs) {
+            Thread.sleep(100);
+            waitedMs += 100;
+        }
+        assertTrue(rlmm.isReady(topicIdPartition),
+                "RLMM should be initialized within " + maxWaitMs + "ms");
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataTombstoneTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataTombstoneTest.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.storage;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.log.remote.metadata.storage.RemoteLogMetadataManagerTestUtils;
+import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
+
+import org.junit.jupiter.api.AfterEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for verifying tombstoning behavior of remote log metadata topic.
+ * This test validates that:
+ * 1. Metadata records are written with correct keys (topicId:partition:endOffset:brokerLeaderEpoch)
+ * 2. Tombstones are published for all historical records when segment is deleted
+ * 3. Topic compaction eventually removes tombstoned records
+ */
+@ClusterTestDefaults(brokers = 3)
+public class RemoteLogMetadataTombstoneTest {
+    private static final Logger log = LoggerFactory.getLogger(RemoteLogMetadataTombstoneTest.class);
+    private static final int SEG_SIZE = 1048576;
+    private static final String METADATA_TOPIC = "__remote_log_metadata";
+
+    private final ClusterInstance clusterInstance;
+    private final Time time = Time.SYSTEM;
+    private TopicBasedRemoteLogMetadataManager remoteLogMetadataManager;
+
+    RemoteLogMetadataTombstoneTest(ClusterInstance clusterInstance) {
+        this.clusterInstance = clusterInstance;
+    }
+
+    private TopicBasedRemoteLogMetadataManager createManager() {
+        if (remoteLogMetadataManager == null) {
+            remoteLogMetadataManager = RemoteLogMetadataManagerTestUtils.builder()
+                    .bootstrapServers(clusterInstance.bootstrapServers())
+                    .build();
+        }
+        return remoteLogMetadataManager;
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        if (remoteLogMetadataManager != null) {
+            remoteLogMetadataManager.close();
+        }
+    }
+
+    /**
+     * Test the full lifecycle of remote log segment metadata with tombstoning.
+     *
+     * This test creates a single segment and uploads it. Then it deletes the segment
+     * and verifies that the metadata record is tombstoned in the __remote_log_metadata topic.
+     */
+    @ClusterTest
+    public void testRemoteLogSegmentLifecycleWithTombstoning() throws Exception {
+        TopicBasedRemoteLogMetadataManager rlmm = createManager();
+
+        // Create test topic partition
+        TopicIdPartition topicIdPartition = new TopicIdPartition(
+                Uuid.randomUuid(),
+                new TopicPartition("test-topic", 0)
+        );
+
+        // Register partition as leader
+        rlmm.onPartitionLeadershipChanges(
+                Collections.singleton(topicIdPartition),
+                Collections.emptySet()
+        );
+
+        // Wait for initialization
+        waitForInitialization(rlmm, topicIdPartition);
+
+        // Create segment ID
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        long endOffset = 1000L;
+        int brokerLeaderEpoch = 1;
+
+        // ===== Phase 1: Upload segment =====
+        RemoteLogSegmentMetadata metadata = new RemoteLogSegmentMetadata(
+                segmentId,
+                0L,             // startOffset
+                endOffset,      // endOffset
+                -1L,            // maxTimestampMs
+                0,              // brokerId
+                time.milliseconds(),
+                SEG_SIZE,
+                Collections.singletonMap(0, 0L),  // segmentLeaderEpochs
+                brokerLeaderEpoch
+        );
+
+        // Add metadata (COPY_SEGMENT_STARTED state)
+        rlmm.addRemoteLogSegmentMetadata(metadata).get();
+
+        // Update to COPY_SEGMENT_FINISHED
+        RemoteLogSegmentMetadataUpdate update = new RemoteLogSegmentMetadataUpdate(
+                segmentId,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
+                0,  // brokerId
+                brokerLeaderEpoch,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(update).get();
+
+        // ===== Phase 2: Verify metadata topic has the record =====
+        Map<String, byte[]> recordsBeforeDeletion = consumeMetadataTopicRecords(topicIdPartition);
+
+        log.info("Records before deletion:");
+        for (String key : recordsBeforeDeletion.keySet()) {
+            log.info("  Key: {}, Value: {}", key,
+                    (recordsBeforeDeletion.get(key) != null ? "present" : "null"));
+        }
+
+        String baseKey = buildExpectedKey(topicIdPartition, endOffset, brokerLeaderEpoch);
+        String updateKey = baseKey + ":UPDATE";
+
+        // Should have both base key (from COPY_SEGMENT_STARTED) and update key (from COPY_SEGMENT_FINISHED)
+        assertTrue(recordsBeforeDeletion.containsKey(baseKey),
+                "Should have base key for brokerLeaderEpoch=" + brokerLeaderEpoch);
+        assertTrue(recordsBeforeDeletion.containsKey(updateKey),
+                "Should have update key for brokerLeaderEpoch=" + brokerLeaderEpoch);
+        assertNotNull(recordsBeforeDeletion.get(baseKey),
+                "Base key should not be tombstone");
+        assertNotNull(recordsBeforeDeletion.get(updateKey),
+                "Update key should not be tombstone");
+
+        // ===== Phase 3: Delete the segment =====
+        RemoteLogSegmentMetadataUpdate deleteStart = new RemoteLogSegmentMetadataUpdate(
+                segmentId,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_STARTED,
+                0,  // brokerId
+                brokerLeaderEpoch,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(deleteStart).get();
+
+        // Mark deletion as finished - this should trigger tombstoning
+        RemoteLogSegmentMetadataUpdate deleteFinish = new RemoteLogSegmentMetadataUpdate(
+                segmentId,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_FINISHED,
+                0,  // brokerId
+                brokerLeaderEpoch,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(deleteFinish).get();
+
+        // ===== Phase 4: Wait for tombstones to appear =====
+        // Both base key and update key should be tombstoned
+        waitForTombstone(topicIdPartition, baseKey, 10000);
+        waitForTombstone(topicIdPartition, updateKey, 10000);
+
+        // Verify both tombstones were published
+        Map<String, byte[]> recordsAfterDeletion = consumeMetadataTopicRecords(topicIdPartition);
+
+        log.info("Records after deletion:");
+        for (String key : recordsAfterDeletion.keySet()) {
+            log.info("  Key: {}, Value: {}", key,
+                    (recordsAfterDeletion.get(key) != null ? "present" : "TOMBSTONE"));
+        }
+
+        // Both keys should still exist but with null values (tombstones)
+        assertTrue(recordsAfterDeletion.containsKey(baseKey),
+                "Should still have base key for brokerLeaderEpoch=" + brokerLeaderEpoch);
+        assertTrue(recordsAfterDeletion.containsKey(updateKey),
+                "Should still have update key for brokerLeaderEpoch=" + brokerLeaderEpoch);
+        assertNull(recordsAfterDeletion.get(baseKey),
+                "Base key should be tombstoned");
+        assertNull(recordsAfterDeletion.get(updateKey),
+                "Update key should be tombstoned");
+    }
+
+    /**
+     * Test leadership change during segment upload and subsequent tombstoning.
+     *
+     * Scenario:
+     * 1. Leader 1 starts uploading segment (COPY_SEGMENT_STARTED with brokerLeaderEpoch=1)
+     * 2. Leadership changes before upload finishes
+     * 3. Leader 2 retries and finishes upload (COPY_SEGMENT_FINISHED with brokerLeaderEpoch=2)
+     * 4. Leader 2 deletes the segment
+     * 5. Verify tombstones are published for both brokerLeaderEpoch=1 and brokerLeaderEpoch=2
+     */
+    @ClusterTest
+    public void testLeadershipChangeDuringUploadWithTombstoning() throws Exception {
+        TopicBasedRemoteLogMetadataManager rlmm = createManager();
+
+        // Create test topic partition
+        TopicIdPartition topicIdPartition = new TopicIdPartition(
+                Uuid.randomUuid(),
+                new TopicPartition("test-topic-leadership", 0)
+        );
+
+        // Register partition as leader
+        rlmm.onPartitionLeadershipChanges(
+                Collections.singleton(topicIdPartition),
+                Collections.emptySet()
+        );
+
+        // Wait for initialization
+        waitForInitialization(rlmm, topicIdPartition);
+
+        // Create segment ID
+        RemoteLogSegmentId segmentId = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        long endOffset = 2000L;
+
+        // ===== Phase 1: Leader 1 starts uploading segment =====
+        int brokerLeaderEpoch1 = 1;
+        RemoteLogSegmentMetadata metadata1 = new RemoteLogSegmentMetadata(
+                segmentId,
+                0L,
+                endOffset,
+                -1L,
+                0,  // broker 0
+                time.milliseconds(),
+                SEG_SIZE,
+                Collections.singletonMap(0, 0L),
+                brokerLeaderEpoch1
+        );
+
+        // Leader 1 adds metadata (COPY_SEGMENT_STARTED state)
+        rlmm.addRemoteLogSegmentMetadata(metadata1).get();
+
+        // Simulate leadership change - Leader 1 never finishes the upload
+        // In real scenario, the segment stays in COPY_SEGMENT_STARTED state
+        // ===== Phase 2: Leadership changes to Leader 2 =====
+        // Leader 2 sees segment in COPY_SEGMENT_STARTED, retries and finishes upload
+        int brokerLeaderEpoch2 = 2;
+        RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+
+        RemoteLogSegmentMetadata metadata2 = new RemoteLogSegmentMetadata(
+                segmentId2,
+                0L,
+                endOffset,
+                -1L,
+                1,  // broker 1
+                time.milliseconds(),
+                SEG_SIZE,
+                Collections.singletonMap(0, 0L),
+                brokerLeaderEpoch2
+        );
+
+        // Leader 1 adds metadata (COPY_SEGMENT_STARTED state)
+        rlmm.addRemoteLogSegmentMetadata(metadata2).get();
+
+        // Leader 2 may re-add the metadata or just update it
+        // In practice, it will update the existing segment with new brokerLeaderEpoch
+        RemoteLogSegmentMetadataUpdate update2Finish = new RemoteLogSegmentMetadataUpdate(
+                segmentId2,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
+                1,  // broker 1 (new leader)
+                brokerLeaderEpoch2,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(update2Finish).get();
+
+        // ===== Phase 3: Verify metadata topic has records for both epochs =====
+        Map<String, byte[]> recordsBeforeDeletion = consumeMetadataTopicRecords(topicIdPartition);
+
+        log.info("Records before deletion (leadership change scenario):");
+        for (String key : recordsBeforeDeletion.keySet()) {
+            log.info("  Key: {}, Value: {}", key,
+                    (recordsBeforeDeletion.get(key) != null ? "present" : "null"));
+        }
+
+        // We should have records for both brokerLeaderEpoch=1 and brokerLeaderEpoch=2
+        // Each has a base key and an update key
+        String baseKey1 = buildExpectedKey(topicIdPartition, endOffset, brokerLeaderEpoch1);
+        String baseKey2 = buildExpectedKey(topicIdPartition, endOffset, brokerLeaderEpoch2);
+        String updateKey2 = baseKey2 + ":UPDATE";
+
+        assertTrue(recordsBeforeDeletion.containsKey(updateKey2),
+                "Should have update record for brokerLeaderEpoch=" + brokerLeaderEpoch2);
+
+        // ===== Phase 4: Leader 2 deletes the segment =====
+        RemoteLogSegmentMetadataUpdate deleteStart = new RemoteLogSegmentMetadataUpdate(
+                segmentId2,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_STARTED,
+                1,  // broker 1
+                brokerLeaderEpoch2,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(deleteStart).get();
+
+        RemoteLogSegmentMetadataUpdate deleteFinish = new RemoteLogSegmentMetadataUpdate(
+                segmentId2,
+                time.milliseconds(),
+                java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_FINISHED,
+                1,  // broker 1
+                brokerLeaderEpoch2,
+                endOffset
+        );
+        rlmm.updateRemoteLogSegmentMetadata(deleteFinish).get();
+
+        // ===== Phase 5: Wait for tombstones to appear =====
+        // All 4 keys should be tombstoned (base and update for both epochs)
+        waitForTombstone(topicIdPartition, baseKey1, 10000);
+        waitForTombstone(topicIdPartition, baseKey2, 10000);
+        waitForTombstone(topicIdPartition, updateKey2, 10000);
+
+        // Verify tombstones for both epochs
+        Map<String, byte[]> recordsAfterDeletion = consumeMetadataTopicRecords(topicIdPartition);
+
+        log.info("Records after deletion (leadership change scenario):");
+        for (String key : recordsAfterDeletion.keySet()) {
+            log.info("  Key: {}, Value: {}", key,
+                    (recordsAfterDeletion.get(key) != null ? "present" : "TOMBSTONE"));
+        }
+
+        // All keys should be tombstoned because brokerLeaderEpoch1 <= brokerLeaderEpoch2
+        assertTrue(recordsAfterDeletion.containsKey(baseKey1),
+                "Should still have base key for brokerLeaderEpoch=" + brokerLeaderEpoch1);
+        assertTrue(recordsAfterDeletion.containsKey(baseKey2),
+                "Should still have base key for brokerLeaderEpoch=" + brokerLeaderEpoch2);
+        assertTrue(recordsAfterDeletion.containsKey(updateKey2),
+                "Should still have update key for brokerLeaderEpoch=" + brokerLeaderEpoch2);
+
+        assertNull(recordsAfterDeletion.get(baseKey1),
+                "Base key with brokerLeaderEpoch=" + brokerLeaderEpoch1 + " should be tombstoned");
+        assertNull(recordsAfterDeletion.get(baseKey2),
+                "Base key with brokerLeaderEpoch=" + brokerLeaderEpoch2 + " should be tombstoned");
+        assertNull(recordsAfterDeletion.get(updateKey2),
+                "Update key with brokerLeaderEpoch=" + brokerLeaderEpoch2 + " should be tombstoned");
+
+        assertEquals(4, recordsAfterDeletion.size(),
+                "Should have exactly 4 tombstone records (base and update for each broker leader epoch)");
+    }
+
+    /**
+     * Test that only records with brokerLeaderEpoch <= current are tombstoned
+     */
+    @ClusterTest
+    public void testTombstoningOnlyAffectsLowerOrEqualEpochs() throws Exception {
+        TopicBasedRemoteLogMetadataManager rlmm = createManager();
+
+        TopicIdPartition topicIdPartition = new TopicIdPartition(
+                Uuid.randomUuid(),
+                new TopicPartition("test-topic-2", 0)
+        );
+
+        rlmm.onPartitionLeadershipChanges(
+                Collections.singleton(topicIdPartition),
+                Collections.emptySet()
+        );
+
+        waitForInitialization(rlmm, topicIdPartition);
+
+        long endOffset = 2000L;
+
+        // Create two segments with same endOffset but different broker leader epochs
+        RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+        RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid());
+
+        // Segment 1: broker leader epoch = 1
+        RemoteLogSegmentMetadata metadata1 = new RemoteLogSegmentMetadata(
+                segmentId1, 0L, endOffset, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 0L), 1
+        );
+        rlmm.addRemoteLogSegmentMetadata(metadata1).get();
+        rlmm.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), java.util.Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, 0, 1, endOffset
+        )).get();
+
+        // Segment 2: broker leader epoch = 3 (higher)
+        RemoteLogSegmentMetadata metadata2 = new RemoteLogSegmentMetadata(
+                segmentId2, 0L, endOffset, -1L, 0, time.milliseconds(), SEG_SIZE,
+                Collections.singletonMap(0, 0L), 3
+        );
+        rlmm.addRemoteLogSegmentMetadata(metadata2).get();
+        rlmm.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId2, time.milliseconds(), java.util.Optional.empty(),
+                RemoteLogSegmentState.COPY_SEGMENT_FINISHED, 0, 3, endOffset
+        )).get();
+
+        // Delete segment 1 (broker leader epoch = 1)
+        rlmm.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_STARTED, 0, 1, endOffset
+        )).get();
+        rlmm.updateRemoteLogSegmentMetadata(new RemoteLogSegmentMetadataUpdate(
+                segmentId1, time.milliseconds(), java.util.Optional.empty(),
+                RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, 0, 1, endOffset
+        )).get();
+
+        String baseKey1 = buildExpectedKey(topicIdPartition, endOffset, 1);
+        String updateKey1 = baseKey1 + ":UPDATE";
+        String baseKey3 = buildExpectedKey(topicIdPartition, endOffset, 3);
+        String updateKey3 = baseKey3 + ":UPDATE";
+
+        // Wait for tombstones to appear for segment 1 (both base and update keys)
+        waitForTombstone(topicIdPartition, baseKey1, 10000);
+        waitForTombstone(topicIdPartition, updateKey1, 10000);
+
+        // Verify: only segment 1's keys should be tombstoned, segment 3 should remain
+        Map<String, byte[]> records = consumeMetadataTopicRecords(topicIdPartition);
+
+        assertNull(records.get(baseKey1), "Base key with brokerLeaderEpoch=1 should be tombstoned");
+        assertNull(records.get(updateKey1), "Update key with brokerLeaderEpoch=1 should be tombstoned");
+        assertNotNull(records.get(baseKey3), "Base key with brokerLeaderEpoch=3 should NOT be tombstoned");
+        assertNotNull(records.get(updateKey3), "Update key with brokerLeaderEpoch=3 should NOT be tombstoned");
+    }
+
+    // ===== Helper Methods =====
+
+    private void waitForInitialization(TopicBasedRemoteLogMetadataManager rlmm,
+                                       TopicIdPartition topicIdPartition) throws InterruptedException {
+        int maxWaitMs = 30000;
+        int waitedMs = 0;
+        while (!rlmm.isReady(topicIdPartition) && waitedMs < maxWaitMs) {
+            Thread.sleep(100);
+            waitedMs += 100;
+        }
+        assertTrue(rlmm.isReady(topicIdPartition),
+                "RLMM should be initialized within " + maxWaitMs + "ms");
+    }
+
+    /**
+     * Consumes all records from the metadata topic partition and returns them as a map.
+     * Key -> Value (null for tombstones)
+     */
+    private Map<String, byte[]> consumeMetadataTopicRecords(TopicIdPartition topicIdPartition) {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + System.currentTimeMillis());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false");  // Allow consuming internal topics
+
+        try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(props)) {
+            // Calculate metadata partition using the partitioner
+            // The metadata topic has 3 partitions by default (see RemoteLogMetadataManagerTestUtils.METADATA_TOPIC_PARTITIONS_COUNT)
+            // Use the same hashing logic as RemoteLogMetadataTopicPartitioner
+
+            List<TopicPartition> allPartitions = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                allPartitions.add(new TopicPartition(METADATA_TOPIC, i));
+            }
+
+            consumer.assign(allPartitions);
+            consumer.seekToBeginning(allPartitions);
+
+            Map<String, byte[]> records = new HashMap<>();
+
+            // Poll until no more records
+            int consecutiveEmptyPolls = 0;
+            int maxEmptyPolls = 2;
+
+            while (consecutiveEmptyPolls < maxEmptyPolls) {
+                ConsumerRecords<String, byte[]> polled = consumer.poll(Duration.ofMillis(500));
+
+                if (polled.isEmpty()) {
+                    consecutiveEmptyPolls++;
+                } else {
+                    consecutiveEmptyPolls = 0;
+                    for (ConsumerRecord<String, byte[]> record : polled) {
+                        records.put(record.key(), record.value());
+                    }
+                }
+            }
+
+            return records;
+        }
+    }
+
+    /**
+     * Wait for a tombstone to appear for the given key in the metadata topic.
+     * Polls the topic periodically until the tombstone is found or timeout is reached.
+     */
+    private void waitForTombstone(TopicIdPartition topicIdPartition, String expectedKey, long timeoutMs)
+            throws InterruptedException {
+        long startTime = System.currentTimeMillis();
+        boolean tombstoneFound = false;
+
+        while (!tombstoneFound && (System.currentTimeMillis() - startTime) < timeoutMs) {
+            Map<String, byte[]> records = consumeMetadataTopicRecords(topicIdPartition);
+            if (records.containsKey(expectedKey) && records.get(expectedKey) == null) {
+                tombstoneFound = true;
+                log.debug("Tombstone found for key: {}", expectedKey);
+            } else {
+                Thread.sleep(500);
+            }
+        }
+
+        if (!tombstoneFound) {
+            log.warn("Tombstone not found within timeout for key: {}", expectedKey);
+        }
+    }
+
+    /**
+     * Build the base metadata key based on the key format:
+     * topicId:partition:endOffset:brokerLeaderEpoch
+     * Note: Update keys have an additional ":UPDATE" suffix
+     */
+    private String buildExpectedKey(TopicIdPartition topicIdPartition,
+                                    long endOffset,
+                                    int brokerLeaderEpoch) {
+        return topicIdPartition.topicId() + ":"
+                + topicIdPartition.partition() + ":"
+                + endOffset + ":"
+                + brokerLeaderEpoch;
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/tools/RemoteLogMetadataMigrationTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/RemoteLogMetadataMigrationTool.java
@@ -1,0 +1,662 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.FeatureUpdate;
+import org.apache.kafka.clients.admin.UpdateFeaturesOptions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.common.utils.internals.Exit;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.internal.HelpScreenException;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tool to manage remote.log.metadata.version upgrades and migrate the __remote_log_metadata topic.
+ *
+ * This tool supports two upgrade paths:
+ *
+ * 1. Version 0 to 1: Upgrades feature and configures topic with retention.ms
+ *    - Changes topic cleanup.policy to "compact,delete"
+ *    - Sets retention.ms to ensure old-format (null-key) messages expire after specified period
+ *    - Sets min.compaction.lag.ms to the same value as retention.ms
+ *    - CRITICAL: This dual configuration ensures safe migration:
+ *      * retention.ms: Old-format (null-key) messages expire naturally after this period
+ *      * min.compaction.lag.ms: Log cleaner waits this long before compacting
+ *      Without these settings, the log cleaner could immediately delete null-key messages during compaction,
+ *      causing data loss. By setting both to the same value, null-key messages expire via retention
+ *      BEFORE compaction begins.
+ *
+ * 2. Version 1 to 2: Validates no null-key messages exist, then upgrades to compact-only cleanup policy
+ *    - Scans the entire topic for null-key messages
+ *    - Only proceeds if no null-key messages are found
+ *    - Changes cleanup.policy to "compact" (removes "delete")
+ *    - Removes min.compaction.lag.ms override (no longer needed)
+ *    - Removes retention.ms override (compact-only topics retain all data)
+ *
+ * Usage:
+ *   # Upgrade from version 0 to 1
+ *   kafka-remote-log-metadata-migration.sh --bootstrap-server localhost:9092 --upgrade-to-v1 --retention-ms 1209600000
+ *
+ *   # Upgrade from version 1 to 2 (with validation)
+ *   kafka-remote-log-metadata-migration.sh --bootstrap-server localhost:9092 --check --upgrade-to-v2
+ *
+ *   # Force upgrade to version 2 (skip validation)
+ *   kafka-remote-log-metadata-migration.sh --bootstrap-server localhost:9092 --check --upgrade-to-v2 --force
+ *
+ * Exit codes:
+ *   0 - Success (no null-key messages found, or operation completed successfully)
+ *   1 - Failure (null-key messages found, or error occurred)
+ */
+public class RemoteLogMetadataMigrationTool {
+    private static final String METADATA_TOPIC = "__remote_log_metadata";
+
+    public static void main(String... args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    static int mainNoExit(String... args) {
+        try {
+            execute(args);
+            return 0;
+        } catch (HelpScreenException e) {
+            return 0;
+        } catch (ArgumentParserException e) {
+            System.err.println("Command line error: " + e.getMessage() + ". Type --help for help.");
+            return 1;
+        } catch (TerseException e) {
+            System.err.println(e.getMessage());
+            return 1;
+        } catch (Throwable e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace(System.err);
+            return 1;
+        }
+    }
+
+    static void execute(String... args) throws Exception {
+        ArgumentParser parser = ArgumentParsers
+            .newArgumentParser("kafka-remote-log-metadata-migration")
+            .defaultHelp(true)
+            .description("Tool to manage remote.log.metadata.version upgrades and migrate the __remote_log_metadata topic.");
+
+        parser.addArgument("--bootstrap-server")
+            .required(true)
+            .help("REQUIRED: A comma-separated list of host:port pairs to use for establishing the connection to the Kafka cluster.");
+
+        parser.addArgument("--command-config")
+            .type(Arguments.fileType())
+            .help("Property file containing configs to be passed to Admin/Consumer Client.");
+
+        parser.addArgument("--upgrade-to-v1")
+            .action(Arguments.storeTrue())
+            .help("Upgrade from remote.log.metadata.version=0 to version 1, and configure topic with min.compaction.lag.ms.");
+
+        parser.addArgument("--check")
+            .action(Arguments.storeTrue())
+            .help("Check if the topic contains any messages with null keys. This is required before upgrading to version 2.");
+
+        parser.addArgument("--upgrade-to-v2")
+            .action(Arguments.storeTrue())
+            .help("Upgrade to remote.log.metadata.version=2 after validation. Requires --check and --auto-upgrade.");
+
+        parser.addArgument("--auto-upgrade")
+            .action(Arguments.storeTrue())
+            .help("Automatically upgrade to version 2 if validation passes. Must be used with --check --upgrade-to-v2. " +
+                  "This is a safety flag to prevent accidental upgrades.");
+
+        parser.addArgument("--force")
+            .action(Arguments.storeTrue())
+            .help("Force upgrade to version 2 even if null-key messages are found. Use with caution: null-key messages will be lost during compaction.");
+
+        parser.addArgument("--retention-ms")
+            .type(Long.class)
+            .setDefault(1209600000L)
+            .help("Retention period in milliseconds for the __remote_log_metadata topic when upgrading to version 1 (default: 1209600000, which is 14 days). " +
+                  "This parameter is CRITICAL: it serves two purposes: " +
+                  "1) retention.ms: Ensures old-format (null-key) messages expire and are deleted after this period. " +
+                  "2) min.compaction.lag.ms: Set to the same value to prevent log cleaner from compacting before old messages expire. " +
+                  "Once the topic cleanup policy is changed to 'compact,delete', the log cleaner could immediately delete null-key messages during compaction. " +
+                  "By setting both retention.ms and min.compaction.lag.ms to the same value, we ensure null-key messages expire naturally via retention " +
+                  "before the log cleaner begins compacting. This prevents data loss during the migration period. Used with --upgrade-to-v1.");
+
+        parser.addArgument("--timeout-ms")
+            .type(Long.class)
+            .setDefault(60000L)
+            .help("Maximum time in milliseconds to wait while checking for messages (default: 60000). Used with --check.");
+
+        Namespace namespace = parser.parseArgs(args);
+
+        String bootstrapServers = namespace.getString("bootstrap_server");
+        String commandConfig = namespace.getString("command_config");
+        boolean upgradeToV1 = namespace.getBoolean("upgrade_to_v1");
+        boolean check = namespace.getBoolean("check");
+        boolean upgradeToV2 = namespace.getBoolean("upgrade_to_v2");
+        boolean autoUpgrade = namespace.getBoolean("auto_upgrade");
+        boolean force = namespace.getBoolean("force");
+        long retentionMs = namespace.getLong("retention_ms");
+        long timeoutMs = namespace.getLong("timeout_ms");
+
+        Properties props = new Properties();
+        if (commandConfig != null) {
+            try {
+                props = Utils.loadProps(commandConfig);
+            } catch (java.io.IOException e) {
+                throw new TerseException("Failed to load properties from file: " + commandConfig + ". Error: " + e.getMessage());
+            }
+        }
+
+        if (upgradeToV2 && !check) {
+            throw new TerseException("--upgrade-to-v2 requires --check to be specified.");
+        }
+
+        if (autoUpgrade && !upgradeToV2) {
+            throw new TerseException("--auto-upgrade can only be used with --upgrade-to-v2.");
+        }
+
+        if (force && !upgradeToV2) {
+            throw new TerseException("--force can only be used with --upgrade-to-v2.");
+        }
+
+        if (upgradeToV1 && check) {
+            throw new TerseException("Cannot specify both --upgrade-to-v1 and --check. Use --upgrade-to-v1 for 0->1 upgrade, or --check for 1->2 validation.");
+        }
+
+        if (upgradeToV1) {
+            performUpgradeToV1(bootstrapServers, props, retentionMs);
+        } else if (check) {
+            checkForNullKeyMessages(bootstrapServers, props, timeoutMs, upgradeToV2, autoUpgrade, force);
+        } else {
+            throw new TerseException("No operation specified. Use --upgrade-to-v1 for version 0->1 upgrade, or --check for version 1->2 validation.");
+        }
+    }
+
+    private static void performUpgradeToV1(String bootstrapServers, Properties baseProps, long retentionMs) throws Exception {
+        System.out.println("Initiating upgrade to remote.log.metadata.version=1...");
+        System.out.println();
+
+        Properties adminProps = new Properties();
+        adminProps.putAll(baseProps);
+        adminProps.put("bootstrap.servers", bootstrapServers);
+
+        try (Admin admin = Admin.create(adminProps)) {
+            // Check current version
+            org.apache.kafka.clients.admin.FeatureMetadata featureMetadata =
+                admin.describeFeatures().featureMetadata().get();
+
+            org.apache.kafka.clients.admin.FinalizedVersionRange versionRange =
+                featureMetadata.finalizedFeatures().get(org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME);
+
+            short currentVersion = (versionRange != null) ? versionRange.maxVersionLevel() : 0;
+
+            System.out.println("Current remote.log.metadata.version: " + currentVersion);
+
+            if (currentVersion != 0) {
+                if (currentVersion == 1) {
+                    System.out.println("ℹ️  Already at version 1. No upgrade needed.");
+                    return;
+                } else {
+                    throw new TerseException("Current version is " + currentVersion + ". This command is for upgrading from version 0 to 1.");
+                }
+            }
+
+            // First, update topic configurations before upgrading feature
+            // This ensures the controller doesn't overwrite with hardcoded values
+            long retentionDays = retentionMs / (24 * 60 * 60 * 1000L);
+
+            System.out.println("Pre-configuring __remote_log_metadata topic...");
+            System.out.println("  - cleanup.policy=compact,delete");
+            System.out.println("  - retention.ms=" + retentionMs + " (" + retentionDays + " days)");
+            System.out.println("  - min.compaction.lag.ms=" + retentionMs + " (same as retention.ms, " + retentionDays + " days)");
+            System.out.println();
+            System.out.println("IMPORTANT: retention.ms and min.compaction.lag.ms are critical for safe migration.");
+            System.out.println("Setting retention.ms=" + retentionMs + "ms ensures old-format (null-key) messages expire after " + retentionDays + " days.");
+            System.out.println("Setting min.compaction.lag.ms to the same value ensures the log cleaner waits " + retentionDays + " days before compacting,");
+            System.out.println("allowing null-key messages to expire naturally via retention before compaction begins.");
+            System.out.println("This prevents data loss during the migration period.");
+            System.out.println();
+
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, METADATA_TOPIC);
+
+            List<AlterConfigOp> configOps = new java.util.ArrayList<>();
+            configOps.add(new AlterConfigOp(new ConfigEntry("cleanup.policy", "compact,delete"), AlterConfigOp.OpType.SET));
+            configOps.add(new AlterConfigOp(new ConfigEntry("retention.ms", String.valueOf(retentionMs)), AlterConfigOp.OpType.SET));
+            configOps.add(new AlterConfigOp(new ConfigEntry("min.compaction.lag.ms", String.valueOf(retentionMs)), AlterConfigOp.OpType.SET));
+
+            Map<ConfigResource, Collection<AlterConfigOp>> configs = new HashMap<>();
+            configs.put(topicResource, configOps);
+
+            admin.incrementalAlterConfigs(configs).all().get();
+            System.out.println("✅ Topic configurations updated successfully.");
+            System.out.println();
+
+            // Now upgrade feature to version 1
+            // The controller will check the topic config and skip updates since it's already correct
+            System.out.println("Upgrading feature to version 1...");
+            Map<String, FeatureUpdate> updates = new HashMap<>();
+            updates.put(
+                org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME,
+                new FeatureUpdate((short) 1, FeatureUpdate.UpgradeType.UPGRADE)
+            );
+
+            admin.updateFeatures(updates, new UpdateFeaturesOptions()).all().get();
+            System.out.println("✅ Feature upgraded to version 1 successfully.");
+            System.out.println();
+            System.out.println("✅ Upgrade to version 1 completed successfully!");
+            System.out.println();
+            System.out.println("==================== NEXT STEPS ====================");
+            System.out.println();
+            System.out.println("Wait for the retention period (" + retentionDays + " days) before upgrading to version 2.");
+            System.out.println();
+            System.out.println("After waiting, run validation and upgrade to version 2:");
+            System.out.println("  kafka-remote-log-metadata-migration.sh --bootstrap-server " + bootstrapServers + " --check --auto-upgrade");
+            System.out.println();
+            System.out.println("The validation will:");
+            System.out.println("  - Scan for remaining null-key messages");
+            System.out.println("  - Show estimated cleanup time based on the last null-key message timestamp");
+            System.out.println("  - Suggest retry time if null-key messages still exist");
+            System.out.println();
+            System.out.println("===================================================");
+        }
+    }
+
+    private static Properties createConsumerProperties(Properties baseProps, String bootstrapServers) {
+        Properties consumerProps = new Properties();
+        consumerProps.putAll(baseProps);
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "remote-log-metadata-migration-tool-" + System.currentTimeMillis());
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        return consumerProps;
+    }
+
+    private static void printCheckHeader(String bootstrapServers, long timeoutMs, boolean upgradeToV2, boolean force) {
+        System.out.println("Checking __remote_log_metadata topic for messages with null keys...");
+        System.out.println("Bootstrap servers: " + bootstrapServers);
+        System.out.println("Timeout: " + timeoutMs + "ms");
+        if (upgradeToV2) {
+            System.out.println("Upgrade to V2: ENABLED (will upgrade to version 2 if validation passes)");
+            if (force) {
+                System.out.println("Force mode: ENABLED (will upgrade even if null-key messages are found)");
+            }
+        }
+        System.out.println();
+    }
+
+    private static void printTopicConfigurationReminder(Admin admin) {
+        try {
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, METADATA_TOPIC);
+            Config topicConfig = admin.describeConfigs(Collections.singleton(topicResource))
+                .all().get().get(topicResource);
+
+            ConfigEntry retentionMsEntry = topicConfig.get(TopicConfig.RETENTION_MS_CONFIG);
+            ConfigEntry minCompactionLagMsEntry = topicConfig.get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG);
+
+            if (retentionMsEntry != null && retentionMsEntry.value() != null) {
+                long retentionMs = Long.parseLong(retentionMsEntry.value());
+                long retentionDays = retentionMs / (24 * 60 * 60 * 1000L);
+
+                System.out.println("========== IMPORTANT REMINDER ==========");
+                System.out.println();
+                System.out.println("Current __remote_log_metadata topic configuration:");
+                System.out.println("  - retention.ms=" + retentionMs + "ms (" + retentionDays + " days)");
+                if (minCompactionLagMsEntry != null && minCompactionLagMsEntry.value() != null) {
+                    long minCompactionLagMs = Long.parseLong(minCompactionLagMsEntry.value());
+                    long minCompactionLagDays = minCompactionLagMs / (24 * 60 * 60 * 1000L);
+                    System.out.println("  - min.compaction.lag.ms=" + minCompactionLagMs + "ms (" + minCompactionLagDays + " days)");
+                }
+                System.out.println();
+                System.out.println("Before proceeding with this validation, ensure that:");
+                System.out.println("1. At least " + retentionDays + " days have passed since upgrading to version 1");
+                System.out.println("2. This allows all old-format (null-key) messages to expire via retention");
+                System.out.println("3. The log cleaner has NOT compacted the topic yet (prevented by min.compaction.lag.ms)");
+                System.out.println();
+                System.out.println("If you upgraded to version 1 recently (less than " + retentionDays + " days ago),");
+                System.out.println("you should WAIT before running this validation to avoid false negatives.");
+                System.out.println();
+                System.out.println("========================================");
+                System.out.println();
+            }
+        } catch (Exception e) {
+            System.out.println("Warning: Could not retrieve topic configuration. Proceeding with validation anyway.");
+            System.out.println("Error: " + e.getMessage());
+            System.out.println();
+        }
+    }
+
+    private static void printRetrySuggestion(Admin admin, long lastNullKeyTimestamp) {
+        try {
+            long currentTime = System.currentTimeMillis();
+            long messageAgeMs = currentTime - lastNullKeyTimestamp;
+            long messageAgeHours = messageAgeMs / (60 * 60 * 1000L);
+
+            System.out.println("Last null-key message timestamp: " + lastNullKeyTimestamp + " (" + new java.util.Date(lastNullKeyTimestamp) + ")");
+            System.out.println("Last null-key message age: " + messageAgeHours + " hours");
+            System.out.println();
+
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, METADATA_TOPIC);
+            Config topicConfig = admin.describeConfigs(Collections.singleton(topicResource))
+                .all().get().get(topicResource);
+            ConfigEntry retentionMsEntry = topicConfig.get(TopicConfig.RETENTION_MS_CONFIG);
+
+            if (retentionMsEntry != null && retentionMsEntry.value() != null) {
+                long retentionMs = Long.parseLong(retentionMsEntry.value());
+                long retentionHours = retentionMs / (60 * 60 * 1000L);
+                long remainingMs = retentionMs - messageAgeMs;
+
+                if (remainingMs > 0) {
+                    long remainingHours = (long) Math.ceil(remainingMs / (60.0 * 60 * 1000));
+                    long retryTimestamp = lastNullKeyTimestamp + retentionMs;
+
+                    System.out.println("Topic retention.ms: " + retentionMs + "ms (" + retentionHours + " hours)");
+                    System.out.println();
+                    System.out.println("💡 SUGGESTION:");
+                    System.out.println("  Estimated cleanup time: " + new java.util.Date(retryTimestamp));
+                    System.out.println("  Remaining wait time: approximately " + remainingHours + " hours");
+                    System.out.println();
+                    System.out.println("  Please retry this validation after the estimated cleanup time.");
+                    System.out.println();
+                }
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            // Ignore errors when trying to get retry suggestion (ExecutionException, InterruptedException, etc.)
+        }
+    }
+
+    private static ScanResult scanMessagesForNullKeys(KafkaConsumer<byte[], byte[]> consumer, long timeoutMs) {
+        List<TopicPartition> partitions = consumer.partitionsFor(METADATA_TOPIC)
+            .stream()
+            .map(info -> new TopicPartition(info.topic(), info.partition()))
+            .toList();
+
+        if (partitions.isEmpty()) {
+            return new ScanResult(0, 0, -1);
+        }
+
+        System.out.println("Found " + partitions.size() + " partition(s) in " + METADATA_TOPIC);
+        consumer.assign(partitions);
+        consumer.seekToBeginning(partitions);
+
+        AtomicLong totalMessages = new AtomicLong(0);
+        AtomicLong nullKeyMessages = new AtomicLong(0);
+        long lastNullKeyTimestamp = -1;
+        long startTime = System.currentTimeMillis();
+        boolean hasMoreRecords = true;
+
+        System.out.println("Scanning messages...");
+
+        while (hasMoreRecords && (System.currentTimeMillis() - startTime) < timeoutMs) {
+            ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(1000));
+
+            if (records.isEmpty()) {
+                hasMoreRecords = checkHasMoreRecords(consumer, partitions);
+            } else {
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    totalMessages.incrementAndGet();
+
+                    if (record.key() == null) {
+                        nullKeyMessages.incrementAndGet();
+                        lastNullKeyTimestamp = Math.max(lastNullKeyTimestamp, record.timestamp());
+                        System.out.println("⚠️  Found message with null key at partition=" + record.partition() +
+                            ", offset=" + record.offset() + ", timestamp=" + record.timestamp());
+                    }
+
+                    if (totalMessages.get() % 10000 == 0) {
+                        System.out.println("Scanned " + totalMessages.get() + " messages so far...");
+                    }
+                }
+            }
+        }
+
+        return new ScanResult(totalMessages.get(), nullKeyMessages.get(), lastNullKeyTimestamp);
+    }
+
+    private static boolean checkHasMoreRecords(KafkaConsumer<byte[], byte[]> consumer, List<TopicPartition> partitions) {
+        for (TopicPartition partition : partitions) {
+            long position = consumer.position(partition);
+            long endOffset = consumer.endOffsets(Collections.singleton(partition)).get(partition);
+            if (position < endOffset) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void handleScanResults(ScanResult result, Admin admin, String bootstrapServers, Properties baseProps,
+                                          boolean upgradeToV2, boolean autoUpgrade, boolean force) throws Exception {
+        System.out.println();
+        System.out.println("Scan completed.");
+        System.out.println("Total messages scanned: " + result.totalMessages);
+        System.out.println("Messages with null keys: " + result.nullKeyMessages);
+        System.out.println();
+
+        if (result.nullKeyMessages > 0) {
+            handleNullKeysFound(result, admin, bootstrapServers, baseProps, upgradeToV2, autoUpgrade, force);
+        } else {
+            handleNoNullKeysFound(bootstrapServers, baseProps, upgradeToV2, autoUpgrade);
+        }
+    }
+
+    private static void handleNullKeysFound(ScanResult result, Admin admin, String bootstrapServers,
+                                            Properties baseProps, boolean upgradeToV2, boolean autoUpgrade, boolean force) throws Exception {
+        System.out.println("❌ VALIDATION FAILED: Found " + result.nullKeyMessages + " message(s) with null keys.");
+        System.out.println();
+
+        if (result.lastNullKeyTimestamp > 0) {
+            printRetrySuggestion(admin, result.lastNullKeyTimestamp);
+        }
+
+        System.out.println("Action required:");
+        System.out.println("1. Wait for null-key messages to expire based on retention.ms setting");
+        System.out.println("2. Then run this tool again to verify all null-key messages are gone");
+        System.out.println("3. Only then proceed with the upgrade to remote.log.metadata.version=2");
+        System.out.println();
+
+        if (force) {
+            System.out.println("⚠️  WARNING: --force flag is enabled. Proceeding with upgrade despite null-key messages.");
+            System.out.println("⚠️  These null-key messages will be LOST during compaction!");
+            System.out.println();
+            if (upgradeToV2 && autoUpgrade) {
+                performUpgradeToV2(bootstrapServers, baseProps);
+            }
+        } else {
+            System.out.println("To force upgrade despite null-key messages (NOT RECOMMENDED), use --force flag.");
+            throw new TerseException("Cannot upgrade to version 2: null-key messages found in " + METADATA_TOPIC);
+        }
+    }
+
+    private static void handleNoNullKeysFound(String bootstrapServers, Properties baseProps, boolean upgradeToV2, boolean autoUpgrade) throws Exception {
+        System.out.println("✅ VALIDATION PASSED: No null-key messages found.");
+        System.out.println("✅ Safe to upgrade to remote.log.metadata.version=2.");
+        System.out.println();
+
+        if (upgradeToV2 && autoUpgrade) {
+            performUpgradeToV2(bootstrapServers, baseProps);
+        } else if (upgradeToV2 && !autoUpgrade) {
+            System.out.println("To complete the upgrade, add --auto-upgrade flag:");
+            System.out.println("  kafka-remote-log-metadata-migration.sh --bootstrap-server " + bootstrapServers + " --check --upgrade-to-v2 --auto-upgrade");
+        } else {
+            System.out.println("To upgrade, run:");
+            System.out.println("  kafka-features.sh upgrade --bootstrap-server " + bootstrapServers + " --feature remote.log.metadata.version=2");
+            System.out.println();
+            System.out.println("Or run this tool with --upgrade-to-v2 --auto-upgrade to automatically upgrade:");
+            System.out.println("  kafka-remote-log-metadata-migration.sh --bootstrap-server " + bootstrapServers + " --check --upgrade-to-v2 --auto-upgrade");
+        }
+    }
+
+    private static class ScanResult {
+        final long totalMessages;
+        final long nullKeyMessages;
+        final long lastNullKeyTimestamp;
+
+        ScanResult(long totalMessages, long nullKeyMessages, long lastNullKeyTimestamp) {
+            this.totalMessages = totalMessages;
+            this.nullKeyMessages = nullKeyMessages;
+            this.lastNullKeyTimestamp = lastNullKeyTimestamp;
+        }
+    }
+
+    private static void checkForNullKeyMessages(String bootstrapServers, Properties baseProps, long timeoutMs, boolean upgradeToV2, boolean autoUpgrade, boolean force) throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.putAll(baseProps);
+        adminProps.put("bootstrap.servers", bootstrapServers);
+
+        // Check current version if upgrade is requested
+        if (upgradeToV2 && autoUpgrade) {
+            try (Admin admin = Admin.create(adminProps)) {
+                org.apache.kafka.clients.admin.FeatureMetadata featureMetadata =
+                    admin.describeFeatures().featureMetadata().get();
+
+                org.apache.kafka.clients.admin.FinalizedVersionRange versionRange =
+                    featureMetadata.finalizedFeatures().get(org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME);
+
+                short currentVersion = (versionRange != null) ? versionRange.maxVersionLevel() : 0;
+
+                if (currentVersion >= 2) {
+                    System.out.println("✅ Cluster is already at remote.log.metadata.version=" + currentVersion);
+                    System.out.println("✅ No upgrade needed.");
+                    return;
+                }
+
+                if (currentVersion == 0) {
+                    throw new TerseException(
+                        "Cannot upgrade directly from version 0 to version 2. " +
+                        "Must upgrade to version 1 first using: " +
+                        "kafka-remote-log-metadata-migration.sh --bootstrap-server " + bootstrapServers + " --upgrade-to-v1");
+                }
+            }
+        }
+
+        try (Admin admin = Admin.create(adminProps)) {
+            printTopicConfigurationReminder(admin);
+        }
+
+        Properties consumerProps = createConsumerProperties(baseProps, bootstrapServers);
+
+        printCheckHeader(bootstrapServers, timeoutMs, upgradeToV2, force);
+
+        try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps)) {
+            List<TopicPartition> partitions = consumer.partitionsFor(METADATA_TOPIC)
+                .stream()
+                .map(info -> new TopicPartition(info.topic(), info.partition()))
+                .toList();
+
+            if (partitions.isEmpty()) {
+                System.out.println("✅ Topic " + METADATA_TOPIC + " does not exist or has no partitions.");
+                System.out.println("✅ No null-key messages found. Safe to upgrade to version 2.");
+                return;
+            }
+
+            ScanResult result = scanMessagesForNullKeys(consumer, timeoutMs);
+
+            try (Admin admin = Admin.create(adminProps)) {
+                handleScanResults(result, admin, bootstrapServers, baseProps, upgradeToV2, autoUpgrade, force);
+            }
+        }
+    }
+
+    private static void performUpgradeToV2(String bootstrapServers, Properties baseProps) throws Exception {
+        System.out.println("Initiating upgrade to remote.log.metadata.version=2...");
+        System.out.println();
+
+        Properties adminProps = new Properties();
+        adminProps.putAll(baseProps);
+        adminProps.put("bootstrap.servers", bootstrapServers);
+
+        try (Admin admin = Admin.create(adminProps)) {
+            // First, check current version
+            org.apache.kafka.clients.admin.FeatureMetadata featureMetadata =
+                admin.describeFeatures().featureMetadata().get();
+
+            org.apache.kafka.clients.admin.FinalizedVersionRange versionRange =
+                featureMetadata.finalizedFeatures().get(org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME);
+
+            short currentVersion = (versionRange != null) ? versionRange.maxVersionLevel() : 0;
+
+            System.out.println("Current remote.log.metadata.version: " + currentVersion);
+
+            if (currentVersion == 0) {
+                throw new TerseException(
+                    "Cannot upgrade directly from version 0 to version 2. " +
+                    "Must upgrade to version 1 first using: " +
+                    "kafka-remote-log-metadata-migration.sh --bootstrap-server " + bootstrapServers + " --upgrade-to-v1");
+            }
+
+            if (currentVersion == 2) {
+                System.out.println("ℹ️  Already at version 2. No upgrade needed.");
+                return;
+            }
+
+            if (currentVersion != 1) {
+                throw new TerseException("Unexpected current version: " + currentVersion + ". Expected version 1.");
+            }
+
+            // Perform the upgrade from 1 to 2
+            // The controller will automatically update topic configurations:
+            //   - Change cleanup.policy to 'compact' (removing 'delete')
+            //   - Remove min.compaction.lag.ms override
+            //   - Remove retention.ms override
+            System.out.println("Upgrading from version 1 to version 2...");
+            Map<String, FeatureUpdate> updates = new HashMap<>();
+            updates.put(
+                org.apache.kafka.server.common.RemoteLogMetadataVersion.FEATURE_NAME,
+                new FeatureUpdate((short) 2, FeatureUpdate.UpgradeType.UPGRADE)
+            );
+
+            admin.updateFeatures(updates, new UpdateFeaturesOptions()).all().get();
+
+            System.out.println();
+            System.out.println("✅ Successfully upgraded to remote.log.metadata.version=2!");
+            System.out.println();
+            System.out.println("The controller has automatically updated __remote_log_metadata topic configuration:");
+            System.out.println("  - cleanup.policy changed to 'compact' (compact-only)");
+            System.out.println("  - min.compaction.lag.ms override removed");
+            System.out.println("  - retention.ms override removed");
+            System.out.println();
+            System.out.println("All metadata messages now have proper keys and will be retained indefinitely via compaction.");
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
@@ -390,7 +390,7 @@ public class DumpLogSegmentsTest {
 
         List<RemotePartitionDeleteMetadata> metadata = List.of(
             new RemotePartitionDeleteMetadata(new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
-                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0)
+                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0, 0, 100L)
         );
 
         SimpleRecord[] records = metadata.stream()
@@ -427,13 +427,17 @@ public class DumpLogSegmentsTest {
                 time.milliseconds(),
                 Optional.of(new RemoteLogSegmentMetadata.CustomMetadata(new byte[] {0, 1, 2, 3})),
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                0
+                0,
+                0,
+                100L
             ),
             new RemotePartitionDeleteMetadata(
                 topicIdPartition,
                 RemotePartitionDeleteState.DELETE_PARTITION_MARKED,
                 time.milliseconds(),
-                0
+                0,
+                0,
+                100L
             )
         );
 
@@ -476,13 +480,17 @@ public class DumpLogSegmentsTest {
                 time.milliseconds(),
                 Optional.of(new RemoteLogSegmentMetadata.CustomMetadata(new byte[] {0, 1, 2, 3})),
                 RemoteLogSegmentState.COPY_SEGMENT_FINISHED,
-                0
+                0,
+                0,
+                100L
             ),
             new RemotePartitionDeleteMetadata(
                 topicIdPartition,
                 RemotePartitionDeleteState.DELETE_PARTITION_MARKED,
                 time.milliseconds(),
-                0
+                0,
+                0,
+                100L
             )
         );
 
@@ -518,7 +526,7 @@ public class DumpLogSegmentsTest {
 
         List<RemotePartitionDeleteMetadata> metadata = List.of(
             new RemotePartitionDeleteMetadata(new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
-                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0)
+                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0, 0, 100L)
         );
 
         SimpleRecord[] metadataRecords = metadata.stream()
@@ -567,7 +575,7 @@ public class DumpLogSegmentsTest {
 
         List<RemotePartitionDeleteMetadata> metadata = List.of(
             new RemotePartitionDeleteMetadata(new TopicIdPartition(topicId, new TopicPartition(topicName, 0)),
-                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0)
+                RemotePartitionDeleteState.DELETE_PARTITION_MARKED, time.milliseconds(), 0, 0, 100L)
         );
 
         SimpleRecord[] metadataRecords = metadata.stream()


### PR DESCRIPTION
# KIP-1266: Enable Log Compaction for __remote_log_metadata Topic

## Summary

Enables log compaction for `__remote_log_metadata` topic to reduce storage by 90%+. Introduces a three-version upgrade path to safely migrate from time-based deletion to compaction without data loss.

## Key Changes

### 1. Feature Flag: `remote.log.metadata.version`
- **V0** (default): `cleanup.policy=delete`, null-key messages
- **V1** (transition): `cleanup.policy=compact,delete`, allows null-key expiration  
- **V2** (final): `cleanup.policy=compact`, keys required

**New file:** `RemoteLogMetadataVersion.java`

### 2. Message Format
Added composite keys: `topicId:topicName:partition:endOffset:brokerLeaderEpoch`

New field `brokerLeaderEpoch` prevents key collisions when segments are recreated.

**Modified:** Message schemas and metadata classes

### 3. Migration Tool
New tool: `kafka-remote-log-metadata-migration.sh`

```bash
# Upgrade to v1
kafka-remote-log-metadata-migration.sh --upgrade-to-v1 --retention-ms 1209600000

# Validate and upgrade to v2
kafka-remote-log-metadata-migration.sh --check --upgrade-to-v2 --auto-upgrade
```

New file: RemoteLogMetadataMigrationTool.java (662 lines)


4. Controller Integration
Automatically applies topic configs on feature version upgrade.
Modified: ConfigurationControlManager.java


5. Backward Compatibility
- Producer: Publishes with keys (forward-compatible)
- Consumer: Handles both keyed and null-key messages
- Index: Added endOffsetToSegments for efficient cleanup

Modified: ProducerManager.java, ConsumerTask.java, RemoteLogMetadataCache.java

## Test
I have tested the migration path on existing clusters which has finished successfully.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
