### PR TITLE
MINOR: Update MetadataVersionTest properly

### DIFF
--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -23,35 +23,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_3_IV3;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_4_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV1;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_5_IV2;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_6_IV2;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV2;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV3;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_7_IV4;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_8_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_3_9_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV1;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV2;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_0_IV3;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_1_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_1_IV1;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_3_IV0;
-import static org.apache.kafka.server.common.MetadataVersion.IBP_4_4_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,74 +55,34 @@ class MetadataVersionTest {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testFromVersionString(MetadataVersion metadataVersion) {
+        assertEquals(metadataVersion,
+            MetadataVersion.fromVersionString(metadataVersion.version(), true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testFromShortVersionString(MetadataVersion metadataVersion) {
+        if (metadataVersion.isProduction()) {
+            MetadataVersion resolved = MetadataVersion.fromVersionString(metadataVersion.shortVersion(), true);
+            assertNotNull(resolved, "Short version string '" + metadataVersion.shortVersion() + "' should resolve");
+            assertEquals(metadataVersion.shortVersion(), resolved.shortVersion());
+            assertTrue(resolved.compareTo(metadataVersion) >= 0,
+                "Short version '" + metadataVersion.shortVersion() + "' should resolve to the latest version in that release line");
+        }
+    }
+
     @Test
-    @SuppressWarnings("checkstyle:JavaNCSS")
-    public void testFromVersionString() {
-        // 3.3-IV3 is the latest production version in the 3.3 line
-        assertEquals(IBP_3_3_IV3, MetadataVersion.fromVersionString("3.3", true));
-        assertEquals(IBP_3_3_IV3, MetadataVersion.fromVersionString("3.3-IV3", true));
-
-        // 3.4-IV0 is the latest production version in the 3.4 line
-        assertEquals(IBP_3_4_IV0, MetadataVersion.fromVersionString("3.4", true));
-        assertEquals(IBP_3_4_IV0, MetadataVersion.fromVersionString("3.4-IV0", true));
-
-        // 3.5-IV2 is the latest production version in the 3.5 line
-        assertEquals(IBP_3_5_IV2, MetadataVersion.fromVersionString("3.5", true));
-        assertEquals(IBP_3_5_IV0, MetadataVersion.fromVersionString("3.5-IV0", true));
-        assertEquals(IBP_3_5_IV1, MetadataVersion.fromVersionString("3.5-IV1", true));
-        assertEquals(IBP_3_5_IV2, MetadataVersion.fromVersionString("3.5-IV2", true));
-
-        // 3.6-IV2 is the latest production version in the 3.6 line
-        assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6", true));
-        assertEquals(IBP_3_6_IV0, MetadataVersion.fromVersionString("3.6-IV0", true));
-        assertEquals(IBP_3_6_IV1, MetadataVersion.fromVersionString("3.6-IV1", true));
-        assertEquals(IBP_3_6_IV2, MetadataVersion.fromVersionString("3.6-IV2", true));
-
-        // 3.7-IV4 is the latest production version in the 3.7 line
-        assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7", true));
-        assertEquals(IBP_3_7_IV0, MetadataVersion.fromVersionString("3.7-IV0", true));
-        assertEquals(IBP_3_7_IV1, MetadataVersion.fromVersionString("3.7-IV1", true));
-        assertEquals(IBP_3_7_IV2, MetadataVersion.fromVersionString("3.7-IV2", true));
-        assertEquals(IBP_3_7_IV3, MetadataVersion.fromVersionString("3.7-IV3", true));
-        assertEquals(IBP_3_7_IV4, MetadataVersion.fromVersionString("3.7-IV4", true));
-
-        // 3.8-IV0 is the latest production version in the 3.8 line
-        assertEquals(IBP_3_8_IV0, MetadataVersion.fromVersionString("3.8", true));
-        assertEquals(IBP_3_8_IV0, MetadataVersion.fromVersionString("3.8-IV0", true));
-
-        // 3.9-IV0 is the latest production version in the 3.9 line
-        assertEquals(IBP_3_9_IV0, MetadataVersion.fromVersionString("3.9", true));
-        assertEquals(IBP_3_9_IV0, MetadataVersion.fromVersionString("3.9-IV0", true));
-
-        // 4.0-IV3 is the latest production version in the 4.0 line
-        assertEquals(IBP_4_0_IV3, MetadataVersion.fromVersionString("4.0", true));
-        assertEquals(IBP_4_0_IV0, MetadataVersion.fromVersionString("4.0-IV0", true));
-        assertEquals(IBP_4_0_IV1, MetadataVersion.fromVersionString("4.0-IV1", true));
-        assertEquals(IBP_4_0_IV2, MetadataVersion.fromVersionString("4.0-IV2", true));
-        assertEquals(IBP_4_0_IV3, MetadataVersion.fromVersionString("4.0-IV3", true));
-
-        // 4.1-IV1 is the latest production version in the 4.1 line
-        assertEquals(IBP_4_1_IV1, MetadataVersion.fromVersionString("4.1", true));
-        assertEquals(IBP_4_1_IV0, MetadataVersion.fromVersionString("4.1-IV0", true));
-        assertEquals(IBP_4_1_IV1, MetadataVersion.fromVersionString("4.1-IV1", true));
-
-        // 4.2-IV1 is the latest production version in the 4.2 line
-        assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2", true));
-        assertEquals(IBP_4_2_IV0, MetadataVersion.fromVersionString("4.2-IV0", true));
-        assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2-IV1", true));
-
-        // 4.3-IV0 is the latest production version in the 4.3 line
-        assertEquals(IBP_4_3_IV0, MetadataVersion.fromVersionString("4.3", true));
-        assertEquals(IBP_4_3_IV0, MetadataVersion.fromVersionString("4.3-IV0", true));
-
-        // 4.4-IV0 is the latest unstable version in the 4.4 line
-        assertEquals(IBP_4_4_IV0, MetadataVersion.fromVersionString("4.4-IV0", true));
-
-        // Throws exception when unstableFeatureVersionsEnabled is false
-        assertEquals("Unknown metadata.version '4.4-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
-            + "3.6-IV0, 3.6-IV1, 3.6-IV2, 3.7-IV0, 3.7-IV1, 3.7-IV2, 3.7-IV3, 3.7-IV4, 3.8-IV0, 3.9-IV0, 4.0-IV0, 4.0-IV1, 4.0-IV2, 4.0-IV3, 4.1-IV0, "
-            + "4.1-IV1, 4.2-IV0, 4.2-IV1, 4.3-IV0",
-            assertThrows(IllegalArgumentException.class, () -> MetadataVersion.fromVersionString("4.4-IV0", false)).getMessage());
+    public void testFromVersionStringUnstableDisabled() {
+        MetadataVersion latestTesting = MetadataVersion.latestTesting();
+        String expectedMsg = "Unknown metadata.version '" + latestTesting.version()
+            + "'. Supported metadata.version are: "
+            + MetadataVersion.metadataVersionsToString(MINIMUM_VERSION, LATEST_PRODUCTION);
+        assertEquals(expectedMsg,
+            assertThrows(IllegalArgumentException.class,
+                () -> MetadataVersion.fromVersionString(latestTesting.version(), false)).getMessage());
     }
 
     @Test
@@ -141,62 +91,32 @@ class MetadataVersionTest {
             MetadataVersion.metadataVersionsToString(MetadataVersion.IBP_3_5_IV0, MetadataVersion.IBP_3_6_IV0));
     }
 
-    @Test
-    public void testShortVersion() {
-        assertEquals("3.3", IBP_3_3_IV3.shortVersion());
-        assertEquals("3.4", IBP_3_4_IV0.shortVersion());
-        assertEquals("3.5", IBP_3_5_IV0.shortVersion());
-        assertEquals("3.5", IBP_3_5_IV1.shortVersion());
-        assertEquals("3.5", IBP_3_5_IV2.shortVersion());
-        assertEquals("3.6", IBP_3_6_IV0.shortVersion());
-        assertEquals("3.6", IBP_3_6_IV1.shortVersion());
-        assertEquals("3.6", IBP_3_6_IV2.shortVersion());
-        assertEquals("3.7", IBP_3_7_IV0.shortVersion());
-        assertEquals("3.7", IBP_3_7_IV1.shortVersion());
-        assertEquals("3.7", IBP_3_7_IV2.shortVersion());
-        assertEquals("3.7", IBP_3_7_IV3.shortVersion());
-        assertEquals("3.7", IBP_3_7_IV4.shortVersion());
-        assertEquals("3.8", IBP_3_8_IV0.shortVersion());
-        assertEquals("3.9", IBP_3_9_IV0.shortVersion());
-        assertEquals("4.0", IBP_4_0_IV0.shortVersion());
-        assertEquals("4.0", IBP_4_0_IV1.shortVersion());
-        assertEquals("4.0", IBP_4_0_IV2.shortVersion());
-        assertEquals("4.0", IBP_4_0_IV3.shortVersion());
-        assertEquals("4.1", IBP_4_1_IV0.shortVersion());
-        assertEquals("4.1", IBP_4_1_IV1.shortVersion());
-        assertEquals("4.2", IBP_4_2_IV0.shortVersion());
-        assertEquals("4.2", IBP_4_2_IV1.shortVersion());
-        assertEquals("4.3", IBP_4_3_IV0.shortVersion());
-        assertEquals("4.4", IBP_4_4_IV0.shortVersion());
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testShortVersion(MetadataVersion metadataVersion) {
+        String expectedShortVersion = deriveShortVersion(metadataVersion);
+        assertEquals(expectedShortVersion, metadataVersion.shortVersion());
     }
 
-    @Test
-    public void testVersion() {
-        assertEquals("3.3-IV3", IBP_3_3_IV3.version());
-        assertEquals("3.4-IV0", IBP_3_4_IV0.version());
-        assertEquals("3.5-IV0", IBP_3_5_IV0.version());
-        assertEquals("3.5-IV1", IBP_3_5_IV1.version());
-        assertEquals("3.5-IV2", IBP_3_5_IV2.version());
-        assertEquals("3.6-IV0", IBP_3_6_IV0.version());
-        assertEquals("3.6-IV1", IBP_3_6_IV1.version());
-        assertEquals("3.6-IV2", IBP_3_6_IV2.version());
-        assertEquals("3.7-IV0", IBP_3_7_IV0.version());
-        assertEquals("3.7-IV1", IBP_3_7_IV1.version());
-        assertEquals("3.7-IV2", IBP_3_7_IV2.version());
-        assertEquals("3.7-IV3", IBP_3_7_IV3.version());
-        assertEquals("3.7-IV4", IBP_3_7_IV4.version());
-        assertEquals("3.8-IV0", IBP_3_8_IV0.version());
-        assertEquals("3.9-IV0", IBP_3_9_IV0.version());
-        assertEquals("4.0-IV0", IBP_4_0_IV0.version());
-        assertEquals("4.0-IV1", IBP_4_0_IV1.version());
-        assertEquals("4.0-IV2", IBP_4_0_IV2.version());
-        assertEquals("4.0-IV3", IBP_4_0_IV3.version());
-        assertEquals("4.1-IV0", IBP_4_1_IV0.version());
-        assertEquals("4.1-IV1", IBP_4_1_IV1.version());
-        assertEquals("4.2-IV0", IBP_4_2_IV0.version());
-        assertEquals("4.2-IV1", IBP_4_2_IV1.version());
-        assertEquals("4.3-IV0", IBP_4_3_IV0.version());
-        assertEquals("4.4-IV0", IBP_4_4_IV0.version());
+    @ParameterizedTest
+    @EnumSource(value = MetadataVersion.class)
+    public void testVersion(MetadataVersion metadataVersion) {
+        String expectedVersion = deriveVersion(metadataVersion);
+        assertEquals(expectedVersion, metadataVersion.version());
+    }
+
+    private static final Pattern ENUM_NAME_PATTERN = Pattern.compile("IBP_(\\d+)_(\\d+)_IV(\\d+)");
+
+    private static String deriveShortVersion(MetadataVersion metadataVersion) {
+        Matcher matcher = ENUM_NAME_PATTERN.matcher(metadataVersion.name());
+        assertTrue(matcher.matches(), "Unexpected enum name format: " + metadataVersion.name());
+        return matcher.group(1) + "." + matcher.group(2);
+    }
+
+    private static String deriveVersion(MetadataVersion metadataVersion) {
+        Matcher matcher = ENUM_NAME_PATTERN.matcher(metadataVersion.name());
+        assertTrue(matcher.matches(), "Unexpected enum name format: " + metadataVersion.name());
+        return matcher.group(1) + "." + matcher.group(2) + "-IV" + matcher.group(3);
     }
 
     @Test

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -41,11 +41,11 @@ import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MetadataVersionTest {
+    private static final Pattern ENUM_NAME_PATTERN = Pattern.compile("IBP_(\\d+)_(\\d+)_IV(\\d+)");
 
     @Test
     public void testFeatureLevels() {
@@ -67,7 +67,6 @@ class MetadataVersionTest {
     public void testFromShortVersionString(MetadataVersion metadataVersion) {
         if (metadataVersion.isProduction()) {
             MetadataVersion resolved = MetadataVersion.fromVersionString(metadataVersion.shortVersion(), true);
-            assertNotNull(resolved, "Short version string '" + metadataVersion.shortVersion() + "' should resolve");
             assertEquals(metadataVersion.shortVersion(), resolved.shortVersion());
             assertTrue(resolved.compareTo(metadataVersion) >= 0,
                 "Short version '" + metadataVersion.shortVersion() + "' should resolve to the latest version in that release line");
@@ -94,18 +93,15 @@ class MetadataVersionTest {
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testShortVersion(MetadataVersion metadataVersion) {
-        String expectedShortVersion = deriveShortVersion(metadataVersion);
-        assertEquals(expectedShortVersion, metadataVersion.shortVersion());
+        assertEquals(deriveShortVersion(metadataVersion), metadataVersion.shortVersion());
     }
 
     @ParameterizedTest
     @EnumSource(value = MetadataVersion.class)
     public void testVersion(MetadataVersion metadataVersion) {
-        String expectedVersion = deriveVersion(metadataVersion);
-        assertEquals(expectedVersion, metadataVersion.version());
+        assertEquals(deriveVersion(metadataVersion), metadataVersion.version());
     }
 
-    private static final Pattern ENUM_NAME_PATTERN = Pattern.compile("IBP_(\\d+)_(\\d+)_IV(\\d+)");
 
     private static String deriveShortVersion(MetadataVersion metadataVersion) {
         Matcher matcher = ENUM_NAME_PATTERN.matcher(metadataVersion.name());

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -47,6 +47,7 @@ import static org.apache.kafka.server.common.MetadataVersion.IBP_4_1_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_2_IV1;
 import static org.apache.kafka.server.common.MetadataVersion.IBP_4_3_IV0;
+import static org.apache.kafka.server.common.MetadataVersion.IBP_4_4_IV0;
 import static org.apache.kafka.server.common.MetadataVersion.LATEST_PRODUCTION;
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -120,7 +121,12 @@ class MetadataVersionTest {
         assertEquals(IBP_4_2_IV0, MetadataVersion.fromVersionString("4.2-IV0", true));
         assertEquals(IBP_4_2_IV1, MetadataVersion.fromVersionString("4.2-IV1", true));
 
+        // 4.3-IV0 is the latest production version in the 4.3 line
+        assertEquals(IBP_4_3_IV0, MetadataVersion.fromVersionString("4.3", true));
         assertEquals(IBP_4_3_IV0, MetadataVersion.fromVersionString("4.3-IV0", true));
+
+        // 4.4-IV0 is the latest unstable version in the 4.4 line
+        assertEquals(IBP_4_4_IV0, MetadataVersion.fromVersionString("4.4-IV0", true));
 
         // Throws exception when unstableFeatureVersionsEnabled is false
         assertEquals("Unknown metadata.version '4.4-IV0'. Supported metadata.version are: 3.3-IV3, 3.4-IV0, 3.5-IV0, 3.5-IV1, 3.5-IV2, "
@@ -161,6 +167,7 @@ class MetadataVersionTest {
         assertEquals("4.2", IBP_4_2_IV0.shortVersion());
         assertEquals("4.2", IBP_4_2_IV1.shortVersion());
         assertEquals("4.3", IBP_4_3_IV0.shortVersion());
+        assertEquals("4.4", IBP_4_4_IV0.shortVersion());
     }
 
     @Test
@@ -189,6 +196,7 @@ class MetadataVersionTest {
         assertEquals("4.2-IV0", IBP_4_2_IV0.version());
         assertEquals("4.2-IV1", IBP_4_2_IV1.version());
         assertEquals("4.3-IV0", IBP_4_3_IV0.version());
+        assertEquals("4.4-IV0", IBP_4_4_IV0.version());
     }
 
     @Test


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/21273 (KAFKA-19774, KIP-1066)
promoted IBP_4_3_IV0 to LATEST_PRODUCTION and introduced IBP_4_4_IV0 as
the new unstable version, but did not add corresponding test coverage
for 4.4-IV0 in testFromVersionString, testShortVersion, or testVersion.
This PR adds the missing assertions, along with the bare "4.3" version
string mapping that was also absent.

So I think the design overall is bad and it didn't prevent this problem.
Therefore I have change the way how it wouild be detected.

Now when someone adds a new MetadataVersion enum value (like
IBP_4_5_IV0), all these tests automatically cover it because they
iterate over every enum constant via:
```
@EnumSource(value = MetadataVersion.class).
```

No one needs to remember to add manual assertions. Before this change,
forgetting to update the test (like what happened with IBP_4_4_IV0 in PR
#21273) would silently pass. Now it can not happen.

Reviewers: PoAn Yang <payang@apache.org>, Chia-Ping Tsai <chia7712@gmail.com>

