### PR TITLE
KAFKA-20724: prevent duplicate task in tasks() during pause and resume

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -634,8 +634,14 @@ public class DefaultStateUpdater implements StateUpdater {
             // do not need to unregister changelog partitions for paused tasks
             try {
                 measureCheckpointLatency(() -> task.maybeCheckpoint());
-                pausedTasks.put(taskId, task);
-                updatingTasks.remove(taskId);
+                // take the lock tasks() holds so a reader never sees the task in both maps
+                restoredActiveTasksLock.lock();
+                try {
+                    pausedTasks.put(taskId, task);
+                    updatingTasks.remove(taskId);
+                } finally {
+                    restoredActiveTasksLock.unlock();
+                }
                 if (task.isActive()) {
                     transitToUpdateStandbysIfOnlyStandbysLeft();
                 }
@@ -649,8 +655,13 @@ public class DefaultStateUpdater implements StateUpdater {
 
         private void resumeTask(final Task task) {
             final TaskId taskId = task.id();
-            updatingTasks.put(taskId, task);
-            pausedTasks.remove(taskId);
+            restoredActiveTasksLock.lock();
+            try {
+                updatingTasks.put(taskId, task);
+                pausedTasks.remove(taskId);
+            } finally {
+                restoredActiveTasksLock.unlock();
+            }
 
             if (task.isActive()) {
                 log.info("Stateful active task " + task.id() + " was resumed to the updating tasks of the state updater");
@@ -808,7 +819,8 @@ public class DefaultStateUpdater implements StateUpdater {
     private final Lock tasksAndActionsLock = new ReentrantLock();
     private final Condition tasksAndActionsCondition = tasksAndActionsLock.newCondition();
     private final Queue<StreamTask> restoredActiveTasks = new LinkedList<>();
-    private final Lock restoredActiveTasksLock = new ReentrantLock();
+    // visible for testing
+    final Lock restoredActiveTasksLock = new ReentrantLock();
     private final Condition restoredActiveTasksCondition = restoredActiveTasksLock.newCondition();
     private final Lock exceptionsAndFailedTasksLock = new ReentrantLock();
     private final Queue<ExceptionAndTask> exceptionsAndFailedTasks = new LinkedList<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -1194,6 +1195,64 @@ class DefaultStateUpdaterTest {
 
         when(topologyMetadata.isPaused(null)).thenReturn(false);
         stateUpdater.signalResume();
+
+        verifyPausedTasks();
+        verifyUpdatingTasks(task);
+    }
+
+    @Test
+    public void shouldHoldRestoredActiveTasksLockWhilePausingTask() throws Exception {
+        final ReentrantLock lock = (ReentrantLock) stateUpdater.restoredActiveTasksLock;
+        final StandbyTask task = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        stateUpdater.start();
+        stateUpdater.add(task);
+        verifyUpdatingTasks(task);
+
+        // while the test holds the lock, the pause must block instead of moving the task (KAFKA-20724)
+        lock.lock();
+        try {
+            when(topologyMetadata.isPaused(null)).thenReturn(true);
+            waitForCondition(
+                lock::hasQueuedThreads,
+                VERIFICATION_TIMEOUT,
+                "State updater thread did not block on the lock while pausing the task!"
+            );
+            assertTrue(stateUpdater.updatingTasks().contains(task));
+            assertTrue(stateUpdater.pausedTasks().isEmpty());
+        } finally {
+            lock.unlock();
+        }
+
+        verifyPausedTasks(task);
+        verifyUpdatingTasks();
+    }
+
+    @Test
+    public void shouldHoldRestoredActiveTasksLockWhileResumingTask() throws Exception {
+        final ReentrantLock lock = (ReentrantLock) stateUpdater.restoredActiveTasksLock;
+        final StandbyTask task = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        stateUpdater.start();
+        stateUpdater.add(task);
+        verifyUpdatingTasks(task);
+        when(topologyMetadata.isPaused(null)).thenReturn(true);
+        verifyPausedTasks(task);
+        verifyUpdatingTasks();
+
+        // the move back must block on the same lock
+        lock.lock();
+        try {
+            when(topologyMetadata.isPaused(null)).thenReturn(false);
+            stateUpdater.signalResume();
+            waitForCondition(
+                lock::hasQueuedThreads,
+                VERIFICATION_TIMEOUT,
+                "State updater thread did not block on the lock while resuming the task!"
+            );
+            assertTrue(stateUpdater.pausedTasks().contains(task));
+            assertTrue(stateUpdater.updatingTasks().isEmpty());
+        } finally {
+            lock.unlock();
+        }
 
         verifyPausedTasks();
         verifyUpdatingTasks(task);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-20724

DefaultStateUpdater.tasks() can return the same TaskId twice. The
snapshot is taken under executeWithQueuesLocked, which holds
tasksAndActionsLock, restoredActiveTasksLock and
exceptionsAndFailedTasksLock, but not updatingTasks or pausedTasks.
pauseTask does pausedTasks.put(id) then updatingTasks.remove(id), and
resumeTask does the reverse, so for a short window the task sits in both
maps. streamOfTasks() reads both, and ReadOnlyTask has no
equals/hashCode, so the returned Set keeps both wrappers. A caller that
does one remove per entry then removes the same task twice. The first
remove succeeds; the second reaches removeTask, finds the task in none
of the collections, and completes the future with null, so waitForFuture
turns it into "Task X was not found in the state updater. This indicates
a bug." The same duplicate also breaks TaskManager.allTasks(), which
uses Collectors.toMap, with "Duplicate key".

Fix: take restoredActiveTasksLock (the same lock tasks() already holds)
around the two map writes in pauseTask and resumeTask, so a reader never
observes the task in both maps. The changelogReader transitions stay
outside the lock.

Tests: two tests in DefaultStateUpdaterTest hold restoredActiveTasksLock
and assert that the pause and resume transitions block on it. They fail
by timeout if the lock is dropped from either method.
restoredActiveTasksLock was relaxed to package private so the tests can
take it.

Noticed while here, not fixed in this PR: the standalone updatingTasks()
and pausedTasks() accessors snapshot without restoredActiveTasksLock, so
a caller that composes both itself could still see an inconsistent pair.
There is no such caller today (pausedTasks() is test only), so I left it
out. Happy to fold it in here or track it separately.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Matthias J. Sax <matthias@confluent.io>
