### PR TITLE
(WIP-PoC) KIP-1356: IQv2 TimestampedKeyWithHeadersQuery for headers-aware state stores

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyWithHeadersQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyWithHeadersQueryIntegrationTest.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.query.TimestampedKeyWithHeadersQuery;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end PoC test for KIP-1356 {@link TimestampedKeyWithHeadersQuery}.
+ *
+ * <p>Builds a KIP-1271 {@code WithHeaders} store, writes records (with headers) into it through a
+ * processor, then queries the store through IQv2 and asserts that the returned
+ * {@link ValueTimestampHeaders} carries value, timestamp, and the exact headers written.
+ */
+@Tag("integration")
+public class TimestampedKeyWithHeadersQueryIntegrationTest {
+
+    private static final String STORE_NAME = "headers-store";
+
+    private static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    private static final Headers HEADERS = new RecordHeaders()
+        .add("source", "test".getBytes())
+        .add("version", "1.0".getBytes());
+
+    private String inputStream;
+    private String outputStream;
+    private long baseTimestamp;
+    private KafkaStreams kafkaStreams;
+    private TestInfo testInfo;
+
+    @BeforeAll
+    public static void before() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterAll
+    public static void after() {
+        CLUSTER.stop();
+    }
+
+    @BeforeEach
+    public void beforeTest(final TestInfo testInfo) throws InterruptedException {
+        this.testInfo = testInfo;
+        final String uniqueTestName = safeUniqueTestName(testInfo);
+        inputStream = "input-stream-" + uniqueTestName;
+        outputStream = "output-stream-" + uniqueTestName;
+        CLUSTER.createTopic(inputStream);
+        CLUSTER.createTopic(outputStream);
+        baseTimestamp = CLUSTER.time.milliseconds();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        if (kafkaStreams != null) {
+            kafkaStreams.close(Duration.ofSeconds(30L));
+            kafkaStreams.cleanUp();
+        }
+    }
+
+    @Test
+    public void shouldHandleTimestampedKeyWithHeadersQuery() throws Exception {
+        startStreams();
+
+        // key 1 has headers, key 2 has empty headers, key 3 is tombstoned (null value)
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp, HEADERS,
+            KeyValue.pair(1, "a0"));
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp + 1, new RecordHeaders(),
+            KeyValue.pair(2, "b0"));
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp + 2, HEADERS,
+            KeyValue.pair(3, "c0"), KeyValue.pair(3, null));
+
+        // wait until all 4 input records have been processed (one output per input record)
+        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+            TestUtils.consumerConfig(CLUSTER.bootstrapServers(), IntegerDeserializer.class, StringDeserializer.class),
+            outputStream,
+            4);
+
+        // key 1: value + timestamp + headers round-trip
+        final ValueTimestampHeaders<String> result1 = query(1);
+        assertEquals("a0", result1.value());
+        assertEquals(baseTimestamp, result1.timestamp());
+        assertEquals(HEADERS, result1.headers());
+
+        // key 2: written with no headers -> empty (never null) headers
+        final ValueTimestampHeaders<String> result2 = query(2);
+        assertEquals("b0", result2.value());
+        assertEquals(baseTimestamp + 1, result2.timestamp());
+        assertEquals(new RecordHeaders(), result2.headers());
+
+        // key 3: tombstoned -> null result, never a partially-populated wrapper
+        assertNull(query(3));
+
+        // never-written key -> null result
+        assertNull(query(999));
+    }
+
+    @Test
+    public void shouldFailWithUnknownQueryTypeAgainstNonHeadersStore() throws Exception {
+        // store built WITHOUT a WithHeaders supplier -> the query type is unsupported
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(
+                Stores.timestampedKeyValueStoreBuilder(
+                    Stores.persistentTimestampedKeyValueStore(STORE_NAME),
+                    Serdes.Integer(),
+                    Serdes.String()))
+            .stream(inputStream, Consumed.with(Serdes.Integer(), Serdes.String()))
+            .process(() -> new PlainStoreWriterProcessor(), STORE_NAME)
+            .to(outputStream, Produced.with(Serdes.Integer(), Serdes.String()));
+
+        kafkaStreams = new KafkaStreams(builder.build(), props());
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        produceDataToTopicWithHeaders(inputStream, baseTimestamp, HEADERS, KeyValue.pair(1, "a0"));
+        IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+            TestUtils.consumerConfig(CLUSTER.bootstrapServers(), IntegerDeserializer.class, StringDeserializer.class),
+            outputStream,
+            1);
+
+        final StateQueryResult<ValueTimestampHeaders<String>> result =
+            kafkaStreams.query(inStore(STORE_NAME).withQuery(TimestampedKeyWithHeadersQuery.withKey(1)));
+
+        assertTrue(result.getOnlyPartitionResult().isFailure());
+        assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, result.getOnlyPartitionResult().getFailureReason());
+    }
+
+    private void startStreams() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(
+                Stores.timestampedKeyValueStoreWithHeadersBuilder(
+                        Stores.persistentTimestampedKeyValueStoreWithHeaders(STORE_NAME),
+                        Serdes.Integer(),
+                        Serdes.String())
+                    // Disable caching so every IQv2 query is forced down to the persistent
+                    // RocksDBTimestampedStoreWithHeaders layer, exercising its KeyQuery handling
+                    // (rather than being short-circuited by a cache hit).
+                    .withCachingDisabled())
+            .stream(inputStream, Consumed.with(Serdes.Integer(), Serdes.String()))
+            .process(() -> new HeadersStoreWriterProcessor(), STORE_NAME)
+            .to(outputStream, Produced.with(Serdes.Integer(), Serdes.String()));
+
+        kafkaStreams = new KafkaStreams(builder.build(), props());
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+    }
+
+    private ValueTimestampHeaders<String> query(final int key) {
+        final StateQueryRequest<ValueTimestampHeaders<String>> request =
+            inStore(STORE_NAME).withQuery(TimestampedKeyWithHeadersQuery.<Integer, String>withKey(key));
+        final StateQueryResult<ValueTimestampHeaders<String>> result = kafkaStreams.query(request);
+        // getOnlyPartitionResult() returns null when the single partition result is a successful
+        // null (tombstoned / absent key), which we surface to the caller as a null lookup.
+        final QueryResult<ValueTimestampHeaders<String>> onlyResult = result.getOnlyPartitionResult();
+        return onlyResult == null ? null : onlyResult.getResult();
+    }
+
+    private Properties props() {
+        final String safeTestName = safeUniqueTestName(testInfo);
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000L);
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return streamsConfiguration;
+    }
+
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    private final void produceDataToTopicWithHeaders(final String topic,
+                                                     final long timestamp,
+                                                     final Headers headers,
+                                                     final KeyValue<Integer, String>... keyValues) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            topic,
+            Arrays.asList(keyValues),
+            TestUtils.producerConfig(CLUSTER.bootstrapServers(), IntegerSerializer.class, StringSerializer.class),
+            headers,
+            timestamp,
+            false);
+    }
+
+    private static class HeadersStoreWriterProcessor implements Processor<Integer, String, Integer, String> {
+        private ProcessorContext<Integer, String> context;
+        private TimestampedKeyValueStoreWithHeaders<Integer, String> store;
+
+        @Override
+        public void init(final ProcessorContext<Integer, String> context) {
+            this.context = context;
+            store = context.getStateStore(STORE_NAME);
+        }
+
+        @Override
+        public void process(final Record<Integer, String> record) {
+            store.put(
+                record.key(),
+                ValueTimestampHeaders.make(record.value(), record.timestamp(), record.headers()));
+            context.forward(record);
+        }
+    }
+
+    private static class PlainStoreWriterProcessor implements Processor<Integer, String, Integer, String> {
+        private ProcessorContext<Integer, String> context;
+        private TimestampedKeyValueStore<Integer, String> store;
+
+        @Override
+        public void init(final ProcessorContext<Integer, String> context) {
+            this.context = context;
+            store = context.getStateStore(STORE_NAME);
+        }
+
+        @Override
+        public void process(final Record<Integer, String> record) {
+            store.put(
+                record.key(),
+                ValueAndTimestamp.make(record.value(), record.timestamp()));
+            context.forward(record);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/query/TimestampedKeyWithHeadersQuery.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/TimestampedKeyWithHeadersQuery.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.query;
+
+import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+
+import java.util.Objects;
+
+/**
+ * Interactive query for retrieving a single record, including its record headers, based on its key
+ * from a {@link TimestampedKeyValueStoreWithHeaders}.
+ *
+ * <p>This is the headers-aware parallel of {@link TimestampedKeyQuery}: it returns a
+ * {@link ValueTimestampHeaders} (value, timestamp, and headers) instead of a
+ * {@link org.apache.kafka.streams.state.ValueAndTimestamp} (value and timestamp only).
+ *
+ * <p>Headers are only returned when the queried store was built with a KIP-1271
+ * {@code WithHeaders} supplier. Against a plain (non-headers) store, this query type is
+ * unsupported and fails with {@link FailureReason#UNKNOWN_QUERY_TYPE}.
+ *
+ * @param <K> Type of keys
+ * @param <V> Type of values
+ */
+@Evolving
+public final class TimestampedKeyWithHeadersQuery<K, V> implements Query<ValueTimestampHeaders<V>> {
+
+    private final K key;
+    private final boolean skipCache;
+
+    private TimestampedKeyWithHeadersQuery(final K key, final boolean skipCache) {
+        this.key = key;
+        this.skipCache = skipCache;
+    }
+
+    /**
+     * Creates a query that will retrieve the record (value, timestamp, and headers) identified by
+     * {@code key} if it exists (or {@code null} otherwise).
+     * @param key The key to retrieve
+     * @param <K> The type of the key
+     * @param <V> The type of the value that will be retrieved
+     */
+    public static <K, V> TimestampedKeyWithHeadersQuery<K, V> withKey(final K key) {
+        Objects.requireNonNull(key, "the key should not be null");
+        return new TimestampedKeyWithHeadersQuery<>(key, false);
+    }
+
+    /**
+     * Specifies that the cache should be skipped during query evaluation. This means, that the query will always
+     * get forwarded to the underlying store.
+     *
+     * <p><b>PoC limitation:</b> this flag is currently a no-op. The header-aware store handler does not yet
+     * propagate it to the underlying cache, so queries are evaluated against the cache regardless. Wiring
+     * this through is out of scope for the proof-of-concept.
+     */
+    public TimestampedKeyWithHeadersQuery<K, V> skipCache() {
+        return new TimestampedKeyWithHeadersQuery<>(key, true);
+    }
+
+    /**
+     * Return the key that was specified for this query.
+     *
+     * @return The key that was specified for this query.
+     */
+    public K key() {
+        return key;
+    }
+
+    /**
+     * The flag whether to skip the cache or not during query evaluation.
+     */
+    public boolean isSkipCache() {
+        return skipCache;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.RangeQuery;
 import org.apache.kafka.streams.query.ResultOrder;
 import org.apache.kafka.streams.query.TimestampedKeyQuery;
+import org.apache.kafka.streams.query.TimestampedKeyWithHeadersQuery;
 import org.apache.kafka.streams.query.TimestampedRangeQuery;
 import org.apache.kafka.streams.query.internals.InternalQueryResultUtil;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -90,6 +91,10 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             mkEntry(
                 TimestampedKeyQuery.class,
                 (query, positionBound, config, store) -> runTimestampedKeyQuery(query, positionBound, config)
+            ),
+            mkEntry(
+                TimestampedKeyWithHeadersQuery.class,
+                (query, positionBound, config, store) -> runTimestampedKeyWithHeadersQuery(query, positionBound, config)
             ),
             mkEntry(
                 RangeQuery.class,
@@ -373,6 +378,37 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
                     : ValueAndTimestamp.make(valueTimestampHeaders.value(), valueTimestampHeaders.timestamp());
             final QueryResult<ValueAndTimestamp<V>> typedQueryResult =
                 InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, valueAndTimestamp);
+            result = (QueryResult<R>) typedQueryResult;
+        } else {
+            // the generic type doesn't matter, since failed queries have no result set.
+            result = (QueryResult<R>) rawResult;
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <R> QueryResult<R> runTimestampedKeyWithHeadersQuery(
+        final Query<R> query,
+        final PositionBound positionBound,
+        final QueryConfig config
+    ) {
+        final QueryResult<R> result;
+        final TimestampedKeyWithHeadersQuery<K, V> typedKeyQuery = (TimestampedKeyWithHeadersQuery<K, V>) query;
+
+        // PoC limitation: typedKeyQuery.isSkipCache() is intentionally NOT propagated to the raw
+        // KeyQuery below. CachingKeyValueStore only honors skipCache when it is set on the forwarded
+        // KeyQuery, so for now skipCache() is a no-op for this query type (the existing
+        // runTimestampedKeyQuery has the same gap). Out of scope for this PoC; would be wired by
+        // calling rawKeyQuery.skipCache() when typedKeyQuery.isSkipCache() is true.
+        final KeyQuery<Bytes, byte[]> rawKeyQuery = KeyQuery.withKey(serializeKey(typedKeyQuery.key(), internalContext.headers()));
+        final QueryResult<byte[]> rawResult = wrapped().query(rawKeyQuery, positionBound, config);
+        if (rawResult.isSuccess()) {
+            // value will be `rawValueTimestampHeader`; no need to pass headers explicitly
+            final Function<byte[], ValueTimestampHeaders<V>> deserializer = StoreQueryUtils.deserializeValue(serdes, wrapped());
+            final ValueTimestampHeaders<V> valueTimestampHeaders = deserializer.apply(rawResult.getResult());
+            // Unlike runTimestampedKeyQuery, the headers are kept rather than discarded.
+            final QueryResult<ValueTimestampHeaders<V>> typedQueryResult =
+                InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, valueTimestampHeaders);
             result = (QueryResult<R>) typedQueryResult;
         } else {
             // the generic type doesn't matter, since failed queries have no result set.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeaders.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
@@ -199,6 +200,22 @@ public class RocksDBTimestampedStoreWithHeaders extends RocksDBStore implements 
     public <R> QueryResult<R> query(final Query<R> query,
                                     final PositionBound positionBound,
                                     final QueryConfig config) {
+        // PoC (KIP-1356): serve raw KeyQuery from the persistent store so that the header-aware
+        // IQv2 query forwarded by MeteredTimestampedKeyValueStoreWithHeaders keeps working after the
+        // record cache has been flushed (a cache miss falls through to this layer). The returned bytes
+        // are the serialized ValueTimestampHeaders; the metered store performs the header-aware
+        // deserialization. Other query types remain unsupported for now.
+        if (query instanceof KeyQuery) {
+            return StoreQueryUtils.handleBasicQueries(
+                query,
+                positionBound,
+                config,
+                this,
+                position,
+                context
+            );
+        }
+
         final long start = config.isCollectExecutionInfo() ? System.nanoTime() : -1L;
         final QueryResult<R> result;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreWithHeadersTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.query.KeyQuery;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryConfig;
 import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.RangeQuery;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import org.junit.jupiter.api.Test;
@@ -981,17 +982,17 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
     }
 
     @Test
-    public void shouldReturnUnknownQueryTypeForQuery() {
+    public void shouldReturnUnknownQueryTypeForUnsupportedQuery() {
         // Initialize the store
         rocksDBStore.init(context, rocksDBStore);
 
-        // Create a query
-        final KeyQuery<Bytes, byte[]> query = KeyQuery.withKey(new Bytes("test-key".getBytes()));
+        // RangeQuery is not (yet) supported by this store; only KeyQuery is wired (KIP-1356 PoC).
+        final RangeQuery<Bytes, byte[]> query = RangeQuery.withNoBounds();
         final PositionBound positionBound = PositionBound.unbounded();
         final QueryConfig config = new QueryConfig(false);
 
         // Execute query
-        final QueryResult<byte[]> result = rocksDBStore.query(query, positionBound, config);
+        final QueryResult<KeyValueIterator<Bytes, byte[]>> result = rocksDBStore.query(query, positionBound, config);
 
         // Verify result indicates unknown query type
         assertFalse(result.isSuccess(), "Expected query to fail with unknown query type");
@@ -1002,6 +1003,27 @@ public class RocksDBTimestampedStoreWithHeadersTest extends RocksDBStoreTest {
         );
 
         // Verify position is set
+        assertNotNull(result.getPosition(), "Expected position to be set");
+    }
+
+    @Test
+    public void shouldHandleKeyQuery() {
+        // Initialize the store
+        rocksDBStore.init(context, rocksDBStore);
+
+        // Store raw (serialized ValueTimestampHeaders) bytes for a key.
+        final Bytes key = new Bytes("test-key".getBytes());
+        final byte[] storedBytes = "headers+timestamp+value".getBytes();
+        rocksDBStore.put(key, storedBytes);
+
+        // KIP-1356 PoC: KeyQuery is now served by this store (rather than UNKNOWN_QUERY_TYPE),
+        // returning the raw stored bytes (the metered store performs header-aware deserialization).
+        final KeyQuery<Bytes, byte[]> query = KeyQuery.withKey(key);
+        final QueryResult<byte[]> result =
+            rocksDBStore.query(query, PositionBound.unbounded(), new QueryConfig(false));
+
+        assertTrue(result.isSuccess(), "Expected KeyQuery to succeed");
+        assertArrayEquals(storedBytes, result.getResult(), "Expected the raw stored bytes to be returned");
         assertNotNull(result.getPosition(), "Expected position to be set");
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderWithHeadersTest.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -560,7 +561,7 @@ public class TimestampedKeyValueStoreBuilderWithHeadersTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void shouldReturnUnknownQueryTypeForKeyQueryOnHeadersStore(final boolean cachingEnabled) {
+    public void shouldHandleKeyQueryOnHeadersStore(final boolean cachingEnabled) {
         final TimestampedKeyValueStoreWithHeaders<String, String> store = headersStoreMaybeWithCache(cachingEnabled);
 
         try {
@@ -571,13 +572,10 @@ public class TimestampedKeyValueStoreBuilderWithHeadersTest {
             final StateStore wrapped = ((WrappedStateStore) store).wrapped();
             final QueryResult<byte[]> result = wrapped.query(query, positionBound, config);
 
-            // Verify: Headers store currently returns UNKNOWN_QUERY_TYPE
-            assertFalse(result.isSuccess(), "Expected query to fail with unknown query type");
-            assertEquals(
-                FailureReason.UNKNOWN_QUERY_TYPE,
-                result.getFailureReason(),
-                "Expected UNKNOWN_QUERY_TYPE failure reason"
-            );
+            // KIP-1356 PoC: the headers store now serves KeyQuery (rather than UNKNOWN_QUERY_TYPE).
+            // No data was written for "test-key", so the result is a successful null lookup.
+            assertTrue(result.isSuccess(), "Expected KeyQuery to be handled");
+            assertNull(result.getResult(), "Expected null result for an absent key");
             assertNotNull(result.getPosition(), "Expected position to be set");
         } finally {
             store.close();


### PR DESCRIPTION
## Summary

Proof-of-concept for [KIP-1356: Introduce IQv2 for headers-aware state stores](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1356), built on top of the KIP-1271 headers-aware store infrastructure.

This PoC implements **only the first of the four proposed query types** — `TimestampedKeyWithHeadersQuery` (the headers-aware parallel of `TimestampedKeyQuery`) — end to end, to validate the approach. It is intentionally not fully polished.

## What's included

- **New `@Evolving` query class** `org.apache.kafka.streams.query.TimestampedKeyWithHeadersQuery`, returning `ValueTimestampHeaders<V>` instead of `ValueAndTimestamp<V>`.
- **Handler** in `MeteredTimestampedKeyValueStoreWithHeaders` that mirrors the existing `runTimestampedKeyQuery` (serialize key, forward a raw `KeyQuery` down the wrapper chain, deserialize the bytes) but keeps the full `ValueTimestampHeaders` instead of stripping the headers.
- **Bottom-layer wiring**: `RocksDBTimestampedStoreWithHeaders.query()` now serves a raw `KeyQuery` via `StoreQueryUtils.handleBasicQueries`. KIP-1271 had hardwired this layer to `UNKNOWN_QUERY_TYPE`, which makes a forwarded query fail once the record cache is flushed (a cache miss falls through to this layer). The metered store still performs the header-aware deserialization; other query types remain unsupported.
- **End-to-end integration test** `TimestampedKeyWithHeadersQueryIntegrationTest` (caching disabled, so every query provably reaches the RocksDB layer) asserting value/timestamp/headers round-trip, including empty-headers and tombstone cases, plus the unknown-query-type failure against a non-headers store.
- Updated the two unit tests that asserted the old "`KeyQuery` → `UNKNOWN_QUERY_TYPE`" behavior on the headers store.

## Out of scope for this PoC
- `skipCache()` is accepted by the new query type but is currently a no-op — the flag is not propagated to the underlying cache (documented in code).

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
