### PR TITLE
KAFKA-20699: TopologyTestDriver.getStateStore must not reset the record context

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -938,7 +938,12 @@ public class TopologyTestDriver implements Closeable {
     private StateStore getStateStore(final String name,
                                      final boolean throwForBuiltInStores) {
         if (task != null) {
-            task.processorContext().setRecordContext(new ProcessorRecordContext(0L, -1L, -1, null, new RecordHeaders()));
+            // Accessing a store must not corrupt the task's record context. Only set a dummy
+            // context when none exists yet (i.e. before any record has been processed) so that
+            // direct store operations have a context to work with; never overwrite a live one.
+            if (task.processorContext().recordContext() == null) {
+                task.processorContext().setRecordContext(new ProcessorRecordContext(0L, -1L, -1, null, new RecordHeaders()));
+            }
             final StateStore stateStore = ((ProcessorContextImpl) task.processorContext()).stateManager().store(name);
             if (stateStore != null) {
                 if (throwForBuiltInStores) {

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -1499,6 +1499,66 @@ public abstract class TopologyTestDriverTest {
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
+    @Test
+    public void shouldNotResetRecordContextWhenAccessingStateStore() {
+        final String storeName = "recordContextStore";
+        final Topology topology = new Topology();
+        topology.addSource("source", "input-topic");
+        topology.addProcessor("writer", () -> new StoreWriter(storeName), "source");
+        topology.addStateStore(
+                Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore(storeName), Serdes.String(), Serdes.Long()),
+                "writer");
+
+        config.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        config.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+        testDriver = new TopologyTestDriver(topology, config);
+
+        final TestInputTopic<String, Long> input =
+                testDriver.createInputTopic("input-topic", new StringSerializer(), new LongSerializer());
+        final TestOutputTopic<String, Long> changelog = testDriver.createOutputTopic(
+                config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-" + storeName + "-changelog",
+                stringDeserializer, longDeserializer);
+
+        // a record processed at stream-time 5000 anchors the task's record context there
+        input.pipeInput("processed", 1L, 5000L);
+        changelog.readRecordsToList();
+
+        // grabbing the store handle and writing to it must not reset the live record context:
+        // the direct write should be logged at the live stream-time (5000), not epoch 0
+        final KeyValueStore<String, Long> handle = testDriver.getKeyValueStore(storeName);
+        handle.put("seeded", 2L);
+        // Force a commit + output capture so the change-logged put() above is flushed to the
+        // changelog topic for readRecordsToList(). ZERO is deliberate: we only need the flush,
+        // not to advance time or disturb the live record context.
+        testDriver.advanceWallClockTime(Duration.ZERO);
+
+        final TestRecord<String, Long> seeded = changelog.readRecordsToList().stream()
+                .filter(record -> record.key().equals("seeded"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("seeded entry was not logged to the changelog"));
+        assertEquals(5000L, seeded.timestamp(),
+                "getStateStore reset the live record context, so the direct write was logged at epoch 0");
+    }
+
+    private static final class StoreWriter implements Processor<String, Long, Void, Void> {
+        private final String storeName;
+        private KeyValueStore<String, Long> store;
+
+        StoreWriter(final String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(final ProcessorContext<Void, Void> context) {
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(final Record<String, Long> record) {
+            store.put(record.key(), record.value());
+        }
+    }
+
     private static class CustomMaxAggregatorSupplier implements ProcessorSupplier<String, Long, String, Long> {
         @Override
         public Processor<String, Long, String, Long> get() {


### PR DESCRIPTION
## Summary

[KAFKA-20699](https://issues.apache.org/jira/browse/KAFKA-20699). A
regression introduced by KAFKA-19638 (#20403):
`TopologyTestDriver#getStateStore` now sets a dummy
`ProcessorRecordContext` (`null` topic, `-1` offset/partition, timestamp
`0`) **unconditionally** and never restores it. Before KAFKA-19638 the
dummy context was set once at task construction and `getStateStore` was
read-only.

As a result, a store lookup mutates the task's live record context as a
side effect. When a store handle is fetched while a record's context is
active — an interactive query interleaved with processing, or a test
seam that resolves a store handle through TTD from production code — the
in-flight record's `RecordMetadata` is wiped: `recordMetadata().topic()`
returns `null` and offset/partition become `-1`. Code building
provenance from `recordMetadata().topic()` then fails, and direct store
writes capture timestamp `0`.

The normal `process()` path masks this because `doProcess` rebuilds the
context per record, so it surfaces on direct store writes after a lookup
and on any context read not preceded by a fresh `process()`.

## Fix

Only materialize the dummy context when none exists yet (before any
record has been processed); never overwrite a live one. Direct store
access still works, while an in-flight record's context is left intact.

## Testing

Added `shouldNotResetRecordContextWhenAccessingStateStore` to
`TopologyTestDriverTest` (runs under both at-least-once and EOS). It
processes a record at stream-time 5000, then grabs the store handle and
writes directly to it; the write must be logged to the changelog at
5000. Fails before the fix (`expected: <5000> but was: <0>`), passes
after. Full `:streams:test-utils:test` + checkstyle + spotbugs pass.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Eduwer Camacaro
 <eduwerc@gmail.com>
