### PR TITLE
MINOR: optimize cooperative assignment validation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -731,9 +731,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         for (final Map.Entry<String, Assignment> entry : assignments.entrySet()) {
             final Assignment assignment = entry.getValue();
             final Set<TopicPartition> addedPartitions = new HashSet<>(assignment.partitions());
-            addedPartitions.removeAll(ownedPartitions.get(entry.getKey()));
+            ownedPartitions.get(entry.getKey()).forEach(addedPartitions::remove);
             final Set<TopicPartition> revokedPartitions = new HashSet<>(ownedPartitions.get(entry.getKey()));
-            revokedPartitions.removeAll(assignment.partitions());
+            assignment.partitions().forEach(revokedPartitions::remove);
 
             totalAddedPartitions.addAll(addedPartitions);
             totalRevokedPartitions.addAll(revokedPartitions);


### PR DESCRIPTION
This PR optimizes cooperative assignment validation in
ConsumerCoordinator.

Avoid HashSet.removeAll(List) in
ConsumerCoordinator.validateCooperativeAssignment  because it may
repeatedly call List.contains and degrade to `O(n^2)` time  complexity.
Use explicit HashSet removals to keep the added/revoked partition
calculation linear in the number of old owned and newly assigned
partitions.

Tests:  ./gradlew clients:test --tests '*ConsumerCoordinatorTest'
./gradlew clients:test --tests '*CooperativeConsumerCoordinatorTest'
