### PR TITLE
KAFKA-20658: Fix Cast ByteBuffer BYTES to string encoding

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -367,7 +367,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         if (value instanceof java.util.Date dateValue) {
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer byteBuffer) {
-            return Base64.getEncoder().encodeToString(Utils.readBytes(byteBuffer));
+            return Base64.getEncoder().encodeToString(Utils.toArray(byteBuffer));
         } else if (value instanceof byte[] rawBytes) {
             return Base64.getEncoder().encodeToString(rawBytes);
         } else {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -572,6 +573,41 @@ public class CastTest {
 
         // The following fields are not changed
         assertEquals(Timestamp.SCHEMA.type(), transformedSchema.field("timestamp").schema().type());
+    }
+
+    @Test
+    public void byteBufferToStringUsesRemainingBytes() {
+        xformValue.configure(Map.of(Cast.SPEC_CONFIG, "bytes:string"));
+
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+        bytes.position(1);
+        bytes.limit(3);
+
+        Schema schema = SchemaBuilder.struct().field("bytes", Schema.BYTES_SCHEMA).build();
+        Struct recordValue = new Struct(schema).put("bytes", bytes);
+
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0, schema, recordValue));
+
+        String expected = Base64.getEncoder().encodeToString(new byte[] {2, 3});
+        assertEquals(expected, ((Struct) transformed.value()).get("bytes"));
+    }
+
+    @Test
+    public void directByteBufferToString() {
+        xformValue.configure(Map.of(Cast.SPEC_CONFIG, "bytes:string"));
+
+        ByteBuffer bytes = ByteBuffer.allocateDirect(2);
+        bytes.put((byte) 1);
+        bytes.put((byte) 2);
+        bytes.flip();
+
+        Schema schema = SchemaBuilder.struct().field("bytes", Schema.BYTES_SCHEMA).build();
+        Struct recordValue = new Struct(schema).put("bytes", bytes);
+
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0, schema, recordValue));
+
+        String expected = Base64.getEncoder().encodeToString(new byte[] {1, 2});
+        assertEquals(expected, ((Struct) transformed.value()).get("bytes"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
Fixes [KAFKA-20658](https://issues.apache.org/jira/browse/KAFKA-20658).
When the Cast SMT casts a Connect `BYTES` field to `STRING`, `ByteBuffer`
values are Base64-encoded in `castToString()`. The code used
`Utils.readBytes(ByteBuffer)`, which reads bytes `[0, limit)` and ignores
`position()`.
For sliced heap buffers this produces the wrong Base64 string (silent data
corruption). Use `Utils.toArray(ByteBuffer)` instead, matching
`Values.convertToBytes()` and reading the buffer's logical remaining bytes
for both heap-backed and direct buffers.
@mimaison 