### PR TITLE
KAFKA-20673: Skip stale-leader lookup retry while the AdminClient is closing (follow-up)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -5166,6 +5166,15 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             boolean handleNodeUnavailable(long currentTimeMs) {
+                // Don't intervene while the client is shutting down. Re-running the lookup enqueues
+                // new calls via runnable.call(), which are rejected during close ("Cannot accept new
+                // calls when AdminClient is closing"). Leaving the call in pendingCalls preserves the
+                // normal close(timeout) handling, so it can still be retried (or assigned, should the
+                // broker reappear) within the shutdown grace period instead of failing immediately.
+                if (hardShutdownTimeMs.get() != INVALID_SHUTDOWN_TIME) {
+                    return false;
+                }
+
                 OptionalInt brokerId = spec.scope.destinationBrokerId();
                 // The fulfillment target broker is no longer present in the cluster metadata. This
                 // happens when a stale entry in the partition leader cache points at a broker that


### PR DESCRIPTION
Follow-up to KAFKA-20673 (#22493). That change lets the AdminClient
recover a partition-leader request whose cached leader has left the
cluster by sending the keys back to the lookup stage from the admin
client thread. The re-lookup is enqueued through the runnable, which
rejects new calls once close() has been initiated, failing them with
"Cannot accept new calls when AdminClient is closing". As a result, a
request that took this recovery path during the close(timeout) grace
period would fail immediately instead of being retried until the
deadline, even though the user asked for a grace period.

This change skips the recovery while the client is shutting down.
handleNodeUnavailable returns false once a hard shutdown time has been
set, so the call is left in pendingCalls and follows the normal
close(timeout) handling: it can still be retried, or assigned if the
broker reappears, within the shutdown grace period rather than being
killed instantly. The behaviour outside of shutdown is unchanged.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
