### PR TITLE
KAFKA-19902: fix(consumer): use latest leader epoch when committing offsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
@@ -176,10 +177,11 @@ public class FetchCollector<K, V> {
                 boolean positionAdvanced = false;
 
                 if (nextInLineFetch.nextFetchOffset() > position.offset) {
+                    Metadata.LeaderAndEpoch currentLeader = metadata.currentLeader(tp);
                     SubscriptionState.FetchPosition nextPosition = new SubscriptionState.FetchPosition(
                             nextInLineFetch.nextFetchOffset(),
                             nextInLineFetch.lastEpoch(),
-                            position.currentLeader);
+                            currentLeader);
                     log.trace("Updating fetch position from {} to {} for partition {} and returning {} records from `poll()`",
                             position, nextPosition, tp, partRecords.size());
                     subscriptions.position(tp, nextPosition);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -786,9 +786,15 @@ public class SubscriptionState {
     public synchronized Map<TopicPartition, OffsetAndMetadata> allConsumed() {
         Map<TopicPartition, OffsetAndMetadata> allConsumed = new HashMap<>();
         assignment.forEach((topicPartition, partitionState) -> {
-            if (partitionState.hasValidPosition())
+            if (partitionState.hasValidPosition()) {
+                Optional<Integer> epoch = partitionState.position.offsetEpoch;
+                Optional<Integer> currentLeaderEpoch = partitionState.position.currentLeader.epoch;
+                Optional<Integer> leaderEpoch = epoch.isPresent() && currentLeaderEpoch.isPresent() ?
+                        Optional.of(Math.max(epoch.get(), currentLeaderEpoch.get())) :
+                        currentLeaderEpoch.isPresent() ? currentLeaderEpoch : epoch;
                 allConsumed.put(topicPartition, new OffsetAndMetadata(partitionState.position.offset,
-                        partitionState.position.offsetEpoch, ""));
+                        leaderEpoch, ""));
+            }
         });
         return allConsumed;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.IsolationLevel;
@@ -35,6 +36,7 @@ import org.apache.kafka.common.record.internal.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.internal.RecordBatch;
 import org.apache.kafka.common.record.internal.Records;
 import org.apache.kafka.common.record.internal.SimpleRecord;
+import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.MockTime;
@@ -190,6 +192,29 @@ public class FetchCollectorTest {
 
         // Verify that when drain() was invoked, the position had already been advanced.
         assertEquals(DEFAULT_RECORD_COUNT, positionAtDrainTime.get());
+    }
+
+    @Test
+    public void testPositionUpdateUsesCurrentLeaderEpoch() {
+        buildDependencies();
+        assignAndSeek(topicAPartition0);
+
+        int leaderEpoch = 15;
+        metadata.requestUpdate(true);
+        Metadata.MetadataRequestAndVersion requestAndVersion = metadata.newMetadataRequestAndVersion(time.milliseconds());
+        metadata.update(requestAndVersion.requestVersion,
+                RequestTestUtils.metadataUpdateWith(1, Collections.singletonMap(topicAPartition0.topic(), 1), tp -> leaderEpoch),
+                false,
+                time.milliseconds());
+
+        CompletedFetch completedFetch = completedFetchBuilder
+                .recordCount(DEFAULT_RECORD_COUNT)
+                .build();
+        fetchBuffer.add(completedFetch);
+
+        Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+        assertFalse(fetch.isEmpty());
+        assertEquals(Optional.of(leaderEpoch), subscriptions.position(topicAPartition0).currentLeader.epoch);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -654,6 +655,37 @@ public class SubscriptionStateTest {
                 Optional.of(broker1), Optional.of(10))));
         assertTrue(state.hasValidPosition(tp0));
         assertFalse(state.awaitingValidation(tp0));
+    }
+
+    @Test
+    public void testAllConsumedUsesLatestAvailableLeaderEpoch() {
+        Node broker1 = new Node(1, "localhost", 9092);
+        state.assignFromUser(Set.of(tp0));
+
+        state.seekValidated(tp0, new SubscriptionState.FetchPosition(10L, Optional.of(5),
+                new Metadata.LeaderAndEpoch(Optional.of(broker1), Optional.of(10))));
+        Map<TopicPartition, OffsetAndMetadata> consumed = state.allConsumed();
+        assertEquals(Optional.of(10), consumed.get(tp0).leaderEpoch());
+
+        state.seekValidated(tp0, new SubscriptionState.FetchPosition(10L, Optional.of(12),
+                new Metadata.LeaderAndEpoch(Optional.of(broker1), Optional.of(10))));
+        consumed = state.allConsumed();
+        assertEquals(Optional.of(12), consumed.get(tp0).leaderEpoch());
+
+        state.seekValidated(tp0, new SubscriptionState.FetchPosition(10L, Optional.of(5),
+                Metadata.LeaderAndEpoch.noLeaderOrEpoch()));
+        consumed = state.allConsumed();
+        assertEquals(Optional.of(5), consumed.get(tp0).leaderEpoch());
+
+        state.seekValidated(tp0, new SubscriptionState.FetchPosition(10L, Optional.empty(),
+                new Metadata.LeaderAndEpoch(Optional.empty(), Optional.of(10))));
+        consumed = state.allConsumed();
+        assertEquals(Optional.of(10), consumed.get(tp0).leaderEpoch());
+
+        state.seekValidated(tp0, new SubscriptionState.FetchPosition(10L, Optional.empty(),
+                Metadata.LeaderAndEpoch.noLeaderOrEpoch()));
+        consumed = state.allConsumed();
+        assertEquals(Optional.empty(), consumed.get(tp0).leaderEpoch());
     }
 
     @Test


### PR DESCRIPTION
When the partition leader changes, the consumer's `FetchPosition.currentLeader` can become stale because it is inherited from the previous position and only refreshed when leader-change errors are observed. `SubscriptionState.allConsumed()` then committed `position.offsetEpoch` (the epoch of the last consumed batch) instead, which can reference log segments that have since been deleted by retention, causing `OFFSET_OUT_OF_RANGE` on the next session and an `auto.offset.reset` jump.

This change keeps `currentLeader` fresh by looking it up in metadata every time the fetch position is advanced in `FetchCollector`, and makes `SubscriptionState.allConsumed()` use the maximum of `offsetEpoch` and `currentLeader.epoch` (falling back to whichever is present) so that the committed offset epoch matches the most recent leader epoch known to the client.

---

Delete this text and replace it with a detailed description of your change. The
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

### Testing strategy

- Updated `SubscriptionStateTest.testAllConsumedUsesLatestAvailableLeaderEpoch` covers the new `allConsumed()` epoch selection across the four combinations of present/absent `offsetEpoch` and `currentLeader.epoch`.
- Added `FetchCollectorTest.testPositionUpdateUsesCurrentLeaderEpoch` to verify that advancing the fetch position refreshes `currentLeader.epoch` from the metadata cache.

- [x] Unit tests added/updated

JIRA: https://issues.apache.org/jira/browse/KAFKA-19902