### PR TITLE
KAFKA-20667: Add principal-level index to AclCache to fix O(N) ACL sc…

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclCache.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclCache.java
@@ -40,17 +40,31 @@ public class AclCache {
      */
     private final ImmutableMap<Uuid, StandardAcl> aclsById;
 
+    /**
+     * Contains all of the current ACLs indexed by principal (e.g. "User:alice").
+     * Each entry maps a principal string to a NavigableSet of ACLs for that principal,
+     * sorted by the natural ordering of StandardAcl.
+     */
+    private final ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal;
+
     AclCache() {
-        this(ImmutableNavigableSet.empty(), ImmutableMap.empty());
+        this(ImmutableNavigableSet.empty(), ImmutableMap.empty(), ImmutableMap.empty());
     }
 
-    private AclCache(final ImmutableNavigableSet<StandardAcl> aclsByResource, final ImmutableMap<Uuid, StandardAcl> aclsById) {
+    private AclCache(final ImmutableNavigableSet<StandardAcl> aclsByResource,
+                     final ImmutableMap<Uuid, StandardAcl> aclsById,
+                     final ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal) {
         this.aclsByResource = aclsByResource;
         this.aclsById = aclsById;
+        this.aclsByPrincipal = aclsByPrincipal;
     }
 
     public ImmutableNavigableSet<StandardAcl> aclsByResource() {
         return aclsByResource;
+    }
+
+    public ImmutableNavigableSet<StandardAcl> aclsForPrincipal(String principal) {
+        return aclsByPrincipal.getOrDefault(principal, ImmutableNavigableSet.empty());
     }
 
     Iterable<AclBinding> acls(AclBindingFilter filter) {
@@ -86,7 +100,15 @@ public class AclCache {
         }
 
         ImmutableNavigableSet<StandardAcl> aclsByResource = this.aclsByResource.added(acl);
-        return new AclCache(aclsByResource, aclsById);
+
+        String principal = acl.principal();
+        ImmutableNavigableSet<StandardAcl> principalSet =
+            this.aclsByPrincipal.getOrDefault(principal, ImmutableNavigableSet.empty());
+        ImmutableNavigableSet<StandardAcl> updatedPrincipalSet = principalSet.added(acl);
+        ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal =
+            this.aclsByPrincipal.updated(principal, updatedPrincipalSet);
+
+        return new AclCache(aclsByResource, aclsById, aclsByPrincipal);
     }
 
     AclCache removeAcl(Uuid id) {
@@ -102,6 +124,21 @@ public class AclCache {
         }
 
         ImmutableNavigableSet<StandardAcl> aclsByResource = this.aclsByResource.removed(acl);
-        return new AclCache(aclsByResource, aclsById);
+
+        String principal = acl.principal();
+        ImmutableNavigableSet<StandardAcl> principalSet = this.aclsByPrincipal.get(principal);
+        ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal;
+        if (principalSet != null) {
+            ImmutableNavigableSet<StandardAcl> updatedPrincipalSet = principalSet.removed(acl);
+            if (updatedPrincipalSet.isEmpty()) {
+                aclsByPrincipal = this.aclsByPrincipal.removed(principal);
+            } else {
+                aclsByPrincipal = this.aclsByPrincipal.updated(principal, updatedPrincipalSet);
+            }
+        } else {
+            aclsByPrincipal = this.aclsByPrincipal;
+        }
+
+        return new AclCache(aclsByResource, aclsById, aclsByPrincipal);
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAcl.java
@@ -17,6 +17,9 @@
 
 package org.apache.kafka.metadata.authorizer;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
@@ -34,6 +37,8 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 public record StandardAcl(ResourceType resourceType, String resourceName, PatternType patternType, String principal,
                           String host, AclOperation operation,
                           AclPermissionType permissionType) implements Comparable<StandardAcl> {
+    private static final Map<String, KafkaPrincipal> PRINCIPAL_CACHE = new ConcurrentHashMap<>();
+
     public static StandardAcl fromRecord(AccessControlEntryRecord record) {
         return new StandardAcl(
             ResourceType.fromCode(record.resourceType()),
@@ -57,14 +62,14 @@ public record StandardAcl(ResourceType resourceType, String resourceName, Patter
     }
 
     public KafkaPrincipal kafkaPrincipal() {
-        int colonIndex = principal.indexOf(":");
-        if (colonIndex == -1) {
-            throw new IllegalStateException("Could not parse principal from `" + principal + "` " +
-                "(no colon is present separating the principal type from the principal name)");
-        }
-        String principalType = principal.substring(0, colonIndex);
-        String principalName = principal.substring(colonIndex + 1);
-        return new KafkaPrincipal(principalType, principalName);
+        return PRINCIPAL_CACHE.computeIfAbsent(principal, principalStr -> {
+            int colonIndex = principalStr.indexOf(":");
+            if (colonIndex == -1) {
+                throw new IllegalStateException("Could not parse principal from `" + principalStr + "` " +
+                    "(no colon is present separating the principal type from the principal name)");
+            }
+            return new KafkaPrincipal(principalStr.substring(0, colonIndex), principalStr.substring(colonIndex + 1));
+        });
     }
 
     public AclBinding toBinding() {

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -26,12 +26,14 @@ import org.apache.kafka.common.errors.AuthorizerNotReadyException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.common.utils.internals.SecurityUtils;
 import org.apache.kafka.server.authorizer.Action;
 import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.immutable.ImmutableNavigableSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -312,54 +314,64 @@ public class StandardAuthorizerData {
         String host,
         Action action
     ) {
-        // This code relies on the ordering of StandardAcl within the NavigableMap.
-        // Entries are sorted by resource type first, then REVERSE resource name.
-        // Therefore, we can find all the applicable ACLs by starting at
-        // (resource_type, resource_name) and stepping forwards until we reach
-        // an ACL with a resource name which is not a prefix of the current one.
-        // At that point, we need to search for if there are any more ACLs at
-        // the first divergence point.
-        //
-        // For example, when trying to authorize a TOPIC resource named foobar, we would
-        // start at element 2, and continue on to 3 and 4 following map:
-        //
-        // 1. rs=TOPIC rn=gar pt=PREFIX
-        // 2. rs=TOPIC rn=foobar pt=PREFIX
-        // 3. rs=TOPIC rn=foob pt=LITERAL
-        // 4. rs=TOPIC rn=foo pt=PREFIX
-        // 5. rs=TOPIC rn=fb pt=PREFIX
-        // 6. rs=TOPIC rn=fa pt=PREFIX
-        // 7. rs=TOPIC rn=f  pt=PREFIX
-        // 8. rs=TOPIC rn=eeee pt=LITERAL
-        //
-        // Once we reached element 5, we would jump to element 7.
         MatchingRuleBuilder matchingRuleBuilder = new MatchingRuleBuilder(noAclRule);
-        StandardAcl exemplar = new StandardAcl(
-            action.resourcePattern().resourceType(),
-            action.resourcePattern().name(),
-            PatternType.UNKNOWN, // Note that the UNKNOWN value sorts before all others.
-            "",
-            "",
-            AclOperation.UNKNOWN,
-            AclPermissionType.UNKNOWN);
         AclCache aclCacheSnapshot = aclCache;
-        checkSection(aclCacheSnapshot, action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
-        if (matchingRuleBuilder.foundDeny()) {
-            return matchingRuleBuilder.build();
+        ResourceType resourceType = action.resourcePattern().resourceType();
+        String resourceName = action.resourcePattern().name();
+
+        // When the default result is ALLOWED, we must scan the full ACL set first
+        // to determine hasResourceAcls. If ANY ACL exists for this resource (even
+        // for a different principal), the result must be DENIED if no ALLOW matches,
+        // rather than falling through to the default ALLOWED rule.
+        if (noAclRule.result == ALLOWED) {
+            StandardAcl fullExemplar = new StandardAcl(
+                resourceType, resourceName, PatternType.UNKNOWN,
+                "", "", AclOperation.UNKNOWN, AclPermissionType.UNKNOWN);
+            checkSection(aclCacheSnapshot.aclsByResource(), action, fullExemplar, false,
+                matchingPrincipals, host, matchingRuleBuilder);
+            if (matchingRuleBuilder.foundDeny()) {
+                return matchingRuleBuilder.build();
+            }
         }
 
-        // In addition to ACLs for this specific resource name, there can also be wildcard
-        // ACLs that match any resource name. These are stored as type = LITERAL,
-        // name = "*". We search these next.
-        exemplar = new StandardAcl(
-            action.resourcePattern().resourceType(),
-            WILDCARD,
-            LITERAL,
-            "",
-            "",
-            AclOperation.UNKNOWN,
-            AclPermissionType.UNKNOWN);
-        checkSection(aclCacheSnapshot, action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
+        for (KafkaPrincipal principal : matchingPrincipals) {
+            ImmutableNavigableSet<StandardAcl> principalAcls =
+                aclCacheSnapshot.aclsForPrincipal(principal.toString());
+            if (principalAcls.isEmpty()) continue;
+
+            StandardAcl exemplar = new StandardAcl(
+                resourceType,
+                resourceName,
+                PatternType.UNKNOWN,
+                principal.getPrincipalType() + ":" + principal.getName(),
+                "",
+                AclOperation.UNKNOWN,
+                AclPermissionType.UNKNOWN);
+            checkSection(principalAcls, action, exemplar, true, matchingPrincipals, host, matchingRuleBuilder);
+            if (matchingRuleBuilder.foundDeny()) {
+                return matchingRuleBuilder.build();
+            }
+        }
+
+        for (KafkaPrincipal principal : matchingPrincipals) {
+            ImmutableNavigableSet<StandardAcl> principalAcls =
+                aclCacheSnapshot.aclsForPrincipal(principal.toString());
+            if (principalAcls.isEmpty()) continue;
+
+            StandardAcl wildcardExemplar = new StandardAcl(
+                resourceType,
+                WILDCARD,
+                LITERAL,
+                principal.getPrincipalType() + ":" + principal.getName(),
+                "",
+                AclOperation.UNKNOWN,
+                AclPermissionType.UNKNOWN);
+            checkSection(principalAcls, action, wildcardExemplar, true, matchingPrincipals, host, matchingRuleBuilder);
+            if (matchingRuleBuilder.foundDeny()) {
+                return matchingRuleBuilder.build();
+            }
+        }
+
         return matchingRuleBuilder.build();
     }
 
@@ -378,49 +390,49 @@ public class StandardAuthorizerData {
     }
 
     private void checkSection(
-            AclCache aclCacheSnapshot, Action action,
-            StandardAcl exemplar,
+            NavigableSet<StandardAcl> acls, Action action,
+            StandardAcl exemplar, boolean skipPrincipalCheck,
             Set<KafkaPrincipal> matchingPrincipals,
             String host,
             MatchingRuleBuilder matchingRuleBuilder
     ) {
         String resourceName = action.resourcePattern().name();
-        NavigableSet<StandardAcl> tailSet = aclCacheSnapshot.aclsByResource().tailSet(exemplar, true);
+        NavigableSet<StandardAcl> tailSet = acls.tailSet(exemplar, true);
         Iterator<StandardAcl> iterator = tailSet.iterator();
         while (iterator.hasNext()) {
             StandardAcl acl = iterator.next();
             if (!acl.resourceType().equals(action.resourcePattern().resourceType())) {
-                // We've stepped outside the section for the resource type we care about and
-                // should stop scanning.
                 break;
             }
             int matchesUpTo = matchesUpTo(resourceName, acl.resourceName());
             if (matchesUpTo == acl.resourceName().length()) {
                 if (acl.patternType() == LITERAL && matchesUpTo != resourceName.length()) {
-                    // This is a literal ACL whose name is a prefix of the resource name, but
-                    // which doesn't match it exactly. We should skip over this ACL, but keep
-                    // scanning in case there are any relevant PREFIX ACLs.
                     continue;
                 }
 
             } else if (!(acl.resourceName().equals(WILDCARD) && acl.patternType() == LITERAL)) {
-                // If the ACL resource name is NOT a prefix of the current resource name,
-                // and we're not dealing with the special case of a wildcard ACL, we've
-                // stepped outside of the section we care about. Scan for any other potential
-                // prefix matches.
-                exemplar = new StandardAcl(exemplar.resourceType(),
-                    exemplar.resourceName().substring(0, matchesUpTo),
-                    exemplar.patternType(),
-                    exemplar.principal(),
-                    exemplar.host(),
-                    exemplar.operation(),
-                    exemplar.permissionType());
-                tailSet = aclCacheSnapshot.aclsByResource().tailSet(exemplar, true);
-                iterator = tailSet.iterator();
+                if (matchesUpTo == 0) {
+                    continue;
+                }
+                String newPrefix = exemplar.resourceName().substring(0, matchesUpTo);
+                if (newPrefix.equals(exemplar.resourceName())) {
+                    tailSet = acls.tailSet(acl, false);
+                    iterator = tailSet.iterator();
+                } else {
+                    exemplar = new StandardAcl(exemplar.resourceType(),
+                        newPrefix,
+                        exemplar.patternType(),
+                        exemplar.principal(),
+                        exemplar.host(),
+                        exemplar.operation(),
+                        exemplar.permissionType());
+                    tailSet = acls.tailSet(exemplar, true);
+                    iterator = tailSet.iterator();
+                }
                 continue;
             }
             matchingRuleBuilder.hasResourceAcls = true;
-            AuthorizationResult result = findResult(action, matchingPrincipals, host, acl);
+            AuthorizationResult result = findResult(action, matchingPrincipals, host, acl, skipPrincipalCheck);
             if (ALLOWED == result) {
                 matchingRuleBuilder.allowAcl = acl;
             } else if (DENIED == result) {
@@ -484,8 +496,18 @@ public class StandardAuthorizerData {
                                           Set<KafkaPrincipal> matchingPrincipals,
                                           String host,
                                           StandardAcl acl) {
+        return findResult(action, matchingPrincipals, host, acl, false);
+    }
+
+    static AuthorizationResult findResult(Action action,
+                                          Set<KafkaPrincipal> matchingPrincipals,
+                                          String host,
+                                          StandardAcl acl,
+                                          boolean skipPrincipalCheck) {
         // Check if the principal matches. If it doesn't, return no result (null).
-        if (!matchingPrincipals.contains(acl.kafkaPrincipal())) {
+        // When skipPrincipalCheck is true, the caller guarantees the ACL's principal
+        // is already in matchingPrincipals (e.g. via principal-indexed scan).
+        if (!skipPrincipalCheck && !matchingPrincipals.contains(acl.kafkaPrincipal())) {
             return null;
         }
         // Check if the host matches. If it doesn't, return no result (null).

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclCacheTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclCacheTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.server.immutable.ImmutableNavigableSet;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@Timeout(value = 40)
+public class AclCacheTest {
+
+    private static StandardAcl newAcl(String principal) {
+        return new StandardAcl(
+            ResourceType.TOPIC, "foo", PatternType.LITERAL,
+            principal, "*", AclOperation.READ, AclPermissionType.ALLOW);
+    }
+
+    private static StandardAcl newAcl(String principal, ResourceType resourceType, String resourceName) {
+        return new StandardAcl(
+            resourceType, resourceName, PatternType.LITERAL,
+            principal, "*", AclOperation.READ, AclPermissionType.ALLOW);
+    }
+
+    @Test
+    public void testEmptyCache() {
+        AclCache cache = new AclCache();
+        assertEquals(0, cache.count());
+        assertTrue(cache.aclsForPrincipal("User:alice").isEmpty());
+    }
+
+    @Test
+    public void testAclsForPrincipalReturnsEmptyForUnknownPrincipal() {
+        AclCache cache = new AclCache();
+        cache = cache.addAcl(Uuid.randomUuid(), newAcl("User:alice"));
+        assertTrue(cache.aclsForPrincipal("User:bob").isEmpty());
+    }
+
+    @Test
+    public void testAddUpdatesPrincipalIndex() {
+        AclCache cache = new AclCache();
+        Uuid id = Uuid.randomUuid();
+        StandardAcl acl = newAcl("User:alice");
+        cache = cache.addAcl(id, acl);
+
+        ImmutableNavigableSet<StandardAcl> aliceAcls = cache.aclsForPrincipal("User:alice");
+        assertEquals(1, aliceAcls.size());
+        assertSame(acl, aliceAcls.first());
+    }
+
+    @Test
+    public void testRemoveUpdatesPrincipalIndex() {
+        AclCache cache = new AclCache();
+        Uuid id = Uuid.randomUuid();
+        StandardAcl acl = newAcl("User:alice");
+        cache = cache.addAcl(id, acl);
+        assertEquals(1, cache.aclsForPrincipal("User:alice").size());
+
+        cache = cache.removeAcl(id);
+        assertTrue(cache.aclsForPrincipal("User:alice").isEmpty());
+        assertEquals(0, cache.count());
+    }
+
+    @Test
+    public void testMultiplePrincipals() {
+        AclCache cache = new AclCache();
+        StandardAcl aliceAcl = newAcl("User:alice");
+        StandardAcl bobAcl = newAcl("User:bob");
+        cache = cache.addAcl(Uuid.randomUuid(), aliceAcl);
+        cache = cache.addAcl(Uuid.randomUuid(), bobAcl);
+
+        assertEquals(1, cache.aclsForPrincipal("User:alice").size());
+        assertEquals(1, cache.aclsForPrincipal("User:bob").size());
+        assertSame(aliceAcl, cache.aclsForPrincipal("User:alice").first());
+        assertSame(bobAcl, cache.aclsForPrincipal("User:bob").first());
+        assertTrue(cache.aclsForPrincipal("User:charlie").isEmpty());
+    }
+
+    @Test
+    public void testCleanupOnLastRemoval() {
+        AclCache cache = new AclCache();
+        Uuid id = Uuid.randomUuid();
+        cache = cache.addAcl(id, newAcl("User:alice"));
+        cache = cache.removeAcl(id);
+
+        assertTrue(cache.aclsForPrincipal("User:alice").isEmpty());
+    }
+
+    @Test
+    public void testConsistencyAcrossIndices() {
+        AclCache cache = new AclCache();
+        Uuid id1 = Uuid.randomUuid();
+        Uuid id2 = Uuid.randomUuid();
+        StandardAcl aliceAcl = newAcl("User:alice", ResourceType.TOPIC, "foo");
+        StandardAcl bobAcl = newAcl("User:bob", ResourceType.TOPIC, "bar");
+
+        cache = cache.addAcl(id1, aliceAcl);
+        cache = cache.addAcl(id2, bobAcl);
+        assertEquals(2, cache.count());
+        assertEquals(1, cache.aclsForPrincipal("User:alice").size());
+        assertEquals(1, cache.aclsForPrincipal("User:bob").size());
+        assertEquals(2, cache.aclsByResource().size());
+        assertSame(aliceAcl, cache.getAcl(id1));
+        assertSame(bobAcl, cache.getAcl(id2));
+
+        cache = cache.removeAcl(id1);
+        assertEquals(1, cache.count());
+        assertEquals(0, cache.aclsForPrincipal("User:alice").size());
+        assertEquals(1, cache.aclsForPrincipal("User:bob").size());
+        assertEquals(1, cache.aclsByResource().size());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAclTest.java
@@ -18,6 +18,10 @@
 package org.apache.kafka.metadata.authorizer;
 
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourceType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -26,6 +30,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 
 @Timeout(value = 40)
@@ -65,5 +70,31 @@ public class StandardAclTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testKafkaPrincipalIsCached() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.TOPIC, "foo", PatternType.LITERAL,
+            "User:alice", "*", AclOperation.READ, AclPermissionType.ALLOW);
+        assertSame(acl.kafkaPrincipal(), acl.kafkaPrincipal());
+    }
+
+    @Test
+    public void testKafkaPrincipalParsing() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.TOPIC, "foo", PatternType.LITERAL,
+            "User:alice", "*", AclOperation.READ, AclPermissionType.ALLOW);
+        assertEquals("User", acl.kafkaPrincipal().getPrincipalType());
+        assertEquals("alice", acl.kafkaPrincipal().getName());
+    }
+
+    @Test
+    public void testKafkaPrincipalWildcard() {
+        StandardAcl acl = new StandardAcl(
+            ResourceType.CLUSTER, "kafka-cluster", PatternType.LITERAL,
+            "User:*", "*", AclOperation.ALTER, AclPermissionType.ALLOW);
+        assertEquals("User", acl.kafkaPrincipal().getPrincipalType());
+        assertEquals("*", acl.kafkaPrincipal().getName());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -379,6 +379,40 @@ public class StandardAuthorizerTest {
     }
 
     @Test
+    public void testCheckSectionNoCommonPrefix() throws Exception {
+        Map<String, Object> configs = Map.of(SUPER_USERS_CONFIG, "User:alice");
+        StandardAuthorizer authorizer = createAndInitializeStandardAuthorizer(configs);
+        List<StandardAcl> acls = List.of(
+            new StandardAcl(TOPIC, "bar", PREFIXED, "User:bob", "*", READ, ALLOW),
+            new StandardAcl(TOPIC, "foo_", PREFIXED, "User:bob", "*", READ, ALLOW)
+        );
+        acls.forEach(acl -> {
+            StandardAclWithId aclWithId = withId(acl);
+            authorizer.addAcl(aclWithId.id(), aclWithId.acl());
+        });
+        assertEquals(List.of(ALLOWED), authorizer.authorize(
+            newRequestContext("bob"),
+            List.of(newAction(READ, TOPIC, "foo_"))));
+    }
+
+    @Test
+    public void testCheckSectionNarrowing() throws Exception {
+        Map<String, Object> configs = Map.of(SUPER_USERS_CONFIG, "User:alice");
+        StandardAuthorizer authorizer = createAndInitializeStandardAuthorizer(configs);
+        List<StandardAcl> acls = List.of(
+            new StandardAcl(TOPIC, "caa", PREFIXED, "User:bob", "*", READ, ALLOW),
+            new StandardAcl(TOPIC, "ca", PREFIXED, "User:bob", "*", READ, ALLOW)
+        );
+        acls.forEach(acl -> {
+            StandardAclWithId aclWithId = withId(acl);
+            authorizer.addAcl(aclWithId.id(), aclWithId.acl());
+        });
+        assertEquals(List.of(ALLOWED), authorizer.authorize(
+            newRequestContext("bob"),
+            List.of(newAction(READ, TOPIC, "cat"))));
+    }
+
+    @Test
     public void testTopicAclWithOperationAll() throws Exception {
         StandardAuthorizer authorizer = createAndInitializeStandardAuthorizer();
         List<StandardAcl> acls = List.of(


### PR DESCRIPTION
(data-plane-kafka-request-handler-0" #80 daemon prio=5 os_prio=0 cpu=17207014.77ms elapsed=18143.19s tid=0x00007f76d50aa800 nid=0x8e7bb runnable [0x00007f7681480000]

  java.lang.Thread.State: RUNNABLE

       at org.apache.kafka.metadata.authorizer.StandardAcl.kafkaPrincipal(StandardAcl.java:106)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.findResult(StandardAuthorizerData.java:493)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.checkSection(StandardAuthorizerData.java:428)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.findAclRule(StandardAuthorizerData.java:367)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizerData.authorize(StandardAuthorizerData.java:247)

       at org.apache.kafka.metadata.authorizer.StandardAuthorizer.authorize(StandardAuthorizer.java:143)

       at kafka.server.AuthHelper.filterByAuthorized(AuthHelper.scala:113)

       at kafka.server.KafkaApis.handleTopicMetadataRequest(KafkaApis.scala:1350)

       at kafka.server.KafkaApis.handle(KafkaApis.scala:192)

       at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:159)

       at java.lang.Thread.run(java.base@11.0.25/Thread.java:829)

)

"""