### PR TITLE
KAFKA-20713: Lower level for client log on self-healing session not found

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -536,7 +536,8 @@ public class FetchSessionHandler {
                 // Other fetch-session errors (e.g. INVALID_FETCH_SESSION_EPOCH, FETCH_SESSION_TOPIC_ID_ERROR) are
                 // also recoverable and self-healing: the existing session is closed and a new one is re-established
                 // with a full fetch.
-                log.debug("Node {} was unable to process the fetch request with {}: {}.",
+                log.debug("Node {} was unable to process the fetch request with {}: {}. " +
+                    "Re-sending a full fetch request, which closes the existing session on the broker and establishes a new one.",
                     node, nextMetadata, response.error());
                 nextMetadata = nextMetadata.nextCloseExistingAttemptNew();
             }

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -527,11 +527,17 @@ public class FetchSessionHandler {
     public boolean handleResponse(FetchResponse response, short version) {
         if (response.error() != Errors.NONE) {
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
-                // This is a recoverable condition logged at DEBUG to avoid noise from routine cache churn.
+                // Recoverable and self-healing, so logged at DEBUG to avoid noise from routine cache churn.
                 log.debug("Node {} returned a {} error; the fetch session {} was likely evicted from the broker's " +
                     "fetch session cache. Re-sending a full fetch request to establish a new session.",
                     node, response.error(), nextMetadata.sessionId());
                 nextMetadata = FetchMetadata.INITIAL;
+            } else if (response.error() == Errors.INVALID_FETCH_SESSION_EPOCH) {
+                // Recoverable and self-healing, so logged at DEBUG.
+                log.debug("Node {} returned a {} error; the fetch session {} epoch is out of sync with the broker. " +
+                    "Re-sending a full fetch request to establish a new session.",
+                    node, response.error(), nextMetadata.sessionId());
+                nextMetadata = nextMetadata.nextCloseExistingAttemptNew();
             } else {
                 log.info("Node {} was unable to process the fetch request with {}: {}.",
                     node, nextMetadata, response.error());

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -526,11 +526,15 @@ public class FetchSessionHandler {
      */
     public boolean handleResponse(FetchResponse response, short version) {
         if (response.error() != Errors.NONE) {
-            log.info("Node {} was unable to process the fetch request with {}: {}.",
-                node, nextMetadata, response.error());
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
+                // This is a recoverable condition logged at DEBUG to avoid noise from routine cache churn.
+                log.debug("Node {} returned a {} error; the fetch session {} was likely evicted from the broker's " +
+                    "fetch session cache. Re-sending a full fetch request to establish a new session.",
+                    node, response.error(), nextMetadata.sessionId());
                 nextMetadata = FetchMetadata.INITIAL;
             } else {
+                log.info("Node {} was unable to process the fetch request with {}: {}.",
+                    node, nextMetadata, response.error());
                 nextMetadata = nextMetadata.nextCloseExistingAttemptNew();
             }
             return false;

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -527,19 +527,16 @@ public class FetchSessionHandler {
     public boolean handleResponse(FetchResponse response, short version) {
         if (response.error() != Errors.NONE) {
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
-                // Recoverable and self-healing, so logged at DEBUG to avoid noise from routine cache churn.
+                // Session does not exist on the broker anymore. Recoverable and self-healing, the client re-sends a full fetch request.
                 log.debug("Node {} returned a {} error; the fetch session {} was likely evicted from the broker's " +
                     "fetch session cache. Re-sending a full fetch request to establish a new session.",
                     node, response.error(), nextMetadata.sessionId());
                 nextMetadata = FetchMetadata.INITIAL;
-            } else if (response.error() == Errors.INVALID_FETCH_SESSION_EPOCH) {
-                // Recoverable and self-healing, so logged at DEBUG.
-                log.debug("Node {} returned a {} error; the fetch session {} epoch is out of sync with the broker. " +
-                    "Re-sending a full fetch request to establish a new session.",
-                    node, response.error(), nextMetadata.sessionId());
-                nextMetadata = nextMetadata.nextCloseExistingAttemptNew();
             } else {
-                log.info("Node {} was unable to process the fetch request with {}: {}.",
+                // Other fetch-session errors (e.g. INVALID_FETCH_SESSION_EPOCH, FETCH_SESSION_TOPIC_ID_ERROR) are
+                // also recoverable and self-healing: the existing session is closed and a new one is re-established
+                // with a full fetch.
+                log.debug("Node {} was unable to process the fetch request with {}: {}.",
                     node, nextMetadata, response.error());
                 nextMetadata = nextMetadata.nextCloseExistingAttemptNew();
             }


### PR DESCRIPTION
Lower to DEBUG and update message for the fetch session not found
(evicted) and similar scenario. The previous INFO log reported this as an error, but
on the client side it is self-healing and not actionable.

Fetch sessions are managed on the broker, which already exposes the
visibility needed (metrics and logs) to detect this situation and
correct it (broker configs for fetch session cache)

Reviewers: Andrew Schofield <aschofield@confluent.io>
