### PR TITLE
MINOR: reduce allocations constructing RecordHeaders

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.record.internal.Record;
 import org.apache.kafka.common.utils.internals.AbstractIterator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -37,7 +36,13 @@ public class RecordHeaders implements Headers {
     }
 
     public RecordHeaders(Header[] headers) {
-        this(headers == null ? null : Arrays.asList(headers));
+        this.headers = new ArrayList<>();
+        if (headers != null) {
+            for (Header header : headers) {
+                Objects.requireNonNull(header, "Header cannot be null.");
+                this.headers.add(header);
+            }
+        }
     }
 
     public RecordHeaders(Iterable<Header> headers) {


### PR DESCRIPTION
I propose a small optimization for the `RecordHeaders(Header[])` constructor. Since this code is used on the hot-path for `Consumer.poll()` (via `Fetcher` --> `FetchCollector` --> `CompletedFetch`), I think this code should not be wasteful.

Have a look at the original code:
```java
    public RecordHeaders(Header[] headers) {
        this(headers == null ? null : Arrays.asList(headers)); // (1)
    }

    public RecordHeaders(Iterable<Header> headers) {
        //Use efficient copy constructor if possible, fallback to iteration otherwise
        if (headers == null) {
            this.headers = new ArrayList<>();
        } else if (headers instanceof RecordHeaders) {
            this.headers = new ArrayList<>(((RecordHeaders) headers).headers);
        } else {
            this.headers = new ArrayList<>(); // (2)
            for (Header header : headers) { // (3)
                Objects.requireNonNull(header, "Header cannot be null.");
                this.headers.add(header);
            }
        }
    }
```
Note:
* If `RecordHeaders(Headers[])` is called with a **zero-length** array, `Arrays.asList()` at (1) creates an `ArrayList` which is then never used, since the `ArrayList` created at (2) will be the result (and the for-each loop at (3) will never be entered).
* If `RecordHeaders(Headers[])` is called with a **non-zero-length** array, the list created with `Arrays.asList()` at (1) is also just a useless wrapper.
* The for-each-loop at (3) is also wasteful in the `Header[]` use-case, since it creates a new `Iterator` via `ArrayList.iterator()`, while a for-each-loop over an array does not construct an object (cf. [JLS 14.14.2](https://docs.oracle.com/javase/specs/jls/se25/html/jls-14.html#jls-14.14.2)).

Thus I propose a simple change that avoids both object creations: the `ArrayList` that's merely used "as transport" to the other constructor and the `Iterator` that's not needed for iterating over an `Array`.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
