### PR TITLE
KAFKA-19583: fix: enable oauthbearer sasl with native image

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -23,7 +23,9 @@ import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.Login;
+import org.apache.kafka.common.security.kerberos.KerberosLogin;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerRefreshingLogin;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.SecurityUtils;
@@ -61,8 +63,8 @@ public class LoginManager {
     private LoginManager(JaasContext jaasContext, String saslMechanism, Map<String, ?> configs,
                  LoginMetadata<?> loginMetadata) throws LoginException {
         this.loginMetadata = loginMetadata;
-        this.login = Utils.newInstance(loginMetadata.loginClass);
-        loginCallbackHandler = Utils.newInstance(loginMetadata.loginCallbackClass);
+        this.login = createLogin(loginMetadata.loginClass);
+        loginCallbackHandler = createLoginCallbackHandler(loginMetadata.loginCallbackClass);
         try {
             loginCallbackHandler.configure(configs, saslMechanism, jaasContext.configurationEntries());
             login.configure(configs, jaasContext.name(), jaasContext.configuration(), loginCallbackHandler);
@@ -225,6 +227,25 @@ public class LoginManager {
         if (clazz == null)
             clazz = defaultClass;
         return clazz;
+    }
+
+    private static Login createLogin(Class<? extends Login> loginClass) {
+        if (loginClass == DefaultLogin.class)
+            return new DefaultLogin();
+        if (loginClass == KerberosLogin.class)
+            return new KerberosLogin();
+        if (loginClass == OAuthBearerRefreshingLogin.class)
+            return new OAuthBearerRefreshingLogin();
+        return Utils.newInstance(loginClass);
+    }
+
+    private static AuthenticateCallbackHandler createLoginCallbackHandler(
+            Class<? extends AuthenticateCallbackHandler> loginCallbackClass) {
+        if (loginCallbackClass == AbstractLogin.DefaultLoginCallbackHandler.class)
+            return new AbstractLogin.DefaultLoginCallbackHandler();
+        if (loginCallbackClass == OAuthBearerUnsecuredLoginCallbackHandler.class)
+            return new OAuthBearerUnsecuredLoginCallbackHandler();
+        return Utils.newInstance(loginCallbackClass);
     }
 
     private static class LoginMetadata<T> {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientProvider.java
@@ -27,8 +27,13 @@ public final class OAuthBearerSaslClientProvider extends Provider {
 
     private OAuthBearerSaslClientProvider() {
         super("SASL/OAUTHBEARER Client Provider", "1.0", "SASL/OAUTHBEARER Client Provider for Kafka");
-        put("SaslClientFactory." + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
-                OAuthBearerSaslClientFactory.class.getName());
+        putService(new Provider.Service(this, "SaslClientFactory", OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
+                OAuthBearerSaslClientFactory.class.getName(), null, null) {
+            @Override
+            public Object newInstance(Object constructorParameter) {
+                return new OAuthBearerSaslClientFactory();
+            }
+        });
     }
 
     public static void initialize() {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerProvider.java
@@ -27,8 +27,13 @@ public final class OAuthBearerSaslServerProvider extends Provider {
 
     private OAuthBearerSaslServerProvider() {
         super("SASL/OAUTHBEARER Server Provider", "1.0", "SASL/OAUTHBEARER Server Provider for Kafka");
-        put("SaslServerFactory." + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
-                OAuthBearerSaslServerFactory.class.getName());
+        putService(new Provider.Service(this, "SaslServerFactory", OAuthBearerLoginModule.OAUTHBEARER_MECHANISM,
+                OAuthBearerSaslServerFactory.class.getName(), null, null) {
+            @Override
+            public Object newInstance(Object constructorParameter) {
+                return new OAuthBearerSaslServerFactory();
+            }
+        });
     }
 
     public static void initialize() {


### PR DESCRIPTION
The native Kafka image fails to start when `KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER` is configured because GraalVM native-image reachability metadata does not retain the no-argument constructors used by the reflective instantiation in `LoginManager` and the SASL provider factories. This avoids the failure by instantiating the known login, callback handler, and SASL factory classes directly rather than via `Utils.newInstance` / `Provider.put`, ensuring they are reachable in the native image.

Changes:
- `LoginManager`: introduce `createLogin` and `createLoginCallbackHandler` helpers that directly instantiate `DefaultLogin`, `KerberosLogin`, `OAuthBearerRefreshingLogin`, `AbstractLogin.DefaultLoginCallbackHandler`, and `OAuthBearerUnsecuredLoginCallbackHandler`, falling back to `Utils.newInstance` for any other class.
- `OAuthBearerSaslClientProvider` and `OAuthBearerSaslServerProvider`: register their services via `putService` with an overridden `newInstance` that constructs the factory directly, instead of registering the class name and relying on `Provider` to instantiate it reflectively.

Reviewers: Murali Basani <muralidhar.basani@aiven.io>, Chia-Ping Tsai <chia7712@gmail.com>

---

Delete this text and replace it with a detailed description of your change. The
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

  - [ ] Tests passed
  - [ ] Integration tests passed (if applicable)
  - [ ] Documentation added (if applicable)
  - [ ] Release notes updated (if applicable)

JIRA: https://issues.apache.org/jira/browse/KAFKA-19583
