### PR TITLE
KAFKA-16337: removed deprecated apis

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/DslKeyValueParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslKeyValueParams.java
@@ -30,19 +30,6 @@ public class DslKeyValueParams {
     private final DslStoreFormat dslStoreFormat;
 
     /**
-     * @deprecated Since 4.3. Use {@link #DslKeyValueParams(String, DslStoreFormat)} instead.
-     * @param name          the name of the store (cannot be {@code null})
-     * @param isTimestamped whether the returned stores should be timestamped, see ({@link TimestampedKeyValueStore}
-     */
-    @Deprecated
-    public DslKeyValueParams(final String name, final boolean isTimestamped) {
-        Objects.requireNonNull(name);
-        this.name = name;
-        // If isTimestamped is false and the user is still calling the old deprecated constructor, we should assume they mean plain.
-        this.dslStoreFormat = isTimestamped ? DslStoreFormat.TIMESTAMPED : DslStoreFormat.PLAIN;
-    }
-
-    /**
      * @param name           the name of the store (cannot be {@code null})
      * @param dslStoreFormat the format of the state store, see ({@link DslStoreFormat}
      */
@@ -53,15 +40,6 @@ public class DslKeyValueParams {
 
     public String name() {
         return name;
-    }
-
-    /**
-     * @deprecated Since 4.3. Use {@link #dslStoreFormat()} instead to check the store format.
-     * @return {@code true} if the store format is {@link DslStoreFormat#TIMESTAMPED}, {@code false} otherwise
-     */
-    @Deprecated
-    public boolean isTimestamped() {
-        return dslStoreFormat == DslStoreFormat.TIMESTAMPED;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslSessionParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslSessionParams.java
@@ -33,22 +33,6 @@ public class DslSessionParams {
     private final EmitStrategy emitStrategy;
     private final DslStoreFormat storeFormat;
 
-    /**
-     * @param name              name of the store (cannot be {@code null})
-     * @param retentionPeriod   length of time to retain data in the store (cannot be negative)
-     *                          (note that the retention period must be at least as long enough to
-     *                          contain the inactivity gap of the session and the entire grace period.)
-     * @param emitStrategy      defines how to emit results
-     */
-    @Deprecated
-    public DslSessionParams(
-            final String name,
-            final Duration retentionPeriod,
-            final EmitStrategy emitStrategy
-    ) {
-        this(name, retentionPeriod, emitStrategy, DslStoreFormat.PLAIN);
-    }
-
     public DslSessionParams(final String name,
                             final Duration retentionPeriod,
                             final EmitStrategy emitStrategy,

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslWindowParams.java
@@ -37,40 +37,6 @@ public class DslWindowParams {
     private final DslStoreFormat dslStoreFormat;
 
     /**
-     * @deprecated Since 4.3. Use {@link #DslWindowParams(String, Duration, Duration, boolean, EmitStrategy, boolean, DslStoreFormat)} Params(String, DslStoreFormat)} instead.
-     * @param name             name of the store (cannot be {@code null})
-     * @param retentionPeriod  length of time to retain data in the store (cannot be negative)
-     *                         (note that the retention period must be at least long enough to contain the
-     *                         windowed data's entire life cycle, from window-start through window-end,
-     *                         and for the entire grace period)
-     * @param windowSize       size of the windows (cannot be negative)
-     * @param retainDuplicates whether to retain duplicates. Turning this on will automatically disable
-     *                         caching and means that null values will be ignored.
-     * @param emitStrategy     defines how to emit results
-     * @param isSlidingWindow  whether the requested store is a sliding window
-     * @param isTimestamped    whether the requested store should be timestamped (see {@link TimestampedWindowStore}
-     */
-    @Deprecated
-    public DslWindowParams(
-            final String name,
-            final Duration retentionPeriod,
-            final Duration windowSize,
-            final boolean retainDuplicates,
-            final EmitStrategy emitStrategy,
-            final boolean isSlidingWindow,
-            final boolean isTimestamped
-    ) {
-        this.name = Objects.requireNonNull(name);
-        this.retentionPeriod = retentionPeriod;
-        this.windowSize = windowSize;
-        this.retainDuplicates = retainDuplicates;
-        this.emitStrategy = emitStrategy;
-        this.isSlidingWindow = isSlidingWindow;
-        // If isTimestamped is false and the user is still calling the old deprecated constructor, we should assume they mean plain.
-        this.dslStoreFormat = isTimestamped ? DslStoreFormat.TIMESTAMPED : DslStoreFormat.PLAIN;
-    }
-
-    /**
      * @param name             name of the store (cannot be {@code null})
      * @param retentionPeriod  length of time to retain data in the store (cannot be negative)
      *                         (note that the retention period must be at least long enough to contain the
@@ -123,15 +89,6 @@ public class DslWindowParams {
 
     public boolean isSlidingWindow() {
         return isSlidingWindow;
-    }
-
-    /**
-     * @deprecated Since 4.3. Use {@link #dslStoreFormat()} instead to check the store format.
-     * @return {@code true} if the store format is {@link DslStoreFormat#TIMESTAMPED}, {@code false} otherwise
-     */
-    @Deprecated
-    public boolean isTimestamped() {
-        return dslStoreFormat == DslStoreFormat.TIMESTAMPED;
     }
 
     /**


### PR DESCRIPTION
This PR implementrs [KAFKA-20654](https://issues.apache.org/jira/browse/KAFKA-20654): Removed the deprecated boolean-based DSL store parameter APIs introduced for removal after KIP-1285. DslKeyValueParams, DslWindowParams, and DslSessionParams now expose only the DslStoreFormat-based constructors/accessors.