### PR TITLE
KAFKA-20695: Extend "describe group" to return "task offset" metadata

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorService.java
@@ -609,8 +609,6 @@ public class GroupCoordinatorService implements GroupCoordinator {
     private static void throwIfStreamsGroupHeartbeatRequestIsUsingUnsupportedFeatures(
         StreamsGroupHeartbeatRequestData request
     ) throws InvalidRequestException {
-        throwIfNotNull(request.taskOffsets(), "TaskOffsets are not supported yet.");
-        throwIfNotNull(request.taskEndOffsets(), "TaskEndOffsets are not supported yet.");
         throwIfNotNullOrEmpty(request.warmupTasks(), "WarmupTasks are not supported yet.");
         if (request.topology() != null) {
             for (StreamsGroupHeartbeatRequestData.Subtopology subtopology : request.topology().subtopologies()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -162,6 +162,7 @@ import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.TaskAssignorException;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 import org.apache.kafka.coordinator.group.streams.topics.InternalTopicManager;
@@ -2040,6 +2041,8 @@ public class GroupMetadataManager {
      * @param ownedWarmupTasks    The list of owned warmup tasks from the request or null.
      * @param userEndpoint        User-defined endpoint for Interactive Queries, or null.
      * @param clientTags          Used for rack-aware assignment algorithm, or null.
+     * @param taskOffsets         The last received cumulative changelog offsets for the member's tasks, or null.
+     * @param taskEndOffsets      The last received cumulative changelog end-offsets for the member's tasks, or null.
      * @param shutdownApplication Whether all Streams clients in the group should shut down.
      * @param memberEndpointEpoch The last endpoint information epoch seen be the group member.
      * @return A result containing the StreamsGroupHeartbeat response and a list of records to update the state machine.
@@ -2060,6 +2063,8 @@ public class GroupMetadataManager {
         String processId,
         Endpoint userEndpoint,
         List<KeyValue> clientTags,
+        List<StreamsGroupHeartbeatRequestData.TaskOffset> taskOffsets,
+        List<StreamsGroupHeartbeatRequestData.TaskOffset> taskEndOffsets,
         boolean shutdownApplication,
         int memberEndpointEpoch
     ) throws ApiException {
@@ -2118,6 +2123,13 @@ public class GroupMetadataManager {
             .setClientHost(clientHost)
             .maybeUpdateProcessId(Optional.ofNullable(processId))
             .maybeUpdateClientTags(Optional.ofNullable(clientTags).map(x -> x.stream().collect(Collectors.toMap(KeyValue::key, KeyValue::value))));
+
+        if (taskOffsets != null) {
+            updatedMemberBuilder.setTaskOffsets(taskOffsetsFromRequest(taskOffsets));
+        }
+        if (taskEndOffsets != null) {
+            updatedMemberBuilder.setTaskEndOffsets(taskOffsetsFromRequest(taskEndOffsets));
+        }
 
         if (isJoining) {
             StreamsGroupMemberMetadataValue.Endpoint userEndpointMetadata = userEndpoint == null ? null :
@@ -2240,6 +2252,9 @@ public class GroupMetadataManager {
 
         // 5. Reconcile the member's assignment with the target assignment if the member is not
         // fully reconciled yet.
+        boolean taskOffsetsChanged = !Objects.equals(member.taskOffsets(), updatedMember.taskOffsets())
+            || !Objects.equals(member.taskEndOffsets(), updatedMember.taskEndOffsets());
+        int recordsSizeBeforeReconcile = records.size();
         updatedMember = maybeReconcile(
             groupId,
             updatedMember,
@@ -2253,6 +2268,13 @@ public class GroupMetadataManager {
             ownedWarmupTasks,
             records
         );
+
+        // If the task offsets changed but reconciliation did not already persist a new current-assignment
+        // record, persist one so that the updated offsets are replayed into the member's state and surfaced
+        // in the describe response.
+        if (taskOffsetsChanged && records.size() == recordsSizeBeforeReconcile) {
+            records.add(newStreamsGroupCurrentAssignmentRecord(groupId, updatedMember));
+        }
 
         scheduleStreamsGroupSessionTimeout(groupId, memberId);
         if (shutdownApplication) {
@@ -2333,6 +2355,20 @@ public class GroupMetadataManager {
             group.storedDescriptionTopologyEpoch(),
             group.failedDescriptionTopologyEpoch()
         ));
+    }
+
+    /**
+     * Converts the task offsets carried in a Streams group heartbeat request into a map keyed by task.
+     *
+     * @param taskOffsets The list of task offsets from the request.
+     * @return A map from {@link TaskId} to the offset.
+     */
+    private static Map<TaskId, Long> taskOffsetsFromRequest(List<StreamsGroupHeartbeatRequestData.TaskOffset> taskOffsets) {
+        Map<TaskId, Long> offsets = new HashMap<>();
+        for (StreamsGroupHeartbeatRequestData.TaskOffset taskOffset : taskOffsets) {
+            offsets.put(new TaskId(taskOffset.subtopologyId(), taskOffset.partition()), taskOffset.offset());
+        }
+        return offsets;
     }
 
     /**
@@ -5384,6 +5420,8 @@ public class GroupMetadataManager {
                 request.processId(),
                 request.userEndpoint(),
                 request.clientTags(),
+                request.taskOffsets(),
+                request.taskEndOffsets(),
                 request.shutdownApplication(),
                 request.endpointInformationEpoch()
             );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpers.java
@@ -30,6 +30,7 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import java.util.ArrayList;
@@ -284,7 +285,9 @@ public class StreamsCoordinatorRecordHelpers {
                     .setWarmupTasks(toTaskIds(member.assignedTasks().warmupTasks()))
                     .setActiveTasksPendingRevocation(toTaskIdsWithEpochs(member.tasksPendingRevocation().activeTasksWithEpochs()))
                     .setStandbyTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().standbyTasks()))
-                    .setWarmupTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().warmupTasks())),
+                    .setWarmupTasksPendingRevocation(toTaskIds(member.tasksPendingRevocation().warmupTasks()))
+                    .setTaskOffsets(toTaskOffsets(member.taskOffsets()))
+                    .setTaskEndOffsets(toTaskOffsets(member.taskEndOffsets())),
                 (short) 0
             )
         );
@@ -349,6 +352,21 @@ public class StreamsCoordinatorRecordHelpers {
         });
         taskIds.sort(Comparator.comparing(StreamsGroupCurrentMemberAssignmentValue.TaskIds::subtopologyId));
         return taskIds;
+    }
+
+    private static List<StreamsGroupCurrentMemberAssignmentValue.TaskOffset> toTaskOffsets(
+        Map<TaskId, Long> offsets
+    ) {
+        if (offsets == null) {
+            return List.of();
+        }
+        return offsets.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> new StreamsGroupCurrentMemberAssignmentValue.TaskOffset()
+                .setSubtopologyId(entry.getKey().subtopologyId())
+                .setPartition(entry.getKey().partition())
+                .setOffset(entry.getValue()))
+            .toList();
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -301,7 +301,17 @@ public record StreamsGroupMember(String memberId,
                     record.memberEpoch()
                 )
             );
+            setTaskOffsets(taskOffsetsFromRecord(record.taskOffsets()));
+            setTaskEndOffsets(taskOffsetsFromRecord(record.taskEndOffsets()));
             return this;
+        }
+
+        private static Map<TaskId, Long> taskOffsetsFromRecord(List<StreamsGroupCurrentMemberAssignmentValue.TaskOffset> taskOffsets) {
+            Map<TaskId, Long> offsets = new HashMap<>();
+            for (StreamsGroupCurrentMemberAssignmentValue.TaskOffset taskOffset : taskOffsets) {
+                offsets.put(new TaskId(taskOffset.subtopologyId(), taskOffset.partition()), taskOffset.offset());
+            }
+            return offsets;
         }
 
         public static Builder withDefaults(String memberId) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMember.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.streams;
 import org.apache.kafka.common.message.StreamsGroupDescribeResponseData;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
 
 import org.slf4j.Logger;
 
@@ -54,6 +55,8 @@ import java.util.stream.Collectors;
  * @param clientTags                    Tags of the client of the member used for rack-aware assignment.
  * @param assignedTasks                 Tasks assigned to the member, including assignment epochs for active tasks.
  * @param tasksPendingRevocation        Tasks owned by the member pending revocation, including assignment epochs for active tasks.
+ * @param taskOffsets                   The last received cumulative changelog offsets for the member's tasks.
+ * @param taskEndOffsets                The last received cumulative changelog end-offsets for the member's tasks.
  */
 @SuppressWarnings("checkstyle:JavaNCSS")
 public record StreamsGroupMember(String memberId,
@@ -70,11 +73,15 @@ public record StreamsGroupMember(String memberId,
                                  Optional<StreamsGroupMemberMetadataValue.Endpoint> userEndpoint,
                                  Map<String, String> clientTags,
                                  TasksTupleWithEpochs assignedTasks,
-                                 TasksTupleWithEpochs tasksPendingRevocation) {
+                                 TasksTupleWithEpochs tasksPendingRevocation,
+                                 Map<TaskId, Long> taskOffsets,
+                                 Map<TaskId, Long> taskEndOffsets) {
 
     public StreamsGroupMember {
         Objects.requireNonNull(memberId, "memberId cannot be null");
         clientTags = clientTags != null ? Collections.unmodifiableMap(clientTags) : null;
+        taskOffsets = taskOffsets != null ? Collections.unmodifiableMap(taskOffsets) : null;
+        taskEndOffsets = taskEndOffsets != null ? Collections.unmodifiableMap(taskEndOffsets) : null;
     }
 
     /**
@@ -99,6 +106,8 @@ public record StreamsGroupMember(String memberId,
         private Map<String, String> clientTags = null;
         private TasksTupleWithEpochs assignedTasks = null;
         private TasksTupleWithEpochs tasksPendingRevocation = null;
+        private Map<TaskId, Long> taskOffsets = null;
+        private Map<TaskId, Long> taskEndOffsets = null;
 
         public Builder(String memberId) {
             this.memberId = Objects.requireNonNull(memberId, "memberId cannot be null");
@@ -126,6 +135,8 @@ public record StreamsGroupMember(String memberId,
             this.state = member.state;
             this.assignedTasks = member.assignedTasks;
             this.tasksPendingRevocation = member.tasksPendingRevocation;
+            this.taskOffsets = member.taskOffsets;
+            this.taskEndOffsets = member.taskEndOffsets;
         }
 
         public Builder updateMemberEpoch(int memberEpoch) {
@@ -240,6 +251,16 @@ public record StreamsGroupMember(String memberId,
             return this;
         }
 
+        public Builder setTaskOffsets(Map<TaskId, Long> taskOffsets) {
+            this.taskOffsets = taskOffsets;
+            return this;
+        }
+
+        public Builder setTaskEndOffsets(Map<TaskId, Long> taskEndOffsets) {
+            this.taskEndOffsets = taskEndOffsets;
+            return this;
+        }
+
         public Builder updateWith(StreamsGroupMemberMetadataValue record) {
             setInstanceId(record.instanceId());
             setRackId(record.rackId());
@@ -298,6 +319,8 @@ public record StreamsGroupMember(String memberId,
                 .setPreviousMemberEpoch(0)
                 .setAssignedTasks(TasksTupleWithEpochs.EMPTY)
                 .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+                .setTaskOffsets(Map.of())
+                .setTaskEndOffsets(Map.of())
                 .setUserEndpoint(null);
         }
 
@@ -317,7 +340,9 @@ public record StreamsGroupMember(String memberId,
                 userEndpoint,
                 clientTags,
                 assignedTasks,
-                tasksPendingRevocation
+                tasksPendingRevocation,
+                taskOffsets,
+                taskEndOffsets
             );
         }
 
@@ -398,6 +423,8 @@ public record StreamsGroupMember(String memberId,
             ).toList())
             .setProcessId(processId)
             .setTopologyEpoch(topologyEpoch)
+            .setTaskOffsets(taskOffsetsToResponse(taskOffsets))
+            .setTaskEndOffsets(taskOffsetsToResponse(taskEndOffsets))
             .setUserEndpoint(
                 userEndpoint.map(
                     endpoint -> new StreamsGroupDescribeResponseData.Endpoint()
@@ -415,6 +442,19 @@ public record StreamsGroupMember(String memberId,
                 .setPartitions(tasks.get(subtopologyId).stream().sorted().toList()));
         });
         return taskIds;
+    }
+
+    private static List<StreamsGroupDescribeResponseData.TaskOffset> taskOffsetsToResponse(Map<TaskId, Long> offsets) {
+        if (offsets == null) {
+            return List.of();
+        }
+        return offsets.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> new StreamsGroupDescribeResponseData.TaskOffset()
+                .setSubtopologyId(entry.getKey().subtopologyId())
+                .setPartition(entry.getKey().partition())
+                .setOffset(entry.getValue()))
+            .toList();
     }
 
     private static List<StreamsGroupDescribeResponseData.TaskIds> taskIdsFromMapWithEpochs(Map<String, Map<Integer, Integer>> tasksWithEpochs) {

--- a/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
+++ b/group-coordinator/src/main/resources/common/message/StreamsGroupCurrentMemberAssignmentValue.json
@@ -37,7 +37,11 @@
     { "name": "StandbyTasksPendingRevocation", "versions": "0+", "type": "[]TaskIds",
       "about": "The standby tasks that must be revoked by this member." },
     { "name": "WarmupTasksPendingRevocation", "versions": "0+", "type": "[]TaskIds",
-      "about": "The warmup tasks that must be revoked by this member." }
+      "about": "The warmup tasks that must be revoked by this member." },
+    { "name": "TaskOffsets", "versions": "0+", "taggedVersions": "0+", "tag": 0, "type": "[]TaskOffset",
+      "about": "The last received cumulative changelog offsets for the member's tasks." },
+    { "name": "TaskEndOffsets", "versions": "0+", "taggedVersions": "0+", "tag": 1, "type": "[]TaskOffset",
+      "about": "The last received cumulative changelog end-offsets for the member's tasks." }
   ],
   "commonStructs": [
     { "name": "TaskIds", "versions": "0+", "fields": [
@@ -47,6 +51,14 @@
         "about": "The partitions of the input topics processed by this member." },
       { "name": "AssignmentEpochs", "versions": "0+", "nullableVersions": "0+", "taggedVersions": "0+", "tag": 0, "type": "[]int32", "default": null,
         "about": "The epoch at which the partition was assigned to the member. Used to fence zombie commits requests. Of the same length as Partitions. Only defined for active tasks." }
+    ]},
+    { "name": "TaskOffset", "versions": "0+", "fields": [
+      { "name": "SubtopologyId", "type": "string", "versions": "0+",
+        "about": "The subtopology ID." },
+      { "name": "Partition", "type": "int32", "versions": "0+",
+        "about": "The partition." },
+      { "name": "Offset", "type": "int64", "versions": "0+",
+        "about": "The offset." }
     ]}
   ]
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorServiceTest.java
@@ -601,40 +601,6 @@ public class GroupCoordinatorServiceTest {
             new StreamsGroupHeartbeatResult(
                 new StreamsGroupHeartbeatResponseData()
                     .setErrorCode(Errors.INVALID_REQUEST.code())
-                    .setErrorMessage("TaskOffsets are not supported yet."),
-                Map.of(),
-                -1,
-                -1,
-                -1
-            ),
-            service.streamsGroupHeartbeat(
-                context,
-                new StreamsGroupHeartbeatRequestData()
-                    .setTaskOffsets(List.of(new StreamsGroupHeartbeatRequestData.TaskOffset()))
-            ).get(5, TimeUnit.SECONDS)
-        );
-
-        assertEquals(
-            new StreamsGroupHeartbeatResult(
-                new StreamsGroupHeartbeatResponseData()
-                    .setErrorCode(Errors.INVALID_REQUEST.code())
-                    .setErrorMessage("TaskEndOffsets are not supported yet."),
-                Map.of(),
-                -1,
-                -1,
-                -1
-            ),
-            service.streamsGroupHeartbeat(
-                context,
-                new StreamsGroupHeartbeatRequestData()
-                    .setTaskEndOffsets(List.of(new StreamsGroupHeartbeatRequestData.TaskOffset()))
-            ).get(5, TimeUnit.SECONDS)
-        );
-
-        assertEquals(
-            new StreamsGroupHeartbeatResult(
-                new StreamsGroupHeartbeatResponseData()
-                    .setErrorCode(Errors.INVALID_REQUEST.code())
                     .setErrorMessage("WarmupTasks are not supported yet."),
                 Map.of(),
                 -1,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -19381,6 +19381,71 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testStreamsGroupHeartbeatPersistsTaskOffsetsAndSurfacesThemInDescribe() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        String subtopology1 = "subtopology1";
+        String fooTopicName = "foo";
+        Uuid fooTopicId = Uuid.randomUuid();
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology().setSubtopologyId(subtopology1).setSourceTopics(List.of(fooTopicName))
+        ));
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 2)
+                .buildCoordinatorMetadataImage())
+            .withConfig(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, 0)
+            .build();
+
+        assignor.prepareGroupAssignment(
+            Map.of(memberId, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1))));
+
+        // Join the group.
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(1500)
+                .setTopology(topology)
+                .setActiveTasks(List.of())
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of()));
+
+        // Send a follow-up heartbeat reporting task offsets and task end-offsets.
+        context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(result.response().data().memberEpoch())
+                .setTaskOffsets(List.of(
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(100L),
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(200L)))
+                .setTaskEndOffsets(List.of(
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(150L),
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(250L))));
+
+        // The describe response surfaces the reported offsets for the member.
+        context.commit();
+        List<StreamsGroupDescribeResponseData.DescribedGroup> described = context.sendStreamsGroupDescribe(List.of(groupId));
+        assertEquals(1, described.size());
+        assertEquals(1, described.get(0).members().size());
+        StreamsGroupDescribeResponseData.Member describedMember = described.get(0).members().get(0);
+
+        assertEquals(List.of(
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(100L),
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(200L)
+        ), describedMember.taskOffsets());
+        assertEquals(List.of(
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(150L),
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(250L)
+        ), describedMember.taskEndOffsets());
+    }
+
+    @Test
     public void testStreamsGroupHeartbeatResponseVersion0() {
         String groupId = "fooup";
         String memberId = Uuid.randomUuid().toString();
@@ -22918,6 +22983,8 @@ public class GroupMetadataManagerTest {
                 TaskAssignmentTestUtil.mkTasksPerSubtopology(TaskAssignmentTestUtil.mkTasks("subtopology-1", 6, 7, 8))
             ))
             .setTasksPendingRevocation(TasksTupleWithEpochs.EMPTY)
+            .setTaskOffsets(Map.of())
+            .setTaskEndOffsets(Map.of())
             .build();
 
         // The group and the member are created if they do not exist.

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -19446,6 +19446,79 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testStreamsGroupHeartbeatRetainsTaskOffsetsWhenNotReported() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        String subtopology1 = "subtopology1";
+        String fooTopicName = "foo";
+        Uuid fooTopicId = Uuid.randomUuid();
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology().setSubtopologyId(subtopology1).setSourceTopics(List.of(fooTopicName))
+        ));
+
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withMetadataImage(new MetadataImageBuilder()
+                .addTopic(fooTopicId, fooTopicName, 2)
+                .buildCoordinatorMetadataImage())
+            .withConfig(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, 0)
+            .build();
+
+        assignor.prepareGroupAssignment(
+            Map.of(memberId, TaskAssignmentTestUtil.mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1))));
+
+        // Join the group.
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(0)
+                .setRebalanceTimeoutMs(1500)
+                .setTopology(topology)
+                .setActiveTasks(List.of())
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of()));
+
+        // First heartbeat reports task offsets and task end-offsets.
+        result = context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(result.response().data().memberEpoch())
+                .setTaskOffsets(List.of(
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(100L),
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(200L)))
+                .setTaskEndOffsets(List.of(
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(150L),
+                    new StreamsGroupHeartbeatRequestData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(250L))));
+
+        // Second heartbeat does NOT report offsets (the fields are left null). The previously
+        // reported offsets must be retained, not cleared.
+        context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(result.response().data().memberEpoch()));
+
+        // The describe response still surfaces the offsets reported in the first heartbeat.
+        context.commit();
+        List<StreamsGroupDescribeResponseData.DescribedGroup> described = context.sendStreamsGroupDescribe(List.of(groupId));
+        assertEquals(1, described.size());
+        assertEquals(1, described.get(0).members().size());
+        StreamsGroupDescribeResponseData.Member describedMember = described.get(0).members().get(0);
+
+        assertEquals(List.of(
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(100L),
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(200L)
+        ), describedMember.taskOffsets());
+        assertEquals(List.of(
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(0).setOffset(150L),
+            new StreamsGroupDescribeResponseData.TaskOffset().setSubtopologyId(subtopology1).setPartition(1).setOffset(250L)
+        ), describedMember.taskEndOffsets());
+    }
+
+    @Test
     public void testStreamsGroupHeartbeatResponseVersion0() {
         String groupId = "fooup";
         String memberId = Uuid.randomUuid().toString();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupMemberTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAss
 import org.apache.kafka.coordinator.group.generated.StreamsGroupCurrentMemberAssignmentValue.TaskIds;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue.KeyValue;
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -87,6 +88,14 @@ public class StreamsGroupMemberTest {
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY1, TASKS5.toArray(Integer[]::new))),
             mkTasksPerSubtopology(mkTasks(SUBTOPOLOGY2, TASKS6.toArray(Integer[]::new)))
         );
+    private static final Map<TaskId, Long> TASK_OFFSETS = mkMap(
+        mkEntry(new TaskId(SUBTOPOLOGY1, 1), 100L),
+        mkEntry(new TaskId(SUBTOPOLOGY1, 2), 200L)
+    );
+    private static final Map<TaskId, Long> TASK_END_OFFSETS = mkMap(
+        mkEntry(new TaskId(SUBTOPOLOGY1, 1), 150L),
+        mkEntry(new TaskId(SUBTOPOLOGY1, 2), 250L)
+    );
 
     @Test
     public void testBuilderWithMemberIdIsNull() {
@@ -146,6 +155,8 @@ public class StreamsGroupMemberTest {
         assertEquals(Map.of(), member.clientTags());
         assertEquals(TasksTupleWithEpochs.EMPTY, member.assignedTasks());
         assertEquals(TasksTupleWithEpochs.EMPTY, member.tasksPendingRevocation());
+        assertEquals(Map.of(), member.taskOffsets());
+        assertEquals(Map.of(), member.taskEndOffsets());
     }
 
     @Test
@@ -166,6 +177,8 @@ public class StreamsGroupMemberTest {
         assertEquals(CLIENT_TAGS, member.clientTags());
         assertEquals(ASSIGNED_TASKS, member.assignedTasks());
         assertEquals(TASKS_PENDING_REVOCATION, member.tasksPendingRevocation());
+        assertEquals(TASK_OFFSETS, member.taskOffsets());
+        assertEquals(TASK_END_OFFSETS, member.taskEndOffsets());
     }
 
     @Test
@@ -393,6 +406,18 @@ public class StreamsGroupMemberTest {
                             .setPartitions(assignedTasks1))
                     )
             )
+            .setTaskOffsets(List.of(
+                new StreamsGroupDescribeResponseData.TaskOffset()
+                    .setSubtopologyId(SUBTOPOLOGY1).setPartition(1).setOffset(100L),
+                new StreamsGroupDescribeResponseData.TaskOffset()
+                    .setSubtopologyId(SUBTOPOLOGY1).setPartition(2).setOffset(200L)
+            ))
+            .setTaskEndOffsets(List.of(
+                new StreamsGroupDescribeResponseData.TaskOffset()
+                    .setSubtopologyId(SUBTOPOLOGY1).setPartition(1).setOffset(150L),
+                new StreamsGroupDescribeResponseData.TaskOffset()
+                    .setSubtopologyId(SUBTOPOLOGY1).setPartition(2).setOffset(250L)
+            ))
             .setUserEndpoint(new StreamsGroupDescribeResponseData.Endpoint()
                 .setHost(USER_ENDPOINT.host())
                 .setPort(USER_ENDPOINT.port())
@@ -472,6 +497,8 @@ public class StreamsGroupMemberTest {
             .setClientTags(CLIENT_TAGS)
             .setAssignedTasks(ASSIGNED_TASKS)
             .setTasksPendingRevocation(TASKS_PENDING_REVOCATION)
+            .setTaskOffsets(TASK_OFFSETS)
+            .setTaskEndOffsets(TASK_END_OFFSETS)
             .build();
     }
 }


### PR DESCRIPTION
# Summary

This PR enables Streams group members to report cumulative changelog offsets (`TaskOffsets`) and end offsets (`TaskEndOffsets`) in heartbeat requests.

Previously, the group coordinator rejected these fields with `INVALID_REQUEST` (`TaskOffsets/TaskEndOffsets are not supported yet.`). With this change, the coordinator now accepts and propagates them so they are:

* persisted in the member's current-assignment record
* surfaced in `StreamsGroupDescribe`

# What changed

## 1. Coordinator validation

* Removed the `throwIfNotNull` guards in `GroupCoordinatorService` that rejected `taskOffsets` and `taskEndOffsets`

## 2. Member model

* Added `taskOffsets` and `taskEndOffsets` (`Map<TaskId, Long>`) to `StreamsGroupMember`
* Updated the record, `Builder`, `withDefaults`, and `updateWith(...)`
* Store both maps as unmodifiable

## 3. Heartbeat handling

* In `GroupMetadataManager`, convert the request's task offsets into per-task maps
* Set those maps on the updated member
* Only update offsets when the heartbeat actually carries them (`taskOffsets != null`)
* A heartbeat that omits offsets leaves the previously reported offsets unchanged
* This preserves incremental reporting semantics, where clients send `null` when offsets are unchanged
* If offsets change but reconciliation does not already write a new current-assignment record, append a record so the updated offsets are replayed into member state and become visible in describe

## 4. Record schema

* Added tagged fields to `StreamsGroupCurrentMemberAssignmentValue.json`
  * `TaskOffsets` (tag 0)
  * `TaskEndOffsets` (tag 1)
* Added a shared `TaskOffset` struct containing:
  * `SubtopologyId`
  * `Partition`
  * `Offset`
* Using tagged fields keeps the change backward compatible and avoids a record version bump

## 5. Record and response serialization

* `StreamsCoordinatorRecordHelpers` now writes offsets into the assignment record
* `StreamsGroupMember.asStreamsGroupDescribeMember` now emits offsets in the describe response
* Both paths emit deterministically sorted `TaskId` output

# Testing

## End-to-end coverage (`GroupMetadataManagerTest`)

* `testStreamsGroupHeartbeatPersistsTaskOffsetsAndSurfacesThemInDescribe`
  * A member joins
  * Sends a follow-up heartbeat with task offsets and end offsets
  * The describe response surfaces the reported values
* `testStreamsGroupHeartbeatRetainsTaskOffsetsWhenNotReported`
  * A member joins and reports offsets in one heartbeat
  * Sends a follow-up heartbeat without offsets
  * The describe response still surfaces the originally reported offsets instead of clearing them

## Unit coverage (`StreamsGroupMemberTest`)

* Builder defaults: new fields default to empty maps
* Full builder round-trip: offsets are stored and returned unchanged
* Describe-response mapping: maps are emitted as deterministically sorted `TaskOffset` lists
* `testReplayStreamsGroupCurrentMemberAssignment` updated so the expected member includes the new empty offset maps, keeping the serialize/replay round-trip assertion in sync

## Cleanup

* Removed obsolete assertions from `GroupCoordinatorServiceTest` that expected rejection errors for `TaskOffsets` and `TaskEndOffsets`

# Result

Streams members can now report task offset progress in heartbeats, and that information is durably stored and returned by `StreamsGroupDescribe`.

Offset reporting remains incremental: heartbeats that omit offsets preserve the last reported values.

Reviewers: nileshkumar3 <nileshkumar3@gmail.com>
