### PR TITLE
KAFKA-19200: Recover pre-allocated never-written time index on startup

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -467,7 +467,7 @@ public abstract class AbstractIndex implements Closeable {
      * Round a number to the greatest exact multiple of the given factor less than the given number.
      * E.g. roundDownToExactMultiple(67, 8) == 64
      */
-    private static int roundDownToExactMultiple(int number, int factor) {
+    static int roundDownToExactMultiple(int number, int factor) {
         return factor * (number / factor);
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LazyIndex.java
@@ -165,6 +165,10 @@ public class LazyIndex<T extends AbstractIndex> implements Closeable {
         return indexWrapper.file();
     }
 
+    public int maxIndexSize() {
+        return maxIndexSize;
+    }
+
     @SuppressWarnings("unchecked")
     public T get() throws IOException {
         IndexWrapper wrapper = indexWrapper;

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -183,11 +183,13 @@ public class LogSegment implements Closeable {
             // Resize the time index file to 0 if it is newly created.
             if (timeIndexFileNewlyCreated)
                 timeIndex().resize(0);
-            // A time index left at its pre-allocated size with no valid entries causes
-            // BufferOverflowException on the next roll. Checking it here triggers LogLoader
-            // to rebuild the index from the log. The offset index is not checked because a
-            // pre-allocated offset index does not cause failures on roll.
-            timeIndex().sanityCheck();
+            // A pre-allocated, untrimmed time index causes BufferOverflowException on the
+            // next segment roll. To avoid eagerly mmapping every time index on startup, only
+            // materialize and check when the file is at its full pre-allocated size.
+            long preAllocatedSize = AbstractIndex.roundDownToExactMultiple(lazyTimeIndex.maxIndexSize(), TimeIndex.ENTRY_SIZE);
+            if (timeIndexFile().length() == preAllocatedSize) {
+                timeIndex().sanityCheck();
+            }
             txnIndex.sanityCheck();
         } else
             throw new NoSuchFileException("Offset index file " + offsetIndexFile().getAbsolutePath() + " does not exist");

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -183,9 +183,11 @@ public class LogSegment implements Closeable {
             // Resize the time index file to 0 if it is newly created.
             if (timeIndexFileNewlyCreated)
                 timeIndex().resize(0);
-            // Sanity checks for time index and offset index are skipped because
-            // we will recover the segments above the recovery point in recoverLog()
-            // in any case so sanity checking them here is redundant.
+            // A time index left at its pre-allocated size with no valid entries causes
+            // BufferOverflowException on the next roll. Checking it here triggers LogLoader
+            // to rebuild the index from the log. The offset index is not checked because a
+            // pre-allocated offset index does not cause failures on roll.
+            timeIndex().sanityCheck();
             txnIndex.sanityCheck();
         } else
             throw new NoSuchFileException("Offset index file " + offsetIndexFile().getAbsolutePath() + " does not exist");

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
@@ -53,7 +53,7 @@ import java.nio.MappedByteBuffer;
  */
 public class TimeIndex extends AbstractIndex {
     private static final Logger log = LoggerFactory.getLogger(TimeIndex.class);
-    private static final int ENTRY_SIZE = 12;
+    static final int ENTRY_SIZE = 12;
 
     private volatile TimestampOffset lastEntry;
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TimeIndex.java
@@ -88,6 +88,9 @@ public class TimeIndex extends AbstractIndex {
         if (length() % ENTRY_SIZE != 0)
             throw new CorruptIndexException("Time index file " + file().getAbsolutePath() + " is corrupt, found " + length()
                 + " bytes which is neither positive nor a multiple of " + ENTRY_SIZE);
+        if (entries() == maxEntries() && lastTimestamp == 0)
+            throw new CorruptIndexException("Time index file " + file().getAbsolutePath() + " is corrupt, found a full index "
+                + "(entries=" + entries() + " equals maxEntries) with lastTimestamp=0");
     }
 
     /**

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -1157,7 +1157,7 @@ public class RemoteLogManagerTest {
         OffsetIndex olderIdx = LazyIndex.forOffset(LogFileUtils.offsetIndexFile(tempDir, olderSegmentStartOffset, ""), olderSegmentStartOffset, 1000).get();
         TimeIndex olderTimeIdx = LazyIndex.forTime(LogFileUtils.timeIndexFile(tempDir, olderSegmentStartOffset, ""), olderSegmentStartOffset, 1500).get();
         File olderTxnFile = UnifiedLog.transactionIndexFile(tempDir, olderSegmentStartOffset, "");
-        oldestTxnFile.createNewFile();
+        olderTxnFile.createNewFile();
         TransactionIndex olderTxnIndex = new TransactionIndex(olderSegmentStartOffset, olderTxnFile);
         when(olderSegment.timeIndex()).thenReturn(olderTimeIdx);
         when(olderSegment.offsetIndex()).thenReturn(olderIdx);
@@ -1706,6 +1706,8 @@ public class RemoteLogManagerTest {
                             metadata.startOffset(), maxEntries * 8);
                     TimeIndex timeIdx = new TimeIndex(new File(tpDir, metadata.startOffset() + UnifiedLog.TIME_INDEX_FILE_SUFFIX),
                             metadata.startOffset(), maxEntries * 12);
+                    timeIdx.close();
+                    offsetIdx.close();
                     return switch (indexType) {
                         case OFFSET -> Files.newInputStream(offsetIdx.file().toPath());
                         case TIMESTAMP -> Files.newInputStream(timeIdx.file().toPath());

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -942,14 +942,46 @@ public class LogSegmentTest {
             seg.close();
 
             try (RandomAccessFile raf = new RandomAccessFile(timeIndexFile, "rw")) {
-                int size = (int) raf.length();
+                raf.setLength(1500);
                 raf.seek(0);
-                raf.write(new byte[size]);
+                raf.write(new byte[1500]);
             }
 
             try (LogSegment reopened = LogTestUtils.createSegment(0, logDir, 10, Time.SYSTEM)) {
                 assertThrows(CorruptIndexException.class, () -> reopened.sanityCheck(false));
             }
+        }
+    }
+
+    @Test
+    public void testSanityCheckSkipsTimeIndexForTrimmedFile() throws Exception {
+        try (LogSegment seg = createSegment(0)) {
+            for (int i = 0; i < 5; i++) {
+                seg.append(i, v1Records(i, String.valueOf(i)));
+            }
+            seg.close();
+        }
+
+        // Reopen. File is trimmed (small), not at preAllocatedSize (1500).
+        // sanityCheck should not throw for a healthy trimmed file.
+        try (LogSegment reopened = LogTestUtils.createSegment(0, logDir, 10, Time.SYSTEM)) {
+            reopened.sanityCheck(false);
+        }
+    }
+
+    @Test
+    public void testSanityCheckPassesForLegitimatelyFullTimeIndex() throws Exception {
+        // A time index that is genuinely full (all entries written with real timestamps)
+        // is at preAllocatedSize on disk but is NOT corrupt. sanityCheck must not throw.
+        try (LogSegment seg = createSegment(0, 1)) {
+            // indexIntervalBytes=1 ensures every append writes a time index entry.
+            // maxIndexSize for time index in createSegment is 1500; 1500/12 = 125 entries.
+            for (int i = 0; i < 125; i++) {
+                seg.append(i, v1Records(i, String.valueOf(i)));
+            }
+            // Time index is now full. Do not close (which would trim).
+            // Verify sanityCheck passes on the full-but-valid index.
+            seg.sanityCheck(false);
         }
     }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -931,4 +931,25 @@ public class LogSegmentTest {
             }
         }
     }
+
+    @Test
+    public void testSanityCheckDetectsCorruptTimeIndex() throws Exception {
+        try (LogSegment seg = createSegment(0)) {
+            for (int i = 0; i < 5; i++) {
+                seg.append(i, v1Records(i, String.valueOf(i)));
+            }
+            File timeIndexFile = seg.timeIndexFile();
+            seg.close();
+
+            try (RandomAccessFile raf = new RandomAccessFile(timeIndexFile, "rw")) {
+                int size = (int) raf.length();
+                raf.seek(0);
+                raf.write(new byte[size]);
+            }
+
+            try (LogSegment reopened = LogTestUtils.createSegment(0, logDir, 10, Time.SYSTEM)) {
+                assertThrows(CorruptIndexException.class, () -> reopened.sanityCheck(false));
+            }
+        }
+    }
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/TimeIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/TimeIndexTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -200,6 +201,27 @@ public class TimeIndexTest {
         File file = TestUtils.tempFile();
         file.delete();
         return file;
+    }
+
+    @Test
+    public void testSanityCheckDetectsPreAllocatedNeverWrittenIndex() throws IOException {
+        idx.close();
+        File file = nonExistentTempFile();
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.setLength(maxEntries * 12);
+        }
+
+        try (TimeIndex corruptIdx = new TimeIndex(file, baseOffset, maxEntries * 12)) {
+            assertEquals(maxEntries, corruptIdx.entries());
+            assertThrows(CorruptIndexException.class, corruptIdx::sanityCheck);
+        }
+    }
+
+    @Test
+    public void testSanityCheckPassesForLegitimatelyFullIndex() {
+        appendEntries(maxEntries - 1);
+        idx.maybeAppend(maxEntries * 10, maxEntries * 10 + baseOffset, true);
+        idx.sanityCheck(); // should not throw
     }
 
 }

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -92,6 +92,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
+import java.io.RandomAccessFile;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -6004,5 +6005,46 @@ public class UnifiedLogTest {
         assertTrue(exception.getMessage().contains("smaller than the last seen epoch"));
         assertTrue(exception.getMessage().contains(String.valueOf(originalEpoch)));
         assertTrue(exception.getMessage().contains(String.valueOf(bumpedEpoch)));
+    }
+
+    @Test
+    public void testLogLoaderRebuildsPreAllocatedTimeIndexViaRecoverSegment() throws IOException {
+        Properties logProps = new Properties();
+        logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, "1200");
+        logProps.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, "1");
+        LogConfig logConfig = new LogConfig(logProps);
+        UnifiedLog log = createLog(logDir, logConfig);
+
+        int numRecords = 5;
+        for (int i = 1; i <= numRecords; i++)
+            log.appendAsLeader(singletonRecords("record".getBytes(), i * 1000L), 0);
+
+        log.close();
+
+        // Corrupt the time index: expand to maxIndexSize bytes with all-zeros content.
+        File timeIndexFile = new File(logDir, "00000000000000000000.timeindex");
+        try (RandomAccessFile raf = new RandomAccessFile(timeIndexFile, "rw")) {
+            raf.setLength(0);
+            raf.setLength(1200);
+        }
+
+        // Verify pre-condition: the index reports full (entries == maxEntries) with an empty last slot.
+        try (TimeIndex preAllocatedIndex = new TimeIndex(timeIndexFile, 0L, 1200)) {
+            assertEquals(preAllocatedIndex.maxEntries(), preAllocatedIndex.entries());
+            assertEquals(0L, preAllocatedIndex.lastEntry().timestamp());
+        }
+
+        // Reload: LogLoader sanity-checks the segment, hits CorruptIndexException, and rebuilds via recoverSegment.
+        UnifiedLog reloadedLog = createLog(logDir, logConfig);
+
+        TimeIndex reloadedTimeIndex = reloadedLog.activeSegment().timeIndex();
+        assertTrue(reloadedTimeIndex.entries() < reloadedTimeIndex.maxEntries(),
+            "Time index entries must be less than maxEntries after recovery");
+        assertTrue(reloadedTimeIndex.lastEntry().timestamp() > 0L,
+            "Time index must have real timestamps after recovery");
+        assertEquals(numRecords, reloadedLog.logEndOffset(),
+            "Log end offset must be preserved after recovery");
+
+        reloadedLog.close();
     }
 }


### PR DESCRIPTION
KAFKA-7283 removed index sanity checks from broker startup to reduce load time. This left a gap: a corrupt time index on a segment that recoverLog() does not reach is loaded without examination and fails at the next roll.

A time index is pre-allocated to its maximum size and trimmed to its real length when the segment closes. If the trim fails (an IOException in close() is swallowed) or the broker crashes before trimming, the file is left at full size with no valid entries. On reload, AbstractIndex positions the buffer at the end of the file, so entries() equals maxEntries() and the index appears full. If the segment is below the recovery point or the shutdown was clean, recoverLog() does not process it, and the corruption persists.

Because the index appears full, TimeIndex.isFull() returns true and the segment is eligible to roll. The next append or retention check triggers the roll, and onBecomeInactiveSegment() appends the largest timestamp through maybeAppend(..., skipFullCheck = true). The buffer is at the end of a full index, so the write overruns it and throws BufferOverflowException. This fails the replica fetcher and leaves the partition under-replicated.

The fix adds a targeted check to TimeIndex.sanityCheck(): reject an index where entries equals maxEntries and the last entry reads a timestamp of zero. A legitimately full index always ends on a positive timestamp, so this combination identifies a never-written one. The resulting CorruptIndexException routes the segment through LogLoader recovery, which rebuilds the index from the log. Only the time index is checked because it is the one appended to on roll; a pre-allocated offset index does not fail the roll.

To avoid materializing every time index at startup, LogSegment.sanityCheck() gates the check on a File.length comparison against the pre-allocated size and runs it only when they match. A healthy trimmed index is smaller, so it takes a single stat with no open, map, or read; only a segment already at the pre-allocated size, the corrupt candidate, is opened and checked. The gate reads the configured maximum through a new LazyIndex.maxIndexSize() getter that returns the stored value without materializing, and computes the pre-allocated size with AbstractIndex.roundDownToExactMultiple, made package-private for this use.

Tests cover detection (TimeIndexTest), propagation through LogSegment.sanityCheck (LogSegmentTest), and end-to-end recovery on reload (UnifiedLogTest). LogSegmentTest also verifies that a healthy trimmed segment skips materialization and that a legitimately full index passes without throwing. RemoteLogManagerTest trims the index files its fetch mock serves so they pass the check.

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>
