### PR TITLE
KAFKA-20663: Stale persisted changelog offset causes OffsetOutOfRangeExceptionAdd

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractColumnFamilyAccessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractColumnFamilyAccessor.java
@@ -52,6 +52,19 @@ abstract class AbstractColumnFamilyAccessor implements RocksDBStore.ColumnFamily
         this.storeOpen = storeOpen;
     }
 
+    /**
+     * The data column family handle(s) backing this accessor (excluding the offsets CF).
+     */
+    protected abstract ColumnFamilyHandle[] columnFamilies();
+
+    @Override
+    public final void flush(final RocksDBStore.DBAccessor accessor) throws RocksDBException {
+        final ColumnFamilyHandle[] dataColumnFamilies = columnFamilies();
+        final ColumnFamilyHandle[] allColumnFamilies = Arrays.copyOf(dataColumnFamilies, dataColumnFamilies.length + 1);
+        allColumnFamilies[dataColumnFamilies.length] = offsetColumnFamilyHandle;
+        accessor.flush(allColumnFamilies);
+    }
+
     @Override
     public final void commit(final RocksDBStore.DBAccessor accessor, final Map<TopicPartition, Long> changelogOffsets) throws RocksDBException {
         if (changelogOffsets.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
@@ -78,6 +78,11 @@ class DualColumnFamilyAccessor extends AbstractColumnFamilyAccessor {
     }
 
     @Override
+    protected ColumnFamilyHandle[] columnFamilies() {
+        return new ColumnFamilyHandle[] {oldColumnFamily, newColumnFamily};
+    }
+
+    @Override
     public void put(final DBAccessor accessor,
                     final byte[] key,
                     final byte[] value) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -144,6 +144,14 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     protected Position position;
     private TaskId taskId;
 
+    // KIP-1035 stale-offset prevention (applies to BOTH at-least-once and exactly-once):
+    // the changelog offset is persisted inside RocksDB (offsets CF) and is otherwise only durable on
+    // an organic memtable flush or a clean close.
+    static final String MAX_FLUSH_INTERVAL_MS_CONFIG = "rocksdb.max.flush.interval.ms";
+    static final long DEFAULT_MAX_FLUSH_INTERVAL_MS = 30_000L;
+    private long maxFlushIntervalMs = DEFAULT_MAX_FLUSH_INTERVAL_MS;
+    private long lastFlushMs = 0L;
+
     public RocksDBStore(final String name,
                         final String metricsScope) {
         this(name, DB_FILE_DIR, new RocksDBMetricsRecorder(metricsScope, name));
@@ -191,6 +199,13 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     @SuppressWarnings("unchecked")
     void openDB(final Map<String, Object> configs, final File stateDir) {
         final boolean eosEnabled = Objects.equals(configs.get(PROCESSING_GUARANTEE_CONFIG), EXACTLY_ONCE_V2);
+
+        final Object flushIntervalCfg = configs.get(MAX_FLUSH_INTERVAL_MS_CONFIG);
+        if (flushIntervalCfg != null) {
+            this.maxFlushIntervalMs = Long.parseLong(flushIntervalCfg.toString());
+        }
+        this.lastFlushMs = System.currentTimeMillis();
+
         // initialize the default rocksdb options
         final DBOptions dbOptions = new DBOptions();
         // Defaults to true. Supports offset managements: KAFKA-20212
@@ -761,8 +776,26 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
         try {
             cfAccessor.commit(dbAccessor, changelogOffsets);
+            maybeFlush();
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error while executing commit from store " + name, e);
+        }
+    }
+
+    /**
+     * Bound the staleness of the persisted changelog offset (KIP-1035) by flushing the store's
+     * memtables to disk at most once per {@link #maxFlushIntervalMs}.
+     * This prevents the offset from drifting far enough behind the changelog log-start offset
+     * to trigger an OffsetOutOfRange / TaskCorrupted on restore, under both at-least-once and exactly-once.
+     */
+    private void maybeFlush() throws RocksDBException {
+        if (maxFlushIntervalMs < 0) {
+            return;
+        }
+        final long now = System.currentTimeMillis();
+        if (now - lastFlushMs >= maxFlushIntervalMs) {
+            cfAccessor.flush(dbAccessor);
+            lastFlushMs = now;
         }
     }
 
@@ -1063,6 +1096,12 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         Position open(final RocksDBStore.DBAccessor accessor, final boolean ignoreInvalidState) throws RocksDBException, StreamsException;
 
         Long getCommittedOffset(final RocksDBStore.DBAccessor accessor, final TopicPartition partition) throws RocksDBException;
+
+        /**
+         * Flush all of this accessor's column families (data CF(s) and the offsets CF) to disk.
+         * With {@code atomicFlush} enabled this persists the data and the changelog offset atomically.
+         */
+        void flush(final RocksDBStore.DBAccessor accessor) throws RocksDBException;
     }
 
     class SingleColumnFamilyAccessor extends AbstractColumnFamilyAccessor {
@@ -1071,6 +1110,11 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         SingleColumnFamilyAccessor(final ColumnFamilyHandle offsetsColumnFamily, final ColumnFamilyHandle columnFamily) {
             super(offsetsColumnFamily, open);
             this.columnFamily = columnFamily;
+        }
+
+        @Override
+        protected ColumnFamilyHandle[] columnFamilies() {
+            return new ColumnFamilyHandle[] {columnFamily};
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -281,6 +281,39 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
     }
 
     @Test
+    public void shouldFlushStoreOnCommitWhenMaxFlushIntervalElapsed() throws Exception {
+        final TopicPartition tp0 = new TopicPartition("topic-0", 0);
+        final Properties props = StreamsTestUtils.getStreamsConfig();
+        props.put(RocksDBStore.MAX_FLUSH_INTERVAL_MS_CONFIG, "0");
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(getProcessorContext(props), rocksDBStore);
+
+        rocksDBStore.put(new Bytes("key".getBytes()), "value".getBytes());
+        rocksDBStore.commit(Map.of(tp0, 100L));
+
+        // atomicFlush => all memtables (data + offsets CFs) were flushed to disk on commit
+        assertEquals(0L, rocksDBStore.db.getAggregatedLongProperty("rocksdb.num-entries-active-mem-table"));
+        assertEquals(100L, rocksDBStore.committedOffset(tp0));
+    }
+
+    @Test
+    public void shouldNotFlushStoreOnCommitBeforeMaxFlushIntervalElapsed() throws Exception {
+        final TopicPartition tp0 = new TopicPartition("topic-0", 0);
+        final Properties props = StreamsTestUtils.getStreamsConfig();
+        props.put(RocksDBStore.MAX_FLUSH_INTERVAL_MS_CONFIG, String.valueOf(Long.MAX_VALUE));
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(getProcessorContext(props), rocksDBStore);
+
+        rocksDBStore.put(new Bytes("key".getBytes()), "value".getBytes());
+        rocksDBStore.commit(Map.of(tp0, 100L));
+
+        // interval not elapsed => no forced flush; writes remain in the active memtable
+        assertTrue(rocksDBStore.db.getAggregatedLongProperty("rocksdb.num-entries-active-mem-table") > 0L);
+        // offset is still readable from the memtable within the same process
+        assertEquals(100L, rocksDBStore.committedOffset(tp0));
+    }
+
+    @Test
     public void shouldRemoveValueProvidersFromInjectedMetricsRecorderOnClose() {
         rocksDBStore = getRocksDBStoreWithRocksDBMetricsRecorder();
         try {


### PR DESCRIPTION
In 4.3, KIP-1035 moved the changelog offset into RocksDB and removed the
forced flush on commit, so the persisted offset is now only made durable
by an organic memtable flush or a clean close. When that offset goes
stale — after an unclean exit, or a clean shutdown followed by changelog
truncation/compaction while the instance is down — and the changelog
log-start offset has advanced past it, the restore consumer seeks out of
range and throws `OffsetOutOfRangeException`, which Streams converts to
a TaskCorruptedException (full local-state wipe and rebuild).
