### PR TITLE
KAFKA-20660: Mark deprecated ConsumerRecords constructor with forRemoval=true

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -40,7 +40,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.1", forRemoval = true)
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
         this(records, Map.of());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -40,7 +40,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     /**
      * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
      */
-    @Deprecated(since = "4.1", forRemoval = true)
+    @Deprecated(since = "4.0", forRemoval = true)
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
         this(records, Map.of());
     }


### PR DESCRIPTION
Marks deprecated ConsumerRecords constructor with `@Deprecated(since =
"4.0", forRemoval = true)`.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
