### PR TITLE
KAFKA-19717: fix(connect/transforms): preserve fractional digits in InsertHeader literal values

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
@@ -19,11 +19,13 @@ package org.apache.kafka.connect.transforms;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
@@ -78,6 +80,31 @@ public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         header = config.getString(HEADER_FIELD);
-        literalValue = Values.parseString(config.getString(VALUE_LITERAL_FIELD));
+        String rawValue = config.getString(VALUE_LITERAL_FIELD);
+        SchemaAndValue parsed = Values.parseString(rawValue);
+        if (parsed != null && parsed.schema() != null) {
+            Schema.Type type = parsed.schema().type();
+            boolean isIntegral = type == Schema.Type.INT8 || type == Schema.Type.INT16 || type == Schema.Type.INT32 || type == Schema.Type.INT64;
+            if (isIntegral && rawValue.contains(".")) {
+                try {
+                    BigDecimal decimal = new BigDecimal(rawValue);
+                    float fValue = decimal.floatValue();
+                    double dValue = decimal.doubleValue();
+                    if (fValue != Float.NEGATIVE_INFINITY && fValue != Float.POSITIVE_INFINITY) {
+                        literalValue = new SchemaAndValue(Schema.FLOAT32_SCHEMA, fValue);
+                    } else if (dValue != Double.NEGATIVE_INFINITY && dValue != Double.POSITIVE_INFINITY) {
+                        literalValue = new SchemaAndValue(Schema.FLOAT64_SCHEMA, dValue);
+                    } else {
+                        literalValue = new SchemaAndValue(org.apache.kafka.connect.data.Decimal.schema(decimal.scale()), decimal);
+                    }
+                } catch (NumberFormatException e) {
+                    literalValue = parsed;
+                }
+            } else {
+                literalValue = parsed;
+            }
+        } else {
+            literalValue = parsed;
+        }
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
@@ -82,6 +82,19 @@ public class InsertHeaderTest {
     }
 
     @Test
+    public void insertionWithFloatHeader() {
+        xform.configure(config("inserted", "2.0"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+        Headers expect = headers.duplicate().addFloat("inserted", 2.0f);
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expect, xformed.headers());
+    }
+
+    @Test
     public void configRejectsNullHeaderKey() {
         assertThrows(ConfigException.class, () -> xform.configure(config(null, "1")));
     }


### PR DESCRIPTION
## What

The `InsertHeader` SMT was dropping the fractional part of literal values when the parsed schema resolved to an integral type. For example, configuring `value.literal: "2.0"` produced a header with value `2` instead of `2.0`. The `configure` method now detects this case and rewrites the schema and value to `FLOAT32`, `FLOAT64`, or `Decimal` so the original literal is preserved.

The behavior change is localized to `connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java`. When `Values.parseString` returns an integral-typed `SchemaAndValue` and the raw configured string contains a decimal point, the literal is re-encoded using `BigDecimal`, falling back to `Decimal` for values outside the range of `float`/`double`. All other inputs keep the previous behavior.

## Why

## Testing

Added `InsertHeaderTest.insertionWithFloatHeader`, which configures the SMT with the literal `"2.0"` and asserts that the resulting header carries a `FLOAT32` value of `2.0f` while preserving any pre-existing headers on the record. Existing tests continue to cover the integral and string literal paths, so non-numeric and integer literals are unchanged.

---

Delete this text and replace it with a detailed description of your change. The
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

JIRA: https://issues.apache.org/jira/browse/KAFKA-19717