### PR TITLE
KAFKA-20622: Define StreamsGroupTopologyDescriptionPlugin SPI and InMemoryTopologyDescriptionPlugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1017,6 +1017,7 @@ project(':server') {
     implementation project(':server-common')
     implementation project(':storage')
     implementation project(':group-coordinator')
+    implementation project(':group-coordinator:group-coordinator-api')
     implementation project(':transaction-coordinator')
     implementation project(':raft')
     implementation project(':share-coordinator')

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
@@ -33,7 +33,15 @@ import java.util.Set;
  * relation; plugins that need both directions reconstruct predecessors in a single
  * pass over the nodes.
  */
-public class StreamsGroupTopologyDescription {
+public record StreamsGroupTopologyDescription(
+    Collection<Subtopology> subtopologies,
+    Collection<GlobalStore> globalStores
+) {
+
+    public StreamsGroupTopologyDescription {
+        subtopologies = List.copyOf(Objects.requireNonNull(subtopologies, "subtopologies"));
+        globalStores = List.copyOf(Objects.requireNonNull(globalStores, "globalStores"));
+    }
 
     /**
      * A processing node in the topology. Predecessor nodes can be inferred from
@@ -44,243 +52,41 @@ public class StreamsGroupTopologyDescription {
         Set<String> successors();
     }
 
-    public static final class Source implements Node {
-        private final String name;
-        private final Set<String> topics;
-        private final Set<String> successors;
-
-        public Source(String name, Set<String> topics, Set<String> successors) {
-            this.name = Objects.requireNonNull(name, "name");
-            this.topics = Set.copyOf(Objects.requireNonNull(topics, "topics"));
-            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        public Set<String> topics() {
-            return topics;
-        }
-
-        @Override
-        public Set<String> successors() {
-            return successors;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Source other)) return false;
-            return name.equals(other.name)
-                && topics.equals(other.topics)
-                && successors.equals(other.successors);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(name, topics, successors);
-        }
-
-        @Override
-        public String toString() {
-            return "Source(name=" + name + ", topics=" + topics + ", successors=" + successors + ")";
+    public record Source(String name, Set<String> topics, Set<String> successors) implements Node {
+        public Source {
+            Objects.requireNonNull(name, "name");
+            topics = Set.copyOf(Objects.requireNonNull(topics, "topics"));
+            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
         }
     }
 
-    public static final class Processor implements Node {
-        private final String name;
-        private final Set<String> stores;
-        private final Set<String> successors;
-
-        public Processor(String name, Set<String> stores, Set<String> successors) {
-            this.name = Objects.requireNonNull(name, "name");
-            this.stores = Set.copyOf(Objects.requireNonNull(stores, "stores"));
-            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        public Set<String> stores() {
-            return stores;
-        }
-
-        @Override
-        public Set<String> successors() {
-            return successors;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Processor other)) return false;
-            return name.equals(other.name)
-                && stores.equals(other.stores)
-                && successors.equals(other.successors);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(name, stores, successors);
-        }
-
-        @Override
-        public String toString() {
-            return "Processor(name=" + name + ", stores=" + stores + ", successors=" + successors + ")";
+    public record Processor(String name, Set<String> stores, Set<String> successors) implements Node {
+        public Processor {
+            Objects.requireNonNull(name, "name");
+            stores = Set.copyOf(Objects.requireNonNull(stores, "stores"));
+            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
         }
     }
 
-    public static final class Sink implements Node {
-        private final String name;
-        private final Optional<String> topic;
-        private final Set<String> successors;
-
-        public Sink(String name, Optional<String> topic, Set<String> successors) {
-            this.name = Objects.requireNonNull(name, "name");
-            this.topic = Objects.requireNonNull(topic, "topic");
-            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        public Optional<String> topic() {
-            return topic;
-        }
-
-        @Override
-        public Set<String> successors() {
-            return successors;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Sink other)) return false;
-            return name.equals(other.name)
-                && topic.equals(other.topic)
-                && successors.equals(other.successors);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(name, topic, successors);
-        }
-
-        @Override
-        public String toString() {
-            return "Sink(name=" + name + ", topic=" + topic + ", successors=" + successors + ")";
+    public record Sink(String name, Optional<String> topic, Set<String> successors) implements Node {
+        public Sink {
+            Objects.requireNonNull(name, "name");
+            Objects.requireNonNull(topic, "topic");
+            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
         }
     }
 
-    public static final class Subtopology {
-        private final String id;
-        private final Collection<Node> nodes;
-
-        public Subtopology(String id, Collection<Node> nodes) {
-            this.id = Objects.requireNonNull(id, "id");
-            this.nodes = List.copyOf(Objects.requireNonNull(nodes, "nodes"));
-        }
-
-        public String id() {
-            return id;
-        }
-
-        public Collection<Node> nodes() {
-            return nodes;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Subtopology other)) return false;
-            return id.equals(other.id) && nodes.equals(other.nodes);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, nodes);
-        }
-
-        @Override
-        public String toString() {
-            return "Subtopology(id=" + id + ", nodes=" + nodes + ")";
+    public record Subtopology(String id, Collection<Node> nodes) {
+        public Subtopology {
+            Objects.requireNonNull(id, "id");
+            nodes = List.copyOf(Objects.requireNonNull(nodes, "nodes"));
         }
     }
 
-    public static final class GlobalStore {
-        private final Source source;
-        private final Processor processor;
-
-        public GlobalStore(Source source, Processor processor) {
-            this.source = Objects.requireNonNull(source, "source");
-            this.processor = Objects.requireNonNull(processor, "processor");
+    public record GlobalStore(Source source, Processor processor) {
+        public GlobalStore {
+            Objects.requireNonNull(source, "source");
+            Objects.requireNonNull(processor, "processor");
         }
-
-        public Source source() {
-            return source;
-        }
-
-        public Processor processor() {
-            return processor;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof GlobalStore other)) return false;
-            return source.equals(other.source) && processor.equals(other.processor);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(source, processor);
-        }
-
-        @Override
-        public String toString() {
-            return "GlobalStore(source=" + source + ", processor=" + processor + ")";
-        }
-    }
-
-    private final Collection<Subtopology> subtopologies;
-    private final Collection<GlobalStore> globalStores;
-
-    public StreamsGroupTopologyDescription(Collection<Subtopology> subtopologies,
-                                           Collection<GlobalStore> globalStores) {
-        this.subtopologies = List.copyOf(Objects.requireNonNull(subtopologies, "subtopologies"));
-        this.globalStores = List.copyOf(Objects.requireNonNull(globalStores, "globalStores"));
-    }
-
-    public Collection<Subtopology> subtopologies() {
-        return subtopologies;
-    }
-
-    public Collection<GlobalStore> globalStores() {
-        return globalStores;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof StreamsGroupTopologyDescription other)) return false;
-        return subtopologies.equals(other.subtopologies) && globalStores.equals(other.globalStores);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(subtopologies, globalStores);
-    }
-
-    @Override
-    public String toString() {
-        return "StreamsGroupTopologyDescription(subtopologies=" + subtopologies
-            + ", globalStores=" + globalStores + ")";
     }
 }

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.coordinator.group.api.streams;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +35,7 @@ import java.util.Set;
  * relation; plugins that need both directions reconstruct predecessors in a single
  * pass over the nodes.
  */
+@InterfaceStability.Evolving
 public record StreamsGroupTopologyDescription(
     Collection<Subtopology> subtopologies,
     Collection<GlobalStore> globalStores

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.api.streams;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Broker-side description of a Kafka Streams topology, as pushed by clients via
+ * {@code StreamsGroupTopologyDescriptionUpdate} and consumed by
+ * {@link StreamsGroupTopologyDescriptionPlugin} implementations.
+ *
+ * <p>This type mirrors {@code org.apache.kafka.streams.TopologyDescription} in shape
+ * but lives in {@code group-coordinator-api} so plugin implementations do not need
+ * to depend on {@code kafka-streams}. The wire schema only carries the successor
+ * relation; plugins that need both directions reconstruct predecessors in a single
+ * pass over the nodes.
+ */
+public class StreamsGroupTopologyDescription {
+
+    /**
+     * A processing node in the topology. Predecessor nodes can be inferred from
+     * the {@link #successors()} relation.
+     */
+    public sealed interface Node {
+        String name();
+        Set<String> successors();
+    }
+
+    public static final class Source implements Node {
+        private final String name;
+        private final Set<String> topics;
+        private final Set<String> successors;
+
+        public Source(String name, Set<String> topics, Set<String> successors) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.topics = Set.copyOf(Objects.requireNonNull(topics, "topics"));
+            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        public Set<String> topics() {
+            return topics;
+        }
+
+        @Override
+        public Set<String> successors() {
+            return successors;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Source other)) return false;
+            return name.equals(other.name)
+                && topics.equals(other.topics)
+                && successors.equals(other.successors);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, topics, successors);
+        }
+
+        @Override
+        public String toString() {
+            return "Source(name=" + name + ", topics=" + topics + ", successors=" + successors + ")";
+        }
+    }
+
+    public static final class Processor implements Node {
+        private final String name;
+        private final Set<String> stores;
+        private final Set<String> successors;
+
+        public Processor(String name, Set<String> stores, Set<String> successors) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.stores = Set.copyOf(Objects.requireNonNull(stores, "stores"));
+            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        public Set<String> stores() {
+            return stores;
+        }
+
+        @Override
+        public Set<String> successors() {
+            return successors;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Processor other)) return false;
+            return name.equals(other.name)
+                && stores.equals(other.stores)
+                && successors.equals(other.successors);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, stores, successors);
+        }
+
+        @Override
+        public String toString() {
+            return "Processor(name=" + name + ", stores=" + stores + ", successors=" + successors + ")";
+        }
+    }
+
+    public static final class Sink implements Node {
+        private final String name;
+        private final Optional<String> topic;
+        private final Set<String> successors;
+
+        public Sink(String name, Optional<String> topic, Set<String> successors) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.topic = Objects.requireNonNull(topic, "topic");
+            this.successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        public Optional<String> topic() {
+            return topic;
+        }
+
+        @Override
+        public Set<String> successors() {
+            return successors;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Sink other)) return false;
+            return name.equals(other.name)
+                && topic.equals(other.topic)
+                && successors.equals(other.successors);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, topic, successors);
+        }
+
+        @Override
+        public String toString() {
+            return "Sink(name=" + name + ", topic=" + topic + ", successors=" + successors + ")";
+        }
+    }
+
+    public static final class Subtopology {
+        private final String id;
+        private final Collection<Node> nodes;
+
+        public Subtopology(String id, Collection<Node> nodes) {
+            this.id = Objects.requireNonNull(id, "id");
+            this.nodes = List.copyOf(Objects.requireNonNull(nodes, "nodes"));
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Collection<Node> nodes() {
+            return nodes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Subtopology other)) return false;
+            return id.equals(other.id) && nodes.equals(other.nodes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, nodes);
+        }
+
+        @Override
+        public String toString() {
+            return "Subtopology(id=" + id + ", nodes=" + nodes + ")";
+        }
+    }
+
+    public static final class GlobalStore {
+        private final Source source;
+        private final Processor processor;
+
+        public GlobalStore(Source source, Processor processor) {
+            this.source = Objects.requireNonNull(source, "source");
+            this.processor = Objects.requireNonNull(processor, "processor");
+        }
+
+        public Source source() {
+            return source;
+        }
+
+        public Processor processor() {
+            return processor;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof GlobalStore other)) return false;
+            return source.equals(other.source) && processor.equals(other.processor);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(source, processor);
+        }
+
+        @Override
+        public String toString() {
+            return "GlobalStore(source=" + source + ", processor=" + processor + ")";
+        }
+    }
+
+    private final Collection<Subtopology> subtopologies;
+    private final Collection<GlobalStore> globalStores;
+
+    public StreamsGroupTopologyDescription(Collection<Subtopology> subtopologies,
+                                           Collection<GlobalStore> globalStores) {
+        this.subtopologies = List.copyOf(Objects.requireNonNull(subtopologies, "subtopologies"));
+        this.globalStores = List.copyOf(Objects.requireNonNull(globalStores, "globalStores"));
+    }
+
+    public Collection<Subtopology> subtopologies() {
+        return subtopologies;
+    }
+
+    public Collection<GlobalStore> globalStores() {
+        return globalStores;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StreamsGroupTopologyDescription other)) return false;
+        return subtopologies.equals(other.subtopologies) && globalStores.equals(other.globalStores);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subtopologies, globalStores);
+    }
+
+    @Override
+    public String toString() {
+        return "StreamsGroupTopologyDescription(subtopologies=" + subtopologies
+            + ", globalStores=" + globalStores + ")";
+    }
+}

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionPlugin.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.api.streams;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A broker-side plugin that stores, forwards, or exposes topology descriptions pushed
+ * by Kafka Streams clients.
+ *
+ * <p>Implementations must be thread-safe. {@link #setTopology} may be called
+ * concurrently by multiple members of the same group; calls with the same
+ * {@code (groupId, topologyEpoch)} carry identical data and must be idempotent.
+ * {@link #deleteTopology} must also be idempotent — it may be called more than once
+ * for the same {@code groupId}, including when nothing is stored.
+ */
+@InterfaceStability.Evolving
+public interface StreamsGroupTopologyDescriptionPlugin extends Configurable, AutoCloseable {
+
+    /**
+     * Store the topology description for a streams group.
+     *
+     * <p>The returned future completes when the topology has been persisted or forwarded.
+     * Failures must be signalled by completing the future exceptionally — implementations
+     * must not throw synchronously; a synchronous throw is treated as a permanent failure
+     * with a generic client-visible error message. The completion exception drives
+     * broker-side behaviour:
+     *
+     * <ul>
+     *   <li>{@link StreamsTopologyDescriptionPermanentFailureException} — the description will never be accepted
+     *       at this topology epoch (e.g. too large, semantically rejected). The broker
+     *       ratchets {@code LastFailedTopologyEpoch} and stops re-soliciting until the
+     *       epoch advances.</li>
+     *   <li>{@link StreamsTopologyDescriptionTransientFailureException} or any other exception — treated as
+     *       transient. The broker arms or extends the per-group back-off (30 s → 1 h,
+     *       exponential) and re-solicits on a later heartbeat.</li>
+     * </ul>
+     *
+     * In both cases the caller receives error code
+     * {@code STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED} with the exception's message in
+     * {@code ErrorMessage}; the permanent-vs-transient split is broker-internal state.
+     */
+    CompletableFuture<Void> setTopology(String groupId, int topologyEpoch, StreamsGroupTopologyDescription description);
+
+    /**
+     * Remove any topology description stored for this group. Called when the group is
+     * deleted or expires. A failure (future completed exceptionally) is reported to the
+     * caller of {@code DeleteGroups} as {@code GROUP_DELETION_FAILED} with the exception
+     * message in the per-group {@code ErrorMessage}, and the broker does not tombstone
+     * the group; a retry of {@code DeleteGroups} re-invokes this method idempotently.
+     * The periodic-cleanup path treats a failure identically — the group's tombstone is
+     * deferred to a future cycle.
+     */
+    CompletableFuture<Void> deleteTopology(String groupId);
+
+    /**
+     * Return the stored topology description for {@code (groupId, topologyEpoch)}, or
+     * {@code null} if the plugin no longer has the data (e.g. backend wipe). If the future
+     * completes exceptionally, the broker reports a read error for the group.
+     */
+    CompletableFuture<StreamsGroupTopologyDescription> getTopology(String groupId, int topologyEpoch);
+}

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsTopologyDescriptionPermanentFailureException.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsTopologyDescriptionPermanentFailureException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.api.streams;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.errors.ApiException;
+
+/**
+ * Signals that the topology description for the current epoch will never be accepted
+ * (e.g. too large, semantically rejected).
+ */
+@InterfaceStability.Evolving
+public class StreamsTopologyDescriptionPermanentFailureException extends ApiException {
+
+    public StreamsTopologyDescriptionPermanentFailureException(String message) {
+        super(message);
+    }
+
+    public StreamsTopologyDescriptionPermanentFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsTopologyDescriptionTransientFailureException.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsTopologyDescriptionTransientFailureException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.api.streams;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.errors.ApiException;
+
+/**
+ * Signals a transient backend failure; the broker re-solicits on a later heartbeat.
+ * Any other exception completed on the future is treated identically.
+ */
+@InterfaceStability.Evolving
+public class StreamsTopologyDescriptionTransientFailureException extends ApiException {
+
+    public StreamsTopologyDescriptionTransientFailureException(String message) {
+        super(message);
+    }
+
+    public StreamsTopologyDescriptionTransientFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/package-info.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Server-side SPI for the Kafka Streams group topology description plugin.
+ * Implementations of {@link org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin}
+ * receive topology descriptions pushed by Streams clients and expose them to operational tooling.
+ */
+package org.apache.kafka.coordinator.group.api.streams;

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.record.internal.Records;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssignor;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
 import org.apache.kafka.coordinator.group.assignor.RangeAssignor;
 import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
@@ -48,6 +49,7 @@ import static org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.ConfigDef.Type.BOOLEAN;
+import static org.apache.kafka.common.config.ConfigDef.Type.CLASS;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
 import static org.apache.kafka.common.config.ConfigDef.Type.LIST;
 import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
@@ -400,6 +402,10 @@ public class GroupCoordinatorConfig {
     public static final int STREAMS_GROUP_MAX_WARMUP_REPLICAS_DEFAULT = 20;
     public static final String STREAMS_GROUP_MAX_WARMUP_REPLICAS_DOC = "The maximum allowed value for the group-level configuration of " + GroupConfig.STREAMS_NUM_WARMUP_REPLICAS_CONFIG;
 
+    public static final String STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG = "group.streams.topology.description.plugin.class";
+    public static final Class<?> STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DEFAULT = null;
+    public static final String STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DOC = "The fully qualified class name of a StreamsGroupTopologyDescriptionPlugin implementation. When not set, the feature is disabled.";
+
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG = "group.streams.acceptable.recovery.lag";
     public static final long STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT = 10000L;
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC = "The maximum acceptable lag (number of offsets to catch up) for a client to be considered caught-up enough to receive an active task assignment.";
@@ -497,6 +503,7 @@ public class GroupCoordinatorConfig {
         .define(STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_CONFIG, INT, STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_DEFAULT, atLeast(1), MEDIUM, STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_DOC)
         .define(STREAMS_GROUP_NUM_WARMUP_REPLICAS_CONFIG, INT, STREAMS_GROUP_NUM_WARMUP_REPLICAS_DEFAULT, atLeast(0), MEDIUM, STREAMS_GROUP_NUM_WARMUP_REPLICAS_DOC)
         .define(STREAMS_GROUP_MAX_WARMUP_REPLICAS_CONFIG, INT, STREAMS_GROUP_MAX_WARMUP_REPLICAS_DEFAULT, atLeast(0), MEDIUM, STREAMS_GROUP_MAX_WARMUP_REPLICAS_DOC)
+        .define(STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG, CLASS, STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DEFAULT, MEDIUM, STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DOC)
         .define(STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG, LONG, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT, atLeast(0L), MEDIUM, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC);
 
 
@@ -565,6 +572,7 @@ public class GroupCoordinatorConfig {
     private final int streamsGroupMinTaskOffsetIntervalMs;
     private final int streamsGroupNumWarmupReplicas;
     private final int streamsGroupMaxWarmupReplicas;
+    private final Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin;
     private final long streamsGroupAcceptableRecoveryLag;
 
     private final AbstractConfig config;
@@ -635,6 +643,7 @@ public class GroupCoordinatorConfig {
         this.streamsGroupMinTaskOffsetIntervalMs = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_CONFIG);
         this.streamsGroupNumWarmupReplicas = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_NUM_WARMUP_REPLICAS_CONFIG);
         this.streamsGroupMaxWarmupReplicas = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_MAX_WARMUP_REPLICAS_CONFIG);
+        this.streamsGroupTopologyDescriptionPlugin = streamsGroupTopologyDescriptionPlugin(config);
         this.streamsGroupAcceptableRecoveryLag = config.getLong(GroupCoordinatorConfig.STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG);
         this.config = config;
 
@@ -895,6 +904,14 @@ public class GroupCoordinatorConfig {
         }
 
         return assignors;
+    }
+
+    protected Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin(
+        AbstractConfig config
+    ) {
+        return Optional.ofNullable(config.getConfiguredInstance(
+            GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            StreamsGroupTopologyDescriptionPlugin.class));
     }
 
     /**
@@ -1372,6 +1389,13 @@ public class GroupCoordinatorConfig {
      */
     public int streamsGroupMaxWarmupReplicas() {
         return streamsGroupMaxWarmupReplicas;
+    }
+
+    /**
+     * The configured streams group topology description plugin, or empty when none is configured.
+     */
+    public Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin() {
+        return streamsGroupTopologyDescriptionPlugin;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -572,7 +573,6 @@ public class GroupCoordinatorConfig {
     private final int streamsGroupMinTaskOffsetIntervalMs;
     private final int streamsGroupNumWarmupReplicas;
     private final int streamsGroupMaxWarmupReplicas;
-    private final Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin;
     private final long streamsGroupAcceptableRecoveryLag;
 
     private final AbstractConfig config;
@@ -643,7 +643,6 @@ public class GroupCoordinatorConfig {
         this.streamsGroupMinTaskOffsetIntervalMs = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_CONFIG);
         this.streamsGroupNumWarmupReplicas = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_NUM_WARMUP_REPLICAS_CONFIG);
         this.streamsGroupMaxWarmupReplicas = config.getInt(GroupCoordinatorConfig.STREAMS_GROUP_MAX_WARMUP_REPLICAS_CONFIG);
-        this.streamsGroupTopologyDescriptionPlugin = streamsGroupTopologyDescriptionPlugin(config);
         this.streamsGroupAcceptableRecoveryLag = config.getLong(GroupCoordinatorConfig.STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG);
         this.config = config;
 
@@ -906,12 +905,14 @@ public class GroupCoordinatorConfig {
         return assignors;
     }
 
-    protected Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin(
-        AbstractConfig config
+    public StreamsGroupTopologyDescriptionPlugin streamsGroupTopologyDescriptionPlugin(
+        Map<String, ?> additionalConfigs
     ) {
-        return Optional.ofNullable(config.getConfiguredInstance(
-            GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
-            StreamsGroupTopologyDescriptionPlugin.class));
+        Map<String, Object> overrides = new HashMap<>(additionalConfigs);
+        return config.getConfiguredInstance(
+            STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            StreamsGroupTopologyDescriptionPlugin.class,
+            overrides);
     }
 
     /**
@@ -1389,13 +1390,6 @@ public class GroupCoordinatorConfig {
      */
     public int streamsGroupMaxWarmupReplicas() {
         return streamsGroupMaxWarmupReplicas;
-    }
-
-    /**
-     * The configured streams group topology description plugin, or empty when none is configured.
-     */
-    public Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin() {
-        return streamsGroupTopologyDescriptionPlugin;
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -27,6 +27,8 @@ import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
 import org.apache.kafka.coordinator.group.api.assignor.PartitionAssignorException;
 import org.apache.kafka.coordinator.group.api.assignor.ShareGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.api.assignor.SubscribedTopicDescriber;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
 import org.apache.kafka.coordinator.group.assignor.RangeAssignor;
 import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
@@ -38,11 +40,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupCoordinatorConfigTest {
 
@@ -819,6 +823,63 @@ public class GroupCoordinatorConfigTest {
         configs.put(GroupCoordinatorConfig.ERRORS_DEADLETTERQUEUE_TOPIC_NAME_PREFIX_CONFIG, "my-dlq-");
         GroupCoordinatorConfig config = createConfig(configs);
         assertEquals("my-dlq-", config.errorsDLQTopicNamePrefix());
+    }
+
+    @Test
+    public void testStreamsGroupTopologyDescriptionPluginDefaultIsEmpty() {
+        GroupCoordinatorConfig config = createConfig(new HashMap<>());
+        assertTrue(config.streamsGroupTopologyDescriptionPlugin().isEmpty());
+    }
+
+    @Test
+    public void testStreamsGroupTopologyDescriptionPluginLoadedAndConfigured() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            TestTopologyDescriptionPlugin.class.getName());
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        var plugin = config.streamsGroupTopologyDescriptionPlugin();
+        assertTrue(plugin.isPresent());
+        assertInstanceOf(TestTopologyDescriptionPlugin.class, plugin.get());
+        assertNotNull(((TestTopologyDescriptionPlugin) plugin.get()).configs);
+    }
+
+    @Test
+    public void testStreamsGroupTopologyDescriptionPluginAcceptsClassObject() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            TestTopologyDescriptionPlugin.class);
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        assertInstanceOf(TestTopologyDescriptionPlugin.class,
+            config.streamsGroupTopologyDescriptionPlugin().orElseThrow());
+    }
+
+    public static class TestTopologyDescriptionPlugin implements StreamsGroupTopologyDescriptionPlugin {
+        public Map<String, ?> configs;
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            this.configs = configs;
+        }
+
+        @Override
+        public CompletableFuture<Void> setTopology(String groupId, int topologyEpoch, StreamsGroupTopologyDescription description) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteTopology(String groupId) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public java.util.concurrent.CompletableFuture<StreamsGroupTopologyDescription> getTopology(String groupId, int topologyEpoch) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void close() { }
     }
 
     public static GroupCoordinatorConfig createConfig(Map<String, Object> configs) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -45,8 +45,9 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupCoordinatorConfigTest {
 
@@ -826,9 +827,9 @@ public class GroupCoordinatorConfigTest {
     }
 
     @Test
-    public void testStreamsGroupTopologyDescriptionPluginDefaultIsEmpty() {
+    public void testStreamsGroupTopologyDescriptionPluginDefaultIsNull() {
         GroupCoordinatorConfig config = createConfig(new HashMap<>());
-        assertTrue(config.streamsGroupTopologyDescriptionPlugin().isEmpty());
+        assertNull(config.streamsGroupTopologyDescriptionPlugin(Map.of()));
     }
 
     @Test
@@ -838,10 +839,10 @@ public class GroupCoordinatorConfigTest {
             TestTopologyDescriptionPlugin.class.getName());
         GroupCoordinatorConfig config = createConfig(configs);
 
-        var plugin = config.streamsGroupTopologyDescriptionPlugin();
-        assertTrue(plugin.isPresent());
-        assertInstanceOf(TestTopologyDescriptionPlugin.class, plugin.get());
-        assertNotNull(((TestTopologyDescriptionPlugin) plugin.get()).configs);
+        StreamsGroupTopologyDescriptionPlugin plugin =
+            config.streamsGroupTopologyDescriptionPlugin(Map.of());
+        assertInstanceOf(TestTopologyDescriptionPlugin.class, plugin);
+        assertNotNull(((TestTopologyDescriptionPlugin) plugin).configs);
     }
 
     @Test
@@ -852,7 +853,34 @@ public class GroupCoordinatorConfigTest {
         GroupCoordinatorConfig config = createConfig(configs);
 
         assertInstanceOf(TestTopologyDescriptionPlugin.class,
-            config.streamsGroupTopologyDescriptionPlugin().orElseThrow());
+            config.streamsGroupTopologyDescriptionPlugin(Map.of()));
+    }
+
+    @Test
+    public void testStreamsGroupTopologyDescriptionPluginReceivesAdditionalConfigs() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            TestTopologyDescriptionPlugin.class);
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        try (TestTopologyDescriptionPlugin plugin = (TestTopologyDescriptionPlugin)
+            config.streamsGroupTopologyDescriptionPlugin(Map.of("injected.handle", "value"))) {
+            assertEquals("value", plugin.configs.get("injected.handle"));
+        }
+    }
+
+    @Test
+    public void testStreamsGroupTopologyDescriptionPluginReturnsFreshInstancePerCall() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG,
+            TestTopologyDescriptionPlugin.class);
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        StreamsGroupTopologyDescriptionPlugin first =
+            config.streamsGroupTopologyDescriptionPlugin(Map.of());
+        StreamsGroupTopologyDescriptionPlugin second =
+            config.streamsGroupTopologyDescriptionPlugin(Map.of());
+        assertNotSame(first, second);
     }
 
     public static class TestTopologyDescriptionPlugin implements StreamsGroupTopologyDescriptionPlugin {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.api.streams;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StreamsGroupTopologyDescriptionTest {
+
+    @Test
+    public void testSourceEqualsAndHashCode() {
+        StreamsGroupTopologyDescription.Source a = new StreamsGroupTopologyDescription.Source(
+            "src", Set.of("in"), Set.of("proc"));
+        StreamsGroupTopologyDescription.Source b = new StreamsGroupTopologyDescription.Source(
+            "src", Set.of("in"), Set.of("proc"));
+        StreamsGroupTopologyDescription.Source c = new StreamsGroupTopologyDescription.Source(
+            "src", Set.of("in", "in2"), Set.of("proc"));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    @Test
+    public void testProcessorEqualsAndHashCode() {
+        StreamsGroupTopologyDescription.Processor a = new StreamsGroupTopologyDescription.Processor(
+            "p", Set.of("store"), Set.of("snk"));
+        StreamsGroupTopologyDescription.Processor b = new StreamsGroupTopologyDescription.Processor(
+            "p", Set.of("store"), Set.of("snk"));
+        StreamsGroupTopologyDescription.Processor c = new StreamsGroupTopologyDescription.Processor(
+            "p", Set.of(), Set.of("snk"));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    @Test
+    public void testSinkEqualsAndHashCode() {
+        StreamsGroupTopologyDescription.Sink a = new StreamsGroupTopologyDescription.Sink(
+            "snk", Optional.of("out"), Set.of());
+        StreamsGroupTopologyDescription.Sink b = new StreamsGroupTopologyDescription.Sink(
+            "snk", Optional.of("out"), Set.of());
+        StreamsGroupTopologyDescription.Sink c = new StreamsGroupTopologyDescription.Sink(
+            "snk", Optional.empty(), Set.of());
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    @Test
+    public void testTopologyEqualsAndHashCode() {
+        StreamsGroupTopologyDescription a = buildSimpleTopology();
+        StreamsGroupTopologyDescription b = buildSimpleTopology();
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testCollectionsAreDefensivelyCopied() {
+        Set<String> mutableTopics = new HashSet<>(Set.of("in"));
+        StreamsGroupTopologyDescription.Source src = new StreamsGroupTopologyDescription.Source(
+            "src", mutableTopics, Set.of("proc"));
+        mutableTopics.add("rogue");
+
+        assertEquals(Set.of("in"), src.topics());
+        assertThrows(UnsupportedOperationException.class, () -> src.topics().add("nope"));
+    }
+
+    @Test
+    public void testNullArgumentsRejected() {
+        assertThrows(NullPointerException.class,
+            () -> new StreamsGroupTopologyDescription.Source(null, Set.of(), Set.of()));
+        assertThrows(NullPointerException.class,
+            () -> new StreamsGroupTopologyDescription.Sink("s", null, Set.of()));
+        assertThrows(NullPointerException.class,
+            () -> new StreamsGroupTopologyDescription(null, List.of()));
+    }
+
+    @Test
+    public void testNodeIsSealedToSourceProcessorSink() {
+        Class<?>[] permitted = StreamsGroupTopologyDescription.Node.class.getPermittedSubclasses();
+        assertNotNull(permitted, "Node must be a sealed interface");
+        assertEquals(
+            Set.of(
+                StreamsGroupTopologyDescription.Source.class,
+                StreamsGroupTopologyDescription.Processor.class,
+                StreamsGroupTopologyDescription.Sink.class
+            ),
+            Set.of(permitted)
+        );
+    }
+
+    private static StreamsGroupTopologyDescription buildSimpleTopology() {
+        StreamsGroupTopologyDescription.Source source = new StreamsGroupTopologyDescription.Source(
+            "src", Set.of("in"), Set.of("proc"));
+        StreamsGroupTopologyDescription.Processor processor = new StreamsGroupTopologyDescription.Processor(
+            "proc", Set.of("store"), Set.of("snk"));
+        StreamsGroupTopologyDescription.Sink sink = new StreamsGroupTopologyDescription.Sink(
+            "snk", Optional.of("out"), Set.of());
+        StreamsGroupTopologyDescription.Subtopology sub = new StreamsGroupTopologyDescription.Subtopology(
+            "0", List.of(source, processor, sink));
+        return new StreamsGroupTopologyDescription(List.of(sub), List.of());
+    }
+}

--- a/server/src/main/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPlugin.java
+++ b/server/src/main/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPlugin.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.streams;
+
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Reference {@link StreamsGroupTopologyDescriptionPlugin} that stores topology descriptions
+ * in an in-memory map. Intended for testing and as a starting point for real implementations;
+ * not suitable for production because its state is lost on broker restart and is not shared
+ * across brokers.
+ *
+ * <p>Stores at most one description per group, identified by its topology epoch. A
+ * {@code setTopology} call overwrites any previously stored description for that group;
+ * {@code getTopology} returns the stored description only when the requested topology epoch
+ * matches the stored epoch, and {@code null} otherwise.
+ */
+public class InMemoryTopologyDescriptionPlugin implements StreamsGroupTopologyDescriptionPlugin {
+
+    private record Entry(int topologyEpoch, StreamsGroupTopologyDescription description) { }
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // No-op.
+    }
+
+    @Override
+    public CompletableFuture<Void> setTopology(String groupId, int topologyEpoch, StreamsGroupTopologyDescription description) {
+        store.put(groupId, new Entry(topologyEpoch, description));
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteTopology(String groupId) {
+        store.remove(groupId);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<StreamsGroupTopologyDescription> getTopology(String groupId, int topologyEpoch) {
+        Entry entry = store.get(groupId);
+        if (entry == null || entry.topologyEpoch() != topologyEpoch) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.completedFuture(entry.description());
+    }
+
+    @Override
+    public void close() {
+        store.clear();
+    }
+}

--- a/server/src/test/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPluginTest.java
+++ b/server/src/test/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPluginTest.java
@@ -46,7 +46,6 @@ public class InMemoryTopologyDescriptionPluginTest {
             StreamsGroupTopologyDescription got = plugin.getTopology("g1", 7).get();
             assertEquals(desc, got);
         }
-
     }
 
     @Test

--- a/server/src/test/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPluginTest.java
+++ b/server/src/test/java/org/apache/kafka/server/streams/InMemoryTopologyDescriptionPluginTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.streams;
+
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InMemoryTopologyDescriptionPluginTest {
+
+    @Test
+    public void testSetThenGetRoundTrip() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            StreamsGroupTopologyDescription desc = topology("src", "in");
+            plugin.setTopology("g1", 7, desc).get();
+            StreamsGroupTopologyDescription got = plugin.getTopology("g1", 7).get();
+            assertEquals(desc, got);
+        }
+
+    }
+
+    @Test
+    public void testGetReturnsNullForMissingGroup() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            assertNull(plugin.getTopology("missing", 0).get());
+        }
+    }
+
+    @Test
+    public void testGetReturnsNullWhenEpochDoesNotMatch() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            plugin.setTopology("g1", 3, topology("src", "in")).get();
+
+            assertNull(plugin.getTopology("g1", 4).get());
+            assertNotNull(plugin.getTopology("g1", 3).get());
+        }
+    }
+
+    @Test
+    public void testSetIsIdempotentAtSameEpoch() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            StreamsGroupTopologyDescription desc = topology("src", "in");
+
+            plugin.setTopology("g1", 5, desc).get();
+            plugin.setTopology("g1", 5, desc).get();
+            plugin.setTopology("g1", 5, desc).get();
+
+            assertEquals(desc, plugin.getTopology("g1", 5).get());
+        }
+    }
+
+    @Test
+    public void testEpochAdvanceOverwritesPreviousDescription() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            StreamsGroupTopologyDescription v1 = topology("v1-src", "in1");
+            StreamsGroupTopologyDescription v2 = topology("v2-src", "in2");
+
+            plugin.setTopology("g1", 1, v1).get();
+            plugin.setTopology("g1", 2, v2).get();
+
+            assertNull(plugin.getTopology("g1", 1).get(), "epoch 1 should no longer be served");
+            assertEquals(v2, plugin.getTopology("g1", 2).get());
+        }
+    }
+
+    @Test
+    public void testDeleteTopologyRemovesEntry() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            plugin.setTopology("g1", 1, topology("src", "in")).get();
+            plugin.deleteTopology("g1").get();
+            assertNull(plugin.getTopology("g1", 1).get());
+        }
+    }
+
+    @Test
+    public void testDeleteIsIdempotentForUnknownGroup() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            plugin.deleteTopology("never-stored").get();
+            plugin.deleteTopology("never-stored").get();
+        }
+    }
+
+    @Test
+    public void testDeleteIsScopedToGroup() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            plugin.setTopology("g1", 1, topology("src", "in")).get();
+            plugin.setTopology("g2", 1, topology("src", "in")).get();
+
+            plugin.deleteTopology("g1").get();
+
+            assertNull(plugin.getTopology("g1", 1).get());
+            assertNotNull(plugin.getTopology("g2", 1).get());
+        }
+    }
+
+    @Test
+    public void testCloseClearsAllState() throws Exception {
+        InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin();
+        plugin.setTopology("g1", 1, topology("src", "in")).get();
+        plugin.close();
+        assertNull(plugin.getTopology("g1", 1).get());
+    }
+
+    @Test
+    public void testConfigureIsNoOp() {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            plugin.configure(Map.of("anything", "ignored"));
+        }
+    }
+
+    @Test
+    public void testConcurrentWritesAreSafe() throws Exception {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            StreamsGroupTopologyDescription desc = topology("src", "in");
+            int threads = 16;
+            ExecutorService exec = Executors.newFixedThreadPool(threads);
+            try {
+                CountDownLatch start = new CountDownLatch(1);
+                CompletableFuture<?>[] futures = new CompletableFuture<?>[threads];
+                for (int i = 0; i < threads; i++) {
+                    futures[i] = CompletableFuture.runAsync(() -> {
+                        try {
+                            start.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(e);
+                        }
+                        plugin.setTopology("g1", 1, desc).join();
+                    }, exec);
+                }
+                start.countDown();
+                CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+            } finally {
+                exec.shutdownNow();
+            }
+
+            assertEquals(desc, plugin.getTopology("g1", 1).get());
+        }
+    }
+
+    @Test
+    public void testFuturesCompleteSynchronously() throws ExecutionException, InterruptedException {
+        try (InMemoryTopologyDescriptionPlugin plugin = new InMemoryTopologyDescriptionPlugin()) {
+            CompletableFuture<Void> setFuture = plugin.setTopology("g1", 1, topology("src", "in"));
+            CompletableFuture<StreamsGroupTopologyDescription> getFuture = plugin.getTopology("g1", 1);
+            CompletableFuture<Void> deleteFuture = plugin.deleteTopology("g1");
+            assertTrue(setFuture.isDone());
+            assertTrue(getFuture.isDone());
+            assertTrue(deleteFuture.isDone());
+            assertNotNull(getFuture.get());
+        }
+    }
+
+    private static StreamsGroupTopologyDescription topology(String sourceName, String topic) {
+        StreamsGroupTopologyDescription.Source src = new StreamsGroupTopologyDescription.Source(
+            sourceName, Set.of(topic), Set.of("proc"));
+        StreamsGroupTopologyDescription.Processor proc = new StreamsGroupTopologyDescription.Processor(
+            "proc", Set.of(), Set.of("snk"));
+        StreamsGroupTopologyDescription.Sink sink = new StreamsGroupTopologyDescription.Sink(
+            "snk", Optional.of("out"), Set.of());
+        StreamsGroupTopologyDescription.Subtopology sub = new StreamsGroupTopologyDescription.Subtopology(
+            "0", List.of(src, proc, sink));
+        return new StreamsGroupTopologyDescription(List.of(sub), List.of());
+    }
+}


### PR DESCRIPTION
JIRA: KAFKA-20622  This PR is a part of KIP-1331.

Public SPI under `org.apache.kafka.coordinator.group.api.streams`
(`group-coordinator-api` module), marked `@InterfaceStability.Evolving`:

- `StreamsGroupTopologyDescriptionPlugin` — `Configurable +
AutoCloseable` interface with three `CompletableFuture`-returning
methods (`setTopology`, `deleteTopology`, `getTopology`), matching the
contract described in KIP-1331.
- `StreamsGroupTopologyDescription` — broker-side value type mirroring
the wire schema common struct from
`StreamsGroupTopologyDescriptionUpdateRequest`. Modelled as a Java
`record` with nested `record`s (`Source`, `Processor`, `Sink`,
`Subtopology`, `GlobalStore`) implementing a sealed `Node` interface.
Successor edges only — predecessors are reconstructed by callers.
Compact constructors do `requireNonNull` + `List.copyOf` / `Set.copyOf`
defensive copies.
- `StreamsTopologyDescriptionPermanentFailureException` and
`StreamsTopologyDescriptionTransientFailureException` — both extend
`ApiException`. Plugins use these on the future's completion to signal
whether the broker should ratchet `FailedDescriptionTopologyEpoch` or
arm the per-group transient back-off.
- `package-info.java` for the new package.

Reference implementation in the `server` module:

- `InMemoryTopologyDescriptionPlugin` — `ConcurrentHashMap`-backed
reference plugin intended for tests and as a template; stores at most
one description per group and serves it only when the requested epoch
matches. Not suitable for production.

Broker configuration:

- New config `group.streams.topology.description.plugin.class`
(`Type.CLASS`, default `null`, importance `MEDIUM`) on
`GroupCoordinatorConfig`.
- Exposed as a factory method: `public
StreamsGroupTopologyDescriptionPlugin
streamsGroupTopologyDescriptionPlugin(Map<String, ?>
additionalConfigs)`. The method instantiates and `configure`s a **fresh
plugin instance on every invocation** — there is no cached `Optional<>`
field; nothing is created at `GroupCoordinatorConfig` construction time.
Returns `null` when the class config is unset. `additionalConfigs` is
merged on top of the broker originals so callers can inject broker-side
references that are not reachable from `AbstractConfig` alone. The
caller owns the returned object's lifecycle, including `close` on broker
shutdown — that wiring lands in KAFKA-20623.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
