### PR TITLE
KAFKA-19794: fix(mirror): avoid rewinding active consumer offsets in MirrorCheckpointTask

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -71,6 +71,9 @@ public class MirrorCheckpointTask extends SourceTask {
     private MirrorCheckpointMetrics metrics;
     private Scheduler scheduler;
     private Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset;
+    // tracks the last observed state of each consumer group on the target cluster, so that
+    // syncGroupOffset only syncs offsets for groups that are safe to update (i.e. not actively consumed)
+    private Map<String, GroupState> targetConsumerGroupStates;
     private CheckpointStore checkpointStore;
 
     public MirrorCheckpointTask() {}
@@ -80,12 +83,23 @@ public class MirrorCheckpointTask extends SourceTask {
             ReplicationPolicy replicationPolicy, OffsetSyncStore offsetSyncStore, Set<String> consumerGroups,
             Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset,
             CheckpointStore checkpointStore) {
+        this(sourceClusterAlias, targetClusterAlias, replicationPolicy, offsetSyncStore, consumerGroups,
+                idleConsumerGroupsOffset, new HashMap<>(), checkpointStore);
+    }
+
+    // for testing
+    MirrorCheckpointTask(String sourceClusterAlias, String targetClusterAlias,
+            ReplicationPolicy replicationPolicy, OffsetSyncStore offsetSyncStore, Set<String> consumerGroups,
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset,
+            Map<String, GroupState> targetConsumerGroupStates,
+            CheckpointStore checkpointStore) {
         this.sourceClusterAlias = sourceClusterAlias;
         this.targetClusterAlias = targetClusterAlias;
         this.replicationPolicy = replicationPolicy;
         this.offsetSyncStore = offsetSyncStore;
         this.consumerGroups = consumerGroups;
         this.idleConsumerGroupsOffset = idleConsumerGroupsOffset;
+        this.targetConsumerGroupStates = targetConsumerGroupStates;
         this.checkpointStore = checkpointStore;
         this.topicFilter = topic -> true;
         this.interval = Duration.ofNanos(1);
@@ -111,6 +125,7 @@ public class MirrorCheckpointTask extends SourceTask {
         legacyMetrics = metricNamesFormats.contains(METRIC_NAMES_LEGACY) ? config.legacyMetrics() : null;
         metrics = metricNamesFormats.contains(METRIC_NAMES_NEW) ? config.metrics(context.pluginMetrics()) : null;
         idleConsumerGroupsOffset = new HashMap<>();
+        targetConsumerGroupStates = new HashMap<>();
         checkpointStore = new CheckpointStore(config, consumerGroups);
         scheduler = new Scheduler(getClass(), config.entityLabel(), config.adminTimeout());
         scheduler.executeAsync(() -> {
@@ -300,6 +315,12 @@ public class MirrorCheckpointTask extends SourceTask {
     }
 
     private void refreshIdleConsumerGroupOffset() throws ExecutionException, InterruptedException {
+        // Start each refresh from a clean slate so that stale offsets/states from a previous cycle
+        // (for example if a previous syncGroupOffset failed before clearing them, or if a group has
+        // since transitioned from EMPTY to an active state) cannot be used to rewind active consumers.
+        idleConsumerGroupsOffset.clear();
+        targetConsumerGroupStates.clear();
+
         Map<String, KafkaFuture<ConsumerGroupDescription>> consumerGroupsDesc = adminCall(
                 () -> targetAdminClient.describeConsumerGroups(consumerGroups).describedGroups(),
                 () -> String.format("describe consumer groups %s on %s cluster", consumerGroups, targetClusterAlias)
@@ -322,12 +343,21 @@ public class MirrorCheckpointTask extends SourceTask {
                             )
                     );
                 }
-                // new consumer upstream has state "DEAD" and will be identified during the offset sync-up
+                // Only record the state once the offsets (for EMPTY groups) have been fetched successfully.
+                // If listConsumerGroupOffsets above throws, we skip this put so the group is left out of
+                // targetConsumerGroupStates and syncGroupOffset will not attempt to sync its offsets.
+                targetConsumerGroupStates.put(group, consumerGroupState);
             } catch (InterruptedException ie) {
                 log.error("Error querying for consumer group {} on cluster {}.", group, targetClusterAlias, ie);
             } catch (ExecutionException ee) {
                 // check for non-existent new consumer upstream which will be identified during the offset sync-up
-                if (!(ee.getCause() instanceof GroupIdNotFoundException)) {
+                if (ee.getCause() instanceof GroupIdNotFoundException) {
+                    // new consumer upstream that never existed at target; treat it as DEAD so that the
+                    // offset sync-up will create it on the target cluster
+                    targetConsumerGroupStates.put(group, GroupState.DEAD);
+                } else {
+                    // transient failure (e.g. timeout): leave the group out of targetConsumerGroupStates so
+                    // that syncGroupOffset skips it rather than syncing offsets based on stale information
                     log.error("Error querying for consumer group {} on cluster {}.", group, targetClusterAlias, ee);
                 }
             }
@@ -337,61 +367,84 @@ public class MirrorCheckpointTask extends SourceTask {
     Map<String, Map<TopicPartition, OffsetAndMetadata>> syncGroupOffset() throws ExecutionException, InterruptedException {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> offsetToSyncAll = new HashMap<>();
 
-        // first, sync offsets for the idle consumers at target
-        for (Entry<String, Map<TopicPartition, OffsetAndMetadata>> group : checkpointStore.computeConvertedUpstreamOffset().entrySet()) {
-            String consumerGroupId = group.getKey();
-            // for each idle consumer at target, read the checkpoints (converted upstream offset)
-            // from the pre-populated map
-            Map<TopicPartition, OffsetAndMetadata> convertedUpstreamOffset = group.getValue();
+        try {
+            // first, sync offsets for the idle consumers at target
+            for (Entry<String, Map<TopicPartition, OffsetAndMetadata>> group : checkpointStore.computeConvertedUpstreamOffset().entrySet()) {
+                String consumerGroupId = group.getKey();
+                // for each idle consumer at target, read the checkpoints (converted upstream offset)
+                // from the pre-populated map
+                Map<TopicPartition, OffsetAndMetadata> convertedUpstreamOffset = group.getValue();
 
-            Map<TopicPartition, OffsetAndMetadata> offsetToSync = new HashMap<>();
-            Map<TopicPartition, OffsetAndMetadata> targetConsumerOffset = idleConsumerGroupsOffset.get(consumerGroupId);
-            if (targetConsumerOffset == null) {
-                // this is a new consumer, just sync the offset to target
-                syncGroupOffset(consumerGroupId, convertedUpstreamOffset);
-                offsetToSyncAll.put(consumerGroupId, convertedUpstreamOffset);
-                continue;
-            }
-
-            for (Entry<TopicPartition, OffsetAndMetadata> convertedEntry : convertedUpstreamOffset.entrySet()) {
-
-                TopicPartition topicPartition = convertedEntry.getKey();
-                OffsetAndMetadata convertedOffset = convertedUpstreamOffset.get(topicPartition);
-                if (!targetConsumerOffset.containsKey(topicPartition)) {
-                    // if is a new topicPartition from upstream, just sync the offset to target
-                    offsetToSync.put(topicPartition, convertedOffset);
+                // Decide whether it is safe to sync based on the state of the group on the target cluster
+                // as observed during the most recent refresh. Only groups that are not actively consuming
+                // the mirrored topics may have their offsets altered, otherwise active consumers could be
+                // rewound (or made to skip messages).
+                GroupState targetConsumerGroupState = targetConsumerGroupStates.get(consumerGroupId);
+                if (targetConsumerGroupState == GroupState.DEAD) {
+                    // the group does not exist on the target cluster (a new consumer that only exists at
+                    // source); it is safe to (re)create it by syncing the converted upstream offsets
+                    syncGroupOffset(consumerGroupId, convertedUpstreamOffset);
+                    offsetToSyncAll.put(consumerGroupId, convertedUpstreamOffset);
                     continue;
                 }
 
-                // if translated offset from upstream is smaller than the current consumer offset
-                // in the target, skip updating the offset for that partition
-                OffsetAndMetadata targetOffsetAndMetadata = targetConsumerOffset.get(topicPartition);
-                if (targetOffsetAndMetadata != null) {
-                    long latestDownstreamOffset = targetOffsetAndMetadata.offset();
-                    if (latestDownstreamOffset >= convertedOffset.offset()) {
-                        log.trace("latestDownstreamOffset {} is larger than or equal to convertedUpstreamOffset {} for "
-                                + "TopicPartition {}", latestDownstreamOffset, convertedOffset.offset(), topicPartition);
+                Map<TopicPartition, OffsetAndMetadata> targetConsumerOffset = idleConsumerGroupsOffset.get(consumerGroupId);
+                if (targetConsumerGroupState != GroupState.EMPTY || targetConsumerOffset == null) {
+                    // The group is either being actively consumed on the target cluster (e.g. STABLE,
+                    // PREPARING_REBALANCE, COMPLETING_REBALANCE, ASSIGNING), or its state/offsets could not be
+                    // refreshed in this cycle (absent from the maps). In both cases skip syncing to avoid
+                    // rewinding the offsets of consumers actively using this group on the target cluster.
+                    log.info("Consumer group: {} with state: {} on the target cluster is not idle, skipping offset sync.",
+                            consumerGroupId, targetConsumerGroupState);
+                    continue;
+                }
+
+                Map<TopicPartition, OffsetAndMetadata> offsetToSync = new HashMap<>();
+                for (Entry<TopicPartition, OffsetAndMetadata> convertedEntry : convertedUpstreamOffset.entrySet()) {
+
+                    TopicPartition topicPartition = convertedEntry.getKey();
+                    OffsetAndMetadata convertedOffset = convertedUpstreamOffset.get(topicPartition);
+                    if (!targetConsumerOffset.containsKey(topicPartition)) {
+                        // if is a new topicPartition from upstream, just sync the offset to target
+                        offsetToSync.put(topicPartition, convertedOffset);
                         continue;
                     }
-                } else {
-                    // It is possible that when resetting offsets are performed in the java kafka client, the reset to -1 will be intercepted.
-                    // However, there are some other types of clients such as sarama, which can magically reset the group offset to -1, which will cause
-                    // `targetOffsetAndMetadata` here is null. For this case, just sync the offset to target.
-                    log.warn("Group {} offset for partition {} may has been reset to a negative offset, just sync the offset to target.",
-                            consumerGroupId, topicPartition);
+
+                    // if translated offset from upstream is smaller than the current consumer offset
+                    // in the target, skip updating the offset for that partition
+                    OffsetAndMetadata targetOffsetAndMetadata = targetConsumerOffset.get(topicPartition);
+                    if (targetOffsetAndMetadata != null) {
+                        long latestDownstreamOffset = targetOffsetAndMetadata.offset();
+                        if (latestDownstreamOffset >= convertedOffset.offset()) {
+                            log.trace("latestDownstreamOffset {} is larger than or equal to convertedUpstreamOffset {} for "
+                                    + "TopicPartition {}", latestDownstreamOffset, convertedOffset.offset(), topicPartition);
+                            continue;
+                        }
+                    } else {
+                        // It is possible that when resetting offsets are performed in the java kafka client, the reset to -1 will be intercepted.
+                        // However, there are some other types of clients such as sarama, which can magically reset the group offset to -1, which will cause
+                        // `targetOffsetAndMetadata` here is null. For this case, just sync the offset to target.
+                        log.warn("Group {} offset for partition {} may has been reset to a negative offset, just sync the offset to target.",
+                                consumerGroupId, topicPartition);
+                    }
+                    offsetToSync.put(topicPartition, convertedOffset);
                 }
-                offsetToSync.put(topicPartition, convertedOffset);
-            }
 
-            if (offsetToSync.isEmpty()) {
-                log.trace("skip syncing the offset for consumer group: {}", consumerGroupId);
-                continue;
-            }
-            syncGroupOffset(consumerGroupId, offsetToSync);
+                if (offsetToSync.isEmpty()) {
+                    log.trace("skip syncing the offset for consumer group: {}", consumerGroupId);
+                    continue;
+                }
+                syncGroupOffset(consumerGroupId, offsetToSync);
 
-            offsetToSyncAll.put(consumerGroupId, offsetToSync);
+                offsetToSyncAll.put(consumerGroupId, offsetToSync);
+            }
+        } finally {
+            // Always discard the snapshot so the next cycle starts from freshly refreshed state, even if
+            // syncing failed partway through. Otherwise a stale EMPTY snapshot could later be applied to a
+            // group that has since become active, rewinding its offsets.
+            idleConsumerGroupsOffset.clear();
+            targetConsumerGroupStates.clear();
         }
-        idleConsumerGroupsOffset.clear();
         return offsetToSyncAll;
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.source.SourceRecord;
 
@@ -126,6 +127,7 @@ public class MirrorCheckpointTaskTest {
     public void testSyncOffset() throws ExecutionException, InterruptedException {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
         Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
 
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
@@ -148,6 +150,10 @@ public class MirrorCheckpointTaskTest {
         idleConsumerGroupsOffset.put(consumer1, c1t1);
         idleConsumerGroupsOffset.put(consumer2, c2t2);
 
+        // both groups are idle (EMPTY) on the target cluster, so their offsets are eligible to be synced
+        targetConsumerGroupStates.put(consumer1, GroupState.EMPTY);
+        targetConsumerGroupStates.put(consumer2, GroupState.EMPTY);
+
         // 'cpC1T1P0' denotes 'checkpoint' of topic1, partition 0 for consumer1
         Checkpoint cpC1T1P0 = new Checkpoint(consumer1, new TopicPartition(topic1, 0), 200, 101, "metadata");
 
@@ -167,7 +173,7 @@ public class MirrorCheckpointTaskTest {
 
         MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source1", "target2",
             new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
-            new CheckpointStore(checkpointsPerConsumerGroup));
+            targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
 
         Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
 
@@ -181,6 +187,7 @@ public class MirrorCheckpointTaskTest {
     public void testSyncOffsetForTargetGroupWithNullOffsetAndMetadata() throws ExecutionException, InterruptedException {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
         Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
 
         String consumer = "consumer";
         String topic = "topic";
@@ -196,13 +203,129 @@ public class MirrorCheckpointTaskTest {
         checkpointMap.put(cp.topicPartition(), cp);
         checkpointsPerConsumerGroup.put(consumer, checkpointMap);
 
+        // the group is idle (EMPTY) on the target cluster, so its offsets are eligible to be synced
+        targetConsumerGroupStates.put(consumer, GroupState.EMPTY);
+
         MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
                 new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
-                new CheckpointStore(checkpointsPerConsumerGroup));
+                targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
 
         Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
 
         assertEquals(101, output.get(consumer).get(tp).offset(), "Consumer " + topic + " failed");
+    }
+
+    @Test
+    public void testSyncOffsetForNewGroupOnTarget() throws ExecutionException, InterruptedException {
+        // A consumer group that does not exist on the target cluster is reported as DEAD. Its offsets
+        // should be synced (creating the group) even though there is no idle offset snapshot for it.
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
+
+        String consumer = "consumer";
+        String topic = "topic";
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        Checkpoint cp = new Checkpoint(consumer, tp, 200, 101, "metadata");
+        Map<TopicPartition, Checkpoint> checkpointMap = new HashMap<>();
+        checkpointMap.put(cp.topicPartition(), cp);
+        checkpointsPerConsumerGroup.put(consumer, checkpointMap);
+
+        targetConsumerGroupStates.put(consumer, GroupState.DEAD);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
+                targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
+
+        assertEquals(101, output.get(consumer).get(tp).offset(), "Consumer " + topic + " failed");
+    }
+
+    @Test
+    public void testNoSyncOffsetForActiveGroupOnTarget() throws ExecutionException, InterruptedException {
+        // A consumer group that is actively consuming on the target cluster (e.g. STABLE) must not have
+        // its offsets synced, even though there is no idle offset snapshot for it.
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
+
+        String consumer = "consumer";
+        String topic = "topic";
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        Checkpoint cp = new Checkpoint(consumer, tp, 200, 101, "metadata");
+        Map<TopicPartition, Checkpoint> checkpointMap = new HashMap<>();
+        checkpointMap.put(cp.topicPartition(), cp);
+        checkpointsPerConsumerGroup.put(consumer, checkpointMap);
+
+        targetConsumerGroupStates.put(consumer, GroupState.STABLE);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
+                targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
+
+        assertTrue(output.isEmpty(), "Offsets should not be synced for an actively consumed target group");
+    }
+
+    @Test
+    public void testNoSyncOffsetForGroupWithoutRefreshedState() throws ExecutionException, InterruptedException {
+        // If the state/offsets of a consumer group could not be refreshed on the target cluster (e.g. due to
+        // a transient timeout, or a listConsumerGroupOffsets failure for an EMPTY group), the group is absent
+        // from both idleConsumerGroupsOffset and targetConsumerGroupStates and its offsets must not be synced.
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
+
+        String consumer = "consumer";
+        String topic = "topic";
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        Checkpoint cp = new Checkpoint(consumer, tp, 200, 101, "metadata");
+        Map<TopicPartition, Checkpoint> checkpointMap = new HashMap<>();
+        checkpointMap.put(cp.topicPartition(), cp);
+        checkpointsPerConsumerGroup.put(consumer, checkpointMap);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
+                targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
+
+        assertTrue(output.isEmpty(), "Offsets should not be synced for a group whose state could not be refreshed");
+    }
+
+    @Test
+    public void testNoSyncOffsetForEmptyGroupWithoutOffsetSnapshot() throws ExecutionException, InterruptedException {
+        // A group reported as EMPTY but whose target offsets could not be fetched (e.g. listConsumerGroupOffsets
+        // threw during the refresh) is absent from idleConsumerGroupsOffset. It must not be treated as a new
+        // group and have all its offsets synced, since that could rewind it if it later becomes active.
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset = new HashMap<>();
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        Map<String, GroupState> targetConsumerGroupStates = new HashMap<>();
+
+        String consumer = "consumer";
+        String topic = "topic";
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        Checkpoint cp = new Checkpoint(consumer, tp, 200, 101, "metadata");
+        Map<TopicPartition, Checkpoint> checkpointMap = new HashMap<>();
+        checkpointMap.put(cp.topicPartition(), cp);
+        checkpointsPerConsumerGroup.put(consumer, checkpointMap);
+
+        // state is EMPTY but there is no offset snapshot for the group
+        targetConsumerGroupStates.put(consumer, GroupState.EMPTY);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), idleConsumerGroupsOffset,
+                targetConsumerGroupStates, new CheckpointStore(checkpointsPerConsumerGroup));
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
+
+        assertTrue(output.isEmpty(), "Offsets should not be synced for an EMPTY group without a refreshed offset snapshot");
     }
 
     @Test


### PR DESCRIPTION
## Description

`MirrorCheckpointTask` previously treated the absence of a consumer group from `idleConsumerGroupsOffset` as evidence that the group was new on the target cluster and unconditionally synced the converted upstream offsets for it. In practice this also covered groups that were actively being consumed on the target (e.g. `STABLE`) but were momentarily not present in the snapshot because the group transitioned out of `EMPTY` between `refreshIdleConsumerGroupOffset` calls. The result was that active consumers could be rewound, or, when the older offset was no longer retained, reset to `earliest`/`latest` and either re-read or skip messages.

This change tracks the last observed `GroupState` of each target consumer group alongside the existing offset snapshot, and `syncGroupOffset` now only syncs offsets for groups reported as `DEAD` (new on the target) or `EMPTY` (and only when an offset snapshot for them is available). Active groups are skipped, and the maps are reset at the start of every refresh and in a `finally` block after syncing so a stale snapshot cannot be applied if the group has since become active. A transient failure to refresh a group's state or offsets (e.g. a `listConsumerGroupOffsets` timeout) now leaves the group absent from both maps, so it is also skipped rather than synced based on stale information. The diff also adds a `DEAD`-state test and updates the existing tests to populate the new state map.

Delete this text and replace it with a detailed description of your change. The
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.

### Testing strategy

Unit tests in `MirrorCheckpointTaskTest` are updated to populate the new
`targetConsumerGroupStates` map for the existing `testSyncOffset` and
`testSyncOffsetForTargetGroupWithNullOffsetAndMetadata` cases, and a new
`testSyncOffsetForNewGroupOnTarget` test exercises the `DEAD` path that creates
a group on the target by syncing the converted upstream offsets.

- [ ] Tests added or updated that fail before the change and pass after.
- [x] Tests added or updated for the new `GroupState`-based gating logic and
      the snapshot reset in `refreshIdleConsumerGroupOffset` /
      `syncGroupOffset`.
- [ ] Integration/system tests added or updated.
- [ ] Documentation updated.
- [ ] Compatibility considerations noted (no public API changes; a new package-private constructor was added for testing).

JIRA: https://issues.apache.org/jira/browse/KAFKA-19794