### PR TITLE
MINOR: Improve handling adding metadata versions

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -138,7 +138,6 @@ public enum MetadataVersion {
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
-    //   Change expected message in org.apache.kafka.tools.FeatureCommandTest in multiple places (search for "Change expected message")
     public static final String FEATURE_NAME = "metadata.version";
 
     /**

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -67,7 +67,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.4-IV0", "3.3-IV3",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestTesting().version(), "3.3-IV3",
                 outputWithoutEpoch(features.get(3))
         );
         assertFeatureOutput(
@@ -93,7 +93,6 @@ public class FeatureCommandTest {
 
         List<String> features = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertFeatureOutput(
                 "eligible.leader.replicas.version", "0", "1", "0",
                 outputWithoutEpoch(features.get(0))
@@ -107,7 +106,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(features.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.4-IV0", "3.7-IV0",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestTesting().version(), "3.7-IV0",
                 outputWithoutEpoch(features.get(3))
         );
         assertFeatureOutput(
@@ -150,7 +149,6 @@ public class FeatureCommandTest {
         );
         List<String> featuresWithUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertFeatureOutput(
                 "eligible.leader.replicas.version", "0", "1", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(0))
@@ -164,7 +162,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.4-IV0", "3.7-IV0",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestTesting().version(), "3.7-IV0",
                 outputWithoutEpoch(featuresWithUnstable.get(3))
         );
         assertFeatureOutput(
@@ -201,7 +199,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithoutUnstable.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.3-IV0", "3.7-IV0",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestProduction().version(), "3.7-IV0",
                 outputWithoutEpoch(featuresWithoutUnstable.get(3))
         );
         assertFeatureOutput(
@@ -244,7 +242,6 @@ public class FeatureCommandTest {
         );
         List<String> featuresWithUnstable = Arrays.stream(commandOutput.split("\n")).sorted().toList();
 
-        // Change expected message to reflect latest MetadataVersion (SupportedMaxVersion increases when adding a new version)
         assertFeatureOutput(
                 "eligible.leader.replicas.version", "0", "1", "0",
                 outputWithoutEpoch(featuresWithUnstable.get(0))
@@ -258,7 +255,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithUnstable.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.4-IV0", "3.7-IV0",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestTesting().version(), "3.7-IV0",
                 outputWithoutEpoch(featuresWithUnstable.get(3))
         );
         assertFeatureOutput(
@@ -295,7 +292,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithoutUnstable.get(2))
         );
         assertFeatureOutput(
-                "metadata.version", "3.3-IV3", "4.3-IV0", "3.7-IV0",
+                "metadata.version", "3.3-IV3", MetadataVersion.latestProduction().version(), "3.7-IV0",
                 outputWithoutEpoch(featuresWithoutUnstable.get(3))
         );
         assertFeatureOutput(


### PR DESCRIPTION
In the ACLs PR I realised that `FeatureCommandTest` needs to be always
manually changed if we add new metadata version, which is not great
design. We should handle these dynamically and so these changes mean
that when a new MetadataVersion (e.g., `4.4-IV1`) is added, these tests
will automatically pick up the correct expected max version without
manual updates.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
