### PR TITLE
KAFKA-12861: MockProducer NPE with default constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -343,7 +343,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         if (!this.cluster.partitionsForTopic(record.topic()).isEmpty())
             partition = partition(record, this.cluster);
         else {
-            //just to throw ClassCastException if serializers are not the proper ones to serialize key/value
+            // Validate serializers if they are set
             if (keySerializer != null)
                 keySerializer.serialize(record.topic(), new RecordHeaders(), record.key());
             if (valueSerializer != null)
@@ -644,8 +644,8 @@ public class MockProducer<K, V> implements Producer<K, V> {
                                                    + "].");
             return partition;
         }
-        byte[] keyBytes = keySerializer.serialize(topic, record.headers(), record.key());
-        byte[] valueBytes = valueSerializer.serialize(topic, record.headers(), record.value());
+        byte[] keyBytes = keySerializer != null ? keySerializer.serialize(topic, record.headers(), record.key()) : null;
+        byte[] valueBytes = valueSerializer != null ? valueSerializer.serialize(topic, record.headers(), record.value()) : null;
         if (partitioner == null) {
             return this.cluster.partitionsForTopic(record.topic()).get(0).partition();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -344,8 +344,10 @@ public class MockProducer<K, V> implements Producer<K, V> {
             partition = partition(record, this.cluster);
         else {
             //just to throw ClassCastException if serializers are not the proper ones to serialize key/value
-            keySerializer.serialize(record.topic(), new RecordHeaders(), record.key());
-            valueSerializer.serialize(record.topic(), new RecordHeaders(), record.value());
+            if (keySerializer != null)
+                keySerializer.serialize(record.topic(), new RecordHeaders(), record.key());
+            if (valueSerializer != null)
+                valueSerializer.serialize(record.topic(), new RecordHeaders(), record.value());
         }
 
         TopicPartition topicPartition = new TopicPartition(record.topic(), partition);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -740,6 +740,25 @@ public class MockProducerTest {
         }
     }
 
+    @Test
+    public void testNoNpeWithDefaultConstructor() {
+        // KAFKA-12861: default constructor passes null serializers
+        MockProducer<byte[], byte[]> producer = new MockProducer<>();
+        assertDoesNotThrow(() -> producer.send(new ProducerRecord<>("topic", null, null)));
+        producer.close();
+    }
+
+    @Test
+    public void testNoNpeInPartitionMethodWithNullSerializers() {
+        // KAFKA-12861: partition() method accesses serializers when computing partition
+        PartitionInfo info = new PartitionInfo("topic", 0, null, null, null);
+        Cluster cluster = new Cluster(null, new ArrayList<>(0),
+            Collections.singletonList(info), Collections.emptySet(), Collections.emptySet());
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(cluster, false, null, null, null);
+        assertDoesNotThrow(() -> producer.send(new ProducerRecord<>("topic", null, null)));
+        producer.close();
+    }
+
     private boolean isError(Future<?> future) {
         try {
             future.get();


### PR DESCRIPTION
Fixes NPE when using no-arg MockProducer constructor with unknown
topics.
