### PR TITLE
KAFKA-20718: Fix flaky test OffsetStorageReaderTest.testClosingOffsetReaderWhenOffsetStoreHangsAndHasIncompleteFutures

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageReaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageReaderTest.java
@@ -107,6 +107,7 @@ public class OffsetStorageReaderTest {
 
         // Mock hanging future
         doAnswer(invocation -> {
+            latchTask1.countDown();
             CompletableFuture<Void> future = new CompletableFuture<>();
             future.get(9999, TimeUnit.SECONDS);
             throw new RuntimeException("Should never get here");
@@ -121,7 +122,6 @@ public class OffsetStorageReaderTest {
                     if (callCount == 0) {
                         callCount += 1;
                         // First connector task
-                        latchTask1.countDown();
                         return hangingFuture;
                     } else {
                         // Second connector task
@@ -144,7 +144,6 @@ public class OffsetStorageReaderTest {
         latchTask1.await();
 
         verify(offsetBackingStore, times(1)).get(any());
-        verify(hangingFuture, times(1)).get();
 
         // Another connector task thread calls `offsets()` --> hangs on offsetBackingStore.get()
         // --> the future is never added to `offsetStorageReaderImpl.offsetReadFutures`


### PR DESCRIPTION
The test had a race condition. It released `latchTask1` inside the
mocked `offsetBackingStore.get()`, but at that point the worker thread
may not have returned from `offsetBackingStore.get()` yet.

As a result, the test thread could resume and run the verification
before `OffsetStorageReaderImpl` had reached `offsetReadFuture.get()`,
causing the test to fail intermittently.

This fix moves the latch release to the mocked `hangingFuture.get()`, so
the test only continues after the worker is actually blocked while
waiting on the future.

Reviewers: Viktor Somogyi-Vass <viktorsomogyi@gmail.com>
