### PR TITLE
HOTFIX: remove incorrect public API change

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/test/TestRecord.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/test/TestRecord.java
@@ -38,10 +38,6 @@ public class TestRecord<K, V> {
     private final V value;
     private final Instant recordTime;
 
-    public boolean equalsIgnorePartition(final TestRecord<? extends K, ? super V> o) {
-        return false;
-    }
-
     /**
      * Creates a record.
      *


### PR DESCRIPTION
This change was merge by accident, and must be reverted to not change public API.

(Accidentally introduced via https://github.com/apache/kafka/pull/22546 -- we will fix-forward on `trunk` but need to revert in `4.3` and `4.2` branches)

Reviewers: Bill Bejeck <bbejeck@apache.org>