### PR TITLE
KAFKA-14405: Log a warning when users attempt to set a config controlled by Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1882,6 +1882,20 @@ public class StreamsConfig extends AbstractConfig {
         }
     }
 
+    /** Set a config that Streams controls, warning if the user tried to set a different value. */
+    private void enforceConfig(final Map<String, Object> props,
+                               final String config,
+                               final Object streamsValue,
+                               final String clientType) {
+        final Object userValue = props.get(config);
+        if (userValue != null && !userValue.equals(streamsValue)) {
+            log.error("Unexpected user-specified {} config '{}' found. User setting ({}) will be ignored "
+                            + "and the Streams default setting ({}) will be used.",
+                    clientType, config, userValue, streamsValue);
+        }
+        props.put(config, streamsValue);
+    }
+
     private void verifyMaxInFlightRequestPerConnection(final Object maxInFlightRequests) {
         if (maxInFlightRequests != null) {
             final int maxInFlightRequestsAsInteger;
@@ -1931,7 +1945,7 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(APPLICATION_ID_CONFIG, groupId);
 
         // add group id, client id with stream client id prefix, and group instance id
-        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        enforceConfig(consumerProps, ConsumerConfig.GROUP_ID_CONFIG, groupId, "consumer");
         consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         final String groupInstanceId = (String) consumerProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
         // Suffix each thread consumer with thread.id to enforce uniqueness of group.instance.id.
@@ -1940,6 +1954,7 @@ public class StreamsConfig extends AbstractConfig {
         }
 
         // add configs required for stream partition assignor
+        enforceConfig(consumerProps, ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName(), "consumer");
         consumerProps.put(UPGRADE_FROM_CONFIG, getString(UPGRADE_FROM_CONFIG));
         consumerProps.put(REPLICATION_FACTOR_CONFIG, getInt(REPLICATION_FACTOR_CONFIG));
         consumerProps.put(APPLICATION_SERVER_CONFIG, getString(APPLICATION_SERVER_CONFIG));
@@ -1947,7 +1962,6 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(ACCEPTABLE_RECOVERY_LAG_CONFIG, getLong(ACCEPTABLE_RECOVERY_LAG_CONFIG));
         consumerProps.put(MAX_WARMUP_REPLICAS_CONFIG, getInt(MAX_WARMUP_REPLICAS_CONFIG));
         consumerProps.put(PROBING_REBALANCE_INTERVAL_MS_CONFIG, getLong(PROBING_REBALANCE_INTERVAL_MS_CONFIG));
-        consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName());
         consumerProps.put(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, getLong(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
         consumerProps.put(RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG, getInt(RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG));
         consumerProps.put(RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG, getString(RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1787,9 +1787,6 @@ public class StreamsConfig extends AbstractConfig {
     private Map<String, Object> getCommonConsumerConfigs() {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(CONSUMER_PREFIX, ConsumerConfig.configNames());
 
-        // The Streams-level group.protocol (classic|streams) shares its name with the consumer config but
-        // has different legal values, so strip any leaked/explicit value here. Streams controls this config
-        // and forces it to "classic" via enforceControlledConsumerConfigs in each consumer builder.
         clientProvidedProps.remove(GROUP_PROTOCOL_CONFIG);
 
         final Map<String, Object> consumerProps = new HashMap<>(DEFAULT_CONSUMER_CONFIGS);

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -171,6 +171,9 @@ public class StreamsConfig extends AbstractConfig {
     private static final long DEFAULT_COMMIT_INTERVAL_MS = 30000L;
     private static final long EOS_DEFAULT_COMMIT_INTERVAL_MS = 100L;
     private static final int DEFAULT_TRANSACTION_TIMEOUT = 10000;
+    private static final String DEFAULT_MAX_POLL_RECORDS = "1000";
+    private static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
+    private static final String DEFAULT_LINGER_MS = "100";
 
     @Deprecated
     @SuppressWarnings("unused")
@@ -892,17 +895,6 @@ public class StreamsConfig extends AbstractConfig {
     @SuppressWarnings("WeakerAccess")
     public static final String WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG = "windowstore.changelog.additional.retention.ms";
     private static final String WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_DOC = "Added to a windows maintainMs to ensure data is not deleted from the log prematurely. Allows for clock drift. Default is 1 day";
-
-    private static final String[] NON_CONFIGURABLE_CONSUMER_DEFAULT_CONFIGS =
-        new String[] {ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, ConsumerConfig.GROUP_PROTOCOL_CONFIG, ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG};
-    private static final String[] NON_CONFIGURABLE_CONSUMER_EOS_CONFIGS =
-        new String[] {ConsumerConfig.ISOLATION_LEVEL_CONFIG};
-    private static final String[] NON_CONFIGURABLE_PRODUCER_EOS_CONFIGS =
-        new String[] {
-            ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG,
-            ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION,
-            ProducerConfig.TRANSACTIONAL_ID_CONFIG
-        };
     /**
      * {@code processing.exception.handler.global.enabled}
      * @deprecated Since 4.3. Default will change to {@code true} when removed.
@@ -1375,36 +1367,41 @@ public class StreamsConfig extends AbstractConfig {
                     TOPOLOGY_DESCRIPTION_PUSH_ENABLED_DOC);
     }
 
-    // this is the list of configs for underlying clients
-    // that streams prefer different default values
-    private static final Map<String, Object> PRODUCER_DEFAULT_OVERRIDES = Map.of(ProducerConfig.LINGER_MS_CONFIG, "100");
-
-    private static final Map<String, Object> PRODUCER_EOS_OVERRIDES;
-    static {
-        final Map<String, Object> tempProducerDefaultOverrides = new HashMap<>(PRODUCER_DEFAULT_OVERRIDES);
-        tempProducerDefaultOverrides.putAll(Map.of(
-            ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE,
-            ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true,
-            // Reduce the transaction timeout for quicker pending offset expiration on broker side.
-            ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, DEFAULT_TRANSACTION_TIMEOUT
-        ));
-        PRODUCER_EOS_OVERRIDES = Collections.unmodifiableMap(tempProducerDefaultOverrides);
-    }
-
-    private static final Map<String, Object> CONSUMER_DEFAULT_OVERRIDES = Map.of(
-        ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1000",
-        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
-        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false",
-        ConsumerConfig.GROUP_PROTOCOL_CONFIG, "classic",
-        ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false"
+    // Configs for the underlying clients that Streams prefers different default values for.
+    // These are only defaults: the user may still override them.
+    private static final Map<String, Object> DEFAULT_CONSUMER_CONFIGS = Map.of(
+        ConsumerConfig.MAX_POLL_RECORDS_CONFIG, DEFAULT_MAX_POLL_RECORDS,
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, DEFAULT_AUTO_OFFSET_RESET
     );
 
-    private static final Map<String, Object> CONSUMER_EOS_OVERRIDES;
+    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS = Map.of(ProducerConfig.LINGER_MS_CONFIG, DEFAULT_LINGER_MS);
+
+    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED;
     static {
-        final Map<String, Object> tempConsumerDefaultOverrides = new HashMap<>(CONSUMER_DEFAULT_OVERRIDES);
-        tempConsumerDefaultOverrides.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_COMMITTED.toString());
-        CONSUMER_EOS_OVERRIDES = Collections.unmodifiableMap(tempConsumerDefaultOverrides);
+        final Map<String, Object> tempProducerDefaults = new HashMap<>(DEFAULT_PRODUCER_CONFIGS);
+        tempProducerDefaults.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
+        // Reduce the transaction timeout for quicker pending offset expiration on broker side.
+        tempProducerDefaults.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, DEFAULT_TRANSACTION_TIMEOUT);
+        DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED = Collections.unmodifiableMap(tempProducerDefaults);
     }
+
+    // Configs that Streams controls: a user-specified value is ignored (with a warning) and the
+    // Streams value is enforced after the user props have been merged.
+    private static final Map<String, Object> CONTROLLED_CONSUMER_CONFIGS = Map.of(
+        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false",
+        ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false",
+        ConsumerConfig.GROUP_PROTOCOL_CONFIG, "classic"
+    );
+
+    private static final Map<String, Object> CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED;
+    static {
+        final Map<String, Object> tempControlledConfigs = new HashMap<>(CONTROLLED_CONSUMER_CONFIGS);
+        tempControlledConfigs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_COMMITTED.toString());
+        CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED = Collections.unmodifiableMap(tempControlledConfigs);
+    }
+
+    private static final Map<String, Object> CONTROLLED_PRODUCER_CONFIGS_EOS_ENABLED =
+        Map.of(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
     private static final Map<String, Object> ADMIN_CLIENT_OVERRIDES =
         Map.of(AdminClientConfig.ENABLE_METRICS_PUSH_CONFIG, true);
@@ -1793,12 +1790,12 @@ public class StreamsConfig extends AbstractConfig {
     private Map<String, Object> getCommonConsumerConfigs() {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(CONSUMER_PREFIX, ConsumerConfig.configNames());
 
+        // The Streams-level group.protocol (classic|streams) shares its name with the consumer config but
+        // has different legal values, so strip any leaked/explicit value here. Streams controls this config
+        // and forces it to "classic" via enforceControlledConsumerConfigs in each consumer builder.
         clientProvidedProps.remove(GROUP_PROTOCOL_CONFIG);
 
-        checkIfUnexpectedUserSpecifiedClientConfig(clientProvidedProps, NON_CONFIGURABLE_CONSUMER_DEFAULT_CONFIGS);
-        checkIfUnexpectedUserSpecifiedClientConfig(clientProvidedProps, NON_CONFIGURABLE_CONSUMER_EOS_CONFIGS);
-
-        final Map<String, Object> consumerProps = new HashMap<>(eosEnabled ? CONSUMER_EOS_OVERRIDES : CONSUMER_DEFAULT_OVERRIDES);
+        final Map<String, Object> consumerProps = new HashMap<>(DEFAULT_CONSUMER_CONFIGS);
         if (StreamsConfigUtils.eosEnabled(this)) {
             consumerProps.put("internal.throw.on.fetch.stable.offset.unsupported", true);
         }
@@ -1811,89 +1808,49 @@ public class StreamsConfig extends AbstractConfig {
         return consumerProps;
     }
 
-    private void checkIfUnexpectedUserSpecifiedClientConfig(final Map<String, Object> clientProvidedProps,
-                                                            final String[] nonConfigurableConfigs) {
-        // Streams does not allow users to configure certain client configurations (consumer/producer),
-        // for example, enable.auto.commit or transactional.id. In cases where user tries to override
-        // such non-configurable client configurations, log a warning and remove the user defined value
-        // from the Map. Thus, the default values for these client configurations that are suitable for
-        // Streams will be used instead.
+    private static final String CONTROLLED_CONFIG_OVERRIDE_MESSAGE =
+        "Unexpected user-specified {} config '{}' found. User setting ({}) will be ignored and the Streams default setting ({}) will be used.";
 
-        final String nonConfigurableConfigMessage = "Unexpected user-specified {} config '{}' found. {} setting ({}) will be ignored and the Streams default setting ({}) will be used.";
-        final String eosMessage = "'" + PROCESSING_GUARANTEE_CONFIG + "' is set to \"" + getString(PROCESSING_GUARANTEE_CONFIG) + "\". Hence, user";
-
-        for (final String config: nonConfigurableConfigs) {
-            if (clientProvidedProps.containsKey(config)) {
-
-                if (CONSUMER_DEFAULT_OVERRIDES.containsKey(config)) {
-                    if (!clientProvidedProps.get(config).equals(CONSUMER_DEFAULT_OVERRIDES.get(config))) {
-                        log.error(
-                            nonConfigurableConfigMessage,
-                            "consumer",
-                            config,
-                            "User",
-                            clientProvidedProps.get(config),
-                            CONSUMER_DEFAULT_OVERRIDES.get(config)
-                        );
-                        clientProvidedProps.remove(config);
-                    }
-                } else if (eosEnabled) {
-                    if (CONSUMER_EOS_OVERRIDES.containsKey(config)) {
-                        if (!clientProvidedProps.get(config).equals(CONSUMER_EOS_OVERRIDES.get(config))) {
-                            log.warn(
-                                nonConfigurableConfigMessage,
-                                "consumer",
-                                config,
-                                eosMessage,
-                                clientProvidedProps.get(config),
-                                CONSUMER_EOS_OVERRIDES.get(config)
-                            );
-                            clientProvidedProps.remove(config);
-                        }
-                    } else if (PRODUCER_EOS_OVERRIDES.containsKey(config)) {
-                        if (!clientProvidedProps.get(config).equals(PRODUCER_EOS_OVERRIDES.get(config))) {
-                            log.warn(
-                                nonConfigurableConfigMessage,
-                                "producer",
-                                config,
-                                eosMessage,
-                                clientProvidedProps.get(config),
-                                PRODUCER_EOS_OVERRIDES.get(config)
-                            );
-                            clientProvidedProps.remove(config);
-                        }
-                    } else if (ProducerConfig.TRANSACTIONAL_ID_CONFIG.equals(config)) {
-                        log.warn(
-                            nonConfigurableConfigMessage,
-                            "producer",
-                            config,
-                            eosMessage,
-                            clientProvidedProps.get(config),
-                            "<appId>-<generatedSuffix>"
-                        );
-                        clientProvidedProps.remove(config);
-                    }
-                }
-            }
-        }
-
-        if (eosEnabled) {
-            verifyMaxInFlightRequestPerConnection(clientProvidedProps.get(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION));
-        }
-    }
-
-    /** Set a config that Streams controls, warning if the user tried to set a different value. */
-    private void enforceConfig(final Map<String, Object> props,
-                               final String config,
-                               final Object streamsValue,
-                               final String clientType) {
-        final Object userValue = props.get(config);
-        if (userValue != null && !userValue.equals(streamsValue)) {
-            log.error("Unexpected user-specified {} config '{}' found. User setting ({}) will be ignored "
-                            + "and the Streams default setting ({}) will be used.",
-                    clientType, config, userValue, streamsValue);
+    /**
+     * Enforce a config that Streams controls: if the user set a different value, log a warning that it
+     * is being ignored, then overwrite it with the Streams value. Must be called after the user-provided
+     * props have been merged into {@code props}, so an override at any prefix is caught in one place.
+     */
+    private void overwriteControlledConfig(final Map<String, Object> props,
+                                           final String config,
+                                           final Object streamsValue,
+                                           final String clientType) {
+        if (props.containsKey(config) && !Objects.equals(props.get(config), streamsValue)) {
+            log.warn(CONTROLLED_CONFIG_OVERRIDE_MESSAGE, clientType, config, props.get(config), streamsValue);
         }
         props.put(config, streamsValue);
+    }
+
+    /** Enforce the consumer configs that Streams controls on an already-assembled consumer config map. */
+    private void enforceControlledConsumerConfigs(final Map<String, Object> consumerProps) {
+        final Map<String, Object> controlledConfigs =
+            eosEnabled ? CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED : CONTROLLED_CONSUMER_CONFIGS;
+        controlledConfigs.forEach((config, streamsValue) ->
+            overwriteControlledConfig(consumerProps, config, streamsValue, "consumer"));
+    }
+
+    /** Enforce the producer configs that Streams controls on an already-assembled producer config map. */
+    private void enforceControlledProducerConfigs(final Map<String, Object> producerProps) {
+        if (!eosEnabled) {
+            return;
+        }
+        CONTROLLED_PRODUCER_CONFIGS_EOS_ENABLED.forEach((config, streamsValue) ->
+            overwriteControlledConfig(producerProps, config, streamsValue, "producer"));
+
+        // Streams assigns a unique transactional.id per task later (see ActiveTaskCreator), so any
+        // user-provided value is ignored. Warn and drop it rather than forcing a fixed value.
+        if (producerProps.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG)) {
+            log.warn(CONTROLLED_CONFIG_OVERRIDE_MESSAGE, "producer", ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+                producerProps.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), "<application.id>-<generated suffix>");
+            producerProps.remove(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
+        }
+
+        verifyMaxInFlightRequestPerConnection(producerProps.get(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION));
     }
 
     private void verifyMaxInFlightRequestPerConnection(final Object maxInFlightRequests) {
@@ -1938,14 +1895,16 @@ public class StreamsConfig extends AbstractConfig {
 
         // Get main consumer override configs
         final Map<String, Object> mainConsumerProps = originalsWithPrefix(MAIN_CONSUMER_PREFIX);
-        checkIfUnexpectedUserSpecifiedClientConfig(mainConsumerProps, NON_CONFIGURABLE_CONSUMER_DEFAULT_CONFIGS);
         consumerProps.putAll(mainConsumerProps);
+
+        // Enforce the configs Streams controls now that all user-provided consumer props are merged.
+        enforceControlledConsumerConfigs(consumerProps);
 
         // this is a hack to work around StreamsConfig constructor inside StreamsPartitionAssignor to avoid casting
         consumerProps.put(APPLICATION_ID_CONFIG, groupId);
 
         // add group id, client id with stream client id prefix, and group instance id
-        enforceConfig(consumerProps, ConsumerConfig.GROUP_ID_CONFIG, groupId, "consumer");
+        overwriteControlledConfig(consumerProps, ConsumerConfig.GROUP_ID_CONFIG, groupId, "consumer");
         consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         final String groupInstanceId = (String) consumerProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
         // Suffix each thread consumer with thread.id to enforce uniqueness of group.instance.id.
@@ -1954,7 +1913,7 @@ public class StreamsConfig extends AbstractConfig {
         }
 
         // add configs required for stream partition assignor
-        enforceConfig(consumerProps, ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName(), "consumer");
+        overwriteControlledConfig(consumerProps, ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamsPartitionAssignor.class.getName(), "consumer");
         consumerProps.put(UPGRADE_FROM_CONFIG, getString(UPGRADE_FROM_CONFIG));
         consumerProps.put(REPLICATION_FACTOR_CONFIG, getInt(REPLICATION_FACTOR_CONFIG));
         consumerProps.put(APPLICATION_SERVER_CONFIG, getString(APPLICATION_SERVER_CONFIG));
@@ -2011,8 +1970,10 @@ public class StreamsConfig extends AbstractConfig {
 
         // Get restore consumer override configs
         final Map<String, Object> restoreConsumerProps = originalsWithPrefix(RESTORE_CONSUMER_PREFIX);
-        checkIfUnexpectedUserSpecifiedClientConfig(restoreConsumerProps, NON_CONFIGURABLE_CONSUMER_DEFAULT_CONFIGS);
         baseConsumerProps.putAll(restoreConsumerProps);
+
+        // Enforce the configs Streams controls now that all user-provided consumer props are merged.
+        enforceControlledConsumerConfigs(baseConsumerProps);
 
         // no need to set group id for a restore consumer
         baseConsumerProps.remove(ConsumerConfig.GROUP_ID_CONFIG);
@@ -2045,8 +2006,10 @@ public class StreamsConfig extends AbstractConfig {
 
         // Get global consumer override configs
         final Map<String, Object> globalConsumerProps = originalsWithPrefix(GLOBAL_CONSUMER_PREFIX);
-        checkIfUnexpectedUserSpecifiedClientConfig(globalConsumerProps, NON_CONFIGURABLE_CONSUMER_DEFAULT_CONFIGS);
         baseConsumerProps.putAll(globalConsumerProps);
+
+        // Enforce the configs Streams controls now that all user-provided consumer props are merged.
+        enforceControlledConsumerConfigs(baseConsumerProps);
 
         // no need to set group id for a global consumer
         baseConsumerProps.remove(ConsumerConfig.GROUP_ID_CONFIG);
@@ -2073,12 +2036,13 @@ public class StreamsConfig extends AbstractConfig {
     public Map<String, Object> getProducerConfigs(final String clientId) {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());
 
-        checkIfUnexpectedUserSpecifiedClientConfig(clientProvidedProps, NON_CONFIGURABLE_PRODUCER_EOS_CONFIGS);
-
         // generate producer configs from original properties and overridden maps
-        final Map<String, Object> props = new HashMap<>(eosEnabled ? PRODUCER_EOS_OVERRIDES : PRODUCER_DEFAULT_OVERRIDES);
+        final Map<String, Object> props = new HashMap<>(eosEnabled ? DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED : DEFAULT_PRODUCER_CONFIGS);
         props.putAll(getClientCustomProps());
         props.putAll(clientProvidedProps);
+
+        // Enforce the configs Streams controls now that all user-provided producer props are merged.
+        enforceControlledProducerConfigs(props);
 
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, originals().get(BOOTSTRAP_SERVERS_CONFIG));
         // add client id with stream client id prefix

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -168,12 +168,16 @@ public class StreamsConfig extends AbstractConfig {
     private static final ConfigDef CONFIG;
 
     private final boolean eosEnabled;
+
+    /**
+     * Completes the controlled-config warning for configs that Streams only controls when EOS is
+     * enabled. Without it such a rule looks arbitrary, because the same config is respected when EOS
+     * is disabled. Empty for configs Streams controls unconditionally.
+     */
+    private final String eosControlledConfigReason;
     private static final long DEFAULT_COMMIT_INTERVAL_MS = 30000L;
     private static final long EOS_DEFAULT_COMMIT_INTERVAL_MS = 100L;
     private static final int DEFAULT_TRANSACTION_TIMEOUT = 10000;
-    private static final String DEFAULT_MAX_POLL_RECORDS = "1000";
-    private static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
-    private static final String DEFAULT_LINGER_MS = "100";
 
     @Deprecated
     @SuppressWarnings("unused")
@@ -1370,20 +1374,18 @@ public class StreamsConfig extends AbstractConfig {
     // Configs for the underlying clients that Streams prefers different default values for.
     // These are only defaults: the user may still override them.
     private static final Map<String, Object> DEFAULT_CONSUMER_CONFIGS = Map.of(
-        ConsumerConfig.MAX_POLL_RECORDS_CONFIG, DEFAULT_MAX_POLL_RECORDS,
-        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, DEFAULT_AUTO_OFFSET_RESET
+        ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1000",
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
     );
 
-    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS = Map.of(ProducerConfig.LINGER_MS_CONFIG, DEFAULT_LINGER_MS);
+    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS = Map.of(ProducerConfig.LINGER_MS_CONFIG, "100");
 
-    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED;
-    static {
-        final Map<String, Object> tempProducerDefaults = new HashMap<>(DEFAULT_PRODUCER_CONFIGS);
-        tempProducerDefaults.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
+    // Producer defaults that apply in addition to DEFAULT_PRODUCER_CONFIGS when EOS is enabled.
+    private static final Map<String, Object> DEFAULT_PRODUCER_CONFIGS_EOS_ONLY = Map.of(
+        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE,
         // Reduce the transaction timeout for quicker pending offset expiration on broker side.
-        tempProducerDefaults.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, DEFAULT_TRANSACTION_TIMEOUT);
-        DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED = Collections.unmodifiableMap(tempProducerDefaults);
-    }
+        ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, DEFAULT_TRANSACTION_TIMEOUT
+    );
 
     // Configs that Streams controls: a user-specified value is ignored (with a warning) and the
     // Streams value is enforced after the user props have been merged.
@@ -1393,14 +1395,12 @@ public class StreamsConfig extends AbstractConfig {
         ConsumerConfig.GROUP_PROTOCOL_CONFIG, "classic"
     );
 
-    private static final Map<String, Object> CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED;
-    static {
-        final Map<String, Object> tempControlledConfigs = new HashMap<>(CONTROLLED_CONSUMER_CONFIGS);
-        tempControlledConfigs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_COMMITTED.toString());
-        CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED = Collections.unmodifiableMap(tempControlledConfigs);
-    }
+    // Controlled configs that apply in addition to CONTROLLED_CONSUMER_CONFIGS when EOS is enabled.
+    private static final Map<String, Object> CONTROLLED_CONSUMER_CONFIGS_EOS_ONLY =
+        Map.of(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_COMMITTED.toString());
 
-    private static final Map<String, Object> CONTROLLED_PRODUCER_CONFIGS_EOS_ENABLED =
+    // Streams controls no producer configs unless EOS is enabled.
+    private static final Map<String, Object> CONTROLLED_PRODUCER_CONFIGS_EOS_ONLY =
         Map.of(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
     private static final Map<String, Object> ADMIN_CLIENT_OVERRIDES =
@@ -1611,6 +1611,8 @@ public class StreamsConfig extends AbstractConfig {
                             final boolean doLog) {
         super(CONFIG, props, doLog);
         eosEnabled = StreamsConfigUtils.eosEnabled(this);
+        eosControlledConfigReason = " Streams controls this config when '" + PROCESSING_GUARANTEE_CONFIG
+            + "' is set to \"" + getString(PROCESSING_GUARANTEE_CONFIG) + "\".";
         if (eosEnabled) {
             verifyEOSTransactionTimeoutCompatibility();
         }
@@ -1809,7 +1811,7 @@ public class StreamsConfig extends AbstractConfig {
     }
 
     private static final String CONTROLLED_CONFIG_OVERRIDE_MESSAGE =
-        "Unexpected user-specified {} config '{}' found. User setting ({}) will be ignored and the Streams default setting ({}) will be used.";
+        "Unexpected user-specified {} config '{}' found. User setting ({}) will be ignored and the Streams default setting ({}) will be used.{}";
 
     /**
      * Enforce a config that Streams controls: if the user set a different value, log a warning that it
@@ -1820,18 +1822,32 @@ public class StreamsConfig extends AbstractConfig {
                                            final String config,
                                            final Object streamsValue,
                                            final String clientType) {
-        if (props.containsKey(config) && !Objects.equals(props.get(config), streamsValue)) {
-            log.warn(CONTROLLED_CONFIG_OVERRIDE_MESSAGE, clientType, config, props.get(config), streamsValue);
+        overwriteControlledConfig(props, config, streamsValue, clientType, "");
+    }
+
+    /**
+     * As {@link #overwriteControlledConfig(Map, String, Object, String)}, but appends {@code reason} to
+     * the warning to explain why Streams controls the config.
+     */
+    private void overwriteControlledConfig(final Map<String, Object> props,
+                                           final String config,
+                                           final Object streamsValue,
+                                           final String clientType,
+                                           final String reason) {
+        if (props.containsKey(config) && !Objects.equals(String.valueOf(props.get(config)), String.valueOf(streamsValue))) {
+            log.warn(CONTROLLED_CONFIG_OVERRIDE_MESSAGE, clientType, config, props.get(config), streamsValue, reason);
         }
         props.put(config, streamsValue);
     }
 
     /** Enforce the consumer configs that Streams controls on an already-assembled consumer config map. */
     private void enforceControlledConsumerConfigs(final Map<String, Object> consumerProps) {
-        final Map<String, Object> controlledConfigs =
-            eosEnabled ? CONTROLLED_CONSUMER_CONFIGS_EOS_ENABLED : CONTROLLED_CONSUMER_CONFIGS;
-        controlledConfigs.forEach((config, streamsValue) ->
+        CONTROLLED_CONSUMER_CONFIGS.forEach((config, streamsValue) ->
             overwriteControlledConfig(consumerProps, config, streamsValue, "consumer"));
+        if (eosEnabled) {
+            CONTROLLED_CONSUMER_CONFIGS_EOS_ONLY.forEach((config, streamsValue) ->
+                overwriteControlledConfig(consumerProps, config, streamsValue, "consumer", eosControlledConfigReason));
+        }
     }
 
     /** Enforce the producer configs that Streams controls on an already-assembled producer config map. */
@@ -1839,14 +1855,15 @@ public class StreamsConfig extends AbstractConfig {
         if (!eosEnabled) {
             return;
         }
-        CONTROLLED_PRODUCER_CONFIGS_EOS_ENABLED.forEach((config, streamsValue) ->
-            overwriteControlledConfig(producerProps, config, streamsValue, "producer"));
+        CONTROLLED_PRODUCER_CONFIGS_EOS_ONLY.forEach((config, streamsValue) ->
+            overwriteControlledConfig(producerProps, config, streamsValue, "producer", eosControlledConfigReason));
 
         // Streams assigns a unique transactional.id per task later (see ActiveTaskCreator), so any
         // user-provided value is ignored. Warn and drop it rather than forcing a fixed value.
         if (producerProps.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG)) {
             log.warn(CONTROLLED_CONFIG_OVERRIDE_MESSAGE, "producer", ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-                producerProps.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), "<application.id>-<generated suffix>");
+                producerProps.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), "<application.id>-<generated suffix>",
+                eosControlledConfigReason);
             producerProps.remove(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
         }
 
@@ -1904,7 +1921,7 @@ public class StreamsConfig extends AbstractConfig {
         consumerProps.put(APPLICATION_ID_CONFIG, groupId);
 
         // add group id, client id with stream client id prefix, and group instance id
-        overwriteControlledConfig(consumerProps, ConsumerConfig.GROUP_ID_CONFIG, groupId, "consumer");
+        overwriteControlledConfig(consumerProps, ConsumerConfig.GROUP_ID_CONFIG, getString(APPLICATION_ID_CONFIG), "consumer");
         consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
         final String groupInstanceId = (String) consumerProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
         // Suffix each thread consumer with thread.id to enforce uniqueness of group.instance.id.
@@ -2037,7 +2054,10 @@ public class StreamsConfig extends AbstractConfig {
         final Map<String, Object> clientProvidedProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());
 
         // generate producer configs from original properties and overridden maps
-        final Map<String, Object> props = new HashMap<>(eosEnabled ? DEFAULT_PRODUCER_CONFIGS_EOS_ENABLED : DEFAULT_PRODUCER_CONFIGS);
+        final Map<String, Object> props = new HashMap<>(DEFAULT_PRODUCER_CONFIGS);
+        if (eosEnabled) {
+            props.putAll(DEFAULT_PRODUCER_CONFIGS_EOS_ONLY);
+        }
         props.putAll(getClientCustomProps());
         props.putAll(clientProvidedProps);
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -169,11 +169,6 @@ public class StreamsConfig extends AbstractConfig {
 
     private final boolean eosEnabled;
 
-    /**
-     * Completes the controlled-config warning for configs that Streams only controls when EOS is
-     * enabled. Without it such a rule looks arbitrary, because the same config is respected when EOS
-     * is disabled. Empty for configs Streams controls unconditionally.
-     */
     private final String eosControlledConfigReason;
     private static final long DEFAULT_COMMIT_INTERVAL_MS = 30000L;
     private static final long EOS_DEFAULT_COMMIT_INTERVAL_MS = 100L;

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -466,7 +466,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.consumerPrefix(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG), "true");
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
-            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
 
@@ -485,13 +485,13 @@ public class StreamsConfigTest {
             assertEquals("false", globalConfigs.get(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
                     "Global consumer should not allow auto topic creation with consumer.* override");
 
-            // Verify exactly 1 error is logged (consumer.* prefix is validated once in getCommonConsumerConfigs for each type of consumer)
-            final List<String> errorMessages = appender.getMessages();
-            final long errorCount = errorMessages.stream()
+            // Verify a warning is logged once per consumer (getCommonConsumerConfigs feeds all three consumer types)
+            final List<String> warnMessages = appender.getMessages();
+            final long warnCount = warnMessages.stream()
                     .filter(msg -> msg.contains("Unexpected user-specified consumer config 'allow.auto.create.topics' found"))
                     .count();
-            assertEquals(3, errorCount,
-                    "Should log exactly 3 error for consumer.* prefix");
+            assertEquals(3, warnCount,
+                    "Should log exactly 3 warnings for consumer.* prefix");
         }
     }
 
@@ -503,7 +503,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.globalConsumerPrefix(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG), "true");
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
-            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
 
@@ -522,22 +522,22 @@ public class StreamsConfigTest {
             assertEquals("false", globalConfigs.get(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
                     "Global consumer should not allow auto topic creation with global.consumer.* override");
 
-            // Verify exactly 3 errors are logged (one for each specific prefix)
-            final List<String> errorMessages = appender.getMessages();
-            final long errorCount = errorMessages.stream()
+            // Verify exactly 3 warnings are logged (one for each specific prefix)
+            final List<String> warnMessages = appender.getMessages();
+            final long warnCount = warnMessages.stream()
                     .filter(msg -> msg.contains("Unexpected user-specified consumer config 'allow.auto.create.topics' found"))
                     .count();
-            assertEquals(3, errorCount,
-                    "Should log exactly 3 errors: one for main.consumer.*, one for restore.consumer.*, one for global.consumer.*");
+            assertEquals(3, warnCount,
+                    "Should log exactly 3 warnings: one for main.consumer.*, one for restore.consumer.*, one for global.consumer.*");
         }
     }
 
     @Test
-    public void shouldLogErrorAndIgnoreUserOverrideOfGroupId() {
+    public void shouldLogWarningAndIgnoreUserOverrideOfGroupId() {
         props.put(consumerPrefix(ConsumerConfig.GROUP_ID_CONFIG), "user-group-id");
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
-            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
             final Map<String, Object> mainConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
@@ -545,19 +545,19 @@ public class StreamsConfigTest {
             assertEquals(groupId, mainConfigs.get(ConsumerConfig.GROUP_ID_CONFIG),
                     "Streams should force group.id to the application id and ignore the user override");
 
-            final long errorCount = appender.getMessages().stream()
+            final long warnCount = appender.getMessages().stream()
                     .filter(msg -> msg.contains("Unexpected user-specified consumer config 'group.id' found"))
                     .count();
-            assertEquals(1, errorCount, "Should log exactly one error for the group.id override");
+            assertEquals(1, warnCount, "Should log exactly one warning for the group.id override");
         }
     }
 
     @Test
-    public void shouldLogErrorAndIgnoreUserOverrideOfPartitionAssignmentStrategy() {
+    public void shouldLogWarningAndIgnoreUserOverrideOfPartitionAssignmentStrategy() {
         props.put(consumerPrefix(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), "com.example.MyAssignor");
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
-            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
             final Map<String, Object> mainConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
@@ -566,17 +566,17 @@ public class StreamsConfigTest {
                     mainConfigs.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
                     "Streams should force its own partition assignor and ignore the user override");
 
-            final long errorCount = appender.getMessages().stream()
+            final long warnCount = appender.getMessages().stream()
                     .filter(msg -> msg.contains("Unexpected user-specified consumer config 'partition.assignment.strategy' found"))
                     .count();
-            assertEquals(1, errorCount, "Should log exactly one error for the partition.assignment.strategy override");
+            assertEquals(1, warnCount, "Should log exactly one warning for the partition.assignment.strategy override");
         }
     }
 
     @Test
-    public void shouldNotLogErrorWhenUserDoesNotOverrideControlledConfigs() {
+    public void shouldNotLogWarningWhenUserDoesNotOverrideControlledConfigs() {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
-            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
             // Building each client's configs must not warn about configs the user never set. This guards
@@ -586,10 +586,10 @@ public class StreamsConfigTest {
             streamsConfig.getRestoreConsumerConfigs(clientId);
             streamsConfig.getGlobalConsumerConfigs(clientId);
 
-            final long errorCount = appender.getMessages().stream()
+            final long warnCount = appender.getMessages().stream()
                     .filter(msg -> msg.contains("Unexpected user-specified"))
                     .count();
-            assertEquals(0, errorCount, "Should not log a controlled-config error when the user overrides nothing");
+            assertEquals(0, warnCount, "Should not log a controlled-config warning when the user overrides nothing");
         }
     }
 
@@ -874,6 +874,31 @@ public class StreamsConfigTest {
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
         assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
+    }
+
+    @Test
+    public void shouldLogWarningAndIgnoreUserOverridesOfControlledProducerConfigsIfEosV2Enabled() {
+        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "user-TxId");
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
+
+            final Map<String, Object> producerConfigs = new StreamsConfig(props).getProducerConfigs(clientId);
+
+            assertTrue((Boolean) producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG),
+                    "Streams should force idempotence on under EOS and ignore the user override");
+            assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
+
+            final List<String> messages = appender.getMessages();
+            assertEquals(1, messages.stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified producer config 'enable.idempotence' found"))
+                    .count(), "Should warn once for the enable.idempotence override");
+            assertEquals(1, messages.stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified producer config 'transactional.id' found"))
+                    .count(), "Should warn once for the transactional.id override");
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -532,23 +532,25 @@ public class StreamsConfigTest {
         }
     }
 
-    @Test
-    public void shouldLogWarningAndIgnoreUserOverrideOfGroupId() {
+    @ParameterizedTest
+    @ValueSource(strings = {"example-application", "dummy", "dummyGroupId"})
+    public void shouldLogWarningAndUseApplicationIdAsGroupIdRegardlessOfRequestedGroupId(final String requestedGroupId) {
         props.put(consumerPrefix(ConsumerConfig.GROUP_ID_CONFIG), "user-group-id");
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
             appender.setClassLogger(StreamsConfig.class, Level.WARN);
 
             final StreamsConfig streamsConfig = new StreamsConfig(props);
-            final Map<String, Object> mainConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
+            final Map<String, Object> mainConfigs =
+                streamsConfig.getMainConsumerConfigs(requestedGroupId, clientId, threadIdx);
 
             assertEquals(groupId, mainConfigs.get(ConsumerConfig.GROUP_ID_CONFIG),
                     "Streams should force group.id to the application id and ignore the user override");
-
-            final long warnCount = appender.getMessages().stream()
-                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'group.id' found"))
-                    .count();
-            assertEquals(1, warnCount, "Should log exactly one warning for the group.id override");
+            assertEquals(1, appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'group.id' found")
+                            && msg.contains(groupId))
+                    .count(),
+                "Should log exactly one warning naming the application id as the value Streams will use");
         }
     }
 
@@ -820,6 +822,62 @@ public class StreamsConfigTest {
     }
 
     @Test
+    public void shouldResetToDefaultIfConsumerIsolationLevelIsOverriddenUnderClientPrefixIfEosV2Enabled() {
+        // Controlled configs are enforced on the assembled config map, so an override supplied under a
+        // per-client prefix is caught for every consumer, not just the ones using the generic prefix.
+        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
+        props.put(StreamsConfig.mainConsumerPrefix(ConsumerConfig.ISOLATION_LEVEL_CONFIG), READ_UNCOMMITTED.toString());
+        props.put(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.ISOLATION_LEVEL_CONFIG), READ_UNCOMMITTED.toString());
+        props.put(StreamsConfig.globalConsumerPrefix(ConsumerConfig.ISOLATION_LEVEL_CONFIG), READ_UNCOMMITTED.toString());
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
+
+            final StreamsConfig streamsConfig = new StreamsConfig(props);
+
+            assertThat(
+                streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx).get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+                equalTo(READ_COMMITTED.toString())
+            );
+            assertThat(
+                streamsConfig.getRestoreConsumerConfigs(clientId).get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+                equalTo(READ_COMMITTED.toString())
+            );
+            assertThat(
+                streamsConfig.getGlobalConsumerConfigs(clientId).get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
+                equalTo(READ_COMMITTED.toString())
+            );
+
+            assertEquals(3, appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'isolation.level' found")
+                            && msg.contains("Streams controls this config when 'processing.guarantee' is set to \""
+                                + EXACTLY_ONCE_V2 + "\""))
+                    .count(),
+                "Should log exactly one warning per consumer, explaining that EOS is the reason");
+        }
+    }
+
+    @Test
+    public void shouldNotLogWarningWhenUserSetsControlledConfigToSameValueWithDifferentType() {
+        // A Boolean false and the "false" that Streams sets are the same setting; warning that the
+        // user's value is being ignored and replaced by an identical one would only confuse them.
+        props.put(StreamsConfig.consumerPrefix(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG), false);
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
+
+            final Map<String, Object> consumerConfigs =
+                new StreamsConfig(props).getMainConsumerConfigs(groupId, clientId, threadIdx);
+
+            assertEquals("false", consumerConfigs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG));
+            assertEquals(0, appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified"))
+                    .count(),
+                "Should not warn when the user-specified value only differs in type");
+        }
+    }
+
+    @Test
     public void shouldAllowSettingConsumerIsolationLevelIfEosDisabled() {
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_UNCOMMITTED.toString());
         final StreamsConfig streamsConfig = new StreamsConfig(props);
@@ -898,6 +956,30 @@ public class StreamsConfigTest {
             assertEquals(1, messages.stream()
                     .filter(msg -> msg.contains("Unexpected user-specified producer config 'transactional.id' found"))
                     .count(), "Should warn once for the transactional.id override");
+            assertEquals(2, messages.stream()
+                    .filter(msg -> msg.contains("Streams controls this config when 'processing.guarantee' is set to \""
+                            + EXACTLY_ONCE_V2 + "\""))
+                    .count(), "Both warnings should explain that the processing guarantee is the reason");
+        }
+    }
+
+    @Test
+    public void shouldNotExplainProcessingGuaranteeForConfigControlledRegardlessOfEosIfEosV2Enabled() {
+        // enable.auto.commit is controlled whether or not EOS is enabled, so the warning must not
+        // attribute it to the processing guarantee even when EOS happens to be on.
+        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
+        props.put(StreamsConfig.consumerPrefix(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG), "true");
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.WARN);
+
+            new StreamsConfig(props).getMainConsumerConfigs(groupId, clientId, threadIdx);
+
+            assertEquals(1, appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'enable.auto.commit' found")
+                            && !msg.contains("processing.guarantee"))
+                    .count(),
+                "The warning must not name the processing guarantee as the reason");
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -532,6 +532,66 @@ public class StreamsConfigTest {
         }
     }
 
+    @Test
+    public void shouldLogErrorAndIgnoreUserOverrideOfGroupId() {
+        props.put(consumerPrefix(ConsumerConfig.GROUP_ID_CONFIG), "user-group-id");
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+
+            final StreamsConfig streamsConfig = new StreamsConfig(props);
+            final Map<String, Object> mainConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
+
+            assertEquals(groupId, mainConfigs.get(ConsumerConfig.GROUP_ID_CONFIG),
+                    "Streams should force group.id to the application id and ignore the user override");
+
+            final long errorCount = appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'group.id' found"))
+                    .count();
+            assertEquals(1, errorCount, "Should log exactly one error for the group.id override");
+        }
+    }
+
+    @Test
+    public void shouldLogErrorAndIgnoreUserOverrideOfPartitionAssignmentStrategy() {
+        props.put(consumerPrefix(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG), "com.example.MyAssignor");
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+
+            final StreamsConfig streamsConfig = new StreamsConfig(props);
+            final Map<String, Object> mainConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
+
+            assertEquals(StreamsPartitionAssignor.class.getName(),
+                    mainConfigs.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+                    "Streams should force its own partition assignor and ignore the user override");
+
+            final long errorCount = appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified consumer config 'partition.assignment.strategy' found"))
+                    .count();
+            assertEquals(1, errorCount, "Should log exactly one error for the partition.assignment.strategy override");
+        }
+    }
+
+    @Test
+    public void shouldNotLogErrorWhenUserDoesNotOverrideControlledConfigs() {
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StreamsConfig.class)) {
+            appender.setClassLogger(StreamsConfig.class, Level.ERROR);
+
+            final StreamsConfig streamsConfig = new StreamsConfig(props);
+            // Building each client's configs must not warn about configs the user never set. This guards
+            // against comparing a Streams-seeded default (e.g. auto.offset.reset="earliest") against the
+            // value Streams forces on the restore/global consumers.
+            streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
+            streamsConfig.getRestoreConsumerConfigs(clientId);
+            streamsConfig.getGlobalConsumerConfigs(clientId);
+
+            final long errorCount = appender.getMessages().stream()
+                    .filter(msg -> msg.contains("Unexpected user-specified"))
+                    .count();
+            assertEquals(0, errorCount, "Should not log a controlled-config error when the user overrides nothing");
+        }
+    }
 
     @Test
     public void shouldSupportNonPrefixedAdminConfigs() {


### PR DESCRIPTION
Kafka Streams assigns some of the underlying consumer and producer
configs itself and silently ignored a user-supplied value for them, so
there was no way to tell that the setting had no effect. Two unrelated
mechanisms did this: a checker driven by the `NON_CONFIGURABLE_*` arrays
that inspected the prefix-extracted user properties, and direct `put()`
calls applied after those properties were merged, which warned about
nothing at all.

Replace both with a single helper, `overwriteControlledConfig`, applied to
the fully assembled config map so that an override is caught in one
place whichever prefix supplied it, and split the config sets by intent:
`DEFAULT_*` holds defaults the user may still override, `CONTROLLED_*` holds
values the user cannot. The `_EOS_ONLY` maps carry only what exactly-once
adds and are applied on top of their counterparts.

This closes two gaps. `group.id` and `partition.assignment.strategy` are
documented as controlled by Streams but produced no log line, because
both are forced with a put() after the merge. The per-client prefixes
were only checked against the non-exactly-once set, so
`restore.consumer.isolation.level=read_uncommitted` gave a restore
consumer reading uncommitted records under exactly-once; it now yields
`read_committed`.

Warnings are now all logged at `WARN`, where the non-exactly-once set was
previously logged at `ERROR`, and a config that is only controlled under
exactly-once names the processing guarantee as the reason.

A value that differs from the Streams value only in type, such as
`Boolean.FALSE` where Streams sets `"false"`, no longer warns that it is
being replaced by an identical value.
`max.in.flight.requests.per.connection` is a producer config and is now
validated only there, so a value supplied under a consumer prefix is no
longer rejected.

Reviewers: Nikita Shupletsov <nikita@shupletsov.ca>, Lucas Brutschy <lbrutschy@confluent.io>
