### PR TITLE
KAFKA-20672: Retry DLQ on SharePartition init for ARCHIVING records.

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -453,6 +453,8 @@ public class SharePartition {
             .build()
         ).whenComplete((result, exception) -> {
             Throwable throwable = null;
+            // Batches read from the persister in the ARCHIVING state whose DLQ flow (phase 2) must be resumed.
+            List<DlqBatch> dlqBatches = new ArrayList<>();
             lock.writeLock().lock();
             try {
                 if (exception != null) {
@@ -522,14 +524,22 @@ public class SharePartition {
                         gapStartOffset = previousBatchLastOffset + 1;
                     }
                     previousBatchLastOffset = stateBatch.lastOffset();
+                    RecordState recordState = RecordState.forId(stateBatch.deliveryState());
                     InFlightBatch inFlightBatch = new InFlightBatch(timer, time, EMPTY_MEMBER_ID, stateBatch.firstOffset(),
-                        stateBatch.lastOffset(), RecordState.forId(stateBatch.deliveryState()), stateBatch.deliveryCount(),
+                        stateBatch.lastOffset(), recordState, stateBatch.deliveryCount(),
                         null, timeoutHandler, sharePartitionMetrics);
                     cachedState.put(stateBatch.firstOffset(), inFlightBatch);
                     // During initialization, deliveryCompleteCount is updated with the number of records that are in the
                     // ACKNOWLEDGED or ARCHIVED state.
-                    if (isStateTerminal(RecordState.forId(stateBatch.deliveryState()))) {
+                    if (isStateTerminal(recordState)) {
                         deliveryCompleteCount.addAndGet((int) (stateBatch.lastOffset() - stateBatch.firstOffset() + 1));
+                    }
+                    // A batch persisted in ARCHIVING means a previous DLQ flow did not complete phase 2; collect
+                    // it so the flow can be resumed once the partition is active. ARCHIVING is non-terminal, so
+                    // it is not counted in deliveryCompleteCount here (phase 2 does that when it reaches ARCHIVED).
+                    if (recordState == RecordState.ARCHIVING) {
+                        dlqBatches.add(new DlqBatch(inFlightBatch::archiveBatch,
+                            stateBatch.firstOffset(), stateBatch.lastOffset(), stateBatch.deliveryCount()));
                     }
                     sharePartitionMetrics.recordInFlightBatchMessageCount(stateBatch.lastOffset() - stateBatch.firstOffset() + 1);
                 }
@@ -571,6 +581,11 @@ public class SharePartition {
                 } else {
                     future.complete(null);
                 }
+            }
+            // Resume the DLQ flow for any records left in the ARCHIVING state by a previously interrupted
+            // flow. Runs only on successful init, after the future completed and outside the write lock.
+            if (throwable == null) {
+                maybeResumeDlqArchiving(dlqBatches);
             }
         });
 
@@ -2603,7 +2618,7 @@ public class SharePartition {
                 // Persister batch state has been moved to ARCHIVING, we must now start the DLQ flow and transition to ARCHIVED.
                 dlqBatches.forEach(persisterBatch -> {
                     initiateDLQAndArchive(
-                        persisterBatch.updatedState,
+                        persisterBatch.updatedState()::archive,
                         persisterBatch.stateBatch.firstOffset(),
                         persisterBatch.stateBatch.lastOffset(),
                         persisterBatch.stateBatch.deliveryCount(),
@@ -2997,7 +3012,7 @@ public class SharePartition {
 
                     // Persister batch state has been moved to ARCHIVING, we must now start the DLQ flow and transition to ARCHIVED.
                     dlqBatches.forEach(dlqBatch -> initiateDLQAndArchive(
-                        dlqBatch.updatedState(),
+                        dlqBatch.archiveAction(),
                         dlqBatch.firstOffset(),
                         dlqBatch.lastOffset(),
                         dlqBatch.deliveryCount(),
@@ -3038,7 +3053,7 @@ public class SharePartition {
             if (updateResult.state() == RecordState.ARCHIVING) {
                 // Don't increment deliveryCompleteCount here — deferred to phase 2
                 // Don't updateFindNextFetchOffset — ARCHIVING is not fetchable
-                dlqBatches.add(new DlqBatch(updateResult,
+                dlqBatches.add(new DlqBatch(updateResult::archive,
                     inFlightBatch.firstOffset(), inFlightBatch.lastOffset(),
                     (short) updateResult.deliveryCount()));
                 return;
@@ -3105,7 +3120,7 @@ public class SharePartition {
             if (updateResult.state() == RecordState.ARCHIVING) {
                 // Don't increment deliveryCompleteCount here — deferred to phase 2
                 // Don't updateFindNextFetchOffset — ARCHIVING is not fetchable
-                dlqBatches.add(new DlqBatch(updateResult, offsetState.getKey(),
+                dlqBatches.add(new DlqBatch(updateResult::archive, offsetState.getKey(),
                     offsetState.getKey(), (short) updateResult.deliveryCount()));
                 continue;
             }
@@ -3338,6 +3353,27 @@ public class SharePartition {
         return shareGroupDlqEnableSupplier.get() && configProvider.errorsDLQTopicName(groupId).isPresent();
     }
 
+    /**
+     * Resume the DLQ flow (phase 2) for records that the persister returned in the ARCHIVING state. This
+     * happens when a previous flow persisted phase 1 (ARCHIVING) but the broker re-initialized this share
+     * partition before completing phase 2 (DLQ enqueue + transition to ARCHIVED). The DLQ cause is not
+     * persisted, hence it is inferred from the delivery count. Draining is unconditional (not gated on the
+     * current DLQ-enabled config) since ARCHIVING is non-terminal and would otherwise stall the start offset.
+     */
+    private void maybeResumeDlqArchiving(List<DlqBatch> dlqBatches) {
+        dlqBatches.forEach(dlqBatch -> {
+            Throwable dlqCause = dlqBatch.deliveryCount() >= maxDeliveryCount()
+                ? ShareGroupDLQManager.DELIVERY_COUNT_EXCEEDED
+                : ShareGroupDLQManager.CLIENT_REJECT;
+            initiateDLQAndArchive(
+                dlqBatch.archiveAction(),
+                dlqBatch.firstOffset(),
+                dlqBatch.lastOffset(),
+                dlqBatch.deliveryCount(),
+                dlqCause);
+        });
+    }
+
     // Visible for testing.
 
     /**
@@ -3346,7 +3382,7 @@ public class SharePartition {
      * Phase 2: Enqueues to DLQ, then transitions ARCHIVING → ARCHIVED and persists ARCHIVED to the persister
      * This method handles the complete phase 2 flow.
      */
-    void initiateDLQAndArchive(InFlightState updatedState, long firstOffset,
+    void initiateDLQAndArchive(Runnable archiveAction, long firstOffset,
                                long lastOffset, short deliveryCount, Throwable dlqCause) {
         // Step 1: Enqueue to DLQ
         shareGroupDLQManager.enqueue(new ShareGroupDLQRecordParameter(
@@ -3363,7 +3399,7 @@ public class SharePartition {
             try {
                 // At this point ARCHIVED is imminent. If we rollback here or tryUpdateState fails,
                 // we risk stalling. So just move to ARCHIVED.
-                updatedState.archive();
+                archiveAction.run();
                 stateBatch = new PersisterStateBatch(firstOffset, lastOffset, RecordState.ARCHIVED.id, deliveryCount);
                 deliveryCompleteCount.addAndGet(numInFlightRecordsInBatch(firstOffset, lastOffset));
             } finally {
@@ -3585,10 +3621,11 @@ public class SharePartition {
     ) { }
 
     /**
-     * Record comprising state as well as offset information for processing by DLQ logic.
+     * Record comprising the archive action as well as offset information for processing by DLQ logic.
+     * The archive action transitions the underlying batch/offset state to ARCHIVED when run.
      */
     private record DlqBatch(
-        InFlightState updatedState,
+        Runnable archiveAction,
         long firstOffset, long lastOffset,
         short deliveryCount
     ) {

--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -422,6 +422,7 @@ public class SharePartition {
      * @return The method returns a future which is completed when the share partition is initialized
      *         or completes with an exception if the share partition is in non-initializable state.
      */
+    @SuppressWarnings("MethodLength")
     public CompletableFuture<Void> maybeInitialize() {
         log.trace("Maybe initialize share partition: {}-{}", groupId, topicIdPartition);
         // Check if the share partition is already initialized.
@@ -454,7 +455,7 @@ public class SharePartition {
         ).whenComplete((result, exception) -> {
             Throwable throwable = null;
             // Batches read from the persister in the ARCHIVING state whose DLQ flow (phase 2) must be resumed.
-            List<DlqBatch> dlqBatches = new ArrayList<>();
+            List<DlqBatch> dlqBatches = null;
             lock.writeLock().lock();
             try {
                 if (exception != null) {
@@ -538,6 +539,9 @@ public class SharePartition {
                     // it so the flow can be resumed once the partition is active. ARCHIVING is non-terminal, so
                     // it is not counted in deliveryCompleteCount here (phase 2 does that when it reaches ARCHIVED).
                     if (recordState == RecordState.ARCHIVING) {
+                        if (dlqBatches == null) {
+                            dlqBatches = new ArrayList<>();
+                        }
                         dlqBatches.add(new DlqBatch(inFlightBatch::archiveBatch,
                             stateBatch.firstOffset(), stateBatch.lastOffset(), stateBatch.deliveryCount()));
                     }
@@ -3361,6 +3365,9 @@ public class SharePartition {
      * current DLQ-enabled config) since ARCHIVING is non-terminal and would otherwise stall the start offset.
      */
     private void maybeResumeDlqArchiving(List<DlqBatch> dlqBatches) {
+        if (dlqBatches == null || dlqBatches.isEmpty()) {
+            return;
+        }
         dlqBatches.forEach(dlqBatch -> {
             Throwable dlqCause = dlqBatch.deliveryCount() >= maxDeliveryCount()
                 ? ShareGroupDLQManager.DELIVERY_COUNT_EXCEEDED

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -110,6 +110,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static kafka.server.share.SharePartition.EMPTY_MEMBER_ID;
@@ -216,6 +217,202 @@ public class SharePartitionTest {
         assertEquals(2, sharePartitionMetrics.inFlightBatchMessageCount().count());
         assertEquals(5, sharePartitionMetrics.inFlightBatchMessageCount().min());
         assertEquals(6, sharePartitionMetrics.inFlightBatchMessageCount().max());
+    }
+
+    @Test
+    public void testMaybeInitializeArchivingStateWithDlqEnabled() {
+        // Records read from the persister in the ARCHIVING state indicate a DLQ flow that persisted phase 1
+        // but did not complete phase 2 before re-initialization. With DLQ enabled, init should resume the
+        // flow: enqueue to the DLQ and transition the records ARCHIVING -> ARCHIVED.
+        Persister persister = Mockito.mock(Persister.class);
+        // startOffset 5, an AVAILABLE batch pins the start offset, followed by an ARCHIVING batch.
+        mockPersisterReadStateWithBatches(persister, 5L, 3, List.of(
+            new PersisterStateBatch(5L, 9L, RecordState.AVAILABLE.id, (short) 2),
+            new PersisterStateBatch(10L, 14L, RecordState.ARCHIVING.id, (short) DEFAULT_MAX_DELIVERY_COUNT)));
+        mockPersisterWriteStateSuccess(persister);
+
+        ShareGroupDLQManager dlqManager = mockDlqManager();
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withPersister(persister)
+            .withShareGroupDlqEnableSupplier(() -> true)
+            .withConfigProvider(configProviderWithDlqTopic())
+            .withShareGroupDlqManager(dlqManager)
+            .build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
+
+        // The ARCHIVING batch is drained to ARCHIVED via the DLQ flow. It remains in the cache because the
+        // leading AVAILABLE batch pins the start offset.
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(5L).batchState());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
+        assertEquals(DEFAULT_MAX_DELIVERY_COUNT, sharePartition.cachedState().get(10L).batchDeliveryCount());
+        assertEquals(5, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        // deliveryCompleteCount accounts for the 5 records (10-14) that reached ARCHIVED in phase 2.
+        assertEquals(5, sharePartition.deliveryCompleteCount());
+
+        // The DLQ enqueue happened exactly once with the inferred cause (delivery count >= max).
+        ArgumentCaptor<ShareGroupDLQRecordParameter> dlqCaptor = ArgumentCaptor.forClass(ShareGroupDLQRecordParameter.class);
+        Mockito.verify(dlqManager, Mockito.times(1)).enqueue(dlqCaptor.capture());
+        ShareGroupDLQRecordParameter dlqParam = dlqCaptor.getValue();
+        assertEquals(10L, dlqParam.firstOffset());
+        assertEquals(14L, dlqParam.lastOffset());
+        assertEquals(Optional.of((short) DEFAULT_MAX_DELIVERY_COUNT), dlqParam.deliveryCount());
+        assertEquals(Optional.of(ShareGroupDLQManager.DELIVERY_COUNT_EXCEEDED), dlqParam.cause());
+
+        // Phase 2 persisted the ARCHIVED state exactly once.
+        Mockito.verify(persister, Mockito.times(1)).writeState(Mockito.any());
+    }
+
+    @Test
+    public void testMaybeInitializeArchivingStateWithDlqDisabled() {
+        // ARCHIVING records persisted from a prior epoch (when DLQ was enabled) must still be drained to
+        // ARCHIVED even if DLQ is now disabled — otherwise ARCHIVING (non-terminal) would permanently stall
+        // the start offset. The drain is unconditional, so the DLQ enqueue is still attempted (best-effort).
+        Persister persister = Mockito.mock(Persister.class);
+        // A single ARCHIVING batch at the start offset; delivery count below max -> inferred CLIENT_REJECT.
+        mockPersisterReadStateWithBatches(persister, 0L, 3, List.of(
+            new PersisterStateBatch(0L, 4L, RecordState.ARCHIVING.id, (short) 2)));
+        mockPersisterWriteStateSuccess(persister);
+
+        ShareGroupDLQManager dlqManager = mockDlqManager();
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withPersister(persister)
+            .withShareGroupDlqEnableSupplier(() -> false)
+            .withShareGroupDlqManager(dlqManager)
+            .build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
+
+        // The batch reached ARCHIVED and, being the only batch at the start offset, was evicted as the start
+        // offset advanced past it.
+        assertTrue(sharePartition.cachedState().isEmpty());
+        assertEquals(5, sharePartition.startOffset());
+        assertEquals(5, sharePartition.endOffset());
+        assertEquals(0, sharePartition.deliveryCompleteCount());
+
+        // Enqueue is still attempted with the inferred cause (delivery count < max -> client reject).
+        ArgumentCaptor<ShareGroupDLQRecordParameter> dlqCaptor = ArgumentCaptor.forClass(ShareGroupDLQRecordParameter.class);
+        Mockito.verify(dlqManager, Mockito.times(1)).enqueue(dlqCaptor.capture());
+        assertEquals(Optional.of(ShareGroupDLQManager.CLIENT_REJECT), dlqCaptor.getValue().cause());
+        Mockito.verify(persister, Mockito.times(1)).writeState(Mockito.any());
+    }
+
+    @Test
+    public void testMaybeInitializeArchivingStateDlqEnqueueFailure() {
+        // If the DLQ enqueue fails, the records must still proceed to ARCHIVED (best-effort) so the partition
+        // does not stall on the non-terminal ARCHIVING state.
+        Persister persister = Mockito.mock(Persister.class);
+        mockPersisterReadStateWithBatches(persister, 0L, 3, List.of(
+            new PersisterStateBatch(0L, 4L, RecordState.ARCHIVING.id, (short) DEFAULT_MAX_DELIVERY_COUNT)));
+        mockPersisterWriteStateSuccess(persister);
+
+        ShareGroupDLQManager dlqManager = Mockito.mock(ShareGroupDLQManager.class);
+        Mockito.when(dlqManager.enqueue(Mockito.any()))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("DLQ enqueue failed")));
+
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withPersister(persister)
+            .withShareGroupDlqEnableSupplier(() -> true)
+            .withConfigProvider(configProviderWithDlqTopic())
+            .withShareGroupDlqManager(dlqManager)
+            .build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        // Initialization itself succeeds regardless of the DLQ outcome.
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
+
+        // Despite the enqueue failure, the records reached ARCHIVED and the start offset advanced.
+        assertTrue(sharePartition.cachedState().isEmpty());
+        assertEquals(5, sharePartition.startOffset());
+        assertEquals(0, sharePartition.deliveryCompleteCount());
+
+        Mockito.verify(dlqManager, Mockito.times(1)).enqueue(Mockito.any());
+        Mockito.verify(persister, Mockito.times(1)).writeState(Mockito.any());
+    }
+
+    @Test
+    public void testMaybeInitializeMultipleArchivingStates() {
+        // Multiple ARCHIVING batches in a single read are each drained via the DLQ flow. A leading AVAILABLE
+        // batch pins the start offset so the archived batches remain observable in the cache. The two
+        // ARCHIVING batches exercise both inferred causes (delivery count < max -> client reject,
+        // delivery count >= max -> delivery count exceeded).
+        Persister persister = Mockito.mock(Persister.class);
+        mockPersisterReadStateWithBatches(persister, 0L, 3, List.of(
+            new PersisterStateBatch(0L, 4L, RecordState.AVAILABLE.id, (short) 1),
+            new PersisterStateBatch(5L, 9L, RecordState.ARCHIVING.id, (short) 2),
+            new PersisterStateBatch(10L, 14L, RecordState.ARCHIVING.id, (short) DEFAULT_MAX_DELIVERY_COUNT)));
+        mockPersisterWriteStateSuccess(persister);
+
+        ShareGroupDLQManager dlqManager = mockDlqManager();
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withPersister(persister)
+            .withShareGroupDlqEnableSupplier(() -> true)
+            .withConfigProvider(configProviderWithDlqTopic())
+            .withShareGroupDlqManager(dlqManager)
+            .build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
+
+        // Both ARCHIVING batches reached ARCHIVED and remain in the cache (start offset pinned at 0).
+        assertEquals(RecordState.AVAILABLE, sharePartition.cachedState().get(0L).batchState());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(5L).batchState());
+        assertEquals(RecordState.ARCHIVED, sharePartition.cachedState().get(10L).batchState());
+        assertEquals(0, sharePartition.startOffset());
+        assertEquals(14, sharePartition.endOffset());
+        // 10 records (5-9 and 10-14) reached ARCHIVED in phase 2.
+        assertEquals(10, sharePartition.deliveryCompleteCount());
+
+        // Each ARCHIVING batch was enqueued exactly once, with the cause inferred from its delivery count.
+        ArgumentCaptor<ShareGroupDLQRecordParameter> dlqCaptor = ArgumentCaptor.forClass(ShareGroupDLQRecordParameter.class);
+        Mockito.verify(dlqManager, Mockito.times(2)).enqueue(dlqCaptor.capture());
+        Map<Long, ShareGroupDLQRecordParameter> byFirstOffset = dlqCaptor.getAllValues().stream()
+            .collect(Collectors.toMap(ShareGroupDLQRecordParameter::firstOffset, p -> p));
+        assertEquals(Optional.of(ShareGroupDLQManager.CLIENT_REJECT), byFirstOffset.get(5L).cause());
+        assertEquals(Optional.of(ShareGroupDLQManager.DELIVERY_COUNT_EXCEEDED), byFirstOffset.get(10L).cause());
+
+        // Phase 2 persisted ARCHIVED once per batch.
+        Mockito.verify(persister, Mockito.times(2)).writeState(Mockito.any());
+    }
+
+    @Test
+    public void testMaybeInitializeArchivingDlqSkippedWhenInitFails() {
+        // If initialization fails after an ARCHIVING batch has been collected, the DLQ flow must not run:
+        // enqueuing/archiving on a FAILED partition would corrupt state. Here a second batch with a first
+        // offset below the start offset (simulating a corrupt persister response) fails initialization.
+        Persister persister = Mockito.mock(Persister.class);
+        mockPersisterReadStateWithBatches(persister, 5L, 3, List.of(
+            new PersisterStateBatch(5L, 9L, RecordState.ARCHIVING.id, (short) DEFAULT_MAX_DELIVERY_COUNT),
+            new PersisterStateBatch(3L, 4L, RecordState.AVAILABLE.id, (short) 1)));
+        mockPersisterWriteStateSuccess(persister);
+
+        ShareGroupDLQManager dlqManager = mockDlqManager();
+        SharePartition sharePartition = SharePartitionBuilder.builder()
+            .withPersister(persister)
+            .withShareGroupDlqEnableSupplier(() -> true)
+            .withConfigProvider(configProviderWithDlqTopic())
+            .withShareGroupDlqManager(dlqManager)
+            .build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.FAILED, sharePartition.partitionState());
+
+        // The DLQ flow was skipped: no enqueue and no phase-2 persist.
+        Mockito.verify(dlqManager, Mockito.never()).enqueue(Mockito.any());
+        Mockito.verify(persister, Mockito.never()).writeState(Mockito.any());
     }
 
     @Test
@@ -13424,7 +13621,7 @@ public class SharePartitionTest {
 
         InFlightState state = new InFlightState(RecordState.ARCHIVING, deliveryCount, EMPTY_MEMBER_ID);
 
-        sharePartition.initiateDLQAndArchive(state, firstOffset, lastOffset, deliveryCount, dlqCause);
+        sharePartition.initiateDLQAndArchive(state::archive, firstOffset, lastOffset, deliveryCount, dlqCause);
 
         assertEquals(expectedState, state.state());
         assertFalse(state.hasOngoingStateTransition());
@@ -13468,6 +13665,24 @@ public class SharePartitionTest {
         ShareGroupDLQManager dlqManager = Mockito.mock(ShareGroupDLQManager.class);
         Mockito.when(dlqManager.enqueue(Mockito.any())).thenReturn(CompletableFuture.completedFuture(null));
         return dlqManager;
+    }
+
+    private static void mockPersisterReadStateWithBatches(Persister persister, long startOffset, int stateEpoch,
+                                                          List<PersisterStateBatch> batches) {
+        ReadShareGroupStateResult readResult = Mockito.mock(ReadShareGroupStateResult.class);
+        Mockito.when(readResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
+                PartitionFactory.newPartitionAllData(0, stateEpoch, startOffset, Errors.NONE.code(),
+                    Errors.NONE.message(), batches)))));
+        Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readResult));
+    }
+
+    private static void mockPersisterWriteStateSuccess(Persister persister) {
+        WriteShareGroupStateResult writeResult = Mockito.mock(WriteShareGroupStateResult.class);
+        Mockito.when(writeResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(TOPIC_ID_PARTITION.topicId(), List.of(
+                PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
+        Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeResult));
     }
 
     private static ShareGroupConfigProvider configProviderWithDlqTopic() {


### PR DESCRIPTION
- In `SharePartition.maybeInitialize`, while loading state batches,
collect any in the `ARCHIVING` state. After initialization succeeds
(partition `ACTIVE`, future completed, write lock released), resume the
DLQ flow for each via the existing `initiateDLQAndArchive` driver. This
is outside the lock and asynchronously, matching the acknowledge/timeout
paths.
- The DLQ cause is not persisted, so it is inferred from the delivery
count: `deliveryCount >= maxDeliveryCount` ⇒ `DELIVERY_COUNT_EXCEEDED`,
otherwise `CLIENT_REJECT`. (A reject issued exactly at max count is
labeled `DELIVERY_COUNT_EXCEEDED`. This is unavoidable without
persisting the cause.)
- Draining is unconditional (not gated on the current
`isDLQEnabledForGroup()`): the archive decision was made in a prior
epoch, and these records must reach `ARCHIVED` regardless to avoid
stalling the start offset. The DLQ enqueue remains best-effort.
`initiateDLQAndArchive` proceeds to `ARCHIVED` even if the enqueue
fails.
- `ARCHIVING` records are not counted in deliveryCompleteCount an they
reach `ARCHIVED`, consistent with the live paths.
- `initiateDLQAndArchive` and the `DlqBatch` record now  have a
`Runnable` arg (a method
reference such as `updateResult::archive` or
`inFlightBatch::archiveBatch`) instead of a raw `InFlightState`.
- 5 new tests have been added to verify various new code paths
introduced.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
