### PR TITLE
KAFKA-20292 [6/N]: Add TargetAssignmentRecordsBuilder

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -36,6 +36,10 @@ import java.util.Set;
  * Records are only created for members which have a new target assignment. If
  * their assignment did not change, no new record is needed.
  *
+ * When a member is deleted, it is assumed that its target assignment record
+ * is deleted as part of the member deletion process. In other words, this class
+ * does not yield a tombstone for removed members.
+ *
  * @param <A> The member's target assignment type.
  */
 public abstract class TargetAssignmentRecordsBuilder<A> {
@@ -244,16 +248,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
             }
         }
 
-        // Tombstone assignments for members that are no longer in the group.
-        // This will always be a no-op in practice since the group coordinator will tombstone target
-        // assignments for members as soon as they leave the group. We leave it in to avoid making
-        // assumptions about caller behavior.
-        for (String memberId : currentTargetAssignment.keySet()) {
-            if (!currentMemberIds.contains(memberId)) {
-                records.add(newTargetAssignmentTombstoneRecord(groupId, memberId));
-            }
-        }
-
         // Bump the target assignment epoch.
         records.add(newTargetAssignmentMetadataRecord(
             groupId,
@@ -331,11 +325,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
         A memberAssignment
     );
 
-    protected abstract CoordinatorRecord newTargetAssignmentTombstoneRecord(
-        String groupId,
-        String memberId
-    );
-
     protected abstract CoordinatorRecord newTargetAssignmentMetadataRecord(
         String groupId,
         int assignmentEpoch,
@@ -363,17 +352,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
                 groupId,
                 memberId,
                 memberAssignment.partitions()
-            );
-        }
-
-        @Override
-        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
-            String groupId,
-            String memberId
-        ) {
-            return GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(
-                groupId,
-                memberId
             );
         }
 
@@ -416,17 +394,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
         }
 
         @Override
-        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
-            String groupId,
-            String memberId
-        ) {
-            return GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentTombstoneRecord(
-                groupId,
-                memberId
-            );
-        }
-
-        @Override
         protected CoordinatorRecord newTargetAssignmentMetadataRecord(
             String groupId,
             int assignmentEpoch,
@@ -461,17 +428,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
                 groupId,
                 memberId,
                 memberAssignment
-            );
-        }
-
-        @Override
-        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
-            String groupId,
-            String memberId
-        ) {
-            return StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord(
-                groupId,
-                memberId
             );
         }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -186,7 +186,8 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
         //  * When static members are replaced, we move the assignment from the old member id to the
         //    new member id.
         //  * When members rejoin with the same member id but a different instance id, they keep
-        //    their existing assignment.
+        //    their existing assignment. This operation will never happen when using the official
+        //    Java client and may be forbidden in the future.
         //
         // Thus, when building the new target assignment records,
         //  * we should not emit records for members that have left the group
@@ -201,8 +202,15 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
             String newMemberId = currentStaticMembers.get(instanceId);
 
             if (currentMemberIds.contains(oldMemberId)) {
-                // The member id is still in the group. We must not create a remapping entry,
+                // The old member id is still in the group. We must not create a remapping entry,
                 // otherwise we could give the same assignment to two different members.
+                continue;
+            }
+
+            if (newTargetAssignment.containsKey(newMemberId)) {
+                // The new member id has been in the group the whole time. Avoid creating a
+                // remapping entry. Note that this is best effort, since newTargetAssignment may not
+                // contain entries for every member that used to be in the group.
                 continue;
             }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -176,7 +176,6 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      *
      * @param records The list to accumulate records.
      */
-    @SuppressWarnings({"CyclomaticComplexity", "NPathComplexity"})
     public void build(List<CoordinatorRecord> records) {
         // The members in the group may have changed while the target assignment was computed.
         // We want to act as if concurrent member operations such as leaves and static member
@@ -217,58 +216,11 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
             if (newMemberId != null) {
                 staticMemberIdRemapping.put(newMemberId, oldMemberId);
             }
-
-            if (log.isDebugEnabled()) {
-                if (newMemberId == null) {
-                    log.debug("[GroupId {}] Previous static member {} with instance id {} has no replacement, discarding their target assignment.",
-                        groupId, oldMemberId, instanceId);
-                } else {
-                    log.debug("[GroupId {}] Previous static member {} with instance id {} has been replaced by {}, transferring target assignment.",
-                        groupId, oldMemberId, instanceId, newMemberId);
-                }
-            }
         }
 
         if (log.isDebugEnabled()) {
-            // Log current static members with no previous static member.
-            for (Map.Entry<String, String> entry : currentStaticMembers.entrySet()) {
-                String instanceId = entry.getKey();
-                String newMemberId = entry.getValue();
-
-                if (newTargetAssignment.containsKey(newMemberId)) {
-                    // The member has been in the group the whole time.
-                    continue;
-                }
-
-                if (!previousStaticMembers.containsKey(instanceId)) {
-                    log.debug("[GroupId {}] Current static member {} with instance id {} has no previous static member and will receive an empty target assignment.",
-                        groupId, newMemberId, instanceId);
-                }
-            }
-
-            // Log previous members that have left the group.
-            for (String memberId : newTargetAssignment.keySet()) {
-                if (currentMemberIds.contains(memberId)) {
-                    // The member has been in the group the whole time.
-                    continue;
-                }
-
-                log.debug("[GroupId {}] Member {} has left the group, discarding their target assignment unless they were static and a corresponding static member exists.",
-                    groupId, memberId);
-            }
-
-            // Log current members that have joined the group.
-            for (String memberId : currentMemberIds) {
-                if (newTargetAssignment.containsKey(memberId)) {
-                    // The member has been in the group the whole time.
-                    continue;
-                }
-
-                if (!staticMemberIdRemapping.containsKey(memberId)) {
-                    log.debug("[GroupId {}] Member {} is new and will receive an empty target assignment or has no target assignment.",
-                        groupId, memberId);
-                }
-            }
+            logStaticMembers();
+            logMembersLeftAndJoined(staticMemberIdRemapping);
         }
 
         for (String memberId : currentMemberIds) {
@@ -308,6 +260,67 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
             targetAssignmentMetadata.assignmentEpoch(),
             targetAssignmentMetadata.assignmentTimestamp()
         ));
+    }
+
+    private void logStaticMembers() {
+        for (Map.Entry<String, String> entry : previousStaticMembers.entrySet()) {
+            String instanceId = entry.getKey();
+            String oldMemberId = entry.getValue();
+            String newMemberId = currentStaticMembers.get(instanceId);
+
+            if (currentMemberIds.contains(oldMemberId) ||
+                newTargetAssignment.containsKey(newMemberId)) {
+                // The member has been in the group the whole time.
+                continue;
+            }
+
+            if (newMemberId == null) {
+                log.debug("[GroupId {}] Previous static member {} with instance id {} has no replacement, discarding their target assignment.",
+                    groupId, oldMemberId, instanceId);
+            } else {
+                log.debug("[GroupId {}] Previous static member {} with instance id {} has been replaced by {}, transferring target assignment.",
+                    groupId, oldMemberId, instanceId, newMemberId);
+            }
+        }
+
+        for (Map.Entry<String, String> entry : currentStaticMembers.entrySet()) {
+            String instanceId = entry.getKey();
+            String newMemberId = entry.getValue();
+
+            if (newTargetAssignment.containsKey(newMemberId)) {
+                // The member has been in the group the whole time.
+                continue;
+            }
+
+            if (!previousStaticMembers.containsKey(instanceId)) {
+                log.debug("[GroupId {}] Current static member {} with instance id {} has no previous static member and will receive an empty target assignment.",
+                    groupId, newMemberId, instanceId);
+            }
+        }
+    }
+
+    private void logMembersLeftAndJoined(Map<String, String> staticMemberIdRemapping) {
+        for (String memberId : newTargetAssignment.keySet()) {
+            if (currentMemberIds.contains(memberId)) {
+                // The member has been in the group the whole time.
+                continue;
+            }
+
+            log.debug("[GroupId {}] Member {} has left the group, discarding their target assignment unless they were static and a corresponding static member exists.",
+                groupId, memberId);
+        }
+
+        for (String memberId : currentMemberIds) {
+            if (newTargetAssignment.containsKey(memberId)) {
+                // The member has been in the group the whole time.
+                continue;
+            }
+
+            if (!staticMemberIdRemapping.containsKey(memberId)) {
+                log.debug("[GroupId {}] Member {} is new and will receive an empty target assignment or has no target assignment.",
+                    groupId, memberId);
+            }
+        }
     }
 
     protected abstract A emptyMemberAssignment();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -1,0 +1,483 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
+import org.apache.kafka.coordinator.group.modern.Assignment;
+import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
+import org.apache.kafka.coordinator.group.streams.TasksTuple;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Builds the records to persist a new target assignment for a group.
+ *
+ * Records are only created for members which have a new target assignment. If
+ * their assignment did not change, no new record is needed.
+ *
+ * @param <A> The member's target assignment type.
+ */
+public abstract class TargetAssignmentRecordsBuilder<A> {
+
+    /**
+     * The logger.
+     */
+    private final Logger log;
+
+    /**
+     * The group id.
+     */
+    private final String groupId;
+
+    /**
+     * The target assignment epoch.
+     */
+    private int assignmentEpoch;
+
+    /**
+     * The time at which the target assignment calculation finished.
+     */
+    private long assignmentTimestampMs;
+
+    /**
+     * The static members in the group at the time the new target assignment was computed.
+     */
+    private Map<String, String> previousStaticMembers = Map.of();
+
+    /**
+     * The current member ids in the group.
+     */
+    private Set<String> currentMemberIds;
+
+    /**
+     * The current static members in the group.
+     */
+    private Map<String, String> currentStaticMembers = Map.of();
+
+    /**
+     * The current target assignment.
+     */
+    private Map<String, A> currentTargetAssignment = Map.of();
+
+    /**
+     * The new target assignment.
+     */
+    private Map<String, A> newTargetAssignment = Map.of();
+
+    /**
+     * Constructs the object.
+     *
+     * @param logContext    The log context.
+     * @param groupId       The group id.
+     */
+    public TargetAssignmentRecordsBuilder(
+        LogContext logContext,
+        String groupId
+    ) {
+        this.log = logContext.logger(this.getClass());
+        this.groupId = Objects.requireNonNull(groupId);
+    }
+
+    /**
+     * Sets the target assignment epoch.
+     *
+     * @param assignmentEpoch The target assignment epoch.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withAssignmentEpoch(int assignmentEpoch) {
+        this.assignmentEpoch = assignmentEpoch;
+        return this;
+    }
+
+    /**
+     * Sets the time at which the target assignment calculation finished.
+     *
+     * @param assignmentTimestampMs The time at which the target assignment calculation finished.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withAssignmentTimestampMs(long assignmentTimestampMs) {
+        this.assignmentTimestampMs = assignmentTimestampMs;
+        return this;
+    }
+
+    /**
+     * Sets the static members in the group at the time the new target assignment was computed.
+     *
+     * @param previousStaticMembers The static members in the group at the time the new target assignment was computed.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withPreviousStaticMembers(Map<String, String> previousStaticMembers) {
+        this.previousStaticMembers = previousStaticMembers;
+        return this;
+    }
+
+    /**
+     * Sets the current member ids in the group.
+     *
+     * @param currentMemberIds The current member ids in the group.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withCurrentMemberIds(Set<String> currentMemberIds) {
+        this.currentMemberIds = currentMemberIds;
+        return this;
+    }
+
+    /**
+     * Sets the current static members in the group.
+     *
+     * @param currentStaticMembers The current static members in the group.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withCurrentStaticMembers(Map<String, String> currentStaticMembers) {
+        this.currentStaticMembers = currentStaticMembers;
+        return this;
+    }
+
+    /**
+     * Sets the current target assignment.
+     *
+     * @param currentTargetAssignment The current target assignment.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withCurrentTargetAssignment(Map<String, A> currentTargetAssignment) {
+        this.currentTargetAssignment = currentTargetAssignment;
+        return this;
+    }
+
+    /**
+     * Sets the new target assignment.
+     *
+     * @param newTargetAssignment The new target assignment.
+     * @return This object.
+     */
+    public TargetAssignmentRecordsBuilder<A> withNewTargetAssignment(Map<String, A> newTargetAssignment) {
+        this.newTargetAssignment = newTargetAssignment;
+        return this;
+    }
+
+    /**
+     * Builds the records for the new target assignment.
+     *
+     * @return The records for the new target assignment.
+     */
+    public List<CoordinatorRecord> build() {
+        List<CoordinatorRecord> records = new ArrayList<>();
+        build(records);
+        return records;
+    }
+
+    /**
+     * Builds the records for the new target assignment.
+     *
+     * @param records The list to accumulate records.
+     */
+    @SuppressWarnings({"CyclomaticComplexity", "NPathComplexity"})
+    public void build(List<CoordinatorRecord> records) {
+        // The members in the group may have changed while the target assignment was computed.
+        // We want to act as if concurrent member operations such as leaves and static member
+        // replacements happened *after* the target assignment was computed.
+        //
+        //  * When members leave the group, we tombstone their target assignment.
+        //  * When static members are replaced, we move the assignment from the old member id to the
+        //    new member id.
+        //  * When members rejoin with the same member id but a different instance id, they keep
+        //    their existing assignment.
+        //
+        // Thus, when building the new target assignment records,
+        //  * we should not emit records for members that have left the group
+        //  * we should relabel records with the latest member id for static members
+        //  * we should match up members using member ids first, then fall back to instance ids.
+
+        // Build map of replacement member ids for static members that have churned.
+        Map<String, String> staticMemberIdRemapping = new HashMap<>();
+        for (Map.Entry<String, String> entry : previousStaticMembers.entrySet()) {
+            String instanceId = entry.getKey();
+            String oldMemberId = entry.getValue();
+            String newMemberId = currentStaticMembers.get(instanceId);
+
+            if (currentMemberIds.contains(oldMemberId)) {
+                // The member id is still in the group. We must not create a remapping entry,
+                // otherwise we could give the same assignment to two different members.
+                continue;
+            }
+
+            if (newMemberId != null) {
+                staticMemberIdRemapping.put(newMemberId, oldMemberId);
+            }
+
+            if (log.isDebugEnabled()) {
+                if (newMemberId == null) {
+                    log.debug("[GroupId {}] Previous static member {} with instance id {} has no replacement, discarding their target assignment.",
+                        groupId, oldMemberId, instanceId);
+                } else {
+                    log.debug("[GroupId {}] Previous static member {} with instance id {} has been replaced by {}, transferring target assignment.",
+                        groupId, oldMemberId, instanceId, newMemberId);
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            // Log current static members with no previous static member.
+            for (Map.Entry<String, String> entry : currentStaticMembers.entrySet()) {
+                String instanceId = entry.getKey();
+                String newMemberId = entry.getValue();
+
+                if (newTargetAssignment.containsKey(newMemberId)) {
+                    // The member has been in the group the whole time.
+                    continue;
+                }
+
+                if (!previousStaticMembers.containsKey(instanceId)) {
+                    log.debug("[GroupId {}] Current static member {} with instance id {} has no previous static member and will receive an empty target assignment.",
+                        groupId, newMemberId, instanceId);
+                }
+            }
+
+            // Log previous members that have left the group.
+            for (String memberId : newTargetAssignment.keySet()) {
+                if (currentMemberIds.contains(memberId)) {
+                    // The member has been in the group the whole time.
+                    continue;
+                }
+
+                log.debug("[GroupId {}] Member {} has left the group, discarding their target assignment unless they were static and a corresponding static member exists.",
+                    groupId, memberId);
+            }
+
+            // Log current members that have joined the group.
+            for (String memberId : currentMemberIds) {
+                if (newTargetAssignment.containsKey(memberId)) {
+                    // The member has been in the group the whole time.
+                    continue;
+                }
+
+                if (!staticMemberIdRemapping.containsKey(memberId)) {
+                    log.debug("[GroupId {}] Member {} is new and will receive an empty target assignment or has no target assignment.",
+                        groupId, memberId);
+                }
+            }
+        }
+
+        for (String memberId : currentMemberIds) {
+            String previousMemberId = staticMemberIdRemapping.getOrDefault(memberId, memberId);
+
+            A oldMemberAssignment = currentTargetAssignment.get(memberId);
+            A newMemberAssignment = newTargetAssignment.get(previousMemberId);
+            if (newMemberAssignment == null) {
+                newMemberAssignment = emptyMemberAssignment();
+            }
+
+            if (oldMemberAssignment == null ||
+                !newMemberAssignment.equals(oldMemberAssignment)) {
+                // If the member had no assignment or had a different assignment, we
+                // create a record for the new assignment.
+                records.add(newTargetAssignmentRecord(
+                    groupId,
+                    memberId,
+                    newMemberAssignment
+                ));
+            }
+        }
+
+        // Tombstone assignments for members that are no longer in the group.
+        // This will always be a no-op in practice since the group coordinator will tombstone target
+        // assignments for members as soon as they leave the group. We leave it in to avoid making
+        // assumptions about caller behavior.
+        for (String memberId : currentTargetAssignment.keySet()) {
+            if (!currentMemberIds.contains(memberId)) {
+                records.add(newTargetAssignmentTombstoneRecord(groupId, memberId));
+            }
+        }
+
+        // Bump the target assignment epoch.
+        records.add(newTargetAssignmentMetadataRecord(groupId, assignmentEpoch, assignmentTimestampMs));
+    }
+
+    protected abstract A emptyMemberAssignment();
+
+    protected abstract CoordinatorRecord newTargetAssignmentRecord(
+        String groupId,
+        String memberId,
+        A memberAssignment
+    );
+
+    protected abstract CoordinatorRecord newTargetAssignmentTombstoneRecord(
+        String groupId,
+        String memberId
+    );
+
+    protected abstract CoordinatorRecord newTargetAssignmentMetadataRecord(
+        String groupId,
+        int assignmentEpoch,
+        long assignmentTimestampMs
+    );
+
+    public static class ConsumerTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<Assignment> {
+
+        public ConsumerTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
+            super(logContext, groupId);
+        }
+
+        @Override
+        protected Assignment emptyMemberAssignment() {
+            return Assignment.EMPTY;
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentRecord(
+            String groupId,
+            String memberId,
+            Assignment memberAssignment
+        ) {
+            return GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord(
+                groupId,
+                memberId,
+                memberAssignment.partitions()
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
+            String groupId,
+            String memberId
+        ) {
+            return GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord(
+                groupId,
+                memberId
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentMetadataRecord(
+            String groupId,
+            int assignmentEpoch,
+            long assignmentTimestampMs
+        ) {
+            return GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord(
+                groupId,
+                assignmentEpoch,
+                assignmentTimestampMs
+            );
+        }
+    }
+
+    public static class ShareTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<Assignment> {
+
+        public ShareTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
+            super(logContext, groupId);
+        }
+
+        @Override
+        protected Assignment emptyMemberAssignment() {
+            return Assignment.EMPTY;
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentRecord(
+            String groupId,
+            String memberId,
+            Assignment memberAssignment
+        ) {
+            return GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord(
+                groupId,
+                memberId,
+                memberAssignment.partitions()
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
+            String groupId,
+            String memberId
+        ) {
+            return GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentTombstoneRecord(
+                groupId,
+                memberId
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentMetadataRecord(
+            String groupId,
+            int assignmentEpoch,
+            long assignmentTimestampMs
+        ) {
+            return GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord(
+                groupId,
+                assignmentEpoch,
+                assignmentTimestampMs
+            );
+        }
+    }
+
+    public static class StreamsTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<TasksTuple> {
+
+        public StreamsTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
+            super(logContext, groupId);
+        }
+
+        @Override
+        protected TasksTuple emptyMemberAssignment() {
+            return TasksTuple.EMPTY;
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentRecord(
+            String groupId,
+            String memberId,
+            TasksTuple memberAssignment
+        ) {
+            return StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord(
+                groupId,
+                memberId,
+                memberAssignment
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentTombstoneRecord(
+            String groupId,
+            String memberId
+        ) {
+            return StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord(
+                groupId,
+                memberId
+            );
+        }
+
+        @Override
+        protected CoordinatorRecord newTargetAssignmentMetadataRecord(
+            String groupId,
+            int assignmentEpoch,
+            long assignmentTimestampMs
+        ) {
+            return StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord(
+                groupId,
+                assignmentEpoch,
+                assignmentTimestampMs
+            );
+        }
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -128,7 +128,7 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      * @return This object.
      */
     public TargetAssignmentRecordsBuilder<A> withPreviousStaticMembers(Map<String, String> previousStaticMembers) {
-        this.previousStaticMembers = previousStaticMembers;
+        this.previousStaticMembers = Objects.requireNonNull(previousStaticMembers);
         return this;
     }
 
@@ -139,7 +139,7 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      * @return This object.
      */
     public TargetAssignmentRecordsBuilder<A> withCurrentMemberIds(Set<String> currentMemberIds) {
-        this.currentMemberIds = currentMemberIds;
+        this.currentMemberIds = Objects.requireNonNull(currentMemberIds);
         return this;
     }
 
@@ -150,7 +150,7 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      * @return This object.
      */
     public TargetAssignmentRecordsBuilder<A> withCurrentStaticMembers(Map<String, String> currentStaticMembers) {
-        this.currentStaticMembers = currentStaticMembers;
+        this.currentStaticMembers = Objects.requireNonNull(currentStaticMembers);
         return this;
     }
 
@@ -161,7 +161,7 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      * @return This object.
      */
     public TargetAssignmentRecordsBuilder<A> withCurrentTargetAssignment(Map<String, A> currentTargetAssignment) {
-        this.currentTargetAssignment = currentTargetAssignment;
+        this.currentTargetAssignment = Objects.requireNonNull(currentTargetAssignment);
         return this;
     }
 
@@ -172,7 +172,7 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
      * @return This object.
      */
     public TargetAssignmentRecordsBuilder<A> withNewTargetAssignment(Map<String, A> newTargetAssignment) {
-        this.newTargetAssignment = newTargetAssignment;
+        this.newTargetAssignment = Objects.requireNonNull(newTargetAssignment);
         return this;
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -51,14 +51,9 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
     private final String groupId;
 
     /**
-     * The target assignment epoch.
+     * The target assignment metadata.
      */
-    private int assignmentEpoch;
-
-    /**
-     * The time at which the target assignment calculation finished.
-     */
-    private long assignmentTimestampMs;
+    private TargetAssignmentMetadata targetAssignmentMetadata;
 
     /**
      * The static members in the group at the time the new target assignment was computed.
@@ -100,24 +95,13 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
     }
 
     /**
-     * Sets the target assignment epoch.
+     * Sets the target assignment metadata.
      *
-     * @param assignmentEpoch The target assignment epoch.
+     * @param targetAssignmentMetadata The target assignment metadata.
      * @return This object.
      */
-    public TargetAssignmentRecordsBuilder<A> withAssignmentEpoch(int assignmentEpoch) {
-        this.assignmentEpoch = assignmentEpoch;
-        return this;
-    }
-
-    /**
-     * Sets the time at which the target assignment calculation finished.
-     *
-     * @param assignmentTimestampMs The time at which the target assignment calculation finished.
-     * @return This object.
-     */
-    public TargetAssignmentRecordsBuilder<A> withAssignmentTimestampMs(long assignmentTimestampMs) {
-        this.assignmentTimestampMs = assignmentTimestampMs;
+    public TargetAssignmentRecordsBuilder<A> withTargetAssignmentMetadata(TargetAssignmentMetadata targetAssignmentMetadata) {
+        this.targetAssignmentMetadata = Objects.requireNonNull(targetAssignmentMetadata);
         return this;
     }
 
@@ -311,7 +295,11 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
         }
 
         // Bump the target assignment epoch.
-        records.add(newTargetAssignmentMetadataRecord(groupId, assignmentEpoch, assignmentTimestampMs));
+        records.add(newTargetAssignmentMetadataRecord(
+            groupId,
+            targetAssignmentMetadata.assignmentEpoch(),
+            targetAssignmentMetadata.assignmentTimestamp()
+        ));
     }
 
     protected abstract A emptyMemberAssignment();

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.coordinator.group;
 
-import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.group.modern.Assignment;
 import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
@@ -89,14 +88,14 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
     /**
      * Constructs the object.
      *
-     * @param logContext    The log context.
-     * @param groupId       The group id.
+     * @param log       The logger.
+     * @param groupId   The group id.
      */
     public TargetAssignmentRecordsBuilder(
-        LogContext logContext,
+        Logger log,
         String groupId
     ) {
-        this.log = logContext.logger(this.getClass());
+        this.log = log;
         this.groupId = Objects.requireNonNull(groupId);
     }
 
@@ -336,8 +335,8 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
 
     public static class ConsumerTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<Assignment> {
 
-        public ConsumerTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
-            super(logContext, groupId);
+        public ConsumerTargetAssignmentRecordsBuilder(Logger log, String groupId) {
+            super(log, groupId);
         }
 
         @Override
@@ -385,8 +384,8 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
 
     public static class ShareTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<Assignment> {
 
-        public ShareTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
-            super(logContext, groupId);
+        public ShareTargetAssignmentRecordsBuilder(Logger log, String groupId) {
+            super(log, groupId);
         }
 
         @Override
@@ -434,8 +433,8 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
 
     public static class StreamsTargetAssignmentRecordsBuilder extends TargetAssignmentRecordsBuilder<TasksTuple> {
 
-        public StreamsTargetAssignmentRecordsBuilder(LogContext logContext, String groupId) {
-            super(logContext, groupId);
+        public StreamsTargetAssignmentRecordsBuilder(Logger log, String groupId) {
+            super(log, groupId);
         }
 
         @Override

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilder.java
@@ -78,12 +78,12 @@ public abstract class TargetAssignmentRecordsBuilder<A> {
     /**
      * The current target assignment.
      */
-    private Map<String, A> currentTargetAssignment = Map.of();
+    private Map<String, A> currentTargetAssignment;
 
     /**
      * The new target assignment.
      */
-    private Map<String, A> newTargetAssignment = Map.of();
+    private Map<String, A> newTargetAssignment;
 
     /**
      * Constructs the object.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
@@ -1,0 +1,548 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
+import org.apache.kafka.coordinator.group.modern.Assignment;
+import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
+import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
+import org.apache.kafka.coordinator.group.streams.TasksTuple;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.coordinator.group.Assertions.assertUnorderedRecordsEquals;
+import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkAssignment;
+import static org.apache.kafka.coordinator.group.AssignmentTestUtil.mkTopicAssignment;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TargetAssignmentRecordsBuilderTest {
+
+    @Test
+    public void testEmpty() {
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of())
+                .withCurrentTargetAssignment(Map.of())
+                .withNewTargetAssignment(Map.of())
+                .build();
+
+        assertEquals(List.of(
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testAssignmentHasNotChanged() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1", "member-2"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 3, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 3, 4, 5)
+                    ))
+                ))
+                .build();
+
+        assertEquals(List.of(
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testAssignmentSwapped() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1", "member-2"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 3, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 3, 4, 5),
+                        mkTopicAssignment(barTopicId, 3, 4, 5)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1, 2),
+                        mkTopicAssignment(barTopicId, 0, 1, 2)
+                    ))
+                ))
+                .build();
+
+        assertUnorderedRecordsEquals(List.of(
+            List.of(
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                    mkTopicAssignment(fooTopicId, 3, 4, 5),
+                    mkTopicAssignment(barTopicId, 3, 4, 5)
+                )),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                    mkTopicAssignment(fooTopicId, 0, 1, 2),
+                    mkTopicAssignment(barTopicId, 0, 1, 2)
+                ))
+            ),
+            List.of(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L))
+        ), records);
+    }
+
+    @Test
+    public void testPartialAssignmentUpdate() {
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid barTopicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0, 1)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3),
+                        mkTopicAssignment(barTopicId, 2, 3)
+                    )),
+                    "member-3", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 4, 5),
+                        mkTopicAssignment(barTopicId, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 0, 1),
+                        mkTopicAssignment(barTopicId, 0, 1)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 2, 3, 4),
+                        mkTopicAssignment(barTopicId, 2, 3, 4)
+                    )),
+                    "member-3", new Assignment(mkAssignment(
+                        mkTopicAssignment(fooTopicId, 5),
+                        mkTopicAssignment(barTopicId, 5)
+                    ))
+                ))
+                .build();
+
+        assertUnorderedRecordsEquals(List.of(
+            List.of(
+                // Member 1 has no record because its assignment did not change.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                    mkTopicAssignment(fooTopicId, 2, 3, 4),
+                    mkTopicAssignment(barTopicId, 2, 3, 4)
+                )),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                    mkTopicAssignment(fooTopicId, 5),
+                    mkTopicAssignment(barTopicId, 5)
+                ))
+            ),
+            List.of(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L))
+        ), records);
+    }
+
+    @Test
+    public void testAssignmentEmptyWhenOmitted() {
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1"))
+                .withCurrentTargetAssignment(Map.of())
+                // The assignor did not include an entry for member 1.
+                .withNewTargetAssignment(Map.of())
+                .build();
+
+        assertEquals(List.of(
+            // An empty target assignment is written for member even though the assignor did not include an entry for it.
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment()),
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testAssignmentRemoved() {
+        Uuid topicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 3, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    ))
+                ))
+                .build();
+
+        assertEquals(List.of(
+            // Member 2's target assignment is tombstoned.
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testMemberLeft() {
+        Uuid topicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                // Member 2 has left.
+                .withCurrentMemberIds(Set.of("member-1"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2, 3)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 2, 3)
+                    ))
+                ))
+                .build();
+
+        assertEquals(List.of(
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                mkTopicAssignment(topicId, 0, 1)
+            )),
+            // No record is written for member 2.
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testMemberJoined() {
+        // This test is equivalent to testAssignmentEmptyWhenOmitted.
+
+        Uuid topicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                // Member 2 has joined.
+                .withCurrentMemberIds(Set.of("member-1", "member-2"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    ))
+                ))
+                .build();
+
+        assertEquals(List.of(
+            // An empty target assignment is written for member 2.
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment()),
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testStaticMemberReplaced() {
+        Uuid topicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                .withCurrentMemberIds(Set.of("member-1", "member-3"))
+                // Static member 2 has been replaced with member 3.
+                .withPreviousStaticMembers(Map.of("instance-id", "member-2"))
+                .withCurrentStaticMembers(Map.of("instance-id", "member-3"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    )),
+                    "member-3", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 3, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 3, 4, 5, 6)
+                    ))
+                ))
+                .build();
+
+        assertEquals(List.of(
+            // Member 2's assignment is given to member 3.
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-3", mkAssignment(
+                mkTopicAssignment(topicId, 3, 4, 5, 6)
+            )),
+            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+        ), records);
+    }
+
+    @Test
+    public void testStaticMemberAndMemberIdConflict() {
+        Uuid topicId = Uuid.randomUuid();
+
+        List<CoordinatorRecord> records =
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                .withAssignmentEpoch(20)
+                .withAssignmentTimestampMs(12345L)
+                // Member 2 is still around but member 3 has its instance id now.
+                .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
+                .withPreviousStaticMembers(Map.of("instance-id", "member-2"))
+                .withCurrentStaticMembers(Map.of("instance-id", "member-3"))
+                .withCurrentTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 3, 4, 5)
+                    ))
+                ))
+                .withNewTargetAssignment(Map.of(
+                    "member-1", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 0, 1, 2)
+                    )),
+                    "member-2", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId, 3, 4, 5, 6)
+                    ))
+                ))
+                .build();
+
+        assertUnorderedRecordsEquals(List.of(
+            List.of(
+                // Member 2 gets the target assignment.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
+                    mkTopicAssignment(topicId, 3, 4, 5, 6)
+                )),
+                // Member 3 does not get member 2's target assignment.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-3", mkAssignment())
+            ),
+            List.of(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L))
+        ), records);
+    }
+
+    @Nested
+    public class ConsumerTargetAssignmentRecordsBuilderTest {
+
+        @Test
+        public void testEmptyMemberAssignment() {
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of())
+                    .withNewTargetAssignment(Map.of())
+                    .build();
+
+            assertEquals(List.of(
+                // An empty target assignment is written for member even though the assignor did not include an entry for it.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment()),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+
+        @Test
+        public void testRecords() {
+            Uuid topicId = Uuid.randomUuid();
+
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of(
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0))),
+                        "member-2", new Assignment(mkAssignment(mkTopicAssignment(topicId, 1)))
+                    ))
+                    .withNewTargetAssignment(Map.of(
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1, 2, 3)))
+                    ))
+                    .build();
+
+            assertEquals(List.of(
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                    mkTopicAssignment(topicId, 0, 1, 2, 3)
+                )),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+    }
+
+    @Nested
+    public class ShareTargetAssignmentRecordsBuilderTest {
+
+        @Test
+        public void testEmptyMemberAssignment() {
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of())
+                    .withNewTargetAssignment(Map.of())
+                    .build();
+
+            assertEquals(List.of(
+                // An empty target assignment is written for member even though the assignor did not include an entry for it.
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment()),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+
+        @Test
+        public void testRecords() {
+            Uuid topicId = Uuid.randomUuid();
+
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of(
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1))),
+                        "member-2", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1)))
+                    ))
+                    .withNewTargetAssignment(Map.of(
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1, 2, 3)))
+                    ))
+                    .build();
+
+            assertEquals(List.of(
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                    mkTopicAssignment(topicId, 0, 1, 2, 3)
+                )),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
+                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+    }
+
+    @Nested
+    public class StreamsTargetAssignmentRecordsBuilderTest {
+
+        @Test
+        public void testEmptyMemberAssignment() {
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of())
+                    .withNewTargetAssignment(Map.of())
+                    .build();
+
+            assertEquals(List.of(
+                // An empty target assignment is written for member even though the assignor did not include an entry for it.
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord("my-group", "member-1", TasksTuple.EMPTY),
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+
+        @Test
+        public void testRecords() {
+            String subtopology1 = "subtopology-1";
+
+            List<CoordinatorRecord> records =
+                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                    .withAssignmentEpoch(20)
+                    .withAssignmentTimestampMs(12345L)
+                    .withCurrentMemberIds(Set.of("member-1"))
+                    .withCurrentTargetAssignment(Map.of(
+                        "member-1", mkTasksTuple(TaskRole.ACTIVE,
+                            mkTasks(subtopology1, 0)
+                        ),
+                        "member-2", mkTasksTuple(TaskRole.ACTIVE,
+                            mkTasks(subtopology1, 1)
+                        )
+                    ))
+                    .withNewTargetAssignment(Map.of(
+                        "member-1", mkTasksTuple(TaskRole.ACTIVE,
+                            mkTasks(subtopology1, 0, 1, 2, 3)
+                        )
+                    ))
+                    .build();
+
+            assertEquals(List.of(
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(TaskRole.ACTIVE,
+                    mkTasks(subtopology1, 0, 1, 2, 3)
+                )),
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
+                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
+            ), records);
+        }
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.coordinator.group.streams.TasksTuple;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -40,10 +41,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TargetAssignmentRecordsBuilderTest {
 
+    private static final Logger LOG = new LogContext().logger(TargetAssignmentRecordsBuilder.class);
+
     @Test
     public void testEmpty() {
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of())
@@ -62,7 +65,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid barTopicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1", "member-2"))
@@ -99,7 +102,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid barTopicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1", "member-2"))
@@ -146,7 +149,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid barTopicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
@@ -199,7 +202,7 @@ public class TargetAssignmentRecordsBuilderTest {
     @Test
     public void testAssignmentEmptyWhenOmitted() {
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1"))
@@ -220,7 +223,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid topicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1"))
@@ -251,7 +254,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid topicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 // Member 2 has left.
@@ -287,7 +290,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid topicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 // Member 2 has joined.
@@ -316,7 +319,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid topicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 .withCurrentMemberIds(Set.of("member-1", "member-3"))
@@ -355,7 +358,7 @@ public class TargetAssignmentRecordsBuilderTest {
         Uuid topicId = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withAssignmentEpoch(20)
                 .withAssignmentTimestampMs(12345L)
                 // Member 2 is still around but member 3 has its instance id now.
@@ -399,7 +402,7 @@ public class TargetAssignmentRecordsBuilderTest {
         @Test
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))
@@ -419,7 +422,7 @@ public class TargetAssignmentRecordsBuilderTest {
             Uuid topicId = Uuid.randomUuid();
 
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))
@@ -448,7 +451,7 @@ public class TargetAssignmentRecordsBuilderTest {
         @Test
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))
@@ -468,7 +471,7 @@ public class TargetAssignmentRecordsBuilderTest {
             Uuid topicId = Uuid.randomUuid();
 
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))
@@ -497,7 +500,7 @@ public class TargetAssignmentRecordsBuilderTest {
         @Test
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))
@@ -517,7 +520,7 @@ public class TargetAssignmentRecordsBuilderTest {
             String subtopology1 = "subtopology-1";
 
             List<CoordinatorRecord> records =
-                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(new LogContext(), "my-group")
+                new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(LOG, "my-group")
                     .withAssignmentEpoch(20)
                     .withAssignmentTimestampMs(12345L)
                     .withCurrentMemberIds(Set.of("member-1"))

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
@@ -47,8 +47,7 @@ public class TargetAssignmentRecordsBuilderTest {
     public void testEmpty() {
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of())
                 .withCurrentTargetAssignment(Map.of())
                 .withNewTargetAssignment(Map.of())
@@ -66,8 +65,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1", "member-2"))
                 .withCurrentTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
@@ -103,8 +101,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1", "member-2"))
                 .withCurrentTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
@@ -150,8 +147,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
                 .withCurrentTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
@@ -203,8 +199,7 @@ public class TargetAssignmentRecordsBuilderTest {
     public void testAssignmentEmptyWhenOmitted() {
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1"))
                 .withCurrentTargetAssignment(Map.of())
                 // The assignor did not include an entry for member 1.
@@ -224,8 +219,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1"))
                 .withCurrentTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
@@ -255,8 +249,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 // Member 2 has left.
                 .withCurrentMemberIds(Set.of("member-1"))
                 .withCurrentTargetAssignment(Map.of(
@@ -291,8 +284,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 // Member 2 has joined.
                 .withCurrentMemberIds(Set.of("member-1", "member-2"))
                 .withCurrentTargetAssignment(Map.of(
@@ -320,8 +312,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 .withCurrentMemberIds(Set.of("member-1", "member-3"))
                 // Static member 2 has been replaced with member 3.
                 .withPreviousStaticMembers(Map.of("instance-id", "member-2"))
@@ -359,8 +350,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withAssignmentEpoch(20)
-                .withAssignmentTimestampMs(12345L)
+                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                 // Member 2 is still around but member 3 has its instance id now.
                 .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
                 .withPreviousStaticMembers(Map.of("instance-id", "member-2"))
@@ -403,8 +393,7 @@ public class TargetAssignmentRecordsBuilderTest {
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of())
                     .withNewTargetAssignment(Map.of())
@@ -423,8 +412,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of(
                         "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0))),
@@ -452,8 +440,7 @@ public class TargetAssignmentRecordsBuilderTest {
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of())
                     .withNewTargetAssignment(Map.of())
@@ -472,8 +459,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.ShareTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of(
                         "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1))),
@@ -501,8 +487,7 @@ public class TargetAssignmentRecordsBuilderTest {
         public void testEmptyMemberAssignment() {
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of())
                     .withNewTargetAssignment(Map.of())
@@ -521,8 +506,7 @@ public class TargetAssignmentRecordsBuilderTest {
 
             List<CoordinatorRecord> records =
                 new TargetAssignmentRecordsBuilder.StreamsTargetAssignmentRecordsBuilder(LOG, "my-group")
-                    .withAssignmentEpoch(20)
-                    .withAssignmentTimestampMs(12345L)
+                    .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of(
                         "member-1", mkTasksTuple(TaskRole.ACTIVE,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
@@ -214,36 +214,6 @@ public class TargetAssignmentRecordsBuilderTest {
     }
 
     @Test
-    public void testAssignmentRemoved() {
-        Uuid topicId = Uuid.randomUuid();
-
-        List<CoordinatorRecord> records =
-            new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
-                .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
-                .withCurrentMemberIds(Set.of("member-1"))
-                .withCurrentTargetAssignment(Map.of(
-                    "member-1", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 0, 1, 2)
-                    )),
-                    "member-2", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 3, 4, 5)
-                    ))
-                ))
-                .withNewTargetAssignment(Map.of(
-                    "member-1", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 0, 1, 2)
-                    ))
-                ))
-                .build();
-
-        assertEquals(List.of(
-            // Member 2's target assignment is tombstoned.
-            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
-            GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
-        ), records);
-    }
-
-    @Test
     public void testMemberLeft() {
         Uuid topicId = Uuid.randomUuid();
 
@@ -430,8 +400,7 @@ public class TargetAssignmentRecordsBuilderTest {
                     .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of(
-                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0))),
-                        "member-2", new Assignment(mkAssignment(mkTopicAssignment(topicId, 1)))
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0)))
                     ))
                     .withNewTargetAssignment(Map.of(
                         "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1, 2, 3)))
@@ -442,7 +411,6 @@ public class TargetAssignmentRecordsBuilderTest {
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                     mkTopicAssignment(topicId, 0, 1, 2, 3)
                 )),
-                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
                 GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
             ), records);
         }
@@ -477,8 +445,7 @@ public class TargetAssignmentRecordsBuilderTest {
                     .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
                     .withCurrentMemberIds(Set.of("member-1"))
                     .withCurrentTargetAssignment(Map.of(
-                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1))),
-                        "member-2", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1)))
+                        "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1)))
                     ))
                     .withNewTargetAssignment(Map.of(
                         "member-1", new Assignment(mkAssignment(mkTopicAssignment(topicId, 0, 1, 2, 3)))
@@ -489,7 +456,6 @@ public class TargetAssignmentRecordsBuilderTest {
                 GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
                     mkTopicAssignment(topicId, 0, 1, 2, 3)
                 )),
-                GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
                 GroupCoordinatorRecordHelpers.newShareGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
             ), records);
         }
@@ -526,9 +492,6 @@ public class TargetAssignmentRecordsBuilderTest {
                     .withCurrentTargetAssignment(Map.of(
                         "member-1", mkTasksTuple(TaskRole.ACTIVE,
                             mkTasks(subtopology1, 0)
-                        ),
-                        "member-2", mkTasksTuple(TaskRole.ACTIVE,
-                            mkTasks(subtopology1, 1)
                         )
                     ))
                     .withNewTargetAssignment(Map.of(
@@ -542,7 +505,6 @@ public class TargetAssignmentRecordsBuilderTest {
                 StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentRecord("my-group", "member-1", mkTasksTuple(TaskRole.ACTIVE,
                     mkTasks(subtopology1, 0, 1, 2, 3)
                 )),
-                StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentTombstoneRecord("my-group", "member-2"),
                 StreamsCoordinatorRecordHelpers.newStreamsGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L)
             ), records);
         }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/TargetAssignmentRecordsBuilderTest.java
@@ -346,41 +346,56 @@ public class TargetAssignmentRecordsBuilderTest {
 
     @Test
     public void testStaticMemberAndMemberIdConflict() {
-        Uuid topicId = Uuid.randomUuid();
+        // This scenario will never happen when using the official Java client and may be forbidden
+        // in the future.
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
 
         List<CoordinatorRecord> records =
             new TargetAssignmentRecordsBuilder.ConsumerTargetAssignmentRecordsBuilder(LOG, "my-group")
                 .withTargetAssignmentMetadata(new TargetAssignmentMetadata(20, 12345L))
-                // Member 2 is still around but member 3 has its instance id now.
-                .withCurrentMemberIds(Set.of("member-1", "member-2", "member-3"))
-                .withPreviousStaticMembers(Map.of("instance-id", "member-2"))
-                .withCurrentStaticMembers(Map.of("instance-id", "member-3"))
+                // instance-id-1 has "moved" from member 1 to member 2.
+                //   member 1 has been around the whole time and member 2 is new.
+                // instance-id-2 has "moved" from member 3 to member 4.
+                //   member 3 left and member 4 has been around the whole time.
+                .withCurrentMemberIds(Set.of("member-1", "member-2", "member-4"))
+                .withPreviousStaticMembers(Map.of("instance-id-1", "member-1", "instance-id-2", "member-3"))
+                .withCurrentStaticMembers(Map.of("instance-id-1", "member-2", "instance-id-2", "member-4"))
                 .withCurrentTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 0, 1, 2)
+                        mkTopicAssignment(topicId1, 0, 1, 2)
                     )),
-                    "member-2", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 3, 4, 5)
+                    // member-3's assignment was removed when they left.
+                    "member-4", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId2, 3, 4, 5)
                     ))
                 ))
                 .withNewTargetAssignment(Map.of(
                     "member-1", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 0, 1, 2)
+                        mkTopicAssignment(topicId1, 0, 1, 2, 3)
                     )),
-                    "member-2", new Assignment(mkAssignment(
-                        mkTopicAssignment(topicId, 3, 4, 5, 6)
+                    "member-3", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId2, 0, 1, 2, 3)
+                    )),
+                    "member-4", new Assignment(mkAssignment(
+                        mkTopicAssignment(topicId2, 4, 5, 6, 7)
                     ))
                 ))
                 .build();
 
         assertUnorderedRecordsEquals(List.of(
             List.of(
-                // Member 2 gets the target assignment.
-                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment(
-                    mkTopicAssignment(topicId, 3, 4, 5, 6)
+                // Member 1 gets the target assignment.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-1", mkAssignment(
+                    mkTopicAssignment(topicId1, 0, 1, 2, 3)
                 )),
-                // Member 3 does not get member 2's target assignment.
-                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-3", mkAssignment())
+                // Member 2 does not get member 1's target assignment.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-2", mkAssignment()),
+                // Member 3 gets nothing because it is no longer in the group.
+                // Member 4 gets the target assignment.
+                GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentRecord("my-group", "member-4", mkAssignment(
+                    mkTopicAssignment(topicId2, 4, 5, 6, 7)
+                ))
             ),
             List.of(GroupCoordinatorRecordHelpers.newConsumerGroupTargetAssignmentMetadataRecord("my-group", 20, 12345L))
         ), records);


### PR DESCRIPTION
To accommodate asynchronous assignors, such as assignors offloaded to
the background thread pool and client-side assignors, we require a
builder to turn a new target assignment into records to be persisted.
Previously, the logic lived within the TargetAssignmentBuilder classes.
We copy the logic out into its own builder class, keeping the existing
logic within the TargetAssignmentBuilders for now.

Future commits will remove the record-building logic from the
TargetAssignmentBuilder classes and update callers to use the new
TargetAssignmentRecordsBuilders.

Additionally, we have to handle concurrent member operations such as
leaves and static member replacements when building the target
assignment records for asynchronous assignors. These member operations
update the target assignment directly. Once the new target assignment is
ready, we have to apply any member operations we missed to it. That is,
we act as if the member removals and static member replacements are
reordered after the assignment calculation.

Reviewers: David Jacot <david.jacot@gmail.com>, David Jacot
 <dajac@apache.org>
