### PR TITLE
MINOR: Add release related paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ tests/venv
 docs/generated/
 
 .release-settings.json
+.release_work_dir/
+release/.venv
 
 kafkatest.egg-info/
 systest/


### PR DESCRIPTION
This PR adds two release-related paths to .gitignore so local release
runs don't show as untracked changes:     - `.release_work_dir/` — the
temp build/staging dir created by `release.py`    - `release/.venv` —
the Python virtualenv for the release tooling

Reviewers: Lianet Magrans <lmagrans@confluent.io>
