### PR TITLE
KAFKA-20714; Refactor KRaft API around message handling

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
+++ b/core/src/main/scala/kafka/raft/KafkaRaftManager.scala
@@ -22,6 +22,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.{OptionalInt, Collection => JCollection, Map => JMap}
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, MetadataRecoveryStrategy, NetworkClient}
@@ -157,7 +158,7 @@ class KafkaRaftManager[T](
     header: RequestHeader,
     request: ApiMessage,
     createdTimeMs: Long
-  ): CompletableFuture[ApiMessage] = {
+  ): CompletionStage[ApiMessage] = {
     clientDriver.handleRequest(context, header, request, createdTimeMs)
   }
 

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -682,10 +682,14 @@ class ControllerApis(
     }
   }
 
-  private def handleRaftRequest(request: Request,
-                                buildResponse: ApiMessage => AbstractResponse): CompletableFuture[Unit] = {
+  private def handleRaftRequest(
+    request: Request,
+    buildResponse: ApiMessage => AbstractResponse
+  ): CompletableFuture[Unit] = {
     val requestBody = request.body(classOf[AbstractRequest])
-    val future = raftManager.handleRequest(request.context, request.header, requestBody.data, time.milliseconds())
+    val future = raftManager
+      .handleRequest(request.context, request.header, requestBody.data, time.milliseconds())
+      .toCompletableFuture
     future.handle[Unit] { (responseData, exception) =>
       val response = if (exception != null) {
         requestBody.getErrorResponse(exception)

--- a/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/CandidateState.java
@@ -25,8 +25,9 @@ import org.apache.kafka.raft.internals.EpochElection;
 import org.slf4j.Logger;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
-public class CandidateState implements NomineeState {
+public final class CandidateState implements NomineeState {
     private final int localId;
     private final Uuid localDirectoryId;
     private final int epoch;
@@ -124,6 +125,11 @@ public class CandidateState implements NomineeState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(OptionalInt.empty(), epoch);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -16,10 +16,9 @@
  */
 package org.apache.kafka.raft;
 
-import java.io.Closeable;
 import java.util.Optional;
 
-public interface EpochState extends Closeable {
+public interface EpochState extends AutoCloseable {
 
     default Optional<LogOffsetMetadata> highWatermark() {
         return Optional.empty();
@@ -49,6 +48,11 @@ public interface EpochState extends Closeable {
     int epoch();
 
     /**
+     * Get the current leader and epoch.
+     */
+    LeaderAndEpoch leaderAndEpoch();
+
+    /**
      * Returns the known endpoints for the leader.
      *
      * If the leader is not known then {@code Endpoints.empty()} is returned.
@@ -61,8 +65,7 @@ public interface EpochState extends Closeable {
     String name();
 
     /**
-     * Since all subclasses implement the Closeable interface while none throw any IOException,
-     * this implementation is provided to eliminate the need for exception handling in the close operation.
+     * Epoch states should be auto closeable but shouldn't throw any checked exceptions.
      */
     @Override
     void close();

--- a/raft/src/main/java/org/apache/kafka/raft/EpochState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/EpochState.java
@@ -18,7 +18,8 @@ package org.apache.kafka.raft;
 
 import java.util.Optional;
 
-public interface EpochState extends AutoCloseable {
+public sealed interface EpochState extends AutoCloseable
+    permits LeaderState, FollowerState, UnattachedState, ResignedState, NomineeState {
 
     default Optional<LogOffsetMetadata> highWatermark() {
         return Optional.empty();

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -26,6 +26,7 @@ import org.apache.kafka.snapshot.RawSnapshotWriter;
 import org.slf4j.Logger;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -89,6 +90,11 @@ public class FollowerState implements EpochState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(OptionalInt.of(leaderId), epoch);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -30,7 +30,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
-public class FollowerState implements EpochState {
+public final class FollowerState implements EpochState {
     private final Logger log;
 
     private final int fetchTimeoutMs;

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaNetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaNetworkChannel.java
@@ -127,7 +127,7 @@ public class KafkaNetworkChannel implements NetworkChannel {
                     request.createdTimeMs(),
                     node,
                     buildRequest(request.data()),
-                    response -> sendOnComplete(request, response, future)
+                    response -> sendOnCompleted(request, response, future)
                 )
             );
             return future;
@@ -142,7 +142,7 @@ public class KafkaNetworkChannel implements NetworkChannel {
         }
     }
 
-    private void sendOnComplete(
+    private void sendOnCompleted(
         RaftRequest.Outbound request,
         ClientResponse clientResponse,
         CompletableFuture<RaftResponse.Inbound> future

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaNetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaNetworkChannel.java
@@ -53,6 +53,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -116,29 +118,35 @@ public class KafkaNetworkChannel implements NetworkChannel {
     }
 
     @Override
-    public void send(RaftRequest.Outbound request) {
+    public CompletionStage<RaftResponse.Inbound> send(RaftRequest.Outbound request) {
         Node node = request.destination();
         if (node != null) {
-            requestThread.sendRequest(new RequestAndCompletionHandler(
-                request.createdTimeMs(),
-                node,
-                buildRequest(request.data()),
-                response -> sendOnComplete(request, response)
-            ));
-        } else
-            sendCompleteFuture(request, errorResponse(request.data(), Errors.BROKER_NOT_AVAILABLE));
+            var future = new CompletableFuture<RaftResponse.Inbound>();
+            requestThread.sendRequest(
+                new RequestAndCompletionHandler(
+                    request.createdTimeMs(),
+                    node,
+                    buildRequest(request.data()),
+                    response -> sendOnComplete(request, response, future)
+                )
+            );
+            return future;
+        } else {
+            return CompletableFuture.completedFuture(
+                new RaftResponse.Inbound(
+                    request.correlationId(),
+                    errorResponse(request.data(), Errors.BROKER_NOT_AVAILABLE),
+                    request.destination()
+                )
+            );
+        }
     }
 
-    private void sendCompleteFuture(RaftRequest.Outbound request, ApiMessage message) {
-        RaftResponse.Inbound response = new RaftResponse.Inbound(
-                request.correlationId(),
-                message,
-                request.destination()
-        );
-        request.completion.complete(response);
-    }
-
-    private void sendOnComplete(RaftRequest.Outbound request, ClientResponse clientResponse) {
+    private void sendOnComplete(
+        RaftRequest.Outbound request,
+        ClientResponse clientResponse,
+        CompletableFuture<RaftResponse.Inbound> future
+    ) {
         ApiMessage response;
         if (clientResponse.versionMismatch() != null) {
             log.error("Request {} failed due to unsupported version error", request, clientResponse.versionMismatch());
@@ -155,7 +163,14 @@ public class KafkaNetworkChannel implements NetworkChannel {
         } else {
             response = clientResponse.responseBody().data();
         }
-        sendCompleteFuture(request, response);
+
+        future.complete(
+            new RaftResponse.Inbound(
+                request.correlationId(),
+                response,
+                request.destination()
+            )
+        );
     }
 
     private ApiMessage errorResponse(ApiMessage request, Errors error) {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2900,7 +2900,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             channel
                 .send(requestMessage)
                 .whenComplete(
-                    (response, exception) -> messageQueue.add(new RaftMessageQueue.QueueEntry(response))
+                    (response, exception) -> messageQueue.add(response)
                 );
             requestSent = true;
             logger.trace("Sent outbound request: {}", requestMessage);
@@ -3657,9 +3657,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * @param request The inbound request
      */
     public CompletionStage<RaftResponse.Outbound> handle(RaftRequest.Inbound request) {
-        var entry = new RaftMessageQueue.QueueEntry(Objects.requireNonNull(request));
-        messageQueue.add(entry);
-        return entry.future().thenApply(message -> {
+        return messageQueue.add(Objects.requireNonNull(request)).thenApply(message -> {
             if (message instanceof RaftResponse.Outbound response) {
                 return response;
             } else {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3651,10 +3651,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     /**
-     * Handle an inbound request. The response will be returned through
-     * {@link RaftRequest.Inbound#completion}.
+     * Handle an inbound request.
      *
      * @param request The inbound request
+     * @return A completion stage that completes with the outbound response
      */
     public CompletionStage<RaftResponse.Outbound> handle(RaftRequest.Inbound request) {
         return messageQueue.add(Objects.requireNonNull(request)).thenApply(message -> {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -112,6 +112,7 @@ import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -372,10 +373,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             logger.debug("Leader high watermark updated to {}", highWatermark);
             log.updateHighWatermark(highWatermark);
 
-            // Notify the add and remove voter handlers that the HWM has been updated in case there are
+            // Notify the voter change handlers that the HWM has been updated in case there are
             // add or remove voter request that need to be completed
-            addVoterHandler.highWatermarkUpdated(state);
-            removeVoterHandler.highWatermarkUpdated(state);
+            maybeNotifyVoterHandlerOnHWmUpdate(state, highWatermark.offset());
 
             // After updating the high watermark, we first clear the append
             // purgatory so that we have an opportunity to route the pending
@@ -392,6 +392,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             // to give lagging listeners an opportunity to catch up as well
             updateListenersProgress(highWatermark.offset());
         });
+    }
+
+    private void maybeNotifyVoterHandlerOnHWmUpdate(LeaderState<T> state, long highWatermark) {
+        addVoterHandler.highWatermarkUpdated(state, highWatermark);
+        removeVoterHandler.highWatermarkUpdated(state, highWatermark);
     }
 
     private void updateListenersProgress(long highWatermark) {
@@ -600,7 +605,6 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
 
         // Specialized update voter handler
         this.updateVoterHandler = new UpdateVoterHandler(
-            nodeId,
             partitionState,
             channel.listenerName(),
             logContext
@@ -1478,7 +1482,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * - {@link Errors#INVALID_REQUEST} if the request epoch is larger than the leader's current epoch
      *     or if either the fetch offset or the last fetched epoch is invalid
      */
-    private CompletableFuture<FetchResponseData> handleFetchRequest(
+    private CompletionStage<FetchResponseData> handleFetchRequest(
         RaftRequest.Inbound requestMetadata,
         long currentTimeMs
     ) {
@@ -1542,12 +1546,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return completedFuture(response);
         }
 
-        CompletableFuture<Long> future = fetchPurgatory.await(
+        return fetchPurgatory.await(
             fetchPartition.fetchOffset(),
             request.maxWaitMs()
-        );
-
-        return future.handle((completionTimeMs, exception) -> {
+        ).handle((completionTimeMs, exception) -> {
             if (exception != null) {
                 Throwable cause = exception instanceof ExecutionException ?
                     exception.getCause() : exception;
@@ -2247,7 +2249,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * - {@link Errors#UNSUPPORTED_VERSION} if the cluster does not support kraft.version 1
      * - {@link Errors#INVALID_REQUEST} if the request does not include a valid voter or endpoint
      */
-    private CompletableFuture<AddRaftVoterResponseData> handleAddVoterRequest(
+    private CompletionStage<AddRaftVoterResponseData> handleAddVoterRequest(
         RaftRequest.Inbound requestMetadata,
         long currentTimeMs
     ) {
@@ -2386,7 +2388,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      * - {@link Errors#UNSUPPORTED_VERSION} if the cluster does not support the required kraft.version
      * - {@link Errors#INVALID_REQUEST} if the request does not include a valid voter or endpoint
      */
-    private CompletableFuture<RemoveRaftVoterResponseData> handleRemoveVoterRequest(
+    private CompletionStage<RemoveRaftVoterResponseData> handleRemoveVoterRequest(
         RaftRequest.Inbound requestMetadata,
         long currentTimeMs
     ) {
@@ -2469,7 +2471,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      *     directory id, endpoint, or KRaft version
      * - {@link Errors#VOTER_NOT_FOUND} if the specified voter does not exist in the current set
      */
-    private CompletableFuture<UpdateRaftVoterResponseData> handleUpdateVoterRequest(
+    private CompletionStage<UpdateRaftVoterResponseData> handleUpdateVoterRequest(
         RaftRequest.Inbound requestMetadata,
         long currentTimeMs
     ) {
@@ -2805,9 +2807,13 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         }
     }
 
-    private void handleRequest(RaftRequest.Inbound request, long currentTimeMs) {
+    private void handleRequest(
+        RaftRequest.Inbound request,
+        CompletableFuture<RaftMessage> future,
+        long currentTimeMs
+    ) {
         ApiKeys apiKey = ApiKeys.forId(request.data().apiKey());
-        final CompletableFuture<? extends ApiMessage> responseFuture = switch (apiKey) {
+        final CompletionStage<? extends ApiMessage> responseStage = switch (apiKey) {
             case FETCH -> handleFetchRequest(request, currentTimeMs);
             case VOTE -> completedFuture(handleVoteRequest(request));
             case BEGIN_QUORUM_EPOCH -> completedFuture(handleBeginQuorumEpochRequest(request, currentTimeMs));
@@ -2820,29 +2826,36 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             default -> throw new IllegalArgumentException("Unexpected request type " + apiKey);
         };
 
-        responseFuture.whenComplete((response, exception) -> {
-            ApiMessage message = response;
-            if (message == null) {
-                message = RaftUtil.errorResponse(apiKey, Errors.forException(exception));
-            }
+        responseStage.whenComplete((response, exception) -> {
+            var message = response == null ?
+                RaftUtil.errorResponse(apiKey, Errors.forException(exception)) :
+                response;
 
-            RaftResponse.Outbound responseMessage = new RaftResponse.Outbound(request.correlationId(), message);
-            request.completion.complete(responseMessage);
-            logger.trace("Sent response {} to inbound request {}", responseMessage, request);
+            var raftResponse = new RaftResponse.Outbound(request.correlationId(), message);
+
+            future.complete(raftResponse);
+            logger.trace("Sent response {} to inbound request {}", raftResponse, request);
         });
     }
 
-    private void handleInboundMessage(RaftMessage message, long currentTimeMs) {
+    private void handleInboundMessage(
+        RaftMessage message,
+        CompletableFuture<RaftMessage> future,
+        long currentTimeMs
+    ) {
         logger.trace("Received inbound message {}", message);
 
         if (message instanceof RaftRequest.Inbound request) {
-            handleRequest(request, currentTimeMs);
+            handleRequest(request, future, currentTimeMs);
         } else if (message instanceof RaftResponse.Inbound response) {
             if (requestManager.isResponseExpected(response.source(), response.correlationId())) {
                 handleResponse(response, currentTimeMs);
             } else {
                 logger.debug("Ignoring response {} since it is no longer needed", response);
             }
+            // Inboud response messages do not have an associated outbound message. Nothing should
+            // be reacting to the future's completion. Let's complete the future for completeness.
+            future.complete(null);
         } else {
             throw new IllegalArgumentException("Unexpected message " + message);
         }
@@ -2883,24 +2896,12 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 currentTimeMs
             );
 
-            requestMessage.completion.whenComplete((response, exception) -> {
-                if (exception != null) {
-                    ApiKeys api = ApiKeys.forId(request.apiKey());
-                    Errors error = Errors.forException(exception);
-                    ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
-
-                    response = new RaftResponse.Inbound(
-                        correlationId,
-                        errorResponse,
-                        destination
-                    );
-                }
-
-                messageQueue.add(response);
-            });
-
             requestManager.onRequestSent(destination, correlationId, currentTimeMs);
-            channel.send(requestMessage);
+            channel
+                .send(requestMessage)
+                .whenComplete(
+                    (response, exception) -> messageQueue.add(new RaftMessageQueue.QueueEntry(response))
+                );
             requestSent = true;
             logger.trace("Sent outbound request: {}", requestMessage);
         }
@@ -3053,10 +3054,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             int epoch = state.epoch();
             LogAppendInfo info = appendAsLeader(batch.data);
             OffsetAndEpoch offsetAndEpoch = new OffsetAndEpoch(info.lastOffset(), epoch);
-            CompletableFuture<Long> future = appendPurgatory.await(
-                offsetAndEpoch.offset() + 1, Integer.MAX_VALUE);
 
-            future.whenComplete((commitTimeMs, exception) -> {
+            appendPurgatory.await(
+                offsetAndEpoch.offset() + 1,
+                Integer.MAX_VALUE
+            ).whenComplete((commitTimeMs, exception) -> {
                 if (exception != null) {
                     logger.debug(
                         "Failed to commit {} records up to last offset {}",
@@ -3179,7 +3181,9 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return 0L;
         }
 
-        long timeUntilVoterChangeExpires = state.maybeExpirePendingOperation(currentTimeMs);
+        long timeUntilVoterChangeExpires = state
+            .changeVoterState()
+            .maybeExpirePendingOperation(currentTimeMs);
 
         long timeUntilFlush = maybeAppendBatches(
             state,
@@ -3652,8 +3656,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
      *
      * @param request The inbound request
      */
-    public void handle(RaftRequest.Inbound request) {
-        messageQueue.add(Objects.requireNonNull(request));
+    public CompletionStage<RaftResponse.Outbound> handle(RaftRequest.Inbound request) {
+        var entry = new RaftMessageQueue.QueueEntry(Objects.requireNonNull(request));
+        messageQueue.add(entry);
+        return entry.future().thenApply(message -> {
+            if (message instanceof RaftResponse.Outbound response) {
+                return response;
+            } else {
+                logger.error("Message must be a response: {}", message);
+                throw new IllegalStateException("KRaft didn't return an expected response");
+            }
+        });
     }
 
     /**
@@ -3677,14 +3690,12 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         long startWaitTimeMs = time.milliseconds();
         kafkaRaftMetrics.updatePollStart(startWaitTimeMs);
 
-        RaftMessage message = messageQueue.poll(pollTimeoutMs);
+        var maybeEntry = messageQueue.poll(pollTimeoutMs);
 
         long endWaitTimeMs = time.milliseconds();
         kafkaRaftMetrics.updatePollEnd(endWaitTimeMs);
 
-        if (message != null) {
-            handleInboundMessage(message, endWaitTimeMs);
-        }
+        maybeEntry.ifPresent(entry -> handleInboundMessage(entry.message(), entry.future(), endWaitTimeMs));
 
         pollListeners();
     }
@@ -3741,7 +3752,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     @Override
-    public CompletableFuture<Void> shutdown(int timeoutMs) {
+    public CompletionStage<Void> shutdown(int timeoutMs) {
         logger.info("Beginning graceful shutdown");
         CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
         shutdown.set(new GracefulShutdown(timeoutMs, shutdownComplete));
@@ -3906,8 +3917,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         final Timer finishTimer;
         final CompletableFuture<Void> completeFuture;
 
-        public GracefulShutdown(long shutdownTimeoutMs,
-                                CompletableFuture<Void> completeFuture) {
+        public GracefulShutdown(
+            long shutdownTimeoutMs,
+            CompletableFuture<Void> completeFuture
+        ) {
             this.finishTimer = time.timer(shutdownTimeoutMs);
             this.completeFuture = completeFuture;
         }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClientDriver.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClientDriver.java
@@ -25,7 +25,7 @@ import org.apache.kafka.server.util.ShutdownableThread;
 
 import org.slf4j.Logger;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * A single-threaded driver for {@link KafkaRaftClient}. Client APIs will only do useful work
@@ -101,7 +101,7 @@ public class KafkaRaftClientDriver<T> extends ShutdownableThread {
         return client.isRunning() && !isThreadFailed();
     }
 
-    public CompletableFuture<ApiMessage> handleRequest(
+    public CompletionStage<ApiMessage> handleRequest(
         RequestContext context,
         RequestHeader header,
         ApiMessage request,
@@ -115,9 +115,7 @@ public class KafkaRaftClientDriver<T> extends ShutdownableThread {
             createdTimeMs
         );
 
-        client.handle(inboundRequest);
-
-        return inboundRequest.completion.thenApply(RaftMessage::data);
+        return client.handle(inboundRequest).thenApply(RaftMessage::data);
     }
 
     public KafkaRaftClient<T> client() {

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -30,11 +30,10 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.raft.errors.NotLeaderException;
-import org.apache.kafka.raft.internals.AddVoterHandlerState;
 import org.apache.kafka.raft.internals.BatchAccumulator;
+import org.apache.kafka.raft.internals.ChangeVoterHandlerState;
 import org.apache.kafka.raft.internals.KRaftVersionUpgrade;
 import org.apache.kafka.raft.internals.KafkaRaftMetrics;
-import org.apache.kafka.raft.internals.RemoveVoterHandlerState;
 import org.apache.kafka.server.common.KRaftVersion;
 
 import org.slf4j.Logger;
@@ -47,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,7 @@ import java.util.stream.Stream;
  * More specifically, the set of unacknowledged voters are targets for BeginQuorumEpoch requests from the leader until
  * they acknowledge the leader.
  */
-public class LeaderState<T> implements EpochState {
+public final class LeaderState<T> implements EpochState {
     static final long OBSERVER_SESSION_TIMEOUT_MS = 300_000L;
     static final double CHECK_QUORUM_TIMEOUT_FACTOR = 1.5;
 
@@ -72,11 +72,10 @@ public class LeaderState<T> implements EpochState {
     // This field is non-empty if the voter set at epoch start came from a snapshot or log segment
     private final OptionalLong offsetOfVotersAtEpochStart;
     private final KRaftVersion kraftVersionAtEpochStart;
+    private final ChangeVoterHandlerState changeVoterState;
 
     private Optional<LogOffsetMetadata> highWatermark = Optional.empty();
     private Map<Integer, ReplicaState> voterStates = new HashMap<>();
-    private Optional<AddVoterHandlerState> addVoterHandlerState = Optional.empty();
-    private Optional<RemoveVoterHandlerState> removeVoterHandlerState = Optional.empty();
 
     private final Map<ReplicaKey, ReplicaState> observerStates = new HashMap<>();
     private final Logger log;
@@ -158,6 +157,7 @@ public class LeaderState<T> implements EpochState {
         this.voterSetAtEpochStart =  voterSetAtEpochStart;
         this.offsetOfVotersAtEpochStart = offsetOfVotersAtEpochStart;
         this.kraftVersionAtEpochStart = kraftVersionAtEpochStart;
+        this.changeVoterState = new ChangeVoterHandlerState(kafkaRaftMetrics);
 
         kafkaRaftMetrics.addLeaderMetrics();
         this.kafkaRaftMetrics = kafkaRaftMetrics;
@@ -282,80 +282,8 @@ public class LeaderState<T> implements EpochState {
         return accumulator;
     }
 
-    public Optional<AddVoterHandlerState> addVoterHandlerState() {
-        return addVoterHandlerState;
-    }
-
-    public void resetAddVoterHandlerState(
-        Errors error,
-        String message,
-        Optional<AddVoterHandlerState> state
-    ) {
-        addVoterHandlerState.ifPresent(
-            handlerState -> handlerState
-                .future()
-                .complete(RaftUtil.addVoterResponse(error, message))
-        );
-        addVoterHandlerState = state;
-        updateUncommittedVoterChangeMetric();
-    }
-
-    public Optional<RemoveVoterHandlerState> removeVoterHandlerState() {
-        return removeVoterHandlerState;
-    }
-
-    public void resetRemoveVoterHandlerState(
-        Errors error,
-        String message,
-        Optional<RemoveVoterHandlerState> state
-    ) {
-        removeVoterHandlerState.ifPresent(
-            handlerState -> handlerState
-                .future()
-                .complete(RaftUtil.removeVoterResponse(error, message))
-        );
-        removeVoterHandlerState = state;
-        updateUncommittedVoterChangeMetric();
-    }
-
-    private void updateUncommittedVoterChangeMetric() {
-        kafkaRaftMetrics.updateUncommittedVoterChange(
-            addVoterHandlerState.isPresent() || removeVoterHandlerState.isPresent()
-        );
-    }
-
-    public long maybeExpirePendingOperation(long currentTimeMs) {
-        // First abort any expired operations
-        long timeUntilAddVoterExpiration = addVoterHandlerState()
-            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
-            .orElse(Long.MAX_VALUE);
-
-        if (timeUntilAddVoterExpiration == 0) {
-            resetAddVoterHandlerState(Errors.REQUEST_TIMED_OUT, null, Optional.empty());
-        }
-
-        long timeUntilRemoveVoterExpiration = removeVoterHandlerState()
-            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
-            .orElse(Long.MAX_VALUE);
-
-        if (timeUntilRemoveVoterExpiration == 0) {
-            resetRemoveVoterHandlerState(Errors.REQUEST_TIMED_OUT, null, Optional.empty());
-        }
-
-        // Reread the timeouts and return the smaller of them
-        return Math.min(
-            addVoterHandlerState()
-                .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
-                .orElse(Long.MAX_VALUE),
-            removeVoterHandlerState()
-                .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
-                .orElse(Long.MAX_VALUE)
-        );
-    }
-
-    public boolean isOperationPending(long currentTimeMs) {
-        maybeExpirePendingOperation(currentTimeMs);
-        return addVoterHandlerState.isPresent() || removeVoterHandlerState.isPresent();
+    public ChangeVoterHandlerState changeVoterState() {
+        return changeVoterState;
     }
 
     private static List<Voter> convertToVoters(Set<Integer> voterIds) {
@@ -693,6 +621,11 @@ public class LeaderState<T> implements EpochState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(OptionalInt.of(localVoterNode.voterKey().id()), epoch);
     }
 
     @Override
@@ -1144,8 +1077,7 @@ public class LeaderState<T> implements EpochState {
 
     @Override
     public void close() {
-        resetAddVoterHandlerState(Errors.NOT_LEADER_OR_FOLLOWER, null, Optional.empty());
-        resetRemoveVoterHandlerState(Errors.NOT_LEADER_OR_FOLLOWER, null, Optional.empty());
+        changeVoterState.maybeResetPendingVoterHandlerState(Errors.NOT_LEADER_OR_FOLLOWER);
         kafkaRaftMetrics.removeLeaderMetrics();
 
         accumulator.close();

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -18,6 +18,8 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.network.ListenerName;
 
+import java.util.concurrent.CompletionStage;
+
 /**
  * A simple network interface with few assumptions. We do not assume ordering
  * of requests or even that every outbound request will receive a response.
@@ -26,15 +28,22 @@ public interface NetworkChannel extends AutoCloseable {
 
     /**
      * Generate a new and unique correlationId for a new request to be sent.
+     *
+     * @return a unique integer for the lifetime of the channel
      */
     int newCorrelationId();
 
     /**
      * Send an outbound request message.
      *
+     * The complete stage return never completes with an exception. It always completes
+     * successfully. Exceptions are turn into error responses.
+     *
      * @param request outbound request to send
+     * @return a complete stage always complete successfully. Errors are always returned in the
+     *         response object
      */
-    void send(RaftRequest.Outbound request);
+    CompletionStage<RaftResponse.Inbound> send(RaftRequest.Outbound request);
 
     /**
      * The name of listener used when sending requests.
@@ -42,6 +51,4 @@ public interface NetworkChannel extends AutoCloseable {
      * @return the name of the listener
      */
     ListenerName listenerName();
-
-    default void close() throws InterruptedException {}
 }

--- a/raft/src/main/java/org/apache/kafka/raft/NomineeState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NomineeState.java
@@ -18,7 +18,9 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.raft.internals.EpochElection;
 
-interface NomineeState extends EpochState {
+sealed interface NomineeState extends EpochState
+    permits ProspectiveState, CandidateState {
+
     EpochElection epochElection();
 
     /**

--- a/raft/src/main/java/org/apache/kafka/raft/ProspectiveState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ProspectiveState.java
@@ -28,7 +28,7 @@ import java.util.OptionalInt;
 
 import static org.apache.kafka.raft.QuorumState.unattachedOrProspectiveCanGrantVote;
 
-public class ProspectiveState implements NomineeState {
+public final class ProspectiveState implements NomineeState {
     private final int localId;
     private final int epoch;
     private final OptionalInt leaderId;
@@ -138,6 +138,11 @@ public class ProspectiveState implements NomineeState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(leaderId, epoch);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -831,8 +831,7 @@ public class QuorumState {
     }
 
     public LeaderAndEpoch leaderAndEpoch() {
-        ElectionState election = state.election();
-        return new LeaderAndEpoch(election.optionalLeaderId(), election.epoch());
+        return state.leaderAndEpoch();
     }
 
     public boolean isFollower() {

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface RaftClient<T> extends AutoCloseable {
 
@@ -200,9 +200,9 @@ public interface RaftClient<T> extends AutoCloseable {
      * in use.
      *
      * @param timeoutMs How long to wait for graceful completion of pending operations.
-     * @return A future which is completed when shutdown completes successfully or the timeout expires.
+     * @return A stage which is completed when shutdown completes successfully or the timeout expires.
      */
-    CompletableFuture<Void> shutdown(int timeoutMs);
+    CompletionStage<Void> shutdown(int timeoutMs);
 
     /**
      * Resign the leadership. The leader will give up its leadership in the passed epoch

--- a/raft/src/main/java/org/apache/kafka/raft/RaftManager.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftManager.java
@@ -22,11 +22,11 @@ import org.apache.kafka.common.requests.RequestContext;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.server.common.serialization.RecordSerde;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface RaftManager<T> {
 
-    CompletableFuture<ApiMessage> handleRequest(
+    CompletionStage<ApiMessage> handleRequest(
         RequestContext context,
         RequestHeader header,
         ApiMessage request,

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -73,5 +73,14 @@ public interface RaftMessageQueue {
         public CompletableFuture<RaftMessage> future() {
             return future;
         }
+
+        @Override
+        public String toString() {
+            return String.format(
+                "QueueEntry(message=%s, future.isDone=%s)",
+                message,
+                future.isDone()
+            );
+        }
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.raft;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
 /**
  * This class is used to serialize inbound requests or responses to outbound requests.
  * It basically just allows us to wrap a blocking queue so that we can have a mocked
@@ -29,18 +32,18 @@ public interface RaftMessageQueue {
      * Block for the arrival of a new message.
      *
      * @param timeoutMs timeout in milliseconds to wait for a new event
-     * @return the event or null if either the timeout was reached or there was
+     * @return the event or {@code Optional.empty()} if either the timeout was reached or there was
      *     a call to {@link #wakeup()} before any events became available
      */
-    RaftMessage poll(long timeoutMs);
+    Optional<QueueEntry> poll(long timeoutMs);
 
     /**
      * Add a new message to the queue.
      *
-     * @param message the message to deliver
+     * @param entry the message to deliver
      * @throws IllegalStateException if the queue cannot accept the message
      */
-    void add(RaftMessage message);
+    void add(QueueEntry entry);
 
     /**
      * Check whether there are pending messages awaiting delivery.
@@ -55,4 +58,20 @@ public interface RaftMessageQueue {
      */
     void wakeup();
 
+    public static final class QueueEntry {
+        private final CompletableFuture<RaftMessage> future = new CompletableFuture<>();
+        private final RaftMessage message;
+
+        public QueueEntry(RaftMessage message) {
+            this.message = message;
+        }
+
+        public RaftMessage message() {
+            return message;
+        }
+
+        public CompletableFuture<RaftMessage> future() {
+            return future;
+        }
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -18,6 +18,7 @@ package org.apache.kafka.raft;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This class is used to serialize inbound requests or responses to outbound requests.
@@ -40,10 +41,11 @@ public interface RaftMessageQueue {
     /**
      * Add a new message to the queue.
      *
-     * @param entry the message to deliver
+     * @param message the message to deliver
+     * @return a completion stage that will be completed when the message is processed
      * @throws IllegalStateException if the queue cannot accept the message
      */
-    void add(QueueEntry entry);
+    CompletionStage<RaftMessage> add(RaftMessage message);
 
     /**
      * Check whether there are pending messages awaiting delivery.
@@ -58,29 +60,18 @@ public interface RaftMessageQueue {
      */
     void wakeup();
 
-    public static final class QueueEntry {
-        private final CompletableFuture<RaftMessage> future = new CompletableFuture<>();
-        private final RaftMessage message;
+    /**
+     * Represents an entry in the message queue.
+     */
+    interface QueueEntry {
+        /**
+         * @return the message associated with this entry
+         */
+        RaftMessage message();
 
-        public QueueEntry(RaftMessage message) {
-            this.message = message;
-        }
-
-        public RaftMessage message() {
-            return message;
-        }
-
-        public CompletableFuture<RaftMessage> future() {
-            return future;
-        }
-
-        @Override
-        public String toString() {
-            return String.format(
-                "QueueEntry(message=%s, future.isDone=%s)",
-                message,
-                future.isDone()
-            );
-        }
+        /**
+         * @return the future associated with this entry
+         */
+        CompletableFuture<RaftMessage> future();
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
@@ -20,8 +20,6 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiMessage;
 
-import java.util.concurrent.CompletableFuture;
-
 public abstract class RaftRequest implements RaftMessage {
     private final int correlationId;
     private final ApiMessage data;
@@ -50,8 +48,6 @@ public abstract class RaftRequest implements RaftMessage {
     public static final class Inbound extends RaftRequest {
         private final short apiVersion;
         private final ListenerName listenerName;
-
-        public final CompletableFuture<RaftResponse.Outbound> completion = new CompletableFuture<>();
 
         public Inbound(
             ListenerName listenerName,
@@ -90,9 +86,13 @@ public abstract class RaftRequest implements RaftMessage {
 
     public static final class Outbound extends RaftRequest {
         private final Node destination;
-        public final CompletableFuture<RaftResponse.Inbound> completion = new CompletableFuture<>();
 
-        public Outbound(int correlationId, ApiMessage data, Node destination, long createdTimeMs) {
+        public Outbound(
+            int correlationId,
+            ApiMessage data,
+            Node destination,
+            long createdTimeMs
+        ) {
             super(correlationId, data, createdTimeMs);
             this.destination = destination;
         }

--- a/raft/src/main/java/org/apache/kafka/raft/ResignedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ResignedState.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
 /**
@@ -41,7 +42,7 @@ import java.util.Set;
  * another election, or our own election timeout expires and we become a
  * Candidate.
  */
-public class ResignedState implements EpochState {
+public final class ResignedState implements EpochState {
     private final int localId;
     private final int epoch;
     private final Endpoints endpoints;
@@ -82,6 +83,11 @@ public class ResignedState implements EpochState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(OptionalInt.of(localId), epoch);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/TimingWheelExpirationService.java
+++ b/raft/src/main/java/org/apache/kafka/raft/TimingWheelExpirationService.java
@@ -58,7 +58,14 @@ public class TimingWheelExpirationService implements ExpirationService {
 
         @Override
         public void run() {
-            future.completeExceptionally(new TimeoutException("Future failed to be completed before timeout of " + delayMs + " ms was reached"));
+            future.completeExceptionally(
+                new TimeoutException(
+                    String.format(
+                        "Future failed to be completed before timeout of %s ms was reached",
+                        delayMs
+                    )
+                )
+            );
         }
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/UnattachedState.java
@@ -41,7 +41,7 @@ import static org.apache.kafka.raft.QuorumState.unattachedOrProspectiveCanGrantV
  * request from the leader.
  */
 
-public class UnattachedState implements EpochState {
+public final class UnattachedState implements EpochState {
     private final int epoch;
     private final OptionalInt leaderId;
     private final Optional<ReplicaKey> votedKey;
@@ -85,6 +85,11 @@ public class UnattachedState implements EpochState {
     @Override
     public int epoch() {
         return epoch;
+    }
+
+    @Override
+    public LeaderAndEpoch leaderAndEpoch() {
+        return new LeaderAndEpoch(leaderId, epoch);
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/AddVoterHandler.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This type implements the protocol for adding a voter to a KRaft partition.
@@ -83,15 +84,16 @@ public final class AddVoterHandler {
         this.logger = logContext.logger(AddVoterHandler.class);
     }
 
-    public CompletableFuture<AddRaftVoterResponseData> handleAddVoterRequest(
+    public CompletionStage<AddRaftVoterResponseData> handleAddVoterRequest(
         LeaderState<?> leaderState,
         ReplicaKey voterKey,
         Endpoints voterEndpoints,
         boolean ackWhenCommitted,
         long currentTimeMs
     ) {
+        var changeVoterState = leaderState.changeVoterState();
         // Check if there are any pending voter change requests
-        if (leaderState.isOperationPending(currentTimeMs)) {
+        if (changeVoterState.isOperationPending(currentTimeMs)) {
             return CompletableFuture.completedFuture(
                 RaftUtil.addVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
@@ -188,7 +190,7 @@ public final class AddVoterHandler {
             ackWhenCommitted,
             time.timer(timeout.getAsLong())
         );
-        leaderState.resetAddVoterHandlerState(
+        changeVoterState.resetAddVoterHandlerState(
             Errors.UNKNOWN_SERVER_ERROR,
             null,
             Optional.of(state)
@@ -204,7 +206,8 @@ public final class AddVoterHandler {
         Optional<ApiVersionsResponseData.SupportedFeatureKey> supportedKraftVersions,
         long currentTimeMs
     ) {
-        Optional<AddVoterHandlerState> handlerState = leaderState.addVoterHandlerState();
+        var changeVoterState = leaderState.changeVoterState();
+        var handlerState = changeVoterState.addVoterHandlerState();
         if (handlerState.isEmpty()) {
             // There are no pending add operation just ignore the api response
             return true;
@@ -232,7 +235,7 @@ public final class AddVoterHandler {
                 error
             );
 
-            leaderState.resetAddVoterHandlerState(
+            changeVoterState.resetAddVoterHandlerState(
                 Errors.REQUEST_TIMED_OUT,
                 String.format(
                     "Aborted add voter operation for since API_VERSIONS returned an error %s",
@@ -255,7 +258,7 @@ public final class AddVoterHandler {
                 supportedKraftVersions
             );
 
-            leaderState.resetAddVoterHandlerState(
+            changeVoterState.resetAddVoterHandlerState(
                 Errors.INVALID_REQUEST,
                 String.format(
                     "Aborted add voter operation for %s since the %s range %s doesn't " +
@@ -288,7 +291,7 @@ public final class AddVoterHandler {
                 leaderState.getReplicaState(current.voterKey())
             );
 
-            leaderState.resetAddVoterHandlerState(
+            changeVoterState.resetAddVoterHandlerState(
                 Errors.REQUEST_TIMED_OUT,
                 String.format(
                     "Aborted add voter operation for %s since it is lagging behind",
@@ -331,17 +334,20 @@ public final class AddVoterHandler {
         return true;
     }
 
-    public void highWatermarkUpdated(LeaderState<?> leaderState) {
-        leaderState.addVoterHandlerState().ifPresent(current ->
-            leaderState.highWatermark().ifPresent(highWatermark ->
+    public void highWatermarkUpdated(LeaderState<?> leaderState, long highWatermark) {
+        var changeVoterState = leaderState.changeVoterState();
+
+        changeVoterState
+            .addVoterHandlerState()
+            .ifPresent(current ->
                 current.lastOffset().ifPresent(lastOffset -> {
-                    if (highWatermark.offset() > lastOffset) {
+                    if (highWatermark > lastOffset) {
                         // VotersRecord with the added voter was committed; complete the RPC
-                        leaderState.resetAddVoterHandlerState(Errors.NONE, null, Optional.empty());
+                        changeVoterState
+                            .resetAddVoterHandlerState(Errors.NONE, null, Optional.empty());
                     }
                 })
-            )
-        );
+            );
     }
 
     private ApiVersionsRequestData buildApiVersionsRequest() {

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -48,10 +48,16 @@ public class BlockingMessageQueue implements RaftMessageQueue {
 
     @Override
     public void add(QueueEntry entry) {
-        queue.add(entry);
-        if (entry.message() != null) {
-            messageCount.incrementAndGet();
+        if (entry == null || entry.message() == null) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Either entry or entry.message is null: %s",
+                    entry
+                )
+            );
         }
+        queue.add(entry);
+        messageCount.incrementAndGet();
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -17,47 +17,82 @@
 package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.raft.RaftMessage;
 import org.apache.kafka.raft.RaftMessageQueue;
 
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class BlockingMessageQueue implements RaftMessageQueue {
-    private final BlockingQueue<QueueEntry> queue = new LinkedBlockingQueue<>();
+    // Marker object for wakeup events
+    private static final Object WAKEUP = new Object();
+
+    private final BlockingQueue<Object> queue = new LinkedBlockingQueue<>();
     private final AtomicInteger messageCount = new AtomicInteger(0);
+
+    /**
+     * A queue entry that contains a message and its associated future.
+     */
+    private static final class MessageEntry implements QueueEntry {
+        private final CompletableFuture<RaftMessage> future = new CompletableFuture<>();
+        private final RaftMessage message;
+
+        MessageEntry(RaftMessage message) {
+            this.message = message;
+        }
+
+        @Override
+        public RaftMessage message() {
+            return message;
+        }
+
+        @Override
+        public CompletableFuture<RaftMessage> future() {
+            return future;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                "MessageEntry(message=%s, future.isDone=%s)",
+                message,
+                future.isDone()
+            );
+        }
+    }
 
     @Override
     public Optional<QueueEntry> poll(long timeoutMs) {
         try {
             var entry = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
-            while (entry != null && entry.message() == null) {
-                // Drain the queue of all of the wakeup events
+            // Drain all wakeup markers; only QueueEntry instances are messages
+            while (entry != null && !(entry instanceof QueueEntry)) {
                 entry = queue.poll();
             }
             if (entry != null) {
                 messageCount.decrementAndGet();
+                return Optional.of((QueueEntry) entry);
             }
-            return Optional.ofNullable(entry);
+            return Optional.empty();
         } catch (InterruptedException e) {
             throw new InterruptException(e);
         }
     }
 
     @Override
-    public void add(QueueEntry entry) {
-        if (entry == null || entry.message() == null) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Either entry or entry.message is null: %s",
-                    entry
-                )
-            );
+    public CompletionStage<RaftMessage> add(RaftMessage message) {
+        if (message == null) {
+            throw new IllegalArgumentException("message cannot be null");
         }
+        var entry = new MessageEntry(message);
         queue.add(entry);
         messageCount.incrementAndGet();
+        return entry.future();
     }
 
     @Override
@@ -67,7 +102,7 @@ public class BlockingMessageQueue implements RaftMessageQueue {
 
     @Override
     public void wakeup() {
-        queue.add(new QueueEntry(null));
+        queue.add(WAKEUP);
     }
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -17,60 +17,51 @@
 package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.errors.InterruptException;
-import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.raft.RaftMessage;
 import org.apache.kafka.raft.RaftMessageQueue;
 
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class BlockingMessageQueue implements RaftMessageQueue {
-    private static final RaftMessage WAKEUP_MESSAGE = new RaftMessage() {
-        @Override
-        public int correlationId() {
-            return 0;
-        }
-
-        @Override
-        public ApiMessage data() {
-            return null;
-        }
-    };
-
-    private final BlockingQueue<RaftMessage> queue = new LinkedBlockingQueue<>();
-    private final AtomicInteger size = new AtomicInteger(0);
+    private final BlockingQueue<QueueEntry> queue = new LinkedBlockingQueue<>();
+    private final AtomicInteger messageCount = new AtomicInteger(0);
 
     @Override
-    public RaftMessage poll(long timeoutMs) {
+    public Optional<QueueEntry> poll(long timeoutMs) {
         try {
-            RaftMessage message = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
-            if (message == null || message == WAKEUP_MESSAGE) {
-                return null;
-            } else {
-                size.decrementAndGet();
-                return message;
+            var entry = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
+            while (entry != null && entry.message() == null) {
+                // Drain the queue of all of the wakeup events
+                entry = queue.poll();
             }
+            if (entry != null) {
+                messageCount.decrementAndGet();
+            }
+            return Optional.ofNullable(entry);
         } catch (InterruptedException e) {
             throw new InterruptException(e);
         }
     }
 
     @Override
-    public void add(RaftMessage message) {
-        queue.add(message);
-        size.incrementAndGet();
+    public void add(QueueEntry entry) {
+        queue.add(entry);
+        if (entry.message() != null) {
+            messageCount.incrementAndGet();
+        }
     }
 
     @Override
     public boolean isEmpty() {
-        return size.get() == 0;
+        return messageCount.get() == 0;
     }
 
     @Override
     public void wakeup() {
-        queue.add(WAKEUP_MESSAGE);
+        queue.add(new QueueEntry(null));
     }
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -29,16 +29,29 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class BlockingMessageQueue implements RaftMessageQueue {
-    // Marker object for wakeup events
-    private static final Object WAKEUP = new Object();
-
-    private final BlockingQueue<Object> queue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<InternalQueueEntry> queue = new LinkedBlockingQueue<>();
     private final AtomicInteger messageCount = new AtomicInteger(0);
+
+    /**
+     * Internal queue entry type used to discriminate between messages and wakeup signals.
+     *
+     * This sealed interface ensures type safety when polling the queue.
+     */
+    private sealed interface InternalQueueEntry { }
+
+    /**
+     * Marker entry used to unblock threads waiting on {@link #poll(long)} without delivering a message.
+     *
+     * Wakeup entries are drained during polling and do not contribute to the message count.
+     */
+    private record WakeupMarker() implements InternalQueueEntry { }
+
+    private static final WakeupMarker WAKEUP = new WakeupMarker();
 
     /**
      * A queue entry that contains a message and its associated future.
      */
-    private static final class MessageEntry implements QueueEntry {
+    private static final class MessageEntry implements QueueEntry, InternalQueueEntry {
         private final CompletableFuture<RaftMessage> future = new CompletableFuture<>();
         private final RaftMessage message;
 
@@ -69,14 +82,14 @@ public class BlockingMessageQueue implements RaftMessageQueue {
     @Override
     public Optional<QueueEntry> poll(long timeoutMs) {
         try {
-            var entry = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
-            // Drain all wakeup markers; only QueueEntry instances are messages
-            while (entry != null && !(entry instanceof QueueEntry)) {
+            InternalQueueEntry entry = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
+            // Drain all wakeup markers until we find a message or the queue is empty
+            while (entry instanceof WakeupMarker) {
                 entry = queue.poll();
             }
-            if (entry != null) {
+            if (entry instanceof MessageEntry messageEntry) {
                 messageCount.decrementAndGet();
-                return Optional.of((QueueEntry) entry);
+                return Optional.of(messageEntry);
             }
             return Optional.empty();
         } catch (InterruptedException e) {
@@ -104,5 +117,4 @@ public class BlockingMessageQueue implements RaftMessageQueue {
     public void wakeup() {
         queue.add(WAKEUP);
     }
-
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/ChangeVoterHandlerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/ChangeVoterHandlerState.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.raft.RaftUtil;
+
+import java.util.Optional;
+
+/**
+ * Manages the state of add and remove voter operations.
+ * <p>
+ * This class maintains at most one pending voter change operation at a time. Add voter and
+ * remove voter operations are mutually exclusive - only one type can be in progress at any
+ * given time. When an operation is reset or expires, its associated future is completed with
+ * an appropriate error response.
+ * <p>
+ * The class also updates the uncommitted voter change metric to reflect whether a voter
+ * change operation is currently pending.
+ */
+public final class ChangeVoterHandlerState {
+    private Optional<AddVoterHandlerState> addVoterHandlerState = Optional.empty();
+    private Optional<RemoveVoterHandlerState> removeVoterHandlerState = Optional.empty();
+    private final KafkaRaftMetrics kafkaRaftMetrics;
+
+    /**
+     * Constructs a new ChangeVoterHandlerState.
+     *
+     * @param kafkaRaftMetrics the metrics instance to update when voter change state changes
+     */
+    public ChangeVoterHandlerState(KafkaRaftMetrics kafkaRaftMetrics) {
+        this.kafkaRaftMetrics = kafkaRaftMetrics;
+    }
+
+    /**
+     * Returns the current add voter handler state, if one exists.
+     *
+     * @return an Optional containing the add voter handler state, or empty if no add voter
+     *         operation is pending
+     */
+    public Optional<AddVoterHandlerState> addVoterHandlerState() {
+        return addVoterHandlerState;
+    }
+
+    /**
+     * Resets the add voter handler state to the specified state.
+     * <p>
+     * If an add voter handler state already exists, its future will be completed with the
+     * provided error and message before being replaced. If the new state is non-empty and a
+     * remove voter handler state is currently present, this method throws an IllegalStateException
+     * to enforce mutual exclusivity.
+     *
+     * @param error the error to complete any existing add voter operation with
+     * @param message the error message to include in the response, or null for no message
+     * @param state the new add voter handler state, or empty to clear the state
+     * @throws IllegalStateException if attempting to set a non-empty add voter state while a
+     *         remove voter state is already present
+     */
+    public void resetAddVoterHandlerState(
+        Errors error,
+        String message,
+        Optional<AddVoterHandlerState> state
+    ) {
+        if (state.isPresent() && removeVoterHandlerState.isPresent()) {
+            throw new IllegalStateException(
+                "Cannot set add voter handler state when remove voter handler state is already present"
+            );
+        }
+        addVoterHandlerState.ifPresent(
+            handlerState -> handlerState
+                .future()
+                .complete(RaftUtil.addVoterResponse(error, message))
+        );
+        addVoterHandlerState = state;
+        updateUncommittedVoterChangeMetric();
+    }
+
+    /**
+     * Returns the current remove voter handler state, if one exists.
+     *
+     * @return an Optional containing the remove voter handler state, or empty if no remove voter
+     *         operation is pending
+     */
+    public Optional<RemoveVoterHandlerState> removeVoterHandlerState() {
+        return removeVoterHandlerState;
+    }
+
+    /**
+     * Resets the remove voter handler state to the specified state.
+     * <p>
+     * If a remove voter handler state already exists, its future will be completed with the
+     * provided error and message before being replaced. If the new state is non-empty and an
+     * add voter handler state is currently present, this method throws an IllegalStateException
+     * to enforce mutual exclusivity.
+     *
+     * @param error the error to complete any existing remove voter operation with
+     * @param message the error message to include in the response, or null for no message
+     * @param state the new remove voter handler state, or empty to clear the state
+     * @throws IllegalStateException if attempting to set a non-empty remove voter state while an
+     *         add voter state is already present
+     */
+    public void resetRemoveVoterHandlerState(
+        Errors error,
+        String message,
+        Optional<RemoveVoterHandlerState> state
+    ) {
+        if (state.isPresent() && addVoterHandlerState.isPresent()) {
+            throw new IllegalStateException(
+                "Cannot set remove voter handler state when add voter handler state is already present"
+            );
+        }
+        removeVoterHandlerState.ifPresent(
+            handlerState -> handlerState
+                .future()
+                .complete(RaftUtil.removeVoterResponse(error, message))
+        );
+        removeVoterHandlerState = state;
+        updateUncommittedVoterChangeMetric();
+    }
+
+    private void updateUncommittedVoterChangeMetric() {
+        kafkaRaftMetrics.updateUncommittedVoterChange(
+            addVoterHandlerState.isPresent() || removeVoterHandlerState.isPresent()
+        );
+    }
+
+    /**
+     * Checks for and expires any pending voter change operations that have timed out.
+     * <p>
+     * This method evaluates both add voter and remove voter operations. Any operation that
+     * has expired (timeUntilOperationExpiration returns 0) is reset with a REQUEST_TIMED_OUT
+     * error. The method then returns the minimum time remaining until the next operation
+     * expiration.
+     *
+     * @param currentTimeMs the current time in milliseconds
+     * @return the time in milliseconds until the next operation expires, or Long.MAX_VALUE if
+     *         no operations are pending
+     */
+    public long maybeExpirePendingOperation(long currentTimeMs) {
+        // First abort any expired operations
+        long timeUntilAddVoterExpiration = addVoterHandlerState()
+            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+            .orElse(Long.MAX_VALUE);
+
+        if (timeUntilAddVoterExpiration == 0) {
+            resetAddVoterHandlerState(Errors.REQUEST_TIMED_OUT, null, Optional.empty());
+        }
+
+        long timeUntilRemoveVoterExpiration = removeVoterHandlerState()
+            .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+            .orElse(Long.MAX_VALUE);
+
+        if (timeUntilRemoveVoterExpiration == 0) {
+            resetRemoveVoterHandlerState(Errors.REQUEST_TIMED_OUT, null, Optional.empty());
+        }
+
+        // Reread the timeouts and return the smaller of them
+        return Math.min(
+            addVoterHandlerState()
+                .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+                .orElse(Long.MAX_VALUE),
+            removeVoterHandlerState()
+                .map(state -> state.timeUntilOperationExpiration(currentTimeMs))
+                .orElse(Long.MAX_VALUE)
+        );
+    }
+
+    /**
+     * Resets all pending voter handler states, completing their futures with the specified error.
+     * <p>
+     * This method clears both add voter and remove voter handler states if they exist. Each
+     * pending operation's future is completed with the provided error.
+     *
+     * @param error the error to complete any pending operations with
+     */
+    public void maybeResetPendingVoterHandlerState(Errors error) {
+        resetAddVoterHandlerState(error, null, Optional.empty());
+        resetRemoveVoterHandlerState(error, null, Optional.empty());
+    }
+
+    /**
+     * Checks whether any voter change operation is currently pending.
+     * <p>
+     * This method first expires any operations that have timed out at the given timestamp,
+     * then returns true if either an add voter or remove voter operation remains pending.
+     *
+     * @param currentTimeMs the current time in milliseconds
+     * @return true if a voter change operation is pending, false otherwise
+     */
+    public boolean isOperationPending(long currentTimeMs) {
+        maybeExpirePendingOperation(currentTimeMs);
+        return addVoterHandlerState.isPresent() || removeVoterHandlerState.isPresent();
+    }
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
@@ -18,15 +18,11 @@ package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.raft.NetworkChannel;
 import org.apache.kafka.raft.RaftMessageQueue;
 import org.apache.kafka.raft.RaftRequest;
-import org.apache.kafka.raft.RaftResponse;
-import org.apache.kafka.raft.RaftUtil;
 import org.apache.kafka.raft.RequestManager;
 
 import org.slf4j.Logger;
@@ -67,9 +63,7 @@ public final class DefaultRequestSender  implements RequestSender {
             long remainingBackoffMs = requestManager.remainingBackoffMs(destination, currentTimeMs);
             logger.debug("Connection for {} is backing off for {} ms", destination, remainingBackoffMs);
             return OptionalLong.empty();
-        }
-
-        if (!requestManager.isReady(destination, currentTimeMs)) {
+        } else if (!requestManager.isReady(destination, currentTimeMs)) {
             long remainingMs = requestManager.remainingRequestTimeMs(destination, currentTimeMs);
             logger.debug("Connection for {} has a pending request for {} ms", destination, remainingMs);
             return OptionalLong.empty();
@@ -85,24 +79,13 @@ public final class DefaultRequestSender  implements RequestSender {
             currentTimeMs
         );
 
-        requestMessage.completion.whenComplete((response, exception) -> {
-            if (exception != null) {
-                ApiKeys api = ApiKeys.forId(request.apiKey());
-                Errors error = Errors.forException(exception);
-                ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
-
-                response = new RaftResponse.Inbound(
-                    correlationId,
-                    errorResponse,
-                    destination
-                );
-            }
-
-            messageQueue.add(response);
-        });
-
         requestManager.onRequestSent(destination, correlationId, currentTimeMs);
-        channel.send(requestMessage);
+        channel
+            .send(requestMessage)
+            .whenComplete(
+                (response, exception) -> messageQueue.add(new RaftMessageQueue.QueueEntry(response))
+            );
+
         logger.trace("Sent outbound request: {}", requestMessage);
 
         return OptionalLong.of(requestManager.remainingRequestTimeMs(destination, currentTimeMs));

--- a/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/DefaultRequestSender.java
@@ -83,7 +83,7 @@ public final class DefaultRequestSender  implements RequestSender {
         channel
             .send(requestMessage)
             .whenComplete(
-                (response, exception) -> messageQueue.add(new RaftMessageQueue.QueueEntry(response))
+                (response, exception) -> messageQueue.add(response)
             );
 
         logger.trace("Sent outbound request: {}", requestMessage);

--- a/raft/src/main/java/org/apache/kafka/raft/internals/FuturePurgatory.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/FuturePurgatory.java
@@ -16,57 +16,53 @@
  */
 package org.apache.kafka.raft.internals;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Simple purgatory interface which supports waiting with expiration for a given threshold
  * to be reached. The threshold is specified through {@link #await(Comparable, long)}.
  * The returned future can be completed in the following ways:
  *
- * 1) The future is completed successfully if the threshold value is reached
+ * 1) The stage is completed successfully if the threshold value is reached
  *    in a call to {@link #maybeComplete(Comparable, long)}.
- * 2) The future is completed successfully if {@link #completeAll(long)} is called.
- * 3) The future is completed exceptionally if {@link #completeAllExceptionally(Throwable)}
+ * 2) The stage is completed successfully if {@link #completeAll(long)} is called.
+ * 3) The stage is completed exceptionally if {@link #completeAllExceptionally(Throwable)}
  *    is called.
  * 4) If none of the above happens before the expiration of the timeout passed to
- *    {@link #await(Comparable, long)}, then the future will be completed exceptionally
+ *    {@link #await(Comparable, long)}, then the stage will be completed exceptionally
  *    with a {@link org.apache.kafka.common.errors.TimeoutException}.
  *
- * It is also possible for the future to be completed externally, but this should
- * generally be avoided.
- *
- * Note that the future objects should be organized in order so that completing awaiting
- * futures would stop early and not traverse all awaiting futures.
+ * Note that the stage objects should be organized in order so that completing awaiting
+ * stages would stop early and not traverse all awaiting futures.
  *
  * @param <T> threshold value type
  */
 public interface FuturePurgatory<T extends Comparable<T>> {
-
     /**
-     * Create a new future which is tracked by the purgatory.
+     * Create a new completion stage which is tracked by the purgatory.
      *
-     * @param threshold     the minimum value that must be reached for the future
+     * @param threshold     the minimum value that must be reached for the stage
      *                      to be successfully completed by {@link #maybeComplete(Comparable, long)}
      * @param maxWaitTimeMs the maximum time to wait for completion. If this
-     *                      timeout is reached, then the future will be completed exceptionally
+     *                      timeout is reached, then the stage will be completed exceptionally
      *                      with a {@link org.apache.kafka.common.errors.TimeoutException}
      *
-     * @return              the future tracking the expected completion
+     * @return              the stage tracking the expected completion
      */
-    CompletableFuture<Long> await(T threshold, long maxWaitTimeMs);
+    CompletionStage<Long> await(T threshold, long maxWaitTimeMs);
 
     /**
-     * Complete awaiting futures whose threshold value from {@link FuturePurgatory#await} are smaller
+     * Complete awaiting stages whose threshold value from {@link FuturePurgatory#await} are smaller
      * than the given threshold value. The completion callbacks will be triggered from the calling thread.
      *
      * @param value         the threshold value used to determine which futures can be completed
      * @param currentTimeMs the current time in milliseconds that will be passed to
-     *                      {@link CompletableFuture#complete(Object)} when the futures are completed
+     *                      {@link CompletableFuture#complete(Object)} when the stages are completed
      */
     void maybeComplete(T value, long currentTimeMs);
 
     /**
-     * Complete all awaiting futures successfully.
+     * Complete all awaiting stages successfully.
      *
      * @param currentTimeMs the current time in milliseconds that will be passed to
      *                      {@link CompletableFuture#complete(Object)} when the futures are completed
@@ -74,10 +70,10 @@ public interface FuturePurgatory<T extends Comparable<T>> {
     void completeAll(long currentTimeMs);
 
     /**
-     * Complete all awaiting futures exceptionally. The completion callbacks will be
+     * Complete all awaiting stages exceptionally. The completion callbacks will be
      * triggered with the passed in exception.
      *
-     * @param exception     the current time in milliseconds that will be passed to
+     * @param exception     the exception that will be passed to
      *                      {@link CompletableFuture#completeExceptionally(Throwable)}
      */
     void completeAllExceptionally(Throwable exception);

--- a/raft/src/main/java/org/apache/kafka/raft/internals/FuturePurgatory.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/FuturePurgatory.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * Simple purgatory interface which supports waiting with expiration for a given threshold
  * to be reached. The threshold is specified through {@link #await(Comparable, long)}.
- * The returned future can be completed in the following ways:
+ * The returned stage can be completed in the following ways:
  *
  * 1) The stage is completed successfully if the threshold value is reached
  *    in a call to {@link #maybeComplete(Comparable, long)}.
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletionStage;
  *    with a {@link org.apache.kafka.common.errors.TimeoutException}.
  *
  * Note that the stage objects should be organized in order so that completing awaiting
- * stages would stop early and not traverse all awaiting futures.
+ * stages would stop early and not traverse all awaiting stages.
  *
  * @param <T> threshold value type
  */
@@ -55,7 +55,7 @@ public interface FuturePurgatory<T extends Comparable<T>> {
      * Complete awaiting stages whose threshold value from {@link FuturePurgatory#await} are smaller
      * than the given threshold value. The completion callbacks will be triggered from the calling thread.
      *
-     * @param value         the threshold value used to determine which futures can be completed
+     * @param value         the threshold value used to determine which stages can be completed
      * @param currentTimeMs the current time in milliseconds that will be passed to
      *                      {@link CompletableFuture#complete(Object)} when the stages are completed
      */
@@ -65,7 +65,7 @@ public interface FuturePurgatory<T extends Comparable<T>> {
      * Complete all awaiting stages successfully.
      *
      * @param currentTimeMs the current time in milliseconds that will be passed to
-     *                      {@link CompletableFuture#complete(Object)} when the futures are completed
+     *                      {@link CompletableFuture#complete(Object)} when the stages are completed
      */
     void completeAll(long currentTimeMs);
 
@@ -79,9 +79,9 @@ public interface FuturePurgatory<T extends Comparable<T>> {
     void completeAllExceptionally(Throwable exception);
 
     /**
-     * The number of currently waiting futures.
+     * The number of currently waiting stages.
      *
-     * @return the number of waiting futures
+     * @return the number of waiting stages
      */
     int numWaiting();
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This type implements the protocol for removing a voter from a KRaft partition.
@@ -74,13 +75,14 @@ public final class RemoveVoterHandler {
         this.logger = logContext.logger(RemoveVoterHandler.class);
     }
 
-    public CompletableFuture<RemoveRaftVoterResponseData> handleRemoveVoterRequest(
+    public CompletionStage<RemoveRaftVoterResponseData> handleRemoveVoterRequest(
         LeaderState<?> leaderState,
         ReplicaKey voterKey,
         long currentTimeMs
     ) {
+        var changeVoterState = leaderState.changeVoterState();
         // Check if there are any pending voter change requests
-        if (leaderState.isOperationPending(currentTimeMs)) {
+        if (changeVoterState.isOperationPending(currentTimeMs)) {
             return CompletableFuture.completedFuture(
                 RaftUtil.removeVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
@@ -150,17 +152,21 @@ public final class RemoveVoterHandler {
             leaderState.appendVotersRecord(newVoters.get(), currentTimeMs),
             time.timer(requestTimeoutMs)
         );
-        leaderState.resetRemoveVoterHandlerState(Errors.UNKNOWN_SERVER_ERROR, null, Optional.of(state));
+        changeVoterState.resetRemoveVoterHandlerState(Errors.UNKNOWN_SERVER_ERROR, null, Optional.of(state));
 
         return state.future();
     }
 
-    public void highWatermarkUpdated(LeaderState<?> leaderState) {
-        leaderState.removeVoterHandlerState().ifPresent(current ->
-            leaderState.highWatermark().ifPresent(highWatermark -> {
-                if (highWatermark.offset() > current.lastOffset()) {
+    public void highWatermarkUpdated(LeaderState<?> leaderState, long highWatermark) {
+        var changeVoterState = leaderState.changeVoterState();
+
+        changeVoterState
+            .removeVoterHandlerState()
+            .ifPresent(current -> {
+                if (highWatermark > current.lastOffset()) {
                     // VotersRecord with the removed voter was committed; complete the RPC
-                    leaderState.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.empty());
+                    changeVoterState
+                        .resetRemoveVoterHandlerState(Errors.NONE, null, Optional.empty());
 
                     // Resign if the leader is not part of the new committed voter set
                     VoterSet voters = partitionState.lastVoterSet();
@@ -182,7 +188,6 @@ public final class RemoveVoterHandler {
                         leaderState.requestResign();
                     }
                 }
-            })
-        );
+            });
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RemoveVoterHandler.java
@@ -165,8 +165,7 @@ public final class RemoveVoterHandler {
             .ifPresent(current -> {
                 if (highWatermark > current.lastOffset()) {
                     // VotersRecord with the removed voter was committed; complete the RPC
-                    changeVoterState
-                        .resetRemoveVoterHandlerState(Errors.NONE, null, Optional.empty());
+                    changeVoterState.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.empty());
 
                     // Resign if the leader is not part of the new committed voter set
                     VoterSet voters = partitionState.lastVoterSet();

--- a/raft/src/main/java/org/apache/kafka/raft/internals/ThresholdPurgatory.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/ThresholdPurgatory.java
@@ -20,6 +20,7 @@ import org.apache.kafka.raft.ExpirationService;
 
 import java.util.NavigableMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -35,7 +36,7 @@ public class ThresholdPurgatory<T extends Comparable<T>> implements FuturePurgat
     }
 
     @Override
-    public CompletableFuture<Long> await(T threshold, long maxWaitTimeMs) {
+    public CompletionStage<Long> await(T threshold, long maxWaitTimeMs) {
         ThresholdKey<T> key = new ThresholdKey<>(idGenerator.incrementAndGet(), threshold);
         CompletableFuture<Long> future = expirationService.failAfter(maxWaitTimeMs);
         thresholdMap.put(key, future);
@@ -83,5 +84,4 @@ public class ThresholdPurgatory<T extends Comparable<T>> implements FuturePurgat
             }
         }
     }
-
 }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/UpdateVoterHandler.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.raft.Endpoints;
-import org.apache.kafka.raft.LeaderAndEpoch;
 import org.apache.kafka.raft.LeaderState;
 import org.apache.kafka.raft.LogOffsetMetadata;
 import org.apache.kafka.raft.RaftUtil;
@@ -34,8 +33,8 @@ import org.apache.kafka.server.common.KRaftVersion;
 import org.slf4j.Logger;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This type implements the protocol for updating a voter from a KRaft partition.
@@ -55,24 +54,21 @@ import java.util.concurrent.CompletableFuture;
  * 7. Send the UpdateVoter successful response to the voter.
  */
 public final class UpdateVoterHandler {
-    private final OptionalInt localId;
     private final KRaftControlRecordStateMachine partitionState;
     private final ListenerName defaultListenerName;
     private final Logger log;
 
     public UpdateVoterHandler(
-        OptionalInt localId,
         KRaftControlRecordStateMachine partitionState,
         ListenerName defaultListenerName,
         LogContext logContext
     ) {
-        this.localId = localId;
         this.partitionState = partitionState;
         this.defaultListenerName = defaultListenerName;
         this.log = logContext.logger(getClass());
     }
 
-    public CompletableFuture<UpdateRaftVoterResponseData> handleUpdateVoterRequest(
+    public CompletionStage<UpdateRaftVoterResponseData> handleUpdateVoterRequest(
         LeaderState<?> leaderState,
         ListenerName requestListenerName,
         ReplicaKey voterKey,
@@ -81,15 +77,12 @@ public final class UpdateVoterHandler {
         long currentTimeMs
     ) {
         // Check if there are any pending voter change requests
-        if (leaderState.isOperationPending(currentTimeMs)) {
+        if (leaderState.changeVoterState().isOperationPending(currentTimeMs)) {
             return CompletableFuture.completedFuture(
                 RaftUtil.updateVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -102,10 +95,7 @@ public final class UpdateVoterHandler {
                 RaftUtil.updateVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -135,10 +125,7 @@ public final class UpdateVoterHandler {
                     RaftUtil.updateVoterResponse(
                         Errors.REQUEST_TIMED_OUT,
                         requestListenerName,
-                        new LeaderAndEpoch(
-                            localId,
-                            leaderState.epoch()
-                        ),
+                        leaderState.leaderAndEpoch(),
                         leaderState.leaderEndpoints()
                     )
                 );
@@ -151,10 +138,7 @@ public final class UpdateVoterHandler {
                 RaftUtil.updateVoterResponse(
                     Errors.REQUEST_TIMED_OUT,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -165,10 +149,7 @@ public final class UpdateVoterHandler {
                 RaftUtil.updateVoterResponse(
                     Errors.INVALID_REQUEST,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -180,10 +161,7 @@ public final class UpdateVoterHandler {
                 RaftUtil.updateVoterResponse(
                     Errors.INVALID_REQUEST,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -207,10 +185,7 @@ public final class UpdateVoterHandler {
                 RaftUtil.updateVoterResponse(
                     Errors.VOTER_NOT_FOUND,
                     requestListenerName,
-                    new LeaderAndEpoch(
-                        localId,
-                        leaderState.epoch()
-                    ),
+                    leaderState.leaderAndEpoch(),
                     leaderState.leaderEndpoints()
                 )
             );
@@ -244,7 +219,7 @@ public final class UpdateVoterHandler {
             voters.updateVoterIgnoringDirectoryId(updatedVoter);
     }
 
-    private CompletableFuture<UpdateRaftVoterResponseData> storeUpdatedVoters(
+    private CompletionStage<UpdateRaftVoterResponseData> storeUpdatedVoters(
         LeaderState<?> leaderState,
         ReplicaKey voterKey,
         Optional<KRaftVersionUpgrade.Voters> inMemoryVoters,
@@ -277,10 +252,7 @@ public final class UpdateVoterHandler {
                     RaftUtil.updateVoterResponse(
                         Errors.REQUEST_TIMED_OUT,
                         requestListenerName,
-                        new LeaderAndEpoch(
-                            localId,
-                            leaderState.epoch()
-                        ),
+                        leaderState.leaderAndEpoch(),
                         leaderState.leaderEndpoints()
                     )
                 );
@@ -294,10 +266,7 @@ public final class UpdateVoterHandler {
             RaftUtil.updateVoterResponse(
                 Errors.NONE,
                 requestListenerName,
-                new LeaderAndEpoch(
-                    localId,
-                    leaderState.epoch()
-                ),
+                leaderState.leaderAndEpoch(),
                 leaderState.leaderEndpoints()
             )
         );

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaNetworkChannelTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaNetworkChannelTest.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -151,10 +152,10 @@ public class KafkaNetworkChannelTest {
         client.prepareResponseFrom(response, destinationNode, false);
 
         ioThread.start();
-        RaftRequest.Outbound request = sendTestRequest(ApiKeys.FETCH, destinationNode);
-
+        var result = sendTestRequest(ApiKeys.FETCH, destinationNode);
         ioThread.join();
-        assertResponseCompleted(request, Errors.INVALID_REQUEST);
+
+        assertResponseCompleted(result.request(), result.stage(), Errors.INVALID_REQUEST);
     }
 
     @Test
@@ -234,27 +235,32 @@ public class KafkaNetworkChannelTest {
         }
     }
 
-    private RaftRequest.Outbound sendTestRequest(ApiKeys apiKey, Node destination) {
+    record SendRequestResult(RaftRequest.Outbound request, CompletionStage<RaftResponse.Inbound> stage) { }
+
+    private SendRequestResult sendTestRequest(ApiKeys apiKey, Node destination) {
         int correlationId = channel.newCorrelationId();
         long createdTimeMs = time.milliseconds();
         ApiMessage apiRequest = buildTestRequest(apiKey);
-        RaftRequest.Outbound request = new RaftRequest.Outbound(
+        var request = new RaftRequest.Outbound(
             correlationId,
             apiRequest,
             destination,
             createdTimeMs
         );
-        channel.send(request);
-        return request;
+        var stage = channel.send(request);
+        return new SendRequestResult(request, stage);
     }
 
     private void assertResponseCompleted(
         RaftRequest.Outbound request,
+        CompletionStage<RaftResponse.Inbound> stage,
         Errors expectedError
     ) throws ExecutionException, InterruptedException {
-        assertTrue(request.completion.isDone());
+        var future = stage.toCompletableFuture();
 
-        RaftResponse.Inbound response = request.completion.get();
+        assertTrue(future.isDone());
+
+        var response = future.get();
         assertEquals(request.destination(), response.source());
         assertEquals(request.correlationId(), response.correlationId());
         assertEquals(request.data().apiKey(), response.data().apiKey());
@@ -266,9 +272,9 @@ public class KafkaNetworkChannelTest {
         Node destination,
         Errors error
     ) throws ExecutionException, InterruptedException {
-        RaftRequest.Outbound request = sendTestRequest(apiKey, destination);
+        var result = sendTestRequest(apiKey, destination);
         channel.pollOnce();
-        assertResponseCompleted(request, error);
+        assertResponseCompleted(result.request(), result.stage(), error);
     }
 
     private ApiMessage buildTestRequest(ApiKeys key) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientAutoJoinTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientAutoJoinTest.java
@@ -314,7 +314,7 @@ public class KafkaRaftClientAutoJoinTest {
             )
         );
         // poll kraft to update the replica's voter set
-        context.client.poll();
+        context.poll();
     }
 
     private int randomReplicaId() {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientFetchTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientFetchTest.java
@@ -91,7 +91,7 @@ public final class KafkaRaftClientFetchTest {
             context.fetchResponse(epoch, electedLeader.id(), records, 0L, Errors.NONE)
         );
 
-        context.client.poll();
+        context.poll();
 
         assertEquals(oldLogEndOffset, context.log.endOffset().offset());
     }
@@ -437,7 +437,7 @@ public final class KafkaRaftClientFetchTest {
             context.fetchResponse(epoch, electedLeader.id(), records, 0L, Errors.NONE)
         );
 
-        context.client.poll();
+        context.poll();
 
         // Check that only the first batch was appended because the second batch has a greater epoch
         assertEquals(oldLogEndOffset + numberOfRecords, context.log.endOffset().offset());
@@ -541,7 +541,7 @@ public final class KafkaRaftClientFetchTest {
 
         // Check that the fetch response was deferred
         for (var i = 0; i < 10; ++i) {
-            context.client.poll();
+            context.poll();
             assertEquals(List.of(), context.drainSentResponses(ApiKeys.FETCH));
         }
     }
@@ -587,7 +587,7 @@ public final class KafkaRaftClientFetchTest {
 
         // Check that the fetch response was deferred
         for (var i = 0; i < 10; ++i) {
-            context.client.poll();
+            context.poll();
             assertEquals(List.of(), context.drainSentResponses(ApiKeys.FETCH));
         }
     }
@@ -695,7 +695,7 @@ public final class KafkaRaftClientFetchTest {
 
         // Check that the fetch response was deferred
         for (var i = 0; i < 10; ++i) {
-            context.client.poll();
+            context.poll();
             assertEquals(List.of(), context.drainSentResponses(ApiKeys.FETCH));
         }
     }
@@ -746,7 +746,7 @@ public final class KafkaRaftClientFetchTest {
 
         // Check that the fetch response was deferred
         for (var i = 0; i < 10; ++i) {
-            context.client.poll();
+            context.poll();
             assertEquals(List.of(), context.drainSentResponses(ApiKeys.FETCH));
         }
 

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientPreVoteTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientPreVoteTest.java
@@ -116,7 +116,7 @@ public class KafkaRaftClientPreVoteTest {
             .withRaftProtocol(KIP_996_PROTOCOL)
             .build();
         // unattached will send fetch request before transitioning to follower, proactively clear the mock sent queue
-        context.client.poll();
+        context.poll();
         context.assertSentFetchRequest();
 
         context.deliverRequest(context.beginEpochRequest(epoch, votedCandidateKey.id(), voters.listeners(votedCandidateKey.id())));
@@ -138,7 +138,7 @@ public class KafkaRaftClientPreVoteTest {
             context.fetchResponse(epoch, votedCandidateKey.id(), MemoryRecords.EMPTY, 0L, Errors.NONE)
         );
 
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isFollower());
         context.deliverRequest(context.preVoteRequest(epoch, otherNodeKey, epoch, 1));
         context.pollUntilResponse();
@@ -412,7 +412,7 @@ public class KafkaRaftClientPreVoteTest {
 
         context.deliverRequest(context.preVoteRequest(leaderEpoch, otherNodeKey, leaderEpoch, 1));
 
-        context.client.poll();
+        context.poll();
 
         context.assertSentVoteResponse(Errors.NONE, leaderEpoch, OptionalInt.of(localId), false);
         context.assertElectedLeader(leaderEpoch, localId);
@@ -527,11 +527,11 @@ public class KafkaRaftClientPreVoteTest {
 
         ReplicaKey observerKey = replicaKey(localId + 2, true);
         context.deliverRequest(context.preVoteRequest(epoch - 1, observerKey, 0, 0));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.FENCED_LEADER_EPOCH, epoch, OptionalInt.of(localId), false);
 
         context.deliverRequest(context.preVoteRequest(epoch, observerKey, 0, 0));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.of(localId), false);
     }
 
@@ -737,7 +737,7 @@ public class KafkaRaftClientPreVoteTest {
 
         // While the vote requests are still inflight, replica receives a BeginEpoch for the same epoch
         context.deliverRequest(context.beginEpochRequest(epoch, voter3.id()));
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, voter3.id());
 
         // If PreVote responses are received now they should be ignored
@@ -755,7 +755,7 @@ public class KafkaRaftClientPreVoteTest {
             voteResponse2
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, voter3.id());
     }
 
@@ -797,7 +797,7 @@ public class KafkaRaftClientPreVoteTest {
         );
 
         // Local should transition to Candidate since it realizes remote node does not support PreVote.
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 1, context.currentEpoch());
         context.client.quorum().isCandidate();
 
@@ -807,14 +807,14 @@ public class KafkaRaftClientPreVoteTest {
             voteRequests.get(1).destination(),
             context.voteResponse(true, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 1, context.currentEpoch());
         context.client.quorum().isCandidate();
         context.collectVoteRequests(epoch + 1, 0, 0);
 
         // Sleep to transition back to Prospective
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 1, context.currentEpoch());
         assertTrue(context.client.quorum().isProspective());
 
@@ -827,7 +827,7 @@ public class KafkaRaftClientPreVoteTest {
             voteRequests.get(0).destination(),
             context.voteResponse(true, OptionalInt.empty(), epoch + 1)
         );
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 2, context.currentEpoch());
         context.client.quorum().isCandidate();
 
@@ -837,7 +837,7 @@ public class KafkaRaftClientPreVoteTest {
             voteRequests.get(1).destination(),
             RaftUtil.errorResponse(ApiKeys.VOTE, Errors.UNSUPPORTED_VERSION)
         );
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 2, context.currentEpoch());
         context.client.quorum().isCandidate();
     }
@@ -871,7 +871,7 @@ public class KafkaRaftClientPreVoteTest {
         assertTrue(context.client.quorum().isProspective());
 
         context.deliverRequest(context.beginEpochRequest(epoch, leader.id()));
-        context.client.poll();
+        context.poll();
 
         assertTrue(context.client.quorum().isFollower());
         context.assertElectedLeader(epoch, leader.id());
@@ -906,7 +906,7 @@ public class KafkaRaftClientPreVoteTest {
 
         // If election timeout expires, replica should transition to unattached to attempt re-discovering leader
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isUnattached());
 
         // After election times out again, replica will transition back to prospective and send PreVote requests
@@ -920,7 +920,7 @@ public class KafkaRaftClientPreVoteTest {
             voteRequest.destination(),
             context.voteResponse(false, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isUnattached());
 
         // After election times out again, replica will transition back to prospective and send PreVote requests
@@ -979,17 +979,17 @@ public class KafkaRaftClientPreVoteTest {
             voteRequests.get(0).destination(),
             context.voteResponse(false, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
 
         context.deliverResponse(
             voteRequests.get(1).correlationId(),
             voteRequests.get(1).destination(),
             context.voteResponse(false, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isFollower());
 
-        context.client.poll();
+        context.poll();
         context.assertSentFetchRequest();
 
         // After election times out again, transition back to prospective and send PreVote requests
@@ -1005,7 +1005,7 @@ public class KafkaRaftClientPreVoteTest {
             voteRequests.get(0).correlationId(),
             voteRequests.get(0).destination(),
             context.voteResponse(Errors.FENCED_LEADER_EPOCH, OptionalInt.of(replica2.id()), epoch + 1));
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isFollower());
         context.assertElectedLeader(epoch + 1, replica2.id());
     }
@@ -1031,12 +1031,12 @@ public class KafkaRaftClientPreVoteTest {
         assertTrue(context.client.quorum().isUnattached());
         // Sleep a little to ensure that we become a prospective
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         // Sleep past election timeout
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
 
         // Prospective should transition to unattached
         assertTrue(context.client.quorum().isUnattached());
@@ -1044,7 +1044,7 @@ public class KafkaRaftClientPreVoteTest {
 
         // If election timeout expires again, it should transition back to prospective
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
         assertTrue(context.client.quorum().hasLeader());
     }
@@ -1086,7 +1086,7 @@ public class KafkaRaftClientPreVoteTest {
         );
 
         // Prospective should transition to Follower
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isFollower());
         assertEquals(OptionalInt.of(leader.id()), context.client.quorum().leaderId());
     }
@@ -1112,7 +1112,7 @@ public class KafkaRaftClientPreVoteTest {
             .build();
         context.assertUnknownLeaderAndNoVotedCandidate(epoch);
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         // Simulate a request timeout
@@ -1121,7 +1121,7 @@ public class KafkaRaftClientPreVoteTest {
         context.time.sleep(context.requestTimeoutMs());
 
         // Prospective should retry the request
-        context.client.poll();
+        context.poll();
         RaftRequest.Outbound retryRequest = context.assertSentPreVoteRequest(epoch, 0, 0L, 1);
 
         // Ignore the timed out response if it arrives late
@@ -1130,7 +1130,7 @@ public class KafkaRaftClientPreVoteTest {
             request.destination(),
             context.voteResponse(true, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         // Become candidate after receiving the retry response
@@ -1139,7 +1139,7 @@ public class KafkaRaftClientPreVoteTest {
             retryRequest.destination(),
             context.voteResponse(true, OptionalInt.empty(), epoch)
         );
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isCandidate());
         context.assertVotedCandidate(epoch + 1, local);
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -314,7 +314,7 @@ public class KafkaRaftClientReconfigTest {
         }
 
         // follower applies the bootstrap records, registering follower2 as a new voter
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isVoter(follower));
     }
 
@@ -353,9 +353,9 @@ public class KafkaRaftClientReconfigTest {
         completeApiVersionsForAddVoter(context, newVoter, newAddress);
 
         // Handle the API_VERSIONS response
-        context.client.poll();
+        context.poll();
         // Append new VotersRecord to log
-        context.client.poll();
+        context.poll();
 
         commitNewVoterSetForAddVoter(context, local, follower, newVoter, epoch);
 
@@ -405,7 +405,7 @@ public class KafkaRaftClientReconfigTest {
         completeApiVersionsForAddVoter(context, newVoter, newAddress);
 
         // Handle the API_VERSIONS response
-        context.client.poll();
+        context.poll();
         // Append new VotersRecord to log
         // Expect a response for AddVoter request before committing the new voter
         context.pollUntilResponse();
@@ -826,7 +826,7 @@ public class KafkaRaftClientReconfigTest {
         );
 
         // Handle the API_VERSIONS response
-        context.client.poll();
+        context.poll();
 
         // Wait for request timeout without sending a FETCH request to timeout the add voter RPC
         context.time.sleep(context.requestTimeoutMs());
@@ -1138,9 +1138,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(follower2));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // follower2 should not be a voter in the latest voter set
         assertFalse(context.client.quorum().isVoter(follower2));
@@ -1189,9 +1189,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(local));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // local should not be a voter in the latest voter set
         assertFalse(context.client.quorum().isVoter(local));
@@ -1231,7 +1231,7 @@ public class KafkaRaftClientReconfigTest {
 
         // Election timeout is random number in [electionTimeoutMs, 2 * electionTimeoutMs)
         context.time.sleep(2L * context.electionTimeoutMs());
-        context.client.poll();
+        context.poll();
 
         assertTrue(context.client.quorum().isObserver());
         assertTrue(context.client.quorum().isUnattached());
@@ -1314,9 +1314,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(follower2));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // Attempt to remove follower1
         context.deliverRequest(context.removeVoterRequest(follower1));
@@ -1486,9 +1486,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(follower2));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // Wait for request timeout without sending a FETCH request to timeout the remove voter RPC
         context.time.sleep(context.requestTimeoutMs());
@@ -1530,9 +1530,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(follower2));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // Leader completes the RemoveVoter RPC when resigning
         context.client.resign(epoch);
@@ -1572,9 +1572,9 @@ public class KafkaRaftClientReconfigTest {
         context.deliverRequest(context.removeVoterRequest(follower2));
 
         // Handle the remove voter request
-        context.client.poll();
+        context.poll();
         // Append the VotersRecord to the log
-        context.client.poll();
+        context.poll();
 
         // Attempt to add a new voter while the RemoveVoter RPC is pending
         ReplicaKey newVoter = replicaKey(local.id() + 2, true);
@@ -2301,7 +2301,7 @@ public class KafkaRaftClientReconfigTest {
                 new LeaderAndEpoch(OptionalInt.of(voter1.id()), epoch)
             )
         );
-        context.client.poll();
+        context.poll();
 
         // after sending an update voter the next requests should be fetch and no update voter
         for (int i = 0; i < 10; i++) {
@@ -2322,7 +2322,7 @@ public class KafkaRaftClientReconfigTest {
                 )
             );
             // poll kraft to handle the fetch response
-            context.client.poll();
+            context.poll();
         }
     }
 
@@ -2454,7 +2454,7 @@ public class KafkaRaftClientReconfigTest {
         assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.kraftVersion());
 
         var localLogEndOffset = context.log.endOffset().offset();
-        context.client.poll();
+        context.poll();
 
         // check if leader writes 2 control records to the log;
         // one for the kraft version and one for the voter set
@@ -2525,7 +2525,7 @@ public class KafkaRaftClientReconfigTest {
         assertEquals(KRaftVersion.KRAFT_VERSION_1, context.client.kraftVersion());
 
         // Push the control records to the log
-        context.client.poll();
+        context.poll();
         // Advance the HWM to the LEO
         for (var voter : List.of(voter1, voter2)) {
             context.deliverRequest(
@@ -2568,7 +2568,7 @@ public class KafkaRaftClientReconfigTest {
 
         // Push the control records to the log
         var localLogEndOffset = context.log.endOffset().offset();
-        context.client.poll();
+        context.poll();
 
         // check that the leader wrote voters control record to the log;
         var records = context.log.read(
@@ -2707,7 +2707,7 @@ public class KafkaRaftClientReconfigTest {
 
         // don't send a response but increase the time
         context.time.sleep(context.requestTimeoutMs() - 1);
-        context.client.poll();
+        context.poll();
         assertFalse(context.channel.hasSentRequests());
 
         // expect an update voter request after the FETCH rpc completes
@@ -2817,7 +2817,7 @@ public class KafkaRaftClientReconfigTest {
             .withKip853Rpc(true)
             .build();
 
-        context.client.poll();
+        context.poll();
 
         HashMap<ListenerName, InetSocketAddress> leaderListenersMap = new HashMap<>(2);
         leaderListenersMap.put(
@@ -2913,11 +2913,11 @@ public class KafkaRaftClientReconfigTest {
         );
 
         context.deliverResponse(request.correlationId(), request.destination(), response);
-        context.client.poll();
+        context.poll();
 
         // Bump the context epoch after resignation completes
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertEquals(epoch + 1, context.currentEpoch());
 
         // Become leader again and verify metrics values have been reset

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -234,7 +234,7 @@ public final class KafkaRaftClientSnapshotTest {
 
         RaftClientTestContext.MockListener secondListener = new RaftClientTestContext.MockListener(OptionalInt.of(localId));
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
 
         // Check that the second listener was notified of the new snapshot
         try (SnapshotReader<String> snapshot = secondListener.drainHandledSnapshot().get()) {
@@ -286,12 +286,12 @@ public final class KafkaRaftClientSnapshotTest {
             snapshot.freeze();
         }
         context.log.deleteBeforeSnapshot(secondSnapshotId);
-        context.client.poll();
+        context.poll();
 
         // Resume the listener from reading commit batches
         context.listener.updateReadCommit(true);
 
-        context.client.poll();
+        context.poll();
         // Check that listener was notified of the second snapshot
         try (SnapshotReader<String> snapshot = context.listener.drainHandledSnapshot().get()) {
             assertEquals(secondSnapshotId, snapshot.snapshotId());
@@ -322,7 +322,7 @@ public final class KafkaRaftClientSnapshotTest {
 
         // Send a fetch request for an end offset and epoch which has been snapshotted
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 6, 2, 500));
-        context.client.poll();
+        context.poll();
 
         // Expect that the leader replies immediately with a snapshot id
         FetchResponseData.PartitionData partitionResponse = context.assertSentFetchPartitionResponse();
@@ -352,7 +352,7 @@ public final class KafkaRaftClientSnapshotTest {
         context.client.prepareAppend(epoch, appendRecords);
         context.client.schedulePreparedAppend();
         context.time.sleep(context.appendLingerMs());
-        context.client.poll();
+        context.poll();
 
         long localLogEndOffset = context.log.endOffset().offset();
         assertTrue(
@@ -369,7 +369,7 @@ public final class KafkaRaftClientSnapshotTest {
             snapshot.freeze();
         }
         context.log.deleteBeforeSnapshot(snapshotId);
-        context.client.poll();
+        context.poll();
 
         // Send Fetch request less than start offset
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, snapshotId.offset() - 2, snapshotId.epoch(), 0));
@@ -402,7 +402,7 @@ public final class KafkaRaftClientSnapshotTest {
         context.client.prepareAppend(epoch, appendRecords);
         context.client.schedulePreparedAppend();
         context.time.sleep(context.appendLingerMs());
-        context.client.poll();
+        context.poll();
 
         long localLogEndOffset = context.log.endOffset().offset();
         assertTrue(
@@ -459,12 +459,12 @@ public final class KafkaRaftClientSnapshotTest {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
-        context.client.poll();
+        context.poll();
 
         context.client.prepareAppend(epoch, List.of("g", "h", "i"));
         context.client.schedulePreparedAppend();
         context.time.sleep(context.appendLingerMs());
-        context.client.poll();
+        context.poll();
 
         // It is an invalid request to send an last fetched epoch greater than the current epoch
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, oldestSnapshotId.offset() + 1, epoch + 1, 0));
@@ -501,7 +501,7 @@ public final class KafkaRaftClientSnapshotTest {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
-        context.client.poll();
+        context.poll();
 
         // This should truncate to the old snapshot
         context.deliverRequest(
@@ -552,7 +552,7 @@ public final class KafkaRaftClientSnapshotTest {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
-        context.client.poll();
+        context.poll();
 
         // Send fetch request at log start offset with valid last fetched epoch
         context.deliverRequest(
@@ -599,7 +599,7 @@ public final class KafkaRaftClientSnapshotTest {
             snapshot.freeze();
         }
         context.log.deleteBeforeSnapshot(oldestSnapshotId);
-        context.client.poll();
+        context.poll();
 
         // Send fetch with log start offset and invalid last fetched epoch
         context.deliverRequest(
@@ -652,7 +652,7 @@ public final class KafkaRaftClientSnapshotTest {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
-        context.client.poll();
+        context.poll();
 
         // Send a epoch less than the oldest snapshot
         context.deliverRequest(
@@ -697,7 +697,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.SNAPSHOT_NOT_FOUND, Errors.forCode(response.errorCode()));
@@ -730,7 +730,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.SNAPSHOT_NOT_FOUND, Errors.forCode(response.errorCode()));
@@ -761,7 +761,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(topicPartition).get();
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.forCode(response.errorCode()));
@@ -802,7 +802,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context
             .assertSentFetchSnapshotResponse(context.metadataPartition)
@@ -879,37 +879,37 @@ public final class KafkaRaftClientSnapshotTest {
 
         // fetch timeout is not expired, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.quorum().isResigned());
 
         // voter1 sends fetchSnapshotRequest, the fetch timer should be reset
         context.deliverRequest(voter1FetchSnapshotRequest);
-        context.client.poll();
+        context.poll();
         context.assertSentFetchSnapshotResponse(context.metadataPartition);
 
         // Since the fetch timer is reset, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.quorum().isResigned());
 
         // voter2 sends fetchSnapshotRequest, the fetch timer should be reset
         context.deliverRequest(voter2FetchSnapshotRequest);
-        context.client.poll();
+        context.poll();
         context.assertSentFetchSnapshotResponse(context.metadataPartition);
 
         // Since the fetch timer is reset, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.quorum().isResigned());
 
         // An observer sends fetchSnapshotRequest, but the fetch timer should not be reset.
         context.deliverRequest(observerFetchSnapshotRequest);
-        context.client.poll();
+        context.poll();
         context.assertSentFetchSnapshotResponse(context.metadataPartition);
 
         // After this sleep, the fetch timeout should expire since we don't receive fetch request from the majority voters within fetchTimeoutMs
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isResigned());
     }
 
@@ -949,7 +949,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context
             .assertSentFetchSnapshotResponse(context.metadataPartition)
@@ -982,7 +982,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.NONE, Errors.forCode(response.errorCode()));
@@ -1018,7 +1018,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, Errors.forCode(response.errorCode()));
@@ -1071,7 +1071,7 @@ public final class KafkaRaftClientSnapshotTest {
                     position
                 )
             );
-            context.client.poll();
+            context.poll();
 
             FetchSnapshotResponseData.PartitionSnapshot response =
                 context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
@@ -1099,7 +1099,7 @@ public final class KafkaRaftClientSnapshotTest {
                 position
             )
         );
-        context.client.poll();
+        context.poll();
         FetchSnapshotResponseData.PartitionSnapshot response =
             context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(epoch, response.currentLeader().leaderEpoch());
@@ -1141,7 +1141,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.POSITION_OUT_OF_RANGE, Errors.forCode(response.errorCode()));
@@ -1159,7 +1159,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.POSITION_OUT_OF_RANGE, Errors.forCode(response.errorCode()));
@@ -1192,7 +1192,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.FENCED_LEADER_EPOCH, Errors.forCode(response.errorCode()));
@@ -1225,7 +1225,7 @@ public final class KafkaRaftClientSnapshotTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(context.metadataPartition).get();
         assertEquals(Errors.UNKNOWN_LEADER_EPOCH, Errors.forCode(response.errorCode()));
@@ -1260,7 +1260,7 @@ public final class KafkaRaftClientSnapshotTest {
         );
 
         // Handle the invalid response
-        context.client.poll();
+        context.poll();
 
         // Expect another fetch request after backoff has expired
         context.time.sleep(context.retryBackoffMs);
@@ -1277,7 +1277,7 @@ public final class KafkaRaftClientSnapshotTest {
         );
 
         // Handle the invalid response
-        context.client.poll();
+        context.poll();
 
         // Expect another fetch request after backoff has expired
         context.time.sleep(context.retryBackoffMs);
@@ -1931,7 +1931,7 @@ public final class KafkaRaftClientSnapshotTest {
         );
 
         // Assert that the response is ignored and the replicas stays as a prospective
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
     }
 
@@ -2052,7 +2052,7 @@ public final class KafkaRaftClientSnapshotTest {
         context.client.prepareAppend(currentEpoch, newRecords);
         context.client.schedulePreparedAppend();
         context.time.sleep(context.appendLingerMs());
-        context.client.poll();
+        context.poll();
         assertEquals(context.log.endOffset().offset(), context.client.highWatermark().getAsLong() + newRecords.size());
 
         OffsetAndEpoch invalidSnapshotId2 = new OffsetAndEpoch(context.client.highWatermark().getAsLong() + newRecords.size(), currentEpoch);
@@ -2146,7 +2146,7 @@ public final class KafkaRaftClientSnapshotTest {
             fetchRequest.destination(),
             context.fetchResponse(epoch, leaderId, batch1, 0L, Errors.NONE)
         );
-        context.client.poll();
+        context.poll();
 
         // 2) The high watermark must be larger than or equal to the snapshotId's endOffset
         int currentEpoch = context.currentEpoch();
@@ -2174,7 +2174,7 @@ public final class KafkaRaftClientSnapshotTest {
             fetchRequest.destination(),
             context.fetchResponse(epoch, leaderId, batch2, 6L, Errors.NONE)
         );
-        context.client.poll();
+        context.poll();
         assertEquals(6L, context.client.highWatermark().getAsLong());
 
         // 3) The quorum epoch must be larger than or equal to the snapshotId's epoch

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -59,7 +59,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
@@ -210,7 +209,7 @@ class KafkaRaftClientTest {
                 context.log.endOffset().offset()
             )
         );
-        context.client.poll();
+        context.poll();
 
         // Replica will first transition to unattached, then grant vote, then transition to unattached voted
         assertTrue(context.client.quorum().isUnattachedAndVoted());
@@ -247,7 +246,7 @@ class KafkaRaftClientTest {
                 context.log.endOffset().offset()
             )
         );
-        context.client.poll();
+        context.poll();
 
         // Replica will first transition to unattached, then grant vote, then transition to unattached voted
         assertTrue(context.client.quorum().isUnattachedAndVoted());
@@ -283,7 +282,7 @@ class KafkaRaftClientTest {
                 context.log.endOffset().offset()
             )
         );
-        context.client.poll();
+        context.poll();
 
         // Replica will first transition to unattached, then grant vote, then transition to unattached voted
         assertTrue(
@@ -318,19 +317,19 @@ class KafkaRaftClientTest {
 
         // Election timeout
         context.time.sleep(context.electionTimeoutMs());
-        context.client.poll();
+        context.poll();
 
         // Become unattached with expired election timeout
         assertTrue(context.client.quorum().isUnattached());
         assertEquals(epoch + 1, context.currentEpoch());
 
         // Become prospective immediately
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         // Become unattached again after election timeout
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isUnattached());
         assertEquals(epoch + 1, context.currentEpoch());
     }
@@ -353,7 +352,7 @@ class KafkaRaftClientTest {
         // in which no additional writes are accepted.
         assertEquals(0L, context.log.endOffset().offset());
         context.assertElectedLeader(epoch, localId);
-        context.client.poll();
+        context.poll();
         assertThrows(NotLeaderException.class, () -> context.client.prepareAppend(epoch, List.of("a", "b")));
 
         context.pollUntilRequest();
@@ -363,11 +362,11 @@ class KafkaRaftClientTest {
             request.destination(),
             context.endEpochResponse(epoch, OptionalInt.of(localId))
         );
-        context.client.poll();
+        context.poll();
 
         // The node will transition to unattached with epoch + 1 after election timeout passes
         context.time.sleep(context.electionTimeoutMs());
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isUnattached());
         assertEquals(epoch + 1, context.currentEpoch());
         UnattachedState unattached = context.client.quorum().unattachedStateOrThrow();
@@ -497,7 +496,7 @@ class KafkaRaftClientTest {
             endEpochOutbound.destination(),
             context.endEpochResponse(epoch, OptionalInt.of(localId))
         );
-        context.client.poll();
+        context.poll();
         assertEquals(List.of(), context.channel.drainSendQueue());
 
         // Now sleep for the request timeout and verify that we get only one
@@ -528,7 +527,7 @@ class KafkaRaftClientTest {
         // send fetch request when become leader
         int epoch = context.currentEpoch();
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, context.log.endOffset().offset(), epoch, 1000));
-        context.client.poll();
+        context.poll();
 
         // append some record, but the fetch in purgatory will still fail
         context.log.appendAsLeader(
@@ -538,13 +537,13 @@ class KafkaRaftClientTest {
 
         // when transition to resign, all request in fetchPurgatory will fail
         context.client.shutdown(1000);
-        context.client.poll();
+        context.poll();
         context.assertSentFetchPartitionResponse(Errors.NOT_LEADER_OR_FOLLOWER, epoch, OptionalInt.of(localId));
         context.assertResignedLeader(epoch, localId);
 
         // shutting down finished
         context.time.sleep(1000);
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.isRunning());
         assertFalse(context.client.isShuttingDown());
     }
@@ -565,11 +564,11 @@ class KafkaRaftClientTest {
 
         int currentEpoch = context.currentEpoch();
         context.client.resign(currentEpoch - 1);
-        context.client.poll();
+        context.poll();
 
         // Ensure we are still leader even after expiration of the election timeout.
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(currentEpoch, localId);
     }
 
@@ -621,16 +620,16 @@ class KafkaRaftClientTest {
 
         // begin epoch requests sent out every beginQuorumEpochTimeoutMs if replicas have not fetched
         context.time.sleep(context.beginQuorumEpochTimeoutMs);
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of(remoteId1, remoteId2));
 
         int partialDelay = context.beginQuorumEpochTimeoutMs / 2;
         context.time.sleep(partialDelay);
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of());
 
         context.time.sleep(context.beginQuorumEpochTimeoutMs - partialDelay);
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of(remoteId1, remoteId2));
     }
 
@@ -657,7 +656,7 @@ class KafkaRaftClientTest {
 
         // begin epoch requests sent out every beginQuorumEpochTimeoutMs if replicas have not fetched
         context.time.sleep(context.beginQuorumEpochTimeoutMs);
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of(remoteId1, remoteId2));
 
         long partialDelay = context.beginQuorumEpochTimeoutMs / 3;
@@ -666,7 +665,7 @@ class KafkaRaftClientTest {
         context.pollUntilResponse();
 
         context.time.sleep(context.beginQuorumEpochTimeoutMs - partialDelay);
-        context.client.poll();
+        context.poll();
         // leader will not send BeginQuorumEpochRequest again for replica 1 since fetchRequest was received
         // before beginQuorumEpochTimeoutMs time has elapsed
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of(remoteId2));
@@ -674,7 +673,7 @@ class KafkaRaftClientTest {
         context.deliverRequest(context.fetchRequest(epoch, replicaKey1, 0, 0, 0));
         context.pollUntilResponse();
         context.time.sleep(context.beginQuorumEpochTimeoutMs);
-        context.client.poll();
+        context.poll();
         // leader should send BeginQuorumEpochRequest to a node if beginQuorumEpochTimeoutMs time has elapsed
         // without receiving a fetch request from that node
         context.assertSentBeginQuorumEpochRequest(epoch, Set.of(remoteId1, remoteId2));
@@ -704,7 +703,7 @@ class KafkaRaftClientTest {
 
         // fetch timeout is not expired, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
 
         assertFalse(context.client.quorum().isResigned());
 
@@ -714,7 +713,7 @@ class KafkaRaftClientTest {
 
         // Since the fetch timer is reset, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
 
         assertFalse(context.client.quorum().isResigned());
 
@@ -724,7 +723,7 @@ class KafkaRaftClientTest {
 
         // Since the fetch timer is reset, the leader should not get resigned
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
 
         assertFalse(context.client.quorum().isResigned());
 
@@ -734,7 +733,7 @@ class KafkaRaftClientTest {
 
         // After this sleep, the fetch timeout should expire since we don't receive fetch request from the majority voters within fetchTimeoutMs
         context.time.sleep(resignLeadershipTimeout / 2);
-        context.client.poll();
+        context.poll();
 
         // The leadership should get resigned now
         assertTrue(context.client.quorum().isResigned());
@@ -755,7 +754,7 @@ class KafkaRaftClientTest {
         // checkQuorum timeout is expired without receiving fetch request from other voters, but since there is only 1 voter,
         // the leader should not get resigned
         context.time.sleep(context.checkQuorumTimeoutMs);
-        context.client.poll();
+        context.poll();
 
         assertFalse(context.client.quorum().isResigned());
     }
@@ -788,11 +787,11 @@ class KafkaRaftClientTest {
         );
 
         context.deliverResponse(request.correlationId(), request.destination(), response);
-        context.client.poll();
+        context.poll();
 
         // Local does not resend `EndQuorumRequest` once the other voter has acknowledged it.
         context.time.sleep(context.retryBackoffMs);
-        context.client.poll();
+        context.poll();
         assertFalse(context.channel.hasSentRequests());
 
         // Any `Fetch` received in the resigned state should result in a NOT_LEADER error.
@@ -814,7 +813,7 @@ class KafkaRaftClientTest {
 
         // Local will become prospective right away
         assertEquals(0, context.client.quorum().unattachedStateOrThrow().electionTimeoutMs());
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
     }
 
@@ -874,7 +873,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, leaderId);
         assertThrows(IllegalStateException.class, () -> context.client.resign(epoch));
     }
@@ -924,7 +923,7 @@ class KafkaRaftClientTest {
         );
 
         // should remain unattached voter
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isUnattached());
         assertTrue(context.client.quorum().isVoter());
 
@@ -955,7 +954,7 @@ class KafkaRaftClientTest {
         assertEquals(1L, context.log.firstUnflushedOffset());
 
         // Send BeginQuorumEpoch to voters
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(1, Set.of(otherNodeId));
 
         Records records = context.log.read(0,
@@ -1007,7 +1006,7 @@ class KafkaRaftClientTest {
         assertEquals(1L, context.log.firstUnflushedOffset());
 
         // Send BeginQuorumEpoch to voters
-        context.client.poll();
+        context.poll();
         context.assertSentBeginQuorumEpochRequest(2, Set.of(firstNodeId, secondNodeId));
 
         Records records = context.log.read(
@@ -1109,7 +1108,7 @@ class KafkaRaftClientTest {
             .withKip853Rpc(true)
             .build();
 
-        context.client.poll();
+        context.poll();
 
         HashMap<ListenerName, InetSocketAddress> leaderListenersMap = new HashMap<>(2);
         leaderListenersMap.put(
@@ -1179,17 +1178,17 @@ class KafkaRaftClientTest {
             )
         );
 
-        context.client.poll();
+        context.poll();
         context.assertSentEndQuorumEpochResponse(Errors.FENCED_LEADER_EPOCH, epoch, OptionalInt.empty());
 
         // Replica should still be candidate until expiration of election timeout
         context.time.sleep(context.electionTimeoutMs() + jitterMs - 1);
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(epoch, localId);
 
         // After election timeout, replica will become prospective again
         context.time.sleep(1);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
     }
 
@@ -1218,7 +1217,7 @@ class KafkaRaftClientTest {
 
         // Replica should still be leader as long as fetch timeout has not expired
         context.time.sleep(context.fetchTimeoutMs - 1);
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, localId);
     }
 
@@ -1250,7 +1249,7 @@ class KafkaRaftClientTest {
         context.assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.of(voter2));
 
         // Should become a prospective immediately
-        context.client.poll();
+        context.poll();
         context.client.quorum().isProspective();
     }
 
@@ -1378,15 +1377,15 @@ class KafkaRaftClientTest {
         context.client.schedulePreparedAppend();
         assertTrue(context.messageQueue.wakeupRequested());
 
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(lingerMs), context.messageQueue.lastPollTimeoutMs());
 
         context.time.sleep(20);
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(30), context.messageQueue.lastPollTimeoutMs());
 
         context.time.sleep(30);
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
     }
 
@@ -1414,7 +1413,7 @@ class KafkaRaftClientTest {
         context.client.schedulePreparedAppend();
         assertTrue(context.messageQueue.wakeupRequested());
 
-        context.client.poll();
+        context.poll();
         assertFalse(context.messageQueue.wakeupRequested());
         assertEquals(OptionalLong.of(lingerMs), context.messageQueue.lastPollTimeoutMs());
 
@@ -1423,7 +1422,7 @@ class KafkaRaftClientTest {
         context.client.schedulePreparedAppend();
         assertTrue(context.messageQueue.wakeupRequested());
 
-        context.client.poll();
+        context.poll();
         assertEquals(3L, context.log.endOffset().offset());
     }
 
@@ -1451,7 +1450,7 @@ class KafkaRaftClientTest {
         context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.NONE, leaderEpoch, OptionalInt.of(oldLeaderId));
 
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
         context.assertElectedLeader(leaderEpoch, oldLeaderId);
     }
@@ -1484,14 +1483,14 @@ class KafkaRaftClientTest {
         // The election won't trigger by one round retry backoff
         context.time.sleep(1);
 
-        context.client.poll();
+        context.poll();
         context.assertSentFetchRequest(leaderEpoch, 0, 0, OptionalLong.empty());
 
         context.time.sleep(context.electionBackoffMaxMs);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
-        context.client.poll();
+        context.poll();
         List<RaftRequest.Outbound> voteRequests = context.collectPreVoteRequests(leaderEpoch, 0, 0);
         assertEquals(2, voteRequests.size());
 
@@ -1519,7 +1518,7 @@ class KafkaRaftClientTest {
         RaftRequest.Outbound request = context.assertSentVoteRequest(epoch, 0, 0L, 1);
 
         context.time.sleep(context.requestTimeoutMs());
-        context.client.poll();
+        context.poll();
         RaftRequest.Outbound retryRequest = context.assertSentVoteRequest(epoch, 0, 0L, 1);
 
         // We will ignore the timed out response if it arrives late
@@ -1528,7 +1527,7 @@ class KafkaRaftClientTest {
             request.destination(),
             context.voteResponse(true, OptionalInt.empty(), 1)
         );
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(epoch, localId);
 
         // Become leader after receiving the retry response
@@ -1537,7 +1536,7 @@ class KafkaRaftClientTest {
             retryRequest.destination(),
             context.voteResponse(true, OptionalInt.empty(), 1)
         );
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, localId);
     }
 
@@ -1621,7 +1620,7 @@ class KafkaRaftClientTest {
 
         // Sleep a little to ensure that we become a prospective
         context.time.sleep(context.fetchTimeoutMs);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeKey, epoch, 1));
@@ -1649,7 +1648,7 @@ class KafkaRaftClientTest {
 
         // Sleep a little to ensure that we become a prospective
         context.time.sleep(context.electionTimeoutMs() * 2L);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspectiveAndVoted());
         context.assertVotedCandidate(epoch, votedCandidateKey.id());
 
@@ -1718,7 +1717,7 @@ class KafkaRaftClientTest {
 
         context.deliverRequest(context.voteRequest(leaderEpoch, otherNodeKey, leaderEpoch - 1, 1));
 
-        context.client.poll();
+        context.poll();
 
         context.assertSentVoteResponse(Errors.NONE, leaderEpoch, OptionalInt.of(localId), false);
         context.assertElectedLeader(leaderEpoch, localId);
@@ -1740,7 +1739,7 @@ class KafkaRaftClientTest {
         int epoch = context.currentEpoch();
 
         // First poll has no high watermark advance
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.empty(), context.client.highWatermark());
         assertEquals(1L, context.log.endOffset().offset());
 
@@ -1754,7 +1753,7 @@ class KafkaRaftClientTest {
         List<String> records = List.of("a", "b", "c");
         long offset = context.client.prepareAppend(epoch, records);
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(0L), context.listener.lastCommitOffset());
 
         // Let the follower send a fetch, it should advance the high watermark
@@ -1791,7 +1790,7 @@ class KafkaRaftClientTest {
 
         // Send a fetch request for an end offset and epoch which has diverged
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 6, 2, 500));
-        context.client.poll();
+        context.poll();
 
         // Expect that the leader replies immediately with a diverging epoch
         FetchResponseData.PartitionData partitionResponse = context.assertSentFetchPartitionResponse();
@@ -1818,7 +1817,7 @@ class KafkaRaftClientTest {
         context.pollUntilRequest();
 
         context.deliverRequest(context.voteRequest(leaderEpoch, otherNodeKey, leaderEpoch - 1, 1));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.NONE, leaderEpoch, OptionalInt.empty(), false);
         context.assertVotedCandidate(leaderEpoch, localId);
     }
@@ -1857,7 +1856,7 @@ class KafkaRaftClientTest {
             context.voteResponse(false, OptionalInt.empty(), 1)
         );
 
-        context.client.poll();
+        context.poll();
         assertTrue(candidate.epochElection().isVoteRejected());
 
         // Election is lost, but local replica should still remember that it has voted
@@ -1866,12 +1865,12 @@ class KafkaRaftClientTest {
         // Even though candidacy was rejected, local replica will backoff for remaining election timeout
         // before transitioning to prospective and starting a new election.
         context.time.sleep(context.electionTimeoutMs() + jitter - 1);
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(epoch, localId);
 
         // After election timeout expires, become a prospective again
         context.time.sleep(1);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
         ProspectiveState prospective = context.client.quorum().prospectiveStateOrThrow();
         context.pollUntilRequest();
@@ -1911,7 +1910,7 @@ class KafkaRaftClientTest {
 
         // If election times out, replica transition to prospective without any additional backoff
         context.time.sleep(candidate.remainingElectionTimeMs(context.time.milliseconds()));
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         ProspectiveState prospective = context.client.quorum().prospectiveStateOrThrow();
@@ -1984,9 +1983,9 @@ class KafkaRaftClientTest {
         context.assertSentFetchRequest(epoch, 1L, lastEpoch, OptionalLong.empty());
 
         context.time.sleep(context.fetchTimeoutMs);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
-        context.client.poll();
+        context.poll();
         context.assertSentPreVoteRequest(epoch, lastEpoch, 1L, 1);
     }
 
@@ -2084,7 +2083,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderNodeId, MemoryRecords.EMPTY, 0L, responseError)
         );
 
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isFollower());
     }
 
@@ -2112,7 +2111,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, leaderId);
     }
 
@@ -2143,7 +2142,7 @@ class KafkaRaftClientTest {
             fetchRequest.destination(),
             context.fetchResponse(-1, -1, MemoryRecords.EMPTY, -1, Errors.UNKNOWN_SERVER_ERROR)
         );
-        context.client.poll();
+        context.poll();
 
         context.time.sleep(context.retryBackoffMs);
         context.pollUntilRequest();
@@ -2157,7 +2156,7 @@ class KafkaRaftClientTest {
             fetchRequest.destination(),
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
-        context.client.poll();
+        context.poll();
 
         context.assertElectedLeader(epoch, leaderId);
     }
@@ -2194,7 +2193,7 @@ class KafkaRaftClientTest {
         );
 
         // unattached observer becomes a follower after discovering leader
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, leaderId);
     }
 
@@ -2217,7 +2216,7 @@ class KafkaRaftClientTest {
             .withKip853Rpc(withKip853Rpc)
             .build();
 
-        context.client.poll();
+        context.poll();
 
         // observer will send fetch to the leader
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
@@ -2226,7 +2225,7 @@ class KafkaRaftClientTest {
 
         // if request times out, observer will retry to a bootstrap server
         context.time.sleep(context.requestTimeoutMs());
-        context.client.poll();
+        context.poll();
         fetchRequest = context.assertSentFetchRequest();
         assertNotEquals(leaderId, fetchRequest.destination().id());
         assertTrue(context.bootstrapIds.contains(fetchRequest.destination().id()));
@@ -2234,7 +2233,7 @@ class KafkaRaftClientTest {
 
         // observer will retry to the leader
         context.time.sleep(context.requestTimeoutMs());
-        context.client.poll();
+        context.poll();
         fetchRequest = context.assertSentFetchRequest();
         assertEquals(leaderId, fetchRequest.destination().id());
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0, context.client.highWatermark());
@@ -2274,7 +2273,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, leaderId);
 
         // Expect a fetch request to the leader
@@ -2300,7 +2299,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderId, records, 0L, Errors.NONE)
         );
 
-        context.client.poll();
+        context.poll();
 
         // Deliver the same delayed responses from the bootstrap server and assume that it is the leader
         records = context.buildBatch(0L, 3, List.of("a", "b"));
@@ -2311,7 +2310,7 @@ class KafkaRaftClientTest {
         );
 
         // This poll should not fail when handling the duplicate response from the bootstrap server
-        context.client.poll();
+        context.poll();
     }
 
     @ParameterizedTest
@@ -2348,7 +2347,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch, leaderId);
 
         // Expect a fetch request to the leader
@@ -2369,7 +2368,7 @@ class KafkaRaftClientTest {
         // At this point toLeaderFetchRequest has timed out but retryToBootstrapServerFetchRequest
         // is still waiting for a response.
         // Confirm that no new fetch request has been sent
-        context.client.poll();
+        context.poll();
         assertFalse(context.channel.hasSentRequests());
     }
 
@@ -2434,7 +2433,7 @@ class KafkaRaftClientTest {
         context.unattachedToLeader();
 
         // First poll has no high watermark advance.
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.empty(), context.client.highWatermark());
         assertEquals(1L, context.log.endOffset().offset());
 
@@ -2712,11 +2711,11 @@ class KafkaRaftClientTest {
 
         ReplicaKey observerKey = replicaKey(localId + 2, withKip853Rpc);
         context.deliverRequest(context.voteRequest(epoch - 1, observerKey, 0, 0));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.FENCED_LEADER_EPOCH, epoch, OptionalInt.of(localId), false);
 
         context.deliverRequest(context.voteRequest(epoch, observerKey, 0, 0));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.of(localId), false);
     }
 
@@ -2783,12 +2782,12 @@ class KafkaRaftClientTest {
         // Follower sends a fetch which cannot be satisfied immediately
         int maxWaitTimeMs = 500;
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 1L, epoch, maxWaitTimeMs));
-        context.client.poll();
+        context.poll();
         assertEquals(0, context.channel.drainSendQueue().size());
 
         // After expiration of the max wait time, the fetch returns an empty record set
         context.time.sleep(maxWaitTimeMs);
-        context.client.poll();
+        context.poll();
         MemoryRecords fetchedRecords = context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(localId));
         assertEquals(0, fetchedRecords.sizeInBytes());
     }
@@ -2810,14 +2809,14 @@ class KafkaRaftClientTest {
 
         // Follower sends a fetch which cannot be satisfied immediately
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 1L, epoch, 500));
-        context.client.poll();
+        context.poll();
         assertEquals(0, context.channel.drainSendQueue().size());
 
         // Append some records that can fulfill the Fetch request
         String[] appendRecords = new String[]{"a", "b", "c"};
         context.client.prepareAppend(epoch, List.of(appendRecords));
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
 
         MemoryRecords fetchedRecords = context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(localId));
         RaftClientTestContext.assertMatchingRecords(appendRecords, fetchedRecords);
@@ -2841,7 +2840,7 @@ class KafkaRaftClientTest {
 
         // Follower sends a fetch which cannot be satisfied immediately
         context.deliverRequest(context.fetchRequest(epoch, voterKey2, 1L, epoch, 500));
-        context.client.poll();
+        context.poll();
         assertTrue(context.channel.drainSendQueue().stream()
             .noneMatch(msg -> msg.data() instanceof FetchResponseData));
 
@@ -2880,7 +2879,7 @@ class KafkaRaftClientTest {
 
         // Now await the fetch timeout and become prospective
         context.time.sleep(context.fetchTimeoutMs);
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isProspective());
 
         // The fetch response from the old leader returns, but it should be ignored
@@ -2891,7 +2890,7 @@ class KafkaRaftClientTest {
             context.fetchResponse(epoch, otherNodeId, records, 0L, Errors.NONE)
         );
 
-        context.client.poll();
+        context.poll();
         assertEquals(0, context.log.endOffset().offset());
         context.expectAndGrantPreVotes(epoch);
     }
@@ -2920,7 +2919,7 @@ class KafkaRaftClientTest {
 
         // Now receive a BeginEpoch from `voter3`
         context.deliverRequest(context.beginEpochRequest(epoch + 1, voter3));
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(epoch + 1, voter3);
 
         // The fetch response from the old leader returns, but it should be ignored
@@ -2932,7 +2931,7 @@ class KafkaRaftClientTest {
             response
         );
 
-        context.client.poll();
+        context.poll();
         assertEquals(0, context.log.endOffset().offset());
         context.assertElectedLeader(epoch + 1, voter3);
     }
@@ -2961,7 +2960,7 @@ class KafkaRaftClientTest {
 
         // While the vote requests are still inflight, we receive a BeginEpoch for the same epoch
         context.deliverRequest(context.beginEpochRequest(epoch + 1, voter3));
-        context.client.poll();
+        context.poll();
         context.assertElectedLeaderAndVotedKey(
             epoch + 1,
             voter3,
@@ -2983,7 +2982,7 @@ class KafkaRaftClientTest {
             voteResponse2
         );
 
-        context.client.poll();
+        context.poll();
         context.assertElectedLeaderAndVotedKey(
             epoch + 1,
             voter3,
@@ -3109,7 +3108,7 @@ class KafkaRaftClientTest {
             fetchRequest2.destination(),
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.NOT_LEADER_OR_FOLLOWER)
         );
-        context.client.poll();
+        context.poll();
 
         context.assertElectedLeader(epoch, leaderId);
     }
@@ -3154,7 +3153,7 @@ class KafkaRaftClientTest {
             fetchRequest2.destination(),
             context.fetchResponse(epoch, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
-        context.client.poll();
+        context.poll();
 
         context.assertElectedLeader(epoch, leaderId);
     }
@@ -3191,14 +3190,14 @@ class KafkaRaftClientTest {
         // We should still be able to handle vote requests during graceful shutdown
         // in order to help the new leader get elected
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeKey, epoch, 1L));
-        context.client.poll();
+        context.poll();
         context.assertSentVoteResponse(Errors.NONE, epoch + 1, OptionalInt.empty(), true);
 
         // Graceful shutdown completes when a new leader is elected
         context.deliverRequest(context.beginEpochRequest(2, otherNodeKey.id()));
 
         TestUtils.waitForCondition(() -> {
-            context.client.poll();
+            context.poll();
             return !context.client.isRunning();
         }, 5000, "Client failed to shutdown before expiration of timeout");
         assertFalse(context.client.isShuttingDown());
@@ -3229,7 +3228,7 @@ class KafkaRaftClientTest {
         // Append some records, so that the close follower will be able to advance further.
         context.client.prepareAppend(epoch, List.of("foo", "bar"));
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
 
         context.deliverRequest(context.fetchRequest(epoch, closeFollower, 3L, epoch, 0));
         context.pollUntilResponse();
@@ -3391,7 +3390,7 @@ class KafkaRaftClientTest {
         long nextFetchOffset = fetchOffset + records.size();
         context.client.prepareAppend(epoch, records);
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
 
         context.time.sleep(100);
         context.deliverRequest(context.describeQuorumRequest());
@@ -3531,7 +3530,7 @@ class KafkaRaftClientTest {
         List<String> records = List.of("foo", "bar");
         context.client.prepareAppend(epoch, records);
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
 
         context.deliverRequest(context.describeQuorumRequest());
         context.pollUntilResponse();
@@ -3607,7 +3606,7 @@ class KafkaRaftClientTest {
         List<String> batch = List.of("foo", "bar");
         context.client.prepareAppend(epoch, batch);
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
         long fetchOffset = withBootstrapSnapshot ? 5L : 3L;
         long followerFetchTime = context.time.milliseconds();
         context.deliverRequest(context.fetchRequest(epoch, follower, fetchOffset, epoch, 0));
@@ -3714,7 +3713,7 @@ class KafkaRaftClientTest {
 
         // Now shutdown
         int shutdownTimeoutMs = 5000;
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
+        var shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
         assertTrue(context.client.isRunning());
@@ -3729,7 +3728,7 @@ class KafkaRaftClientTest {
         // The shutdown timeout is hit before we receive any requests or responses indicating an epoch bump
         context.time.sleep(shutdownTimeoutMs);
 
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.isRunning());
         assertTrue(shutdownFuture.isCompletedExceptionally());
         assertFutureThrows(TimeoutException.class, shutdownFuture);
@@ -3749,14 +3748,14 @@ class KafkaRaftClientTest {
             .build();
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.client.poll();
+        context.poll();
 
         int shutdownTimeoutMs = 5000;
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
+        var shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
         assertTrue(context.client.isRunning());
         assertFalse(shutdownFuture.isDone());
 
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.isRunning());
         assertTrue(shutdownFuture.isDone());
         assertNull(shutdownFuture.get());
@@ -3774,16 +3773,16 @@ class KafkaRaftClientTest {
             .withUnknownLeader(5)
             .withKip853Rpc(withKip853Rpc)
             .build();
-        context.client.poll();
+        context.poll();
         context.assertUnknownLeaderAndNoVotedCandidate(5);
 
         // Observer shutdown should complete immediately even if the
         // current leader is unknown
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(5000).toCompletableFuture();
+        var shutdownFuture = context.client.shutdown(5000).toCompletableFuture();
         assertTrue(context.client.isRunning());
         assertFalse(shutdownFuture.isDone());
 
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.isRunning());
         assertTrue(shutdownFuture.isDone());
         assertNull(shutdownFuture.get());
@@ -3798,12 +3797,12 @@ class KafkaRaftClientTest {
             .build();
 
         context.assertElectedLeader(1, localId);
-        context.client.poll();
+        context.poll();
         assertEquals(0, context.channel.drainSendQueue().size());
         int shutdownTimeoutMs = 5000;
         context.client.shutdown(shutdownTimeoutMs);
         assertTrue(context.client.isRunning());
-        context.client.poll();
+        context.poll();
         assertFalse(context.client.isRunning());
     }
 
@@ -3832,7 +3831,7 @@ class KafkaRaftClientTest {
             response
         );
 
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
         assertEquals(2L, context.log.firstUnflushedOffset());
     }
@@ -3863,7 +3862,7 @@ class KafkaRaftClientTest {
             response
         );
 
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
         long firstUnflushedOffset = canBecomeVoter ? 2L : 0L;
         assertEquals(firstUnflushedOffset, context.log.firstUnflushedOffset());
@@ -3898,7 +3897,7 @@ class KafkaRaftClientTest {
             fetchQuorumRequest.destination(),
             fetchResponse
         );
-        context.client.poll();
+        context.poll();
         assertEquals(0L, context.log.endOffset().offset());
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
 
@@ -3912,7 +3911,7 @@ class KafkaRaftClientTest {
             fetchQuorumRequest.destination(),
             fetchResponse
         );
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
 
@@ -3931,7 +3930,7 @@ class KafkaRaftClientTest {
             fetchQuorumRequest.destination(),
             fetchResponse
         );
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
         assertEquals(OptionalLong.of(2L), context.client.highWatermark());
     }
@@ -3960,13 +3959,13 @@ class KafkaRaftClientTest {
 
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 0L, 0, 500));
 
-        context.client.poll();
+        context.poll();
 
         // The BeginEpoch request eventually times out. We should not send another one.
         context.assertSentFetchPartitionResponse(Errors.NONE, epoch, OptionalInt.of(localId));
         context.time.sleep(context.requestTimeoutMs());
 
-        context.client.poll();
+        context.poll();
 
         List<RaftRequest.Outbound> sentMessages = context.channel.drainSendQueue();
         assertEquals(0, sentMessages.size());
@@ -3992,14 +3991,14 @@ class KafkaRaftClientTest {
         String[] appendRecords = new String[]{"a", "b", "c"};
 
         // First poll has no high watermark advance
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(1L), context.client.highWatermark());
 
         context.client.prepareAppend(context.currentEpoch(), List.of(appendRecords));
         context.client.schedulePreparedAppend();
 
         // Then poll the appended data with leader change record
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(4L), context.client.highWatermark());
 
         // Now try reading it
@@ -4087,12 +4086,12 @@ class KafkaRaftClientTest {
         context.deliverResponse(request.correlationId(), request.destination(), response);
 
         // Poll again to complete truncation
-        context.client.poll();
+        context.poll();
         assertEquals(2L, context.log.endOffset().offset());
         assertEquals(2L, context.log.firstUnflushedOffset());
 
         // Now we should be fetching
-        context.client.poll();
+        context.poll();
         context.assertSentFetchRequest(epoch, 2L, lastEpoch, context.client.highWatermark());
     }
 
@@ -4128,7 +4127,7 @@ class KafkaRaftClientTest {
 
         context.client.prepareAppend(epoch, List.of("a", "b", "c"));
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
 
         assertEquals(4L, getMetric(context.metrics, "high-watermark").metricValue());
         assertEquals(4L, getMetric(context.metrics, "log-end-offset").metricValue());
@@ -4154,7 +4153,7 @@ class KafkaRaftClientTest {
             .build();
 
         context.unattachedToLeader();
-        context.client.poll();
+        context.poll();
         int epoch = context.currentEpoch();
 
         // After becoming leader, we expect the `LeaderChange` record to be appended.
@@ -4169,7 +4168,7 @@ class KafkaRaftClientTest {
         // be exposed until it is able to reach the start of the leader epoch,
         // so we are unable to deliver committed data or fire `handleLeaderChange`.
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 0L, 0, 0));
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalInt.empty(), context.listener.currentClaimedEpoch());
         assertEquals(OptionalLong.empty(), context.listener.lastCommitOffset());
 
@@ -4178,11 +4177,11 @@ class KafkaRaftClientTest {
         // listener. Note that the `LeaderChange` control record is included
         // in the committed batches.
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 1L, epoch, 0));
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(0), context.listener.lastCommitOffset());
 
         // Poll again now that the listener has caught up to the HWM
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalInt.of(epoch), context.listener.currentClaimedEpoch());
         assertEquals(0, context.listener.claimedEpochStartOffset(epoch));
     }
@@ -4211,7 +4210,7 @@ class KafkaRaftClientTest {
             .build();
 
         context.unattachedToLeader();
-        context.client.poll();
+        context.poll();
 
         // After becoming leader, we expect the `LeaderChange` record to be appended
         // in addition to the initial 9 records in the log.
@@ -4226,7 +4225,7 @@ class KafkaRaftClientTest {
         // be exposed until it is able to reach the start of the leader epoch,
         // so we are unable to deliver committed data or fire `handleLeaderChange`.
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 3L, 1, 500));
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalInt.empty(), context.listener.currentClaimedEpoch());
         assertEquals(OptionalLong.empty(), context.listener.lastCommitOffset());
 
@@ -4277,7 +4276,7 @@ class KafkaRaftClientTest {
             .build();
 
         context.unattachedToLeader();
-        context.client.poll();
+        context.poll();
         assertEquals(10L, context.log.endOffset().offset());
 
         // Let the initial listener catch up
@@ -4320,7 +4319,7 @@ class KafkaRaftClientTest {
             .build();
 
         context.unattachedToLeader();
-        context.client.poll();
+        context.poll();
         assertEquals(10L, context.log.endOffset().offset());
 
         // Let the initial listener catch up
@@ -4336,7 +4335,7 @@ class KafkaRaftClientTest {
         // Write to the log and show that the default listener gets updated...
         assertEquals(10L, context.client.prepareAppend(epoch, List.of("a")));
         context.client.schedulePreparedAppend();
-        context.client.poll();
+        context.poll();
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
         context.pollUntil(() -> OptionalLong.of(10).equals(context.listener.lastCommitOffset()));
         // ... but unregister listener doesn't
@@ -4371,7 +4370,7 @@ class KafkaRaftClientTest {
             fetchRequest.destination(),
             context.fetchResponse(epoch, otherNodeId, batch1, 0L, Errors.NONE)
         );
-        context.client.poll();
+        context.poll();
 
         // The listener should not have seen any data
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
@@ -4392,7 +4391,7 @@ class KafkaRaftClientTest {
             fetchRequest.destination(),
             context.fetchResponse(epoch, otherNodeId, batch2, 3L, Errors.NONE)
         );
-        context.client.poll();
+        context.poll();
 
         // The listener should have seen only the data from the first batch
         assertEquals(OptionalLong.of(3L), context.client.highWatermark());
@@ -4423,7 +4422,7 @@ class KafkaRaftClientTest {
         // Start off as the leader and receive a fetch to initialize the high watermark
         context.unattachedToLeader();
         context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 10L, epoch, 500));
-        context.client.poll();
+        context.poll();
         assertEquals(OptionalLong.of(10L), context.client.highWatermark());
 
         // Now we receive a vote request which transitions us to the 'voted' state
@@ -4438,7 +4437,7 @@ class KafkaRaftClientTest {
             OptionalInt.of(localId)
         );
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(candidateEpoch, otherNodeKey.id());
 
         // Note the offset is 9 because from offsets 0 to 8 there are data records,
@@ -4485,7 +4484,7 @@ class KafkaRaftClientTest {
         // Timeout the election and become prospective then candidate
         context.unattachedToCandidate();
         int candidateEpoch = epoch + 2;
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(candidateEpoch, localId);
 
         // Register another listener and verify that it catches up
@@ -4493,7 +4492,7 @@ class KafkaRaftClientTest {
             OptionalInt.of(localId)
         );
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
         context.assertVotedCandidate(candidateEpoch, localId);
 
         // Note the offset is 9 because from offsets 0 to 8 there are data records,
@@ -4527,7 +4526,7 @@ class KafkaRaftClientTest {
             OptionalInt.of(localId)
         );
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
 
         // Expected leader change notification
         LeaderAndEpoch expectedLeaderAndEpoch = new LeaderAndEpoch(OptionalInt.empty(), epoch);
@@ -4562,7 +4561,7 @@ class KafkaRaftClientTest {
             OptionalInt.of(localId)
         );
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
 
         LeaderAndEpoch expectedLeaderAndEpoch = new LeaderAndEpoch(OptionalInt.of(otherNodeId), epoch);
         assertEquals(expectedLeaderAndEpoch, secondListener.currentLeaderAndEpoch());
@@ -4583,7 +4582,7 @@ class KafkaRaftClientTest {
             .withKip853Rpc(withKip853Rpc)
             .build();
 
-        context.client.poll();
+        context.poll();
         assertTrue(context.client.quorum().isResigned());
         assertEquals(LeaderAndEpoch.UNKNOWN, context.listener.currentLeaderAndEpoch());
 
@@ -4592,7 +4591,7 @@ class KafkaRaftClientTest {
             OptionalInt.of(localId)
         );
         context.client.register(secondListener);
-        context.client.poll();
+        context.poll();
 
         assertTrue(context.client.quorum().isResigned());
         assertEquals(LeaderAndEpoch.UNKNOWN, secondListener.currentLeaderAndEpoch());
@@ -4629,7 +4628,7 @@ class KafkaRaftClientTest {
             fetchRequest1.destination(),
             context.fetchResponse(5, leaderId, MemoryRecords.EMPTY, 0L, Errors.FENCED_LEADER_EPOCH)
         );
-        context.client.poll();
+        context.poll();
         context.assertElectedLeader(leaderEpoch, leaderId);
 
         // Second fetch goes to the discovered leader
@@ -4646,7 +4645,7 @@ class KafkaRaftClientTest {
             fetchRequest2.destination(),
             context.fetchResponse(leaderEpoch, leaderId, batch1, 0L, Errors.NONE)
         );
-        context.client.poll();
+        context.poll();
         assertEquals(3L, context.log.endOffset().offset());
         assertEquals(3, context.log.lastFetchedEpoch());
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -3175,7 +3175,7 @@ class KafkaRaftClientTest {
 
         // Now shutdown
         int shutdownTimeoutMs = 5000;
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs);
+        var shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
         assertTrue(context.client.isShuttingDown());
@@ -3714,7 +3714,7 @@ class KafkaRaftClientTest {
 
         // Now shutdown
         int shutdownTimeoutMs = 5000;
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs);
+        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
 
         // We should still be running until we have had a chance to send EndQuorumEpoch
         assertTrue(context.client.isRunning());
@@ -3752,7 +3752,7 @@ class KafkaRaftClientTest {
         context.client.poll();
 
         int shutdownTimeoutMs = 5000;
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs);
+        CompletableFuture<Void> shutdownFuture = context.client.shutdown(shutdownTimeoutMs).toCompletableFuture();
         assertTrue(context.client.isRunning());
         assertFalse(shutdownFuture.isDone());
 
@@ -3779,7 +3779,7 @@ class KafkaRaftClientTest {
 
         // Observer shutdown should complete immediately even if the
         // current leader is unknown
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(5000);
+        CompletableFuture<Void> shutdownFuture = context.client.shutdown(5000).toCompletableFuture();
         assertTrue(context.client.isRunning());
         assertFalse(shutdownFuture.isDone());
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -1405,13 +1405,12 @@ public class RaftEventSimulationTest {
             cluster.nodeIfRunning(destination.id()).ifPresent(node -> {
                 inflight.put(correlationId, new InflightRequest(senderId, destination));
 
-                inbound.completion.whenComplete((response, exception) -> {
+                node.client.handle(inbound).whenComplete((response, exception) -> {
                     if (response != null && filters.get(destination.id()).acceptOutbound(response)) {
                         deliver(response);
                     }
                 });
 
-                node.client.handle(inbound);
             });
         }
 

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.raft.RaftMessage;
-import org.apache.kafka.raft.RaftMessageQueue;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -37,19 +36,25 @@ class BlockingMessageQueueTest {
         assertTrue(queue.isEmpty());
         assertEquals(Optional.empty(), queue.poll(0));
 
-        var message1 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
-        queue.add(message1);
+        var mockMessage1 = Mockito.mock(RaftMessage.class);
+        queue.add(mockMessage1);
         assertFalse(queue.isEmpty());
-        assertEquals(Optional.of(message1), queue.poll(0));
+        var entry1 = queue.poll(0);
+        assertTrue(entry1.isPresent());
+        assertEquals(mockMessage1, entry1.get().message());
         assertTrue(queue.isEmpty());
 
-        var message2 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
-        var message3 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
-        queue.add(message2);
-        queue.add(message3);
+        var mockMessage2 = Mockito.mock(RaftMessage.class);
+        var mockMessage3 = Mockito.mock(RaftMessage.class);
+        queue.add(mockMessage2);
+        queue.add(mockMessage3);
         assertFalse(queue.isEmpty());
-        assertEquals(Optional.of(message2), queue.poll(0));
-        assertEquals(Optional.of(message3), queue.poll(0));
+        var entry2 = queue.poll(0);
+        var entry3 = queue.poll(0);
+        assertTrue(entry2.isPresent());
+        assertTrue(entry3.isPresent());
+        assertEquals(mockMessage2, entry2.get().message());
+        assertEquals(mockMessage3, entry3.get().message());
 
     }
 
@@ -70,40 +75,36 @@ class BlockingMessageQueueTest {
         assertTrue(queue.isEmpty());
 
         // Adding a real message makes the queue non-empty
-        var message = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
-        queue.add(message);
+        var mockMessage = Mockito.mock(RaftMessage.class);
+        queue.add(mockMessage);
         assertFalse(queue.isEmpty());
 
         // Poll should drain all wakeups and return the message in one call
-        assertEquals(Optional.of(message), queue.poll(0));
+        var entry = queue.poll(0);
+        assertTrue(entry.isPresent());
+        assertEquals(mockMessage, entry.get().message());
         assertTrue(queue.isEmpty());
     }
 
     @Test
-    public void testAddRejectsNullEntryOrMessage() {
+    public void testAddRejectsNullMessage() {
         var queue = new BlockingMessageQueue();
 
-        // Null entry should be rejected
+        // Null message should be rejected
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
             () -> queue.add(null)
         );
-        assertTrue(exception.getMessage().contains("Either entry or entry.message is null"));
+        assertTrue(exception.getMessage().contains("message cannot be null"));
         assertTrue(queue.isEmpty());
 
-        // Entry with null message should be rejected
-        exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> queue.add(new RaftMessageQueue.QueueEntry(null))
-        );
-        assertTrue(exception.getMessage().contains("Either entry or entry.message is null"));
-        assertTrue(queue.isEmpty());
-
-        // Valid entry should succeed
-        var validMessage = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
+        // Valid message should succeed
+        var validMessage = Mockito.mock(RaftMessage.class);
         queue.add(validMessage);
         assertFalse(queue.isEmpty());
-        assertEquals(Optional.of(validMessage), queue.poll(0));
+        var entry = queue.poll(0);
+        assertTrue(entry.isPresent());
+        assertEquals(validMessage, entry.get().message());
         assertTrue(queue.isEmpty());
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockingMessageQueueTest {
@@ -75,6 +76,34 @@ class BlockingMessageQueueTest {
 
         // Poll should drain all wakeups and return the message in one call
         assertEquals(Optional.of(message), queue.poll(0));
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void testAddRejectsNullEntryOrMessage() {
+        var queue = new BlockingMessageQueue();
+
+        // Null entry should be rejected
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> queue.add(null)
+        );
+        assertTrue(exception.getMessage().contains("Either entry or entry.message is null"));
+        assertTrue(queue.isEmpty());
+
+        // Entry with null message should be rejected
+        exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> queue.add(new RaftMessageQueue.QueueEntry(null))
+        );
+        assertTrue(exception.getMessage().contains("Either entry or entry.message is null"));
+        assertTrue(queue.isEmpty());
+
+        // Valid entry should succeed
+        var validMessage = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
+        queue.add(validMessage);
+        assertFalse(queue.isEmpty());
+        assertEquals(Optional.of(validMessage), queue.poll(0));
         assertTrue(queue.isEmpty());
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
@@ -17,44 +17,64 @@
 package org.apache.kafka.raft.internals;
 
 import org.apache.kafka.raft.RaftMessage;
+import org.apache.kafka.raft.RaftMessageQueue;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockingMessageQueueTest {
 
     @Test
     public void testOfferAndPoll() {
-        BlockingMessageQueue queue = new BlockingMessageQueue();
+        var queue = new BlockingMessageQueue();
         assertTrue(queue.isEmpty());
-        assertNull(queue.poll(0));
+        assertEquals(Optional.empty(), queue.poll(0));
 
-        RaftMessage message1 = Mockito.mock(RaftMessage.class);
+        var message1 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
         queue.add(message1);
         assertFalse(queue.isEmpty());
-        assertEquals(message1, queue.poll(0));
+        assertEquals(Optional.of(message1), queue.poll(0));
         assertTrue(queue.isEmpty());
 
-        RaftMessage message2 = Mockito.mock(RaftMessage.class);
-        RaftMessage message3 = Mockito.mock(RaftMessage.class);
+        var message2 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
+        var message3 = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
         queue.add(message2);
         queue.add(message3);
         assertFalse(queue.isEmpty());
-        assertEquals(message2, queue.poll(0));
-        assertEquals(message3, queue.poll(0));
+        assertEquals(Optional.of(message2), queue.poll(0));
+        assertEquals(Optional.of(message3), queue.poll(0));
 
     }
 
     @Test
     public void testWakeupFromPoll() {
-        BlockingMessageQueue queue = new BlockingMessageQueue();
+        var queue = new BlockingMessageQueue();
         queue.wakeup();
-        assertNull(queue.poll(Long.MAX_VALUE));
+        assertEquals(Optional.empty(), queue.poll(Long.MAX_VALUE));
     }
 
+    @Test
+    public void testWakeupsAreTransparentToIsEmptyAndDrainedOnPoll() {
+        var queue = new BlockingMessageQueue();
+
+        // Wakeups alone should not affect isEmpty
+        queue.wakeup();
+        queue.wakeup();
+        assertTrue(queue.isEmpty());
+
+        // Adding a real message makes the queue non-empty
+        var message = new RaftMessageQueue.QueueEntry(Mockito.mock(RaftMessage.class));
+        queue.add(message);
+        assertFalse(queue.isEmpty());
+
+        // Poll should drain all wakeups and return the message in one call
+        assertEquals(Optional.of(message), queue.poll(0));
+        assertTrue(queue.isEmpty());
+    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/ChangeVoterHandlerStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/ChangeVoterHandlerStateTest.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.AddRaftVoterResponseData;
+import org.apache.kafka.common.message.RemoveRaftVoterResponseData;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.raft.Endpoints;
+import org.apache.kafka.raft.ReplicaKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ChangeVoterHandlerStateTest {
+
+    private KafkaMetric getMetric(Metrics metrics, String name) {
+        return metrics.metrics().get(metrics.metricName(name, "raft-metrics"));
+    }
+
+    @Test
+    public void testAddVoterLifecycle() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            ReplicaKey voterKey = ReplicaKey.of(1, Uuid.randomUuid());
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                voterKey,
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            CompletableFuture<AddRaftVoterResponseData> future = addVoterState.future();
+
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+            assertTrue(state.addVoterHandlerState().isPresent());
+            assertEquals(addVoterState, state.addVoterHandlerState().get());
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            assertFalse(future.isDone());
+            state.resetAddVoterHandlerState(Errors.INVALID_REQUEST, "test error", Optional.empty());
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            assertTrue(future.isDone());
+            assertEquals(Errors.INVALID_REQUEST, Errors.forCode(future.join().errorCode()));
+            assertEquals("test error", future.join().errorMessage());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testRemoveVoterLifecycle() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            assertFalse(state.removeVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            RemoveVoterHandlerState removeVoterState = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+            CompletableFuture<RemoveRaftVoterResponseData> future = removeVoterState.future();
+
+            state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(removeVoterState));
+            assertTrue(state.removeVoterHandlerState().isPresent());
+            assertEquals(removeVoterState, state.removeVoterHandlerState().get());
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            assertFalse(future.isDone());
+            state.resetRemoveVoterHandlerState(Errors.INVALID_REQUEST, "test error", Optional.empty());
+            assertFalse(state.removeVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            assertTrue(future.isDone());
+            assertEquals(Errors.INVALID_REQUEST, Errors.forCode(future.join().errorCode()));
+            assertEquals("test error", future.join().errorMessage());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testMaybeExpirePendingAddVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            assertEquals(Long.MAX_VALUE, state.maybeExpirePendingOperation(time.milliseconds()));
+
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+
+            time.sleep(500);
+            assertEquals(500, state.maybeExpirePendingOperation(time.milliseconds()));
+            assertTrue(state.addVoterHandlerState().isPresent());
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            time.sleep(500);
+            assertEquals(Long.MAX_VALUE, state.maybeExpirePendingOperation(time.milliseconds()));
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+            assertTrue(addVoterState.future().isDone());
+            assertEquals(Errors.REQUEST_TIMED_OUT, Errors.forCode(addVoterState.future().join().errorCode()));
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testMaybeExpirePendingRemoveVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            RemoveVoterHandlerState removeVoterState = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+            state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(removeVoterState));
+
+            time.sleep(500);
+            assertEquals(500, state.maybeExpirePendingOperation(time.milliseconds()));
+            assertTrue(state.removeVoterHandlerState().isPresent());
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            time.sleep(500);
+            assertEquals(Long.MAX_VALUE, state.maybeExpirePendingOperation(time.milliseconds()));
+            assertFalse(state.removeVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+            assertTrue(removeVoterState.future().isDone());
+            assertEquals(Errors.REQUEST_TIMED_OUT, Errors.forCode(removeVoterState.future().join().errorCode()));
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testIsOperationPendingWithAddVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            assertFalse(state.isOperationPending(time.milliseconds()));
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+
+            assertTrue(state.isOperationPending(time.milliseconds()));
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            time.sleep(1000);
+            assertFalse(state.isOperationPending(time.milliseconds()));
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testIsOperationPendingWithRemoveVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            assertFalse(state.isOperationPending(time.milliseconds()));
+
+            RemoveVoterHandlerState removeVoterState = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+            state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(removeVoterState));
+
+            assertTrue(state.isOperationPending(time.milliseconds()));
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            time.sleep(1000);
+            assertFalse(state.isOperationPending(time.milliseconds()));
+            assertFalse(state.removeVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testMaybeResetPendingVoterHandlerState() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+
+            CompletableFuture<AddRaftVoterResponseData> addFuture = addVoterState.future();
+
+            assertFalse(addFuture.isDone());
+            assertEquals(1, getMetric(metrics, "uncommitted-voter-change").metricValue());
+
+            state.maybeResetPendingVoterHandlerState(Errors.NOT_LEADER_OR_FOLLOWER);
+
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertEquals(0, getMetric(metrics, "uncommitted-voter-change").metricValue());
+            assertTrue(addFuture.isDone());
+            assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, Errors.forCode(addFuture.join().errorCode()));
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testCannotSetAddVoterWhenRemoveVoterPresent() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            RemoveVoterHandlerState removeVoterState = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+            state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(removeVoterState));
+            assertTrue(state.removeVoterHandlerState().isPresent());
+
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+
+            assertThrows(IllegalStateException.class, () -> {
+                state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+            });
+
+            assertTrue(state.removeVoterHandlerState().isPresent());
+            assertFalse(state.addVoterHandlerState().isPresent());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testCannotSetRemoveVoterWhenAddVoterPresent() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            AddVoterHandlerState addVoterState = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(addVoterState));
+            assertTrue(state.addVoterHandlerState().isPresent());
+
+            RemoveVoterHandlerState removeVoterState = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+
+            assertThrows(IllegalStateException.class, () -> {
+                state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(removeVoterState));
+            });
+
+            assertTrue(state.addVoterHandlerState().isPresent());
+            assertFalse(state.removeVoterHandlerState().isPresent());
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testCanReplaceAddVoterWithAnotherAddVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            AddVoterHandlerState firstAddVoter = new AddVoterHandlerState(
+                ReplicaKey.of(1, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            CompletableFuture<AddRaftVoterResponseData> firstFuture = firstAddVoter.future();
+            state.resetAddVoterHandlerState(Errors.NONE, null, Optional.of(firstAddVoter));
+
+            AddVoterHandlerState secondAddVoter = new AddVoterHandlerState(
+                ReplicaKey.of(2, Uuid.randomUuid()),
+                Endpoints.empty(),
+                false,
+                time.timer(1000)
+            );
+            state.resetAddVoterHandlerState(Errors.OPERATION_NOT_ATTEMPTED, null, Optional.of(secondAddVoter));
+
+            assertTrue(state.addVoterHandlerState().isPresent());
+            assertEquals(secondAddVoter, state.addVoterHandlerState().get());
+            assertFalse(state.removeVoterHandlerState().isPresent());
+            assertTrue(firstFuture.isDone());
+            assertEquals(Errors.OPERATION_NOT_ATTEMPTED, Errors.forCode(firstFuture.join().errorCode()));
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    public void testCanReplaceRemoveVoterWithAnotherRemoveVoter() {
+        MockTime time = new MockTime();
+        Metrics metrics = new Metrics(time);
+        KafkaRaftMetrics raftMetrics = new KafkaRaftMetrics(metrics, "raft");
+        raftMetrics.addLeaderMetrics();
+
+        try {
+            ChangeVoterHandlerState state = new ChangeVoterHandlerState(raftMetrics);
+
+            RemoveVoterHandlerState firstRemoveVoter = new RemoveVoterHandlerState(
+                100L,
+                time.timer(1000)
+            );
+            CompletableFuture<RemoveRaftVoterResponseData> firstFuture = firstRemoveVoter.future();
+            state.resetRemoveVoterHandlerState(Errors.NONE, null, Optional.of(firstRemoveVoter));
+
+            RemoveVoterHandlerState secondRemoveVoter = new RemoveVoterHandlerState(
+                200L,
+                time.timer(1000)
+            );
+            state.resetRemoveVoterHandlerState(Errors.OPERATION_NOT_ATTEMPTED, null, Optional.of(secondRemoveVoter));
+
+            assertTrue(state.removeVoterHandlerState().isPresent());
+            assertEquals(secondRemoveVoter, state.removeVoterHandlerState().get());
+            assertFalse(state.addVoterHandlerState().isPresent());
+            assertTrue(firstFuture.isDone());
+            assertEquals(Errors.OPERATION_NOT_ATTEMPTED, Errors.forCode(firstFuture.join().errorCode()));
+        } finally {
+            raftMetrics.close();
+            metrics.close();
+        }
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/internals/ThresholdPurgatoryTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/ThresholdPurgatoryTest.java
@@ -23,8 +23,6 @@ import org.apache.kafka.raft.MockExpirationService;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
-
 import static org.apache.kafka.test.TestUtils.assertFutureThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,9 +35,9 @@ class ThresholdPurgatoryTest {
 
     @Test
     public void testThresholdCompletion() throws Exception {
-        CompletableFuture<Long> future1 = purgatory.await(3L, 500);
-        CompletableFuture<Long> future2 = purgatory.await(1L, 500);
-        CompletableFuture<Long> future3 = purgatory.await(5L, 500);
+        var future1 = purgatory.await(3L, 500).toCompletableFuture();
+        var future2 = purgatory.await(1L, 500).toCompletableFuture();
+        var future3 = purgatory.await(5L, 500).toCompletableFuture();
         assertEquals(3, purgatory.numWaiting());
 
         long completionTime1 = time.milliseconds();
@@ -77,14 +75,14 @@ class ThresholdPurgatoryTest {
 
     @Test
     public void testExpiration() {
-        CompletableFuture<Long> future1 = purgatory.await(1L, 200);
-        CompletableFuture<Long> future2 = purgatory.await(1L, 200);
+        var future1 = purgatory.await(1L, 200).toCompletableFuture();
+        var future2 = purgatory.await(1L, 200).toCompletableFuture();
         assertEquals(2, purgatory.numWaiting());
 
         time.sleep(100);
-        CompletableFuture<Long> future3 = purgatory.await(5L, 50);
-        CompletableFuture<Long> future4 = purgatory.await(5L, 200);
-        CompletableFuture<Long> future5 = purgatory.await(5L, 100);
+        var future3 = purgatory.await(5L, 50).toCompletableFuture();
+        var future4 = purgatory.await(5L, 200).toCompletableFuture();
+        var future5 = purgatory.await(5L, 100).toCompletableFuture();
         assertEquals(5, purgatory.numWaiting());
 
         time.sleep(50);
@@ -113,9 +111,9 @@ class ThresholdPurgatoryTest {
 
     @Test
     public void testCompleteAll() throws Exception {
-        CompletableFuture<Long> future1 = purgatory.await(3L, 500);
-        CompletableFuture<Long> future2 = purgatory.await(1L, 500);
-        CompletableFuture<Long> future3 = purgatory.await(5L, 500);
+        var future1 = purgatory.await(3L, 500).toCompletableFuture();
+        var future2 = purgatory.await(1L, 500).toCompletableFuture();
+        var future3 = purgatory.await(5L, 500).toCompletableFuture();
         assertEquals(3, purgatory.numWaiting());
 
         long completionTime = time.milliseconds();
@@ -128,9 +126,9 @@ class ThresholdPurgatoryTest {
 
     @Test
     public void testCompleteAllExceptionally() {
-        CompletableFuture<Long> future1 = purgatory.await(3L, 500);
-        CompletableFuture<Long> future2 = purgatory.await(1L, 500);
-        CompletableFuture<Long> future3 = purgatory.await(5L, 500);
+        var future1 = purgatory.await(3L, 500).toCompletableFuture();
+        var future2 = purgatory.await(1L, 500).toCompletableFuture();
+        var future3 = purgatory.await(5L, 500).toCompletableFuture();
         assertEquals(3, purgatory.numWaiting());
 
         purgatory.completeAllExceptionally(new NotLeaderOrFollowerException());
@@ -141,22 +139,68 @@ class ThresholdPurgatoryTest {
     }
 
     @Test
-    public void testExternalCompletion() {
-        CompletableFuture<Long> future1 = purgatory.await(3L, 500);
-        CompletableFuture<Long> future2 = purgatory.await(1L, 500);
-        CompletableFuture<Long> future3 = purgatory.await(5L, 500);
+    public void testMultipleAwaitersWithSameThreshold() throws Exception {
+        var future1 = purgatory.await(3L, 500).toCompletableFuture();
+        var future2 = purgatory.await(3L, 500).toCompletableFuture();
+        var future3 = purgatory.await(3L, 500).toCompletableFuture();
         assertEquals(3, purgatory.numWaiting());
 
-        future2.complete(time.milliseconds());
-        assertFalse(future1.isDone());
-        assertFalse(future3.isDone());
-        assertEquals(2, purgatory.numWaiting());
+        long completionTime = time.milliseconds();
+        purgatory.maybeComplete(3L, completionTime);
+        assertTrue(future1.isDone());
+        assertTrue(future2.isDone());
+        assertTrue(future3.isDone());
+        assertEquals(completionTime, future1.get());
+        assertEquals(completionTime, future2.get());
+        assertEquals(completionTime, future3.get());
+        assertEquals(0, purgatory.numWaiting());
+    }
 
-        future1.complete(time.milliseconds());
-        assertFalse(future3.isDone());
+    @Test
+    public void testMaybeCompleteWithHigherValue() throws Exception {
+        var future1 = purgatory.await(1L, 500).toCompletableFuture();
+        var future2 = purgatory.await(3L, 500).toCompletableFuture();
+        var future3 = purgatory.await(5L, 500).toCompletableFuture();
+        assertEquals(3, purgatory.numWaiting());
+
+        long completionTime = time.milliseconds();
+        purgatory.maybeComplete(10L, completionTime);
+        assertTrue(future1.isDone());
+        assertTrue(future2.isDone());
+        assertTrue(future3.isDone());
+        assertEquals(completionTime, future1.get());
+        assertEquals(completionTime, future2.get());
+        assertEquals(completionTime, future3.get());
+        assertEquals(0, purgatory.numWaiting());
+    }
+
+    @Test
+    public void testNumWaitingWithMixedCompletions() {
+        purgatory.await(1L, 500);
+        purgatory.await(2L, 500);
+        purgatory.await(3L, 500);
+        purgatory.await(4L, 500);
+        assertEquals(4, purgatory.numWaiting());
+
+        purgatory.maybeComplete(1L, time.milliseconds());
+        assertEquals(3, purgatory.numWaiting());
+
+        purgatory.maybeComplete(3L, time.milliseconds());
         assertEquals(1, purgatory.numWaiting());
 
-        future3.complete(time.milliseconds());
+        purgatory.completeAll(time.milliseconds());
+        assertEquals(0, purgatory.numWaiting());
+    }
+
+    @Test
+    public void testExpirationReducesWaitingCount() {
+        var future1 = purgatory.await(1L, 100).toCompletableFuture();
+        var future2 = purgatory.await(2L, 100).toCompletableFuture();
+        assertEquals(2, purgatory.numWaiting());
+
+        time.sleep(100);
+        assertFutureThrows(TimeoutException.class, future1);
+        assertFutureThrows(TimeoutException.class, future2);
         assertEquals(0, purgatory.numWaiting());
     }
 

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/MockMessageQueue.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/MockMessageQueue.java
@@ -20,6 +20,8 @@ import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,6 +33,34 @@ public class MockMessageQueue implements RaftMessageQueue {
     private final AtomicBoolean wakeupRequested = new AtomicBoolean(false);
     private final AtomicLong lastPollTimeout = new AtomicLong(-1);
 
+    private static final class MessageEntry implements QueueEntry {
+        private final CompletableFuture<RaftMessage> future = new CompletableFuture<>();
+        private final RaftMessage message;
+
+        MessageEntry(RaftMessage message) {
+            this.message = message;
+        }
+
+        @Override
+        public RaftMessage message() {
+            return message;
+        }
+
+        @Override
+        public CompletableFuture<RaftMessage> future() {
+            return future;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                "MessageEntry(message=%s, future.isDone=%s)",
+                message,
+                future.isDone()
+            );
+        }
+    }
+
     @Override
     public Optional<QueueEntry> poll(long timeoutMs) {
         wakeupRequested.set(false);
@@ -39,8 +69,10 @@ public class MockMessageQueue implements RaftMessageQueue {
     }
 
     @Override
-    public void add(QueueEntry message) {
-        messages.offer(message);
+    public CompletionStage<RaftMessage> add(RaftMessage message) {
+        MessageEntry entry = new MessageEntry(message);
+        messages.offer(entry);
+        return entry.future();
     }
 
     public OptionalLong lastPollTimeoutMs() {

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/MockMessageQueue.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/MockMessageQueue.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.raft;
 
 import java.util.ArrayDeque;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,19 +27,19 @@ import java.util.concurrent.atomic.AtomicLong;
  * Mocked implementation which does not block in {@link #poll(long)}..
  */
 public class MockMessageQueue implements RaftMessageQueue {
-    private final Queue<RaftMessage> messages = new ArrayDeque<>();
+    private final Queue<QueueEntry> messages = new ArrayDeque<>();
     private final AtomicBoolean wakeupRequested = new AtomicBoolean(false);
     private final AtomicLong lastPollTimeout = new AtomicLong(-1);
 
     @Override
-    public RaftMessage poll(long timeoutMs) {
+    public Optional<QueueEntry> poll(long timeoutMs) {
         wakeupRequested.set(false);
         lastPollTimeout.set(timeoutMs);
-        return messages.poll();
+        return Optional.ofNullable(messages.poll());
     }
 
     @Override
-    public void add(RaftMessage message) {
+    public void add(QueueEntry message) {
         messages.offer(message);
     }
 

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/MockNetworkChannel.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/MockNetworkChannel.java
@@ -95,7 +95,7 @@ public class MockNetworkChannel implements NetworkChannel {
         future.complete(response);
     }
 
-    private static record RequestEntry(
+    private record RequestEntry(
         RaftRequest.Outbound request,
         CompletableFuture<RaftResponse.Inbound> future
     ) { }

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/MockNetworkChannel.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/MockNetworkChannel.java
@@ -21,18 +21,19 @@ import org.apache.kafka.common.protocol.ApiKeys;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class MockNetworkChannel implements NetworkChannel {
     public static final ListenerName LISTENER_NAME = VoterSetTestUtil.DEFAULT_LISTENER_NAME;
 
     private final AtomicInteger correlationIdCounter;
-    private final List<RaftRequest.Outbound> sendQueue = new ArrayList<>();
-    private final Map<Integer, RaftRequest.Outbound> awaitingResponse = new HashMap<>();
+    private final List<RequestEntry> sendQueue = new ArrayList<>();
+    private final Map<Integer, CompletableFuture<RaftResponse.Inbound>> awaitingResponse = new HashMap<>();
 
     public MockNetworkChannel(AtomicInteger correlationIdCounter) {
         this.correlationIdCounter = correlationIdCounter;
@@ -48,8 +49,10 @@ public class MockNetworkChannel implements NetworkChannel {
     }
 
     @Override
-    public void send(RaftRequest.Outbound request) {
-        sendQueue.add(request);
+    public CompletionStage<RaftResponse.Inbound> send(RaftRequest.Outbound request) {
+        var future = new CompletableFuture<RaftResponse.Inbound>();
+        sendQueue.add(new RequestEntry(request, future));
+        return future;
     }
 
     @Override
@@ -57,17 +60,22 @@ public class MockNetworkChannel implements NetworkChannel {
         return LISTENER_NAME;
     }
 
+    @Override
+    public void close() { }
+
     public List<RaftRequest.Outbound> drainSendQueue() {
         return drainSentRequests(Optional.empty());
     }
 
     public List<RaftRequest.Outbound> drainSentRequests(Optional<ApiKeys> apiKeyFilter) {
-        List<RaftRequest.Outbound> requests = new ArrayList<>();
-        Iterator<RaftRequest.Outbound> iterator = sendQueue.iterator();
+        var requests = new ArrayList<RaftRequest.Outbound>();
+        var iterator = sendQueue.iterator();
         while (iterator.hasNext()) {
-            RaftRequest.Outbound request = iterator.next();
+            var requestEntry = iterator.next();
+            var request = requestEntry.request();
+            var future = requestEntry.future();
             if (apiKeyFilter.isEmpty() || request.data().apiKey() == apiKeyFilter.get().id) {
-                awaitingResponse.put(request.correlationId(), request);
+                awaitingResponse.put(request.correlationId(), future);
                 requests.add(request);
                 iterator.remove();
             }
@@ -80,10 +88,15 @@ public class MockNetworkChannel implements NetworkChannel {
     }
 
     public void mockReceive(RaftResponse.Inbound response) {
-        RaftRequest.Outbound request = awaitingResponse.get(response.correlationId());
-        if (request == null) {
+        var future = awaitingResponse.get(response.correlationId());
+        if (future == null) {
             throw new IllegalStateException("Received response for a request which is not being awaited");
         }
-        request.completion.complete(response);
+        future.complete(response);
     }
+
+    private static record RequestEntry(
+        RaftRequest.Outbound request,
+        CompletableFuture<RaftResponse.Inbound> future
+    ) { }
 }

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -968,14 +968,14 @@ public final class RaftClientTestContext {
             versionedRequest,
             time.milliseconds()
         );
-        inboundRequest.completion.whenComplete((response, exception) -> {
+        client.handle(inboundRequest).whenComplete((response, exception) -> {
             if (exception != null) {
+                // TODO: this doesn't do anything interesting. Figure out a way to fail the test
                 throw new RuntimeException(exception);
             } else {
                 sentResponses.add(response);
             }
         });
-        client.handle(inboundRequest);
     }
 
     void deliverResponse(int correlationId, Node source, ApiMessage response) {
@@ -989,7 +989,7 @@ public final class RaftClientTestContext {
      * This is used to expire the update voter set timer without also expiring the fetch timer,
      * which is needed for add, remove, and update voter tests.
      * For voters and observers, polling after exiting this method expires the update voter set timer.
-     * @param epoch - the current epoch 
+     * @param epoch - the current epoch
      * @param leaderId - the leader id
      * @param expireUpdateVoterSetTimer - if true, advance time again to expire this timer
      */

--- a/raft/src/testFixtures/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -148,6 +148,7 @@ public final class RaftClientTestContext {
     final boolean canBecomeVoter;
 
     private final List<RaftResponse.Outbound> sentResponses = new ArrayList<>();
+    private final List<Throwable> uncaughtExceptions = new ArrayList<>();
 
     private static final int NUMBER_FETCH_TIMEOUTS_IN_UPDATE_VOTER_SET_PERIOD = 1;
 
@@ -687,13 +688,37 @@ public final class RaftClientTestContext {
         for (RaftRequest.Outbound request : collectBeginEpochRequests(epoch)) {
             BeginQuorumEpochResponseData beginEpochResponse = beginEpochResponse(epoch, localIdOrThrow());
             deliverResponse(request.correlationId(), request.destination(), beginEpochResponse);
-            client.poll();
+            poll();
         }
+    }
+
+    /**
+     * Asserts that no uncaught exceptions occurred in async callbacks (e.g., CompletionStage.whenComplete).
+     * This method is automatically called by the poll() wrapper method, but can also be called directly
+     * by tests to check for async exceptions at any point.
+     *
+     * @throws AssertionError if any uncaught exceptions were captured
+     */
+    public void assertNoAsyncExceptions() {
+        if (!uncaughtExceptions.isEmpty()) {
+            Throwable first = uncaughtExceptions.get(0);
+            uncaughtExceptions.clear();
+            throw new AssertionError("Uncaught exception in async callback", first);
+        }
+    }
+
+    /**
+     * Poll for new events and check for any uncaught exceptions in async callbacks.
+     * This is a wrapper around client.poll() that also calls assertNoAsyncExceptions().
+     */
+    public void poll() {
+        client.poll();
+        assertNoAsyncExceptions();
     }
 
     public void pollUntil(TestCondition condition) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
-            client.poll();
+            poll();
             return condition.conditionMet();
         }, 5000, "Condition failed to be satisfied before timeout");
     }
@@ -970,8 +995,7 @@ public final class RaftClientTestContext {
         );
         client.handle(inboundRequest).whenComplete((response, exception) -> {
             if (exception != null) {
-                // TODO: this doesn't do anything interesting. Figure out a way to fail the test
-                throw new RuntimeException(exception);
+                uncaughtExceptions.add(exception);
             } else {
                 sentResponses.add(response);
             }


### PR DESCRIPTION
This is an internal refactoring with no changes to external behavior or
wire protocol.

The current KRaft API embeds CompletableFuture fields directly in
RaftRequest and RaftResponse objects via the completion field. This
design has several drawbacks. First, it creates API clarity issues
because requests and responses are data carriers, but the embedded
future makes them also responsible for asynchronous completion
signaling. Second, it creates ownership confusion about who owns the
lifecycle of the embedded future. Third, it reduces type safety because
the completion future is exposed as a mutable field, allowing external
code to complete it incorrectly.

This PR refactors the message handling API to return CompletionStage
from methods instead of embedding futures in data objects. The
RaftMessageQueue now uses a QueueEntry wrapper class that pairs a
RaftMessage with its CompletableFuture<RaftMessage>. The poll() method
returns Optional<QueueEntry> instead of nullable RaftMessage, and the
add() method accepts QueueEntry instead of RaftMessage.

The NetworkChannel interface changed send(RaftRequest.Outbound) from
void to CompletionStage<RaftResponse.Inbound>, and the completion field
was removed from RaftRequest. The KafkaRaftClient changed
handle(RaftRequest.Inbound) from void to
CompletionStage<RaftResponse.Outbound>. Request handling now creates the
QueueEntry, adds it to the message queue, and returns its future.
Response completion is managed internally by the queue system.

The RaftManager interface changed handleRequest() return type to
CompletionStage<ApiMessage> from CompletableFuture<ApiMessage>. Callers
convert to CompletableFuture only when needed via toCompletableFuture.

This refactoring provides several benefits. The asynchronous behavior is
now explicit in method signatures, creating a cleaner API. Messages are
pure data with completion handled by the API methods, improving
separation of concerns. Type safety is improved because futures are
returned from methods rather than exposed as mutable fields. The design
now follows standard Java patterns by using CompletionStage in
interfaces and CompletableFuture in implementations.

Reviewers: Kevin Wu <kevin.wu2412@gmail.com>, Alyssa Huang
 <ahuang@confluent.io>, Kevin Wu <kwu@confluent.io>, Jonah Hooper
 <jhooper@confluent.io>, Jun Rao <junrao@gmail.com>
