### PR TITLE
KAFKA-20700: Resolve symlinks in AllowedPaths before validation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/internals/AllowedPaths.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/AllowedPaths.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.config.internals;
 
 import org.apache.kafka.common.config.ConfigException;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +50,11 @@ public class AllowedPaths {
                 } else if (!Files.exists(normalisedPath)) {
                     throw new ConfigException("Path " + normalisedPath + " does not exist");
                 } else {
-                    allowedPaths.add(normalisedPath);
+                    try {
+                        allowedPaths.add(normalisedPath.toRealPath());
+                    } catch (IOException e) {
+                        throw new ConfigException("Path " + normalisedPath + " could not be resolved", e);
+                    }
                 }
             });
 
@@ -69,12 +74,16 @@ public class AllowedPaths {
         Path parsedPath = Paths.get(path);
 
         if (allowedPaths != null) {
-            Path normalisedPath = parsedPath.normalize();
-            long allowed = allowedPaths.stream().filter(normalisedPath::startsWith).count();
-            if (allowed == 0) {
+            try {
+                Path realPath = parsedPath.toRealPath();
+                long allowed = allowedPaths.stream().filter(realPath::startsWith).count();
+                if (allowed == 0) {
+                    return null;
+                }
+                return realPath;
+            } catch (IOException e) {
                 return null;
             }
-            return normalisedPath;
         }
 
         return parsedPath;

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/AllowedPathsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/AllowedPathsTest.java
@@ -50,11 +50,11 @@ class AllowedPathsTest {
     }
 
     @Test
-    public void testAllowedPath() {
+    public void testAllowedPath() throws IOException {
         allowedPaths = new AllowedPaths(String.join(",", dir, dir2));
 
         Path actual = allowedPaths.parseUntrustedPath(myFile);
-        assertEquals(myFile, actual.toString());
+        assertEquals(Paths.get(myFile).toRealPath(), actual);
     }
 
     @Test
@@ -82,12 +82,30 @@ class AllowedPathsTest {
     }
 
     @Test
-    public void testAllowedTraversal() {
+    public void testAllowedTraversal() throws IOException {
         allowedPaths = new AllowedPaths(String.join(",", dir, dir2));
 
         Path traversedPath = Paths.get(dir, "..", "dir2");
         Path actual = allowedPaths.parseUntrustedPath(traversedPath.toString());
-        assertEquals(traversedPath.normalize(), actual);
+        assertEquals(Paths.get(dir2).toRealPath(), actual);
+    }
+
+    @Test
+    public void testSymlinkOutsideAllowedDirRejected() throws IOException {
+        Path outsideFile = Files.createFile(Paths.get(dir2, "outsideFile"));
+        Path symlink = Files.createSymbolicLink(Paths.get(dir, "link"), outsideFile);
+
+        allowedPaths = new AllowedPaths(dir);
+        assertNull(allowedPaths.parseUntrustedPath(symlink.toString()));
+    }
+
+    @Test
+    public void testSymlinkInsideAllowedDirAllowed() throws IOException {
+        Path symlink = Files.createSymbolicLink(Paths.get(dir, "link"), Paths.get(myFile));
+
+        allowedPaths = new AllowedPaths(dir);
+        Path actual = allowedPaths.parseUntrustedPath(symlink.toString());
+        assertEquals(Paths.get(myFile).toRealPath(), actual);
     }
 
     @Test


### PR DESCRIPTION
Summary  Resolve symlinks with toRealPath() in AllowedPaths before
validating paths against allowed.paths, so symlinks inside an allowed
directory cannot point outside the boundary.

Fixes https://issues.apache.org/jira/browse/KAFKA-20700

Reviewers: Mickael Maison <mickael.maison@gmail.com>, Ken Huang <s7133700@gmail.com>
