### PR TITLE
KAFKA-20644: Fail fast when admin.listeners overlaps listeners

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -118,6 +118,8 @@ public abstract class RestServer {
      * Adds Jetty connector for each configured listener
      */
     public final void createConnectors(List<String> listeners, List<String> adminListeners) {
+        validateListenerConfig(listeners, adminListeners);
+
         List<Connector> connectors = new ArrayList<>();
 
         for (String listener : listeners) {
@@ -135,6 +137,57 @@ public abstract class RestServer {
                 log.info("Added admin connector for {}", adminListener);
             }
         }
+    }
+
+    /**
+     * Validate that no admin listener shares a host and port with a regular listener. The REST server creates a
+     * dedicated Jetty connector for each admin listener (bound to the {@link #ADMIN_SERVER_CONNECTOR_NAME} virtual
+     * host); if an admin listener reused the host and port of a regular listener, the two connectors would attempt
+     * to bind the same socket and the server would fail to start with an opaque "address already in use" error.
+     * To expose the admin endpoints on the regular listeners, leave {@code admin.listeners} unset.
+     */
+    private static void validateListenerConfig(List<String> listeners, List<String> adminListeners) {
+        if (adminListeners == null || adminListeners.isEmpty()) {
+            return;
+        }
+        for (String adminListener : adminListeners) {
+            for (String listener : listeners) {
+                if (listenersBindSameSocket(listener, adminListener)) {
+                    throw new ConfigException(String.format(
+                        "Admin listener %s conflicts with %s entry %s: %s and %s entries must not share a host and port. "
+                            + "To expose the admin endpoints on the regular listeners, leave %s unset.",
+                        adminListener, RestServerConfig.LISTENERS_CONFIG, listener,
+                        RestServerConfig.ADMIN_LISTENERS_CONFIG, RestServerConfig.LISTENERS_CONFIG,
+                        RestServerConfig.ADMIN_LISTENERS_CONFIG));
+                }
+            }
+        }
+    }
+
+    private static boolean listenersBindSameSocket(String listener, String adminListener) {
+        Matcher listenerMatcher = LISTENER_PATTERN.matcher(listener);
+        Matcher adminMatcher = LISTENER_PATTERN.matcher(adminListener);
+        if (!listenerMatcher.matches() || !adminMatcher.matches()) {
+            return false;
+        }
+
+        int port = Integer.parseInt(listenerMatcher.group(3));
+        int adminPort = Integer.parseInt(adminMatcher.group(3));
+        if (port != adminPort || port == 0) {
+            return false;
+        }
+
+        String host = normalizeListenerHost(listenerMatcher.group(2));
+        String adminHost = normalizeListenerHost(adminMatcher.group(2));
+        return host.equals(adminHost) || isWildcardHost(host) || isWildcardHost(adminHost);
+    }
+
+    private static String normalizeListenerHost(String host) {
+        return host == null ? "" : host.trim().toLowerCase(Locale.ENGLISH);
+    }
+
+    private static boolean isWildcardHost(String host) {
+        return host.isEmpty() || host.equals("0.0.0.0") || host.equals("::") || host.equals("[::]");
     }
 
     /**
@@ -242,8 +295,8 @@ public abstract class RestServer {
                 log.info("Adding admin resources to main listener");
                 adminResourceConfig = resourceConfig;
             } else {
-                // TODO: we need to check if these listeners are same as 'listeners'
-                // TODO: the following code assumes that they are different
+                // Admin listeners are validated in createConnectors() to be distinct from the regular listeners,
+                // so the admin resources are served on their own dedicated connector here.
                 log.info("Adding admin resources to admin listener");
                 adminResourceConfig = newResourceConfig();
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServerConfig.java
@@ -86,6 +86,8 @@ public abstract class RestServerConfig extends AbstractConfig {
             " The supported protocols are HTTP and HTTPS." +
             " An empty or blank string will disable this feature." +
             " The default behavior is to use the regular listener (specified by the 'listeners' property)." +
+            " These URIs must not share a host and port with any 'listeners' entry; to expose the admin endpoints" +
+            " on the regular listener, leave this property unset." +
             " A comma-separated list of valid URLs, e.g., http://localhost:8080,https://localhost:8443.";
     public static final String ADMIN_LISTENERS_HTTPS_CONFIGS_PREFIX = "admin.listeners.https.";
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/ConnectRestServerTest.java
@@ -16,8 +16,44 @@
  */
 package org.apache.kafka.connect.runtime.rest;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MediaType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Monitorable;
@@ -30,21 +66,6 @@ import org.apache.kafka.connect.runtime.MockConnectMetrics;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.isolation.PluginsTest;
 import org.apache.kafka.connect.runtime.rest.entities.LoggerLevel;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,30 +75,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import jakarta.ws.rs.core.MediaType;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.reset;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -325,6 +322,52 @@ public class ConnectRestServerTest {
         HttpRequest request = new HttpGet("/admin/loggers");
         HttpResponse response = executeRequest(server.advertisedUrl(), request);
         assertEquals(404, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testAdminListenersConflictingWithListenersFailsFast() {
+        reset(herder);
+
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8083");
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://localhost:8083");
+
+        ConfigException e = assertThrows(ConfigException.class,
+            () -> new ConnectRestServer(null, restClient, configMap));
+        assertTrue(e.getMessage().contains(RestServerConfig.ADMIN_LISTENERS_CONFIG));
+    }
+
+    @Test
+    public void testWildcardAdminListenerConflictsWithListenerOnSamePort() {
+        reset(herder);
+
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8083");
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://0.0.0.0:8083");
+
+        assertThrows(ConfigException.class, () -> new ConnectRestServer(null, restClient, configMap));
+    }
+
+    @Test
+    public void testAdminListenersDistinctFromListenersAllowed() {
+        reset(herder);
+
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:8083");
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://localhost:8084");
+
+        server = new ConnectRestServer(null, restClient, configMap);
+    }
+
+    @Test
+    public void testAdminListenersWithEphemeralPortNotTreatedAsConflict() {
+        reset(herder);
+
+        Map<String, String> configMap = new HashMap<>(baseServerProps());
+        configMap.put(RestServerConfig.LISTENERS_CONFIG, "http://localhost:0");
+        configMap.put(RestServerConfig.ADMIN_LISTENERS_CONFIG, "http://localhost:0");
+
+        server = new ConnectRestServer(null, restClient, configMap);
     }
 
     @Test


### PR DESCRIPTION
The Connect REST server supports a separate `admin.listeners` endpoint and handles three cases: 

1. unset (admin resources inherit the regular listeners), 
2. empty (admin resources disabled), 
3. distinct value (admin resources get their own connector). 

It did not handle the case where `admin.listeners` shares a host and port with listeners: `createConnectors()` builds a second Jetty connector on the same socket, which fails to bind at startup with an opaque "address already in use" error and no hint that admin.listeners is the cause. The code carried two TODOs acknowledging that it assumed the two were different.

Validate the configuration in `createConnectors()` before any connector is built, and throw a `ConfigException` when an admin.listeners entry shares a host and port with a listeners entry. The message directs the user to leave admin.listeners unset to serve the admin endpoints on the regular
listeners. Overlap detection treats wildcard hosts (0.0.0.0, ::) as binding all interfaces and ignores ephemeral port 0, which resolves to a distinct port per connector.

Also document the distinctness requirement on the `admin.listeners` config and remove the two stale TODOs.

Added unit tests covering exact overlap, wildcard overlap, distinct host:port, and ephemeral port 0. 
No KIP required: this only tightens validation of a configuration that already failed at startup.