### PR TITLE
MINOR: Remove unused maybeEmitMetric from MetricsEmitter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/telemetry/internals/MetricsEmitter.java
+++ b/clients/src/main/java/org/apache/kafka/common/telemetry/internals/MetricsEmitter.java
@@ -72,15 +72,6 @@ public interface MetricsEmitter extends Closeable {
     }
 
     /**
-     * Emits a metric if {@link MetricsEmitter#shouldEmitMetric(MetricKeyable)} returns <tt>true</tt>.
-     * @param metric to emit
-     * @return true if emit is successful, false otherwise
-     */
-    default boolean maybeEmitMetric(SinglePointMetric metric) {
-        return shouldEmitMetric(metric) && emitMetric(metric);
-    }
-
-    /**
      * Allows the {@code MetricsEmitter} implementation to initialize itself. This method should be invoked
      * by the telemetry reporter before calls to {@link #emitMetric(SinglePointMetric)} are made.
      *


### PR DESCRIPTION
Remove the unused `maybeEmitMetric` default method from
`MetricsEmitter`.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
