### PR TITLE
MINOR: remove no-op call when HB fails and member already unsubscribed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -445,7 +445,6 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
                 if (membershipManager().state() == MemberState.UNSUBSCRIBED) {
                     logger.info("{} received GROUP_ID_NOT_FOUND for group {} while unsubscribed. ",
                             heartbeatRequestName(), membershipManager().groupId());
-                    membershipManager().onHeartbeatRequestSkipped();
                 } else {
                     // Else, this is a fatal error, we should throw it and transition to fatal state.
                     logger.error("{} failed due to unexpected error {}: {}", heartbeatRequestName(), error, errorMessage);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -476,9 +476,9 @@ public class ConsumerHeartbeatRequestManagerTest {
         ClientResponse response = createHeartbeatResponse(result.unsentRequests.get(0), Errors.GROUP_ID_NOT_FOUND);
         result.unsentRequests.get(0).handler().onComplete(response);
 
-        // Verify: no fatal error, heartbeat skipped (benign)
+        // Verify no fatal error, the member was already out of the group (benign)
         verify(membershipManager, never()).transitionToFatal();
-        verify(membershipManager).onHeartbeatRequestSkipped();
+        verify(membershipManager).onHeartbeatFailure(false);
         verify(backgroundEventHandler, never()).add(any());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -375,9 +375,9 @@ public class ShareHeartbeatRequestManagerTest {
         ClientResponse response = createHeartbeatResponse(result.unsentRequests.get(0), Errors.GROUP_ID_NOT_FOUND);
         result.unsentRequests.get(0).handler().onComplete(response);
 
-        // Verify: no fatal error, heartbeat skipped (benign)
+        // Verify no fatal error, the member was already out of the group (benign)
         verify(membershipManager, never()).transitionToFatal();
-        verify(membershipManager).onHeartbeatRequestSkipped();
+        verify(membershipManager).onHeartbeatFailure(false);
         verify(backgroundEventHandler, never()).add(any());
     }
 


### PR DESCRIPTION
Remove no-op call to complete open leave operations. It is always no-op
in this case because the member already left (the call applies only if
member is LEAVING, called here when member is UNSUBCRIBED). No changes
in logic.

This came out reviewing GROUP_ID_NOT_FOUND handling (expected to be
ignored, no action needed if the member already unsubscribed)

Reviewers: TengYao Chi <frankvicky@apache.org>, nileshkumar3
 <nileshkumar3@gmail.com>
