### PR TITLE
KAFKA-20658: Cast SMT honors ByteBuffer remaining bytes

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -367,7 +367,10 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         if (value instanceof java.util.Date dateValue) {
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer byteBuffer) {
-            return Base64.getEncoder().encodeToString(Utils.readBytes(byteBuffer));
+            // Utils.readBytes reads from index 0 to limit, ignoring position; use
+            // Utils.toArray so a sliced or partially consumed buffer is encoded
+            // from its current position to its limit.
+            return Base64.getEncoder().encodeToString(Utils.toArray(byteBuffer));
         } else if (value instanceof byte[] rawBytes) {
             return Base64.getEncoder().encodeToString(rawBytes);
         } else {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -574,6 +574,23 @@ public class CastTest {
         assertEquals(Timestamp.SCHEMA.type(), transformedSchema.field("timestamp").schema().type());
     }
 
+    @Test
+    public void castSlicedByteBufferFieldToStringUsesRemainingBytes() {
+        xformValue.configure(Map.of(Cast.SPEC_CONFIG, "bytes:string"));
+
+        Schema schema = SchemaBuilder.struct()
+                .field("bytes", Schema.BYTES_SCHEMA)
+                .build();
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+        byteBuffer.position(1);
+        byteBuffer.limit(3);
+
+        Struct value = new Struct(schema).put("bytes", byteBuffer);
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0, schema, value));
+
+        assertEquals("AgM=", ((Struct) transformed.value()).get("bytes"));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void castFieldsSchemaless() {


### PR DESCRIPTION
JIRA: [KAFKA-20658](https://issues.apache.org/jira/browse/KAFKA-20658)

### What

`Cast.castToString` Base64-encoded `ByteBuffer` BYTES values via `Utils.readBytes(ByteBuffer)`. `Utils.readBytes(ByteBuffer)` reads from index `0` to the buffer's `limit` and ignores `position`, so a sliced or partially consumed buffer produced a string for bytes outside the logical BYTES value.

Switched the one call site to `Utils.toArray(ByteBuffer)`, which the sibling Connect conversion paths already use. It respects the buffer's `position..limit` contract and also supports direct buffers. `Utils` was already imported in this file.

### Tests

Added one `CastTest` case that fails against the previous implementation and passes with this change:

- `castSlicedByteBufferFieldToStringUsesRemainingBytes` wraps `{1,2,3,4}`, slides the buffer to `position=1`/`limit=3`, casts the struct field to `string`, and asserts the Base64 output is `AgM=` (`{2,3}`) instead of `AQID` (`{1,2,3}`).

The existing `castFieldsWithSchema` case still passes (covers the `byte[]` path and a heap-backed-from-position-0 `ByteBuffer`).

### Validation

```
./gradlew :connect:transforms:test \
  --tests org.apache.kafka.connect.transforms.CastTest.castSlicedByteBufferFieldToStringUsesRemainingBytes \
  --tests org.apache.kafka.connect.transforms.CastTest.castFieldsWithSchema
```

Both tests pass locally on JDK 17.

### Scope

This PR targets only the `Cast` SMT. KAFKA-20657 (`JsonConverter`) is already up as #22533; KAFKA-20656 (`Struct.getBytes`/`equals`) and KAFKA-20666 (Connect offset backing stores) cover the same `ByteBuffer.array()`-class bug in their own components and are intentionally left for separate PRs.

### Committer Checklist

- [x] Verified design and implementation
- [x] Verified test coverage and CI build status
- [x] Verified documentation (including upgrade notes) updates (no user-facing surface change beyond bug-fix behavior)
