### PR TITLE
KAFKA-20651: Cache parsed KafkaPrincipal in StandardAcl (#v1)

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.metadata.authorizer;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
@@ -34,6 +36,12 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 public record StandardAcl(ResourceType resourceType, String resourceName, PatternType patternType, String principal,
                           String host, AclOperation operation,
                           AclPermissionType permissionType) implements Comparable<StandardAcl> {
+    // Cache of parsed KafkaPrincipal per unique principal string.
+    // The cache is bounded by the number of distinct principals in the ACL store,
+    // which is typically orders of magnitude smaller than the total ACL count.
+    // ACL data is infrequently updated, so no eviction mechanism is needed.
+    private static final Map<String, KafkaPrincipal> PRINCIPAL_CACHE = new ConcurrentHashMap<>();
+
     public static StandardAcl fromRecord(AccessControlEntryRecord record) {
         return new StandardAcl(
             ResourceType.fromCode(record.resourceType()),
@@ -57,14 +65,14 @@ public record StandardAcl(ResourceType resourceType, String resourceName, Patter
     }
 
     public KafkaPrincipal kafkaPrincipal() {
-        int colonIndex = principal.indexOf(":");
-        if (colonIndex == -1) {
-            throw new IllegalStateException("Could not parse principal from `" + principal + "` " +
-                "(no colon is present separating the principal type from the principal name)");
-        }
-        String principalType = principal.substring(0, colonIndex);
-        String principalName = principal.substring(colonIndex + 1);
-        return new KafkaPrincipal(principalType, principalName);
+        return PRINCIPAL_CACHE.computeIfAbsent(principal, principalStr -> {
+            int colonIndex = principalStr.indexOf(":");
+            if (colonIndex == -1) {
+                throw new IllegalStateException("Could not parse principal from `" + principalStr + "` " +
+                    "(no colon is present separating the principal type from the principal name)");
+            }
+            return new KafkaPrincipal(principalStr.substring(0, colonIndex), principalStr.substring(colonIndex + 1));
+        });
     }
 
     public AclBinding toBinding() {

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
@@ -18,6 +18,10 @@
 package org.apache.kafka.metadata.authorizer;
 
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -26,6 +30,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 
 @Timeout(value = 40)
@@ -65,5 +70,31 @@ public class StandardAclTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testKafkaPrincipalIsCached() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.TOPIC, "foo", PatternType.LITERAL,
+            "User:alice", "*", AclOperation.READ, AclPermissionType.ALLOW);
+        assertSame(acl.kafkaPrincipal(), acl.kafkaPrincipal());
+    }
+
+    @Test
+    public void testKafkaPrincipalParsing() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.TOPIC, "foo", PatternType.LITERAL,
+            "User:alice", "*", AclOperation.READ, AclPermissionType.ALLOW);
+        assertEquals("User", acl.kafkaPrincipal().getPrincipalType());
+        assertEquals("alice", acl.kafkaPrincipal().getName());
+    }
+
+    @Test
+    public void testKafkaPrincipalWildcard() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL,
+            "User:*", "*", AclOperation.ALTER, AclPermissionType.ALLOW);
+        assertEquals("User", acl.kafkaPrincipal().getPrincipalType());
+        assertEquals("*", acl.kafkaPrincipal().getName());
     }
 }


### PR DESCRIPTION
Use ConcurrentHashMap to cache parsed KafkaPrincipal objects per unique principal string, reducing allocation overhead from repeated substring/constructor calls during ACL authorization.



`(data-plane-kafka-request-handler-0" #80 daemon prio=5 os_prio=0 cpu=17207014.77ms elapsed=18143.19s tid=0x00007f76d50aa800 nid=0x8e7bb runnable [0x00007f7681480000]

  java.lang.Thread.State: RUNNABLE

       at org.apache.kafka.metadata.authorizer.StandardAcl.kafkaPrincipal(StandardAcl.java:106)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.findResult(StandardAuthorizerData.java:493)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.checkSection(StandardAuthorizerData.java:428)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.findAclRule(StandardAuthorizerData.java:367)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.authorize(StandardAuthorizerData.java:247)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizer.authorize(StandardAuthorizer.java:143)

       at kafka.server.AuthHelper.filterByAuthorized(AuthHelper.scala:113)

       at kafka.server.KafkaApis.handleTopicMetadataRequest(KafkaApis.scala:1350)

       at kafka.server.KafkaApis.handle(KafkaApis.scala:192)

       at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:159)

       at java.lang.Thread.run(java.base@11.0.25/Thread.java:829)

)`