### PR TITLE
MINOR: Fix missing parenthesis in under-min-ISR trace log

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -430,7 +430,7 @@ import static org.apache.kafka.common.utils.Utils.propsToMap;
  *
  * <p>
  * Partitions with transactional messages will include commit or abort markers which indicate the result of a transaction.
- * There markers are not returned to applications, yet have an offset in the log. As a result, applications reading from
+ * These markers are not returned to applications, yet have an offset in the log. As a result, applications reading from
  * topics with transactional messages will see gaps in the consumed offsets. These missing messages would be the transaction
  * markers, and they are filtered out for consumers in both isolation levels. Additionally, applications using
  * {@code read_committed} consumers may also see gaps due to aborted transactions, since those messages would not

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -509,7 +509,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
      * @param timer Timer bounding how long this method can block
      * @param waitForJoinGroup Boolean flag indicating if we should wait until re-join group completes
      * @throws KafkaException if the rebalance callback throws an exception
-     * @return true if the operation succeeded
+     * @return true iff the operation succeeded
      */
     public boolean poll(Timer timer, boolean waitForJoinGroup) {
         maybeUpdateSubscriptionMetadata();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -509,7 +509,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
      * @param timer Timer bounding how long this method can block
      * @param waitForJoinGroup Boolean flag indicating if we should wait until re-join group completes
      * @throws KafkaException if the rebalance callback throws an exception
-     * @return true iff the operation succeeded
+     * @return true if the operation succeeded
      */
     public boolean poll(Timer timer, boolean waitForJoinGroup) {
         maybeUpdateSubscriptionMetadata();
@@ -1413,7 +1413,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                                     if (ConsumerCoordinator.this.state == MemberState.PREPARING_REBALANCE) {
                                         exception = new RebalanceInProgressException("Offset commit cannot be completed since the " +
                                             "consumer member's old generation is fenced by its group instance id, it is possible that " +
-                                            "this consumer has already participated another rebalance and got a new generation");
+                                            "this consumer has already participated in another rebalance and got a new generation");
                                     } else {
                                         exception = new CommitFailedException();
                                     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -230,7 +230,7 @@ public class RecordAccumulator {
      * @param partitionInfo The built-in partitioner's partition info
      * @param deque The partition queue
      * @param nowMs The current time, in milliseconds
-     * @param cluster THe cluster metadata
+     * @param cluster The cluster metadata
      * @return 'true' if partition changed and we need to get new partition info and retry,
      *         'false' otherwise
      */
@@ -510,7 +510,7 @@ public class RecordAccumulator {
     }
 
     /**
-     * Split the big batch that has been rejected and reenqueue the split batches in to the accumulator.
+     * Split the big batch that has been rejected and reenqueue the split batches into the accumulator.
      * @return the number of split batches.
      */
     public int splitAndReenqueue(ProducerBatch bigBatch) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -287,7 +287,7 @@ public abstract class Type {
             if (item instanceof Integer)
                 return (Integer) item;
             else
-                throw new SchemaException(item + " is not an a Integer (encoding an unsigned short)");
+                throw new SchemaException(item + " is not an Integer (encoding an unsigned short)");
         }
 
         @Override

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1009,7 +1009,7 @@ class Partition(val topicPartition: TopicPartition,
    */
   private def maybeIncrementLeaderHW(leaderLog: UnifiedLog, currentTimeMs: Long = time.milliseconds): Boolean = {
     if (isUnderMinIsr) {
-      trace(s"Not increasing HWM because partition is under min ISR(ISR=${partitionState.isr}")
+      trace(s"Not increasing HWM because partition is under min ISR(ISR=${partitionState.isr})")
       return false
     }
     // maybeIncrementLeaderHW is in the hot path, the following code is written to


### PR DESCRIPTION
This PR fixes a missing closing parenthesis in an under-min-ISR trace
log message.

Before: Not increasing HWM because partition is under min ISR(ISR=Set(1,
2)

After: Not increasing HWM because partition is under min ISR(ISR=Set(1,
2))

This is a log message cleanup only. No behavior change.

Previous PR source branch was accidentally overwritten while syncing
fork trunk.  Re-opening the exact same patch in a dedicated feature
branch.

Reviewers: Ken Huang <s7133700@gmail.com>, Mickael Maison
 <mickael.maison@gmail.com>
