### PR TITLE
MINOR: improve ListDeserializer exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
@@ -178,6 +178,9 @@ public class ListDeserializer<Inner> implements Deserializer<List<Inner>> {
             SerializationStrategy serStrategy = parseSerializationStrategyFlag(dis.readByte());
             List<Integer> nullIndexList = null;
             if (serStrategy == SerializationStrategy.CONSTANT_SIZE) {
+                if (primitiveSize == null) {
+                    throw new SerializationException("Data is encode as constant size entries, but configured inner deserializer is not a known fixed-size deserializer.");
+                }
                 // In CONSTANT_SIZE strategy, indexes of null entries are decoded from a null index list
                 nullIndexList = deserializeNullIndexList(dis, data.length);
             }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ListDeserializer.java
@@ -179,7 +179,7 @@ public class ListDeserializer<Inner> implements Deserializer<List<Inner>> {
             List<Integer> nullIndexList = null;
             if (serStrategy == SerializationStrategy.CONSTANT_SIZE) {
                 if (primitiveSize == null) {
-                    throw new SerializationException("Data is encode as constant size entries, but configured inner deserializer is not a known fixed-size deserializer.");
+                    throw new SerializationException("Data is encoded as constant size entries, but configured inner deserializer is not a known fixed-size deserializer.");
                 }
                 // In CONSTANT_SIZE strategy, indexes of null entries are decoded from a null index list
                 nullIndexList = deserializeNullIndexList(dis, data.length);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/test/TestRecord.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/test/TestRecord.java
@@ -38,6 +38,10 @@ public class TestRecord<K, V> {
     private final V value;
     private final Instant recordTime;
 
+    public boolean equalsIgnorePartition(final TestRecord<? extends K, ? super V> o) {
+        return false;
+    }
+
     /**
      * Creates a record.
      *


### PR DESCRIPTION
We would currently get a NPE trying to use `primitiveSize`. This PR adds
a check to throw a SerializationException instead.

Reviewers: nileshkumar3 <nileshkumar3@gmail.com>, Lucas Brutschy
 <lbrutschy@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
