### PR TITLE
KAFKA-19543: fix(consumer): keep metrics available after close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -114,6 +114,7 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
@@ -132,6 +133,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -397,6 +399,7 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     private final AtomicReference<Set<TopicPartition>> groupAssignmentSnapshot = new AtomicReference<>(Collections.emptySet());
     private final ConsumerMetadata metadata;
     private final Metrics metrics;
+    private final List<WeakReference<ConsumerMetricsView>> metricsViews = new CopyOnWriteArrayList<>();
     private final long retryBackoffMs;
     private final int requestTimeoutMs;
     private final Duration defaultApiTimeoutMs;
@@ -1295,7 +1298,13 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return Collections.unmodifiableMap(metrics.metrics());
+        if (closed) {
+            return Collections.unmodifiableMap(metrics.metrics());
+        }
+        ConsumerMetricsView metricsView = new ConsumerMetricsView(metrics);
+        metricsViews.removeIf(reference -> reference.get() == null);
+        metricsViews.add(new WeakReference<>(metricsView));
+        return metricsView;
     }
 
     @Override
@@ -1637,6 +1646,11 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     private void close(Duration timeout, CloseOptions.GroupMembershipOperation membershipOperation, boolean swallowException) {
         log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+        metricsViews.forEach(reference -> {
+            ConsumerMetricsView metricsView = reference.get();
+            if (metricsView != null)
+                metricsView.freeze();
+        });
 
         // We are already closing with a timeout, don't allow wake-ups from here on.
         wakeupTrigger.disableWakeups();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
@@ -63,6 +63,7 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
@@ -77,6 +78,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -120,6 +122,7 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     public static final String DEFAULT_REASON = "rebalance enforced by user";
 
     private final Metrics metrics;
+    private final List<WeakReference<ConsumerMetricsView>> metricsViews = new CopyOnWriteArrayList<>();
     private final KafkaConsumerMetrics kafkaConsumerMetrics;
     private Logger log;
     private final String clientId;
@@ -935,7 +938,13 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return Collections.unmodifiableMap(this.metrics.metrics());
+        if (closed) {
+            return Collections.unmodifiableMap(metrics.metrics());
+        }
+        ConsumerMetricsView metricsView = new ConsumerMetricsView(metrics);
+        metricsViews.removeIf(reference -> reference.get() == null);
+        metricsViews.add(new WeakReference<>(metricsView));
+        return metricsView;
     }
 
     @Override
@@ -1145,6 +1154,11 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
     private void close(Duration timeout, CloseOptions.GroupMembershipOperation membershipOperation, boolean swallowException) {
         log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+        metricsViews.forEach(reference -> {
+            ConsumerMetricsView metricsView = reference.get();
+            if (metricsView != null)
+                metricsView.freeze();
+        });
 
         final Timer closeTimer = createTimerForRequest(timeout);
         clientTelemetryReporter.ifPresent(ClientTelemetryReporter::initiateClose);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetricsView.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetricsView.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+class ConsumerMetricsView extends AbstractMap<MetricName, KafkaMetric> {
+
+    private final Metrics metrics;
+    private volatile Map<MetricName, KafkaMetric> frozenMetrics;
+
+    ConsumerMetricsView(Metrics metrics) {
+        this.metrics = metrics;
+    }
+
+    void freeze() {
+        if (frozenMetrics == null) {
+            frozenMetrics = Collections.unmodifiableMap(new HashMap<>(metrics.metrics()));
+        }
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate().containsKey(key);
+    }
+
+    @Override
+    public KafkaMetric get(Object key) {
+        return delegate().get(key);
+    }
+
+    @Override
+    public Set<Entry<MetricName, KafkaMetric>> entrySet() {
+        return Collections.unmodifiableMap(delegate()).entrySet();
+    }
+
+    private Map<MetricName, KafkaMetric> delegate() {
+        Map<MetricName, KafkaMetric> snapshot = frozenMetrics;
+        return snapshot == null ? metrics.metrics() : snapshot;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -77,6 +77,7 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
@@ -91,6 +92,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -200,6 +202,7 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     private final SubscriptionState subscriptions;
     private final ShareConsumerMetadata metadata;
     private final Metrics metrics;
+    private final List<WeakReference<ConsumerMetricsView>> metricsViews = new CopyOnWriteArrayList<>();
     private final int requestTimeoutMs;
     private final int defaultApiTimeoutMs;
     private volatile boolean closed = false;
@@ -959,7 +962,13 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
      */
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
-        return Collections.unmodifiableMap(metrics.metrics());
+        if (closed) {
+            return Collections.unmodifiableMap(metrics.metrics());
+        }
+        ConsumerMetricsView metricsView = new ConsumerMetricsView(metrics);
+        metricsViews.removeIf(reference -> reference.get() == null);
+        metricsViews.add(new WeakReference<>(metricsView));
+        return metricsView;
     }
 
     /**
@@ -1017,6 +1026,11 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
     private void close(final Duration timeout, final boolean swallowException) {
         log.trace("Closing the Kafka consumer");
         AtomicReference<Throwable> firstException = new AtomicReference<>();
+        metricsViews.forEach(reference -> {
+            ConsumerMetricsView metricsView = reference.get();
+            if (metricsView != null)
+                metricsView.freeze();
+        });
 
         // We are already closing with a timeout, don't allow wake-ups from here on.
         wakeupTrigger.disableWakeups();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -410,6 +410,23 @@ public class KafkaConsumerTest {
         assertMetricsMap(false);
     }
 
+    @ParameterizedTest
+    @EnumSource(GroupProtocol.class)
+    public void testReturnedMetricsRemainAvailableAfterClose(GroupProtocol groupProtocol) {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, groupProtocol.name());
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        consumer = newConsumer(props, new StringDeserializer(), new StringDeserializer());
+
+        Map<MetricName, ? extends Metric> beforeClose = consumer.metrics();
+        Set<MetricName> expectedMetricNames = Set.copyOf(beforeClose.keySet());
+        assertFalse(expectedMetricNames.isEmpty());
+
+        consumer.close(CloseOptions.timeout(Duration.ZERO));
+
+        assertEquals(expectedMetricNames, beforeClose.keySet());
+    }
+
     private void assertMetricsMap(boolean metricsShouldBePresent) {
         // Copy the map because we're going to modify it.
         Map<MetricName, ? extends Metric> metrics = new HashMap<>(consumer.metrics());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
@@ -189,6 +189,23 @@ public class KafkaShareConsumerMetricsTest {
     }
 
     @Test
+    public void testReturnedMetricsRemainAvailableAfterClose() {
+        Time time = new MockTime(1L);
+        ShareConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Map.of(topic, 1));
+
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        Map<MetricName, ? extends Metric> beforeClose = consumer.metrics();
+        Set<MetricName> expectedMetricNames = Set.copyOf(beforeClose.keySet());
+        assertFalse(expectedMetricNames.isEmpty());
+
+        consumer.close();
+
+        assertEquals(expectedMetricNames, beforeClose.keySet());
+    }
+
+    @Test
     public void testRegisteringCustomMetricsDoesntAffectConsumerMetrics() {
         Time time = new MockTime(1L);
         ShareConsumerMetadata metadata = createMetadata(subscription);


### PR DESCRIPTION
## What changed

Previously, calling `Consumer#metrics()` returned a live view of the underlying `Metrics` instance. Once `close()` was invoked, the metric registry was torn down, so any reference obtained before close would lose metrics that were unregistered as part of shutdown. This change ensures that a `Map<MetricName, ? extends Metric>` returned before `close()` continues to expose the same set of metrics after the consumer has been closed.

## Implementation

- A new internal class `ConsumerMetricsView` (in `clients/.../internals`) wraps `Metrics` and lazily freezes a snapshot of the current metric set when `freeze()` is called. Reads from the view return the live map while unfrozen, and the frozen snapshot afterwards.
- `AsyncKafkaConsumer`, `ClassicKafkaConsumer`, and `ShareConsumerImpl` now track weak references to every `ConsumerMetricsView` they hand out from `metrics()`. On `close()`, each still-reachable view is frozen so it keeps serving its captured set of metrics even after the underlying `Metrics` registry has been cleared. If the consumer has already been closed, `metrics()` simply returns the current `metrics.metrics()` map as before.
- New tests in `KafkaConsumerTest` and `KafkaShareConsumerMetricsTest` capture the metrics map before close and assert that the same metric names remain visible afterwards.

## Testing strategy

The behaviour change is covered by unit tests:

- `KafkaConsumerTest#testReturnedMetricsRemainAvailableAfterClose` exercises both classic (`GroupProtocol.CLASSIC`) and consumer group (`GroupProtocol.CONSUMER`) paths and verifies the pre-close metrics map is unchanged after `close()`.
- `KafkaShareConsumerMetricsTest#testReturnedMetricsRemainAvailableAfterClose` does the same for the share consumer using the existing mock client infrastructure.

Existing metrics tests continue to apply and were not modified.

---

Delete this text and replace it with a detailed description of your change. The
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

- [x] The pull request description includes the appropriate summary of the change.
- [x] The commit message(s) follow the project's conventions.
- [x] New and existing unit tests pass locally and on the build server.
- [x] The change is sufficiently documented (API docs, Javadoc, comments).
- [ ] New public classes, interfaces, methods, fields, etc. are linked in the documentation.
- [ ] Larger changes have been discussed with the project maintainers.
- [ ] I have considered possible security implications and do not see any.

JIRA: https://issues.apache.org/jira/browse/KAFKA-19543