### PR TITLE
KAFKA-20685: Delete checkpoint file when EOS task completes restoration (4.2)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -306,6 +306,14 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 processorContext.initialize();
                 if (!eosEnabled) {
                     maybeCheckpoint(true);
+                } else {
+                    // Deleting checkpoint file written during restoration before transition to RUNNING state (KAFKA-20685)
+                    try {
+                        stateMgr.deleteCheckPointFileIfEOSEnabled();
+                        log.debug("Deleted check point file upon completing restoration with EOS enabled");
+                    } catch (final IOException ioe) {
+                        log.error("Encountered error while deleting the checkpoint file upon completing restoration", ioe);
+                    }
                 }
 
                 transitionTo(State.RUNNING);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -3058,6 +3058,40 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldDeleteCheckpointFileAfterRestorationWhenExactlyOnceEnabled() throws IOException {
+        final ProcessorStateManager processorStateManager = mockStateManager();
+        recordCollector = mock(RecordCollectorImpl.class);
+
+        task = createStatefulTask(createConfig(EXACTLY_ONCE_V2, "100"), true, processorStateManager);
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+        verify(processorStateManager).deleteCheckPointFileIfEOSEnabled();
+    }
+
+    @Test
+    public void shouldNotDeleteCheckpointFileAfterRestorationWhenAtLeastOnceEnabled() throws IOException {
+        final ProcessorStateManager processorStateManager = mockStateManager();
+        recordCollector = mock(RecordCollectorImpl.class);
+
+        task = createStatefulTask(createConfig(AT_LEAST_ONCE, "100"), true, processorStateManager);
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+        verify(processorStateManager, never()).deleteCheckPointFileIfEOSEnabled();
+    }
+
+    @Test
+    public void shouldStillCompleteRestorationWhenCheckpointFileDeletionFails() throws IOException {
+        final ProcessorStateManager processorStateManager = mockStateManager();
+        recordCollector = mock(RecordCollectorImpl.class);
+        doThrow(new IOException("KABOOM!")).when(processorStateManager).deleteCheckPointFileIfEOSEnabled();
+
+        task = createStatefulTask(createConfig(EXACTLY_ONCE_V2, "100"), true, processorStateManager);
+        task.initializeIfNeeded();
+        task.completeRestoration(noOpResetter -> { });
+        assertEquals(RUNNING, task.state());
+    }
+
+    @Test
     public void punctuateShouldNotHandleFailProcessingExceptionAndThrowStreamsException() {
         when(stateManager.taskId()).thenReturn(taskId);
         when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);


### PR DESCRIPTION
Under exactly_once_v2 the default state updater writes an enforced
checkpoint when a task finishes restoration
(DefaultStateUpdater.maybeCompleteRestoration) and nothing removes that
file when the task transitions to RUNNING.
StreamTask.completeRestoration only skips writing its own checkpoint
under EOS, which suggests the intent was that no checkpoint should exist
past that point. The leftover file survives the whole processing
session, so an unclean crash during RUNNING finds it on restart,
initializes the stores from it and skips the TaskCorruptedException
wipe. RocksDB runs with the WAL disabled and Streams does not flush on
commit under EOS, so background memtable flushes can persist writes from
a transaction that is later aborted, and the read_committed tail replay
cannot remove them.

This change deletes the checkpoint file when an EOS task completes
restoration, before the transition to RUNNING, restoring the invariant
that no checkpoint exists during RUNNING under EOS. It mirrors what
KAFKA-10362 did on the resume path with the same helper. The checkpoints
written during restoration itself are untouched, so a crash during
restoration still resumes from them, which is safe because restored
bytes are committed changelog data.

Trunk and 4.3 are not affected: stores that manage their own offsets
detect an unclean shutdown through the KIP-1035 status marker, and
KAFKA-19712 moved the legacy checkpoint file handling into
LegacyCheckpointingStateStore, which writes the file only under
at_least_once and deletes it at init under EOS. This PR therefore
targets the 4.2 branch.

Testing: three unit tests added to StreamTaskTest next to the existing
restoration checkpoint tests. The EOS test fails without the fix, the
at_least_once test verifies the delete does not run there, and a third
test verifies a failed delete does not prevent the transition to
RUNNING. Full StreamTaskTest, checkstyle and spotbugs pass on the
streams module.

Reviewers: Bill Bejeck <bbejeck@apache.org>
