### PR TITLE
KAFKA-20444: [11/N] Refresh metadata before TxnOffsetCommit (KIP-1319)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -93,6 +93,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -789,31 +790,24 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     }
 
     /**
-     * Ensure every topic is present in the producer's metadata cache.
-     * {@link ProducerMetadata#add(String, long)} refreshes the expiry for known
-     * topics and triggers a fetch for new ones; if any topic is new, blocks the
-     * user thread on {@link ProducerMetadata#awaitUpdate(int, long)} up to
-     * {@code max.block.ms}, mirroring {@link #partitionsFor(String)}. Returns
-     * the elapsed wait time in milliseconds so the caller can subtract it from
-     * its own {@code max.block.ms} budget.
+     * Request a partial metadata refresh for the given topics and await the next
+     * metadata update on a best-effort basis (up to {@code max.block.ms}). Returns
+     * the elapsed wait time so the caller can subtract it from its own
+     * {@code max.block.ms} budget.
      */
     private long awaitTopicMetadata(Set<String> topics) {
-        long nowMs = time.milliseconds();
-        boolean hasNewTopics = false;
-        for (String topic : topics) {
-            hasNewTopics |= metadata.add(topic, nowMs);
-        }
-        if (!hasNewTopics) return 0L;
-        int version = metadata.requestUpdate(true);
-        // Wake the sender so it picks up the metadata request immediately
-        // instead of waiting for its next selector poll to elapse.
+        long startNanos = time.nanoseconds();
+        OptionalInt versionOpt = metadata.add(topics, time.milliseconds());
+        if (versionOpt.isEmpty()) return 0L;
         sender.wakeup();
         try {
-            metadata.awaitUpdate(version, maxBlockTimeMs);
+            metadata.awaitUpdate(versionOpt.getAsInt(), maxBlockTimeMs);
         } catch (InterruptedException e) {
             throw new InterruptException(e);
         }
-        return time.milliseconds() - nowMs;
+        long elapsedNanos = time.nanoseconds() - startNanos;
+        producerMetrics.recordMetadataWait(elapsedNanos);
+        return TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -94,10 +94,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 
 /**
@@ -741,7 +743,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * Note, that the consumer should have {@code enable.auto.commit=false} and should
      * also not commit offsets manually (via {@link KafkaConsumer#commitSync(Map) sync} or
      * {@link KafkaConsumer#commitAsync(Map, OffsetCommitCallback) async} commits).
-     * This method will raise {@link TimeoutException} if the producer cannot send offsets before expiration of {@code max.block.ms}.
+     * This method will raise {@link TimeoutException} if the producer cannot resolve the metadata for the topics in
+     * {@code offsets} and send the offsets before expiration of {@code max.block.ms}.
      * Additionally, it will raise {@link InterruptException} if interrupted.
      *
      * @throws IllegalStateException if no transactional.id has been configured or no transaction has been started.
@@ -762,7 +765,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *         to the partition leader. See the exception for more details
      * @throws KafkaException if the producer has encountered a previous fatal or abortable error, or for any
      *         other unexpected error
-     * @throws TimeoutException if the time taken for sending the offsets has surpassed <code>max.block.ms</code>.
+     * @throws TimeoutException if the combined time taken for resolving topic metadata and sending the offsets
+     *         has surpassed <code>max.block.ms</code>.
      * @throws InterruptException if the thread is interrupted while blocked
      */
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
@@ -774,11 +778,42 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
 
         if (!offsets.isEmpty()) {
             long start = time.nanoseconds();
+            var topics = offsets.keySet().stream().map(TopicPartition::topic).collect(Collectors.toSet());
+            var waitMs = awaitTopicMetadata(topics);
+            var remainingMs = Math.max(0L, maxBlockTimeMs - waitMs);
             TransactionalRequestResult result = transactionManager.sendOffsetsToTransaction(offsets, groupMetadata);
             sender.wakeup();
-            result.await(maxBlockTimeMs, TimeUnit.MILLISECONDS, SEND_OFFSETS_TIMEOUT_MSG);
+            result.await(remainingMs, TimeUnit.MILLISECONDS, SEND_OFFSETS_TIMEOUT_MSG);
             producerMetrics.recordSendOffsets(time.nanoseconds() - start);
         }
+    }
+
+    /**
+     * Ensure every topic is present in the producer's metadata cache.
+     * {@link ProducerMetadata#add(String, long)} refreshes the expiry for known
+     * topics and triggers a fetch for new ones; if any topic is new, blocks the
+     * user thread on {@link ProducerMetadata#awaitUpdate(int, long)} up to
+     * {@code max.block.ms}, mirroring {@link #partitionsFor(String)}. Returns
+     * the elapsed wait time in milliseconds so the caller can subtract it from
+     * its own {@code max.block.ms} budget.
+     */
+    private long awaitTopicMetadata(Set<String> topics) {
+        long nowMs = time.milliseconds();
+        boolean hasNewTopics = false;
+        for (String topic : topics) {
+            hasNewTopics |= metadata.add(topic, nowMs);
+        }
+        if (!hasNewTopics) return 0L;
+        int version = metadata.requestUpdate(true);
+        // Wake the sender so it picks up the metadata request immediately
+        // instead of waiting for its next selector poll to elapse.
+        sender.wakeup();
+        try {
+            metadata.awaitUpdate(version, maxBlockTimeMs);
+        } catch (InterruptedException e) {
+            throw new InterruptException(e);
+        }
+        return time.milliseconds() - nowMs;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -28,10 +28,12 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
 
 public class ProducerMetadata extends Metadata {
@@ -68,19 +70,31 @@ public class ProducerMetadata extends Metadata {
         return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
     }
 
-    /**
-     * Add the topic to the working set or refresh its expiry if already
-     * present. Returns {@code true} if the topic was newly added (in which
-     * case a metadata fetch has been requested).
-     */
-    public synchronized boolean add(String topic, long nowMs) {
+    public synchronized void add(String topic, long nowMs) {
         Objects.requireNonNull(topic, "topic cannot be null");
         if (topics.put(topic, nowMs + metadataIdleMs) == null) {
             newTopics.add(topic);
             requestUpdateForNewTopics();
-            return true;
         }
-        return false;
+    }
+
+    /**
+     * Atomically add a batch of topics to the working set, refreshing the
+     * expiry for those already present. If any of the topics was newly added,
+     * a partial metadata refresh is requested and the current updateVersion is
+     * returned so the caller can pass it to {@link #awaitUpdate(int, long)} to
+     * wait for the next response. Returns an empty {@code OptionalInt} when no
+     * topic was newly added (no refresh requested, nothing to wait for).
+     */
+    public synchronized OptionalInt add(Collection<String> topics, long nowMs) {
+        boolean anyNew = false;
+        for (String topic : topics) {
+            if (this.topics.put(topic, nowMs + metadataIdleMs) == null) {
+                newTopics.add(topic);
+                anyNew = true;
+            }
+        }
+        return anyNew ? OptionalInt.of(requestUpdateForNewTopics()) : OptionalInt.empty();
     }
 
     public synchronized int requestUpdateForTopic(String topic) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -68,12 +68,19 @@ public class ProducerMetadata extends Metadata {
         return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
     }
 
-    public synchronized void add(String topic, long nowMs) {
+    /**
+     * Add the topic to the working set or refresh its expiry if already
+     * present. Returns {@code true} if the topic was newly added (in which
+     * case a metadata fetch has been requested).
+     */
+    public synchronized boolean add(String topic, long nowMs) {
         Objects.requireNonNull(topic, "topic cannot be null");
         if (topics.put(topic, nowMs + metadataIdleMs) == null) {
             newTopics.add(topic);
             requestUpdateForNewTopics();
+            return true;
         }
+        return false;
     }
 
     public synchronized int requestUpdateForTopic(String topic) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2074,6 +2074,161 @@ public class KafkaProducerTest {
     }
 
     @Test
+    public void testSendOffsetsToTransactionNegotiatesV6WhenMetadataKnowsTopicId() {
+        var topic = "topic";
+        var topicId = Uuid.randomUuid();
+        var tp = new TopicPartition(topic, 0);
+        var groupId = "group";
+
+        var properties = new Properties();
+        properties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        properties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10000);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        var time = new MockTime(1);
+        var metadata = newMetadata(0, 0, Long.MAX_VALUE);
+        var client = new MockClient(time, metadata);
+        // Seed the metadata cache with a known topic id so the producer can
+        // negotiate v6 of TxnOffsetCommit (KIP-1319).
+        client.updateMetadata(RequestTestUtils.metadataUpdateWithIds(
+            1,
+            Map.of(topic, 1),
+            Map.of(topic, topicId)
+        ));
+
+        var nodeApiVersions = new NodeApiVersions(
+            NodeApiVersions.create().allSupportedApiVersions().values(),
+            List.of(new ApiVersionsResponseData.SupportedFeatureKey()
+                .setName("transaction.version")
+                .setMaxVersion((short) 2)
+                .setMinVersion((short) 0)),
+            List.of(new ApiVersionsResponseData.FinalizedFeatureKey()
+                .setName("transaction.version")
+                .setMaxVersionLevel((short) 2)
+                .setMinVersionLevel((short) 2)),
+            0
+        );
+        client.setNodeApiVersions(nodeApiVersions);
+        var apiVersions = new ApiVersions();
+        apiVersions.update(NODE.idString(), nodeApiVersions);
+
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(request -> {
+            var txnRequest = (TxnOffsetCommitRequest) request;
+            assertEquals(groupId, txnRequest.data().groupId());
+            assertTrue(txnRequest.version() >= 6, "Expected TxnOffsetCommit at v6+, got " + txnRequest.version());
+            assertEquals(1, txnRequest.data().topics().size());
+            assertEquals(topicId, txnRequest.data().topics().get(0).topicId());
+            return true;
+        }, txnOffsetsCommitResponse(Map.of(tp, Errors.NONE)));
+        client.prepareResponse(endTxnResponse(Errors.NONE));
+
+        try (var producer = new KafkaProducer<String, String>(
+            new ProducerConfig(properties),
+            new StringSerializer(),
+            new StringSerializer(),
+            metadata,
+            client,
+            new ProducerInterceptors<>(List.of(), null),
+            apiVersions,
+            time
+        )) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.sendOffsetsToTransaction(
+                Map.of(tp, new OffsetAndMetadata(5L)),
+                new ConsumerGroupMetadata(groupId)
+            );
+            producer.commitTransaction();
+        }
+    }
+
+    @Test
+    public void testSendOffsetsToTransactionTriggersMetadataRefreshThenNegotiatesV6() {
+        var topic = "topic";
+        var topicId = Uuid.randomUuid();
+        var tp = new TopicPartition(topic, 0);
+        var groupId = "group";
+
+        var properties = new Properties();
+        properties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "some.id");
+        properties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10000);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        var time = new MockTime(1);
+        var metadata = newMetadata(0, 0, Long.MAX_VALUE);
+        var client = new MockClient(time, metadata);
+        // The initial metadata snapshot contains the topic so the producer can
+        // discover the coordinator, but has no topic-id mapping yet -- the
+        // topic-id is only populated by the refresh triggered from
+        // `sendOffsetsToTransaction`.
+        client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, Map.of(topic, 1)));
+        client.prepareMetadataUpdate(RequestTestUtils.metadataUpdateWithIds(
+            1,
+            Map.of(topic, 1),
+            Map.of(topic, topicId)
+        ));
+
+        var nodeApiVersions = new NodeApiVersions(
+            NodeApiVersions.create().allSupportedApiVersions().values(),
+            List.of(new ApiVersionsResponseData.SupportedFeatureKey()
+                .setName("transaction.version")
+                .setMaxVersion((short) 2)
+                .setMinVersion((short) 0)),
+            List.of(new ApiVersionsResponseData.FinalizedFeatureKey()
+                .setName("transaction.version")
+                .setMaxVersionLevel((short) 2)
+                .setMinVersionLevel((short) 2)),
+            0
+        );
+        client.setNodeApiVersions(nodeApiVersions);
+        var apiVersions = new ApiVersions();
+        apiVersions.update(NODE.idString(), nodeApiVersions);
+
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(initProducerIdResponse(1L, (short) 5, Errors.NONE));
+        client.prepareResponse(FindCoordinatorResponse.prepareResponse(Errors.NONE, "some.id", NODE));
+        client.prepareResponse(request -> {
+            var txnRequest = (TxnOffsetCommitRequest) request;
+            assertEquals(groupId, txnRequest.data().groupId());
+            assertTrue(txnRequest.version() >= 6, "Expected TxnOffsetCommit at v6+ after metadata refresh, got " + txnRequest.version());
+            assertEquals(1, txnRequest.data().topics().size());
+            assertEquals(topicId, txnRequest.data().topics().get(0).topicId());
+            return true;
+        }, txnOffsetsCommitResponse(Map.of(tp, Errors.NONE)));
+        client.prepareResponse(endTxnResponse(Errors.NONE));
+
+        try (var producer = new KafkaProducer<String, String>(
+            new ProducerConfig(properties),
+            new StringSerializer(),
+            new StringSerializer(),
+            metadata,
+            client,
+            new ProducerInterceptors<>(List.of(), null),
+            apiVersions,
+            time
+        )) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            // The topic is not yet user-tracked in the producer's metadata, so
+            // awaitTopicMetadata adds it, requests an update, and waits. The
+            // queued metadata refresh above supplies the topic id, and the
+            // subsequent TxnOffsetCommit negotiates v6+.
+            producer.sendOffsetsToTransaction(
+                Map.of(tp, new OffsetAndMetadata(5L)),
+                new ConsumerGroupMetadata(groupId)
+            );
+            producer.commitTransaction();
+        }
+    }
+
+    @Test
     public void testTransactionV2Produce() throws Exception {
         StringSerializer serializer = new StringSerializer();
         KafkaProducerTestContext<String> ctx = new KafkaProducerTestContext<>(testInfo, serializer);
@@ -2153,6 +2308,10 @@ public class KafkaProducerTest {
         Time time = new MockTime(tick.toMillis());
         MetadataResponse initialUpdateResponse = RequestTestUtils.metadataUpdateWith(1, singletonMap("topic", 1));
         ProducerMetadata metadata = newMetadata(0, 0, Long.MAX_VALUE);
+        // Pre-track the topic so sendOffsetsToTransaction does not trigger a
+        // metadata refresh (which would tick the mock clock and exhaust
+        // max.block.ms via auto-tick).
+        metadata.add("topic", time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
         client.updateMetadata(initialUpdateResponse);


### PR DESCRIPTION
`TransactionManager` now reads topic ids from the producer's metadata
cache when building a `TxnOffsetCommit` request (added in the previous
patch), but the cache may not yet contain entries for topics the
producer has not produced to. This patch ensures the cache is fresh
before the delegation, so v6+ (KIP-1319) negotiation actually fires.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
