### PR TITLE
KAFKA-20660: Add detection of use of legacy ConsumerRecords(Map) constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -19,12 +19,16 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.internals.AbstractIterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A container that holds the list {@link ConsumerRecord} per partition for a
@@ -32,17 +36,25 @@ import java.util.Set;
  * partition returned by a {@link Consumer#poll(java.time.Duration)} operation.
  */
 public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
+    private static final Logger log = LoggerFactory.getLogger(ConsumerRecords.class);
+
+    // Ensures the tainted-records error (see nextOffsets()) is logged at most once per JVM since nextOffsets() is called on every poll
+    static final AtomicBoolean TAINTED_NEXT_OFFSETS_LOGGED = new AtomicBoolean(false);
+
     public static final ConsumerRecords<Object, Object> EMPTY = new ConsumerRecords<>(Map.of(), Map.of());
 
     private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
     private final Map<TopicPartition, OffsetAndMetadata> nextOffsets;
+
+    // Flag to detect if legacy ConsumerRecords(Map) constructor is used. See KAFKA-20660 for more details.
+    private final boolean tainted;
 
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
      */
     @Deprecated
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
-        this(records, Map.of());
+        this(records, Map.of(), true);
     }
 
     /**
@@ -54,8 +66,13 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
      *                    start reading from on the next poll.
      */
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records, final Map<TopicPartition, OffsetAndMetadata> nextOffsets) {
+        this(records, nextOffsets, false);
+    }
+
+    private ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records, final Map<TopicPartition, OffsetAndMetadata> nextOffsets, boolean tainted) {
         this.records = records;
         this.nextOffsets = Map.copyOf(nextOffsets);
+        this.tainted = tainted;
     }
 
     /**
@@ -76,6 +93,14 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
      * @return The next offsets that the consumer will consume
      */
     public Map<TopicPartition, OffsetAndMetadata> nextOffsets() {
+        if (this.tainted && TAINTED_NEXT_OFFSETS_LOGGED.compareAndSet(false, true)) {
+            log.error("ConsumerRecords#nextOffsets() returned empty because this instance was built with the " +
+                    "deprecated ConsumerRecords(Map) constructor (see KIP-1094), which does not supply next offsets. " +
+                    "Downstream logic that relies on these offsets to advance the consumer's committed position " +
+                    "(for example, Kafka Streams under exactly-once semantics) will be unable to commit, leading to " +
+                    "reprocessing. Update the interceptor or wrapper that constructed it to use the " +
+                    "ConsumerRecords(Map, Map) constructor that supplies next offsets.");
+        }
         return nextOffsets;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -46,7 +46,9 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
 
     // Flag to detect if legacy ConsumerRecords(Map) constructor is used. See KAFKA-20660 for more details.
     private final boolean tainted;
+    // Visible for testing
     static final long TAINT_LOG_INTERVAL_NS = TimeUnit.MINUTES.toNanos(5);
+    // Visible for testing
     static final AtomicLong TAINTED_NEXT_OFFSETS_LAST_LOG_NS = new AtomicLong(System.nanoTime() - TAINT_LOG_INTERVAL_NS);
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -52,7 +52,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
      */
-    @Deprecated(since = "4.1", forRemoval = true)
+    @Deprecated
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
         this(records, Map.of(), true);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -52,7 +52,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.1", forRemoval = true)
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
         this(records, Map.of(), true);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -28,7 +28,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A container that holds the list {@link ConsumerRecord} per partition for a
@@ -38,9 +39,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     private static final Logger log = LoggerFactory.getLogger(ConsumerRecords.class);
 
-    // Ensures the tainted-records error (see nextOffsets()) is logged at most once per JVM since nextOffsets() is called on every poll
-    static final AtomicBoolean TAINTED_NEXT_OFFSETS_LOGGED = new AtomicBoolean(false);
-
     public static final ConsumerRecords<Object, Object> EMPTY = new ConsumerRecords<>(Map.of(), Map.of());
 
     private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
@@ -48,6 +46,8 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
 
     // Flag to detect if legacy ConsumerRecords(Map) constructor is used. See KAFKA-20660 for more details.
     private final boolean tainted;
+    static final long TAINT_LOG_INTERVAL_NS = TimeUnit.MINUTES.toNanos(5);
+    static final AtomicLong TAINTED_NEXT_OFFSETS_LAST_LOG_NS = new AtomicLong(System.nanoTime() - TAINT_LOG_INTERVAL_NS);
 
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
@@ -93,13 +93,19 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
      * @return The next offsets that the consumer will consume
      */
     public Map<TopicPartition, OffsetAndMetadata> nextOffsets() {
-        if (this.tainted && TAINTED_NEXT_OFFSETS_LOGGED.compareAndSet(false, true)) {
-            log.error("ConsumerRecords#nextOffsets() returned empty because this instance was built with the " +
-                    "deprecated ConsumerRecords(Map) constructor (see KIP-1094), which does not supply next offsets. " +
-                    "Downstream logic that relies on these offsets to advance the consumer's committed position " +
-                    "(for example, Kafka Streams under exactly-once semantics) will be unable to commit, leading to " +
-                    "reprocessing. Update the interceptor or wrapper that constructed it to use the " +
-                    "ConsumerRecords(Map, Map) constructor that supplies next offsets.");
+        if (this.tainted) {
+            final long now = System.nanoTime();
+            final long lastLog = TAINTED_NEXT_OFFSETS_LAST_LOG_NS.get();
+            // nextOffsets() is called on every poll, so a tainted instance would otherwise log the deprecation error log on
+            // every call. A time based approach is used to avoid this. See KAFKA-20660 for more details.
+            if (now - lastLog >= TAINT_LOG_INTERVAL_NS && TAINTED_NEXT_OFFSETS_LAST_LOG_NS.compareAndSet(lastLog, now)) {
+                log.error("ConsumerRecords#nextOffsets() returned empty because this instance was built with the " +
+                        "deprecated ConsumerRecords(Map) constructor (see KIP-1094), which does not supply next offsets. " +
+                        "Downstream logic that relies on these offsets to advance the consumer's committed position " +
+                        "(for example, Kafka Streams under exactly-once semantics) will be unable to commit, leading to " +
+                        "reprocessing. Update the interceptor or wrapper that constructed it to use the " +
+                        "ConsumerRecords(Map, Map) constructor that supplies next offsets.");
+            }
         }
         return nextOffsets;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -178,6 +180,57 @@ public class ConsumerRecordsTest {
         assertThrows(UnsupportedOperationException.class, () -> emptyRecords.iterator().remove());
         assertThrows(UnsupportedOperationException.class, () -> emptyRecords.records(topic).iterator().remove());
         assertEquals(0, emptyRecords.count());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testNextOffsetsLogsErrorOnceWhenConstructedWithDeprecatedConstructor() {
+        ConsumerRecords.TAINTED_NEXT_OFFSETS_LOGGED.set(false);
+
+        TopicPartition tp = new TopicPartition("topic", 0);
+        Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
+            Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
+
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
+            ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+
+            // deprecated constructor does not supply next offsets, so the map is empty
+            assertTrue(consumerRecords.nextOffsets().isEmpty());
+
+            List<String> errors = appender.getMessages("ERROR");
+            assertEquals(1, errors.size());
+            assertTrue(errors.get(0).contains("deprecated ConsumerRecords(Map) constructor"),
+                "Unexpected error message: " + errors.get(0));
+
+            // check that error log for deprecated constructor is only logged once
+            assertTrue(consumerRecords.nextOffsets().isEmpty());
+            assertTrue(new ConsumerRecords<>(records).nextOffsets().isEmpty());
+            assertEquals(1, appender.getMessages("ERROR").size());
+        }
+    }
+
+    @Test
+    public void testNextOffsetsDoesNotLogErrorWhenConstructedWithNextOffsets() {
+        TopicPartition tp = new TopicPartition("topic", 0);
+        Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
+            Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
+        Map<TopicPartition, OffsetAndMetadata> nextOffsets = Map.of(tp, new OffsetAndMetadata(1L));
+
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
+            ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, nextOffsets);
+
+            assertFalse(consumerRecords.nextOffsets().isEmpty());
+            assertEquals(nextOffsets, consumerRecords.nextOffsets());
+            assertTrue(appender.getMessages("ERROR").isEmpty());
+        }
+    }
+
+    @Test
+    public void testNextOffsetsDoesNotLogErrorForEmptyRecords() {
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
+            assertTrue(ConsumerRecords.empty().nextOffsets().isEmpty());
+            assertTrue(appender.getMessages("ERROR").isEmpty());
+        }
     }
 
     private ConsumerRecords<Integer, String> buildTopicTestRecords(int recordSize,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -189,6 +189,8 @@ public class ConsumerRecordsTest {
         Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
             Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
 
+        // Capture the global throttle state so it can be restored, to avoid leaking into other tests.
+        final long previousLastLogNs = ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.get();
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
             // Force the rate-limit window to have elapsed so the next tainted call logs.
             ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(
@@ -214,6 +216,8 @@ public class ConsumerRecordsTest {
                 System.nanoTime() - ConsumerRecords.TAINT_LOG_INTERVAL_NS - 1);
             assertTrue(consumerRecords.nextOffsets().isEmpty());
             assertEquals(2, appender.getMessages("ERROR").size());
+        } finally {
+            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(previousLastLogNs);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -184,14 +184,16 @@ public class ConsumerRecordsTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testNextOffsetsLogsErrorOnceWhenConstructedWithDeprecatedConstructor() {
-        ConsumerRecords.TAINTED_NEXT_OFFSETS_LOGGED.set(false);
-
+    public void testNextOffsetsLogsErrorPeriodicallyWhenConstructedWithDeprecatedConstructor() {
         TopicPartition tp = new TopicPartition("topic", 0);
         Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
             Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
 
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
+            // Force the rate-limit window to have elapsed so the next tainted call logs.
+            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(
+                System.nanoTime() - ConsumerRecords.TAINT_LOG_INTERVAL_NS - 1);
+
             ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
 
             // deprecated constructor does not supply next offsets, so the map is empty
@@ -202,10 +204,16 @@ public class ConsumerRecordsTest {
             assertTrue(errors.get(0).contains("deprecated ConsumerRecords(Map) constructor"),
                 "Unexpected error message: " + errors.get(0));
 
-            // check that error log for deprecated constructor is only logged once
+            // Within the rate-limit window, neither repeated calls nor new tainted instances log again.
             assertTrue(consumerRecords.nextOffsets().isEmpty());
             assertTrue(new ConsumerRecords<>(records).nextOffsets().isEmpty());
             assertEquals(1, appender.getMessages("ERROR").size());
+
+            // Once the window has elapsed, the error is logged again.
+            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(
+                System.nanoTime() - ConsumerRecords.TAINT_LOG_INTERVAL_NS - 1);
+            assertTrue(consumerRecords.nextOffsets().isEmpty());
+            assertEquals(2, appender.getMessages("ERROR").size());
         }
     }
 


### PR DESCRIPTION
Add detection of the use of the deprecated ConsumerRecords(Map)
constructor through a log line in nextOffsets(). Since nextOffsets() is
called on every poll, we log once every 5 minutes

Cherry pick to 4.0 and after.

https://issues.apache.org/jira/browse/KAFKA-20660
