### PR TITLE
MINOR: Fix raw type warnings in AbstractHeartbeatRequestManagerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -70,10 +70,14 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
     protected AbstractMembershipManager<R> membershipManager;
     protected AbstractHeartbeatRequestManager<R> heartbeatRequestManager;
 
+    protected final Class<R> responseClass;
+
+    protected AbstractHeartbeatRequestManagerTest(Class<R> responseClass) {
+        this.responseClass = responseClass;
+    }
+
     protected abstract ClientResponse createHeartbeatResponse(
         NetworkClientDelegate.UnsentRequest request, Errors error);
-
-    protected abstract Class<R> responseClass();
 
     @Test
     public void testTimerNotDue() {
@@ -222,7 +226,7 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
             result.unsentRequests.get(0),
             error);
         result.unsentRequests.get(0).handler().onComplete(response);
-        R mockResponse = responseClass().cast(response.responseBody());
+        R mockResponse = responseClass.cast(response.responseBody());
 
         assertHeartbeatErrorHandling(error, isFatal, mockResponse);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
  * behavior implemented in the abstract manager and must produce the same outcome for every
  * concrete subclass.
  */
-abstract class AbstractHeartbeatRequestManagerTest {
+abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
 
     protected static final String DEFAULT_GROUP_ID = "groupId";
     protected static final String DEFAULT_MEMBER_ID = "member-id";
@@ -67,11 +67,13 @@ abstract class AbstractHeartbeatRequestManagerTest {
     protected SubscriptionState subscriptions;
     protected BackgroundEventHandler backgroundEventHandler;
     protected HeartbeatRequestState heartbeatRequestState;
-    protected AbstractMembershipManager membershipManager;
-    protected AbstractHeartbeatRequestManager heartbeatRequestManager;
+    protected AbstractMembershipManager<R> membershipManager;
+    protected AbstractHeartbeatRequestManager<R> heartbeatRequestManager;
 
     protected abstract ClientResponse createHeartbeatResponse(
         NetworkClientDelegate.UnsentRequest request, Errors error);
+
+    protected abstract Class<R> responseClass();
 
     @Test
     public void testTimerNotDue() {
@@ -220,14 +222,14 @@ abstract class AbstractHeartbeatRequestManagerTest {
             result.unsentRequests.get(0),
             error);
         result.unsentRequests.get(0).handler().onComplete(response);
-        AbstractResponse mockResponse = response.responseBody();
+        R mockResponse = responseClass().cast(response.responseBody());
 
         assertHeartbeatErrorHandling(error, isFatal, mockResponse);
     }
 
     protected void assertHeartbeatErrorHandling(final Errors error,
                                                 final boolean isFatal,
-                                                final AbstractResponse response) {
+                                                final R response) {
         switch (error) {
             case NONE:
                 verify(membershipManager).onHeartbeatSuccess(response);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.when;
 
 
 public class ConsumerHeartbeatRequestManagerTest
-        extends AbstractHeartbeatRequestManagerTest {
+        extends AbstractHeartbeatRequestManagerTest<ConsumerGroupHeartbeatResponse> {
 
     private static final String DEFAULT_REMOTE_ASSIGNOR = "uniform";
     private static final String DEFAULT_GROUP_INSTANCE_ID = "group-instance-id";
@@ -904,6 +904,11 @@ public class ConsumerHeartbeatRequestManagerTest
     protected ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,
                                                      Errors error) {
         return createHeartbeatResponse(request, error, "stubbed error message");
+    }
+
+    @Override
+    protected Class<ConsumerGroupHeartbeatResponse> responseClass() {
+        return ConsumerGroupHeartbeatResponse.class;
     }
 
     private ClientResponse createHeartbeatResponse(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -102,6 +102,10 @@ public class ConsumerHeartbeatRequestManagerTest
     private HeartbeatState heartbeatState;
     private LogContext logContext;
 
+    public ConsumerHeartbeatRequestManagerTest() {
+        super(ConsumerGroupHeartbeatResponse.class);
+    }
+
     @BeforeEach
     public void setUp() {
         this.time = new MockTime();
@@ -904,11 +908,6 @@ public class ConsumerHeartbeatRequestManagerTest
     protected ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,
                                                      Errors error) {
         return createHeartbeatResponse(request, error, "stubbed error message");
-    }
-
-    @Override
-    protected Class<ConsumerGroupHeartbeatResponse> responseClass() {
-        return ConsumerGroupHeartbeatResponse.class;
     }
 
     private ClientResponse createHeartbeatResponse(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -457,7 +457,6 @@ public class ShareHeartbeatRequestManagerTest
         assertEquals(0, pollResult.unsentRequests.size());
     }
 
-
     @Override
     protected ClientResponse createHeartbeatResponse(
             final NetworkClientDelegate.UnsentRequest request,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -84,6 +84,10 @@ public class ShareHeartbeatRequestManagerTest
     private Metrics metrics;
     private LogContext logContext;
 
+    public ShareHeartbeatRequestManagerTest() {
+        super(ShareGroupHeartbeatResponse.class);
+    }
+
     @BeforeEach
     public void setUp() {
         time = new MockTime();
@@ -453,10 +457,6 @@ public class ShareHeartbeatRequestManagerTest
         assertEquals(0, pollResult.unsentRequests.size());
     }
 
-    @Override
-    protected Class<ShareGroupHeartbeatResponse> responseClass() {
-        return ShareGroupHeartbeatResponse.class;
-    }
 
     @Override
     protected ClientResponse createHeartbeatResponse(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ShareHeartbeatRequestManagerTest
-        extends AbstractHeartbeatRequestManagerTest {
+        extends AbstractHeartbeatRequestManagerTest<ShareGroupHeartbeatResponse> {
 
     private static final String SHARE_CONSUMER_COORDINATOR_METRICS = "consumer-share-coordinator-metrics";
 
@@ -451,6 +451,11 @@ public class ShareHeartbeatRequestManagerTest
     private void assertNoHeartbeat(AbstractHeartbeatRequestManager<ShareGroupHeartbeatResponse> hrm) {
         NetworkClientDelegate.PollResult pollResult = hrm.poll(time.milliseconds());
         assertEquals(0, pollResult.unsentRequests.size());
+    }
+
+    @Override
+    protected Class<ShareGroupHeartbeatResponse> responseClass() {
+        return ShareGroupHeartbeatResponse.class;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix the `unchecked` compile warning in
`AbstractHeartbeatRequestManagerTest`: `AbstractHeartbeatRequestManager`
field is raw for the same reason.
```
> Task :clients:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note:
clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

Changes:
- Parameterize `AbstractHeartbeatRequestManagerTest` with `<R extends
AbstractResponse>` so `membershipManager` and `heartbeatRequestManager`
are strongly typed instead of raw.
- Change `assertHeartbeatErrorHandling` to take a typed `R response`.
- Constructor Injection: Use a constructor in the base test class to
pass the responseClass, allowing type-safe casting via Class.cast() and
removing the need for @SuppressWarnings.
- Update `ConsumerHeartbeatRequestManagerTest` and
`ShareHeartbeatRequestManagerTest` to extend the base with their
concrete heartbeat response types (`ConsumerGroupHeartbeatResponse` and
`ShareGroupHeartbeatResponse`).

## Testing

- `./gradlew clients:compileTestJava --rerun-tasks` → BUILD SUCCESSFUL,
no `unchecked` note for `AbstractHeartbeatRequestManagerTest`.
- `./gradlew clients:test --tests
"*ConsumerHeartbeatRequestManagerTest*" --tests
"*ShareHeartbeatRequestManagerTest*"` → all tests pass.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
