### PR TITLE
KAFKA-20623: Wire topology description plugin into GroupCoordinatorService

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -712,6 +712,8 @@ class BrokerServer(
       .withPersister(persister)
       .withAuthorizerPlugin(authorizerPlugin.toJava)
       .withPartitionMetadataClient(partitionMetadataClient)
+      .withStreamsGroupTopologyDescriptionPlugin(
+        Optional.ofNullable(config.groupCoordinatorConfig.streamsGroupTopologyDescriptionPlugin(java.util.Map.of())))
       .build()
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -11049,7 +11049,7 @@ class KafkaApisTest extends Logging {
     val streamsGroupHeartbeatResponse = new StreamsGroupHeartbeatResponseData()
       .setMemberId("member")
 
-    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, util.Map.of(), -1))
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, util.Map.of(), -1, -1, -1))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(streamsGroupHeartbeatResponse, response.data)
   }
@@ -11119,7 +11119,7 @@ class KafkaApisTest extends Logging {
     val streamsGroupHeartbeatResponse = new StreamsGroupHeartbeatResponseData()
       .setMemberId("member")
 
-    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, util.Map.of(), -1))
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, util.Map.of(), -1, -1, -1))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(streamsGroupHeartbeatResponse, response.data)
   }
@@ -11351,7 +11351,7 @@ class KafkaApisTest extends Logging {
     val streamsGroupHeartbeatResponse = new StreamsGroupHeartbeatResponseData()
       .setMemberId("member")
 
-    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1))
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1, -1, -1))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(streamsGroupHeartbeatResponse, response.data)
     verify(autoTopicCreationManager).createStreamsInternalTopics(any(), any(), anyLong())
@@ -11400,7 +11400,7 @@ class KafkaApisTest extends Logging {
     val streamsGroupHeartbeatResponse = new StreamsGroupHeartbeatResponseData()
       .setMemberId("member")
 
-    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1))
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1, -1, -1))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     assertEquals(Errors.NONE.code, response.data.errorCode())
     assertEquals(null, response.data.errorMessage())
@@ -11451,7 +11451,7 @@ class KafkaApisTest extends Logging {
           .setStatusDetail("Internal topics are missing: [test-topic]")
       ))
 
-    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1))
+    future.complete(new StreamsGroupHeartbeatResult(streamsGroupHeartbeatResponse, missingTopics, -1, -1, -1))
     val response = verifyNoThrottling[StreamsGroupHeartbeatResponse](requestChannelRequest)
     
     assertEquals(Errors.NONE.code, response.data.errorCode())

--- a/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
+++ b/group-coordinator/group-coordinator-api/src/main/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescription.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.api.streams;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,16 +59,16 @@ public record StreamsGroupTopologyDescription(
     public record Source(String name, Set<String> topics, Set<String> successors) implements Node {
         public Source {
             Objects.requireNonNull(name, "name");
-            topics = Set.copyOf(Objects.requireNonNull(topics, "topics"));
-            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+            topics = Collections.unmodifiableSet(Objects.requireNonNull(topics, "topics"));
+            successors = Collections.unmodifiableSet(Objects.requireNonNull(successors, "successors"));
         }
     }
 
     public record Processor(String name, Set<String> stores, Set<String> successors) implements Node {
         public Processor {
             Objects.requireNonNull(name, "name");
-            stores = Set.copyOf(Objects.requireNonNull(stores, "stores"));
-            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+            stores = Collections.unmodifiableSet(Objects.requireNonNull(stores, "stores"));
+            successors = Collections.unmodifiableSet(Objects.requireNonNull(successors, "successors"));
         }
     }
 
@@ -75,7 +76,7 @@ public record StreamsGroupTopologyDescription(
         public Sink {
             Objects.requireNonNull(name, "name");
             Objects.requireNonNull(topic, "topic");
-            successors = Set.copyOf(Objects.requireNonNull(successors, "successors"));
+            successors = Collections.unmodifiableSet(Objects.requireNonNull(successors, "successors"));
         }
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinator.java
@@ -47,6 +47,8 @@ import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateRequestData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -96,6 +98,27 @@ public interface GroupCoordinator {
     CompletableFuture<StreamsGroupHeartbeatResult> streamsGroupHeartbeat(
         AuthorizableRequestContext context,
         StreamsGroupHeartbeatRequestData request
+    );
+
+    /**
+     * Persist the full topology description pushed by a Streams group member.
+     *
+     * <p>The broker forwards the description to the configured
+     * {@code StreamsGroupTopologyDescriptionPlugin}. On success the broker writes a
+     * metadata record advancing {@code StoredDescriptionTopologyEpoch}. On a permanent
+     * plugin failure it writes {@code FailedDescriptionTopologyEpoch} to stop re-soliciting
+     * at the same epoch. On a transient failure no record is written and the broker arms
+     * an in-memory back-off.
+     *
+     * @param context   The request context.
+     * @param request   The StreamsGroupTopologyDescriptionUpdateRequest data.
+     *
+     * @return A future yielding the response. The error code is set to indicate any error
+     *         encountered during the execution.
+     */
+    CompletableFuture<StreamsGroupTopologyDescriptionUpdateResponseData> streamsGroupTopologyDescriptionUpdate(
+        AuthorizableRequestContext context,
+        StreamsGroupTopologyDescriptionUpdateRequestData request
     );
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -59,6 +59,8 @@ import org.apache.kafka.common.message.ShareGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateRequestData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateResponseData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
@@ -77,6 +79,7 @@ import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.requests.ShareGroupDescribeRequest;
 import org.apache.kafka.common.requests.ShareGroupHeartbeatRequest;
 import org.apache.kafka.common.requests.StreamsGroupDescribeRequest;
+import org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.utils.Time;
@@ -98,9 +101,14 @@ import org.apache.kafka.coordinator.common.runtime.MultiThreadedEventProcessor;
 import org.apache.kafka.coordinator.common.runtime.PartitionWriter;
 import org.apache.kafka.coordinator.group.GroupCoordinatorShard.DeletedTopic;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
+import org.apache.kafka.coordinator.group.api.streams.StreamsTopologyDescriptionPermanentFailureException;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupDescribeResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupTopologyDescriptionBackoff;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupTopologyDescriptionConverter;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.TopicsDelta;
@@ -143,6 +151,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 
@@ -175,6 +184,7 @@ public class GroupCoordinatorService implements GroupCoordinator {
         private Persister persister;
         private Optional<Plugin<Authorizer>> authorizerPlugin;
         private PartitionMetadataClient partitionMetadataClient;
+        private Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin = Optional.empty();
 
         public Builder(
             int nodeId,
@@ -234,6 +244,13 @@ public class GroupCoordinatorService implements GroupCoordinator {
             return this;
         }
 
+        public Builder withStreamsGroupTopologyDescriptionPlugin(
+            Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin
+        ) {
+            this.streamsGroupTopologyDescriptionPlugin = streamsGroupTopologyDescriptionPlugin;
+            return this;
+        }
+
         public GroupCoordinatorService build() {
             requireNonNull(config, "Config must be set.");
             requireNonNull(writer, "Writer must be set.");
@@ -246,12 +263,21 @@ public class GroupCoordinatorService implements GroupCoordinator {
             requireNonNull(persister, "Persister must be set.");
             requireNonNull(authorizerPlugin, "Authorizer must be set.");
             requireNonNull(partitionMetadataClient, "PartitionMetadataClient must be set.");
+            requireNonNull(streamsGroupTopologyDescriptionPlugin, "StreamsGroupTopologyDescriptionPlugin must be set.");
 
             String logPrefix = String.format("GroupCoordinator id=%d", nodeId);
             LogContext logContext = new LogContext(String.format("[%s] ", logPrefix));
 
+            // The back-off is constructed here (not inside the service constructor) so the
+            // shard-builder supplier closure can capture a reference to it and wire the
+            // streams-group removal listener that fires from GroupMetadataManager when a
+            // streams group is tombstoned, expired, or unloaded.
+            StreamsGroupTopologyDescriptionBackoff streamsGroupTopologyDescriptionBackoff =
+                new StreamsGroupTopologyDescriptionBackoff(time);
+
             CoordinatorShardBuilderSupplier<GroupCoordinatorShard, CoordinatorRecord> supplier = () ->
                 new GroupCoordinatorShard.Builder(config, groupConfigManager)
+                    .withStreamsGroupRemovalListener(streamsGroupTopologyDescriptionBackoff::clear)
                     .withAuthorizerPlugin(authorizerPlugin);
 
             CoordinatorEventProcessor processor = new MultiThreadedEventProcessor(
@@ -297,7 +323,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 groupConfigManager,
                 persister,
                 timer,
-                partitionMetadataClient
+                partitionMetadataClient,
+                streamsGroupTopologyDescriptionPlugin,
+                streamsGroupTopologyDescriptionBackoff
             );
         }
     }
@@ -353,6 +381,19 @@ public class GroupCoordinatorService implements GroupCoordinator {
     private final PartitionMetadataClient partitionMetadataClient;
 
     /**
+     * The streams group topology description plugin. Empty when the broker config
+     * {@code group.streams.topology.description.plugin.class} is unset, which
+     * disables the feature.
+     */
+    private final Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin;
+
+    /**
+     * In-memory per-group back-off that throttles re-soliciting a topology description push.
+     * Only consulted when {@link #streamsGroupTopologyDescriptionPlugin} is present.
+     */
+    private final StreamsGroupTopologyDescriptionBackoff streamsGroupTopologyDescriptionBackoff;
+
+    /**
      * The number of partitions of the __consumer_offsets topics. This is provided
      * when the component is started.
      */
@@ -382,7 +423,9 @@ public class GroupCoordinatorService implements GroupCoordinator {
         GroupConfigManager groupConfigManager,
         Persister persister,
         Timer timer,
-        PartitionMetadataClient partitionMetadataClient
+        PartitionMetadataClient partitionMetadataClient,
+        Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin,
+        StreamsGroupTopologyDescriptionBackoff streamsGroupTopologyDescriptionBackoff
     ) {
         this.log = logContext.logger(GroupCoordinatorService.class);
         this.config = config;
@@ -397,6 +440,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
             .map(ConsumerGroupPartitionAssignor::name)
             .collect(Collectors.toSet());
         this.partitionMetadataClient = partitionMetadataClient;
+        this.streamsGroupTopologyDescriptionPlugin = streamsGroupTopologyDescriptionPlugin;
+        this.streamsGroupTopologyDescriptionBackoff = streamsGroupTopologyDescriptionBackoff;
     }
 
     /**
@@ -608,6 +653,8 @@ public class GroupCoordinatorService implements GroupCoordinator {
                 new StreamsGroupHeartbeatResult(
                     new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()),
                     Map.of(),
+                    -1,
+                    -1,
                     -1
                 )
             );
@@ -624,15 +671,19 @@ public class GroupCoordinatorService implements GroupCoordinator {
                         .setErrorCode(apiError.error().code())
                         .setErrorMessage(apiError.message()),
                     Map.of(),
+                    -1,
+                    -1,
                     -1
                 )
             );
         }
 
+        final String heartbeatGroupId = request.groupId();
         return runtime.scheduleWriteOperation(
             "streams-group-heartbeat",
-            topicPartitionFor(request.groupId()),
+            topicPartitionFor(heartbeatGroupId),
             coordinator -> coordinator.streamsGroupHeartbeat(context, request)
+        ).thenApply(result -> maybeSetTopologyDescriptionRequired(result, heartbeatGroupId)
         ).exceptionally(exception -> handleOperationException(
             "streams-group-heartbeat",
             request,
@@ -643,11 +694,233 @@ public class GroupCoordinatorService implements GroupCoordinator {
                         .setErrorCode(error.code())
                         .setErrorMessage(message),
                     Map.of(),
+                    -1,
+                    -1,
                     -1
                 ),
             log
         ));
     }
+
+    /**
+     * Post-processes a successful streams group heartbeat result by deciding whether the
+     * broker should set {@code TopologyDescriptionRequired=true} on the response, and
+     * arming the per-group back-off when it does.
+     *
+     * <p>The flag is set when the topology description plugin is configured, the group
+     * has resolved to a topology epoch, that epoch is neither stored nor permanently
+     * failed at the plugin, no back-off is in effect for this epoch, and the response
+     * does not carry a {@code STALE_TOPOLOGY} status (the member would just be told to
+     * catch up first). When the response already carries an error code we leave it
+     * alone.
+     */
+    private StreamsGroupHeartbeatResult maybeSetTopologyDescriptionRequired(
+        StreamsGroupHeartbeatResult result,
+        String groupId
+    ) {
+        if (streamsGroupTopologyDescriptionPlugin.isEmpty()) {
+            return result;
+        }
+        StreamsGroupHeartbeatResponseData response = result.data();
+        if (response.errorCode() != Errors.NONE.code()) {
+            return result;
+        }
+        int currentEpoch = result.currentTopologyEpoch();
+        if (currentEpoch < 0
+            || result.storedDescriptionTopologyEpoch() == currentEpoch
+            || result.failedDescriptionTopologyEpoch() == currentEpoch
+            || responseHasStaleTopology(response)) {
+            return result;
+        }
+        // Atomic check-and-arm: only set the flag if the back-off window is not already
+        // in effect for this epoch, so two concurrent heartbeats for the same group cannot
+        // both arm the back-off and double the window beyond its intended length.
+        if (streamsGroupTopologyDescriptionBackoff.armIfNotActive(groupId, currentEpoch)) {
+            response.setTopologyDescriptionRequired(true);
+        }
+        return result;
+    }
+
+    private static boolean responseHasStaleTopology(StreamsGroupHeartbeatResponseData response) {
+        if (response.status() == null) {
+            return false;
+        }
+        byte staleCode = Status.STALE_TOPOLOGY.code();
+        return response.status().stream().anyMatch(s -> s.statusCode() == staleCode);
+    }
+
+    /**
+     * See {@link GroupCoordinator#streamsGroupTopologyDescriptionUpdate(AuthorizableRequestContext, StreamsGroupTopologyDescriptionUpdateRequestData)}.
+     */
+    @Override
+    public CompletableFuture<StreamsGroupTopologyDescriptionUpdateResponseData> streamsGroupTopologyDescriptionUpdate(
+        AuthorizableRequestContext context,
+        StreamsGroupTopologyDescriptionUpdateRequestData request
+    ) {
+        Optional<StreamsGroupTopologyDescriptionUpdateResponseData> earlyResponse =
+            preCheckTopologyDescriptionUpdate(request);
+        if (earlyResponse.isPresent()) {
+            return CompletableFuture.completedFuture(earlyResponse.get());
+        }
+
+        final String groupId = request.groupId();
+        final String memberId = request.memberId();
+        final int pushedEpoch = request.topologyEpoch();
+        final TopicPartition tp = topicPartitionFor(groupId);
+        final StreamsGroupTopologyDescriptionPlugin plugin = streamsGroupTopologyDescriptionPlugin.get();
+
+        // Validate group + member first, so a fenced caller gets UNKNOWN_MEMBER_ID rather than
+        // an INVALID_REQUEST surfaced from converting a malformed payload. Only after the member
+        // is confirmed do we convert the wire payload, hand it to the plugin, and persist the
+        // outcome. Back-off state is mutated in a single whenComplete to centralize the
+        // permanent-vs-transient-vs-success accounting in one place. The chain carries the
+        // terminal disposition through a holder so whenComplete can act on it without having
+        // to reason about the response shape.
+        final AtomicReference<BackoffAction> backoffAction = new AtomicReference<>(BackoffAction.ARM);
+        return runtime.scheduleReadOperation(
+            "streams-group-topology-description-validate",
+            tp,
+            (coordinator, lastCommittedOffset) -> {
+                coordinator.validateStreamsGroupMember(groupId, memberId, lastCommittedOffset);
+                return null;
+            }
+        ).thenApply(__ -> StreamsGroupTopologyDescriptionConverter.fromRequest(request.topologyDescription())
+        ).thenCompose(description -> invokePluginSetTopology(plugin, groupId, pushedEpoch, description)
+        ).thenCompose(pluginOutcome -> switch (pluginOutcome.kind()) {
+            case SUCCESS -> runtime.scheduleWriteOperation(
+                "streams-group-set-stored-topology-epoch",
+                tp,
+                coordinator -> coordinator.streamsGroupSetTopologyDescriptionEpoch(groupId, pushedEpoch, false)
+            ).thenApply(unused -> {
+                backoffAction.set(BackoffAction.CLEAR);
+                return new StreamsGroupTopologyDescriptionUpdateResponseData();
+            });
+            case PERMANENT -> runtime.scheduleWriteOperation(
+                "streams-group-set-failed-topology-epoch",
+                tp,
+                coordinator -> coordinator.streamsGroupSetTopologyDescriptionEpoch(groupId, pushedEpoch, true)
+            ).thenApply(unused -> {
+                backoffAction.set(BackoffAction.CLEAR);
+                return topologyDescriptionUpdateErrorResponse(
+                    Errors.STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED, pluginOutcome.message());
+            });
+            case TRANSIENT -> CompletableFuture.completedFuture(topologyDescriptionUpdateErrorResponse(
+                Errors.STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED, pluginOutcome.message()));
+        }).whenComplete((response, throwable) -> {
+            // Success and permanent failure both terminate re-solicitation at this epoch
+            // (success advances StoredDescriptionTopologyEpoch, permanent ratchets
+            // FailedDescriptionTopologyEpoch), so the back-off entry is dropped. Transient
+            // failures and any post-plugin failure — including a metadata-record write that
+            // failed after a successful plugin call — leave the action at ARM so the next
+            // heartbeat does not immediately re-solicit; the idempotent re-push then closes
+            // the gap, matching the KIP-1331 invariant.
+            if (backoffAction.get() == BackoffAction.CLEAR) {
+                streamsGroupTopologyDescriptionBackoff.clear(groupId);
+            } else {
+                streamsGroupTopologyDescriptionBackoff.armOrExtend(groupId, pushedEpoch);
+            }
+        }).exceptionally(exception -> handleOperationException(
+            "streams-group-topology-description-update",
+            request,
+            exception,
+            GroupCoordinatorService::topologyDescriptionUpdateErrorResponse,
+            log
+        ));
+    }
+
+    private static StreamsGroupTopologyDescriptionUpdateResponseData topologyDescriptionUpdateErrorResponse(
+        Errors error,
+        String message
+    ) {
+        return new StreamsGroupTopologyDescriptionUpdateResponseData()
+            .setErrorCode(error.code())
+            .setErrorMessage(message);
+    }
+
+    /**
+     * Reject the request synchronously when the coordinator is not active, no plugin is
+     * configured, or the request fails basic validation. Returns the response to send back
+     * to the client, or empty when the request is accepted for further processing.
+     */
+    private Optional<StreamsGroupTopologyDescriptionUpdateResponseData> preCheckTopologyDescriptionUpdate(
+        StreamsGroupTopologyDescriptionUpdateRequestData request
+    ) {
+        if (!isActive.get()) {
+            return Optional.of(topologyDescriptionUpdateErrorResponse(Errors.COORDINATOR_NOT_AVAILABLE, null));
+        }
+        if (streamsGroupTopologyDescriptionPlugin.isEmpty()) {
+            return Optional.of(topologyDescriptionUpdateErrorResponse(
+                Errors.UNSUPPORTED_VERSION,
+                "The broker has no streams group topology description plugin configured."
+            ));
+        }
+        if (request.memberId() == null || request.memberId().isEmpty()) {
+            return Optional.of(topologyDescriptionUpdateErrorResponse(
+                Errors.INVALID_REQUEST, "MemberId can't be empty."
+            ));
+        }
+        if (!isGroupIdNotEmpty(request.groupId())) {
+            return Optional.of(topologyDescriptionUpdateErrorResponse(
+                Errors.INVALID_REQUEST, "GroupId can't be empty."
+            ));
+        }
+        if (request.topologyDescription() == null) {
+            return Optional.of(topologyDescriptionUpdateErrorResponse(
+                Errors.INVALID_REQUEST, "TopologyDescription can't be null."
+            ));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Calls the plugin's {@code setTopology} and folds the result into a {@link PluginOutcome}.
+     * The future never completes exceptionally — the outcome carries the failure category.
+     */
+    private static CompletableFuture<PluginOutcome> invokePluginSetTopology(
+        StreamsGroupTopologyDescriptionPlugin plugin,
+        String groupId,
+        int pushedEpoch,
+        StreamsGroupTopologyDescription description
+    ) {
+        final CompletableFuture<Void> pluginFuture;
+        try {
+            pluginFuture = plugin.setTopology(groupId, pushedEpoch, description);
+        } catch (Throwable t) {
+            // A synchronous throw from the plugin is treated as a permanent failure with a
+            // generic client-visible message.
+            return CompletableFuture.completedFuture(PluginOutcome.permanent(t.getMessage()));
+        }
+        return pluginFuture.handle((unused, throwable) -> {
+            if (throwable == null) {
+                return PluginOutcome.success();
+            }
+            Throwable cause = throwable instanceof CompletionException && throwable.getCause() != null
+                ? throwable.getCause()
+                : throwable;
+            if (cause instanceof StreamsTopologyDescriptionPermanentFailureException) {
+                return PluginOutcome.permanent(cause.getMessage());
+            }
+            return PluginOutcome.transientFailure(cause.getMessage());
+        });
+    }
+
+    private record PluginOutcome(Kind kind, String message) {
+        enum Kind { SUCCESS, PERMANENT, TRANSIENT }
+
+        static PluginOutcome success() {
+            return new PluginOutcome(Kind.SUCCESS, null);
+        }
+
+        static PluginOutcome permanent(String message) {
+            return new PluginOutcome(Kind.PERMANENT, message);
+        }
+
+        static PluginOutcome transientFailure(String message) {
+            return new PluginOutcome(Kind.TRANSIENT, message);
+        }
+    }
+
+    private enum BackoffAction { CLEAR, ARM }
 
     /**
      * Validates the ShareGroupHeartbeat request.
@@ -1434,9 +1707,17 @@ public class GroupCoordinatorService implements GroupCoordinator {
                     return CompletableFuture.completedFuture(deletableGroupResults);
                 }
 
-                return handleDeleteGroups(context, topicPartition, retainedGroupIds)
-                    .whenComplete((resp, __) -> resp.forEach(result -> deletableGroupResults.add(result.duplicate())))
-                    .thenApply(__ -> deletableGroupResults);
+                return deleteStreamsGroupTopologyDescriptions(topicPartition, retainedGroupIds)
+                    .thenCompose(streamsErrMap -> {
+                        List<String> afterStreams = filterStreamsTopologyErrors(
+                            streamsErrMap, retainedGroupIds, deletableGroupResults, context.requestVersion());
+                        if (afterStreams.isEmpty()) {
+                            return CompletableFuture.completedFuture(deletableGroupResults);
+                        }
+                        return handleDeleteGroups(context, topicPartition, afterStreams)
+                            .whenComplete((resp, __) -> resp.forEach(result -> deletableGroupResults.add(result.duplicate())))
+                            .thenApply(__ -> deletableGroupResults);
+                    });
             });
             // deleteShareGroups has its own exceptionally block, so we don't need one here.
 
@@ -1493,6 +1774,114 @@ public class GroupCoordinatorService implements GroupCoordinator {
         // Let us invoke the standard procedure of any non-share
         // groups or successfully deleted share groups remaining.
         return groupSet.stream().toList();
+    }
+
+    /**
+     * Call {@code plugin.deleteTopology} for every retained group id that is a streams
+     * group carrying a stored topology description. Returns a per-group map of failures
+     * keyed by group id; groups absent from the map either had no plugin state or the
+     * plugin call succeeded. Empty (no-op) when no plugin is configured.
+     */
+    private CompletableFuture<Map<String, ApiError>> deleteStreamsGroupTopologyDescriptions(
+        TopicPartition topicPartition,
+        List<String> groupIds
+    ) {
+        if (streamsGroupTopologyDescriptionPlugin.isEmpty()) {
+            return CompletableFuture.completedFuture(Map.of());
+        }
+        final StreamsGroupTopologyDescriptionPlugin plugin = streamsGroupTopologyDescriptionPlugin.get();
+        return runtime.scheduleReadOperation(
+            "streams-group-topology-pre-delete",
+            topicPartition,
+            (coordinator, lastCommittedOffset) ->
+                coordinator.streamsGroupsWithStoredTopologyDescription(groupIds, lastCommittedOffset)
+        ).thenCompose(groupsWithStored -> {
+            if (groupsWithStored.isEmpty()) {
+                return CompletableFuture.completedFuture(Map.<String, ApiError>of());
+            }
+            Map<String, CompletableFuture<Throwable>> calls = new HashMap<>(groupsWithStored.size());
+            for (String groupId : groupsWithStored) {
+                CompletableFuture<Throwable> outcome;
+                try {
+                    outcome = plugin.deleteTopology(groupId).handle((unused, throwable) -> throwable);
+                } catch (Throwable t) {
+                    outcome = CompletableFuture.completedFuture(t);
+                }
+                calls.put(groupId, outcome);
+            }
+            CompletableFuture<?>[] all = calls.values().toArray(new CompletableFuture<?>[0]);
+            return CompletableFuture.allOf(all).thenApply(unused -> {
+                Map<String, ApiError> failures = new HashMap<>();
+                calls.forEach((groupId, throwableFuture) -> {
+                    Throwable t = throwableFuture.join();
+                    if (t != null) {
+                        Throwable cause = t instanceof CompletionException && t.getCause() != null
+                            ? t.getCause() : t;
+                        log.warn("Topology description plugin failed to delete topology for streams group {}.",
+                            groupId, cause);
+                        streamsGroupTopologyDescriptionBackoff.clear(groupId);
+                        failures.put(groupId, new ApiError(Errors.GROUP_DELETION_FAILED, cause.getMessage()));
+                    } else {
+                        streamsGroupTopologyDescriptionBackoff.clear(groupId);
+                    }
+                });
+                return failures;
+            });
+        }).exceptionally(exception -> {
+            // A failure to read the streams group state (NOT_COORDINATOR etc.) is treated
+            // the same as a plugin failure: every retained group is held back from
+            // tombstoning so the caller can retry. The downstream chain prefers the more
+            // specific error from the runtime over GROUP_DELETION_FAILED.
+            Errors error = Errors.forException(exception);
+            Map<String, ApiError> failures = new HashMap<>();
+            for (String groupId : groupIds) {
+                failures.put(groupId, new ApiError(error, exception.getMessage()));
+            }
+            return failures;
+        });
+    }
+
+    /**
+     * Move plugin failures into {@code deletableGroupResults} and return the group ids
+     * that should still proceed to tombstoning.
+     *
+     * <p>Per KIP-1331, {@code GROUP_DELETION_FAILED} and the per-group {@code ErrorMessage}
+     * field were introduced in DeleteGroups v3. For older clients we downgrade the error to
+     * {@code UNKNOWN_SERVER_ERROR} with no message — matching the convention used by KIP-1043
+     * for new error codes that pre-existing request versions cannot interpret. Errors that
+     * predate this KIP (e.g. NOT_COORDINATOR surfaced from the runtime via the exceptionally
+     * branch above) are passed through unchanged.
+     */
+    private static List<String> filterStreamsTopologyErrors(
+        Map<String, ApiError> streamsErrMap,
+        List<String> groupIds,
+        DeleteGroupsResponseData.DeletableGroupResultCollection deletableGroupResults,
+        int requestVersion
+    ) {
+        if (streamsErrMap.isEmpty()) {
+            return groupIds;
+        }
+        List<String> retained = new ArrayList<>(groupIds.size() - streamsErrMap.size());
+        for (String groupId : groupIds) {
+            ApiError err = streamsErrMap.get(groupId);
+            if (err == null) {
+                retained.add(groupId);
+            } else {
+                Errors effectiveError = err.error();
+                String effectiveMessage = err.message();
+                if (effectiveError == Errors.GROUP_DELETION_FAILED && requestVersion < 3) {
+                    effectiveError = Errors.UNKNOWN_SERVER_ERROR;
+                    effectiveMessage = null;
+                }
+                deletableGroupResults.add(
+                    new DeleteGroupsResponseData.DeletableGroupResult()
+                        .setGroupId(groupId)
+                        .setErrorCode(effectiveError.code())
+                        .setErrorMessage(effectiveMessage)
+                );
+            }
+        }
+        return retained;
     }
 
     private CompletableFuture<DeleteGroupsResponseData.DeletableGroupResultCollection> handleDeleteGroups(

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -131,6 +131,7 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -140,6 +141,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * The group coordinator shard is a replicated state machine that manages the metadata of all
@@ -165,6 +167,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         private CoordinatorMetrics coordinatorMetrics;
         private TopicPartition topicPartition;
         private Optional<Plugin<Authorizer>> authorizerPlugin;
+        private Consumer<String> streamsGroupRemovalListener = groupId -> { };
 
         public Builder(
             GroupCoordinatorConfig config,
@@ -235,6 +238,13 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             return this;
         }
 
+        public Builder withStreamsGroupRemovalListener(
+            Consumer<String> streamsGroupRemovalListener
+        ) {
+            this.streamsGroupRemovalListener = streamsGroupRemovalListener;
+            return this;
+        }
+
         @SuppressWarnings("NPathComplexity")
         @Override
         public GroupCoordinatorShard build() {
@@ -272,6 +282,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 .withGroupCoordinatorMetricsShard(metricsShard)
                 .withShareGroupAssignor(config.shareGroupAssignors().get(0))
                 .withAuthorizerPlugin(authorizerPlugin)
+                .withStreamsGroupRemovalListener(streamsGroupRemovalListener)
                 .build();
 
             OffsetMetadataManager offsetMetadataManager = new OffsetMetadataManager.Builder()
@@ -930,6 +941,37 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         long committedOffset
     ) {
         groupMetadataManager.validateStreamsGroupMember(groupId, memberId, committedOffset);
+    }
+
+    /**
+     * Persist the outcome of a topology description plugin call. Writes a metadata record
+     * advancing either {@code StoredDescriptionTopologyEpoch} (on plugin success) or
+     * {@code FailedDescriptionTopologyEpoch} (on permanent plugin failure).
+     *
+     * @param groupId           The streams group id.
+     * @param pushedEpoch       The topology epoch on the push that just completed.
+     * @param permanentFailure  True if the plugin signalled a permanent failure; false on success.
+     * @return A coordinator result carrying the metadata record.
+     * @throws GroupIdNotFoundException if the streams group no longer exists.
+     */
+    public CoordinatorResult<Void, CoordinatorRecord> streamsGroupSetTopologyDescriptionEpoch(
+        String groupId,
+        int pushedEpoch,
+        boolean permanentFailure
+    ) {
+        return groupMetadataManager.streamsGroupSetTopologyDescriptionEpoch(groupId, pushedEpoch, permanentFailure);
+    }
+
+    /**
+     * Return the subset of {@code groupIds} that are streams groups with a stored topology
+     * description. Used during {@code DeleteGroups} to identify which groups need a
+     * {@code plugin.deleteTopology} call before being tombstoned.
+     */
+    public Set<String> streamsGroupsWithStoredTopologyDescription(
+        Collection<String> groupIds,
+        long committedOffset
+    ) {
+        return groupMetadataManager.streamsGroupsWithStoredTopologyDescription(groupIds, committedOffset);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -182,6 +182,7 @@ import org.slf4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -196,6 +197,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -338,6 +340,7 @@ public class GroupMetadataManager {
         private GroupCoordinatorMetricsShard metrics;
         private Optional<Plugin<Authorizer>> authorizerPlugin = null;
         private List<TaskAssignor> streamsGroupAssignors = null;
+        private Consumer<String> streamsGroupRemovalListener = groupId -> { };
 
         Builder withLogContext(LogContext logContext) {
             this.logContext = logContext;
@@ -399,6 +402,11 @@ public class GroupMetadataManager {
             return this;
         }
 
+        Builder withStreamsGroupRemovalListener(Consumer<String> streamsGroupRemovalListener) {
+            this.streamsGroupRemovalListener = streamsGroupRemovalListener;
+            return this;
+        }
+
         GroupMetadataManager build() {
             if (logContext == null) logContext = new LogContext();
             if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
@@ -433,7 +441,8 @@ public class GroupMetadataManager {
                 groupConfigManager,
                 shareGroupAssignor,
                 authorizerPlugin,
-                streamsGroupAssignors
+                streamsGroupAssignors,
+                streamsGroupRemovalListener
             );
         }
     }
@@ -558,6 +567,15 @@ public class GroupMetadataManager {
      */
     private final TopicRegexResolver topicRegexResolver;
 
+    /**
+     * Listener fired when a streams group is removed from this shard (explicit DeleteGroups,
+     * offset-expiration sweep, replayed tombstone, partition unload). Used by the
+     * GroupCoordinatorService to clear the in-memory topology-description back-off entry
+     * for the group so the cross-broker-but-not-cross-partition back-off map does not retain
+     * stale entries indefinitely.
+     */
+    private final Consumer<String> streamsGroupRemovalListener;
+
     private GroupMetadataManager(
         SnapshotRegistry snapshotRegistry,
         LogContext logContext,
@@ -570,7 +588,8 @@ public class GroupMetadataManager {
         GroupConfigManager groupConfigManager,
         ShareGroupPartitionAssignor shareGroupAssignor,
         Optional<Plugin<Authorizer>> authorizerPlugin,
-        List<TaskAssignor> streamsGroupAssignors
+        List<TaskAssignor> streamsGroupAssignors,
+        Consumer<String> streamsGroupRemovalListener
     ) {
         this.logContext = logContext;
         this.log = logContext.logger(GroupMetadataManager.class);
@@ -594,6 +613,7 @@ public class GroupMetadataManager {
         this.streamsGroupAssignors = streamsGroupAssignors.stream().collect(Collectors.toMap(TaskAssignor::name, Function.identity()));
         this.topicRegexResolver = new TopicRegexResolver(() -> authorizerPlugin, this.time);
         this.topicHashCache = new HashMap<>();
+        this.streamsGroupRemovalListener = streamsGroupRemovalListener;
     }
 
     /**
@@ -1456,14 +1476,19 @@ public class GroupMetadataManager {
     }
 
     /**
-     * Removes the group.
+     * Removes the group. Fires the streams-group removal listener when the removed
+     * group was a streams group so the service-level back-off can release its entry.
      *
      * @param groupId The group id.
      */
     private void removeGroup(
         String groupId
     ) {
+        Group removed = groups.get(groupId, Long.MAX_VALUE);
         groups.remove(groupId);
+        if (removed != null && removed.type() == Group.GroupType.STREAMS) {
+            streamsGroupRemovalListener.accept(groupId);
+        }
     }
 
     /**
@@ -2308,7 +2333,13 @@ public class GroupMetadataManager {
 
         response.setStatus(returnedStatus);
 
-        return new CoordinatorResult<>(records, new StreamsGroupHeartbeatResult(response, internalTopicsToBeCreated, updatedTopology.topologyEpoch()));
+        return new CoordinatorResult<>(records, new StreamsGroupHeartbeatResult(
+            response,
+            internalTopicsToBeCreated,
+            updatedTopology.topologyEpoch(),
+            group.storedDescriptionTopologyEpoch(),
+            group.failedDescriptionTopologyEpoch()
+        ));
     }
 
     /**
@@ -4447,7 +4478,13 @@ public class GroupMetadataManager {
         if (instanceId == null) {
             StreamsGroupMember member = group.getMemberOrThrow(memberId);
             log.info("[GroupId {}][MemberId {}] Member {} left the streams group.", groupId, memberId, memberId);
-            return streamsGroupFenceMember(group, member, new StreamsGroupHeartbeatResult(response, Map.of(), group.currentTopologyEpoch()));
+            return streamsGroupFenceMember(group, member, new StreamsGroupHeartbeatResult(
+                response,
+                Map.of(),
+                group.currentTopologyEpoch(),
+                group.storedDescriptionTopologyEpoch(),
+                group.failedDescriptionTopologyEpoch()
+            ));
         } else {
             StreamsGroupMember member = group.staticMember(instanceId);
             throwIfStaticMemberIsUnknown(member, instanceId);
@@ -4459,7 +4496,13 @@ public class GroupMetadataManager {
             } else {
                 log.info("[GroupId {}][MemberId {}] Static member {} with instance id {} left the streams group.",
                     group.groupId(), memberId, memberId, instanceId);
-                return streamsGroupFenceMember(group, member, new StreamsGroupHeartbeatResult(response, Map.of(), group.currentTopologyEpoch()));
+                return streamsGroupFenceMember(group, member, new StreamsGroupHeartbeatResult(
+                    response,
+                    Map.of(),
+                    group.currentTopologyEpoch(),
+                    group.storedDescriptionTopologyEpoch(),
+                    group.failedDescriptionTopologyEpoch()
+                ));
             }
         }
     }
@@ -4528,7 +4571,13 @@ public class GroupMetadataManager {
 
         return new CoordinatorResult<>(
             List.of(record),
-            new StreamsGroupHeartbeatResult(response, Map.of(), group.currentTopologyEpoch())
+            new StreamsGroupHeartbeatResult(
+                response,
+                Map.of(),
+                group.currentTopologyEpoch(),
+                group.storedDescriptionTopologyEpoch(),
+                group.failedDescriptionTopologyEpoch()
+            )
         );
     }
 
@@ -6544,6 +6593,7 @@ public class GroupMetadataManager {
                     StreamsGroup streamsGroup = (StreamsGroup) group;
                     log.info("[GroupId={}] Unloaded group metadata for group epoch {}.",
                         streamsGroup.groupId(), streamsGroup.groupEpoch());
+                    streamsGroupRemovalListener.accept(streamsGroup.groupId());
                     break;
                 case CONSUMER:
                     ConsumerGroup consumerGroup = (ConsumerGroup) group;
@@ -8339,6 +8389,71 @@ public class GroupMetadataManager {
     ) throws GroupIdNotFoundException, UnknownMemberIdException {
         StreamsGroup group = streamsGroup(groupId, committedOffset);
         return group.getMemberOrThrow(memberId, committedOffset);
+    }
+
+    /**
+     * Filter the given group ids down to those that are streams groups with a non-default
+     * {@code StoredDescriptionTopologyEpoch}. The result is used by {@code DeleteGroups}
+     * to decide which groups warrant a {@code plugin.deleteTopology} call before the
+     * group is tombstoned. Non-existent groups and non-streams groups are silently
+     * skipped — they have no plugin state to clean up.
+     *
+     * @param groupIds        Candidate group ids on this shard.
+     * @param committedOffset A committed offset corresponding to the desired snapshot.
+     * @return The subset of {@code groupIds} that are streams groups with a stored topology.
+     */
+    public Set<String> streamsGroupsWithStoredTopologyDescription(
+        Collection<String> groupIds,
+        long committedOffset
+    ) {
+        Set<String> withStored = new HashSet<>();
+        for (String groupId : groupIds) {
+            try {
+                StreamsGroup group = streamsGroup(groupId, committedOffset);
+                if (group.storedDescriptionTopologyEpoch(committedOffset) != -1) {
+                    withStored.add(groupId);
+                }
+            } catch (GroupIdNotFoundException ignored) {
+                // Not a streams group on this shard; nothing to clean up.
+            }
+        }
+        return withStored;
+    }
+
+    /**
+     * Persist the outcome of a topology description plugin call for a streams group.
+     *
+     * <p>On a successful plugin {@code setTopology} the {@code StoredDescriptionTopologyEpoch}
+     * field is advanced to the pushed epoch; on a permanent failure the
+     * {@code FailedDescriptionTopologyEpoch} field is advanced instead so subsequent
+     * heartbeats at the same epoch do not re-solicit a push.
+     *
+     * @param groupId           The streams group id.
+     * @param pushedEpoch       The topology epoch on the push that just completed.
+     * @param permanentFailure  True if the plugin signalled a permanent failure; false on success.
+     * @return A coordinator result carrying the metadata record that updates the field.
+     * @throws GroupIdNotFoundException if the streams group no longer exists.
+     */
+    public CoordinatorResult<Void, CoordinatorRecord> streamsGroupSetTopologyDescriptionEpoch(
+        String groupId,
+        int pushedEpoch,
+        boolean permanentFailure
+    ) throws GroupIdNotFoundException {
+        StreamsGroup group = streamsGroup(groupId);
+
+        int newStored = permanentFailure ? group.storedDescriptionTopologyEpoch() : pushedEpoch;
+        int newFailed = permanentFailure ? pushedEpoch : group.failedDescriptionTopologyEpoch();
+
+        CoordinatorRecord record = newStreamsGroupMetadataRecord(
+            groupId,
+            group.groupEpoch(),
+            group.metadataHash(),
+            group.validatedTopologyEpoch(),
+            group.lastAssignmentConfigs(),
+            newStored,
+            newFailed
+        );
+        return new CoordinatorResult<>(List.of(record), null);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupHeartbeatResult.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupHeartbeatResult.java
@@ -26,16 +26,27 @@ import java.util.Objects;
 /**
  * A simple record to hold the result of a StreamsGroupHeartbeat request.
  *
- * @param data                  The data to be returned to the client.
- * @param creatableTopics       The internal topics to be created.
- * @param currentTopologyEpoch  The topology epoch the group is operating at after this heartbeat, or -1 if the
- *                              group has no topology yet. The service layer uses this to decide whether to set
- *                              TopologyDescriptionRequired on the response (KIP-1331).
+ * <p>The three epoch fields let the service layer decide, without re-reading the group,
+ * whether to set {@code TopologyDescriptionRequired} on the response: a push is needed
+ * when the stored epoch lags the current epoch and the same epoch has not already been
+ * recorded as a permanent failure. All three are -1 for failure-fast paths that do not
+ * resolve a group.
+ *
+ * @param data                              The data to be returned to the client.
+ * @param creatableTopics                   The internal topics to be created.
+ * @param currentTopologyEpoch              The topology epoch the group is operating at after this heartbeat,
+ *                                          or -1 if the group has no topology yet.
+ * @param storedDescriptionTopologyEpoch    The most recent topology epoch successfully stored by the topology
+ *                                          description plugin, or -1 if none.
+ * @param failedDescriptionTopologyEpoch    The most recent topology epoch the plugin permanently rejected,
+ *                                          or -1 if none.
  */
 public record StreamsGroupHeartbeatResult(
     StreamsGroupHeartbeatResponseData data,
     Map<String, CreatableTopic> creatableTopics,
-    int currentTopologyEpoch
+    int currentTopologyEpoch,
+    int storedDescriptionTopologyEpoch,
+    int failedDescriptionTopologyEpoch
 ) {
 
     public StreamsGroupHeartbeatResult {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionBackoff.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionBackoff.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.utils.Time;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory per-group back-off that throttles broker re-solicitation of a topology
+ * description push. An entry is armed when the broker decides to set
+ * {@code TopologyDescriptionRequired=true} on a heartbeat or after a transient plugin
+ * failure; consecutive arms at the same topology epoch double the window from
+ * {@value #INITIAL_DELAY_MS} ms up to {@value #MAX_DELAY_MS} ms. Successful pushes,
+ * permanent plugin failures, and topology-epoch advances clear the entry.
+ */
+public class StreamsGroupTopologyDescriptionBackoff {
+
+    static final long INITIAL_DELAY_MS = 30_000L;
+    static final long MAX_DELAY_MS = 3_600_000L;
+
+    private final Time time;
+    private final ConcurrentHashMap<String, Entry> state = new ConcurrentHashMap<>();
+
+    record Entry(int topologyEpoch, long currentDelayMs, long nextAttemptMs) { }
+
+    public StreamsGroupTopologyDescriptionBackoff(Time time) {
+        this.time = time;
+    }
+
+    /**
+     * @return true if a back-off window is in effect for the given group at the given
+     *         topology epoch and the broker should suppress soliciting another push.
+     */
+    public boolean isActive(String groupId, int topologyEpoch) {
+        Entry entry = state.get(groupId);
+        return entry != null
+            && entry.topologyEpoch() == topologyEpoch
+            && time.milliseconds() < entry.nextAttemptMs();
+    }
+
+    /**
+     * Atomic check-and-arm. Returns true if no window was in effect and a new one was
+     * armed, false if a window was already active and nothing changed. Used on the
+     * heartbeat path to fold the "check + arm" pair into a single compute so two
+     * concurrent heartbeats for the same group cannot both arm the back-off.
+     */
+    public boolean armIfNotActive(String groupId, int topologyEpoch) {
+        final long now = time.milliseconds();
+        final boolean[] armed = new boolean[]{false};
+        state.compute(groupId, (key, existing) -> {
+            if (existing != null
+                && existing.topologyEpoch() == topologyEpoch
+                && now < existing.nextAttemptMs()) {
+                return existing;
+            }
+            armed[0] = true;
+            return new Entry(topologyEpoch, INITIAL_DELAY_MS, now + INITIAL_DELAY_MS);
+        });
+        return armed[0];
+    }
+
+    /**
+     * Arm a new back-off window or extend the existing one. If the existing entry is for a
+     * different topology epoch the window is reset to {@link #INITIAL_DELAY_MS}.
+     */
+    public void armOrExtend(String groupId, int topologyEpoch) {
+        final long now = time.milliseconds();
+        state.compute(groupId, (key, existing) -> {
+            if (existing == null || existing.topologyEpoch() != topologyEpoch) {
+                return new Entry(topologyEpoch, INITIAL_DELAY_MS, now + INITIAL_DELAY_MS);
+            }
+            long nextDelay = Math.min(existing.currentDelayMs() * 2, MAX_DELAY_MS);
+            return new Entry(topologyEpoch, nextDelay, now + nextDelay);
+        });
+    }
+
+    /**
+     * Drop the back-off entry for a group. Called on a successful push, a permanent plugin
+     * failure, or when the group is removed.
+     */
+    public void clear(String groupId) {
+        state.remove(groupId);
+    }
+
+    // Visible for testing.
+    Entry entry(String groupId) {
+        return state.get(groupId);
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionConverter.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionConverter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateRequestData;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.GlobalStore;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.Node;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.Processor;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.Sink;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.Source;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription.Subtopology;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Translates between the wire form of a streams topology description (as carried on
+ * {@code StreamsGroupTopologyDescriptionUpdateRequest}) and the broker-side
+ * {@link StreamsGroupTopologyDescription} POJO that is handed to the plugin.
+ *
+ * <p>String collections are wrapped in {@link LinkedHashSet} so that the wire ordering
+ * is preserved through to the POJO and any downstream pretty-printing.
+ */
+public final class StreamsGroupTopologyDescriptionConverter {
+
+    static final byte NODE_TYPE_SOURCE = 1;
+    static final byte NODE_TYPE_PROCESSOR = 2;
+    static final byte NODE_TYPE_SINK = 3;
+
+    private StreamsGroupTopologyDescriptionConverter() {
+    }
+
+    public static StreamsGroupTopologyDescription fromRequest(
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire
+    ) {
+        List<Subtopology> subtopologies = wire.subtopologies().stream()
+            .map(StreamsGroupTopologyDescriptionConverter::convertSubtopology)
+            .toList();
+        List<GlobalStore> globalStores = wire.globalStores().stream()
+            .map(StreamsGroupTopologyDescriptionConverter::convertGlobalStore)
+            .toList();
+        return new StreamsGroupTopologyDescription(subtopologies, globalStores);
+    }
+
+    private static Subtopology convertSubtopology(
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionSubtopology wire
+    ) {
+        List<Node> nodes = wire.nodes().stream()
+            .map(StreamsGroupTopologyDescriptionConverter::convertNode)
+            .toList();
+        return new Subtopology(wire.subtopologyId(), nodes);
+    }
+
+    private static GlobalStore convertGlobalStore(
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionGlobalStore wire
+    ) {
+        Node source = convertNode(wire.source());
+        Node processor = convertNode(wire.processor());
+        if (!(source instanceof Source) || !(processor instanceof Processor)) {
+            throw new InvalidRequestException(
+                "Global store must be composed of a source and a processor node."
+            );
+        }
+        return new GlobalStore((Source) source, (Processor) processor);
+    }
+
+    private static Node convertNode(
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode wire
+    ) {
+        return switch (wire.nodeType()) {
+            case NODE_TYPE_SOURCE -> new Source(
+                wire.name(),
+                new LinkedHashSet<>(wire.sourceTopics()),
+                new LinkedHashSet<>(wire.successors())
+            );
+            case NODE_TYPE_PROCESSOR -> new Processor(
+                wire.name(),
+                new LinkedHashSet<>(wire.stores()),
+                new LinkedHashSet<>(wire.successors())
+            );
+            case NODE_TYPE_SINK -> new Sink(
+                wire.name(),
+                Optional.ofNullable(wire.sinkTopic()),
+                new LinkedHashSet<>(wire.successors())
+            );
+            default -> throw new InvalidRequestException(
+                "Unknown topology node type: " + wire.nodeType()
+            );
+        };
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -92,9 +92,11 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
 import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupDescribeResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupTopologyDescriptionBackoff;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
@@ -474,6 +476,8 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupHeartbeatResult(
                 new StreamsGroupHeartbeatResponseData().setErrorCode(Errors.COORDINATOR_NOT_AVAILABLE.code()),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             future.get()
@@ -506,6 +510,8 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupHeartbeatResult(
                 new StreamsGroupHeartbeatResponseData(),
                 Map.of(),
+                -1,
+                -1,
                 -1
             )
         ));
@@ -515,7 +521,7 @@ public class GroupCoordinatorServiceTest {
             request
         );
 
-        assertEquals(new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), -1), future.get(5, TimeUnit.SECONDS));
+        assertEquals(new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), -1, -1, -1), future.get(5, TimeUnit.SECONDS));
     }
 
     private static Stream<Arguments> testStreamsGroupHeartbeatWithExceptionSource() {
@@ -575,6 +581,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(expectedErrorCode)
                     .setErrorMessage(expectedErrorMessage),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             future.get(5, TimeUnit.SECONDS)
@@ -597,6 +605,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("TaskOffsets are not supported yet."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -612,6 +622,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("TaskEndOffsets are not supported yet."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -627,6 +639,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("WarmupTasks are not supported yet."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -642,6 +656,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("Regular expressions for source topics are not supported yet."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -676,6 +692,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("MemberId can't be empty."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -691,6 +709,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("MemberId can't be empty."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -707,6 +727,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("GroupId can't be empty."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -723,6 +745,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("GroupId can't be empty."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -740,6 +764,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("RebalanceTimeoutMs must be provided in first request."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -758,6 +784,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("ActiveTasks must be empty when (re-)joining."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -777,6 +805,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("StandbyTasks must be empty when (re-)joining."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -797,6 +827,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("WarmupTasks must be empty when (re-)joining."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -818,6 +850,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("Topology must be non-null when (re-)joining."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -840,6 +874,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("RackId can't be empty."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -859,6 +895,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("InstanceId can't be null."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -882,6 +920,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("MemberEpoch is -3, but must be greater than or equal to -2."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -901,6 +941,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("Topology can only be provided when (re-)joining."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -924,6 +966,8 @@ public class GroupCoordinatorServiceTest {
                     .setErrorCode(Errors.STREAMS_INVALID_TOPOLOGY.code())
                     .setErrorMessage("Changelog topic changelog_topic_with_fixed_partition must have an undefined partition count, but it is set to 3."),
                 Map.of(),
+                -1,
+                -1,
                 -1
             ),
             service.streamsGroupHeartbeat(
@@ -5921,6 +5965,7 @@ public class GroupCoordinatorServiceTest {
         private Persister persister = new NoOpStatePersister();
         private MetadataImage metadataImage = null;
         private PartitionMetadataClient partitionMetadataClient = null;
+        private Optional<StreamsGroupTopologyDescriptionPlugin> streamsGroupTopologyDescriptionPlugin = Optional.empty();
 
         GroupCoordinatorService build() {
             return build(false);
@@ -5933,6 +5978,7 @@ public class GroupCoordinatorServiceTest {
                     .build();
             }
 
+            MockTimer mockTimer = new MockTimer();
             var service = new GroupCoordinatorService(
                 logContext,
                 config,
@@ -5940,8 +5986,10 @@ public class GroupCoordinatorServiceTest {
                 metrics,
                 configManager,
                 persister,
-                new MockTimer(),
-                partitionMetadataClient
+                mockTimer,
+                partitionMetadataClient,
+                streamsGroupTopologyDescriptionPlugin,
+                new StreamsGroupTopologyDescriptionBackoff(mockTimer.time())
             );
 
             if (serviceStartup) {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTopologyDescriptionTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTopologyDescriptionTest.java
@@ -1,0 +1,613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.message.DeleteGroupsResponseData;
+import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateRequestData;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.internals.BufferSupplier;
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRecord;
+import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescriptionPlugin;
+import org.apache.kafka.coordinator.group.api.streams.StreamsTopologyDescriptionPermanentFailureException;
+import org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupTopologyDescriptionBackoff;
+import org.apache.kafka.server.share.persister.NoOpStatePersister;
+import org.apache.kafka.server.util.timer.MockTimer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.requests.StreamsGroupHeartbeatResponse.Status;
+import static org.apache.kafka.coordinator.common.runtime.TestUtil.requestContext;
+import static org.apache.kafka.coordinator.group.GroupConfigManagerTest.createConfigManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the topology-description plugin paths added to {@link GroupCoordinatorService}:
+ * the new {@code streamsGroupTopologyDescriptionUpdate} RPC, the heartbeat post-processing
+ * that sets {@code TopologyDescriptionRequired}, and the back-off interaction.
+ */
+public class GroupCoordinatorServiceTopologyDescriptionTest {
+
+    private static final TopicPartition GROUP_TP = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
+
+    @SuppressWarnings("unchecked")
+    private static CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> mockRuntime() {
+        return (CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord>) mock(CoordinatorRuntime.class);
+    }
+
+    private static GroupCoordinatorService buildService(
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime,
+        Optional<StreamsGroupTopologyDescriptionPlugin> plugin,
+        boolean startup
+    ) {
+        MockTimer timer = new MockTimer();
+        MockTime time = timer.time();
+        GroupCoordinatorService service = new GroupCoordinatorService(
+            new LogContext(),
+            GroupCoordinatorConfigTest.createGroupCoordinatorConfig(4096, 600000L, 24),
+            runtime,
+            new GroupCoordinatorMetrics(),
+            createConfigManager(),
+            new NoOpStatePersister(),
+            timer,
+            null,
+            plugin,
+            new StreamsGroupTopologyDescriptionBackoff(time)
+        );
+        if (startup) {
+            service.startup(() -> 1);
+        }
+        return service;
+    }
+
+    @Test
+    public void testUpdateRejectedWhenCoordinatorNotActive() throws Exception {
+        GroupCoordinatorService service = buildService(mockRuntime(), Optional.empty(), false);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.COORDINATOR_NOT_AVAILABLE.code(), response.errorCode());
+    }
+
+    @Test
+    public void testUpdateReturnsUnsupportedVersionWhenNoPlugin() throws Exception {
+        GroupCoordinatorService service = buildService(mockRuntime(), Optional.empty(), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.UNSUPPORTED_VERSION.code(), response.errorCode());
+        assertNotNull(response.errorMessage());
+    }
+
+    @Test
+    public void testUpdateRejectsEmptyMemberId() throws Exception {
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        GroupCoordinatorService service = buildService(mockRuntime(), Optional.of(plugin), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest().setMemberId("")
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.INVALID_REQUEST.code(), response.errorCode());
+        assertEquals("MemberId can't be empty.", response.errorMessage());
+    }
+
+    @Test
+    public void testUpdateRejectsEmptyGroupId() throws Exception {
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        GroupCoordinatorService service = buildService(mockRuntime(), Optional.of(plugin), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest().setGroupId("")
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.INVALID_REQUEST.code(), response.errorCode());
+    }
+
+    @Test
+    public void testUpdateSuccessPersistsStoredEpoch() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.setTopology(anyString(), anyInt(), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-description-validate"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(null));
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-set-stored-topology-epoch"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(null));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.NONE.code(), response.errorCode());
+        verify(plugin, times(1)).setTopology(eq("foo"), eq(3), any());
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("streams-group-set-stored-topology-epoch"), eq(GROUP_TP), any());
+    }
+
+    @Test
+    public void testUpdatePermanentFailurePersistsFailedEpoch() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.setTopology(anyString(), anyInt(), any()))
+            .thenReturn(CompletableFuture.failedFuture(
+                new StreamsTopologyDescriptionPermanentFailureException("too large")));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-description-validate"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(null));
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-set-failed-topology-epoch"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(null));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED.code(), response.errorCode());
+        assertEquals("too large", response.errorMessage());
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("streams-group-set-failed-topology-epoch"), eq(GROUP_TP), any());
+    }
+
+    @Test
+    public void testUpdateTransientFailureWritesNoRecord() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.setTopology(anyString(), anyInt(), any()))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("backend offline")));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-description-validate"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(null));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        StreamsGroupTopologyDescriptionUpdateResponseData response = service.streamsGroupTopologyDescriptionUpdate(
+            requestContext(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE),
+            validUpdateRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertEquals(Errors.STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED.code(), response.errorCode());
+        assertEquals("backend offline", response.errorMessage());
+        verify(runtime, never()).scheduleWriteOperation(
+            eq("streams-group-set-stored-topology-epoch"), any(), any());
+        verify(runtime, never()).scheduleWriteOperation(
+            eq("streams-group-set-failed-topology-epoch"), any(), any());
+    }
+
+    @Test
+    public void testHeartbeatSetsTopologyDescriptionRequiredWhenStoredLags() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-heartbeat"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), 5, -1, -1)));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+        StreamsGroupHeartbeatResult result = service.streamsGroupHeartbeat(
+            requestContext(ApiKeys.STREAMS_GROUP_HEARTBEAT), validHeartbeatRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertTrue(result.data().topologyDescriptionRequired());
+    }
+
+    @Test
+    public void testHeartbeatSkipsFlagWhenStoredMatchesCurrent() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-heartbeat"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), 5, 5, -1)));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+        StreamsGroupHeartbeatResult result = service.streamsGroupHeartbeat(
+            requestContext(ApiKeys.STREAMS_GROUP_HEARTBEAT), validHeartbeatRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result.data().topologyDescriptionRequired());
+    }
+
+    @Test
+    public void testHeartbeatSkipsFlagWhenFailedAtCurrentEpoch() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-heartbeat"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), 5, -1, 5)));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+        StreamsGroupHeartbeatResult result = service.streamsGroupHeartbeat(
+            requestContext(ApiKeys.STREAMS_GROUP_HEARTBEAT), validHeartbeatRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result.data().topologyDescriptionRequired());
+    }
+
+    @Test
+    public void testHeartbeatSkipsFlagWhenStaleTopologyStatusPresent() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        StreamsGroupHeartbeatResponseData responseData = new StreamsGroupHeartbeatResponseData()
+            .setStatus(List.of(new StreamsGroupHeartbeatResponseData.Status()
+                .setStatusCode(Status.STALE_TOPOLOGY.code())
+                .setStatusDetail("behind")));
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-heartbeat"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsGroupHeartbeatResult(responseData, Map.of(), 5, -1, -1)));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+        StreamsGroupHeartbeatResult result = service.streamsGroupHeartbeat(
+            requestContext(ApiKeys.STREAMS_GROUP_HEARTBEAT), validHeartbeatRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result.data().topologyDescriptionRequired());
+    }
+
+    @Test
+    public void testHeartbeatNeverSetsFlagWithoutPlugin() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        when(runtime.scheduleWriteOperation(
+            eq("streams-group-heartbeat"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(
+            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), 5, -1, -1)));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.empty(), true);
+        StreamsGroupHeartbeatResult result = service.streamsGroupHeartbeat(
+            requestContext(ApiKeys.STREAMS_GROUP_HEARTBEAT), validHeartbeatRequest()
+        ).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result.data().topologyDescriptionRequired());
+    }
+
+    @Test
+    public void testDeleteGroupsPluginFailureReturnsGroupDeletionFailed() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.deleteTopology("foo"))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("plugin offline")));
+
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Set.of("foo")));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS),
+                List.of("foo"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult result = results.find("foo");
+        assertNotNull(result);
+        assertEquals(Errors.GROUP_DELETION_FAILED.code(), result.errorCode());
+        assertEquals("plugin offline", result.errorMessage());
+        verify(runtime, never()).scheduleWriteOperation(
+            eq("delete-groups"), any(), any());
+    }
+
+    @Test
+    public void testDeleteGroupsPluginFailureDowngradesErrorOnV2() throws Exception {
+        // KIP-1331: GROUP_DELETION_FAILED and the per-group ErrorMessage field arrive in
+        // DeleteGroups v3. For older clients the broker downgrades the error code to
+        // UNKNOWN_SERVER_ERROR and drops the message so the v2 wire format is preserved.
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.deleteTopology("foo"))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("plugin offline")));
+
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Set.of("foo")));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS, (short) 2),
+                List.of("foo"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult result = results.find("foo");
+        assertNotNull(result);
+        assertEquals(Errors.UNKNOWN_SERVER_ERROR.code(), result.errorCode());
+        assertNull(result.errorMessage());
+    }
+
+    @Test
+    public void testDeleteGroupsPluginSuccessProceedsToTombstone() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.deleteTopology("foo"))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Set.of("foo")));
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection tombstoneResult =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+        tombstoneResult.add(new DeleteGroupsResponseData.DeletableGroupResult().setGroupId("foo"));
+        when(runtime.scheduleWriteOperation(
+            eq("delete-groups"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(tombstoneResult));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS),
+                List.of("foo"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult result = results.find("foo");
+        assertNotNull(result);
+        assertEquals(Errors.NONE.code(), result.errorCode());
+        assertNull(result.errorMessage());
+        verify(plugin, times(1)).deleteTopology("foo");
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("delete-groups"), eq(GROUP_TP), any());
+    }
+
+    @Test
+    public void testDeleteGroupsWithoutPluginSkipsPluginCall() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection tombstoneResult =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+        tombstoneResult.add(new DeleteGroupsResponseData.DeletableGroupResult().setGroupId("foo"));
+        when(runtime.scheduleWriteOperation(
+            eq("delete-groups"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(tombstoneResult));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.empty(), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS),
+                List.of("foo"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult result = results.find("foo");
+        assertNotNull(result);
+        assertEquals(Errors.NONE.code(), result.errorCode());
+        verify(runtime, never()).scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"), any(), any());
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("delete-groups"), eq(GROUP_TP), any());
+    }
+
+    @Test
+    public void testDeleteGroupsSkipsPluginCallWhenNoStoredTopology() throws Exception {
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Set.of()));
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection tombstoneResult =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+        tombstoneResult.add(new DeleteGroupsResponseData.DeletableGroupResult().setGroupId("foo"));
+        when(runtime.scheduleWriteOperation(
+            eq("delete-groups"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(tombstoneResult));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS),
+                List.of("foo"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult result = results.find("foo");
+        assertNotNull(result);
+        assertEquals(Errors.NONE.code(), result.errorCode());
+        verify(plugin, never()).deleteTopology(anyString());
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("delete-groups"), eq(GROUP_TP), any());
+    }
+
+    @Test
+    public void testDeleteGroupsMixedPluginOutcome() throws Exception {
+        // Two streams groups on the same partition; plugin succeeds for "good", fails for "bad".
+        // Only "good" should reach the underlying delete-groups write; "bad" surfaces as
+        // GROUP_DELETION_FAILED in the response.
+        CoordinatorRuntime<GroupCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        StreamsGroupTopologyDescriptionPlugin plugin = mock(StreamsGroupTopologyDescriptionPlugin.class);
+        when(plugin.deleteTopology("good"))
+            .thenReturn(CompletableFuture.completedFuture(null));
+        when(plugin.deleteTopology("bad"))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("rejected")));
+
+        when(runtime.scheduleWriteOperation(
+            eq("delete-share-groups"),
+            any(),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Map.of()));
+        when(runtime.scheduleReadOperation(
+            eq("streams-group-topology-pre-delete"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(Set.of("good", "bad")));
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection tombstoneResult =
+            new DeleteGroupsResponseData.DeletableGroupResultCollection();
+        tombstoneResult.add(new DeleteGroupsResponseData.DeletableGroupResult().setGroupId("good"));
+        when(runtime.scheduleWriteOperation(
+            eq("delete-groups"),
+            eq(GROUP_TP),
+            any()
+        )).thenReturn(CompletableFuture.completedFuture(tombstoneResult));
+
+        GroupCoordinatorService service = buildService(runtime, Optional.of(plugin), true);
+
+        DeleteGroupsResponseData.DeletableGroupResultCollection results =
+            service.deleteGroups(
+                requestContext(ApiKeys.DELETE_GROUPS),
+                List.of("good", "bad"),
+                BufferSupplier.NO_CACHING
+            ).get(5, TimeUnit.SECONDS);
+
+        DeleteGroupsResponseData.DeletableGroupResult goodResult = results.find("good");
+        assertNotNull(goodResult);
+        assertEquals(Errors.NONE.code(), goodResult.errorCode());
+
+        DeleteGroupsResponseData.DeletableGroupResult badResult = results.find("bad");
+        assertNotNull(badResult);
+        assertEquals(Errors.GROUP_DELETION_FAILED.code(), badResult.errorCode());
+        assertEquals("rejected", badResult.errorMessage());
+    }
+
+    private static StreamsGroupTopologyDescriptionUpdateRequestData validUpdateRequest() {
+        return new StreamsGroupTopologyDescriptionUpdateRequestData()
+            .setGroupId("foo")
+            .setMemberId(Uuid.randomUuid().toString())
+            .setTopologyEpoch(3)
+            .setTopologyDescription(
+                new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                    .setSubtopologies(List.of())
+                    .setGlobalStores(List.of()));
+    }
+
+    private static StreamsGroupHeartbeatRequestData validHeartbeatRequest() {
+        return new StreamsGroupHeartbeatRequestData()
+            .setGroupId("foo")
+            .setMemberId(Uuid.randomUuid().toString())
+            .setMemberEpoch(0)
+            .setRebalanceTimeoutMs(1500)
+            .setActiveTasks(List.of())
+            .setStandbyTasks(List.of())
+            .setWarmupTasks(List.of())
+            .setTopology(new StreamsGroupHeartbeatRequestData.Topology());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorShardTest.java
@@ -195,7 +195,7 @@ public class GroupCoordinatorShardTest {
         StreamsGroupHeartbeatRequestData request = new StreamsGroupHeartbeatRequestData();
         CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = new CoordinatorResult<>(
             List.of(),
-            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), -1)
+            new StreamsGroupHeartbeatResult(new StreamsGroupHeartbeatResponseData(), Map.of(), -1, -1, -1)
         );
 
         when(groupMetadataManager.streamsGroupHeartbeat(

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/api/streams/StreamsGroupTopologyDescriptionTest.java
@@ -81,14 +81,11 @@ public class StreamsGroupTopologyDescriptionTest {
     }
 
     @Test
-    public void testCollectionsAreDefensivelyCopied() {
-        Set<String> mutableTopics = new HashSet<>(Set.of("in"));
+    public void testCollectionAccessorsAreUnmodifiable() {
         StreamsGroupTopologyDescription.Source src = new StreamsGroupTopologyDescription.Source(
-            "src", mutableTopics, Set.of("proc"));
-        mutableTopics.add("rogue");
-
-        assertEquals(Set.of("in"), src.topics());
+            "src", new HashSet<>(Set.of("in")), Set.of("proc"));
         assertThrows(UnsupportedOperationException.class, () -> src.topics().add("nope"));
+        assertThrows(UnsupportedOperationException.class, () -> src.successors().add("nope"));
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupHeartbeatResultTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupHeartbeatResultTest.java
@@ -30,30 +30,43 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class StreamsGroupHeartbeatResultTest {
 
     @Test
-    public void testThreeArgConstructorPreservesTopologyEpoch() {
+    public void testConstructorPreservesEpochs() {
         StreamsGroupHeartbeatResult result = new StreamsGroupHeartbeatResult(
-            new StreamsGroupHeartbeatResponseData(), Map.of(), 7);
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 7, 5, 3);
         assertEquals(7, result.currentTopologyEpoch());
+        assertEquals(5, result.storedDescriptionTopologyEpoch());
+        assertEquals(3, result.failedDescriptionTopologyEpoch());
     }
 
     @Test
     public void testCurrentTopologyEpochIsPartOfEquality() {
-        // Records derive equals from all components; two results with different topology epochs are unequal.
         StreamsGroupHeartbeatResult a = new StreamsGroupHeartbeatResult(
-            new StreamsGroupHeartbeatResponseData(), Map.of(), 1);
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 1, -1, -1);
         StreamsGroupHeartbeatResult b = new StreamsGroupHeartbeatResult(
-            new StreamsGroupHeartbeatResponseData(), Map.of(), 2);
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 2, -1, -1);
         assertNotEquals(a, b);
 
         StreamsGroupHeartbeatResult c = new StreamsGroupHeartbeatResult(
-            new StreamsGroupHeartbeatResponseData(), Map.of(), 1);
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 1, -1, -1);
         assertEquals(a, c);
+    }
+
+    @Test
+    public void testStoredAndFailedEpochsArePartOfEquality() {
+        StreamsGroupHeartbeatResult a = new StreamsGroupHeartbeatResult(
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 1, 1, -1);
+        StreamsGroupHeartbeatResult differentStored = new StreamsGroupHeartbeatResult(
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 1, 0, -1);
+        StreamsGroupHeartbeatResult differentFailed = new StreamsGroupHeartbeatResult(
+            new StreamsGroupHeartbeatResponseData(), Map.of(), 1, 1, 0);
+        assertNotEquals(a, differentStored);
+        assertNotEquals(a, differentFailed);
     }
 
     @Test
     public void testCreatableTopicsMapIsImmutable() {
         StreamsGroupHeartbeatResult result = new StreamsGroupHeartbeatResult(
-            new StreamsGroupHeartbeatResponseData(), Map.of(), -1);
+            new StreamsGroupHeartbeatResponseData(), Map.of(), -1, -1, -1);
         assertThrows(UnsupportedOperationException.class,
             () -> result.creatableTopics().put("t", null));
     }
@@ -61,7 +74,7 @@ public class StreamsGroupHeartbeatResultTest {
     @Test
     public void testNullDataIsRejected() {
         assertThrows(NullPointerException.class,
-            () -> new StreamsGroupHeartbeatResult(null, Map.of(), -1));
+            () -> new StreamsGroupHeartbeatResult(null, Map.of(), -1, -1, -1));
         assertTrue(true);
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionBackoffTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionBackoffTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StreamsGroupTopologyDescriptionBackoffTest {
+
+    @Test
+    public void testFirstArmUsesInitialDelay() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        backoff.armOrExtend("g", 1);
+        assertTrue(backoff.isActive("g", 1));
+        time.sleep(StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS - 1);
+        assertTrue(backoff.isActive("g", 1));
+        time.sleep(1);
+        assertFalse(backoff.isActive("g", 1));
+    }
+
+    @Test
+    public void testConsecutiveArmsDoubleTheWindowUpToMax() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+
+        long expected = StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS;
+        backoff.armOrExtend("g", 1);
+        assertEquals(expected, backoff.entry("g").currentDelayMs());
+
+        // Each consecutive arm at the same epoch doubles, until we hit the cap.
+        for (int i = 0; i < 20; i++) {
+            backoff.armOrExtend("g", 1);
+            expected = Math.min(expected * 2, StreamsGroupTopologyDescriptionBackoff.MAX_DELAY_MS);
+            assertEquals(expected, backoff.entry("g").currentDelayMs(),
+                "iteration " + i);
+        }
+        assertEquals(StreamsGroupTopologyDescriptionBackoff.MAX_DELAY_MS,
+            backoff.entry("g").currentDelayMs());
+    }
+
+    @Test
+    public void testDifferentEpochResetsTheWindow() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        backoff.armOrExtend("g", 1);
+        backoff.armOrExtend("g", 1); // doubled
+        long doubled = backoff.entry("g").currentDelayMs();
+        assertTrue(doubled > StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS);
+        backoff.armOrExtend("g", 2);
+        assertEquals(StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS,
+            backoff.entry("g").currentDelayMs());
+        assertEquals(2, backoff.entry("g").topologyEpoch());
+    }
+
+    @Test
+    public void testIsActiveIsScopedToEpoch() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        backoff.armOrExtend("g", 1);
+        assertTrue(backoff.isActive("g", 1));
+        // A query at a different epoch never matches — the broker should re-solicit.
+        assertFalse(backoff.isActive("g", 2));
+    }
+
+    @Test
+    public void testClearRemovesEntry() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        backoff.armOrExtend("g", 1);
+        assertNotNull(backoff.entry("g"));
+        backoff.clear("g");
+        assertNull(backoff.entry("g"));
+        assertFalse(backoff.isActive("g", 1));
+    }
+
+    @Test
+    public void testArmIfNotActiveArmsWhenIdle() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        assertTrue(backoff.armIfNotActive("g", 1));
+        assertTrue(backoff.isActive("g", 1));
+        assertEquals(StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS,
+            backoff.entry("g").currentDelayMs());
+    }
+
+    @Test
+    public void testArmIfNotActiveReturnsFalseWhenAlreadyActive() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        assertTrue(backoff.armIfNotActive("g", 1));
+        long armedAt = backoff.entry("g").nextAttemptMs();
+        // A second call inside the window does not arm and does not extend the window.
+        assertFalse(backoff.armIfNotActive("g", 1));
+        assertEquals(armedAt, backoff.entry("g").nextAttemptMs());
+    }
+
+    @Test
+    public void testArmIfNotActiveReArmsAfterEpochAdvance() {
+        MockTime time = new MockTime();
+        StreamsGroupTopologyDescriptionBackoff backoff = new StreamsGroupTopologyDescriptionBackoff(time);
+        assertTrue(backoff.armIfNotActive("g", 1));
+        // A query at the new epoch sees no active window and arms a fresh one.
+        assertTrue(backoff.armIfNotActive("g", 2));
+        assertEquals(2, backoff.entry("g").topologyEpoch());
+        assertEquals(StreamsGroupTopologyDescriptionBackoff.INITIAL_DELAY_MS,
+            backoff.entry("g").currentDelayMs());
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionConverterTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTopologyDescriptionConverterTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.message.StreamsGroupTopologyDescriptionUpdateRequestData;
+import org.apache.kafka.coordinator.group.api.streams.StreamsGroupTopologyDescription;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StreamsGroupTopologyDescriptionConverterTest {
+
+    @Test
+    public void testConvertsAllThreeNodeKindsAndPreservesOrder() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode source =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("src")
+                .setNodeType((byte) 1)
+                .setSourceTopics(List.of("topic-a", "topic-b"))
+                .setSuccessors(List.of("proc-1", "proc-2"));
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode processor =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("proc")
+                .setNodeType((byte) 2)
+                .setStores(List.of("store-x", "store-y"))
+                .setSuccessors(List.of("sink"));
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode sink =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("sink")
+                .setNodeType((byte) 3)
+                .setSinkTopic("out-topic")
+                .setSuccessors(List.of());
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionSubtopology subtopology =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionSubtopology()
+                .setSubtopologyId("0")
+                .setNodes(List.of(source, processor, sink));
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of(subtopology))
+                .setGlobalStores(List.of());
+
+        StreamsGroupTopologyDescription pojo = StreamsGroupTopologyDescriptionConverter.fromRequest(wire);
+
+        assertEquals(1, pojo.subtopologies().size());
+        StreamsGroupTopologyDescription.Subtopology st = pojo.subtopologies().iterator().next();
+        assertEquals("0", st.id());
+
+        Iterator<StreamsGroupTopologyDescription.Node> nodes = st.nodes().iterator();
+        StreamsGroupTopologyDescription.Source src = assertInstanceOf(StreamsGroupTopologyDescription.Source.class, nodes.next());
+        assertEquals("src", src.name());
+        assertEquals(List.of("topic-a", "topic-b"), new ArrayList<>(src.topics()));
+        assertEquals(List.of("proc-1", "proc-2"), new ArrayList<>(src.successors()));
+
+        StreamsGroupTopologyDescription.Processor proc = assertInstanceOf(StreamsGroupTopologyDescription.Processor.class, nodes.next());
+        assertEquals("proc", proc.name());
+        assertEquals(List.of("store-x", "store-y"), new ArrayList<>(proc.stores()));
+
+        StreamsGroupTopologyDescription.Sink sk = assertInstanceOf(StreamsGroupTopologyDescription.Sink.class, nodes.next());
+        assertEquals("sink", sk.name());
+        assertTrue(sk.topic().isPresent());
+        assertEquals("out-topic", sk.topic().get());
+    }
+
+    @Test
+    public void testSinkWithoutTopicYieldsEmptyOptional() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode sink =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("sink")
+                .setNodeType((byte) 3)
+                .setSinkTopic(null)
+                .setSuccessors(List.of());
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of(
+                    new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionSubtopology()
+                        .setSubtopologyId("0")
+                        .setNodes(List.of(sink))))
+                .setGlobalStores(List.of());
+
+        StreamsGroupTopologyDescription pojo = StreamsGroupTopologyDescriptionConverter.fromRequest(wire);
+        StreamsGroupTopologyDescription.Sink sk = (StreamsGroupTopologyDescription.Sink)
+            pojo.subtopologies().iterator().next().nodes().iterator().next();
+        assertTrue(sk.topic().isEmpty());
+    }
+
+    @Test
+    public void testGlobalStoreIsConverted() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode source =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("g-src")
+                .setNodeType((byte) 1)
+                .setSourceTopics(List.of("global-topic"))
+                .setSuccessors(List.of("g-proc"));
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode processor =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("g-proc")
+                .setNodeType((byte) 2)
+                .setStores(List.of("global-store"))
+                .setSuccessors(List.of());
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionGlobalStore gs =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionGlobalStore()
+                .setSource(source)
+                .setProcessor(processor);
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of())
+                .setGlobalStores(List.of(gs));
+
+        StreamsGroupTopologyDescription pojo = StreamsGroupTopologyDescriptionConverter.fromRequest(wire);
+        assertEquals(1, pojo.globalStores().size());
+        StreamsGroupTopologyDescription.GlobalStore converted = pojo.globalStores().iterator().next();
+        assertEquals("g-src", converted.source().name());
+        assertEquals("g-proc", converted.processor().name());
+    }
+
+    @Test
+    public void testUnknownNodeTypeIsRejected() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode unknown =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("?")
+                .setNodeType((byte) 99)
+                .setSuccessors(List.of());
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of(
+                    new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionSubtopology()
+                        .setSubtopologyId("0")
+                        .setNodes(List.of(unknown))))
+                .setGlobalStores(List.of());
+
+        assertThrows(InvalidRequestException.class,
+            () -> StreamsGroupTopologyDescriptionConverter.fromRequest(wire));
+    }
+
+    @Test
+    public void testGlobalStoreWithMismatchedNodesIsRejected() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode sourceA =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("a").setNodeType((byte) 1).setSuccessors(List.of());
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode sourceB =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionNode()
+                .setName("b").setNodeType((byte) 1).setSuccessors(List.of());
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionGlobalStore gs =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescriptionGlobalStore()
+                .setSource(sourceA).setProcessor(sourceB);
+
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of()).setGlobalStores(List.of(gs));
+
+        assertThrows(InvalidRequestException.class,
+            () -> StreamsGroupTopologyDescriptionConverter.fromRequest(wire));
+    }
+
+    @Test
+    public void testEmptyTopologyIsAccepted() {
+        StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription wire =
+            new StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription()
+                .setSubtopologies(List.of())
+                .setGlobalStores(List.of());
+        StreamsGroupTopologyDescription pojo = StreamsGroupTopologyDescriptionConverter.fromRequest(wire);
+        assertTrue(pojo.subtopologies().isEmpty());
+        assertTrue(pojo.globalStores().isEmpty());
+    }
+}


### PR DESCRIPTION
JIRA: KAFKA-20623  This PR is a part of KIP-1331.

### Builder plumbing
- `GroupCoordinatorService.Builder` accepts an
  `Optional<StreamsGroupTopologyDescriptionPlugin>` and constructs the
per-group back-off
  state at build time so the shard-builder supplier closure can wire a
removal listener
  back into it.
- `BrokerServer` reads
  `groupCoordinatorConfig.streamsGroupTopologyDescriptionPlugin(...)`
and passes the
  resulting `Optional` through. When the config is unset the feature is
fully disabled.

### Heartbeat post-processing
- `StreamsGroupHeartbeatResult` now carries
`storedDescriptionTopologyEpoch` and
  `failedDescriptionTopologyEpoch` alongside `currentTopologyEpoch`, so
the service layer
  can decide whether to set `TopologyDescriptionRequired=true` without
re-reading the
  group.
- `maybeSetTopologyDescriptionRequired` applies the KIP-1331 gating:
plugin present,
  response has no error code, c
  initial delay; a successful push or a permanent plugin failure clears
the entry.
- The back-off is per broker (service-level), not per partition. To
avoid leaking entries
  for groups that vanish, `GroupMetadataManager` now exposes a
`Consumer<String>`
  streams-group removal listener (wired through
`GroupCoordinatorShard.Builder`). The
  listener fires from `removeGroup` whenever the removed group is a
streams group, and
  from the `STREAMS` branch of `onUnloaded`; the service registers it as
  `backoff::clear`.

### `StreamsGroupTopologyDescriptionUpdate` handler
- Synchronous pre-checks reject the request fast when the coordinator is
inactive
  (`COORDINATOR_NOT_AVAILABLE`), no plugin is configured
(`UNSUPPORTED_VERSION`), or
  the request is structurally malformed (`INVALID_REQUEST` for empty
`MemberId`,
  empty `GroupId`, or null `TopologyDescription`).
- The chain runs `validateStreamsGroupMember` *first* (so a fenced
caller gets
  `UNKNOWN_MEMBER_ID` rather than an `INVALID_REQUEST` from a payload
conversion
  failure), then converts the wire payload to the broker-side POJO, then
calls the
  plugin.
- Plugin success writes a metadata record advancing
`StoredDescriptionTopologyEpoch`;
  a `StreamsTopologyDescriptionPermanentFailureException` (or a
synchronous throw)
  writes `FailedDescriptionTopologyEpoch`; any other exception is
treated as transient
  and writes no record.
- The client-visible error is always
`STREAMS_TOPOLOGY_DESCRIPTION_UPDATE_FAILED` with
  the plugin's message; the permanent-vs-transient split is
broker-internal.
- All back-off state mutations happen in a single `whenComplete`, driven
by a
  `BackoffAction` holder populated by each terminal branch. A
post-plugin write failure
  leaves the action at `ARM`, so the next heartbeat sees the drift and
re-solicits an
  idempotent re-push, matching the KIP-1331 invariant.

### `DeleteGroups` integration
- Before tombstoning, the service identifies retained group ids that are
streams groups
  with a non-default `StoredDescriptionTopologyEpoch`
(`streamsGroupsWithStoredTopologyDescription`)
  and calls `plugin.deleteTopology` for each in parallel.
- Per-group plugin failure surfaces as `GROUP_DELETION_FAILED` with the
cause string in
  `ErrorMessage`; the group is held back from tombstoning so the caller
can retry.
  Mixed batches are honoured: groups that succeed proceed to tombstone,
groups that fail
  return the per-group error.
- For DeleteGroups requests at version < 3 (pre-KIP-1331), the error is
downgraded to
  `UNKNOWN_SERVER_ERROR` with no message, matching the convention used
by KIP-1043 for
  new error codes that older request versions cannot interpret.

### Wire ↔ POJO converter
- `StreamsGroupTopologyDescriptionConverter` translates
  `StreamsGroupTopologyDescriptionUpdateRequestData.TopologyDescription`
into the
  broker-side `StreamsGroupTopologyDescription` POJO. Subtopology node
ordering and
  string-collection iteration order are preserved via `LinkedHashSet`,
so a downstream
  pretty-printer (e.g. the future `kafka-streams-groups.sh --topology`
command) can
  reproduce the source ordering.
- Wire-level node types (`SOURCE=1`, `PROCESSOR=2`, `SINK=3`) map to the
sealed `Node`
  hierarchy. `GlobalStore` shape is validated; a malformed payload
throws
  `InvalidRequestException`.

Reviewers: David Jacot <david.jacot@gmail.com>, Lucas Brutschy
 <lbrutschy@confluent.io>
