### PR TITLE
KAFKA-20663: Fix startup state manager close to release StateDirectory task lock (#22490) - 4.3 backport

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -271,7 +271,10 @@ public class StateDirectory implements AutoCloseable {
                     } finally {
                         // Make sure the state manager writes the local checkpoint file before closing the stores
                         // This will be replaced in the future when removing the checkpoint file dependency.
-                        temporaryStateManager.close();
+                        StateManagerUtil.closeStateManager(
+                            log, threadLogPrefix, true, eosEnabled,
+                            temporaryStateManager, this, Task.TaskType.ACTIVE
+                        );
                     }
                     tasksInLocalState.add(task);
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -878,11 +878,20 @@ public class StateDirectoryTest {
     }
 
     @Test
+    public void shouldNotHoldLockAfterInitializeStartupStores() {
+        final TaskId taskId = new TaskId(0, 0);
+        initializeStartupStores(taskId, true);
+
+        assertTrue(directory.hasStartupTasks());
+        assertNull(directory.lockOwner(taskId));
+    }
+
+    @Test
     public void shouldUnlockStartupStateOnClose() {
         final TaskId taskId = new TaskId(0, 0);
         initializeStartupStores(taskId, true);
 
-        assertEquals(Thread.currentThread(), directory.lockOwner(taskId));
+        assertNull(directory.lockOwner(taskId));
         directory.close();
         assertNull(directory.lockOwner(taskId));
     }


### PR DESCRIPTION
Backport of #22490 (3d1a16a28f) to 4.3.

  Adapted for 4.3: dropped the `transactionalStateStoresEnabled`
argument and the
`TopologyConfig` import, since transactional state stores (KIP-892)
aren't present
in 4.3 and its `StateManagerUtil.closeStateManager()` uses the 7-arg
signature.
Behaviour-preserving — the startup path passes `closeClean=true`, so
`wipeStateStore`
is `false` regardless and the dropped argument never affected this call
site.

Reviewers: Nick Telford <nick.telford@gmail.com>, Matthias Sax
 <mjsax@apache.org>
