### PR TITLE
KAFKA-20116: Make task-end-offset-sum available to client background thread (2/N)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceData.java
@@ -341,6 +341,8 @@ public class StreamsRebalanceData {
 
     private final Supplier<Map<TaskId, Long>> taskOffsetSum;
 
+    private final Supplier<Map<TaskId, Long>> taskEndOffsetSum;
+
     private final AtomicReference<Assignment> reconciledAssignment = new AtomicReference<>(Assignment.EMPTY);
 
     private final AtomicReference<Map<HostInfo, EndpointPartitions>> partitionsByHost = new AtomicReference<>(Collections.emptyMap());
@@ -364,13 +366,15 @@ public class StreamsRebalanceData {
                                 final Optional<String> rackId,
                                 final Map<String, Subtopology> subtopologies,
                                 final Map<String, String> clientTags,
-                                final Supplier<Map<TaskId, Long>> taskOffsetSum) {
+                                final Supplier<Map<TaskId, Long>> taskOffsetSum,
+                                final Supplier<Map<TaskId, Long>> taskEndOffsetSum) {
         this.processId = Objects.requireNonNull(processId, "Process ID cannot be null");
         this.endpoint = Objects.requireNonNull(endpoint, "Endpoint cannot be null");
         this.rackId = Objects.requireNonNull(rackId, "Rack ID cannot be null");
         this.subtopologies = Map.copyOf(Objects.requireNonNull(subtopologies, "Subtopologies cannot be null"));
         this.clientTags = Map.copyOf(Objects.requireNonNull(clientTags, "Client tags cannot be null"));
         this.taskOffsetSum = Objects.requireNonNull(taskOffsetSum, "Task offset sum supplier cannot be null");
+        this.taskEndOffsetSum = Objects.requireNonNull(taskEndOffsetSum, "Task end offset sum supplier cannot be null");
     }
 
     public UUID processId() {
@@ -395,6 +399,10 @@ public class StreamsRebalanceData {
 
     public Map<TaskId, Long> taskOffsetSum() {
         return taskOffsetSum.get();
+    }
+
+    public Map<TaskId, Long> taskEndOffsetSum() {
+        return taskEndOffsetSum.get();
     }
 
     public int topologyEpoch() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -1664,7 +1664,7 @@ public class AsyncKafkaConsumerTest {
     public void testStreamRebalanceData() {
         final String groupId = "consumerGroupA";
         try (final MockedStatic<RequestManagers> requestManagers = mockStatic(RequestManagers.class)) {
-            StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+            StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
             consumer = newConsumerWithStreamRebalanceData(requiredConsumerConfigAndGroupId(groupId), streamsRebalanceData);
             final Optional<StreamsRebalanceData> groupMetadataUpdateListener = captureStreamRebalanceData(requestManagers);
             assertTrue(groupMetadataUpdateListener.isPresent());
@@ -2588,7 +2588,7 @@ public class AsyncKafkaConsumerTest {
     @Test
     public void testCloseInvokesStreamsRebalanceListenerOnTasksRevokedWhenMemberEpochPositive() {
         final String groupId = "streamsGroup";
-        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         
         try (final MockedStatic<RequestManagers> requestManagers = mockStatic(RequestManagers.class)) {
             consumer = newConsumerWithStreamRebalanceData(requiredConsumerConfigAndGroupId(groupId), streamsRebalanceData);
@@ -2608,7 +2608,7 @@ public class AsyncKafkaConsumerTest {
     @Test
     public void testCloseInvokesStreamsRebalanceListenerOnAllTasksLostWhenMemberEpochZeroOrNegative() {
         final String groupId = "streamsGroup";
-        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         
         try (final MockedStatic<RequestManagers> requestManagers = mockStatic(RequestManagers.class)) {
             consumer = newConsumerWithStreamRebalanceData(requiredConsumerConfigAndGroupId(groupId), streamsRebalanceData);
@@ -2628,7 +2628,7 @@ public class AsyncKafkaConsumerTest {
     @Test
     public void testCloseWrapsStreamsRebalanceListenerException() {
         final String groupId = "streamsGroup";
-        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+        final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         
         try (final MockedStatic<RequestManagers> requestManagers = mockStatic(RequestManagers.class)) {
             consumer = newConsumerWithStreamRebalanceData(requiredConsumerConfigAndGroupId(groupId), streamsRebalanceData);
@@ -2693,7 +2693,7 @@ public class AsyncKafkaConsumerTest {
     @Test
     public void testStreamsTasksAssignedEventSendsErrorWhenApplyAssignmentFails() {
         final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(
-            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         final InterruptException applyAssignmentError = new InterruptException("Thread was interrupted");
 
         consumer = newConsumerWithStreamRebalanceData(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestManagersTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestManagersTest.java
@@ -117,7 +117,7 @@ public class RequestManagersTest {
             new Metrics(),
             mock(OffsetCommitCallbackInvoker.class),
             listener,
-            Optional.of(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of)),
+            Optional.of(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of)),
             new PositionsValidator(logContext, time, subscriptions, metadata)
         ).get();
         assertTrue(requestManagers.streamsMembershipManager.isPresent());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -167,6 +167,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
         Optional.of(RACK_ID),
         SUBTOPOLOGIES,
         CLIENT_TAGS,
+        Map::of,
         Map::of
     );
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceDataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceDataTest.java
@@ -303,6 +303,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -336,6 +337,7 @@ public class StreamsRebalanceDataTest {
                 Optional.empty(),
                 subtopologies,
                 clientTags,
+                Map::of,
                 Map::of
             )
         );
@@ -356,6 +358,7 @@ public class StreamsRebalanceDataTest {
                 Optional.empty(),
                 subtopologies,
                 clientTags,
+                Map::of,
                 Map::of
             )
         );
@@ -376,6 +379,7 @@ public class StreamsRebalanceDataTest {
                 Optional.empty(),
                 null,
                 clientTags,
+                Map::of,
                 Map::of
             )
         );
@@ -397,6 +401,7 @@ public class StreamsRebalanceDataTest {
                 null,
                 subtopologies,
                 clientTags,
+                Map::of,
                 Map::of
             )
         );
@@ -417,6 +422,7 @@ public class StreamsRebalanceDataTest {
                 Optional.empty(),
                 subtopologies,
                 null,
+                Map::of,
                 Map::of
             )
         );
@@ -435,6 +441,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -453,6 +460,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -471,6 +479,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -489,6 +498,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -509,6 +519,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 
@@ -529,6 +540,7 @@ public class StreamsRebalanceDataTest {
             Optional.empty(),
             subtopologies,
             clientTags,
+            Map::of,
             Map::of
         );
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceDataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsRebalanceDataTest.java
@@ -551,12 +551,13 @@ public class StreamsRebalanceDataTest {
     @Test
     public void streamsRebalanceDataShouldDefaultAndUpdateTopologyPushFields() {
         final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(
-                UUID.randomUUID(),
-                Optional.of(new StreamsRebalanceData.HostInfo("localhost", 9090)),
-                Optional.empty(),
-                Map.of(),
-                Map.of("clientTag1", "clientTagValue1"),
-                Map::of
+            UUID.randomUUID(),
+            Optional.of(new StreamsRebalanceData.HostInfo("localhost", 9090)),
+            Optional.empty(),
+            Map.of(),
+            Map.of("clientTag1", "clientTagValue1"),
+            Map::of,
+            Map::of
         );
 
         assertNull(streamsRebalanceData.wireTopologyDescription());

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -3947,6 +3947,7 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
           util.Set.of()
         )),
       Map.empty[String, String].asJava,
+      () => util.Map.of[StreamsRebalanceData.TaskId, java.lang.Long](),
       () => util.Map.of[StreamsRebalanceData.TaskId, java.lang.Long]()
     ))
     consumer.subscribe(

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -267,6 +267,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
           util.Set.of()
         )),
       Map.empty[String, String].asJava,
+      () => util.Map.of[StreamsRebalanceData.TaskId, java.lang.Long](),
       () => util.Map.of[StreamsRebalanceData.TaskId, java.lang.Long]()
     )
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -55,6 +55,11 @@ public interface ChangelogReader extends ChangelogRegister {
     Set<TopicPartition> completedChangelogs();
 
     /**
+     * @return the logical changelog partitions end-offsets
+     */
+    Map<TopicPartition, Long> logicalChangelogEndOffsets();
+
+    /**
      * Returns whether all changelog partitions were completely read.
      *
      * Since changelog partitions for standby tasks are never completely read, this method will always return

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -481,7 +481,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 );
             }
 
-            taskEndOffsetSumSnapshot.set(endOffsetSnapshot);
+            taskEndOffsetSumSnapshot.set(Collections.unmodifiableMap(endOffsetSnapshot));
         }
 
         private void waitIfAllChangelogsCompletelyRead() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -451,7 +451,13 @@ public class DefaultStateUpdater implements StateUpdater {
         // end-offsets are not tracked there, so the end-offset-sum is computed here from the changelog reader's
         // (logical) end-offsets for the tasks the state updater is currently restoring/updating.
         private void updateTaskEndOffsetSumSnapshot() {
-            final Map<TopicPartition, Long> changelogEndOffsets = changelogReader.logicalChangelogEndOffsets();
+            final Map<TopicPartition, Long> changelogEndOffsets;
+            if (!updatingTasks.isEmpty()) {
+                changelogEndOffsets = changelogReader.logicalChangelogEndOffsets();
+            } else {
+                changelogEndOffsets = Collections.emptyMap();
+            }
+
             final Map<StreamsRebalanceData.TaskId, Long> endOffsetSnapshot = new HashMap<>(updatingTasks.size());
 
             for (final Task task : updatingTasks.values()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.internals.StreamsRebalanceData;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -48,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -62,6 +64,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -202,6 +205,8 @@ public class DefaultStateUpdater implements StateUpdater {
 
             final long checkpointStartTimeMs = time.milliseconds();
             maybeCheckpointTasks(checkpointStartTimeMs);
+
+            updateTaskEndOffsetSumSnapshot();
 
             final long waitStartTimeMs = time.milliseconds();
             waitIfAllChangelogsCompletelyRead();
@@ -440,6 +445,37 @@ public class DefaultStateUpdater implements StateUpdater {
             } finally {
                 exceptionsAndFailedTasksLock.unlock();
             }
+        }
+
+        // Current offset sums are sourced from the StateDirectory (see TaskManager#maybeUpdateTaskOffsetSumSnapshot);
+        // end-offsets are not tracked there, so the end-offset-sum is computed here from the changelog reader's
+        // (logical) end-offsets for the tasks the state updater is currently restoring/updating.
+        private void updateTaskEndOffsetSumSnapshot() {
+            final Map<TopicPartition, Long> changelogEndOffsets = changelogReader.logicalChangelogEndOffsets();
+            final Map<StreamsRebalanceData.TaskId, Long> endOffsetSnapshot = new HashMap<>(updatingTasks.size());
+
+            for (final Task task : updatingTasks.values()) {
+                long endSum = 0L; // ok to init with zero, as we have at least one changelog topic partition
+                for (final TopicPartition partition : task.changelogPartitions()) {
+                    final Long endOffset = changelogEndOffsets.get(partition);
+                    if (endOffset == null) {
+                        endSum = Long.MAX_VALUE;
+                        break;
+                    }
+                    if (endSum > Long.MAX_VALUE - endOffset) {
+                        endSum = Long.MAX_VALUE;
+                        break;
+                    }
+                    endSum += endOffset;
+                }
+
+                endOffsetSnapshot.put(
+                    new StreamsRebalanceData.TaskId(String.valueOf(task.id().subtopology()), task.id().partition()),
+                    endSum
+                );
+            }
+
+            taskEndOffsetSumSnapshot.set(endOffsetSnapshot);
         }
 
         private void waitIfAllChangelogsCompletelyRead() {
@@ -818,6 +854,8 @@ public class DefaultStateUpdater implements StateUpdater {
     private final long commitIntervalMs;
     private long lastCommitMs;
 
+    private final AtomicReference<Map<StreamsRebalanceData.TaskId, Long>> taskEndOffsetSumSnapshot = new AtomicReference<>(Map.of());
+
     private StateUpdaterThread stateUpdaterThread = null;
 
     public DefaultStateUpdater(final String name,
@@ -1052,6 +1090,11 @@ public class DefaultStateUpdater implements StateUpdater {
     @Override
     public KafkaFutureImpl<Uuid> restoreConsumerInstanceId(final Duration timeout) {
         return stateUpdaterThread.restoreConsumerInstanceId(timeout);
+    }
+
+    @Override
+    public Map<StreamsRebalanceData.TaskId, Long> taskEndOffsetSumSnapshot() {
+        return taskEndOffsetSumSnapshot.get();
     }
 
     public boolean isRunning() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.internals.StreamsRebalanceData;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.processor.StandbyUpdateListener;
@@ -23,6 +24,7 @@ import org.apache.kafka.streams.processor.TaskId;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -246,4 +248,10 @@ public interface StateUpdater {
      * Get the restore consumer instance id for telemetry, and complete the given future to return it.
      */
     KafkaFutureImpl<Uuid> restoreConsumerInstanceId(final Duration timeout);
+
+    /**
+     * Returns the latest per-task changelog end-offset-sum snapshot for tasks currently
+     * being restored. Safe to invoke from any thread.
+     */
+    Map<StreamsRebalanceData.TaskId, Long> taskEndOffsetSumSnapshot();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -432,6 +432,23 @@ public class StoreChangelogReader implements ChangelogReader {
             .collect(Collectors.toSet());
     }
 
+    // report a conservative value (higher as real value) as fallback
+    // only "source topic optimized" changelogs have a logical offset from `ChangelogMetadata` (the committed offset on the source topic)
+    // -> if not known (not set yet, or no "source topic optimization"), fall back to physical endOffset
+    @Override
+    public Map<TopicPartition, Long> logicalChangelogEndOffsets() {
+        final Map<TopicPartition, Long> endOffsets = new HashMap<>(changelogs.size());
+        for (final Map.Entry<TopicPartition, ChangelogMetadata> entry : changelogs.entrySet()) {
+            final ChangelogMetadata metadata = entry.getValue();
+            Long endOffset = metadata.restoreEndOffset;
+            if (endOffset == null) {
+                endOffset = metadata.storeMetadata.endOffset();
+            }
+            endOffsets.put(entry.getKey(), endOffset);
+        }
+        return endOffsets;
+    }
+
     // 1. if there are any registered changelogs that needs initialization, try to initialize them first;
     // 2. if all changelogs have finished, return early;
     // 3. if there are any restoring changelogs, try to read from the restore consumer and process them.
@@ -652,6 +669,7 @@ public class StoreChangelogReader implements ChangelogReader {
         if (numRecords != 0) {
             final List<ConsumerRecord<byte[], byte[]>> records = changelogMetadata.bufferedRecords.subList(0, numRecords);
             final OptionalLong optionalLag = restoreConsumer.currentLag(partition);
+            maybeRefreshNonSourceStandbyEndOffset(changelogMetadata, partition, optionalLag);
             stateManager.restore(storeMetadata, records, optionalLag);
 
             // NOTE here we use removeRange of ArrayList in order to achieve efficiency with range shifting,
@@ -711,6 +729,21 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         return numRecords;
+    }
+
+    // For non-source-topic standby changelogs, the reader never populates restoreEndOffset
+    // through initializeChangelogs / maybeUpdateLimitOffsetsForStandbyChangelogs. Refresh it
+    // here from data we already have on hand (the consumer's cached Fetch high-water-mark),
+    // so taskEndOffsetSumSnapshot can report the changelog's log-end-offset for warm-up lag
+    // without issuing a new RPC.
+    private void maybeRefreshNonSourceStandbyEndOffset(final ChangelogMetadata changelogMetadata,
+                                                       final TopicPartition partition,
+                                                       final OptionalLong optionalLag) {
+        if (optionalLag.isPresent()
+                && changelogMetadata.stateManager.taskType() == TaskType.STANDBY
+                && !changelogMetadata.stateManager.changelogAsSource(partition)) {
+            changelogMetadata.restoreEndOffset = optionalLag.getAsLong() + restoreConsumer.position(partition);
+        }
     }
 
     private Set<Task> getTasksFromPartitions(final Map<TaskId, Task> tasks,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -432,9 +432,9 @@ public class StoreChangelogReader implements ChangelogReader {
             .collect(Collectors.toSet());
     }
 
-    // report a conservative value (higher as real value) as fallback
-    // only "source topic optimized" changelogs have a logical offset from `ChangelogMetadata` (the committed offset on the source topic)
-    // -> if not known (not set yet, or no "source topic optimization"), fall back to physical endOffset
+    // Report a conservative value (higher than the real value) as fallback.
+    // Only "source topic optimized" changelogs have a logical end offset from `ChangelogMetadata` (the committed offset on the source topic).
+    // If not known (not set yet, or no "source topic optimization"), fall back to physical end offset.
     @Override
     public Map<TopicPartition, Long> logicalChangelogEndOffsets() {
         final Map<TopicPartition, Long> endOffsets = new HashMap<>(changelogs.size());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -669,7 +669,6 @@ public class StoreChangelogReader implements ChangelogReader {
         if (numRecords != 0) {
             final List<ConsumerRecord<byte[], byte[]>> records = changelogMetadata.bufferedRecords.subList(0, numRecords);
             final OptionalLong optionalLag = restoreConsumer.currentLag(partition);
-            maybeRefreshNonSourceStandbyEndOffset(changelogMetadata, partition, optionalLag);
             stateManager.restore(storeMetadata, records, optionalLag);
 
             // NOTE here we use removeRange of ArrayList in order to achieve efficiency with range shifting,
@@ -729,21 +728,6 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         return numRecords;
-    }
-
-    // For non-source-topic standby changelogs, the reader never populates restoreEndOffset
-    // through initializeChangelogs / maybeUpdateLimitOffsetsForStandbyChangelogs. Refresh it
-    // here from data we already have on hand (the consumer's cached Fetch high-water-mark),
-    // so taskEndOffsetSumSnapshot can report the changelog's log-end-offset for warm-up lag
-    // without issuing a new RPC.
-    private void maybeRefreshNonSourceStandbyEndOffset(final ChangelogMetadata changelogMetadata,
-                                                       final TopicPartition partition,
-                                                       final OptionalLong optionalLag) {
-        if (optionalLag.isPresent()
-                && changelogMetadata.stateManager.taskType() == TaskType.STANDBY
-                && !changelogMetadata.stateManager.changelogAsSource(partition)) {
-            changelogMetadata.restoreEndOffset = optionalLag.getAsLong() + restoreConsumer.position(partition);
-        }
     }
 
     private Set<Task> getTasksFromPartitions(final Map<TaskId, Task> tasks,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -521,7 +521,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             clientSupplier,
             processId,
             consumerConfigs,
-            taskManager::taskOffsetSumSnapshot
+            taskManager::taskOffsetSumSnapshot,
+            taskManager::taskEndOffsetSumSnapshot
         );
 
         taskManager.setMainConsumer(mainConsumerSetup.mainConsumer);
@@ -565,7 +566,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                        final KafkaClientSupplier clientSupplier,
                                                        final UUID processId,
                                                        final Map<String, Object> consumerConfigs,
-                                                       final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskOffsetSum) {
+                                                       final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskOffsetSum,
+                                                       final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskEndOffsetSum) {
         if (config.getString(StreamsConfig.GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name)) {
             if (topologyMetadata.hasNamedTopologies()) {
                 throw new IllegalStateException("Named topologies and the STREAMS protocol cannot be used at the same time.");
@@ -577,7 +579,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                     parseHostInfo(config.getString(StreamsConfig.APPLICATION_SERVER_CONFIG)),
                     parseRackId((String) config.originals().get(CommonClientConfigs.CLIENT_RACK_CONFIG)),
                     topologyMetadata,
-                    taskOffsetSum
+                    taskOffsetSum,
+                    taskEndOffsetSum
                 )
             );
             final ByteArrayDeserializer keyDeserializer = new ByteArrayDeserializer();
@@ -702,7 +705,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                                  final Optional<StreamsRebalanceData.HostInfo> endpoint,
                                                                  final Optional<String> rackId,
                                                                  final TopologyMetadata topologyMetadata,
-                                                                 final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskOffsetSum) {
+                                                                 final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskOffsetSum,
+                                                                 final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskEndOffsetSum) {
         final InternalTopologyBuilder internalTopologyBuilder = topologyMetadata.lookupBuilderForNamedTopology(null);
 
         final Map<String, StreamsRebalanceData.Subtopology> subtopologies = initBrokerTopology(config, internalTopologyBuilder);
@@ -713,7 +717,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             rackId,
             subtopologies,
             config.getClientTags(),
-            taskOffsetSum
+            taskOffsetSum,
+            taskEndOffsetSum
         );
 
         if (config.getBoolean(StreamsConfig.TOPOLOGY_DESCRIPTION_PUSH_ENABLED_CONFIG)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1294,6 +1294,14 @@ public class TaskManager {
     }
 
     /**
+     * Returns the per-task changelog end-offset-sum snapshot published by the state updater.
+     * Safe to invoke from any thread.
+     */
+    public Map<StreamsRebalanceData.TaskId, Long> taskEndOffsetSumSnapshot() {
+        return stateUpdater.taskEndOffsetSumSnapshot();
+    }
+
+    /**
      * Compute the offset total summed across all stores in a task. Includes offset sum for any tasks we own the
      * lock for, which includes assigned and unassigned tasks we locked in {@link #tryToLockAllNonEmptyTaskDirectories()}.
      * Does not include stateless or non-logged tasks.

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.consumer.internals.StreamsRebalanceData;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
@@ -621,6 +622,95 @@ class DefaultStateUpdaterTest {
         final InOrder orderVerifier = inOrder(changelogReader, task1, task2);
         orderVerifier.verify(changelogReader, times(2)).enforceRestoreActive();
         orderVerifier.verify(changelogReader).transitToUpdateStandby();
+    }
+
+    @Test
+    public void shouldPublishEmptyTaskEndOffsetSumSnapshotBeforeStart() {
+        assertThat(stateUpdater.taskEndOffsetSumSnapshot(), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldPublishTaskEndOffsetSumSnapshotForRestoringTask() throws Exception {
+        final StreamTask task = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        when(task.changelogOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 42L));
+        when(changelogReader.logicalChangelogEndOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 100L));
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        when(changelogReader.restore(anyMap())).thenReturn(1L);
+        stateUpdater.add(task);
+        stateUpdater.start();
+
+        assertEndOffsetSnapshotEntry(TASK_0_0, 100L);
+    }
+
+    @Test
+    public void shouldReportMaxValueInEndOffsetSnapshotWhenAnyPartitionIsUnknown() throws Exception {
+        // Unknown end-offset for any partition saturates the task's end-offset-sum to MAX_VALUE.
+        // This biases reported lag upward — the conservative direction for warm-up promotion.
+        final StreamTask task = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_A_1)).inState(State.RESTORING).build();
+        when(task.changelogOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 7L, TOPIC_PARTITION_A_1, 8L));
+        when(changelogReader.logicalChangelogEndOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 100L));
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        when(changelogReader.restore(anyMap())).thenReturn(1L);
+        stateUpdater.add(task);
+        stateUpdater.start();
+
+        assertEndOffsetSnapshotEntry(TASK_0_0, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void shouldReportMaxValueInEndOffsetSnapshotOnOverflow() throws Exception {
+        final StreamTask task = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0, TOPIC_PARTITION_A_1)).inState(State.RESTORING).build();
+        when(task.changelogOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 1L, TOPIC_PARTITION_A_1, 2L));
+        when(changelogReader.logicalChangelogEndOffsets()).thenReturn(Map.of(
+            TOPIC_PARTITION_A_0, Long.MAX_VALUE - 1L,
+            TOPIC_PARTITION_A_1, 100L
+        ));
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        when(changelogReader.restore(anyMap())).thenReturn(1L);
+        stateUpdater.add(task);
+        stateUpdater.start();
+
+        assertEndOffsetSnapshotEntry(TASK_0_0, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void shouldPublishTaskEndOffsetSumSnapshotForMultipleRestoringTasks() throws Exception {
+        final StreamTask t1 = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final StandbyTask t2 = standbyTask(TASK_1_0, Set.of(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
+        when(t1.changelogOffsets()).thenReturn(Map.of(TOPIC_PARTITION_A_0, 1L));
+        when(t2.changelogOffsets()).thenReturn(Map.of(TOPIC_PARTITION_B_0, 2L));
+        when(changelogReader.logicalChangelogEndOffsets()).thenReturn(Map.of(
+            TOPIC_PARTITION_A_0, 100L,
+            TOPIC_PARTITION_B_0, 200L
+        ));
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        when(changelogReader.restore(anyMap())).thenReturn(1L);
+        stateUpdater.add(t1);
+        stateUpdater.add(t2);
+        stateUpdater.start();
+
+        waitForCondition(
+            () -> {
+                final Map<StreamsRebalanceData.TaskId, Long> s = stateUpdater.taskEndOffsetSumSnapshot();
+                return s.size() == 2
+                    && Long.valueOf(100L).equals(s.get(new StreamsRebalanceData.TaskId("0", 0)))
+                    && Long.valueOf(200L).equals(s.get(new StreamsRebalanceData.TaskId("1", 0)));
+            },
+            VERIFICATION_TIMEOUT,
+            "End-offset snapshot did not publish both restoring tasks"
+        );
+    }
+
+    private void assertEndOffsetSnapshotEntry(final TaskId taskId, final long expectedSum) throws Exception {
+        final StreamsRebalanceData.TaskId key = new StreamsRebalanceData.TaskId(String.valueOf(taskId.subtopology()), taskId.partition());
+        waitForCondition(
+            () -> {
+                final Map<StreamsRebalanceData.TaskId, Long> s = stateUpdater.taskEndOffsetSumSnapshot();
+                return s.size() == 1 && Long.valueOf(expectedSum).equals(s.get(key));
+            },
+            VERIFICATION_TIMEOUT,
+            () -> "End-offset snapshot did not publish expected entry " + key + "=" + expectedSum + "; got " + stateUpdater.taskEndOffsetSumSnapshot()
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
@@ -107,6 +107,7 @@ public class DefaultStreamsRebalanceListenerTest {
                 )
             ),
             Map.of(),
+            Map::of,
             Map::of
         ));
         when(streamThread.state()).thenReturn(state);
@@ -132,7 +133,7 @@ public class DefaultStreamsRebalanceListenerTest {
         final Exception exception = new RuntimeException("sample exception");
         doThrow(exception).when(taskManager).handleRevocation(any());
 
-        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of));
+        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of));
 
         final Exception actualException = assertThrows(RuntimeException.class, () -> defaultStreamsRebalanceListener.onTasksRevoked(Set.of()));
 
@@ -268,6 +269,7 @@ public class DefaultStreamsRebalanceListenerTest {
                 )
             ),
             Map.of(),
+            Map::of,
             Map::of
         ));
 
@@ -304,6 +306,7 @@ public class DefaultStreamsRebalanceListenerTest {
                 )
             ),
             Map.of(),
+            Map::of,
             Map::of
         ));
 
@@ -334,7 +337,7 @@ public class DefaultStreamsRebalanceListenerTest {
             return null;
         }).when(taskManager).handleLostAll();
 
-        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of));
+        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of));
 
         defaultStreamsRebalanceListener.onAllTasksLost();
 
@@ -366,6 +369,7 @@ public class DefaultStreamsRebalanceListenerTest {
                 )
             ),
             Map.of(),
+            Map::of,
             Map::of
         ));
 
@@ -386,7 +390,7 @@ public class DefaultStreamsRebalanceListenerTest {
             throw exception;
         }).when(taskManager).handleAssignment(any(), any());
 
-        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of));
+        createRebalanceListenerWithRebalanceData(new StreamsRebalanceData(UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of));
 
         assertThrows(RuntimeException.class, () -> defaultStreamsRebalanceListener.onTasksAssigned(
             new StreamsRebalanceData.Assignment(Set.of(), Set.of(), Set.of(), false)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/MockChangelogReader.java
@@ -74,6 +74,11 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
+    public Map<TopicPartition, Long> logicalChangelogEndOffsets() {
+        return Collections.emptyMap();
+    }
+
+    @Override
     public boolean allChangelogsCompleted() {
         return false;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -1038,12 +1038,43 @@ public class StoreChangelogReaderTest {
         // we should be able to restore to the log end offsets since there's no limit
         changelogReader.restore(mockTasks);
         assertEquals(StoreChangelogReader.ChangelogState.RESTORING, changelogReader.changelogMetadata(tp).state());
-        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+        // For non-source-topic standbys, the reader refreshes restoreEndOffset from the consumer's
+        // cached Fetch high-water-mark every restore batch (no RPC) so taskEndOffsetSumSnapshot
+        // can publish lag for warm-up promotion. The records went up to offset 11, so the
+        // exclusive limit lands at the partition's next-to-be-assigned offset 12.
+        assertEquals(12L, (long) changelogReader.changelogMetadata(tp).endOffset());
         assertEquals(6L, changelogReader.changelogMetadata(tp).totalRestored());
         assertEquals(0, changelogReader.changelogMetadata(tp).bufferedRecords().size());
         assertEquals(0, changelogReader.changelogMetadata(tp).bufferedLimitIndex());
         assertNull(callback.storeNameCalledStates.get(RESTORE_END));
         assertNull(callback.storeNameCalledStates.get(RESTORE_BATCH));
+    }
+
+    @Test
+    public void changelogEndOffsetsShouldFallBackToStoreMetadataWhenLogicalChangelogMetadataIsNull() {
+        // Verifies the 3-step fallback chain in changelogEndOffsets():
+        //   1) ChangelogMetadata.restoreEndOffset (preferred)
+        //   2) StateStoreMetadata.endOffset (physical Fetch high-water-mark)
+        //   3) null  (caller treats as MAX_VALUE — conservative for warm-up promotion)
+        // This test wires a standby with restoreEndOffset == null but
+        // storeMetadata.endOffset == 42L → fallback returns 42L.
+        setupStandbyStateManager();
+        when(storeMetadata.endOffset()).thenReturn(42L);
+
+        changelogReader.register(tp, standbyStateManager);
+
+        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+        assertEquals(Long.valueOf(42L), changelogReader.logicalChangelogEndOffsets().get(tp));
+    }
+
+    @Test
+    public void logicalChangelogEndOffsetsShouldReturnNullWhenBothSourcesUnknown() {
+        setupStandbyStateManager();
+        when(storeMetadata.endOffset()).thenReturn(null);
+
+        changelogReader.register(tp, standbyStateManager);
+
+        assertNull(changelogReader.logicalChangelogEndOffsets().get(tp));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -1038,11 +1038,7 @@ public class StoreChangelogReaderTest {
         // we should be able to restore to the log end offsets since there's no limit
         changelogReader.restore(mockTasks);
         assertEquals(StoreChangelogReader.ChangelogState.RESTORING, changelogReader.changelogMetadata(tp).state());
-        // For non-source-topic standbys, the reader refreshes restoreEndOffset from the consumer's
-        // cached Fetch high-water-mark every restore batch (no RPC) so taskEndOffsetSumSnapshot
-        // can publish lag for warm-up promotion. The records went up to offset 11, so the
-        // exclusive limit lands at the partition's next-to-be-assigned offset 12.
-        assertEquals(12L, (long) changelogReader.changelogMetadata(tp).endOffset());
+        assertNull(changelogReader.changelogMetadata(tp).endOffset());
         assertEquals(6L, changelogReader.changelogMetadata(tp).totalRestored());
         assertEquals(0, changelogReader.changelogMetadata(tp).bufferedRecords().size());
         assertEquals(0, changelogReader.changelogMetadata(tp).bufferedLimitIndex());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1703,7 +1703,7 @@ public class StreamThreadTest {
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(
-            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         thread = new StreamThread(
             mockTime, config, null,
             mainConsumer, consumer,
@@ -1736,7 +1736,7 @@ public class StreamThreadTest {
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         final StreamsRebalanceData streamsRebalanceData = new StreamsRebalanceData(
-            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of);
+            UUID.randomUUID(), Optional.empty(), Optional.empty(), Map.of(), Map.of(), Map::of, Map::of);
         thread = new StreamThread(
             mockTime, config, null,
             mainConsumer, consumer,
@@ -2982,6 +2982,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
 
@@ -3939,6 +3940,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
         final Runnable shutdownErrorHook = mock(Runnable.class);
@@ -4001,6 +4003,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
 
@@ -4104,6 +4107,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
         final Runnable shutdownErrorHook = mock(Runnable.class);
@@ -4177,6 +4181,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
         final Runnable shutdownErrorHook = mock(Runnable.class);
@@ -4242,6 +4247,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
 
@@ -4305,6 +4311,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
 
@@ -4378,6 +4385,7 @@ public class StreamThreadTest {
             Optional.empty(),
             Map.of(),
             Map.of(),
+            Map::of,
             Map::of
         );
 


### PR DESCRIPTION
This PR adds base logic to make task-end-offset-sum available to the
client background thread,  allowing us to add task-end-offset-sum to the
StreamsHeartbeatRequest in a follow up PR.  We are getting the
task-end0offset-sum from StateUpdater thread, and thus the supplier must
be thread-safe.  For source-topic optimized changelog, we need to use
the "logical endOffset" (ie, committed offset).

Part of KIP-1071.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
