### PR TITLE
KAFKA-19919: Avoid reverse DNS for built-in SASL servers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -61,6 +61,8 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.kerberos.KerberosError;
 import org.apache.kafka.common.security.kerberos.KerberosName;
 import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServer;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.utils.Time;
@@ -206,7 +208,7 @@ public class SaslServerAuthenticator implements Authenticator {
         } else {
             try {
                 saslServer = SecurityManagerCompatibility.get().callAs(subject, () ->
-                    Sasl.createSaslServer(saslMechanism, "kafka", serverAddress().getHostName(), configs, callbackHandler));
+                    Sasl.createSaslServer(saslMechanism, "kafka", serverName(saslMechanism), configs, callbackHandler));
                 if (saslServer == null) {
                     throw new SaslException("Kafka Server failed to create a SaslServer to interact with a client during session authentication with server mechanism " + saslMechanism);
                 }
@@ -214,6 +216,18 @@ public class SaslServerAuthenticator implements Authenticator {
                 throw new SaslException("Kafka Server failed to create a SaslServer to interact with a client during session authentication with server mechanism " + saslMechanism, e.getCause());
             }
         }
+    }
+
+    private String serverName(String mechanism) {
+        if (usesUnboundServerName(mechanism))
+            return null;
+        return serverAddress().getHostName();
+    }
+
+    private static boolean usesUnboundServerName(String mechanism) {
+        return PlainSaslServer.PLAIN_MECHANISM.equals(mechanism) ||
+                ScramMechanism.isScram(mechanism) ||
+                OAuthBearerLoginModule.OAUTHBEARER_MECHANISM.equals(mechanism);
     }
 
     private SaslServer createSaslKerberosServer(final AuthenticateCallbackHandler saslServerCallbackHandler, final Map<String, ?> configs, Subject subject) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -54,6 +54,8 @@ import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -62,8 +64,10 @@ import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.Socket;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -79,11 +83,13 @@ import javax.security.sasl.SaslServer;
 
 import static org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -299,12 +305,60 @@ public class SaslServerAuthenticatorTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512", "OAUTHBEARER"})
+    public void testBuiltInNonGssapiSaslServerCreationUsesUnboundServerName(String mechanism) throws Exception {
+        SaslServer saslServer = mock(SaslServer.class);
+        Socket socket = mock(Socket.class);
+        TransportLayer transportLayer = mockTransportLayer(socket, InetAddress.getLoopbackAddress(), InetAddress.getLoopbackAddress());
+        ArgumentCaptor<String> serverNameCaptor = ArgumentCaptor.forClass(String.class);
+
+        try (
+            MockedStatic<Sasl> sasl = Mockito.mockStatic(Sasl.class, invocation -> saslServer);
+            MockedStatic<?> ignored = mockKafkaPrincipal("[principal-type]", "[principal-name]")
+        ) {
+            SaslServerAuthenticator authenticator = setupAuthenticator(configsForMechanism(mechanism), transportLayer,
+                    mechanism, new DefaultChannelMetadataRegistry());
+
+            mockRequest(saslHandshakeRequest(mechanism), transportLayer);
+            authenticator.authenticate();
+
+            sasl.verify(() -> Sasl.createSaslServer(eq(mechanism), eq("kafka"), serverNameCaptor.capture(),
+                    anyMap(), any()));
+            assertNull(serverNameCaptor.getValue());
+            verify(socket, never()).getLocalAddress();
+        }
+    }
+
+    @Test
+    public void testCustomNonGssapiSaslServerCreationPreservesServerName() throws Exception {
+        String mechanism = "CUSTOM-MECHANISM";
+        String serverName = "broker.example.com";
+        SaslServer saslServer = mock(SaslServer.class);
+        InetAddress serverAddress = mock(InetAddress.class);
+        when(serverAddress.getHostName()).thenReturn(serverName);
+
+        TransportLayer transportLayer = mockTransportLayer(mock(Socket.class), InetAddress.getLoopbackAddress(), serverAddress);
+
+        try (
+            MockedStatic<Sasl> sasl = Mockito.mockStatic(Sasl.class, invocation -> saslServer);
+            MockedStatic<?> ignored = mockKafkaPrincipal("[principal-type]", "[principal-name]")
+        ) {
+            SaslServerAuthenticator authenticator = setupAuthenticator(configsForMechanism(mechanism), transportLayer,
+                    mechanism, new DefaultChannelMetadataRegistry());
+
+            mockRequest(saslHandshakeRequest(mechanism), transportLayer);
+            authenticator.authenticate();
+
+            sasl.verify(() -> Sasl.createSaslServer(eq(mechanism), eq("kafka"), eq(serverName), anyMap(), any()));
+            verify(serverAddress).getHostName();
+        }
+    }
+
     private SaslServerAuthenticator getSaslServerAuthenticatorForOAuth(String mechanism, TransportLayer transportLayer, Time time, Long maxReauth) {
-        Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
-                Collections.singletonList(mechanism));
         ChannelMetadataRegistry metadataRegistry = new DefaultChannelMetadataRegistry();
 
-        return setupAuthenticator(configs, transportLayer, mechanism, metadataRegistry, time, maxReauth);
+        return setupAuthenticator(configsForMechanism(mechanism), transportLayer, mechanism, metadataRegistry, time, maxReauth);
     }
 
     private MockedStatic<?> mockSaslServer(SaslServer saslServer, String mechanism, Time time, Duration tokenExpirationDuration) throws SaslException {
@@ -371,8 +425,16 @@ public class SaslServerAuthenticatorTest {
     }
 
     private TransportLayer mockTransportLayer() throws IOException {
-        TransportLayer transportLayer = mock(TransportLayer.class, Answers.RETURNS_DEEP_STUBS);
-        when(transportLayer.socketChannel().socket().getInetAddress()).thenReturn(InetAddress.getLoopbackAddress());
+        return mockTransportLayer(mock(Socket.class), InetAddress.getLoopbackAddress(), InetAddress.getLoopbackAddress());
+    }
+
+    private TransportLayer mockTransportLayer(Socket socket, InetAddress clientAddress, InetAddress serverAddress) throws IOException {
+        TransportLayer transportLayer = mock(TransportLayer.class);
+        SocketChannel socketChannel = mock(SocketChannel.class);
+        when(transportLayer.socketChannel()).thenReturn(socketChannel);
+        when(socketChannel.socket()).thenReturn(socket);
+        when(socket.getInetAddress()).thenReturn(clientAddress);
+        when(socket.getLocalAddress()).thenReturn(serverAddress);
         when(transportLayer.write(any(ByteBuffer[].class))).thenReturn(Long.MAX_VALUE);
         return transportLayer;
     }
@@ -438,6 +500,11 @@ public class SaslServerAuthenticatorTest {
         return new SaslServerAuthenticator(configs, callbackHandlers, "node", subjects, null,
                 new ListenerName("ssl"), SecurityProtocol.SASL_SSL, transportLayer, connectionsMaxReauthMsByMechanism,
                 metadataRegistry, time, version -> apiVersionsResponse);
+    }
+
+    private Map<String, ?> configsForMechanism(String mechanism) {
+        return Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
+                Collections.singletonList(mechanism));
     }
 
 }


### PR DESCRIPTION
### Summary

This patch avoids a broker-side reverse DNS lookup when creating Kafka's built-in non-GSSAPI `SaslServer` instances.

The blocking path reported in KAFKA-19919 is:

`KafkaChannel.prepare()` -> `SaslServerAuthenticator#createSaslServer()` -> `serverAddress().getHostName()`

`InetAddress#getHostName()` may perform a reverse DNS lookup on the network thread during connection preparation.

### Change

For Kafka's built-in non-GSSAPI server mechanisms:

- `PLAIN`
- `SCRAM-SHA-256`
- `SCRAM-SHA-512`
- `OAUTHBEARER`

the `Sasl.createSaslServer` `serverName` argument is now passed as `null`, using Java SASL's unbound server-name form. Kafka's built-in server implementations for these mechanisms do not use the `serverName` argument.

The GSSAPI/Kerberos path is unchanged because it derives the service host from the Kerberos service principal. Custom non-GSSAPI mechanisms are also left on the existing path and continue to receive `serverAddress().getHostName()`.

### Tests

Added focused coverage in `SaslServerAuthenticatorTest` for:

- built-in non-GSSAPI mechanisms using an unbound `serverName`
- built-in non-GSSAPI creation not reading the socket local address
- custom non-GSSAPI mechanisms preserving the existing hostname behavior

Verified locally with:

```bash
./gradlew clients:test --tests org.apache.kafka.common.security.authenticator.SaslServerAuthenticatorTest
```

Result:

```text
BUILD SUCCESSFUL
```
