### PR TITLE
KAFKA-19602: fix(streams): propagate state store names from KTable.transformValues to downstream KTable join

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -466,7 +466,8 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final KTableProcessorSupplier<K, V, K, VR> processorSupplier = new KTableTransformValues<>(
             this,
             transformerSupplier,
-            queryableStoreName);
+            queryableStoreName,
+            stateStoreNames);
 
         final ProcessorParameters<K, VR, ?, ?> processorParameters =
             unsafeCastProcessorParametersToCompletelyDifferentType(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableTransformValues.java
@@ -40,14 +40,23 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
     private final KTableImpl<K, ?, V> parent;
     private final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VOut> transformerSupplier;
     private final String queryableName;
+    private final String[] stateStoreNames;
     private boolean sendOldValues = false;
 
     KTableTransformValues(final KTableImpl<K, ?, V> parent,
                           final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VOut> transformerSupplier,
                           final String queryableName) {
+        this(parent, transformerSupplier, queryableName, new String[0]);
+    }
+
+    KTableTransformValues(final KTableImpl<K, ?, V> parent,
+                          final ValueTransformerWithKeySupplier<? super K, ? super V, ? extends VOut> transformerSupplier,
+                          final String queryableName,
+                          final String[] stateStoreNames) {
         this.parent = Objects.requireNonNull(parent, "parent");
         this.transformerSupplier = Objects.requireNonNull(transformerSupplier, "transformerSupplier");
         this.queryableName = queryableName;
+        this.stateStoreNames = Objects.requireNonNull(stateStoreNames, "stateStoreNames");
     }
 
     @Override
@@ -72,7 +81,11 @@ class KTableTransformValues<K, V, VOut> implements KTableProcessorSupplier<K, V,
 
             @Override
             public String[] storeNames() {
-                return parentValueGetterSupplier.storeNames();
+                final String[] parentStoreNames = parentValueGetterSupplier.storeNames();
+                final String[] storeNames = new String[parentStoreNames.length + stateStoreNames.length];
+                System.arraycopy(parentStoreNames, 0, storeNames, 0, parentStoreNames.length);
+                System.arraycopy(stateStoreNames, 0, storeNames, parentStoreNames.length, stateStoreNames.length);
+                return storeNames;
             }
         };
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
@@ -29,16 +29,21 @@ import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.api.MockProcessorContext;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockApiProcessor;
 import org.apache.kafka.test.MockApiProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -66,6 +71,56 @@ public class KTableKTableInnerJoinTest {
         Materialized.with(Serdes.Integer(), Serdes.String());
     private Properties props = StreamsTestUtils.getStreamsConfig(Serdes.Integer(), Serdes.String());
 
+
+    @Test
+    public void shouldJoinAfterUnmaterializedTransformValuesWithExtraStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final StoreBuilder<KeyValueStore<Integer, String>> transformerStore = Stores.keyValueStoreBuilder(
+            Stores.inMemoryKeyValueStore("transformer-store"),
+            Serdes.Integer(),
+            Serdes.String()
+        );
+        builder.addStateStore(transformerStore);
+
+        final KTable<Integer, String> transformed = builder
+            .table(topic1, consumed, materialized)
+            .transformValues(
+                () -> new ValueTransformerWithKey<>() {
+                    @Override
+                    public void init(final ProcessorContext context) {
+                        context.getStateStore(transformerStore.name());
+                    }
+
+                    @Override
+                    public String transform(final Integer readOnlyKey, final String value) {
+                        return value;
+                    }
+
+                    @Override
+                    public void close() {}
+                },
+                Materialized.with(Serdes.Integer(), Serdes.String()),
+                transformerStore.name()
+            );
+
+        transformed
+            .join(transformed, (value1, value2) -> value1)
+            .toStream()
+            .to(output);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<Integer, String> inputTopic =
+                driver.createInputTopic(
+                    topic1,
+                    Serdes.Integer().serializer(),
+                    Serdes.String().serializer(),
+                    Instant.ofEpochMilli(0L),
+                    Duration.ZERO
+                );
+
+            inputTopic.pipeInput(1, "A");
+        }
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -306,6 +306,19 @@ public class KTableTransformValuesTest {
     }
 
     @Test
+    public void shouldGetStoreNamesFromParentAndExtraStoresIfNotMaterialized() {
+        final KTableTransformValues<String, String, String> transformValues =
+            new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), null, new String[]{"store3", "store4"});
+
+        when(parent.valueGetterSupplier()).thenReturn(parentGetterSupplier);
+        when(parentGetterSupplier.storeNames()).thenReturn(new String[]{"store1", "store2"});
+
+        final String[] storeNames = transformValues.view().storeNames();
+
+        assertThat(storeNames, is(new String[]{"store1", "store2", "store3", "store4"}));
+    }
+
+    @Test
     public void shouldGetQueryableStoreNameIfMaterialized() {
         final KTableTransformValues<String, String, String> transformValues =
             new KTableTransformValues<>(parent, new ExclamationValueTransformerSupplier(), QUERYABLE_NAME);


### PR DESCRIPTION
## Change description

When `KTable.transformValues` is called with extra state stores (via the `stateStoreNames` parameter) and the result is not materialized, the resulting `KTableTransformValues` `ProcessorSupplier` did not expose those extra stores via `storeNames()`. As a result, a downstream `KTable` join operator had no way to learn about the extra stores and could not wire them through to the join processor, causing initialization to fail with `Processor ... has no access to StateStore ...`.

This change adds a new constructor to `KTableTransformValues` that accepts the `stateStoreNames` and merges them with the parent value getter's `storeNames()` so the full set of stores is reported. `KTableImpl` now passes the `stateStoreNames` it already received to this new constructor. Tests are added in `KTableTransformValuesTest` and `KTableKTableInnerJoinTest` to cover both the unit-level `storeNames()` behavior and the end-to-end join scenario from the issue.

### Testing strategy

Unit tests verify that the `view()` `storeNames()` method of `KTableTransformValues` returns the union of parent store names and the extra `stateStoreNames` when the result is not materialized. A new integration-style test in `KTableKTableInnerJoinTest` reproduces the exact scenario from KAFKA-19602: a `transformValues` on a `KTable` with an extra manually-added state store, followed by a self join, which previously failed during topology initialization.

JIRA: https://issues.apache.org/jira/browse/KAFKA-19602
Reviewers: Uladzislau Blok <blokv75@gmail.com>
