### PR TITLE
MINOR: Add LICENSE and NOTICE to site-docs tar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1308,6 +1308,8 @@ project(':core') {
     archiveClassifier = 'site-docs'
     compression = Compression.GZIP
     from project.file("$rootDir/docs")
+    from "$rootDir/LICENSE"
+    from "$rootDir/NOTICE"
     into 'site-docs'
     duplicatesStrategy 'exclude'
   }


### PR DESCRIPTION
Title says it all

validated by
```
./gradlew -q clean siteDocsTar && tar tzf
core/build/distributions/*site-docs.tgz | grep -E
'site-docs/(LICENSE|NOTICE)$'
site-docs/LICENSE
site-docs/NOTICE
```

Reviewers: Matthias J. Sax <matthias@confluent.io>
