### PR TITLE
KAFKA-20668: Add --checkpoint option to kafka-metadata-shell

### DIFF
--- a/docs/operations/kraft.md
+++ b/docs/operations/kraft.md
@@ -273,7 +273,7 @@ $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cl
 The kafka-metadata-shell.sh tool can be used to interactively inspect the state of the cluster metadata partition:
 
 ```bash
-$ bin/kafka-metadata-shell.sh --snapshot metadata_log_dir/__cluster_metadata-0/00000000000000007228-0000000001.checkpoint
+$ bin/kafka-metadata-shell.sh --checkpoint metadata_log_dir/__cluster_metadata-0/00000000000000007228-0000000001.checkpoint
 >> ls /
 brokers  local  metadataQuorum  topicIds  topics
 >> ls /topics

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -62,11 +62,11 @@ public final class MetadataShell {
     record MetadataShellArguments(String checkpointPath, List<String> command) { }
 
     public static class Builder {
-        private String snapshotPath = null;
+        private String checkpointPath = null;
         private FaultHandler faultHandler = new LoggingFaultHandler("shell", () -> { });
 
-        public Builder setSnapshotPath(String snapshotPath) {
-            this.snapshotPath = snapshotPath;
+        public Builder setCheckpointPath(String checkpointPath) {
+            this.checkpointPath = checkpointPath;
             return this;
         }
 
@@ -76,7 +76,7 @@ public final class MetadataShell {
         }
 
         public MetadataShell build() {
-            return new MetadataShell(snapshotPath, faultHandler);
+            return new MetadataShell(checkpointPath, faultHandler);
         }
     }
 
@@ -91,7 +91,7 @@ public final class MetadataShell {
             .help("The metadata checkpoint file to read.");
         checkpointGroup.addArgument("--snapshot", "-s")
             .type(String.class)
-            .help("(DEPRECATED) The metadata snapshot file to read. Use --checkpoint instead.");
+            .help("(DEPRECATED) The metadata checkpoint file to read. Use --checkpoint instead.");
         parser.addArgument("command")
             .nargs("*")
             .help("The command to run.");
@@ -101,11 +101,11 @@ public final class MetadataShell {
     static MetadataShellArguments parseArguments(String[] args, PrintStream out) throws ArgumentParserException {
         Namespace res = createArgumentParser().parseArgs(args);
         String checkpointPath = res.getString("checkpoint");
-        String snapshotPath = res.getString("snapshot");
-        if (snapshotPath != null) {
+        String deprecatedCheckpointPath = res.getString("snapshot");
+        if (deprecatedCheckpointPath != null) {
             out.println("Option --snapshot is deprecated and will be removed in a future version. " +
                 "Use --checkpoint instead.");
-            checkpointPath = snapshotPath;
+            checkpointPath = deprecatedCheckpointPath;
         }
         return new MetadataShellArguments(checkpointPath, res.getList("command"));
     }
@@ -245,7 +245,7 @@ public final class MetadataShell {
         }
         try {
             Builder builder = new Builder();
-            builder.setSnapshotPath(shellArguments.checkpointPath());
+            builder.setCheckpointPath(shellArguments.checkpointPath());
             Path tempDir = Files.createTempDirectory("MetadataShell");
             Exit.addShutdownHook("agent-shutdown-hook", () -> {
                 log.debug("Removing temporary directory " + tempDir.toAbsolutePath());

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -33,6 +33,8 @@ import org.apache.kafka.shell.state.MetadataShellState;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.slf4j.Logger;
@@ -42,6 +44,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -55,6 +58,8 @@ import java.util.concurrent.TimeUnit;
  */
 public final class MetadataShell {
     private static final Logger log = LoggerFactory.getLogger(MetadataShell.class);
+
+    record MetadataShellArguments(String checkpointPath, List<String> command) { }
 
     public static class Builder {
         private String snapshotPath = null;
@@ -73,6 +78,36 @@ public final class MetadataShell {
         public MetadataShell build() {
             return new MetadataShell(snapshotPath, faultHandler);
         }
+    }
+
+    static ArgumentParser createArgumentParser() {
+        ArgumentParser parser = ArgumentParsers
+            .newArgumentParser("kafka-metadata-shell")
+            .defaultHelp(true)
+            .description("The Apache Kafka metadata shell");
+        MutuallyExclusiveGroup checkpointGroup = parser.addMutuallyExclusiveGroup().required(true);
+        checkpointGroup.addArgument("--checkpoint")
+            .type(String.class)
+            .help("The metadata checkpoint file to read.");
+        checkpointGroup.addArgument("--snapshot", "-s")
+            .type(String.class)
+            .help("(DEPRECATED) The metadata snapshot file to read. Use --checkpoint instead.");
+        parser.addArgument("command")
+            .nargs("*")
+            .help("The command to run.");
+        return parser;
+    }
+
+    static MetadataShellArguments parseArguments(String[] args, PrintStream out) throws ArgumentParserException {
+        Namespace res = createArgumentParser().parseArgs(args);
+        String checkpointPath = res.getString("checkpoint");
+        String snapshotPath = res.getString("snapshot");
+        if (snapshotPath != null) {
+            out.println("Option --snapshot is deprecated and will be removed in a future version. " +
+                "Use --checkpoint instead.");
+            checkpointPath = snapshotPath;
+        }
+        return new MetadataShellArguments(checkpointPath, res.getList("command"));
     }
 
     /**
@@ -200,21 +235,17 @@ public final class MetadataShell {
     }
 
     public static void main(String[] args) {
-        ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("kafka-metadata-shell")
-            .defaultHelp(true)
-            .description("The Apache Kafka metadata shell");
-        parser.addArgument("--snapshot", "-s")
-            .type(String.class)
-            .required(true)
-            .help("The metadata snapshot file to read.");
-        parser.addArgument("command")
-            .nargs("*")
-            .help("The command to run.");
-        Namespace res = parser.parseArgsOrFail(args);
+        MetadataShellArguments shellArguments;
+        try {
+            shellArguments = parseArguments(args, System.out);
+        } catch (ArgumentParserException e) {
+            e.getParser().handleError(e);
+            Exit.exit(1);
+            return;
+        }
         try {
             Builder builder = new Builder();
-            builder.setSnapshotPath(res.getString("snapshot"));
+            builder.setSnapshotPath(shellArguments.checkpointPath());
             Path tempDir = Files.createTempDirectory("MetadataShell");
             Exit.addShutdownHook("agent-shutdown-hook", () -> {
                 log.debug("Removing temporary directory " + tempDir.toAbsolutePath());
@@ -227,7 +258,7 @@ public final class MetadataShell {
             });
             MetadataShell shell = builder.build();
             try {
-                shell.run(res.getList("command"));
+                shell.run(shellArguments.command());
             } finally {
                 shell.close();
             }

--- a/shell/src/test/java/org/apache/kafka/shell/MetadataShellTest.java
+++ b/shell/src/test/java/org/apache/kafka/shell/MetadataShellTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.shell;
+
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(value = 120)
+public class MetadataShellTest {
+
+    @Test
+    public void testParseCheckpoint() throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        MetadataShell.MetadataShellArguments arguments = MetadataShell.parseArguments(
+            new String[] {"--checkpoint", "metadata.checkpoint"},
+            new PrintStream(stream, true, StandardCharsets.UTF_8));
+
+        assertEquals("metadata.checkpoint", arguments.checkpointPath());
+        assertEquals(List.of(), arguments.command());
+        assertEquals("", stream.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testParseCheckpointWithCommand() throws Exception {
+        MetadataShell.MetadataShellArguments arguments = MetadataShell.parseArguments(
+            new String[] {"--checkpoint", "metadata.checkpoint", "ls", "/topics"},
+            System.out);
+
+        assertEquals("metadata.checkpoint", arguments.checkpointPath());
+        assertEquals(List.of("ls", "/topics"), arguments.command());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"--snapshot", "-s"})
+    public void testParseDeprecatedSnapshot(String snapshotOption) throws Exception {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        MetadataShell.MetadataShellArguments arguments = MetadataShell.parseArguments(
+            new String[] {snapshotOption, "metadata.checkpoint"},
+            new PrintStream(stream, true, StandardCharsets.UTF_8));
+
+        assertEquals("metadata.checkpoint", arguments.checkpointPath());
+        assertEquals(List.of(), arguments.command());
+        assertTrue(stream.toString(StandardCharsets.UTF_8).contains(
+            "Option --snapshot is deprecated and will be removed in a future version. Use --checkpoint instead."));
+    }
+
+    @Test
+    public void testParseCheckpointAndDeprecatedSnapshotFails() {
+        ArgumentParserException exception = assertThrows(ArgumentParserException.class, () ->
+            MetadataShell.parseArguments(
+                new String[] {
+                    "--checkpoint", "metadata.checkpoint",
+                    "--snapshot", "metadata.snapshot"
+                },
+                System.out));
+
+        assertTrue(exception.getMessage().contains("not allowed with argument"));
+    }
+
+    @Test
+    public void testParseWithoutCheckpointFails() {
+        ArgumentParserException exception = assertThrows(ArgumentParserException.class, () ->
+            MetadataShell.parseArguments(new String[] {"ls", "/"}, System.out));
+
+        assertTrue(exception.getMessage().contains("required"));
+    }
+}


### PR DESCRIPTION
The metadata shell currently exposes `--snapshot` for selecting the metadata file to read, but the files users should pass to this tool use the `.checkpoint` suffix. This adds `--checkpoint` as the preferred option while keeping `--snapshot` and `-s` as deprecated aliases for compatibility.

The command-line parsing is now factored into package-private helpers so that the CLI behavior can be tested without invoking `main`, `Exit.exit`, or loading a real checkpoint. The new tests cover parsing the new option, preserving shell commands, accepting the deprecated aliases with a warning, rejecting simultaneous new and old options, and failing when no checkpoint option is provided.

The KRaft operations documentation now shows `--checkpoint` in the metadata shell example.

Testing:

- `./gradlew :shell:test --tests org.apache.kafka.shell.MetadataShellTest`
- `./gradlew :shell:test --tests org.apache.kafka.shell.MetadataShellIntegrationTest`
- `./gradlew :shell:check`

Reviewers: Lianet Magrans <lmagrans@confluent.io>
