### PR TITLE
KAFKA-20712: Fix transaction state name in log decoder output

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/DumpLogSegments.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DumpLogSegments.java
@@ -730,8 +730,14 @@ public class DumpLogSegments {
             JsonNode json = org.apache.kafka.coordinator.transaction.generated.CoordinatorRecordJsonConverters
                 .writeRecordValueAsJson(message, version);
             if (message instanceof TransactionLogValue) {
-                ((ObjectNode) json).put("transactionStatus",
-                    TransactionState.fromId(((TransactionLogValue) message).transactionStatus()).stateName());
+                byte statusId = ((TransactionLogValue) message).transactionStatus();
+                String statusName;
+                try {
+                    statusName = TransactionState.fromId(statusId).stateName();
+                } catch (IllegalStateException e) {
+                    statusName = String.valueOf(statusId);
+                }
+                ((ObjectNode) json).put("transactionStatus", statusName);
             }
             return json;
         }

--- a/tools/src/main/java/org/apache/kafka/tools/DumpLogSegments.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DumpLogSegments.java
@@ -53,6 +53,8 @@ import org.apache.kafka.coordinator.common.runtime.Deserializer;
 import org.apache.kafka.coordinator.group.GroupCoordinatorRecordSerde;
 import org.apache.kafka.coordinator.share.ShareCoordinatorRecordSerde;
 import org.apache.kafka.coordinator.transaction.TransactionCoordinatorRecordSerde;
+import org.apache.kafka.coordinator.transaction.TransactionState;
+import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
 import org.apache.kafka.metadata.MetadataRecordSerde;
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -725,8 +727,13 @@ public class DumpLogSegments {
 
         @Override
         protected JsonNode valueAsJson(ApiMessage message, short version) {
-            return org.apache.kafka.coordinator.transaction.generated.CoordinatorRecordJsonConverters
+            JsonNode json = org.apache.kafka.coordinator.transaction.generated.CoordinatorRecordJsonConverters
                 .writeRecordValueAsJson(message, version);
+            if (message instanceof TransactionLogValue) {
+                ((ObjectNode) json).put("transactionStatus",
+                    TransactionState.fromId(((TransactionLogValue) message).transactionStatus()).stateName());
+            }
+            return json;
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
@@ -44,8 +44,14 @@ public class TransactionLogMessageFormatter extends CoordinatorRecordMessageForm
     protected JsonNode valueAsJson(ApiMessage message, short version) {
         JsonNode json = CoordinatorRecordJsonConverters.writeRecordValueAsJson(message, version);
         if (message instanceof TransactionLogValue) {
-            ((ObjectNode) json).put("transactionStatus",
-                TransactionState.fromId(((TransactionLogValue) message).transactionStatus()).stateName());
+            byte statusId = ((TransactionLogValue) message).transactionStatus();
+            String statusName;
+            try {
+                statusName = TransactionState.fromId(statusId).stateName();
+            } catch (IllegalStateException e) {
+                statusName = String.valueOf(statusId);
+            }
+            ((ObjectNode) json).put("transactionStatus", statusName);
         }
         return json;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatter.java
@@ -18,9 +18,12 @@ package org.apache.kafka.tools.consumer;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.coordinator.transaction.TransactionCoordinatorRecordSerde;
+import org.apache.kafka.coordinator.transaction.TransactionState;
 import org.apache.kafka.coordinator.transaction.generated.CoordinatorRecordJsonConverters;
+import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class TransactionLogMessageFormatter extends CoordinatorRecordMessageFormatter {
     public TransactionLogMessageFormatter() {
@@ -39,6 +42,11 @@ public class TransactionLogMessageFormatter extends CoordinatorRecordMessageForm
 
     @Override
     protected JsonNode valueAsJson(ApiMessage message, short version) {
-        return CoordinatorRecordJsonConverters.writeRecordValueAsJson(message, version);
+        JsonNode json = CoordinatorRecordJsonConverters.writeRecordValueAsJson(message, version);
+        if (message instanceof TransactionLogValue) {
+            ((ObjectNode) json).put("transactionStatus",
+                TransactionState.fromId(((TransactionLogValue) message).transactionStatus()).stateName());
+        }
+        return json;
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
@@ -990,7 +990,7 @@ public class DumpLogSegmentsTest {
             )),
             Optional.of("{\"type\":\"0\",\"data\":{\"transactionalId\":\"txnId\"}}"),
             Optional.of("{\"version\":\"0\",\"data\":{\"producerId\":123,\"producerEpoch\":0,\"transactionTimeoutMs\":0," +
-                "\"transactionStatus\":0,\"transactionPartitions\":[],\"transactionLastUpdateTimestampMs\":0," +
+                "\"transactionStatus\":\"Empty\",\"transactionPartitions\":[],\"transactionLastUpdateTimestampMs\":0," +
                 "\"transactionStartTimestampMs\":0}}")
         );
 
@@ -1047,7 +1047,7 @@ public class DumpLogSegmentsTest {
             )),
             Optional.of("{\"type\":\"0\",\"data\":{\"transactionalId\":\"txnId\"}}"),
             Optional.of("{\"version\":\"1\",\"data\":{\"producerId\":12,\"previousProducerId\":11,\"nextProducerId\":10," +
-                "\"producerEpoch\":2,\"transactionTimeoutMs\":14,\"transactionStatus\":0," +
+                "\"producerEpoch\":2,\"transactionTimeoutMs\":14,\"transactionStatus\":\"Empty\"," +
                 "\"transactionPartitions\":[{\"topic\":\"topic1\",\"partitionIds\":[0,1,2]}," +
                 "{\"topic\":\"topic2\",\"partitionIds\":[3,4,5]}],\"transactionLastUpdateTimestampMs\":123," +
                 "\"transactionStartTimestampMs\":13}}")

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
@@ -45,9 +45,9 @@ import org.apache.kafka.coordinator.group.generated.OffsetCommitKey;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitKeyJsonConverter;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValueJsonConverter;
+import org.apache.kafka.coordinator.transaction.TransactionState;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKey;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKeyJsonConverter;
-import org.apache.kafka.coordinator.transaction.TransactionState;
 import org.apache.kafka.server.util.MockTime;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -296,7 +296,7 @@ public class ConsoleConsumerTest {
             admin.createTopics(Set.of(newTopic));
             produceMessagesWithTxn(cluster);
 
-            String[] transactionLogMessageFormatter = createConsoleConsumerArgs(cluster, 
+            String[] transactionLogMessageFormatter = createConsoleConsumerArgs(cluster,
                     Topic.TRANSACTION_STATE_TOPIC_NAME, 
                     "org.apache.kafka.tools.consumer.TransactionLogMessageFormatter");
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerTest.java
@@ -47,8 +47,7 @@ import org.apache.kafka.coordinator.group.generated.OffsetCommitValue;
 import org.apache.kafka.coordinator.group.generated.OffsetCommitValueJsonConverter;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKey;
 import org.apache.kafka.coordinator.transaction.generated.TransactionLogKeyJsonConverter;
-import org.apache.kafka.coordinator.transaction.generated.TransactionLogValue;
-import org.apache.kafka.coordinator.transaction.generated.TransactionLogValueJsonConverter;
+import org.apache.kafka.coordinator.transaction.TransactionState;
 import org.apache.kafka.server.util.MockTime;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -316,12 +315,10 @@ public class ConsoleConsumerTest {
                 assertNotNull(logKey);
                 assertEquals(transactionId, logKey.transactionalId());
 
-                JsonNode valueNode = jsonNode.get("value");
-                TransactionLogValue logValue =
-                        TransactionLogValueJsonConverter.read(valueNode.get("data"), TransactionLogValue.HIGHEST_SUPPORTED_VERSION);
-                assertNotNull(logValue);
-                assertEquals(0, logValue.producerId());
-                assertEquals(0, logValue.transactionStatus());
+                JsonNode valueData = jsonNode.get("value").get("data");
+                assertNotNull(valueData);
+                assertEquals(0, valueData.get("producerId").asInt());
+                assertEquals(TransactionState.EMPTY.stateName(), valueData.get("transactionStatus").asText());
             } finally {
                 consumerWrapper.cleanup();
             }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/TransactionLogMessageFormatterTest.java
@@ -60,7 +60,7 @@ public class TransactionLogMessageFormatterTest extends CoordinatorRecordMessage
                               "data":{"producerId":100,
                                       "producerEpoch":50,
                                       "transactionTimeoutMs":500,
-                                      "transactionStatus":4,
+                                      "transactionStatus":"CompleteCommit",
                                       "transactionPartitions":[],
                                       "transactionLastUpdateTimestampMs":1000,
                                       "transactionStartTimestampMs":750}}}
@@ -75,7 +75,7 @@ public class TransactionLogMessageFormatterTest extends CoordinatorRecordMessage
                               "data":{"producerId":100,
                                       "producerEpoch":50,
                                       "transactionTimeoutMs":500,
-                                      "transactionStatus":4,
+                                      "transactionStatus":"CompleteCommit",
                                       "transactionPartitions":[],
                                       "transactionLastUpdateTimestampMs":1000,
                                       "transactionStartTimestampMs":750}}}


### PR DESCRIPTION
The TransactionLogMessageParser and TransactionLogMessageFormatter
output the numeric transactionStatus (e.g. 4) instead of the human
readable state name (e.g. CompleteCommit). This patch eesolve the   byte
to the state name via TransactionState.fromId() in both the   dump log
and consumer formatter code paths.

Reviewers: Luke Chen <showuon@gmail.com>, Justine Olshan
 <jolshan@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
