### PR TITLE
MINOR: Bump Setup Gradle to 6.2.0

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -42,7 +42,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       env:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
       with:


### PR DESCRIPTION
The CI is currently failing with:
```
##[error]The action
gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 is
not allowed in apache/kafka because all actions must be from a
repository owned by your enterprise, created by GitHub, or match one of
the patterns:
1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259,
1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259,
AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*,
DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101,
DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9,
DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd,
EnricoMi/publish-unit-test-result-action@*,
JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f,
JetBrains/qodana-action@89eb4357efd2b52e639f3216e63edaf33b82622b,
JetBrains/qodana-action@d7b5ec2fbec32197ef447c450e00589ed5f34fd5,
Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec7...
```

Setup-gradle action v5.0.2 is now expired as per:
https://github.com/apache/infrastructure-actions/blob/main/actions.yml#L483-L486

So bumping to the latest version. v6 introduced terms of use changes:
https://github.com/gradle/actions/releases/tag/v6.0.0 but it seems a few
other projects have already updated, so it should be fine.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>, Russole Chen <850905junior@gmail.com>, PoAn Yang
 <payang@apache.org>
