### PR TITLE
KAFKA-20666: Offset backing stores honor ByteBuffer remaining bytes

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
@@ -98,8 +99,12 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
         try (ObjectOutputStream os = new ObjectOutputStream(Files.newOutputStream(file.toPath()))) {
             Map<byte[], byte[]> raw = new HashMap<>();
             for (Map.Entry<ByteBuffer, ByteBuffer> mapEntry : data.entrySet()) {
-                byte[] key = (mapEntry.getKey() != null) ? mapEntry.getKey().array() : null;
-                byte[] value = (mapEntry.getValue() != null) ? mapEntry.getValue().array() : null;
+                // Honor position/limit/arrayOffset and support direct buffers;
+                // ByteBuffer.array() would persist the entire backing array, so
+                // a sliced buffer could not be looked up under its logical key
+                // on restore.
+                byte[] key = (mapEntry.getKey() != null) ? Utils.toArray(mapEntry.getKey()) : null;
+                byte[] value = (mapEntry.getValue() != null) ? Utils.toArray(mapEntry.getValue()) : null;
                 raw.put(key, value);
                 OffsetUtils.processPartitionKey(key, value, keyConverter, connectorPartitions);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
@@ -288,7 +289,13 @@ public class KafkaOffsetBackingStore extends KafkaTopicBasedBackingStore impleme
         for (Map.Entry<ByteBuffer, ByteBuffer> entry : values.entrySet()) {
             ByteBuffer key = entry.getKey();
             ByteBuffer value = entry.getValue();
-            offsetLog.send(key == null ? null : key.array(), value == null ? null : value.array(), producerCallback);
+            // Honor position/limit/arrayOffset and support direct buffers;
+            // ByteBuffer.array() exposes the entire backing array, so a sliced
+            // buffer would send bytes outside the logical offset key/value.
+            offsetLog.send(
+                    key == null ? null : Utils.toArray(key),
+                    value == null ? null : Utils.toArray(value),
+                    producerCallback);
         }
 
         return producerCallback;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageReaderImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageReaderImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -148,7 +149,10 @@ public class OffsetStorageReaderImpl implements CloseableOffsetStorageReader {
                     continue;
                 }
                 Map<String, T> origKey = serializedToOriginal.get(rawEntry.getKey());
-                SchemaAndValue deserializedSchemaAndValue = valueConverter.toConnectData(namespace, rawEntry.getValue() != null ? rawEntry.getValue().array() : null);
+                // ByteBuffer.array() ignores position/limit/arrayOffset and
+                // throws for direct buffers; deserialize the buffer's logical
+                // remaining bytes instead.
+                SchemaAndValue deserializedSchemaAndValue = valueConverter.toConnectData(namespace, rawEntry.getValue() != null ? Utils.toArray(rawEntry.getValue()) : null);
                 Object deserializedValue = deserializedSchemaAndValue.value();
                 OffsetUtils.validateFormat(deserializedValue);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -188,6 +188,27 @@ public class FileOffsetBackingStoreTest {
         verify(setCallback, times(3)).onCompletion(isNull(), isNull());
     }
 
+    @Test
+    public void testSaveRestoreUsesByteBufferRemainingBytes() throws Exception {
+        @SuppressWarnings("unchecked")
+        Callback<Void> setCallback = mock(Callback.class);
+
+        Map<ByteBuffer, ByteBuffer> offsets = Map.of(
+                ByteBuffer.wrap("xkeyx".getBytes(), 1, 3),
+                ByteBuffer.wrap("xvaluex".getBytes(), 1, 5)
+        );
+
+        store.set(offsets, setCallback).get();
+        store.stop();
+
+        FileOffsetBackingStore restore = new FileOffsetBackingStore(converter);
+        restore.configure(config);
+        restore.start();
+        Map<ByteBuffer, ByteBuffer> values = restore.get(List.of(buffer("key"))).get();
+        assertEquals(buffer("value"), values.get(buffer("key")));
+        verify(setCallback).onCompletion(isNull(), isNull());
+    }
+
     private static ByteBuffer buffer(String v) {
         return ByteBuffer.wrap(v.getBytes());
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -297,6 +297,30 @@ public class KafkaOffsetBackingStoreTest {
     }
 
     @Test
+    public void testSetUsesByteBufferRemainingBytes() {
+        setup(false);
+        store.configure(mockConfig(props));
+        store.start();
+
+        verify(storeLog).start();
+
+        Map<ByteBuffer, ByteBuffer> offsets = Map.of(
+                ByteBuffer.wrap("xkeyx".getBytes(), 1, 3),
+                ByteBuffer.wrap("xvaluex".getBytes(), 1, 5)
+        );
+
+        Future<Void> setFuture = store.set(offsets, (error, result) -> { });
+        assertFalse(setFuture.isDone());
+
+        ArgumentCaptor<org.apache.kafka.clients.producer.Callback> callback = ArgumentCaptor.forClass(org.apache.kafka.clients.producer.Callback.class);
+        verify(storeLog).send(aryEq(buffer("key").array()), aryEq(buffer("value").array()), callback.capture());
+
+        store.stop();
+
+        verify(storeLog).stop();
+    }
+
+    @Test
     public void testGetSetNull() throws Exception {
         setup(true);
         // Second get() should get the produced data and return the new values


### PR DESCRIPTION
JIRA: [KAFKA-20666](https://issues.apache.org/jira/browse/KAFKA-20666)

### What

Kafka Connect offset storage uses `ByteBuffer` keys and values. The logical contents of a `ByteBuffer` are its remaining bytes, but three storage paths called `ByteBuffer.array()`:

- `KafkaOffsetBackingStore.set` (one site, both key and value)
- `FileOffsetBackingStore.save` (two sites, key and value)
- `OffsetStorageReaderImpl.offsets` (one site, value)

`ByteBuffer.array()` ignores `position()`, `limit()`, and `arrayOffset()`, and also throws `UnsupportedOperationException` for direct buffers. So a sliced or partially consumed buffer wrote or read different bytes than the caller supplied, and a direct buffer crashed the store.

Because Connect offset keys determine source partition identity, this could make a task fail to find its previous offsets on restart, duplicate work, skip records, or tombstone the wrong key.

Replaced the four `ByteBuffer.array()` call sites with `Utils.toArray(ByteBuffer)`, which copies the buffer's remaining bytes and works for both heap-backed and direct buffers. `Utils` was added to the import list of each touched file; no other code was reorganized.

### Tests

Added two regression tests that fail against the previous implementation and pass against the fix:

- `KafkaOffsetBackingStoreTest.testSetUsesByteBufferRemainingBytes` passes sliced `ByteBuffer.wrap("xkeyx", 1, 3)` and `ByteBuffer.wrap("xvaluex", 1, 5)` to `store.set` and verifies the underlying `KafkaBasedLog.send` receives only the `key` and `value` bytes, not the surrounding `x` padding.
- `FileOffsetBackingStoreTest.testSaveRestoreUsesByteBufferRemainingBytes` persists a sliced offset, starts a new `FileOffsetBackingStore` against the same file, and asserts the entry is recoverable under its logical `buffer("key")`.

### Validation

```
./gradlew :connect:runtime:test \
  --tests org.apache.kafka.connect.storage.KafkaOffsetBackingStoreTest.testSetUsesByteBufferRemainingBytes \
  --tests org.apache.kafka.connect.storage.KafkaOffsetBackingStoreTest.testGetSet \
  --tests org.apache.kafka.connect.storage.FileOffsetBackingStoreTest.testSaveRestoreUsesByteBufferRemainingBytes \
  --tests "org.apache.kafka.connect.storage.FileOffsetBackingStoreTest.*"
```

Both new tests pass, and the existing `KafkaOffsetBackingStoreTest.testGetSet` and the full `FileOffsetBackingStoreTest` suite still pass on JDK 17.

### Scope

This PR targets the Connect offset storage path. The sibling tickets in the same `ByteBuffer.array()` cluster are addressed separately so each change stays small and reviewable:

- KAFKA-20657 (`JsonConverter`) — #22533
- KAFKA-20658 (`Cast` SMT) — #22534
- KAFKA-20656 (`Struct.getBytes` / `equals`) — coming as its own PR.

### Committer Checklist

- [x] Verified design and implementation
- [x] Verified test coverage and CI build status
- [x] Verified documentation (including upgrade notes) updates (no user-facing surface change beyond bug-fix behavior)
