### PR TITLE
KAFKA-20635: Spurious "Writing records..." failed errors in the group coordinator... (4.2)

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -20,7 +20,11 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.CoordinatorLoadInProgressException;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.kafka.common.errors.RecordBatchTooLargeException;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -794,12 +798,20 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          */
         private void enqueueAdaptiveFlush(int expectedBatchEpoch) {
             enqueueLast(new CoordinatorInternalEvent("FlushBatch", tp, () -> {
-                withActiveContextOrThrow(tp, context -> {
+                withActiveContext(tp, context -> {
                     // The batch could have already been flushed because it reached the maximum
                     // batch size or a transactional write came in. When this happens, we want
                     // to avoid flushing the next batch early.
                     if (context.currentBatch != null && context.batchEpoch == expectedBatchEpoch) {
-                        context.flushCurrentBatch();
+                        try {
+                            context.flushCurrentBatch();
+                        } catch (Throwable t) {
+                            // The failure has already been logged by flushCurrentBatch. We log it
+                            // here too, rather than rely on that, so a failure is always traced on
+                            // the flush path, and we do not propagate it to avoid it being re-logged
+                            // at ERROR by the CoordinatorInternalEvent.
+                            log.debug("Failed to flush the pending records to {}: {}.", tp, t.getMessage());
+                        }
                     }
                 });
             }));
@@ -859,7 +871,23 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     // Free up the current batch.
                     freeCurrentBatch();
                 } catch (Throwable t) {
-                    log.error("Writing records to {} failed due to: {}.", tp, t.getMessage(), t);
+                    if (t instanceof NotCoordinatorException) {
+                        // Thrown above when the state machine is out of sync; it is already logged there.
+                    } else if (t instanceof NotLeaderOrFollowerException) {
+                        log.debug("Failed to write records to {} because this broker is no longer the " +
+                            "leader of the partition.", tp, t);
+                    } else if (t instanceof InvalidProducerEpochException) {
+                        log.debug("Failed to write records to {} because the producer {} with epoch {} has been fenced.",
+                            tp, currentBatch.builder.producerId(), currentBatch.builder.producerEpoch(), t);
+                    } else if (t instanceof RecordTooLargeException || t instanceof RecordBatchTooLargeException) {
+                        log.error("Failed to write a batch of {} record(s) to {} because it is " +
+                            "larger than the maximum batch size of {} bytes. This usually means " +
+                            "that a single record is too large. Consider increasing the maximum " +
+                            "batch size.", currentBatch.builder.numRecords(), tp, currentBatch.maxBatchSize, t);
+                    } else {
+                        log.error("Failed to write records to {} due to an unexpected error: {}.",
+                            tp, t.getMessage(), t);
+                    }
                     failCurrentBatch(t);
                     // We rethrow the exception for the caller to handle it too.
                     throw t;
@@ -937,7 +965,17 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                                 // to ensure that the linger time is respected.
                                 enqueueFirst(new CoordinatorInternalEvent("FlushBatch", tp, () -> {
                                     if (this.isCancelled()) return;
-                                    withActiveContextOrThrow(tp, CoordinatorContext::flushCurrentBatch);
+                                    withActiveContext(tp, context -> {
+                                        try {
+                                            context.flushCurrentBatch();
+                                        } catch (Throwable t) {
+                                            // The failure has already been logged by flushCurrentBatch. We log it
+                                            // here too, rather than rely on that, so a failure is always traced on
+                                            // the flush path, and we do not propagate it to avoid it being re-logged
+                                            // at ERROR by the CoordinatorInternalEvent.
+                                            log.debug("Failed to flush the pending records to {}: {}.", tp, t.getMessage());
+                                        }
+                                    });
                                 }));
                             }
                         });
@@ -1192,6 +1230,19 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
 
                 deferredEventQueue.add(offset, DeferredEventCollection.of(log, event));
             } catch (Throwable t) {
+                if (t instanceof NotLeaderOrFollowerException) {
+                    log.debug("Failed to write the transaction marker to {} because this broker is " +
+                        "no longer the leader of the partition.", tp, t);
+                } else if (t instanceof InvalidProducerEpochException) {
+                    log.debug("Failed to write the transaction marker to {} because the producer {} " +
+                        "with epoch {} has been fenced.", tp, producerId, producerEpoch, t);
+                } else if (t instanceof RecordTooLargeException || t instanceof RecordBatchTooLargeException) {
+                    log.error("Failed to write the transaction marker to {} because it is too large " +
+                        "to be persisted. Consider increasing the maximum batch size.", tp, t);
+                } else {
+                    log.error("Failed to write the transaction marker to {} due to an unexpected " +
+                        "error: {}.", tp, t.getMessage(), t);
+                }
                 coordinator.revertLastWrittenOffset(prevLastWrittenOffset);
                 event.complete(t);
             }
@@ -2221,6 +2272,32 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
             }
         } finally {
             context.lock.unlock();
+        }
+    }
+
+    /**
+     * Calls the provided function with the context of the partition if the coordinator
+     * is active and does nothing otherwise. Unlike {@link #withActiveContextOrThrow}, it
+     * does not throw when the coordinator does not exist or is not active. The context
+     * lock is acquired before calling the function and released afterwards.
+     *
+     * @param tp    The topic partition.
+     * @param func  The function that will receive the context.
+     */
+    private void withActiveContext(
+        TopicPartition tp,
+        Consumer<CoordinatorContext> func
+    ) {
+        CoordinatorContext context = coordinators.get(tp);
+        if (context != null) {
+            try {
+                context.lock.lock();
+                if (context.state == CoordinatorState.ACTIVE) {
+                    func.accept(context);
+                }
+            } finally {
+                context.lock.unlock();
+            }
         }
     }
 


### PR DESCRIPTION
Backport of #22466 to 4.2.

During routine `__consumer_offsets` partition leadership changes, the
group coordinator spams ERROR-level logs for every in-flight write at
the moment of transition:

```
[GroupCoordinator id=N] Writing records to __consumer_offsets-N
failed due to: For requests intended only for the leader, this error
indicates that the broker is not the current leader ...
[GroupCoordinator id=N] Execution of FlushBatch failed due to For
requests intended only for the leader, this error indicates that the
broker is not the current leader ...
```

These appear on the group coordinator that lost leadership and last for
the duration of the in-flight batch queue. The behavior is correct:
`NotLeaderOrFollowerException` propagates through `failCurrentBatch` to
the deferred events and is mapped to `NOT_COORDINATOR` for clients via
`CoordinatorOperationExceptionHelper`, so clients retry against the new
coordinator. This is purely a logging-noise issue.

This patch classifies the flush failures in `flushCurrentBatch`:

- `NotLeaderOrFollowerException` (leadership change) and
  `InvalidProducerEpochException` (fenced producer) are logged at DEBUG;
- `RecordTooLargeException` and `RecordBatchTooLargeException` remain at
  ERROR with added context (record count and maximum batch size);
- `NotCoordinatorException`, thrown when the state machine is out of
  sync, is not re-logged since that condition is already logged;
- any other failure is logged at ERROR as an unexpected error.

The redundant re-log from the `FlushBatch` event is also suppressed so
that a failure is logged once.

The cherry-pick applied cleanly except that `CoordinatorBatch` already
has a `maxBatchSize` field on 4.2 (the original patch added that field
on trunk, but it already exists here). The redundant field, constructor
parameter, assignment, and constructor argument were dropped, and the
new log message uses the existing `maxBatchSize` field. The change is
otherwise identical to the original commit.

Reviewers: Dongnuo Lyu <dlyu@confluent.io>, Sean Quah
 <squah@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
