### PR TITLE
MINOR: Make VerifiableConsumer close timeout configurable

### DIFF
--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -238,9 +238,11 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                  static_membership=False, max_messages=-1, session_timeout_sec=0, enable_autocommit=False,
                  assignment_strategy=None, group_protocol=None, group_remote_assignor=None,
                  version=DEV_BRANCH, stop_timeout_sec=30, log_level="INFO", jaas_override_variables=None,
-                 on_record_consumed=None, reset_policy="earliest", verify_offsets=True, prop_file=""):
+                 on_record_consumed=None, reset_policy="earliest", verify_offsets=True,
+                 close_timeout_sec=15, prop_file=""):
         """
         :param jaas_override_variables: A dict of variables to be used in the jaas.conf template file
+        :param close_timeout_sec: Timeout in seconds for closing the consumer (default: 15)
         """
         super(VerifiableConsumer, self).__init__(context, num_nodes)
         self.log_level = log_level
@@ -257,6 +259,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         self.assignment_strategy = assignment_strategy
         self.prop_file = prop_file
         self.stop_timeout_sec = stop_timeout_sec
+        self.close_timeout_sec = close_timeout_sec
         self.on_record_consumed = on_record_consumed
         self.verify_offsets = verify_offsets
 
@@ -438,6 +441,9 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
 
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
+
+        if self.close_timeout_sec > 0:
+            cmd += " --close-timeout %s" % (self.close_timeout_sec * 1000)
 
         version = get_version(node)
         if version.supports_command_config():

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -442,10 +442,11 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
 
-        if self.close_timeout_sec >= 0:
+        version = get_version(node)
+
+        if self.close_timeout_sec >= 0 and version.supports_consumer_close_timeout():
             cmd += " --close-timeout %s" % (self.close_timeout_sec * 1000)
 
-        version = get_version(node)
         if version.supports_command_config():
             cmd += " --command-config %s" % VerifiableConsumer.CONFIG_FILE
         else:

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -442,7 +442,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
 
-        if self.close_timeout_sec > 0:
+        if self.close_timeout_sec >= 0:
             cmd += " --close-timeout %s" % (self.close_timeout_sec * 1000)
 
         version = get_version(node)

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -118,6 +118,11 @@ class KafkaVersion(LooseVersion):
         # - For older versions, continue using --property
         return self >= V_4_2_0
 
+    def supports_consumer_close_timeout(self):
+        # The VerifiableConsumer --close-timeout option was added in the 4.4.0 development cycle.
+        # Older versions do not recognize the argument and fail to start, so only pass it on newer versions.
+        return self >= DEV_VERSION
+
 def get_version(node=None):
     """Return the version attached to the given node.
     Default to DEV_BRANCH if node or node.version is undefined (aka None)

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.tools;
 
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -104,6 +105,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
     private final int maxMessages;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1);
     private int consumedMessages = 0;
+    private final int closeTimeoutMs;
 
     public VerifiableConsumer(KafkaConsumer<String, String> consumer,
                               PrintStream out,
@@ -111,7 +113,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                               int maxMessages,
                               boolean useAutoCommit,
                               boolean useAsyncCommit,
-                              boolean verbose) {
+                              boolean verbose,
+                              int closeTimeoutMs) {
         this.consumer = consumer;
         this.out = out;
         this.topic = topic;
@@ -119,6 +122,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         this.useAutoCommit = useAutoCommit;
         this.useAsyncCommit = useAsyncCommit;
         this.verbose = verbose;
+        this.closeTimeoutMs = closeTimeoutMs;
         addKafkaSerializerModule();
     }
 
@@ -252,7 +256,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             // Log the error so it goes to the service log and not stdout
             log.error("Error during processing, terminating consumer process: ", t);
         } finally {
-            consumer.close();
+            consumer.close(CloseOptions.timeout(Duration.ofMillis(closeTimeoutMs)));
             printJson(new ShutdownComplete());
             shutdownLatch.countDown();
         }
@@ -602,6 +606,15 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
             .metavar("ENABLE-AUTOCOMMIT")
             .help("Enable offset auto-commit on consumer");
 
+        parser.addArgument("--close-timeout")
+                .action(store())
+                .required(false)
+                .type(Integer.class)
+                .setDefault(30000)
+                .dest("closeTimeout")
+                .metavar("CLOSE-TIMEOUT-MS")
+                .help("Timeout in milliseconds for closing the consumer (default: 30000)");
+
         parser.addArgument("--reset-policy")
             .action(store())
             .required(false)
@@ -643,6 +656,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         Namespace res = parser.parseArgs(args);
 
         boolean useAutoCommit = res.getBoolean("useAutoCommit");
+        int closeTimeout = res.getInt("closeTimeout");
         String configFile = res.getString("consumer.config");
         String commandConfigFile = res.getString("commandConfigFile");
         String brokerHostAndPort = res.getString("bootstrapServer");
@@ -716,7 +730,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 maxMessages,
                 useAutoCommit,
                 false,
-                verbose);
+                verbose,
+                closeTimeout);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This change makes the consumer close timeout configurable in the
`VerifiableConsumer` system test tool instead of relying on a hardcoded
value. The Java tool now accepts a `--close-timeout` argument in
milliseconds, and the Python test service (`verifiable_consumer.py`)
exposes this as a `close_timeout_sec` parameter that is passed through
on the command line. While here, the deprecated
`KafkaConsumer.close(Duration)` call is replaced with the newer
`CloseOptions.timeout()` API.

The motivation is test stability. The Python service waits for nodes to
exit within 30 seconds, so the consumer close needs to complete in less
than that. The service now defaults to a 15 second close timeout, which
leaves enough headroom, and individual tests can override it when a
particular scenario needs a different value.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
