### PR TITLE
KAFKA-19753: Fix duplicated topic metrics in FetchMetricsManager for topic names containing dots

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManager.java
@@ -114,7 +114,8 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
 
     void recordBytesFetched(String topic, int bytes) {
         String name = topicBytesFetchedMetricName(topic);
-        maybeRecordDeprecatedBytesFetched(name, topic, bytes);
+        maybeRecordDeprecatedBytesFetched(topic, bytes);
+        maybeRemoveDeprecatedBytesFetched(topic);
 
         Sensor bytesFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
             .withAvg(metricsRegistry.topicFetchSizeAvg)
@@ -126,7 +127,8 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
 
     void recordRecordsFetched(String topic, int records) {
         String name = topicRecordsFetchedMetricName(topic);
-        maybeRecordDeprecatedRecordsFetched(name, topic, records);
+        maybeRecordDeprecatedRecordsFetched(topic, records);
+        maybeRemoveDeprecatedRecordsFetched(topic);
 
         Sensor recordsFetched = new SensorBuilder(metrics, name, () -> Map.of("topic", topic))
             .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
@@ -139,7 +141,8 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
         this.recordsLag.record(lag);
 
         String name = partitionRecordsLagMetricName(tp);
-        maybeRecordDeprecatedPartitionLag(name, tp, lag);
+        maybeRecordDeprecatedPartitionLag(tp, lag);
+        maybeRemoveDeprecatedPartitionLag(tp);
 
         Sensor recordsLag = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLag)
@@ -154,7 +157,8 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
         this.recordsLead.record(lead);
 
         String name = partitionRecordsLeadMetricName(tp);
-        maybeRecordDeprecatedPartitionLead(name, tp, lead);
+        maybeRecordDeprecatedPartitionLead(tp, lead);
+        maybeRemoveDeprecatedPartitionLead(tp);
 
         Sensor recordsLead = new SensorBuilder(metrics, name, () -> mkMap(mkEntry("topic", tp.topic()), mkEntry("partition", String.valueOf(tp.partition()))))
             .withValue(metricsRegistry.partitionRecordsLead)
@@ -184,15 +188,17 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
                     metrics.removeSensor(partitionRecordsLeadMetricName(tp));
                     metrics.removeMetric(partitionPreferredReadReplicaMetricName(tp));
                     // Remove deprecated metrics.
-                    metrics.removeSensor(deprecatedMetricName(partitionRecordsLagMetricName(tp)));
-                    metrics.removeSensor(deprecatedMetricName(partitionRecordsLeadMetricName(tp)));
-                    metrics.removeMetric(deprecatedPartitionPreferredReadReplicaMetricName(tp));
+                    metrics.removeSensor(deprecatedPartitionRecordsLagMetricName(tp));
+                    metrics.removeSensor(deprecatedPartitionRecordsLeadMetricName(tp));
+                    if (!newAssignedPartitions.contains(deprecatedTopicPartition(tp))) {
+                        metrics.removeMetric(deprecatedPartitionPreferredReadReplicaMetricName(tp));
+                    }
                 }
             }
 
             for (TopicPartition tp : newAssignedPartitions) {
                 if (!this.assignedPartitions.contains(tp)) {
-                    maybeRecordDeprecatedPreferredReadReplica(tp, subscription);
+                    maybeRemoveDeprecatedPreferredReadReplica(tp);
 
                     MetricName metricName = partitionPreferredReadReplicaMetricName(tp);
                     metrics.addMetricIfAbsent(
@@ -203,15 +209,23 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
                 }
             }
 
+            for (TopicPartition tp : newAssignedPartitions) {
+                maybeRecordDeprecatedPreferredReadReplica(tp, subscription, newAssignedPartitions);
+            }
+
             this.assignedPartitions = newAssignedPartitions;
             this.assignmentId = newAssignmentId;
         }
     }
 
     @Deprecated // To be removed in Kafka 5.0 release.
-    private void maybeRecordDeprecatedBytesFetched(String name, String topic, int bytes) {
-        if (shouldReportDeprecatedMetric(topic)) {
-            Sensor deprecatedBytesFetched = new SensorBuilder(metrics, deprecatedMetricName(name), () -> topicTags(topic))
+    private void maybeRecordDeprecatedBytesFetched(String topic, int bytes) {
+        if (shouldReportDeprecatedMetric(topic) &&
+                metrics.getSensor(topicBytesFetchedMetricName(topic.replace('.', '_'))) == null) {
+            Sensor deprecatedBytesFetched = new SensorBuilder(
+                    metrics,
+                    deprecatedTopicBytesFetchedMetricName(topic),
+                    () -> topicTags(topic))
                 .withAvg(metricsRegistry.topicFetchSizeAvg)
                 .withMax(metricsRegistry.topicFetchSizeMax)
                 .withMeter(metricsRegistry.topicBytesConsumedRate, metricsRegistry.topicBytesConsumedTotal)
@@ -221,9 +235,13 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
     }
 
     @Deprecated // To be removed in Kafka 5.0 release.
-    private void maybeRecordDeprecatedRecordsFetched(String name, String topic, int records) {
-        if (shouldReportDeprecatedMetric(topic)) {
-            Sensor deprecatedRecordsFetched = new SensorBuilder(metrics, deprecatedMetricName(name), () -> topicTags(topic))
+    private void maybeRecordDeprecatedRecordsFetched(String topic, int records) {
+        if (shouldReportDeprecatedMetric(topic) &&
+                metrics.getSensor(topicRecordsFetchedMetricName(topic.replace('.', '_'))) == null) {
+            Sensor deprecatedRecordsFetched = new SensorBuilder(
+                    metrics,
+                    deprecatedTopicRecordsFetchedMetricName(topic),
+                    () -> topicTags(topic))
                 .withAvg(metricsRegistry.topicRecordsPerRequestAvg)
                 .withMeter(metricsRegistry.topicRecordsConsumedRate, metricsRegistry.topicRecordsConsumedTotal)
                 .build();
@@ -232,9 +250,13 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
     }
 
     @Deprecated // To be removed in Kafka 5.0 release.
-    private void maybeRecordDeprecatedPartitionLag(String name, TopicPartition tp, long lag) {
-        if (shouldReportDeprecatedMetric(tp.topic())) {
-            Sensor deprecatedRecordsLag = new SensorBuilder(metrics, deprecatedMetricName(name), () -> topicPartitionTags(tp))
+    private void maybeRecordDeprecatedPartitionLag(TopicPartition tp, long lag) {
+        if (shouldReportDeprecatedMetric(tp.topic()) &&
+                metrics.getSensor(partitionRecordsLagMetricName(deprecatedTopicPartition(tp))) == null) {
+            Sensor deprecatedRecordsLag = new SensorBuilder(
+                    metrics,
+                    deprecatedPartitionRecordsLagMetricName(tp),
+                    () -> topicPartitionTags(tp))
                 .withValue(metricsRegistry.partitionRecordsLag)
                 .withMax(metricsRegistry.partitionRecordsLagMax)
                 .withAvg(metricsRegistry.partitionRecordsLagAvg)
@@ -245,9 +267,13 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
     }
 
     @Deprecated // To be removed in Kafka 5.0 release.
-    private void maybeRecordDeprecatedPartitionLead(String name, TopicPartition tp, double lead) {
-        if (shouldReportDeprecatedMetric(tp.topic())) {
-            Sensor deprecatedRecordsLead = new SensorBuilder(metrics, deprecatedMetricName(name), () -> topicPartitionTags(tp))
+    private void maybeRecordDeprecatedPartitionLead(TopicPartition tp, double lead) {
+        if (shouldReportDeprecatedMetric(tp.topic()) &&
+                metrics.getSensor(partitionRecordsLeadMetricName(deprecatedTopicPartition(tp))) == null) {
+            Sensor deprecatedRecordsLead = new SensorBuilder(
+                    metrics,
+                    deprecatedPartitionRecordsLeadMetricName(tp),
+                    () -> topicPartitionTags(tp))
                 .withValue(metricsRegistry.partitionRecordsLead)
                 .withMin(metricsRegistry.partitionRecordsLeadMin)
                 .withAvg(metricsRegistry.partitionRecordsLeadAvg)
@@ -258,14 +284,52 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
     }
 
     @Deprecated // To be removed in Kafka 5.0 release.
-    private void maybeRecordDeprecatedPreferredReadReplica(TopicPartition tp, SubscriptionState subscription) {
-        if (shouldReportDeprecatedMetric(tp.topic())) {
+    private void maybeRecordDeprecatedPreferredReadReplica(
+            TopicPartition tp,
+            SubscriptionState subscription,
+            Set<TopicPartition> assignedPartitions) {
+        if (shouldReportDeprecatedMetric(tp.topic()) && !assignedPartitions.contains(deprecatedTopicPartition(tp))) {
             MetricName metricName = deprecatedPartitionPreferredReadReplicaMetricName(tp);
             metrics.addMetricIfAbsent(
                 metricName,
                 null,
                 (Gauge<Integer>) (config, now) -> subscription.preferredReadReplica(tp, 0L).orElse(-1)
             );
+        }
+    }
+
+    @Deprecated // To be removed in Kafka 5.0 release.
+    private void maybeRemoveDeprecatedBytesFetched(String topic) {
+        if (!shouldReportDeprecatedMetric(topic)) {
+            metrics.removeSensor(deprecatedTopicBytesFetchedMetricName(topic));
+        }
+    }
+
+    @Deprecated // To be removed in Kafka 5.0 release.
+    private void maybeRemoveDeprecatedRecordsFetched(String topic) {
+        if (!shouldReportDeprecatedMetric(topic)) {
+            metrics.removeSensor(deprecatedTopicRecordsFetchedMetricName(topic));
+        }
+    }
+
+    @Deprecated // To be removed in Kafka 5.0 release.
+    private void maybeRemoveDeprecatedPartitionLag(TopicPartition tp) {
+        if (!shouldReportDeprecatedMetric(tp.topic())) {
+            metrics.removeSensor(deprecatedPartitionRecordsLagMetricName(tp));
+        }
+    }
+
+    @Deprecated // To be removed in Kafka 5.0 release.
+    private void maybeRemoveDeprecatedPartitionLead(TopicPartition tp) {
+        if (!shouldReportDeprecatedMetric(tp.topic())) {
+            metrics.removeSensor(deprecatedPartitionRecordsLeadMetricName(tp));
+        }
+    }
+
+    @Deprecated // To be removed in Kafka 5.0 release.
+    private void maybeRemoveDeprecatedPreferredReadReplica(TopicPartition tp) {
+        if (!shouldReportDeprecatedMetric(tp.topic())) {
+            metrics.removeMetric(deprecatedPartitionPreferredReadReplicaMetricName(tp));
         }
     }
 
@@ -277,12 +341,37 @@ public class FetchMetricsManager extends AbstractConsumerMetricsManager {
         return "topic." + topic + ".records-fetched";
     }
 
+    @Deprecated
+    private static String deprecatedTopicBytesFetchedMetricName(String topic) {
+        return deprecatedMetricName(topicBytesFetchedMetricName(topic.replace('.', '_')));
+    }
+
+    @Deprecated
+    private static String deprecatedTopicRecordsFetchedMetricName(String topic) {
+        return deprecatedMetricName(topicRecordsFetchedMetricName(topic.replace('.', '_')));
+    }
+
     private static String partitionRecordsLeadMetricName(TopicPartition tp) {
         return tp + ".records-lead";
     }
 
     private static String partitionRecordsLagMetricName(TopicPartition tp) {
         return tp + ".records-lag";
+    }
+
+    @Deprecated
+    private static String deprecatedPartitionRecordsLeadMetricName(TopicPartition tp) {
+        return deprecatedMetricName(partitionRecordsLeadMetricName(deprecatedTopicPartition(tp)));
+    }
+
+    @Deprecated
+    private static String deprecatedPartitionRecordsLagMetricName(TopicPartition tp) {
+        return deprecatedMetricName(partitionRecordsLagMetricName(deprecatedTopicPartition(tp)));
+    }
+
+    @Deprecated
+    private static TopicPartition deprecatedTopicPartition(TopicPartition tp) {
+        return new TopicPartition(tp.topic().replace('.', '_'), tp.partition());
     }
 
     private static String deprecatedMetricName(String name) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchMetricsManagerTest.java
@@ -38,6 +38,8 @@ import java.util.Set;
 import static org.apache.kafka.clients.consumer.internals.FetchMetricsManager.topicPartitionTags;
 import static org.apache.kafka.clients.consumer.internals.FetchMetricsManager.topicTags;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FetchMetricsManagerTest {
@@ -203,6 +205,63 @@ public class FetchMetricsManagerTest {
     }
 
     @Test
+    public void testRecordsFetchedTopicWithPeriodBeforeUnderscoreTopic() {
+        String dottedTopic = "my.topic";
+        String underscoreTopic = "my_topic";
+        Map<String, String> dottedTags = Map.of("topic", dottedTopic);
+        Map<String, String> underscoreTags = Map.of("topic", underscoreTopic);
+        int initialMetricsSize = metrics.metrics().size();
+
+        metricsManager.recordRecordsFetched(dottedTopic, 1);
+        assertEquals(6, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("topic.my.topic.records-fetched"));
+        assertNotNull(metrics.getSensor("topic.my_topic.records-fetched.deprecated"));
+        assertNull(metrics.getSensor("topic.my_topic.records-fetched"));
+
+        metricsManager.recordRecordsFetched(underscoreTopic, 2);
+        assertEquals(6, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("topic.my_topic.records-fetched"));
+        assertNull(metrics.getSensor("topic.my_topic.records-fetched.deprecated"));
+        assertEquals(1, metricValue(metricsRegistry.topicRecordsConsumedTotal, dottedTags), EPSILON);
+        assertEquals(2, metricValue(metricsRegistry.topicRecordsConsumedTotal, underscoreTags), EPSILON);
+    }
+
+    @Test
+    public void testRecordsFetchedTopicWithUnderscoreBeforePeriodTopic() {
+        String dottedTopic = "my.topic";
+        String underscoreTopic = "my_topic";
+        Map<String, String> dottedTags = Map.of("topic", dottedTopic);
+        Map<String, String> underscoreTags = Map.of("topic", underscoreTopic);
+        int initialMetricsSize = metrics.metrics().size();
+
+        metricsManager.recordRecordsFetched(underscoreTopic, 2);
+        assertEquals(3, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("topic.my_topic.records-fetched"));
+        assertNull(metrics.getSensor("topic.my_topic.records-fetched.deprecated"));
+
+        metricsManager.recordRecordsFetched(dottedTopic, 1);
+        assertEquals(6, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("topic.my.topic.records-fetched"));
+        assertNull(metrics.getSensor("topic.my_topic.records-fetched.deprecated"));
+        assertEquals(1, metricValue(metricsRegistry.topicRecordsConsumedTotal, dottedTags), EPSILON);
+        assertEquals(2, metricValue(metricsRegistry.topicRecordsConsumedTotal, underscoreTags), EPSILON);
+    }
+
+    @Test
+    public void testRecordsFetchedTopicWithoutPeriodDoesNotRegisterDeprecatedSensor() {
+        String topicName = "my_topic";
+        Map<String, String> tags = Map.of("topic", topicName);
+        int initialMetricsSize = metrics.metrics().size();
+
+        metricsManager.recordRecordsFetched(topicName, 2);
+
+        assertEquals(3, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("topic.my_topic.records-fetched"));
+        assertNull(metrics.getSensor("topic.my_topic.records-fetched.deprecated"));
+        assertEquals(2, metricValue(metricsRegistry.topicRecordsConsumedTotal, tags), EPSILON);
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     public void testPartitionLag() {
         TopicPartition tp1 = new TopicPartition(TOPIC_NAME, 0);
@@ -295,6 +354,68 @@ public class FetchMetricsManagerTest {
         assertEquals(15, metricValue(metricsRegistry.partitionRecordsLead, deprecatedTags), EPSILON);
         assertEquals(12, metricValue(metricsRegistry.partitionRecordsLeadMin, deprecatedTags), EPSILON);
         assertEquals(15, metricValue(metricsRegistry.partitionRecordsLeadAvg, deprecatedTags), EPSILON);
+    }
+
+    @Test
+    public void testPartitionMetricsWithPeriodBeforeUnderscoreTopic() {
+        TopicPartition dottedTp = new TopicPartition("my.topic", 0);
+        TopicPartition underscoreTp = new TopicPartition("my_topic", 0);
+        Map<String, String> dottedTags = Map.of(
+            "topic", dottedTp.topic(),
+            "partition", String.valueOf(dottedTp.partition()));
+        Map<String, String> underscoreTags = Map.of(
+            "topic", underscoreTp.topic(),
+            "partition", String.valueOf(underscoreTp.partition()));
+        int initialMetricsSize = metrics.metrics().size();
+
+        metricsManager.recordPartitionLag(dottedTp, 4);
+        metricsManager.recordPartitionLead(dottedTp, 8);
+        assertEquals(12, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("my.topic-0.records-lag"));
+        assertNotNull(metrics.getSensor("my_topic-0.records-lag.deprecated"));
+        assertNotNull(metrics.getSensor("my.topic-0.records-lead"));
+        assertNotNull(metrics.getSensor("my_topic-0.records-lead.deprecated"));
+
+        metricsManager.recordPartitionLag(underscoreTp, 2);
+        metricsManager.recordPartitionLead(underscoreTp, 6);
+        assertEquals(12, metrics.metrics().size() - initialMetricsSize);
+        assertNotNull(metrics.getSensor("my_topic-0.records-lag"));
+        assertNull(metrics.getSensor("my_topic-0.records-lag.deprecated"));
+        assertNotNull(metrics.getSensor("my_topic-0.records-lead"));
+        assertNull(metrics.getSensor("my_topic-0.records-lead.deprecated"));
+        assertEquals(4, metricValue(metricsRegistry.partitionRecordsLag, dottedTags), EPSILON);
+        assertEquals(2, metricValue(metricsRegistry.partitionRecordsLag, underscoreTags), EPSILON);
+        assertEquals(8, metricValue(metricsRegistry.partitionRecordsLead, dottedTags), EPSILON);
+        assertEquals(6, metricValue(metricsRegistry.partitionRecordsLead, underscoreTags), EPSILON);
+    }
+
+    @Test
+    public void testMaybeUpdateAssignmentWithPeriodBeforeUnderscoreTopic() {
+        TopicPartition dottedTp = new TopicPartition("my.topic", 0);
+        TopicPartition underscoreTp = new TopicPartition("my_topic", 0);
+        Map<String, String> dottedTags = Map.of(
+            "topic", dottedTp.topic(),
+            "partition", String.valueOf(dottedTp.partition()));
+        Map<String, String> underscoreTags = Map.of(
+            "topic", underscoreTp.topic(),
+            "partition", String.valueOf(underscoreTp.partition()));
+
+        SubscriptionState subscriptionState = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
+        subscriptionState.assignFromUser(Set.of(dottedTp));
+        subscriptionState.updatePreferredReadReplica(dottedTp, 1, () -> 0L);
+        metricsManager.maybeUpdateAssignment(subscriptionState);
+        assertEquals(1, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, dottedTags), EPSILON);
+        assertEquals(1, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, underscoreTags), EPSILON);
+
+        subscriptionState.assignFromUser(Set.of(dottedTp, underscoreTp));
+        subscriptionState.updatePreferredReadReplica(underscoreTp, 2, () -> 0L);
+        metricsManager.maybeUpdateAssignment(subscriptionState);
+        assertEquals(2, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, underscoreTags), EPSILON);
+
+        subscriptionState.assignFromUser(Set.of(underscoreTp));
+        subscriptionState.updatePreferredReadReplica(underscoreTp, 2, () -> 0L);
+        metricsManager.maybeUpdateAssignment(subscriptionState);
+        assertEquals(2, readReplicaMetricValue(metricsRegistry.partitionPreferredReadReplica, underscoreTags), EPSILON);
     }
 
     @Test


### PR DESCRIPTION
Since 4.1.0, `FetchMetricsManager` registers the KIP-1109 deprecated metrics (topic names with dots replaced by underscores) alongside the new verbatim-name metrics. The deprecated names were derived by string-wrapping the new-format metric name, which produced colliding and duplicated sensors when a consumer subscribes to topics whose names differ only by dots versus underscores (for example `my.topic` and `my_topic`), and left stale deprecated sensors registered when they should no longer be reported. Users scraping these metrics through Micrometer or Prometheus saw duplicated topic-tagged series.

This change:
- Derives the deprecated metric and sensor names through dedicated `deprecated*MetricName` helpers based on the mangled (dot-to-underscore) topic name, instead of wrapping the new-format name.
- Registers a deprecated sensor only when it does not collide with the sensor of a real topic whose name equals the mangled name, covering both registration orders (dotted topic seen first, underscore topic seen first).
- Adds `maybeRemoveDeprecated*` cleanup so deprecated sensors and metrics are unregistered once they should no longer be reported, including during assignment updates, with collision-aware removal so a still-assigned partition's metrics are never dropped.

The deprecated metrics themselves remain in place for topics with dots, as intended by KIP-1109, until their removal in Kafka 5.0.

Testing: five new unit tests in `FetchMetricsManagerTest` cover the dotted-versus-underscore topic interplay in both registration orders, topics without dots (no deprecated sensor registered), the partition-level lag/lead/preferred-read-replica metrics, and assignment updates. Verified with the scoped module run `./gradlew :clients:test --tests org.apache.kafka.clients.consumer.internals.FetchMetricsManagerTest`.


JIRA: https://issues.apache.org/jira/browse/KAFKA-19753
