### PR TITLE
KAFKA-20641: ConsumerGroup should clean up the state when a static member temporarily leaves.

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4262,8 +4262,13 @@ public class GroupMetadataManager {
         // We will write a member epoch of -2 for this departing static member.
         // Assignment epochs are reset to 0 so when the static member rejoins, partitions
         // are considered assigned from epoch 0 to the new member ID.
+        MemberState nextState = member.state() == MemberState.UNREVOKED_PARTITIONS ?
+            MemberState.STABLE :
+            member.state();
+
         ConsumerGroupMember leavingStaticMember = new ConsumerGroupMember.Builder(member)
             .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
+            .setState(nextState)
             .setPartitionsPendingRevocation(Map.of())
             .resetAssignedPartitionsEpochsToZero()
             .build();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4259,16 +4259,27 @@ public class GroupMetadataManager {
         ConsumerGroup group,
         ConsumerGroupMember member
     ) {
+        ConsumerGroupMember reconciledMember = member;
+        if (member.state() == MemberState.UNREVOKED_PARTITIONS) {
+            reconciledMember = new CurrentAssignmentBuilder(member)
+                .withMetadataImage(metadataImage)
+                .withTargetAssignment(
+                    group.assignmentEpoch(),
+                    group.targetAssignment(member.memberId())
+                )
+                .withResolvedRegularExpressions(group.resolvedRegularExpressions())
+                .withCurrentPartitionEpoch(group::currentPartitionEpoch)
+                .withOwnedTopicPartitions(List.of())
+                .build();
+        }
+
         // We will write a member epoch of -2 for this departing static member.
         // Assignment epochs are reset to 0 so when the static member rejoins, partitions
         // are considered assigned from epoch 0 to the new member ID.
-        MemberState nextState = member.state() == MemberState.UNREVOKED_PARTITIONS ?
-            MemberState.STABLE :
-            member.state();
-
         ConsumerGroupMember leavingStaticMember = new ConsumerGroupMember.Builder(member)
             .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
-            .setState(nextState)
+            .setState(reconciledMember.state())
+            .setAssignedPartitions(reconciledMember.assignedPartitions())
             .setPartitionsPendingRevocation(Map.of())
             .resetAssignedPartitionsEpochsToZero()
             .build();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -4271,6 +4271,8 @@ public class GroupMetadataManager {
                 .withCurrentPartitionEpoch(group::currentPartitionEpoch)
                 .withOwnedTopicPartitions(List.of())
                 .build();
+
+            cancelGroupRebalanceTimeout(group.groupId(), reconciledMember.memberId());
         }
 
         // We will write a member epoch of -2 for this departing static member.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2809,13 +2809,15 @@ public class GroupMetadataManagerTest {
     @Test
     public void testStaticMemberInUnrevokedPartitionsTemporarilyLeavesAsStable() {
         String groupId = "fooup";
-        String instnaceId = "instance-id";
+        String instanceId = "instance-id";
         String memberId = Uuid.randomUuid().toString();
         Uuid topicId = Uuid.randomUuid();
+        String topicName = "foo";
 
         ConsumerGroupMember member = new ConsumerGroupMember.Builder(memberId)
-            .setInstanceId(instnaceId)
+            .setInstanceId(instanceId)
             .setState(MemberState.UNREVOKED_PARTITIONS)
+            .setSubscribedTopicNames(List.of(topicName))
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(10)
             .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
@@ -2824,7 +2826,12 @@ public class GroupMetadataManagerTest {
                 mkTopicAssignment(topicId, 1)), 10))
             .build();
 
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(topicId, topicName, 2)
+            .buildCoordinatorMetadataImage();
+        
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(metadataImage)
             .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
                 .withMember(member)
                 .withAssignment(memberId, mkAssignment(mkTopicAssignment(topicId, 0)))
@@ -2835,7 +2842,7 @@ public class GroupMetadataManagerTest {
             context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
                 .setMemberId(memberId)
-                .setInstanceId("instance-id")
+                .setInstanceId(instanceId)
                 .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH));
 
         ConsumerGroupMember expectedMember = new ConsumerGroupMember.Builder(member)
@@ -2857,6 +2864,78 @@ public class GroupMetadataManagerTest {
             result.records().get(0)
         );
     }
+
+    @Test
+    public void testStaticMemberInUnrevokedPartitionsTemporarilyLeavesAsUnreleased() {
+        String groupId = "fooup";
+        String instanceId = "instance-id";
+        String memberId1 = Uuid.randomUuid().toString();
+        String memberId2 = Uuid.randomUuid().toString();
+        Uuid topicId = Uuid.randomUuid();
+        String topicName = "foo";
+
+        ConsumerGroupMember member1 = new ConsumerGroupMember.Builder(memberId1)
+            .setInstanceId(instanceId)
+            .setState(MemberState.UNREVOKED_PARTITIONS)
+            .setSubscribedTopicNames(List.of(topicName))
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(topicId, 0)), 10))
+            .setPartitionsPendingRevocation(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(topicId, 1)), 10))
+            .build();
+
+        ConsumerGroupMember member2 = new ConsumerGroupMember.Builder(memberId2)
+            .setState(MemberState.STABLE)
+            .setSubscribedTopicNames(List.of(topicName))
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(topicId, 2)), 10))
+            .build();
+
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(topicId, topicName, 3)
+            .buildCoordinatorMetadataImage();
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withMetadataImage(metadataImage)
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member1)
+                .withMember(member2)
+                .withAssignment(memberId1, mkAssignment(mkTopicAssignment(topicId, 0, 2)))
+                .withAssignment(memberId2, mkAssignment(mkTopicAssignment(topicId, 1)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result =
+            context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setInstanceId(instanceId)
+                .setMemberId(memberId1)
+                .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH));
+
+        ConsumerGroupMember expectedMember = new ConsumerGroupMember.Builder(member1)
+            .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
+            .setState(MemberState.UNRELEASED_PARTITIONS)
+            .setPartitionsPendingRevocation(Map.of())
+            .resetAssignedPartitionsEpochsToZero()
+            .build();
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId1)
+                .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH),
+            result.response()
+        );
+        assertEquals(1, result.records().size());
+        assertRecordEquals(
+            GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember),
+            result.records().get(0)
+        );
+    }
+
 
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2818,6 +2818,7 @@ public class GroupMetadataManagerTest {
             .setInstanceId(instanceId)
             .setState(MemberState.UNREVOKED_PARTITIONS)
             .setSubscribedTopicNames(List.of(topicName))
+            .setRebalanceTimeoutMs(5000)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(10)
             .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
@@ -2837,6 +2838,9 @@ public class GroupMetadataManagerTest {
                 .withAssignment(memberId, mkAssignment(mkTopicAssignment(topicId, 0)))
                 .withAssignmentEpoch(10))
             .build();
+
+        context.onLoaded();
+        context.assertRebalanceTimeout(groupId, memberId, 5000);
 
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result =
             context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
@@ -2863,6 +2867,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember),
             result.records().get(0)
         );
+        context.assertNoRebalanceTimeout(groupId, memberId);
     }
 
     @Test
@@ -2878,6 +2883,7 @@ public class GroupMetadataManagerTest {
             .setInstanceId(instanceId)
             .setState(MemberState.UNREVOKED_PARTITIONS)
             .setSubscribedTopicNames(List.of(topicName))
+            .setRebalanceTimeoutMs(5000)
             .setMemberEpoch(10)
             .setPreviousMemberEpoch(10)
             .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
@@ -2909,6 +2915,9 @@ public class GroupMetadataManagerTest {
                 .withAssignmentEpoch(10))
             .build();
 
+        context.onLoaded();
+        context.assertRebalanceTimeout(groupId, memberId1, 5000);
+
         CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result =
             context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
                 .setGroupId(groupId)
@@ -2934,6 +2943,7 @@ public class GroupMetadataManagerTest {
             GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember),
             result.records().get(0)
         );
+        context.assertNoRebalanceTimeout(groupId, memberId1);
     }
 
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -2807,6 +2807,59 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testStaticMemberInUnrevokedPartitionsTemporarilyLeavesAsStable() {
+        String groupId = "fooup";
+        String instnaceId = "instance-id";
+        String memberId = Uuid.randomUuid().toString();
+        Uuid topicId = Uuid.randomUuid();
+
+        ConsumerGroupMember member = new ConsumerGroupMember.Builder(memberId)
+            .setInstanceId(instnaceId)
+            .setState(MemberState.UNREVOKED_PARTITIONS)
+            .setMemberEpoch(10)
+            .setPreviousMemberEpoch(10)
+            .setAssignedPartitions(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(topicId, 0)), 10))
+            .setPartitionsPendingRevocation(toAssignmentWithEpochs(mkAssignment(
+                mkTopicAssignment(topicId, 1)), 10))
+            .build();
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withConsumerGroup(new ConsumerGroupBuilder(groupId, 10)
+                .withMember(member)
+                .withAssignment(memberId, mkAssignment(mkTopicAssignment(topicId, 0)))
+                .withAssignmentEpoch(10))
+            .build();
+
+        CoordinatorResult<ConsumerGroupHeartbeatResponseData, CoordinatorRecord> result =
+            context.consumerGroupHeartbeat(new ConsumerGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setInstanceId("instance-id")
+                .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH));
+
+        ConsumerGroupMember expectedMember = new ConsumerGroupMember.Builder(member)
+            .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH)
+            .setState(MemberState.STABLE)
+            .setPartitionsPendingRevocation(Map.of())
+            .resetAssignedPartitionsEpochsToZero()
+            .build();
+
+        assertResponseEquals(
+            new ConsumerGroupHeartbeatResponseData()
+                .setMemberId(memberId)
+                .setMemberEpoch(LEAVE_GROUP_STATIC_MEMBER_EPOCH),
+            result.response()
+        );
+        assertEquals(1, result.records().size());
+        assertRecordEquals(
+            GroupCoordinatorRecordHelpers.newConsumerGroupCurrentAssignmentRecord(groupId, expectedMember),
+            result.records().get(0)
+        );
+    }
+
+
+    @Test
     public void testLeavingStaticMemberBumpsGroupEpoch() {
         String groupId = "fooup";
         // Use a static member id as it makes the test easier.


### PR DESCRIPTION
Previously, when a static member temporarily left a modern consumer
group while in `UNREVOKED_PARTITIONS`, the coordinator cleared its
pending revocations but kept the member in the unrevoked state.

This change transitions such leaving static members to `STABLE` while
writing the static leave epoch, so the retained static member state is
consistent with the cleared pending revocations and reset assignment
epochs. Other member states are preserved. A unit test was added for the
temporary leave path from `UNREVOKED_PARTITIONS`.

Reviewers: David Jacot <david.jacot@gmail.com>
