### PR TITLE
MINOR: Truncate cluster.json when generating in ducker-ak

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -471,7 +471,7 @@ attempting to start new ones."
         docker_run "${node}" "${image_name}" "${expose_ports}"
     done
     mkdir -p "${ducker_dir}/build"
-    exec 3<> "${ducker_dir}/build/node_hosts"
+    exec 3> "${ducker_dir}/build/node_hosts"
     for n in $(seq -f %02g 1 ${num_nodes}); do
         local node="ducker${n}"
         if [[ "${ipv6}" == "true" ]]; then
@@ -512,7 +512,7 @@ attempting to start new ones."
 generate_cluster_json_file() {
     local num_nodes="${1}"
     local path="${2}"
-    exec 3<> "${path}"
+    exec 3> "${path}"
 cat<<EOF >&3
 {
   "_comment": [


### PR DESCRIPTION
### Background
`generate_cluster_json_file` and the `node_hosts` writer inside
`ducker_up` both open their output files with `exec 3<> "${path}"`
before writing the JSON. The `<>` form opens the file for read+write
without clearing it first. So when this function runs a second time and
the new content is shorter than what was already in the file, the
leftover bytes from the previous run stay at the end. The result is
`cluster.json` and `node_hosts` that look like valid content followed by
leftover bytes - ducktape fails to parse `cluster.json`, and the stale
entries in `node_hosts` can mislead container `/etc/hosts` setup.

Current `ducker_up` already refuses to run when ducker containers are
still running, so two consecutive `up` invocations don't trigger this.
The bug surfaces when the containers are gone but  the build files from
a previous run remain on disk, and the next  `up` writes shorter
content. For example, a previous `up` was not  followed by a successful
`down` - after a host crash, a Docker  daemon restart, or `down` failing
before its `rm -f` step.

### Verification
To simulate the stale state, we remove containers with
`docker rm -f $(docker ps -aq --filter "name=ducker")`. This leaves
`cluster.json` and `node_hosts` from the previous `up` in place.

```bash
# Start large
tests/docker/ducker-ak up -n 5
ls -la tests/docker/build/
# cluster.json 1965 bytes
# node_hosts    100 bytes

# Simulate stale state: remove containers but keep build/ files
docker rm -f $(docker ps -aq --filter "name=ducker")

# Run again with fewer nodes
tests/docker/ducker-ak up -n 3
ls -la tests/docker/build/
# cluster.json 1429 bytes   ← correctly truncated
# node_hosts    60 bytes    ← correctly truncated
python3 -c "import json;
json.load(open('tests/docker/build/cluster.json'))"
# (valid JSON, no error)
wc -l tests/docker/build/node_host
# (exactly 3 entries, no stale rows)
```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
