### PR TITLE
MINOR: Fix error message for streams group reset

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/streams/StreamsGroupCommand.java
@@ -958,7 +958,7 @@ public class StreamsGroupCommand {
                 return partitions;
             } else {
                 if (!opts.options.has(opts.resetFromFileOpt))
-                    CommandLineUtils.printUsageAndExit(opts.parser, "One of the reset scopes should be defined: --all-topics, --topic.");
+                    CommandLineUtils.printUsageAndExit(opts.parser, "One of the reset scopes should be defined: --all-input-topics, --input-topic.");
 
                 return List.of();
             }


### PR DESCRIPTION
This PR fixes a tiny problem in the error message for missing command
options in `kafka-streams-groups.sh`.

Before:

```
% bin/kafka-streams-groups.sh --bootstrap-server localhost:9092
--reset-offsets --group CG1 --dry-run
One of the reset scopes should be defined: --all-topics, --topic.
```

In this tool, `--all-topics` and `--topic` are not valid options. They
should be `--all-input-topics` and `--input-topic`.

After:

```
% bin/kafka-streams-groups.sh --bootstrap-server localhost:9092
--reset-offsets --group CG1 --dry-run
One of the reset scopes should be defined: --all-input-topics,
--input-topic.
```

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
