### PR TITLE
KAFKA-19867: fix(raft): avoid UpdateVoteRequest from broker-only nodes

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3298,6 +3298,10 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private boolean shouldSendUpdateVoteRequest(FollowerState state) {
+        if (!canBecomeVoter) {
+            return false;
+        }
+
         var version = partitionState.lastKraftVersion();
         /* When the cluster supports reconfiguration, send an updated voter configuration if the
          * one in the log doesn't match the local configuration.

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -2228,6 +2228,7 @@ public class KafkaRaftClientReconfigTest {
             .withBootstrapSnapshot(Optional.of(voters))
             .withElectedLeader(epoch, voter1.id())
             .withLocalListeners(localListeners)
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting for FETCH requests until the UpdateRaftVoter request is sent
@@ -2250,6 +2251,42 @@ public class KafkaRaftClientReconfigTest {
         );
 
         // after sending an update voter the next request should be a fetch
+        context.pollUntilRequest();
+        RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
+        context.assertFetchRequestData(fetchRequest, epoch, 0L, 0, context.client.highWatermark());
+    }
+
+    @Test
+    void testFollowerDoesNotSendUpdateVoterWhenItCannotBecomeVoter() throws Exception {
+        ReplicaKey local = replicaKey(randomReplicaId(), true);
+        ReplicaKey voter1 = replicaKey(local.id() + 1, true);
+        ReplicaKey voter2 = replicaKey(local.id() + 2, true);
+
+        VoterSet voters = VoterSetTest.voterSet(Stream.of(local, voter1, voter2));
+        int epoch = 4;
+
+        HashMap<ListenerName, InetSocketAddress> listenersMap = new HashMap<>(2);
+        listenersMap.put(
+            VoterSetTest.DEFAULT_LISTENER_NAME,
+            InetSocketAddress.createUnresolved("localhost", 9990 + local.id())
+        );
+        listenersMap.put(
+            ListenerName.normalised("ANOTHER_LISTENER"),
+            InetSocketAddress.createUnresolved("localhost", 8990 + local.id())
+        );
+        Endpoints localListeners = Endpoints.fromInetSocketAddresses(listenersMap);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(local.id(), local.directoryId().get())
+            .withKip853Rpc(true)
+            .withBootstrapSnapshot(Optional.of(voters))
+            .withElectedLeader(epoch, voter1.id())
+            .withLocalListeners(localListeners)
+            .withCanBecomeVoter(false)
+            .build();
+
+        // waiting for FETCH requests until the UpdateRaftVoter request would be sent
+        context.advanceTimeAndCompleteFetch(epoch, voter1.id(), true);
+
         context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0, context.client.highWatermark());
@@ -2281,6 +2318,7 @@ public class KafkaRaftClientReconfigTest {
             .withStaticVoters(voters)
             .withElectedLeader(epoch, voter1.id())
             .withLocalListeners(localListeners)
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting for FETCH request until the UpdateRaftVoter request is set
@@ -2352,6 +2390,7 @@ public class KafkaRaftClientReconfigTest {
             .withStaticVoters(voters)
             .withElectedLeader(epoch, voter1.id())
             .withLocalListeners(localListeners)
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting for FETCH request until the UpdateRaftVoter request is set
@@ -2654,6 +2693,7 @@ public class KafkaRaftClientReconfigTest {
             .withKip853Rpc(true)
             .withBootstrapSnapshot(Optional.of(voters))
             .withElectedLeader(epoch, voter1.id())
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting for FETCH request until the UpdateRaftVoter request is set
@@ -2695,6 +2735,7 @@ public class KafkaRaftClientReconfigTest {
             .withBootstrapSnapshot(Optional.of(voters))
             .withElectedLeader(epoch, voter1.id())
             .withLocalListeners(localListeners)
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting up to the last FETCH request before the UpdateRaftVoter request is set
@@ -2756,6 +2797,7 @@ public class KafkaRaftClientReconfigTest {
             .withBootstrapSnapshot(Optional.of(voters))
             .withElectedLeader(epoch, voter1.id())
             .withLocalListeners(localListeners)
+            .withCanBecomeVoter(true)
             .build();
 
         // waiting for FETCH request until the UpdateRaftVoter request is set


### PR DESCRIPTION
## Description

`KafkaRaftClient.shouldSendUpdateVoteRequest` now checks the `canBecomeVoter` flag before sending an `UpdateRaftVoter` request. Previously, a node that is no longer a controller (for example, a node that was restarted as a broker-only node while still listed in the voter set) could still send an `UpdateRaftVoter` request and then fail to handle the response, which led to a fatal `IllegalStateException` in the Raft IO thread. This brings the behavior in line with `shouldSendAddOrRemoveVoterRequest`, which already gates on `canBecomeVoter`.

### Testing strategy

Added a new test, `testFollowerDoesNotSendUpdateVoterWhenItCannotBecomeVoter`, that drives a follower whose `canBecomeVoter` is `false` and asserts that only a FETCH request is sent (not an `UpdateRaftVoter` request). Existing reconfiguration tests were updated to explicitly set `canBecomeVoter(true)` so their assertions about `UpdateRaftVoter` requests remain valid under the new check.

Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected 
for any behavior change and system tests should be considered for larger 
changes.

JIRA: https://issues.apache.org/jira/browse/KAFKA-19867