### PR TITLE
KAFKA-20444: [12/12] Mark TxnOffsetCommit v6 as stable (KIP-1319)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1295,7 +1295,7 @@ public class TransactionManager {
             .setGroupInstanceId(groupMetadata.groupInstanceId().orElse(null))
             .setTopics(topics);
         var builder = allHaveTopicIds
-            ? TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, isTransactionV2Enabled(), true)
+            ? TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, isTransactionV2Enabled())
             : TxnOffsetCommitRequest.Builder.forTopicNames(data, isTransactionV2Enabled());
         if (result == null) {
             // In this case, transaction V2 is in use.

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitRequest.java
@@ -85,14 +85,13 @@ public class TxnOffsetCommitRequest extends AbstractRequest {
 
         public static Builder forTopicIdsOrNames(
             final TxnOffsetCommitRequestData data,
-            final boolean isTransactionV2Enabled,
-            final boolean enableUnstableLastVersion
+            final boolean isTransactionV2Enabled
         ) {
             return new Builder(
                 data,
                 ApiKeys.TXN_OFFSET_COMMIT.oldestVersion(),
                 isTransactionV2Enabled
-                    ? ApiKeys.TXN_OFFSET_COMMIT.latestVersion(enableUnstableLastVersion)
+                    ? ApiKeys.TXN_OFFSET_COMMIT.latestVersion()
                     : LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
             );
         }

--- a/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
@@ -33,7 +33,6 @@
   //
   // Version 6 adds support for topic IDs and removes support for topic names (KIP-1319).
   "validVersions": "0-6",
-  "latestVersionUnstable": true,
   "flexibleVersions": "3+",
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "0+", "entityType": "transactionalId",

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -2617,7 +2617,7 @@ public class TransactionManagerTest {
                         .setErrorCode(Errors.NONE.code())))));
         client.prepareResponse(request -> {
             TxnOffsetCommitRequest txnRequest = (TxnOffsetCommitRequest) request;
-            assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(true), txnRequest.version());
+            assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(), txnRequest.version());
             assertEquals(1, txnRequest.data().topics().size());
             assertEquals(TOPIC_ID, txnRequest.data().topics().get(0).topicId());
             return true;
@@ -2687,7 +2687,7 @@ public class TransactionManagerTest {
                     .setErrorCode(Errors.UNKNOWN_TOPIC_ID.code())))));
         client.prepareResponse(request -> {
             TxnOffsetCommitRequest txnRequest = (TxnOffsetCommitRequest) request;
-            assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(true), txnRequest.version());
+            assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(), txnRequest.version());
             return true;
         }, new TxnOffsetCommitResponse(unknownTopicId));
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2876,7 +2876,7 @@ public class RequestResponseTest {
         }
 
         if (version >= 6) {
-            return TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build(version);
+            return TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build(version);
         } else {
             return TxnOffsetCommitRequest.Builder.forTopicNames(data, version >= 5).build(version);
         }

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
@@ -169,7 +169,7 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
 
         assertEquals(expectedResponseData, TxnOffsetCommitRequest.getErrorResponse(data, Errors.UNKNOWN_MEMBER_ID));
 
-        var request = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build();
+        var request = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build();
         var response = request.getErrorResponse(throttleTimeMs, Errors.UNKNOWN_MEMBER_ID.exception());
         assertEquals(expectedResponseData.setThrottleTimeMs(throttleTimeMs), response.data());
     }
@@ -205,10 +205,10 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
 
         if (version >= 6) {
             assertThrows(UnsupportedVersionException.class,
-                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build(version));
+                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build(version));
         } else {
             assertDoesNotThrow(
-                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build(version));
+                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build(version));
         }
     }
 
@@ -230,11 +230,11 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
                             .setCommittedOffset(0L)))));
 
         if (version >= 6) {
-            var request = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build(version);
+            var request = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build(version);
             assertEquals(data, request.data());
         } else {
             assertThrows(UnsupportedVersionException.class,
-                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true, true).build(version));
+                () -> TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(data, true).build(version));
         }
     }
 
@@ -260,29 +260,17 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
     public void testForTopicIdsOrNamesCapsAtTransactionV1WhenTransactionV2IsDisabled() {
         var builder = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(
             new TxnOffsetCommitRequestData(),
-            false,
-            true
+            false
         );
         assertEquals(TxnOffsetCommitRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2, builder.latestAllowedVersion());
     }
 
     @Test
-    public void testForTopicIdsOrNamesUsesLatestStableVersionWhenUnstableIsDisabled() {
+    public void testForTopicIdsOrNamesUsesLatestVersionWhenTransactionV2IsEnabled() {
         var builder = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(
             new TxnOffsetCommitRequestData(),
-            true,
-            false
-        );
-        assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(false), builder.latestAllowedVersion());
-    }
-
-    @Test
-    public void testForTopicIdsOrNamesUsesLatestUnstableVersionWhenUnstableIsEnabled() {
-        var builder = TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(
-            new TxnOffsetCommitRequestData(),
-            true,
             true
         );
-        assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(true), builder.latestAllowedVersion());
+        assertEquals(ApiKeys.TXN_OFFSET_COMMIT.latestVersion(), builder.latestAllowedVersion());
     }
 }

--- a/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/GroupCoordinatorBaseRequestTest.scala
@@ -262,7 +262,7 @@ class GroupCoordinatorBaseRequestTest(cluster: ClusterInstance) {
      partition: Int,
      offset: Long,
      expectedError: Errors,
-     version: Short = ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)
+     version: Short = ApiKeys.TXN_OFFSET_COMMIT.latestVersion()
   ): Unit = {
     val request = TxnOffsetCommitRequest.Builder.forTopicNames(
       new TxnOffsetCommitRequestData()

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1415,7 +1415,7 @@ class KafkaApisTest extends Logging {
               .setCommittedOffset(10)))))
 
     val requestChannelRequest = buildRequest(
-      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true, true).build(version)
+      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true).build(version)
     )
 
     val future = new CompletableFuture[TxnOffsetCommitResponseData]()
@@ -1479,7 +1479,7 @@ class KafkaApisTest extends Logging {
               .setCommittedOffset(10)))))
 
     val requestChannelRequest = buildRequest(
-      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true, true).build(version)
+      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true).build(version)
     )
 
     val future = new CompletableFuture[TxnOffsetCommitResponseData]()
@@ -1561,7 +1561,7 @@ class KafkaApisTest extends Logging {
               .setCommittedOffset(70)))))
 
     val requestChannelRequest = buildRequest(
-      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true, true).build(version)
+      TxnOffsetCommitRequest.Builder.forTopicIdsOrNames(txnOffsetCommitRequest, true).build(version)
     )
 
     // This is the request expected by the group coordinator.

--- a/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TxnOffsetCommitRequestTest.scala
@@ -78,7 +78,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     val topicId = createTopic(topic, 1)
 
-    for (version <- 0 to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
+    for (version <- 0 to ApiKeys.TXN_OFFSET_COMMIT.latestVersion()) {
       // Verify that the TXN_OFFSET_COMMIT request is processed correctly when member id is UNKNOWN_MEMBER_ID
       // and generation id is UNKNOWN_GENERATION_ID under all api versions.
       verifyTxnCommitAndFetch(
@@ -288,7 +288,7 @@ class TxnOffsetCommitRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     val topicId = createTopic(topic, 1)
 
-    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
+    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion()) {
       val useTV2 = version > EndTxnRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
 
       // Initialize producer. Wait until the coordinator finishes loading.

--- a/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/WriteTxnMarkersRequestTest.scala
@@ -66,7 +66,7 @@ class WriteTxnMarkersRequestTest(cluster:ClusterInstance) extends GroupCoordinat
 
     val topicId = createTopic(topic, 1)
 
-    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion(isUnstableApiEnabled)) {
+    for (version <- ApiKeys.TXN_OFFSET_COMMIT.oldestVersion to ApiKeys.TXN_OFFSET_COMMIT.latestVersion()) {
       val useTV2 = version > EndTxnRequest.LAST_STABLE_VERSION_BEFORE_TRANSACTION_V2
 
       // Initialize producer. Wait until the coordinator finishes loading.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/modern/consumer/ConsumerGroupTest.java
@@ -1004,7 +1004,7 @@ public class ConsumerGroupTest {
                 builder.add(Arguments.of(false, version, type));
             }
         }
-        for (short version = ApiKeys.TXN_OFFSET_COMMIT.oldestVersion(); version <= ApiKeys.TXN_OFFSET_COMMIT.latestVersion(true); version++) {
+        for (short version = ApiKeys.TXN_OFFSET_COMMIT.oldestVersion(); version <= ApiKeys.TXN_OFFSET_COMMIT.latestVersion(); version++) {
             for (PartitionAssignmentType type : PartitionAssignmentType.values()) {
                 builder.add(Arguments.of(true, version, type));
             }
@@ -1098,7 +1098,7 @@ public class ConsumerGroupTest {
         for (short version = ApiKeys.OFFSET_COMMIT.oldestVersion(); version <= ApiKeys.OFFSET_COMMIT.latestVersion(true); version++) {
             builder.add(Arguments.of(false, version));
         }
-        for (short version = ApiKeys.TXN_OFFSET_COMMIT.oldestVersion(); version <= ApiKeys.TXN_OFFSET_COMMIT.latestVersion(true); version++) {
+        for (short version = ApiKeys.TXN_OFFSET_COMMIT.oldestVersion(); version <= ApiKeys.TXN_OFFSET_COMMIT.latestVersion(); version++) {
             builder.add(Arguments.of(true, version));
         }
 


### PR DESCRIPTION
This patch marks `TxnOffsetCommit` v6 as stable.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
