### PR TITLE
KAFKA-20009: Add short descriptions to documentation sections

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: AK 4.3.X
-description: Documentation for AK 4.3.X
+description: Apache Kafka documentation for version 4.3.x.
 weight: 
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/apis/_index.md
+++ b/docs/apis/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: 
+description: An overview of the core Kafka APIs for client applications, stream processing, Connect integrations, and cluster administration.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: 
+description: Kafka configuration reference for clusters, clients, and supporting components.
 weight: 3
 tags: ['kafka', 'docs', 'configuration']
 aliases: 

--- a/docs/configuration/admin-configs.md
+++ b/docs/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: Kafka Admin client configuration reference.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/broker-configs.md
+++ b/docs/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: Kafka broker configuration reference.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/configuration-providers.md
+++ b/docs/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: Kafka configuration providers for loading configuration values from external sources.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/consumer-configs.md
+++ b/docs/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer and Share Consumer Configs
-description: Consumer and Share Consumer Configs
+description: Kafka consumer and share consumer configuration reference.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/group-configs.md
+++ b/docs/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: Kafka group configuration reference for consumer, share, and streams groups.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/kafka-connect-configs.md
+++ b/docs/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: Kafka Connect configuration reference.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/kafka-streams-configs.md
+++ b/docs/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: Kafka Streams configuration reference.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/mirrormaker-configs.md
+++ b/docs/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: Kafka MirrorMaker configuration reference.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/producer-configs.md
+++ b/docs/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: Kafka producer configuration reference.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/system-properties.md
+++ b/docs/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: Java system properties used to configure Kafka components.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/tiered-storage-configs.md
+++ b/docs/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: Kafka tiered storage configuration reference.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/configuration/topic-configs.md
+++ b/docs/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: Kafka topic configuration reference.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture, design principles, and wire protocol.
 weight: 4
 tags: ['kafka', 'docs', 'design']
 aliases: 

--- a/docs/design/design.md
+++ b/docs/design/design.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture design and the principles behind its core features.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/design/protocol.md
+++ b/docs/design/protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Protocol
-description: 
+description: Kafka communication protocol, request formats, API versions, and client implementation details.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: This section provides an overview of what Kafka is, why it is useful, and how to get started using it.
+description: Start here to learn Kafka fundamentals and common use cases, try a local setup, and find Docker, upgrade, and compatibility guidance.
 weight: 1
 tags: ['kafka', 'docs', 'getting-started']
 aliases: 

--- a/docs/getting-started/compatibility.md
+++ b/docs/getting-started/compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Compatibility
-description: 
+description: Check Java, server, and client/broker compatibility matrices for planning Kafka upgrades.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: 
+description: Learn how to pull and run the Kafka JVM Docker image and the experimental native Docker image.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/ecosystem.md
+++ b/docs/getting-started/ecosystem.md
@@ -1,6 +1,6 @@
 ---
 title: Ecosystem
-description: 
+description: Discover tools and integrations that extend Kafka beyond the main distribution.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what event streaming is, how Kafka works, and the core Kafka concepts and APIs.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Run Kafka locally, create a topic, produce and consume events, and explore Kafka Connect and Kafka Streams.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-description: 
+description: Find upgrade steps for Kafka clusters and clients, along with compatibility requirements and notable changes across releases.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/uses.md
+++ b/docs/getting-started/uses.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: 
+description: Explore common Kafka use cases for messaging, activity tracking, stream processing, and storing event data.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/getting-started/zk2kraft.md
+++ b/docs/getting-started/zk2kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft vs ZooKeeper
-description: 
+description: Understand how KRaft mode differs from ZooKeeper mode, including removed features, metric changes, and behavioral changes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/implementation/_index.md
+++ b/docs/implementation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation
-description: 
+description: Kafka implementation internals for data storage, records, networking, and offset tracking.
 weight: 5
 tags: ['kafka', 'docs', 'implementation']
 aliases: 

--- a/docs/implementation/distribution.md
+++ b/docs/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: Kafka consumer offset tracking via the group coordinator.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/implementation/log.md
+++ b/docs/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: Kafka log storage format and segment management.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/implementation/message-format.md
+++ b/docs/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: The on-disk binary formats for Kafka record batches and records.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/implementation/messages.md
+++ b/docs/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: Kafka message structure, including headers and opaque key/value payloads.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/implementation/network-layer.md
+++ b/docs/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: Kafka NIO-based network layer implementation.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/kafka-connect/_index.md
+++ b/docs/kafka-connect/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect
-description: 
+description: Kafka Connect documentation for integrating Kafka with external systems.
 weight: 8
 tags: ['kafka', 'docs', 'connect']
 aliases: 

--- a/docs/kafka-connect/administration.md
+++ b/docs/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: Kafka Connect administration with REST APIs, connector and task states, and rebalancing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/kafka-connect/connector-development-guide.md
+++ b/docs/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: Guide to building Kafka Connect source and sink connectors.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/kafka-connect/overview.md
+++ b/docs/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: Scalable, reliable data integration between Kafka and external systems.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: Guide to running, configuring, and managing Kafka Connect workers and connectors.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/_index.md
+++ b/docs/operations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations
-description: 
+description: Operational guidance for running, monitoring, and managing Kafka clusters.
 weight: 6
 tags: ['kafka', 'docs', 'ops']
 aliases: 

--- a/docs/operations/basic-kafka-operations.md
+++ b/docs/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: Common Kafka cluster administration tasks and command-line tools.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/consumer-rebalance-protocol.md
+++ b/docs/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: Kafka consumer rebalance protocol behavior, migration paths, and limitations.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/datacenters.md
+++ b/docs/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: Kafka deployment patterns for multiple datacenters.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/eligible-leader-replicas.md
+++ b/docs/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: Kafka Eligible Leader Replicas behavior, upgrades, and tooling.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/docs/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: Kafka geo-replication and cross-cluster data mirroring with MirrorMaker.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/hardware-and-os.md
+++ b/docs/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: Kafka hardware, operating system, disk, and filesystem recommendations.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/java-version.md
+++ b/docs/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: Java version support and runtime recommendations for Kafka.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/kraft.md
+++ b/docs/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: Kafka KRaft configuration, upgrades, provisioning, and quorum management.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: Kafka metrics and JMX monitoring for brokers, clients, and components.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/multi-tenancy.md
+++ b/docs/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: Kafka multi-tenant cluster planning and operational practices.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/tiered-storage.md
+++ b/docs/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: Kafka tiered storage configuration, quick start, and operational limits.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/operations/transaction-protocol.md
+++ b/docs/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: Kafka transaction protocol overview, version upgrades and downgrades, and performance characteristics.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/_index.md
+++ b/docs/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: 
+description: Kafka security configuration for authentication, encryption, and authorization.
 weight: 7
 tags: ['kafka', 'docs', 'security']
 aliases: 

--- a/docs/security/authentication-using-sasl.md
+++ b/docs/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: Kafka SASL authentication configuration for brokers and clients.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/authorization-and-acls.md
+++ b/docs/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: Kafka authorization model and ACL management.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/encryption-and-authentication-using-ssl.md
+++ b/docs/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: Kafka SSL setup for broker and client encryption and authentication.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/incorporating-security-features-in-a-running-cluster.md
+++ b/docs/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: Phased rollout of security features in a running Kafka cluster.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/listener-configuration.md
+++ b/docs/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: Kafka listener configuration for client, inter-broker, and controller communication.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/security/security-overview.md
+++ b/docs/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: Supported security protocols and features available in Kafka.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/_index.md
+++ b/docs/streams/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams
-description: 
+description: Kafka Streams documentation for building and operating stream processing applications.
 weight: 9
 tags: ['kafka', 'docs', 'streams']
 aliases: 

--- a/docs/streams/architecture.md
+++ b/docs/streams/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: 
+description: Kafka Streams architecture for tasks, threading, state, and fault tolerance.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/core-concepts.md
+++ b/docs/streams/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: 
+description: Core Kafka Streams concepts, including topologies, time, state, windowing, and processing guarantees.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/_index.md
+++ b/docs/streams/developer-guide/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Developer Guide
-description: 
+description: Developer guide for building, configuring, testing, and running Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs', 'streams', 'developer-guide']
 aliases: 

--- a/docs/streams/developer-guide/app-reset-tool.md
+++ b/docs/streams/developer-guide/app-reset-tool.md
@@ -1,6 +1,6 @@
 ---
 title: Application Reset Tool
-description: 
+description: Kafka Streams application reset tool usage and limitations.
 weight: 13
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/config-streams.md
+++ b/docs/streams/developer-guide/config-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring a Streams Application
-description: 
+description: Kafka Streams application configuration options and runtime settings.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/datatypes.md
+++ b/docs/streams/developer-guide/datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: Data Types and Serialization
-description: 
+description: Kafka Streams data types, serialization, and SerDes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/dsl-api.md
+++ b/docs/streams/developer-guide/dsl-api.md
@@ -1,6 +1,6 @@
 ---
 title: Streams DSL
-description: 
+description: Kafka Streams DSL API for defining stream processing logic.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/dsl-topology-naming.md
+++ b/docs/streams/developer-guide/dsl-topology-naming.md
@@ -1,6 +1,6 @@
 ---
 title: Naming Operators in a Streams DSL application
-description: 
+description: Kafka Streams DSL operator naming for stable topology upgrades.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive Queries
-description: 
+description: Kafka Streams interactive queries for local and remote state stores.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/kafka-streams-group-sh.md
+++ b/docs/streams/developer-guide/kafka-streams-group-sh.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka Streams Groups Tool
 type: docs
-description: 
+description: Kafka Streams groups tool for inspecting and managing streams groups.
 weight: 15
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/manage-topics.md
+++ b/docs/streams/developer-guide/manage-topics.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Streams Application Topics
-description: 
+description: Kafka Streams user and internal topic management and configuration.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/memory-mgmt.md
+++ b/docs/streams/developer-guide/memory-mgmt.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Management
-description: 
+description: Kafka Streams memory management for caches, state stores, and record buffers.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/processor-api.md
+++ b/docs/streams/developer-guide/processor-api.md
@@ -1,6 +1,6 @@
 ---
 title: Processor API
-description: 
+description: Kafka Streams Processor API for low-level stream processing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/running-app.md
+++ b/docs/streams/developer-guide/running-app.md
@@ -1,6 +1,6 @@
 ---
 title: Running Streams Applications
-description: 
+description: Guide to running and scaling Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/scala-migration.md
+++ b/docs/streams/developer-guide/scala-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from Streams Scala to Java API
-description:
+description: Migration guidance from the Kafka Streams Scala API to the Java API.
 weight: 16
 tags: ['kafka', 'docs']
 aliases:

--- a/docs/streams/developer-guide/security.md
+++ b/docs/streams/developer-guide/security.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Security
-description: 
+description: Security configuration and required ACLs for Kafka Streams applications.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/streams-rebalance-protocol.md
+++ b/docs/streams/developer-guide/streams-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Rebalance Protocol
-description:
+description: Kafka Streams rebalance protocol behavior, migration paths, and limitations.
 weight: 14
 tags: ['kafka', 'docs']
 aliases:

--- a/docs/streams/developer-guide/testing.md
+++ b/docs/streams/developer-guide/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing a Streams Application
-description: 
+description: Guide to testing Kafka Streams applications.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/developer-guide/write-streams-app.md
+++ b/docs/streams/developer-guide/write-streams-app.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Streams Application
-description: 
+description: Guide to writing Kafka Streams applications with the DSL and Processor API.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/introduction.md
+++ b/docs/streams/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what Kafka Streams is and how to build stream processing applications with it.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/quickstart.md
+++ b/docs/streams/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Quick start for running the Kafka Streams demo application.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/tutorial.md
+++ b/docs/streams/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Write a streams app
-description: 
+description: Build your first Kafka Streams application step by step.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/docs/streams/upgrade-guide.md
+++ b/docs/streams/upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Guide
-description: 
+description: Kafka Streams upgrade guidance and compatibility notes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 


### PR DESCRIPTION
Adds short descriptions under section titles on documentation pages.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
