### PR TITLE
MINOR: Fix spotless import order violation in OAuthBearerValidatorCallbackHandlerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerValidatorCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerValidatorCallbackHandlerTest.java
@@ -23,9 +23,9 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenBuilder;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableVerificationKeyResolver;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.OAuthBearerTest;
-
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwk.PublicJsonWebKey;


### PR DESCRIPTION
Trunk's `:clients:spotlessJavaCheck` has been failing since
6c7927bd8ab039d4362d47973d19c35a97c8b9d0 ("MINOR: Validate OAuthBearer
server callback handler configuration at startup") due to an
import-grouping violation in
`OAuthBearerValidatorCallbackHandlerTest.java`: a stray blank line
inside the `org.apache.kafka` import group and a missing blank line
before the third-party `org.jose4j` group.

Failing trunk run:
https://github.com/apache/kafka/actions/runs/27403172613

This also breaks the "Compile and Check (Merge Ref)" job for every open
PR, since merge-ref builds include the trunk breakage.

The change applies exactly the formatting that Spotless suggests (the
`./gradlew spotlessApply` diff shown in the CI log) — whitespace only,
no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
