### PR TITLE
KAFKA-20656: Struct honors ByteBuffer remaining bytes

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.data;
 
 import org.apache.kafka.common.annotation.InterfaceAudience;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.DataException;
 
 import java.nio.ByteBuffer;
@@ -166,7 +167,9 @@ public class Struct {
     public byte[] getBytes(String fieldName) {
         Object bytes = getCheckType(fieldName, Schema.Type.BYTES);
         if (bytes instanceof ByteBuffer)
-            return ((ByteBuffer) bytes).array();
+            // ByteBuffer.array() ignores position/limit/arrayOffset and throws
+            // for direct buffers; return the logical remaining bytes instead.
+            return Utils.toArray((ByteBuffer) bytes);
         return (byte[]) bytes;
     }
 
@@ -242,12 +245,34 @@ public class Struct {
         if (o == null || getClass() != o.getClass()) return false;
         Struct struct = (Struct) o;
         return Objects.equals(schema, struct.schema) &&
-                Arrays.deepEquals(values, struct.values);
+                Arrays.deepEquals(normalizedBytesValues(), struct.normalizedBytesValues());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, Arrays.deepHashCode(values));
+        return Objects.hash(schema, Arrays.deepHashCode(normalizedBytesValues()));
+    }
+
+    /**
+     * Returns a copy of {@link #values} with top-level BYTES fields stored as
+     * {@code byte[]}, so that an equivalent value supplied as {@code byte[]} or
+     * {@code ByteBuffer} compares equal and hashes the same. The original
+     * {@link #values} array is left untouched; callers that observe a field via
+     * {@link #get(String)} still see whatever representation was put in.
+     */
+    private Object[] normalizedBytesValues() {
+        Object[] normalized = null;
+        List<Field> fields = schema.fields();
+        for (int i = 0; i < values.length; i++) {
+            Object value = values[i];
+            if (!(value instanceof ByteBuffer)) continue;
+            if (i >= fields.size() || fields.get(i).schema().type() != Schema.Type.BYTES) continue;
+            if (normalized == null) {
+                normalized = values.clone();
+            }
+            normalized[i] = Utils.toArray((ByteBuffer) value);
+        }
+        return normalized == null ? values : normalized;
     }
 
     private Field lookupField(String fieldName) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,6 +88,75 @@ public class StructTest {
         assertEquals(ByteBuffer.wrap("foobar".getBytes()), ByteBuffer.wrap(struct.getBytes("bytes")));
 
         struct.validate();
+    }
+
+    @Test
+    public void testGetBytesPreservesByteBufferRemainingBytes() {
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+        bytes.position(1);
+        bytes.limit(3);
+
+        Struct struct = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", bytes);
+
+        assertArrayEquals(new byte[] {2, 3}, struct.getBytes("bytes"));
+    }
+
+    @Test
+    public void testGetBytesSupportsDirectByteBuffer() {
+        ByteBuffer bytes = ByteBuffer.allocateDirect(2);
+        bytes.put((byte) 1);
+        bytes.put((byte) 2);
+        bytes.flip();
+
+        Struct struct = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", bytes);
+
+        assertArrayEquals(new byte[] {1, 2}, struct.getBytes("bytes"));
+    }
+
+    @Test
+    public void testEqualsAndHashCodeWithEquivalentByteArrayAndByteBufferValues() {
+        Struct byteArrayStruct = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", "foobar".getBytes());
+
+        Struct byteBufferStruct = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", ByteBuffer.wrap("foobar".getBytes()));
+
+        assertEquals(byteArrayStruct, byteBufferStruct);
+        assertEquals(byteArrayStruct.hashCode(), byteBufferStruct.hashCode());
     }
 
     @Test


### PR DESCRIPTION
JIRA: [KAFKA-20656](https://issues.apache.org/jira/browse/KAFKA-20656)

### What

Kafka Connect BYTES values may be either `byte[]` or `ByteBuffer`, and `ConnectSchema` recommends `ByteBuffer` because plain arrays do not implement content-based `equals()`/`hashCode()`. `Struct` did not honor that contract:

- `getBytes(...)` called `ByteBuffer.array()`, returning the entire backing array instead of the logical remaining bytes, and throwing `UnsupportedOperationException` for direct buffers.
- `equals` and `hashCode` delegated straight to `Arrays.deepEquals`/`deepHashCode` over the raw `values` array, so two structs holding the same logical BYTES value supplied as `byte[]` vs. `ByteBuffer` were not equal.

### Changes

- `Struct.getBytes(String)` now goes through `Utils.toArray(ByteBuffer)`. That copies the buffer's remaining bytes and works for direct buffers — the same approach `Values.convertToBytes` already uses elsewhere in this module.
- `Struct.equals(Object)` and `Struct.hashCode()` now compare/hash a `normalizedBytesValues()` view of the struct that copies top-level BYTES fields stored as `ByteBuffer` into `byte[]`. The underlying `values` array is not mutated, so `get(String)` callers still see whatever representation was put in. Non-BYTES fields go through `Arrays.deepEquals`/`deepHashCode` unchanged.

The normalization is scoped to top-level BYTES fields, matching the reporter's reproducer. Nested BYTES inside `ARRAY`/`MAP`/`STRUCT` fields keep the previous behavior in this PR.

### Tests

Added three regression tests in `StructTest` that fail against the previous implementation and pass with this change:

- `testGetBytesPreservesByteBufferRemainingBytes`: a sliced `ByteBuffer` returns only the logical bytes.
- `testGetBytesSupportsDirectByteBuffer`: a direct buffer serializes instead of throwing.
- `testEqualsAndHashCodeWithEquivalentByteArrayAndByteBufferValues`: a `byte[]`-valued struct and a `ByteBuffer`-valued struct with the same logical content are `.equals` and share a `hashCode`.

### Validation

```
./gradlew :connect:api:test --tests "org.apache.kafka.connect.data.StructTest.*"
```

All `StructTest` tests pass on JDK 17, including the new three, the existing `testFlatStruct`, and the existing `testEqualsAndHashCodeWithByteArrayValue` (which exercises the unchanged `byte[]`-only equality path).

### Scope

This PR completes the four-ticket `ByteBuffer.array()` cluster for Kafka Connect BYTES values; the other three are split into independent PRs to keep each reviewable:

- KAFKA-20657 (`JsonConverter`) — #22533
- KAFKA-20658 (`Cast` SMT) — #22534
- KAFKA-20666 (offset backing stores) — #22535

### Committer Checklist

- [x] Verified design and implementation
- [x] Verified test coverage and CI build status
- [x] Verified documentation (including upgrade notes) updates (no public API surface change beyond bug-fix behavior; equality semantics now match the documented BYTES contract)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
