### PR TITLE
KAFKA-20710:  Share coordinator - Fence stale periodic jobs

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -140,7 +140,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
     /**
      * Config based sentinel used to start or eventually stop defined periodic job tasks.
      */
-    private volatile boolean shouldRunPeriodicJob;
+    private volatile boolean periodicJobsEnabled;
 
     private final AtomicLong periodicJobGeneration = new AtomicLong();
 
@@ -342,7 +342,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
-                if (!shouldRunPeriodicJob(generation)) {
+                if (!shouldRunPeriodicJobForGeneration(generation)) {
                     return;
                 }
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -353,7 +353,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error in share-group state topic prune.", exp);
                         }
-                        if (!shouldRunPeriodicJob(generation)) {
+                        if (!shouldRunPeriodicJobForGeneration(generation)) {
                             return;
                         }
                         // Perpetual recursion, failure or not.
@@ -433,7 +433,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         timer.add(new TimerTask(config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
             @Override
             public void run() {
-                if (!shouldRunPeriodicJob(generation)) {
+                if (!shouldRunPeriodicJobForGeneration(generation)) {
                     return;
                 }
                 List<CompletableFuture<Void>> futures = runtime.scheduleWriteAllOperation(
@@ -446,7 +446,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error while snapshotting cold partitions.", exp);
                         }
-                        if (!shouldRunPeriodicJob(generation)) {
+                        if (!shouldRunPeriodicJobForGeneration(generation)) {
                             return;
                         }
                         setupSnapshotColdPartitions(generation);
@@ -1147,13 +1147,13 @@ public class ShareCoordinatorService implements ShareCoordinator {
         }
 
         boolean enabled = isShareGroupsEnabled(newImage);
-        // enabled    shouldRunJob         result (XOR)
+        // enabled    periodicJobsEnabled result (XOR)
         // 0            0               no op on flag, do not call jobs
         // 0            1               disable flag, do not call jobs                      => action
         // 1            0               enable flag, call jobs as they are not recursing    => action
         // 1            1               no op on flag, do not call jobs
-        if (enabled ^ shouldRunPeriodicJob) {
-            shouldRunPeriodicJob = enabled;
+        if (enabled ^ periodicJobsEnabled) {
+            periodicJobsEnabled = enabled;
             long generation = periodicJobGeneration.incrementAndGet();
             if (enabled) {
                 setupPeriodicJobs(generation);
@@ -1196,12 +1196,7 @@ public class ShareCoordinatorService implements ShareCoordinator {
         ).supportsShareGroups();
     }
 
-    // Visibility for tests
-    boolean shouldRunPeriodicJob() {
-        return shouldRunPeriodicJob;
-    }
-
-    private boolean shouldRunPeriodicJob(long generation) {
-        return shouldRunPeriodicJob && periodicJobGeneration.get() == generation;
+    private boolean shouldRunPeriodicJobForGeneration(long generation) {
+        return periodicJobsEnabled && periodicJobGeneration.get() == generation;
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -76,6 +76,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntSupplier;
 
 import static org.apache.kafka.coordinator.common.runtime.CoordinatorOperationExceptionHelper.handleOperationException;
@@ -140,6 +141,8 @@ public class ShareCoordinatorService implements ShareCoordinator {
      * Config based sentinel used to start or eventually stop defined periodic job tasks.
      */
     private volatile boolean shouldRunPeriodicJob;
+
+    private final AtomicLong periodicJobGeneration = new AtomicLong();
 
     public static class Builder {
         private final int nodeId;
@@ -319,9 +322,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
         log.info("Startup complete.");
     }
 
-    private void setupPeriodicJobs() {
-        setupRecordPruning();
-        setupSnapshotColdPartitions();
+    private void setupPeriodicJobs(long generation) {
+        setupRecordPruning(generation);
+        setupSnapshotColdPartitions(generation);
     }
 
     /**
@@ -331,11 +334,15 @@ public class ShareCoordinatorService implements ShareCoordinator {
      */
     // Visibility for tests
     void setupRecordPruning() {
+        setupRecordPruning(periodicJobGeneration.get());
+    }
+
+    private void setupRecordPruning(long generation) {
         log.debug("Scheduling share-group state topic prune job.");
         timer.add(new TimerTask(config.shareCoordinatorTopicPruneIntervalMs()) {
             @Override
             public void run() {
-                if (!shouldRunPeriodicJob) {
+                if (!shouldRunPeriodicJob(generation)) {
                     return;
                 }
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -346,8 +353,11 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error in share-group state topic prune.", exp);
                         }
+                        if (!shouldRunPeriodicJob(generation)) {
+                            return;
+                        }
                         // Perpetual recursion, failure or not.
-                        setupRecordPruning();
+                        setupRecordPruning(generation);
                     });
             }
         });
@@ -415,11 +425,15 @@ public class ShareCoordinatorService implements ShareCoordinator {
      */
     // Visibility for tests
     void setupSnapshotColdPartitions() {
+        setupSnapshotColdPartitions(periodicJobGeneration.get());
+    }
+
+    private void setupSnapshotColdPartitions(long generation) {
         log.debug("Scheduling cold share-partition snapshotting.");
         timer.add(new TimerTask(config.shareCoordinatorColdPartitionSnapshotIntervalMs()) {
             @Override
             public void run() {
-                if (!shouldRunPeriodicJob) {
+                if (!shouldRunPeriodicJob(generation)) {
                     return;
                 }
                 List<CompletableFuture<Void>> futures = runtime.scheduleWriteAllOperation(
@@ -432,7 +446,10 @@ public class ShareCoordinatorService implements ShareCoordinator {
                         if (exp != null) {
                             log.error("Received error while snapshotting cold partitions.", exp);
                         }
-                        setupSnapshotColdPartitions();
+                        if (!shouldRunPeriodicJob(generation)) {
+                            return;
+                        }
+                        setupSnapshotColdPartitions(generation);
                     });
             }
         });
@@ -1137,8 +1154,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
         // 1            1               no op on flag, do not call jobs
         if (enabled ^ shouldRunPeriodicJob) {
             shouldRunPeriodicJob = enabled;
+            long generation = periodicJobGeneration.incrementAndGet();
             if (enabled) {
-                setupPeriodicJobs();
+                setupPeriodicJobs(generation);
             }
         }
     }
@@ -1181,5 +1199,9 @@ public class ShareCoordinatorService implements ShareCoordinator {
     // Visibility for tests
     boolean shouldRunPeriodicJob() {
         return shouldRunPeriodicJob;
+    }
+
+    private boolean shouldRunPeriodicJob(long generation) {
+        return shouldRunPeriodicJob && periodicJobGeneration.get() == generation;
     }
 }

--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorService.java
@@ -1147,12 +1147,10 @@ public class ShareCoordinatorService implements ShareCoordinator {
         }
 
         boolean enabled = isShareGroupsEnabled(newImage);
-        // enabled    periodicJobsEnabled result (XOR)
-        // 0            0               no op on flag, do not call jobs
-        // 0            1               disable flag, do not call jobs                      => action
-        // 1            0               enable flag, call jobs as they are not recursing    => action
-        // 1            1               no op on flag, do not call jobs
-        if (enabled ^ periodicJobsEnabled) {
+        // Only act when the enabled state actually changes. Each change bumps the
+        // generation, which fences any jobs from the previous generation so they
+        // stop rescheduling. A fresh set of jobs is started only when enabling.
+        if (enabled != periodicJobsEnabled) {
             periodicJobsEnabled = enabled;
             long generation = periodicJobGeneration.incrementAndGet();
             if (enabled) {

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -71,7 +71,6 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.kafka.coordinator.common.runtime.TestUtil.requestContext;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -2002,8 +2001,6 @@ class ShareCoordinatorServiceTest {
             any()
         )).thenReturn(List.of());
 
-        assertFalse(service.shouldRunPeriodicJob());
-
         service.startup(() -> 1);
 
         MetadataImage mockedImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
@@ -2022,8 +2019,6 @@ class ShareCoordinatorServiceTest {
             eq("snapshot-cold-partitions"),
             any()
         );
-        assertFalse(service.shouldRunPeriodicJob());
-
         // Enable feature.
         Mockito.reset(mockedImage);
         when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 1);
@@ -2040,8 +2035,6 @@ class ShareCoordinatorServiceTest {
             eq("snapshot-cold-partitions"),
             any()
         );
-        assertTrue(service.shouldRunPeriodicJob());
-
         // Disable feature
         Mockito.reset(mockedImage);
         when(mockedImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
@@ -2058,8 +2051,6 @@ class ShareCoordinatorServiceTest {
             eq("snapshot-cold-partitions"),
             any()
         );
-        assertFalse(service.shouldRunPeriodicJob());
-
         timer.advanceClock(30001L);
         verify(timer, times(4)).add(any()); // No new additions.
 
@@ -2126,10 +2117,8 @@ class ShareCoordinatorServiceTest {
         );
 
         service.onMetadataUpdate(mock(MetadataDelta.class), disabledImage);
-        assertFalse(service.shouldRunPeriodicJob());
 
         service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
-        assertTrue(service.shouldRunPeriodicJob());
         verify(timer, times(4)).add(any());
 
         firstPruneFuture.complete(Optional.empty());

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -2067,6 +2067,82 @@ class ShareCoordinatorServiceTest {
     }
 
     @Test
+    public void testPeriodicJobsDoNotDuplicateAfterDisableEnableWithInFlightJobs() throws InterruptedException {
+        CoordinatorRuntime<ShareCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
+        PartitionWriter writer = mock(PartitionWriter.class);
+        MockTime time = new MockTime();
+        MockTimer timer = spy(new MockTimer(time));
+
+        Metrics metrics = new Metrics();
+
+        ShareCoordinatorService service = spy(new ShareCoordinatorService(
+            new LogContext(),
+            ShareCoordinatorTestConfig.testConfig(),
+            runtime,
+            new ShareCoordinatorMetrics(metrics),
+            time,
+            timer,
+            writer
+        ));
+
+        CompletableFuture<Optional<Long>> firstPruneFuture = new CompletableFuture<>();
+        CompletableFuture<Optional<Long>> secondPruneFuture = new CompletableFuture<>();
+        CompletableFuture<Void> firstSnapshotFuture = new CompletableFuture<>();
+        CompletableFuture<Void> secondSnapshotFuture = new CompletableFuture<>();
+
+        when(runtime.<Optional<Long>>scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any()
+        ))
+            .thenReturn(firstPruneFuture)
+            .thenReturn(secondPruneFuture);
+
+        when(runtime.<Void>scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any()
+        ))
+            .thenReturn(List.of(firstSnapshotFuture))
+            .thenReturn(List.of(secondSnapshotFuture));
+
+        service.startup(() -> 1);
+
+        MetadataImage disabledImage = mock(MetadataImage.class, RETURNS_DEEP_STUBS);
+        when(disabledImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
+
+        MetadataImage enabledImage = mockMetadataImageWithShareGroupsEnabled();
+        service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
+
+        verify(timer, times(2)).add(any());
+        timer.advanceClock(30001L);
+        verify(runtime, times(1)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any()
+        );
+        verify(runtime, times(1)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any()
+        );
+
+        service.onMetadataUpdate(mock(MetadataDelta.class), disabledImage);
+        assertFalse(service.shouldRunPeriodicJob());
+
+        service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
+        assertTrue(service.shouldRunPeriodicJob());
+        verify(timer, times(4)).add(any());
+
+        firstPruneFuture.complete(Optional.empty());
+        firstSnapshotFuture.complete(null);
+
+        verify(timer, times(4)).add(any());
+
+        checkMetrics(metrics);
+
+        service.shutdown();
+    }
+
+    @Test
     public void testShareStateTopicConfigs() {
         CoordinatorRuntime<ShareCoordinatorShard, CoordinatorRecord> runtime = mockRuntime();
         MockTime time = new MockTime();

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorServiceTest.java
@@ -2102,9 +2102,12 @@ class ShareCoordinatorServiceTest {
         when(disabledImage.features().finalizedVersions().getOrDefault(eq(ShareVersion.FEATURE_NAME), anyShort())).thenReturn((short) 0);
 
         MetadataImage enabledImage = mockMetadataImageWithShareGroupsEnabled();
-        service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
 
+        // Enable the feature: schedules the prune and snapshot jobs (generation 1).
+        service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
         verify(timer, times(2)).add(any());
+
+        // Fire both jobs. Their futures stay pending, so they are still in flight.
         timer.advanceClock(30001L);
         verify(runtime, times(1)).scheduleWriteOperation(
             eq("write-state-record-prune"),
@@ -2116,15 +2119,38 @@ class ShareCoordinatorServiceTest {
             any()
         );
 
+        // Disable then re-enable while the generation 1 jobs are still in flight.
+        // Re-enabling bumps the generation and schedules a fresh pair of jobs.
         service.onMetadataUpdate(mock(MetadataDelta.class), disabledImage);
-
         service.onMetadataUpdate(mock(MetadataDelta.class), enabledImage);
         verify(timer, times(4)).add(any());
 
+        // The stale generation 1 jobs now complete. They are fenced, so they must
+        // not reschedule themselves: the timer count stays at 4.
         firstPruneFuture.complete(Optional.empty());
         firstSnapshotFuture.complete(null);
-
         verify(timer, times(4)).add(any());
+
+        // Fire the current generation jobs. This is their second run overall
+        // (hence times(2)), and their futures are again left in flight.
+        timer.advanceClock(30001L);
+        verify(runtime, times(2)).scheduleWriteOperation(
+            eq("write-state-record-prune"),
+            any(),
+            any()
+        );
+        verify(runtime, times(2)).scheduleWriteAllOperation(
+            eq("snapshot-cold-partitions"),
+            any()
+        );
+
+        // Completing each current generation job reschedules itself, so the timer
+        // count grows one at a time: 4 -> 5 (prune) -> 6 (snapshot).
+        secondPruneFuture.complete(Optional.empty());
+        verify(timer, times(5)).add(any());
+
+        secondSnapshotFuture.complete(null);
+        verify(timer, times(6)).add(any());
 
         checkMetrics(metrics);
 


### PR DESCRIPTION
Ref https://issues.apache.org/jira/browse/KAFKA-20710

`ShareCoordinatorService` with a periodic-job generation guard so stale
timer tasks and stale async   completions cannot reschedule after
disable/re-enable.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Sushant Mahajan
 <smahajan@confluent.io>
