### PR TITLE
MINOR: Reduce unnecessary offset reads during log recovery

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogLoader.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogLoader.java
@@ -506,7 +506,9 @@ public class LogLoader {
         if (hadCleanShutdown && logEndOffsetOptional.isPresent()) {
             return new RecoveryOffsets(logEndOffsetOptional.get(), logEndOffsetOptional.get());
         } else {
-            long logEndOffset = logEndOffsetOptional.orElse(segments.lastSegment().get().readNextOffset());
+            long logEndOffset = logEndOffsetOptional.isPresent()
+                ? logEndOffsetOptional.get()
+                : segments.lastSegment().get().readNextOffset();
             return new RecoveryOffsets(Math.min(recoveryPointCheckpoint, logEndOffset), logEndOffset);
         }
     }


### PR DESCRIPTION
**LogLoader** computes recovery offsets after loading and validating the local log segments. In the branch where the log end offset may already be available, the previous code used Optional.orElse with _readNextOffset_ as the fallback.

Optional.orElse evaluates its fallback eagerly, so _readNextOffset_ could be called even when the existing log end offset was already present. Since _readNextOffset_ reads the next offset from the segment, this can add unnecessary work during log recovery.

This change keeps the behavior the same, but makes the fallback explicit so _readNextOffset_ is only called when the log end offset was not already computed.
