### PR TITLE
MINOR: Speed up ShareConsumerTest.testAcquisitionLockTimeoutOnConsumer

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -1439,7 +1439,10 @@ public class ShareConsumerTest extends ShareConsumerTestBase {
         verifyShareGroupStateTopicRecordsProduced();
     }
 
-    @ClusterTest
+    @ClusterTest(serverProperties = {
+        @ClusterConfigProperty(key = "group.share.min.record.lock.duration.ms", value = "1000"),
+        @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "1000")
+    })
     public void testAcquisitionLockTimeoutOnConsumer() throws InterruptedException {
         alterShareAutoOffsetReset("group1", "earliest");
         try (Producer<byte[], byte[]> producer = createProducer();
@@ -1483,7 +1486,7 @@ public class ShareConsumerTest extends ShareConsumerTestBase {
             assertEquals(1, consumerRecords.count());
 
             // Allow the acquisition lock to time out.
-            Thread.sleep(20000);
+            Thread.sleep(3000);
 
             consumerRecords = shareConsumer.poll(Duration.ofMillis(5000));
             consumerRecord = consumerRecords.records(tp).get(0);

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -1440,8 +1440,8 @@ public class ShareConsumerTest extends ShareConsumerTestBase {
     }
 
     @ClusterTest(serverProperties = {
-        @ClusterConfigProperty(key = "group.share.min.record.lock.duration.ms", value = "1000"),
-        @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "1000")
+        @ClusterConfigProperty(key = "group.share.min.record.lock.duration.ms", value = "5000"),
+        @ClusterConfigProperty(key = "group.share.record.lock.duration.ms", value = "5000")
     })
     public void testAcquisitionLockTimeoutOnConsumer() throws InterruptedException {
         alterShareAutoOffsetReset("group1", "earliest");
@@ -1486,7 +1486,7 @@ public class ShareConsumerTest extends ShareConsumerTestBase {
             assertEquals(1, consumerRecords.count());
 
             // Allow the acquisition lock to time out.
-            Thread.sleep(3000);
+            Thread.sleep(8000);
 
             consumerRecords = shareConsumer.poll(Duration.ofMillis(5000));
             consumerRecord = consumerRecords.records(tp).get(0);


### PR DESCRIPTION
## Summary

Speed up `ShareConsumerTest.testAcquisitionLockTimeoutOnConsumer` by
overriding the broker-side share record lock duration for this test.

The test previously relied on the class-level
`group.share.record.lock.duration.ms=15000` and waited `20000ms` for the
acquisition lock to expire. This PR lowers the test-specific lock
duration to `5000ms` and reduces the sleep to `8000ms`.

Both `group.share.min.record.lock.duration.ms` and
`group.share.record.lock.duration.ms` are set because the actual lock
duration must be greater than or equal to the configured minimum.

Reviewers: Chia-Ping Tsai
 [chia7712@gmail.com](mailto:chia7712@gmail.com)

## Testing

Ran the target test repeatedly to check for flakiness:

```bash
./gradlew :clients:clients-integration-tests:test --tests
org.apache.kafka.clients.consumer.ShareConsumerTest.testAcquisitionLockTimeoutOnConsumer
--rerun-tasks
Result: 10/10 passed.
```

Reviewers: Andrew Schofield <aschofield@confluent.io>
