### PR TITLE
MINOR: Share common implementation for downstream offset translation boundary in MirrorMaker offset syncs

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSync.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSync.java
@@ -45,6 +45,14 @@ public record OffsetSync(TopicPartition topicPartition, long upstreamOffset, lon
             topicPartition, upstreamOffset, downstreamOffset);
     }
 
+    static long downstreamOffsetAfterSync(long downstreamOffset) {
+        return downstreamOffset + 1;
+    }
+
+    long translateDownstream(long upstreamOffset) {
+        return upstreamOffset == this.upstreamOffset ? downstreamOffset : downstreamOffsetAfterSync(downstreamOffset);
+    }
+
     ByteBuffer serializeValue() {
         Struct struct = valueStruct();
         ByteBuffer buffer = ByteBuffer.allocate(VALUE_SCHEMA.sizeOf(struct));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncStore.java
@@ -150,13 +150,13 @@ public class OffsetSyncStore implements AutoCloseable {
             //          | /
             //          vv
             // target |-sg----r-----|
-            long upstreamStep = upstreamOffset == offsetSync.get().upstreamOffset() ? 0 : 1;
+            long translatedDownstreamOffset = offsetSync.get().translateDownstream(upstreamOffset);
             log.debug("translateDownstream({},{},{}): Translated {} (relative to {})",
                     group, sourceTopicPartition, upstreamOffset,
-                    offsetSync.get().downstreamOffset() + upstreamStep,
+                    translatedDownstreamOffset,
                     offsetSync.get()
             );
-            return OptionalLong.of(offsetSync.get().downstreamOffset() + upstreamStep);
+            return OptionalLong.of(translatedDownstreamOffset);
         } else {
             log.debug("translateDownstream({},{},{}): Skipped (offset sync not found)",
                     group, sourceTopicPartition, upstreamOffset);

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncWriter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncWriter.java
@@ -169,9 +169,8 @@ class OffsetSyncWriter implements AutoCloseable {
         boolean update(long upstreamOffset, long downstreamOffset) {
             // Emit an offset sync if any of the following conditions are true
             boolean noPreviousSyncThisLifetime = lastSyncDownstreamOffset == -1L;
-            // the OffsetSync::translateDownstream method will translate this offset 1 past the last sync, so add 1.
-            // TODO: share common implementation to enforce this relationship
-            boolean translatedOffsetTooStale = downstreamOffset - (lastSyncDownstreamOffset + 1) >= maxOffsetLag;
+            // OffsetSync translates offsets after the last sync to one downstream offset past the sync.
+            boolean translatedOffsetTooStale = downstreamOffset - OffsetSync.downstreamOffsetAfterSync(lastSyncDownstreamOffset) >= maxOffsetLag;
             boolean skippedUpstreamRecord = upstreamOffset - previousUpstreamOffset != 1L;
             boolean truncatedDownstreamTopic = downstreamOffset < previousDownstreamOffset;
             if (noPreviousSyncThisLifetime || translatedOffsetTooStale || skippedUpstreamRecord || truncatedDownstreamTopic) {


### PR DESCRIPTION
This is a small refactor to resolve the TODO in
[`OffsetSyncWriter`](https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetSyncWriter.java#L172-L174)
by centralizing the downstream offset boundary calculation used by
MirrorMaker offset sync translation.

The existing behavior is unchanged. `OffsetSyncStore` and
`OffsetSyncWriter` now share the same implementation in `OffsetSync`
instead of duplicating the `downstreamOffset + 1` logic.

Reviewers: Chia-Ping Tsai
 [chia7712@gmail.com](mailto:chia7712@gmail.com), Mickael Maison
 <mickael.maison@gmail.com>
