### PR TITLE
KAFKA-20495: Add transactional support to in-memory window and session stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -565,15 +565,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             this.latestSessionStartTime = latestSessionStartTime;
 
             final InMemorySessionTransactionBuffer.SessionEntryKey from =
-                new InMemorySessionTransactionBuffer.SessionEntryKey(
-                    earliestSessionEndTime,
-                    keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]),
-                    0);
+                new InMemorySessionTransactionBuffer.SessionEntryKey(earliestSessionEndTime, keyFrom, 0);
             final InMemorySessionTransactionBuffer.SessionEntryKey to =
-                new InMemorySessionTransactionBuffer.SessionEntryKey(
-                    latestSessionEndTime,
-                    keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}),
-                    Long.MAX_VALUE);
+                new InMemorySessionTransactionBuffer.SessionEntryKey(latestSessionEndTime, keyTo, Long.MAX_VALUE);
 
             this.delegate = buffer.range(from, to, forward, true);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -79,6 +80,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
     private StateStoreContext stateStoreContext;
     private final Position position;
+    private InMemorySessionTransactionBuffer transactionBuffer;
 
     public InMemorySessionStore(
         final String name,
@@ -146,6 +148,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             );
         }
         open = true;
+
+        final boolean transactional = StreamsConfig.InternalConfig.getBoolean(
+            stateStoreContext.appConfigs(),
+            StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG,
+            false);
+        if (transactional) {
+            this.transactionBuffer = new InMemorySessionTransactionBuffer(endTimeMap);
+        }
     }
 
     @Override
@@ -169,13 +179,17 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                 }
                 LOG.warn("Skipping record for expired segment.");
             } else {
-                if (aggregate != null) {
-                    endTimeMap.computeIfAbsent(windowEndTimestamp, t -> new ConcurrentSkipListMap<>());
-                    final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(windowEndTimestamp);
-                    keyMap.computeIfAbsent(sessionKey.key(), t -> new ConcurrentSkipListMap<>());
-                    keyMap.get(sessionKey.key()).put(sessionKey.window().start(), aggregate);
+                if (transactionBuffer != null) {
+                    transactionBuffer.stage(sessionKey, aggregate);
                 } else {
-                    remove(sessionKey);
+                    if (aggregate != null) {
+                        endTimeMap.computeIfAbsent(windowEndTimestamp, t -> new ConcurrentSkipListMap<>());
+                        final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(windowEndTimestamp);
+                        keyMap.computeIfAbsent(sessionKey.key(), t -> new ConcurrentSkipListMap<>());
+                        keyMap.get(sessionKey.key()).put(sessionKey.window().start(), aggregate);
+                    } else {
+                        remove(sessionKey);
+                    }
                 }
             }
 
@@ -185,6 +199,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
     @Override
     public void remove(final Windowed<Bytes> sessionKey) {
+        if (transactionBuffer != null) {
+            transactionBuffer.stage(sessionKey, null);
+            return;
+        }
+        removeFromBase(sessionKey);
+    }
+
+    private void removeFromBase(final Windowed<Bytes> sessionKey) {
         final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(sessionKey.window().end());
         if (keyMap == null) {
             return;
@@ -215,6 +237,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         // Only need to search if the record hasn't expired yet
         if (sessionEndTime > observedStreamTime - retentionPeriod) {
+            if (transactionBuffer != null) {
+                final Optional<byte[]> staged = transactionBuffer.get(key, sessionStartTime, sessionEndTime);
+                if (staged != null) {
+                    return staged.orElse(null);
+                }
+            }
+
             final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(sessionEndTime);
             if (keyMap != null) {
                 final ConcurrentNavigableMap<Long, byte[]> startTimeMap = keyMap.get(key);
@@ -231,6 +260,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                                                                   final long latestSessionEndTime) {
         removeExpiredSegments();
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(
+                null, null, Long.MAX_VALUE, earliestSessionEndTime, latestSessionEndTime, true
+            );
+        }
+
         final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimSubMap
             = endTimeMap.subMap(earliestSessionEndTime, true, latestSessionEndTime, true);
 
@@ -244,6 +279,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         Objects.requireNonNull(key, "key cannot be null");
 
         removeExpiredSegments();
+
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(
+                key, key, latestSessionStartTime, earliestSessionEndTime, Long.MAX_VALUE, true
+            );
+        }
 
         return registerNewIterator(key,
                                    key,
@@ -259,6 +300,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         Objects.requireNonNull(key, "key cannot be null");
 
         removeExpiredSegments();
+
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(
+                key, key, latestSessionStartTime, earliestSessionEndTime, Long.MAX_VALUE, false
+            );
+        }
 
         return registerNewIterator(
             key,
@@ -281,6 +328,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             return KeyValueIterators.emptyIterator();
         }
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(
+                keyFrom, keyTo, latestSessionStartTime, earliestSessionEndTime, Long.MAX_VALUE, true
+            );
+        }
+
         return registerNewIterator(keyFrom,
                                    keyTo,
                                    latestSessionStartTime,
@@ -300,6 +353,12 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             return KeyValueIterators.emptyIterator();
         }
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(
+                keyFrom, keyTo, latestSessionStartTime, earliestSessionEndTime, Long.MAX_VALUE, false
+            );
+        }
+
         return registerNewIterator(
             keyFrom,
             keyTo,
@@ -316,6 +375,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         removeExpiredSegments();
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(key, key, Long.MAX_VALUE, 0, Long.MAX_VALUE, true);
+        }
+
         return registerNewIterator(key, key, Long.MAX_VALUE, endTimeMap.entrySet().iterator(), true);
     }
 
@@ -326,6 +389,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         removeExpiredSegments();
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(key, key, Long.MAX_VALUE, 0, Long.MAX_VALUE, false);
+        }
+
         return registerNewIterator(key, key, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
     }
 
@@ -333,12 +400,20 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
         removeExpiredSegments();
 
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(keyFrom, keyTo, Long.MAX_VALUE, 0, Long.MAX_VALUE, true);
+        }
+
         return registerNewIterator(keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.entrySet().iterator(), true);
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo) {
         removeExpiredSegments();
+
+        if (transactionBuffer != null) {
+            return newTransactionalSessionIterator(keyFrom, keyTo, Long.MAX_VALUE, 0, Long.MAX_VALUE, false);
+        }
 
         return registerNewIterator(
             keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.descendingMap().entrySet().iterator(), false);
@@ -370,12 +445,26 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        if (transactionBuffer != null) {
+            return transactionBuffer.approximateNumUncommittedBytes();
+        }
+        return 0;
+    }
+
+    @Override
     public void commit(final Map<TopicPartition, Long> changelogOffsets) {
-        // do-nothing since it is in-memory
+        if (transactionBuffer != null) {
+            transactionBuffer.commit();
+        }
     }
 
     @Override
     public void close() {
+        if (transactionBuffer != null) {
+            transactionBuffer.rollback();
+        }
+
         if (openIterators.size() != 0) {
             LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
             for (final InMemorySessionStoreIterator it : openIterators) {
@@ -405,6 +494,19 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         endTimeMap.headMap(minLiveTime, false).clear();
     }
 
+    private KeyValueIterator<Windowed<Bytes>, byte[]> newTransactionalSessionIterator(
+            final Bytes keyFrom,
+            final Bytes keyTo,
+            final long latestSessionStartTime,
+            final long earliestSessionEndTime,
+            final long latestSessionEndTime,
+            final boolean forward) {
+        return new TransactionalSessionIterator(
+            transactionBuffer, keyFrom, keyTo, latestSessionStartTime,
+            earliestSessionEndTime, latestSessionEndTime, forward
+        );
+    }
+
     private InMemorySessionStoreIterator registerNewIterator(final Bytes keyFrom,
                                                              final Bytes keyTo,
                                                              final long latestSessionStartTime,
@@ -421,6 +523,86 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             );
         openIterators.add(iterator);
         return iterator;
+    }
+
+    /**
+     * A session iterator backed by a transactional buffer's merge scan.
+     * Converts SessionEntryKey/byte[] pairs into Windowed<Bytes>/byte[] pairs,
+     * filtering by latestSessionStartTime.
+     */
+    private static class TransactionalSessionIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+        private final KeyValueIterator<InMemorySessionTransactionBuffer.SessionEntryKey, byte[]> delegate;
+        private final long latestSessionStartTime;
+        private KeyValue<Windowed<Bytes>, byte[]> prefetched;
+
+        TransactionalSessionIterator(
+                final InMemorySessionTransactionBuffer buffer,
+                final Bytes keyFrom,
+                final Bytes keyTo,
+                final long latestSessionStartTime,
+                final long earliestSessionEndTime,
+                final long latestSessionEndTime,
+                final boolean forward) {
+            this.latestSessionStartTime = latestSessionStartTime;
+
+            final InMemorySessionTransactionBuffer.SessionEntryKey from =
+                new InMemorySessionTransactionBuffer.SessionEntryKey(
+                    earliestSessionEndTime,
+                    keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]),
+                    0);
+            final InMemorySessionTransactionBuffer.SessionEntryKey to =
+                new InMemorySessionTransactionBuffer.SessionEntryKey(
+                    latestSessionEndTime,
+                    keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}),
+                    Long.MAX_VALUE);
+
+            this.delegate = buffer.range(from, to, forward, true);
+        }
+
+        @Override
+        public Windowed<Bytes> peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return prefetched.key;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (prefetched != null) {
+                return true;
+            }
+            prefetched = computeNext();
+            return prefetched != null;
+        }
+
+        @Override
+        public KeyValue<Windowed<Bytes>, byte[]> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<Windowed<Bytes>, byte[]> result = prefetched;
+            prefetched = null;
+            return result;
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        private KeyValue<Windowed<Bytes>, byte[]> computeNext() {
+            while (delegate.hasNext()) {
+                final KeyValue<InMemorySessionTransactionBuffer.SessionEntryKey, byte[]> entry = delegate.next();
+                // Filter by latestSessionStartTime
+                if (entry.key.startTime() <= latestSessionStartTime) {
+                    final SessionWindow sessionWindow = new SessionWindow(entry.key.startTime(), entry.key.endTime());
+                    final Windowed<Bytes> windowedKey = new Windowed<>(entry.key.key(), sessionWindow);
+                    return new KeyValue<>(windowedKey, entry.value);
+                }
+            }
+            return null;
+        }
     }
 
     interface ClosingCallback {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -551,6 +551,8 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
      */
     private static class TransactionalSessionIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
         private final KeyValueIterator<InMemorySessionTransactionBuffer.SessionEntryKey, byte[]> delegate;
+        private final Bytes keyFrom;
+        private final Bytes keyTo;
         private final long latestSessionStartTime;
         private KeyValue<Windowed<Bytes>, byte[]> prefetched;
 
@@ -562,12 +564,16 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                 final long earliestSessionEndTime,
                 final long latestSessionEndTime,
                 final boolean forward) {
+            this.keyFrom = keyFrom;
+            this.keyTo = keyTo;
             this.latestSessionStartTime = latestSessionStartTime;
 
+            // startTime sorts descending, so the lower bound carries the largest startTime and the
+            // upper bound the smallest. A null key leaves the key dimension open (see SessionEntryKey).
             final InMemorySessionTransactionBuffer.SessionEntryKey from =
-                new InMemorySessionTransactionBuffer.SessionEntryKey(earliestSessionEndTime, keyFrom, 0);
+                new InMemorySessionTransactionBuffer.SessionEntryKey(earliestSessionEndTime, keyFrom, Long.MAX_VALUE);
             final InMemorySessionTransactionBuffer.SessionEntryKey to =
-                new InMemorySessionTransactionBuffer.SessionEntryKey(latestSessionEndTime, keyTo, Long.MAX_VALUE);
+                new InMemorySessionTransactionBuffer.SessionEntryKey(latestSessionEndTime, keyTo, 0);
 
             this.delegate = buffer.range(from, to, forward, true);
         }
@@ -607,8 +613,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         private KeyValue<Windowed<Bytes>, byte[]> computeNext() {
             while (delegate.hasNext()) {
                 final KeyValue<InMemorySessionTransactionBuffer.SessionEntryKey, byte[]> entry = delegate.next();
-                // Filter by latestSessionStartTime
-                if (entry.key.startTime() <= latestSessionStartTime) {
+                // The staged scan is bounded only by endTime, so filter the key range and
+                // latestSessionStartTime here to drop any staged entries outside the query.
+                if (entry.key.startTime() <= latestSessionStartTime && keyInRange(entry.key.key())) {
                     final SessionWindow sessionWindow = new SessionWindow(entry.key.startTime(), entry.key.endTime());
                     final Windowed<Bytes> windowedKey = new Windowed<>(entry.key.key(), sessionWindow);
                     return new KeyValue<>(windowedKey, entry.value);
@@ -616,13 +623,18 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             }
             return null;
         }
+
+        private boolean keyInRange(final Bytes key) {
+            return (keyFrom == null || key.compareTo(keyFrom) >= 0)
+                && (keyTo == null || key.compareTo(keyTo) <= 0);
+        }
     }
 
     interface ClosingCallback {
         void deregisterIterator(final InMemorySessionStoreIterator iterator);
     }
 
-    private static class InMemorySessionStoreIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+    static class InMemorySessionStoreIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
 
         private final Iterator<Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>>> endTimeIterator;
         private Iterator<Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>>> keyIterator;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Consumer;
 
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 
@@ -75,6 +76,7 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeMap = new ConcurrentSkipListMap<>();
     private final Set<InMemorySessionStoreIterator> openIterators  = ConcurrentHashMap.newKeySet();
+    private final Set<TransactionalSessionIterator> openTransactionalIterators = ConcurrentHashMap.newKeySet();
 
     private volatile boolean open = false;
 
@@ -484,15 +486,20 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             transactionBuffer.rollback();
         }
 
-        if (openIterators.size() != 0) {
-            LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
+        final int openCount = openIterators.size() + openTransactionalIterators.size();
+        if (openCount != 0) {
+            LOG.warn("Closing {} open iterators for store {}", openCount, name);
             for (final InMemorySessionStoreIterator it : openIterators) {
+                it.close();
+            }
+            for (final TransactionalSessionIterator it : openTransactionalIterators) {
                 it.close();
             }
         }
 
         endTimeMap.clear();
         openIterators.clear();
+        openTransactionalIterators.clear();
         open = false;
     }
 
@@ -520,10 +527,13 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             final long earliestSessionEndTime,
             final long latestSessionEndTime,
             final boolean forward) {
-        return new TransactionalSessionIterator(
+        final TransactionalSessionIterator iterator = new TransactionalSessionIterator(
             transactionBuffer, keyFrom, keyTo, latestSessionStartTime,
-            earliestSessionEndTime, latestSessionEndTime, forward
+            earliestSessionEndTime, latestSessionEndTime,
+            observedStreamTime - retentionPeriod, forward, openTransactionalIterators::remove
         );
+        openTransactionalIterators.add(iterator);
+        return iterator;
     }
 
     private InMemorySessionStoreIterator registerNewIterator(final Bytes keyFrom,
@@ -554,7 +564,10 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
         private final Bytes keyFrom;
         private final Bytes keyTo;
         private final long latestSessionStartTime;
+        private final long oldestRetainedEndTime;
+        private final Consumer<TransactionalSessionIterator> deregister;
         private KeyValue<Windowed<Bytes>, byte[]> prefetched;
+        private boolean closed = false;
 
         TransactionalSessionIterator(
                 final InMemorySessionTransactionBuffer buffer,
@@ -563,10 +576,14 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                 final long latestSessionStartTime,
                 final long earliestSessionEndTime,
                 final long latestSessionEndTime,
-                final boolean forward) {
+                final long oldestRetainedEndTime,
+                final boolean forward,
+                final Consumer<TransactionalSessionIterator> deregister) {
             this.keyFrom = keyFrom;
             this.keyTo = keyTo;
             this.latestSessionStartTime = latestSessionStartTime;
+            this.oldestRetainedEndTime = oldestRetainedEndTime;
+            this.deregister = deregister;
 
             // startTime sorts descending, so the lower bound carries the largest startTime and the
             // upper bound the smallest. A null key leaves the key dimension open (see SessionEntryKey).
@@ -588,6 +605,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         @Override
         public boolean hasNext() {
+            if (closed) {
+                return false;
+            }
             if (prefetched != null) {
                 return true;
             }
@@ -607,15 +627,24 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
 
         @Override
         public void close() {
-            delegate.close();
+            closed = true;
+            prefetched = null;
+            try {
+                delegate.close();
+            } finally {
+                deregister.accept(this);
+            }
         }
 
         private KeyValue<Windowed<Bytes>, byte[]> computeNext() {
             while (delegate.hasNext()) {
                 final KeyValue<InMemorySessionTransactionBuffer.SessionEntryKey, byte[]> entry = delegate.next();
-                // The staged scan is bounded only by endTime, so filter the key range and
-                // latestSessionStartTime here to drop any staged entries outside the query.
-                if (entry.key.startTime() <= latestSessionStartTime && keyInRange(entry.key.key())) {
+                // The committed side is already pruned by removeExpiredSegments, but the staged side is
+                // not; drop expired entries here. The staged scan is also bounded only by endTime, so
+                // filter the key range and latestSessionStartTime too.
+                if (entry.key.endTime() > oldestRetainedEndTime
+                    && entry.key.startTime() <= latestSessionStartTime
+                    && keyInRange(entry.key.key())) {
                     final SessionWindow sessionWindow = new SessionWindow(entry.key.startTime(), entry.key.endTime());
                     final Windowed<Bytes> windowedKey = new Windowed<>(entry.key.key(), sessionWindow);
                     return new KeyValue<>(windowedKey, entry.value);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -135,13 +135,29 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                 root,
                 (RecordBatchingStateRestoreCallback) records -> {
                     synchronized (position) {
+                        long expiredRecords = 0;
                         for (final ConsumerRecord<byte[], byte[]> record : records) {
-                            put(SessionKeySchema.from(Bytes.wrap(record.key())), record.value());
+                            final Windowed<Bytes> sessionKey = SessionKeySchema.from(Bytes.wrap(record.key()));
+                            final long windowEndTimestamp = sessionKey.window().end();
+                            observedStreamTime = Math.max(observedStreamTime, windowEndTimestamp);
+                            if (windowEndTimestamp <= observedStreamTime - retentionPeriod) {
+                                expiredRecords++;
+                            } else {
+                                // Write directly to the committed map: restored records are already committed.
+                                putInternal(sessionKey, record.value());
+                            }
                             ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                                 record,
                                 consistencyEnabled,
                                 position
                             );
+                        }
+                        removeExpiredSegments();
+                        if (expiredRecords > 0) {
+                            if (expiredRecordSensor != null && context != null) {
+                                expiredRecordSensor.record(expiredRecords, context.currentSystemTimeMs());
+                            }
+                            LOG.warn("Skipping {} records for expired segments.", expiredRecords);
                         }
                     }
                 }
@@ -178,22 +194,25 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                     expiredRecordSensor.record(1.0d, context.currentSystemTimeMs());
                 }
                 LOG.warn("Skipping record for expired segment.");
+            } else if (transactionBuffer != null) {
+                transactionBuffer.stage(sessionKey, aggregate);
             } else {
-                if (transactionBuffer != null) {
-                    transactionBuffer.stage(sessionKey, aggregate);
-                } else {
-                    if (aggregate != null) {
-                        endTimeMap.computeIfAbsent(windowEndTimestamp, t -> new ConcurrentSkipListMap<>());
-                        final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(windowEndTimestamp);
-                        keyMap.computeIfAbsent(sessionKey.key(), t -> new ConcurrentSkipListMap<>());
-                        keyMap.get(sessionKey.key()).put(sessionKey.window().start(), aggregate);
-                    } else {
-                        remove(sessionKey);
-                    }
-                }
+                putInternal(sessionKey, aggregate);
             }
 
             StoreQueryUtils.updatePosition(position, stateStoreContext);
+        }
+    }
+
+    private void putInternal(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
+        if (aggregate != null) {
+            final long windowEndTimestamp = sessionKey.window().end();
+            endTimeMap.computeIfAbsent(windowEndTimestamp, t -> new ConcurrentSkipListMap<>());
+            final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(windowEndTimestamp);
+            keyMap.computeIfAbsent(sessionKey.key(), t -> new ConcurrentSkipListMap<>());
+            keyMap.get(sessionKey.key()).put(sessionKey.window().start(), aggregate);
+        } else {
+            removeFromBase(sessionKey);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
@@ -73,9 +73,11 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
             if (cmp != 0) {
                 return cmp;
             }
-            cmp = this.key.compareTo(other.key);
-            if (cmp != 0) {
-                return cmp;
+            if (this.key != null && other.key != null) {
+                cmp = this.key.compareTo(other.key);
+                if (cmp != 0) {
+                    return cmp;
+                }
             }
             return Long.compare(this.startTime, other.startTime);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
@@ -19,10 +19,9 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.KeyValueIterator;
 
-import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -79,7 +78,9 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
                     return cmp;
                 }
             }
-            return Long.compare(this.startTime, other.startTime);
+            // Descending startTime, matching the order the reused InMemorySessionStoreIterator emits,
+            // so the staged map and the base iterator merge in lock-step.
+            return Long.compare(other.startTime, this.startTime);
         }
 
         @Override
@@ -137,10 +138,7 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
             timeRange = endTimeMap;
         }
 
-        return new FlattenedSessionIterator(
-            forward ? timeRange : timeRange.descendingMap(),
-            from, to, forward, toInclusive
-        );
+        return baseIterator(forward ? timeRange : timeRange.descendingMap(), from, to, forward);
     }
 
     /**
@@ -171,10 +169,29 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
             copy.put(endTimeEntry.getKey(), keyCopy);
         }
 
-        return new FlattenedSessionIterator(
-            forward ? copy : copy.descendingMap(),
-            from, to, forward, toInclusive
-        );
+        return baseIterator(forward ? copy : copy.descendingMap(), from, to, forward);
+    }
+
+    /**
+     * Builds the committed-side base iterator by reusing the non-transactional
+     * {@link InMemorySessionStore.InMemorySessionStoreIterator}, which bounds keys at every endTime and
+     * emits in the same (endTime, key, descending-startTime) order as the staged map. The
+     * latestSessionStartTime bound is left open here (the store's {@code TransactionalSessionIterator}
+     * applies it); a null from/to key leaves the key dimension open.
+     */
+    private static ManagedKeyValueIterator<SessionEntryKey, byte[]> baseIterator(
+            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> timeRange,
+            final SessionEntryKey from,
+            final SessionEntryKey to,
+            final boolean forward) {
+        return new SessionEntryKeyIterator(
+            new InMemorySessionStore.InMemorySessionStoreIterator(
+                from != null ? from.key() : null,
+                to != null ? to.key() : null,
+                Long.MAX_VALUE,
+                timeRange.entrySet().iterator(),
+                ignored -> { },
+                forward));
     }
 
     @Override
@@ -211,150 +228,31 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
     }
 
     /**
-     * Iterator that flattens the three-level endTimeMap structure into a stream of
-     * SessionEntryKey/byte[] pairs, respecting key bounds and direction.
+     * Adapts the non-transactional session iterator's {@code Windowed<Bytes>} output to the
+     * {@link SessionEntryKey} space the staged-merge consumes.
      */
-    private static class FlattenedSessionIterator implements ManagedKeyValueIterator<SessionEntryKey, byte[]> {
-        private final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>>> endTimeIterator;
-        private final SessionEntryKey from;
-        private final SessionEntryKey to;
-        private final boolean forward;
-        private final boolean toInclusive;
-
-        private Iterator<Map.Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>>> keyIterator;
-        private Iterator<Map.Entry<Long, byte[]>> startTimeIterator;
-        private long currentEndTime;
-        private Bytes currentKey;
-        private KeyValue<SessionEntryKey, byte[]> prefetched;
-        private boolean closed = false;
+    private static final class SessionEntryKeyIterator implements ManagedKeyValueIterator<SessionEntryKey, byte[]> {
+        private final KeyValueIterator<Windowed<Bytes>, byte[]> delegate;
         private Runnable closeCallback;
 
-        FlattenedSessionIterator(
-                final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> timeRange,
-                final SessionEntryKey from,
-                final SessionEntryKey to,
-                final boolean forward,
-                final boolean toInclusive) {
-            this.from = from;
-            this.to = to;
-            this.forward = forward;
-            this.toInclusive = toInclusive;
-            this.endTimeIterator = timeRange.entrySet().iterator();
-            advanceToNextRecord();
-        }
-
-        private void advanceToNextRecord() {
-            // Try advancing within current startTimeIterator
-            if (startTimeIterator != null && startTimeIterator.hasNext()) {
-                return;
-            }
-            // Try advancing within current keyIterator
-            if (advanceWithinKeyIterator()) {
-                return;
-            }
-            // Advance to next endTime segment
-            advanceToNextEndTimeSegment();
-        }
-
-        private boolean advanceWithinKeyIterator() {
-            if (keyIterator == null) {
-                return false;
-            }
-            while (keyIterator.hasNext()) {
-                final Map.Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyEntry = keyIterator.next();
-                currentKey = keyEntry.getKey();
-                startTimeIterator = getStartTimeIterator(keyEntry.getValue());
-                if (startTimeIterator.hasNext()) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void advanceToNextEndTimeSegment() {
-            while (endTimeIterator.hasNext()) {
-                final Map.Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeEntry =
-                    endTimeIterator.next();
-                currentEndTime = endTimeEntry.getKey();
-
-                final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> subMap =
-                    boundKeyMap(endTimeEntry.getValue());
-                keyIterator = (forward ? subMap : subMap.descendingMap()).entrySet().iterator();
-                if (advanceWithinKeyIterator()) {
-                    return;
-                }
-            }
-            startTimeIterator = null;
-        }
-
-        private ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> boundKeyMap(
-                final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> kvMap) {
-            final Bytes keyFrom = (from != null && currentEndTime == from.endTime()) ? from.key() : null;
-            final Bytes keyTo = (to != null && currentEndTime == to.endTime()) ? to.key() : null;
-            if (keyFrom != null && keyTo != null) {
-                return kvMap.subMap(keyFrom, true, keyTo, true);
-            } else if (keyFrom != null) {
-                return kvMap.tailMap(keyFrom, true);
-            } else if (keyTo != null) {
-                return kvMap.headMap(keyTo, true);
-            } else {
-                return kvMap;
-            }
-        }
-
-        private Iterator<Map.Entry<Long, byte[]>> getStartTimeIterator(
-                final ConcurrentNavigableMap<Long, byte[]> startTimeMap) {
-            final ConcurrentNavigableMap<Long, byte[]> subMap = boundStartTimeMap(startTimeMap);
-            return (forward ? subMap : subMap.descendingMap()).entrySet().iterator();
-        }
-
-        private ConcurrentNavigableMap<Long, byte[]> boundStartTimeMap(
-                final ConcurrentNavigableMap<Long, byte[]> startTimeMap) {
-            final Long startFrom = (from != null && currentEndTime == from.endTime()
-                && currentKey.equals(from.key())) ? from.startTime() : null;
-            final Long startTo = (to != null && currentEndTime == to.endTime()
-                && currentKey.equals(to.key())) ? to.startTime() : null;
-            final boolean startToInclusive = (startTo != null) ? toInclusive : true;
-
-            if (startFrom != null && startTo != null) {
-                return startTimeMap.subMap(startFrom, true, startTo, startToInclusive);
-            } else if (startFrom != null) {
-                return startTimeMap.tailMap(startFrom, true);
-            } else if (startTo != null) {
-                return startTimeMap.headMap(startTo, startToInclusive);
-            } else {
-                return startTimeMap;
-            }
+        SessionEntryKeyIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> delegate) {
+            this.delegate = delegate;
         }
 
         @Override
         public boolean hasNext() {
-            if (closed) {
-                throw new IllegalStateException("Iterator has already been closed.");
-            }
-            if (prefetched != null) {
-                return true;
-            }
-            prefetched = computeNext();
-            return prefetched != null;
+            return delegate.hasNext();
         }
 
         @Override
         public KeyValue<SessionEntryKey, byte[]> next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            final KeyValue<SessionEntryKey, byte[]> result = prefetched;
-            prefetched = null;
-            return result;
+            final KeyValue<Windowed<Bytes>, byte[]> entry = delegate.next();
+            return new KeyValue<>(toKey(entry.key), entry.value);
         }
 
         @Override
         public SessionEntryKey peekNextKey() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return prefetched.key;
+            return toKey(delegate.peekNextKey());
         }
 
         @Override
@@ -364,31 +262,17 @@ class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemor
 
         @Override
         public void close() {
-            closed = true;
-            if (closeCallback != null) {
-                closeCallback.run();
+            try {
+                delegate.close();
+            } finally {
+                if (closeCallback != null) {
+                    closeCallback.run();
+                }
             }
         }
 
-        private KeyValue<SessionEntryKey, byte[]> computeNext() {
-            if (startTimeIterator == null) {
-                return null;
-            }
-            if (!startTimeIterator.hasNext()) {
-                advanceToNextRecord();
-                if (startTimeIterator == null || !startTimeIterator.hasNext()) {
-                    return null;
-                }
-            }
-            final Map.Entry<Long, byte[]> entry = startTimeIterator.next();
-            final KeyValue<SessionEntryKey, byte[]> result =
-                new KeyValue<>(new SessionEntryKey(currentEndTime, currentKey, entry.getKey()), entry.getValue());
-
-            // Pre-advance so hasNext() works correctly
-            if (!startTimeIterator.hasNext()) {
-                advanceToNextRecord();
-            }
-            return result;
+        private static SessionEntryKey toKey(final Windowed<Bytes> windowed) {
+            return new SessionEntryKey(windowed.window().end(), windowed.key(), windowed.window().start());
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionTransactionBuffer.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * A {@link TransactionBuffer} implementation for {@link InMemorySessionStore}.
+ * Uses a composite key of (endTime, key, startTime) to maintain correct sort order in the staging map.
+ */
+class InMemorySessionTransactionBuffer extends AbstractTransactionBuffer<InMemorySessionTransactionBuffer.SessionEntryKey> {
+
+    private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeMap;
+
+    InMemorySessionTransactionBuffer(
+            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeMap) {
+        this.endTimeMap = endTimeMap;
+    }
+
+    /**
+     * Composite key for the session store staging map. Sorts by endTime, then key, then startTime.
+     */
+    static final class SessionEntryKey implements Comparable<SessionEntryKey> {
+        private final long endTime;
+        private final Bytes key;
+        private final long startTime;
+
+        SessionEntryKey(final long endTime, final Bytes key, final long startTime) {
+            this.endTime = endTime;
+            this.key = key;
+            this.startTime = startTime;
+        }
+
+        long endTime() {
+            return endTime;
+        }
+
+        Bytes key() {
+            return key;
+        }
+
+        long startTime() {
+            return startTime;
+        }
+
+        @Override
+        public int compareTo(final SessionEntryKey other) {
+            int cmp = Long.compare(this.endTime, other.endTime);
+            if (cmp != 0) {
+                return cmp;
+            }
+            cmp = this.key.compareTo(other.key);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Long.compare(this.startTime, other.startTime);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SessionEntryKey)) return false;
+            final SessionEntryKey that = (SessionEntryKey) o;
+            return endTime == that.endTime && startTime == that.startTime && Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(endTime, key, startTime);
+        }
+    }
+
+    // -- Convenience methods for the store --
+
+    void stage(final Windowed<Bytes> sessionKey, final byte[] value) {
+        super.stage(new SessionEntryKey(sessionKey.window().end(), sessionKey.key(), sessionKey.window().start()), value);
+    }
+
+    Optional<byte[]> get(final Bytes key, final long startTime, final long endTime) {
+        return super.get(new SessionEntryKey(endTime, key, startTime));
+    }
+
+    // -- AbstractTransactionBuffer implementation --
+
+    @Override
+    int estimateKeySize(final SessionEntryKey key) {
+        return 2 * Long.BYTES + key.key().get().length;
+    }
+
+    @Override
+    void stageToBackend(final SessionEntryKey key, final byte[] value) {
+        // no-op — staging map is sufficient; no write-batch concept for in-memory
+    }
+
+    @Override
+    ManagedKeyValueIterator<SessionEntryKey, byte[]> newBaseIterator(final SessionEntryKey from, final SessionEntryKey to) {
+        return newBaseIterator(from, to, true, true);
+    }
+
+    @Override
+    ManagedKeyValueIterator<SessionEntryKey, byte[]> newBaseIterator(final SessionEntryKey from, final SessionEntryKey to,
+                                                                     final boolean forward, final boolean toInclusive) {
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> timeRange;
+        if (from != null && to != null) {
+            timeRange = endTimeMap.subMap(from.endTime(), true, to.endTime(), true);
+        } else if (from != null) {
+            timeRange = endTimeMap.tailMap(from.endTime(), true);
+        } else if (to != null) {
+            timeRange = endTimeMap.headMap(to.endTime(), true);
+        } else {
+            timeRange = endTimeMap;
+        }
+
+        return new FlattenedSessionIterator(
+            forward ? timeRange : timeRange.descendingMap(),
+            from, to, forward, toInclusive
+        );
+    }
+
+    /**
+     * Non-owner (IQ) path: eagerly deep-copies the bounded end-time range while the caller holds
+     * the snapshot read-lock, providing true point-in-time isolation. The returned iterator never
+     * touches the live end-time map, so concurrent owner mutation cannot disturb it.
+     */
+    @Override
+    ManagedKeyValueIterator<SessionEntryKey, byte[]> newBaseSnapshotIterator(final SessionEntryKey from, final SessionEntryKey to,
+                                                                             final boolean forward, final boolean toInclusive) {
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> timeRange;
+        if (from != null && to != null) {
+            timeRange = endTimeMap.subMap(from.endTime(), true, to.endTime(), true);
+        } else if (from != null) {
+            timeRange = endTimeMap.tailMap(from.endTime(), true);
+        } else if (to != null) {
+            timeRange = endTimeMap.headMap(to.endTime(), true);
+        } else {
+            timeRange = endTimeMap;
+        }
+
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> copy = new ConcurrentSkipListMap<>();
+        for (final Map.Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeEntry : timeRange.entrySet()) {
+            final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyCopy = new ConcurrentSkipListMap<>();
+            for (final Map.Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyEntry : endTimeEntry.getValue().entrySet()) {
+                keyCopy.put(keyEntry.getKey(), new ConcurrentSkipListMap<>(keyEntry.getValue()));
+            }
+            copy.put(endTimeEntry.getKey(), keyCopy);
+        }
+
+        return new FlattenedSessionIterator(
+            forward ? copy : copy.descendingMap(),
+            from, to, forward, toInclusive
+        );
+    }
+
+    @Override
+    void flushToBase() {
+        for (final Map.Entry<SessionEntryKey, Optional<byte[]>> entry : pendingWrites.entrySet()) {
+            final long endTime = entry.getKey().endTime();
+            final Bytes key = entry.getKey().key();
+            final long startTime = entry.getKey().startTime();
+            if (entry.getValue().isPresent()) {
+                endTimeMap.computeIfAbsent(endTime, t -> new ConcurrentSkipListMap<>())
+                    .computeIfAbsent(key, k -> new ConcurrentSkipListMap<>())
+                    .put(startTime, entry.getValue().get());
+            } else {
+                final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(endTime);
+                if (keyMap != null) {
+                    final ConcurrentNavigableMap<Long, byte[]> startTimeMap = keyMap.get(key);
+                    if (startTimeMap != null) {
+                        startTimeMap.remove(startTime);
+                        if (startTimeMap.isEmpty()) {
+                            keyMap.remove(key);
+                            if (keyMap.isEmpty()) {
+                                endTimeMap.remove(endTime);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    void discardPendingBatch() {
+        // no-op — no backend batch to discard
+    }
+
+    /**
+     * Iterator that flattens the three-level endTimeMap structure into a stream of
+     * SessionEntryKey/byte[] pairs, respecting key bounds and direction.
+     */
+    private static class FlattenedSessionIterator implements ManagedKeyValueIterator<SessionEntryKey, byte[]> {
+        private final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>>> endTimeIterator;
+        private final SessionEntryKey from;
+        private final SessionEntryKey to;
+        private final boolean forward;
+        private final boolean toInclusive;
+
+        private Iterator<Map.Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>>> keyIterator;
+        private Iterator<Map.Entry<Long, byte[]>> startTimeIterator;
+        private long currentEndTime;
+        private Bytes currentKey;
+        private KeyValue<SessionEntryKey, byte[]> prefetched;
+        private boolean closed = false;
+        private Runnable closeCallback;
+
+        FlattenedSessionIterator(
+                final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> timeRange,
+                final SessionEntryKey from,
+                final SessionEntryKey to,
+                final boolean forward,
+                final boolean toInclusive) {
+            this.from = from;
+            this.to = to;
+            this.forward = forward;
+            this.toInclusive = toInclusive;
+            this.endTimeIterator = timeRange.entrySet().iterator();
+            advanceToNextRecord();
+        }
+
+        private void advanceToNextRecord() {
+            // Try advancing within current startTimeIterator
+            if (startTimeIterator != null && startTimeIterator.hasNext()) {
+                return;
+            }
+            // Try advancing within current keyIterator
+            if (advanceWithinKeyIterator()) {
+                return;
+            }
+            // Advance to next endTime segment
+            advanceToNextEndTimeSegment();
+        }
+
+        private boolean advanceWithinKeyIterator() {
+            if (keyIterator == null) {
+                return false;
+            }
+            while (keyIterator.hasNext()) {
+                final Map.Entry<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyEntry = keyIterator.next();
+                currentKey = keyEntry.getKey();
+                startTimeIterator = getStartTimeIterator(keyEntry.getValue());
+                if (startTimeIterator.hasNext()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void advanceToNextEndTimeSegment() {
+            while (endTimeIterator.hasNext()) {
+                final Map.Entry<Long, ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>>> endTimeEntry =
+                    endTimeIterator.next();
+                currentEndTime = endTimeEntry.getKey();
+
+                final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> subMap =
+                    boundKeyMap(endTimeEntry.getValue());
+                keyIterator = (forward ? subMap : subMap.descendingMap()).entrySet().iterator();
+                if (advanceWithinKeyIterator()) {
+                    return;
+                }
+            }
+            startTimeIterator = null;
+        }
+
+        private ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> boundKeyMap(
+                final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> kvMap) {
+            final Bytes keyFrom = (from != null && currentEndTime == from.endTime()) ? from.key() : null;
+            final Bytes keyTo = (to != null && currentEndTime == to.endTime()) ? to.key() : null;
+            if (keyFrom != null && keyTo != null) {
+                return kvMap.subMap(keyFrom, true, keyTo, true);
+            } else if (keyFrom != null) {
+                return kvMap.tailMap(keyFrom, true);
+            } else if (keyTo != null) {
+                return kvMap.headMap(keyTo, true);
+            } else {
+                return kvMap;
+            }
+        }
+
+        private Iterator<Map.Entry<Long, byte[]>> getStartTimeIterator(
+                final ConcurrentNavigableMap<Long, byte[]> startTimeMap) {
+            final ConcurrentNavigableMap<Long, byte[]> subMap = boundStartTimeMap(startTimeMap);
+            return (forward ? subMap : subMap.descendingMap()).entrySet().iterator();
+        }
+
+        private ConcurrentNavigableMap<Long, byte[]> boundStartTimeMap(
+                final ConcurrentNavigableMap<Long, byte[]> startTimeMap) {
+            final Long startFrom = (from != null && currentEndTime == from.endTime()
+                && currentKey.equals(from.key())) ? from.startTime() : null;
+            final Long startTo = (to != null && currentEndTime == to.endTime()
+                && currentKey.equals(to.key())) ? to.startTime() : null;
+            final boolean startToInclusive = (startTo != null) ? toInclusive : true;
+
+            if (startFrom != null && startTo != null) {
+                return startTimeMap.subMap(startFrom, true, startTo, startToInclusive);
+            } else if (startFrom != null) {
+                return startTimeMap.tailMap(startFrom, true);
+            } else if (startTo != null) {
+                return startTimeMap.headMap(startTo, startToInclusive);
+            } else {
+                return startTimeMap;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (closed) {
+                throw new IllegalStateException("Iterator has already been closed.");
+            }
+            if (prefetched != null) {
+                return true;
+            }
+            prefetched = computeNext();
+            return prefetched != null;
+        }
+
+        @Override
+        public KeyValue<SessionEntryKey, byte[]> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<SessionEntryKey, byte[]> result = prefetched;
+            prefetched = null;
+            return result;
+        }
+
+        @Override
+        public SessionEntryKey peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return prefetched.key;
+        }
+
+        @Override
+        public void onClose(final Runnable closeCallback) {
+            this.closeCallback = closeCallback;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            if (closeCallback != null) {
+                closeCallback.run();
+            }
+        }
+
+        private KeyValue<SessionEntryKey, byte[]> computeNext() {
+            if (startTimeIterator == null) {
+                return null;
+            }
+            if (!startTimeIterator.hasNext()) {
+                advanceToNextRecord();
+                if (startTimeIterator == null || !startTimeIterator.hasNext()) {
+                    return null;
+                }
+            }
+            final Map.Entry<Long, byte[]> entry = startTimeIterator.next();
+            final KeyValue<SessionEntryKey, byte[]> result =
+                new KeyValue<>(new SessionEntryKey(currentEndTime, currentKey, entry.getKey()), entry.getValue());
+
+            // Pre-advance so hasNext() works correctly
+            if (!startTimeIterator.hasNext()) {
+                advanceToNextRecord();
+            }
+            return result;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Consumer;
 
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.extractStoreKeyBytes;
@@ -73,6 +74,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap = new ConcurrentSkipListMap<>();
     private final Set<InMemoryWindowStoreIteratorWrapper> openIterators = ConcurrentHashMap.newKeySet();
+    private final Set<KeyValueIterator<?, ?>> openTransactionalIterators = ConcurrentHashMap.newKeySet();
 
     private InternalProcessorContext<?, ?> internalProcessorContext;
     private Sensor expiredRecordSensor;
@@ -267,9 +269,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         if (transactionBuffer != null) {
             final Bytes keyFrom = retainDuplicates ? wrapForDups(key, 0) : key;
             final Bytes keyTo = retainDuplicates ? wrapForDups(key, Integer.MAX_VALUE) : key;
-            return new TransactionalWindowStoreIterator(
-                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates
-            );
+            return registerTransactional(new TransactionalWindowStoreIterator(
+                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates,
+                openTransactionalIterators::remove
+            ));
         }
 
         if (forward) {
@@ -330,9 +333,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         if (transactionBuffer != null) {
             final Bytes keyFrom = (retainDuplicates && from != null) ? wrapForDups(from, 0) : from;
             final Bytes keyTo = (retainDuplicates && to != null) ? wrapForDups(to, Integer.MAX_VALUE) : to;
-            return new TransactionalWindowedKeyValueIterator(
-                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates, windowSize
-            );
+            return registerTransactional(new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates, windowSize, openTransactionalIterators::remove
+            ));
         }
 
         if (forward) {
@@ -375,9 +378,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         }
 
         if (transactionBuffer != null) {
-            return new TransactionalWindowedKeyValueIterator(
-                transactionBuffer, null, null, minTime, timeTo, forward, retainDuplicates, windowSize
-            );
+            return registerTransactional(new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime, timeTo, forward, retainDuplicates, windowSize, openTransactionalIterators::remove
+            ));
         }
 
         if (forward) {
@@ -406,9 +409,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final long minTime = observedStreamTime - retentionPeriod;
 
         if (transactionBuffer != null) {
-            return new TransactionalWindowedKeyValueIterator(
-                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, true, retainDuplicates, windowSize
-            );
+            return registerTransactional(new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, true, retainDuplicates, windowSize, openTransactionalIterators::remove
+            ));
         }
 
         return registerNewWindowedKeyValueIterator(
@@ -426,9 +429,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         final long minTime = observedStreamTime - retentionPeriod;
 
         if (transactionBuffer != null) {
-            return new TransactionalWindowedKeyValueIterator(
-                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, false, retainDuplicates, windowSize
-            );
+            return registerTransactional(new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, false, retainDuplicates, windowSize, openTransactionalIterators::remove
+            ));
         }
 
         return registerNewWindowedKeyValueIterator(
@@ -485,15 +488,25 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             transactionBuffer.rollback();
         }
 
-        if (openIterators.size() != 0) {
-            LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
+        final int openCount = openIterators.size() + openTransactionalIterators.size();
+        if (openCount != 0) {
+            LOG.warn("Closing {} open iterators for store {}", openCount, name);
             for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
+                it.close();
+            }
+            for (final KeyValueIterator<?, ?> it : openTransactionalIterators) {
                 it.close();
             }
         }
 
         segmentMap.clear();
+        openTransactionalIterators.clear();
         open = false;
+    }
+
+    private <T extends KeyValueIterator<?, ?>> T registerTransactional(final T iterator) {
+        openTransactionalIterators.add(iterator);
+        return iterator;
     }
 
     long numEntries() {
@@ -599,7 +612,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         private final Bytes unwrappedFrom;
         private final Bytes unwrappedTo;
         private final boolean retainDuplicates;
+        private final Consumer<KeyValueIterator<?, ?>> deregister;
         private KeyValue<Long, byte[]> prefetched;
+        private boolean closed = false;
 
         TransactionalWindowStoreIterator(
                 final InMemoryWindowTransactionBuffer buffer,
@@ -608,8 +623,10 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 final long timeFrom,
                 final long timeTo,
                 final boolean forward,
-                final boolean retainDuplicates) {
+                final boolean retainDuplicates,
+                final Consumer<KeyValueIterator<?, ?>> deregister) {
             this.retainDuplicates = retainDuplicates;
+            this.deregister = deregister;
             this.unwrappedFrom = unwrapBound(keyFrom, retainDuplicates);
             this.unwrappedTo = unwrapBound(keyTo, retainDuplicates);
             final InMemoryWindowTransactionBuffer.WindowEntryKey from =
@@ -630,6 +647,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         @Override
         public boolean hasNext() {
+            if (closed) {
+                return false;
+            }
             if (prefetched != null) {
                 return true;
             }
@@ -649,7 +669,13 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         @Override
         public void close() {
-            delegate.close();
+            closed = true;
+            prefetched = null;
+            try {
+                delegate.close();
+            } finally {
+                deregister.accept(this);
+            }
         }
 
         private KeyValue<Long, byte[]> computeNext() {
@@ -673,7 +699,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         private final Bytes unwrappedTo;
         private final boolean retainDuplicates;
         private final long windowSize;
+        private final Consumer<KeyValueIterator<?, ?>> deregister;
         private KeyValue<Windowed<Bytes>, byte[]> prefetched;
+        private boolean closed = false;
 
         TransactionalWindowedKeyValueIterator(
                 final InMemoryWindowTransactionBuffer buffer,
@@ -683,9 +711,11 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 final long timeTo,
                 final boolean forward,
                 final boolean retainDuplicates,
-                final long windowSize) {
+                final long windowSize,
+                final Consumer<KeyValueIterator<?, ?>> deregister) {
             this.retainDuplicates = retainDuplicates;
             this.windowSize = windowSize;
+            this.deregister = deregister;
             this.unwrappedFrom = unwrapBound(keyFrom, retainDuplicates);
             this.unwrappedTo = unwrapBound(keyTo, retainDuplicates);
             final InMemoryWindowTransactionBuffer.WindowEntryKey from =
@@ -706,6 +736,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         @Override
         public boolean hasNext() {
+            if (closed) {
+                return false;
+            }
             if (prefetched != null) {
                 return true;
             }
@@ -725,7 +758,13 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         @Override
         public void close() {
-            delegate.close();
+            closed = true;
+            prefetched = null;
+            try {
+                delegate.close();
+            } finally {
+                deregister.accept(this);
+            }
         }
 
         private KeyValue<Windowed<Bytes>, byte[]> computeNext() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -81,6 +82,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
     private volatile boolean open = false;
 
     private final Position position;
+    private InMemoryWindowTransactionBuffer transactionBuffer;
 
     public InMemoryWindowStore(final String name,
                                final long retentionPeriod,
@@ -146,6 +148,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             );
         }
         open = true;
+
+        final boolean transactional = StreamsConfig.InternalConfig.getBoolean(
+            stateStoreContext.appConfigs(),
+            StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG,
+            false);
+        if (transactional) {
+            this.transactionBuffer = new InMemoryWindowTransactionBuffer(segmentMap);
+        }
     }
 
     @Override
@@ -166,17 +176,25 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 if (value != null) {
                     maybeUpdateSeqnumForDups();
                     final Bytes keyBytes = retainDuplicates ? wrapForDups(key, seqnum) : key;
-                    segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
-                    segmentMap.get(windowStartTimestamp).put(keyBytes, value);
+                    if (transactionBuffer != null) {
+                        transactionBuffer.stage(windowStartTimestamp, keyBytes, value);
+                    } else {
+                        segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
+                        segmentMap.get(windowStartTimestamp).put(keyBytes, value);
+                    }
                 } else if (!retainDuplicates) {
                     // Skip if value is null and duplicates are allowed since this delete is a no-op
-                    segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
-                        kvMap.remove(key);
-                        if (kvMap.isEmpty()) {
-                            segmentMap.remove(windowStartTimestamp);
-                        }
-                        return kvMap;
-                    });
+                    if (transactionBuffer != null) {
+                        transactionBuffer.stage(windowStartTimestamp, key, null);
+                    } else {
+                        segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
+                            kvMap.remove(key);
+                            if (kvMap.isEmpty()) {
+                                segmentMap.remove(windowStartTimestamp);
+                            }
+                            return kvMap;
+                        });
+                    }
                 }
             }
 
@@ -192,6 +210,13 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
             return null;
+        }
+
+        if (transactionBuffer != null) {
+            final Optional<byte[]> staged = transactionBuffer.get(windowStartTimestamp, key);
+            if (staged != null) {
+                return staged.orElse(null);
+            }
         }
 
         final ConcurrentNavigableMap<Bytes, byte[]> kvMap = segmentMap.get(windowStartTimestamp);
@@ -222,6 +247,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         if (timeTo < minTime) {
             return WrappedInMemoryWindowStoreIterator.emptyIterator();
+        }
+
+        if (transactionBuffer != null) {
+            final Bytes keyFrom = retainDuplicates ? wrapForDups(key, 0) : key;
+            final Bytes keyTo = retainDuplicates ? wrapForDups(key, Integer.MAX_VALUE) : key;
+            return new TransactionalWindowStoreIterator(
+                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates
+            );
         }
 
         if (forward) {
@@ -279,6 +312,14 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             return KeyValueIterators.emptyIterator();
         }
 
+        if (transactionBuffer != null) {
+            final Bytes keyFrom = (retainDuplicates && from != null) ? wrapForDups(from, 0) : from;
+            final Bytes keyTo = (retainDuplicates && to != null) ? wrapForDups(to, Integer.MAX_VALUE) : to;
+            return new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, keyFrom, keyTo, minTime, timeTo, forward, retainDuplicates, windowSize
+            );
+        }
+
         if (forward) {
             return registerNewWindowedKeyValueIterator(
                 from,
@@ -318,6 +359,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             return KeyValueIterators.emptyIterator();
         }
 
+        if (transactionBuffer != null) {
+            return new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime, timeTo, forward, retainDuplicates, windowSize
+            );
+        }
+
         if (forward) {
             return registerNewWindowedKeyValueIterator(
                 null,
@@ -343,6 +390,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         final long minTime = observedStreamTime - retentionPeriod;
 
+        if (transactionBuffer != null) {
+            return new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, true, retainDuplicates, windowSize
+            );
+        }
+
         return registerNewWindowedKeyValueIterator(
             null,
             null,
@@ -356,6 +409,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         removeExpiredSegments();
 
         final long minTime = observedStreamTime - retentionPeriod;
+
+        if (transactionBuffer != null) {
+            return new TransactionalWindowedKeyValueIterator(
+                transactionBuffer, null, null, minTime + 1, Long.MAX_VALUE, false, retainDuplicates, windowSize
+            );
+        }
 
         return registerNewWindowedKeyValueIterator(
             null,
@@ -391,12 +450,26 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
     }
 
     @Override
+    public long approximateNumUncommittedBytes() {
+        if (transactionBuffer != null) {
+            return transactionBuffer.approximateNumUncommittedBytes();
+        }
+        return 0;
+    }
+
+    @Override
     public void commit(final Map<TopicPartition, Long> changelogOffsets) {
-        // do-nothing since it is in-memory
+        if (transactionBuffer != null) {
+            transactionBuffer.commit();
+        }
     }
 
     @Override
     public void close() {
+        if (transactionBuffer != null) {
+            transactionBuffer.rollback();
+        }
+
         if (openIterators.size() != 0) {
             LOG.warn("Closing {} open iterators for store {}", openIterators.size(), name);
             for (final InMemoryWindowStoreIteratorWrapper it : openIterators) {
@@ -473,6 +546,120 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 forward);
         openIterators.add(iterator);
         return iterator;
+    }
+
+    /**
+     * A WindowStoreIterator backed by a transactional buffer's merge scan.
+     * Converts WindowEntryKey/byte[] pairs into Long/byte[] pairs (timestamp/value).
+     */
+    private static class TransactionalWindowStoreIterator implements WindowStoreIterator<byte[]> {
+        private final KeyValueIterator<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> delegate;
+        private final boolean retainDuplicates;
+
+        TransactionalWindowStoreIterator(
+                final InMemoryWindowTransactionBuffer buffer,
+                final Bytes keyFrom,
+                final Bytes keyTo,
+                final long timeFrom,
+                final long timeTo,
+                final boolean forward,
+                final boolean retainDuplicates) {
+            this.retainDuplicates = retainDuplicates;
+            final InMemoryWindowTransactionBuffer.WindowEntryKey from =
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]));
+            final InMemoryWindowTransactionBuffer.WindowEntryKey to =
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}));
+
+            this.delegate = buffer.range(from, to, forward, true);
+        }
+
+        @Override
+        public Long peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return delegate.peekNextKey().timestamp();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public KeyValue<Long, byte[]> next() {
+            final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
+            return new KeyValue<>(entry.key.timestamp(), entry.value);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+
+    /**
+     * A Windowed KeyValueIterator backed by a transactional buffer's merge scan.
+     * Converts WindowEntryKey/byte[] pairs into Windowed<Bytes>/byte[] pairs.
+     */
+    private static class TransactionalWindowedKeyValueIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
+        private final KeyValueIterator<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> delegate;
+        private final boolean retainDuplicates;
+        private final long windowSize;
+
+        TransactionalWindowedKeyValueIterator(
+                final InMemoryWindowTransactionBuffer buffer,
+                final Bytes keyFrom,
+                final Bytes keyTo,
+                final long timeFrom,
+                final long timeTo,
+                final boolean forward,
+                final boolean retainDuplicates,
+                final long windowSize) {
+            this.retainDuplicates = retainDuplicates;
+            this.windowSize = windowSize;
+            final InMemoryWindowTransactionBuffer.WindowEntryKey from =
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]));
+            final InMemoryWindowTransactionBuffer.WindowEntryKey to =
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}));
+
+            this.delegate = buffer.range(from, to, forward, true);
+        }
+
+        @Override
+        public Windowed<Bytes> peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return toWindowed(delegate.peekNextKey());
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public KeyValue<Windowed<Bytes>, byte[]> next() {
+            final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
+            return new KeyValue<>(toWindowed(entry.key), entry.value);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        private Windowed<Bytes> toWindowed(final InMemoryWindowTransactionBuffer.WindowEntryKey entryKey) {
+            final Bytes key = retainDuplicates ? getKey(entryKey.key()) : entryKey.key();
+            long endTime = entryKey.timestamp() + windowSize;
+            if (endTime < 0) {
+                LOG.warn("Warning: window end time was truncated to Long.MAX");
+                endTime = Long.MAX_VALUE;
+            }
+            final TimeWindow timeWindow = new TimeWindow(entryKey.timestamp(), endTime);
+            return new Windowed<>(key, timeWindow);
+        }
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -164,7 +164,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG,
             false);
         if (transactional) {
-            this.transactionBuffer = new InMemoryWindowTransactionBuffer(segmentMap);
+            this.transactionBuffer = new InMemoryWindowTransactionBuffer(segmentMap, retainDuplicates);
         }
     }
 
@@ -563,13 +563,43 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
         return iterator;
     }
 
+    private static Bytes lowerBoundKey(final Bytes keyFrom) {
+        // The staged composite scan needs a non-null lower bound; empty bytes is the natural minimum.
+        return keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]);
+    }
+
+    private static Bytes unwrapBound(final Bytes wrappedBound, final boolean retainDuplicates) {
+        if (wrappedBound == null) {
+            return null;
+        }
+        return retainDuplicates ? getKey(wrappedBound) : wrappedBound;
+    }
+
     /**
-     * A WindowStoreIterator backed by a transactional buffer's merge scan.
-     * Converts WindowEntryKey/byte[] pairs into Long/byte[] pairs (timestamp/value).
+     * Whether a stored (possibly seqnum-wrapped) key falls within the original key range. Needed
+     * because the staged composite scan is bounded only by timestamp (and, at the boundary
+     * timestamps, by wrapped-key order, which can admit out-of-range keys); the committed base
+     * iterator is already correctly bounded.
+     */
+    private static boolean keyInRange(final Bytes storedKey,
+                                      final Bytes unwrappedFrom,
+                                      final Bytes unwrappedTo,
+                                      final boolean retainDuplicates) {
+        final Bytes key = retainDuplicates ? getKey(storedKey) : storedKey;
+        return (unwrappedFrom == null || key.compareTo(unwrappedFrom) >= 0)
+            && (unwrappedTo == null || key.compareTo(unwrappedTo) <= 0);
+    }
+
+    /**
+     * A WindowStoreIterator over the transaction buffer's merge scan, exposing each entry's
+     * timestamp/value, filtered to the requested key.
      */
     private static class TransactionalWindowStoreIterator implements WindowStoreIterator<byte[]> {
         private final KeyValueIterator<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> delegate;
+        private final Bytes unwrappedFrom;
+        private final Bytes unwrappedTo;
         private final boolean retainDuplicates;
+        private KeyValue<Long, byte[]> prefetched;
 
         TransactionalWindowStoreIterator(
                 final InMemoryWindowTransactionBuffer buffer,
@@ -580,10 +610,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 final boolean forward,
                 final boolean retainDuplicates) {
             this.retainDuplicates = retainDuplicates;
+            this.unwrappedFrom = unwrapBound(keyFrom, retainDuplicates);
+            this.unwrappedTo = unwrapBound(keyTo, retainDuplicates);
             final InMemoryWindowTransactionBuffer.WindowEntryKey from =
-                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]));
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, lowerBoundKey(keyFrom));
             final InMemoryWindowTransactionBuffer.WindowEntryKey to =
-                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}));
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo);
 
             this.delegate = buffer.range(from, to, forward, true);
         }
@@ -593,34 +625,55 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            return delegate.peekNextKey().timestamp();
+            return prefetched.key;
         }
 
         @Override
         public boolean hasNext() {
-            return delegate.hasNext();
+            if (prefetched != null) {
+                return true;
+            }
+            prefetched = computeNext();
+            return prefetched != null;
         }
 
         @Override
         public KeyValue<Long, byte[]> next() {
-            final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
-            return new KeyValue<>(entry.key.timestamp(), entry.value);
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<Long, byte[]> result = prefetched;
+            prefetched = null;
+            return result;
         }
 
         @Override
         public void close() {
             delegate.close();
         }
+
+        private KeyValue<Long, byte[]> computeNext() {
+            while (delegate.hasNext()) {
+                final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
+                if (keyInRange(entry.key.key(), unwrappedFrom, unwrappedTo, retainDuplicates)) {
+                    return new KeyValue<>(entry.key.timestamp(), entry.value);
+                }
+            }
+            return null;
+        }
     }
 
     /**
-     * A Windowed KeyValueIterator backed by a transactional buffer's merge scan.
-     * Converts WindowEntryKey/byte[] pairs into Windowed<Bytes>/byte[] pairs.
+     * A Windowed KeyValueIterator over the transaction buffer's merge scan, filtered to the key
+     * range and with the stored (possibly seqnum-wrapped) key unwrapped.
      */
     private static class TransactionalWindowedKeyValueIterator implements KeyValueIterator<Windowed<Bytes>, byte[]> {
         private final KeyValueIterator<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> delegate;
+        private final Bytes unwrappedFrom;
+        private final Bytes unwrappedTo;
         private final boolean retainDuplicates;
         private final long windowSize;
+        private KeyValue<Windowed<Bytes>, byte[]> prefetched;
 
         TransactionalWindowedKeyValueIterator(
                 final InMemoryWindowTransactionBuffer buffer,
@@ -633,10 +686,12 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 final long windowSize) {
             this.retainDuplicates = retainDuplicates;
             this.windowSize = windowSize;
+            this.unwrappedFrom = unwrapBound(keyFrom, retainDuplicates);
+            this.unwrappedTo = unwrapBound(keyTo, retainDuplicates);
             final InMemoryWindowTransactionBuffer.WindowEntryKey from =
-                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, keyFrom != null ? keyFrom : Bytes.wrap(new byte[0]));
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeFrom, lowerBoundKey(keyFrom));
             final InMemoryWindowTransactionBuffer.WindowEntryKey to =
-                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo != null ? keyTo : Bytes.wrap(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}));
+                new InMemoryWindowTransactionBuffer.WindowEntryKey(timeTo, keyTo);
 
             this.delegate = buffer.range(from, to, forward, true);
         }
@@ -646,23 +701,41 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            return toWindowed(delegate.peekNextKey());
+            return prefetched.key;
         }
 
         @Override
         public boolean hasNext() {
-            return delegate.hasNext();
+            if (prefetched != null) {
+                return true;
+            }
+            prefetched = computeNext();
+            return prefetched != null;
         }
 
         @Override
         public KeyValue<Windowed<Bytes>, byte[]> next() {
-            final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
-            return new KeyValue<>(toWindowed(entry.key), entry.value);
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<Windowed<Bytes>, byte[]> result = prefetched;
+            prefetched = null;
+            return result;
         }
 
         @Override
         public void close() {
             delegate.close();
+        }
+
+        private KeyValue<Windowed<Bytes>, byte[]> computeNext() {
+            while (delegate.hasNext()) {
+                final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> entry = delegate.next();
+                if (keyInRange(entry.key.key(), unwrappedFrom, unwrappedTo, retainDuplicates)) {
+                    return new KeyValue<>(toWindowed(entry.key), entry.value);
+                }
+            }
+            return null;
         }
 
         private Windowed<Bytes> toWindowed(final InMemoryWindowTransactionBuffer.WindowEntryKey entryKey) {
@@ -889,6 +962,61 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
             final TimeWindow timeWindow = new TimeWindow(super.currentTime, endTime);
             return new Windowed<>(key, timeWindow);
+        }
+    }
+
+    /**
+     * Yields each entry as an {@link InMemoryWindowTransactionBuffer.WindowEntryKey} keyed by the
+     * stored (possibly seqnum-wrapped) key. Reused by {@link InMemoryWindowTransactionBuffer} as the
+     * committed-side base iterator, so it merges in lock-step with the staged composite map; the
+     * store's transactional read wrappers unwrap the key afterwards.
+     */
+    static final class WindowEntryKeyIterator extends InMemoryWindowStoreIteratorWrapper
+        implements ManagedKeyValueIterator<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> {
+
+        private Runnable closeCallback;
+
+        WindowEntryKeyIterator(final Bytes keyFrom,
+                               final Bytes keyTo,
+                               final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator,
+                               final boolean retainDuplicates,
+                               final boolean forward) {
+            super(keyFrom, keyTo, segmentIterator, ignored -> { }, retainDuplicates, forward);
+        }
+
+        @Override
+        public InMemoryWindowTransactionBuffer.WindowEntryKey peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return new InMemoryWindowTransactionBuffer.WindowEntryKey(super.currentTime, super.next.key);
+        }
+
+        @Override
+        public KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<InMemoryWindowTransactionBuffer.WindowEntryKey, byte[]> result =
+                new KeyValue<>(new InMemoryWindowTransactionBuffer.WindowEntryKey(super.currentTime, super.next.key), super.next.value);
+            super.next = null;
+            return result;
+        }
+
+        @Override
+        public void onClose(final Runnable closeCallback) {
+            this.closeCallback = closeCallback;
+        }
+
+        @Override
+        public void close() {
+            try {
+                super.close();
+            } finally {
+                if (closeCallback != null) {
+                    closeCallback.run();
+                }
+            }
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -131,17 +131,27 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                 root,
                 (RecordBatchingStateRestoreCallback) records -> {
                     synchronized (position) {
+                        long expiredRecords = 0;
                         for (final ConsumerRecord<byte[], byte[]> record : records) {
-                            put(
-                                Bytes.wrap(extractStoreKeyBytes(record.key())),
-                                record.value(),
-                                extractStoreTimestamp(record.key())
-                            );
+                            final Bytes key = Bytes.wrap(extractStoreKeyBytes(record.key()));
+                            final long windowStartTimestamp = extractStoreTimestamp(record.key());
+                            observedStreamTime = Math.max(observedStreamTime, windowStartTimestamp);
+                            if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
+                                expiredRecords++;
+                            } else {
+                                // Write directly to the committed map: restored records are already committed.
+                                putInternal(key, record.value(), windowStartTimestamp);
+                            }
                             ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                                 record,
                                 consistencyEnabled,
                                 position
                             );
+                        }
+                        removeExpiredSegments();
+                        if (expiredRecords > 0) {
+                            expiredRecordSensor.record(expiredRecords, internalProcessorContext.currentSystemTimeMs());
+                            LOG.warn("Skipping {} records for expired segments.", expiredRecords);
                         }
                     }
                 }
@@ -172,33 +182,38 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
             if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
                 expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
                 LOG.warn("Skipping record for expired segment.");
-            } else {
+            } else if (transactionBuffer != null) {
                 if (value != null) {
                     maybeUpdateSeqnumForDups();
                     final Bytes keyBytes = retainDuplicates ? wrapForDups(key, seqnum) : key;
-                    if (transactionBuffer != null) {
-                        transactionBuffer.stage(windowStartTimestamp, keyBytes, value);
-                    } else {
-                        segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
-                        segmentMap.get(windowStartTimestamp).put(keyBytes, value);
-                    }
+                    transactionBuffer.stage(windowStartTimestamp, keyBytes, value);
                 } else if (!retainDuplicates) {
                     // Skip if value is null and duplicates are allowed since this delete is a no-op
-                    if (transactionBuffer != null) {
-                        transactionBuffer.stage(windowStartTimestamp, key, null);
-                    } else {
-                        segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
-                            kvMap.remove(key);
-                            if (kvMap.isEmpty()) {
-                                segmentMap.remove(windowStartTimestamp);
-                            }
-                            return kvMap;
-                        });
-                    }
+                    transactionBuffer.stage(windowStartTimestamp, key, null);
                 }
+            } else {
+                putInternal(key, value, windowStartTimestamp);
             }
 
             StoreQueryUtils.updatePosition(position, internalProcessorContext);
+        }
+    }
+
+    private void putInternal(final Bytes key, final byte[] value, final long windowStartTimestamp) {
+        if (value != null) {
+            maybeUpdateSeqnumForDups();
+            final Bytes keyBytes = retainDuplicates ? wrapForDups(key, seqnum) : key;
+            segmentMap.computeIfAbsent(windowStartTimestamp, t -> new ConcurrentSkipListMap<>());
+            segmentMap.get(windowStartTimestamp).put(keyBytes, value);
+        } else if (!retainDuplicates) {
+            // Skip if value is null and duplicates are allowed since this delete is a no-op
+            segmentMap.computeIfPresent(windowStartTimestamp, (t, kvMap) -> {
+                kvMap.remove(key);
+                if (kvMap.isEmpty()) {
+                    segmentMap.remove(windowStartTimestamp);
+                }
+                return kvMap;
+            });
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowTransactionBuffer.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * A {@link TransactionBuffer} implementation for {@link InMemoryWindowStore}.
+ * Uses a composite key of (timestamp, key) to maintain correct sort order in the staging map.
+ */
+class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemoryWindowTransactionBuffer.WindowEntryKey> {
+
+    private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap;
+
+    InMemoryWindowTransactionBuffer(
+            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap) {
+        this.segmentMap = segmentMap;
+    }
+
+    /**
+     * Composite key for the window store staging map. Sorts by timestamp first, then by key.
+     */
+    static final class WindowEntryKey implements Comparable<WindowEntryKey> {
+        private final long timestamp;
+        private final Bytes key;
+
+        WindowEntryKey(final long timestamp, final Bytes key) {
+            this.timestamp = timestamp;
+            this.key = key;
+        }
+
+        long timestamp() {
+            return timestamp;
+        }
+
+        Bytes key() {
+            return key;
+        }
+
+        @Override
+        public int compareTo(final WindowEntryKey other) {
+            final int cmp = Long.compare(this.timestamp, other.timestamp);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return this.key.compareTo(other.key);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof WindowEntryKey)) return false;
+            final WindowEntryKey that = (WindowEntryKey) o;
+            return timestamp == that.timestamp && Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(timestamp, key);
+        }
+    }
+
+    // -- Convenience methods for the store --
+
+    void stage(final long timestamp, final Bytes key, final byte[] value) {
+        super.stage(new WindowEntryKey(timestamp, key), value);
+    }
+
+    Optional<byte[]> get(final long timestamp, final Bytes key) {
+        return super.get(new WindowEntryKey(timestamp, key));
+    }
+
+    // -- AbstractTransactionBuffer implementation --
+
+    @Override
+    int estimateKeySize(final WindowEntryKey key) {
+        return Long.BYTES + key.key().get().length;
+    }
+
+    @Override
+    void stageToBackend(final WindowEntryKey key, final byte[] value) {
+        // no-op — staging map is sufficient; no write-batch concept for in-memory
+    }
+
+    @Override
+    ManagedKeyValueIterator<WindowEntryKey, byte[]> newBaseIterator(final WindowEntryKey from, final WindowEntryKey to) {
+        return newBaseIterator(from, to, true, true);
+    }
+
+    @Override
+    ManagedKeyValueIterator<WindowEntryKey, byte[]> newBaseIterator(final WindowEntryKey from, final WindowEntryKey to,
+                                                                    final boolean forward, final boolean toInclusive) {
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> timeRange;
+        if (from != null && to != null) {
+            timeRange = segmentMap.subMap(from.timestamp(), true, to.timestamp(), true);
+        } else if (from != null) {
+            timeRange = segmentMap.tailMap(from.timestamp(), true);
+        } else if (to != null) {
+            timeRange = segmentMap.headMap(to.timestamp(), true);
+        } else {
+            timeRange = segmentMap;
+        }
+
+        return new FlattenedSegmentIterator(
+            forward ? timeRange : timeRange.descendingMap(),
+            from, to, forward, toInclusive
+        );
+    }
+
+    /**
+     * Non-owner (IQ) path: eagerly deep-copies the bounded time range while the caller holds the
+     * snapshot read-lock, providing true point-in-time isolation. The returned iterator never
+     * touches the live segment map, so concurrent owner mutation cannot disturb it.
+     */
+    @Override
+    ManagedKeyValueIterator<WindowEntryKey, byte[]> newBaseSnapshotIterator(final WindowEntryKey from, final WindowEntryKey to,
+                                                                            final boolean forward, final boolean toInclusive) {
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> timeRange;
+        if (from != null && to != null) {
+            timeRange = segmentMap.subMap(from.timestamp(), true, to.timestamp(), true);
+        } else if (from != null) {
+            timeRange = segmentMap.tailMap(from.timestamp(), true);
+        } else if (to != null) {
+            timeRange = segmentMap.headMap(to.timestamp(), true);
+        } else {
+            timeRange = segmentMap;
+        }
+
+        final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> copy = new ConcurrentSkipListMap<>();
+        for (final Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>> segment : timeRange.entrySet()) {
+            copy.put(segment.getKey(), new ConcurrentSkipListMap<>(segment.getValue()));
+        }
+
+        return new FlattenedSegmentIterator(
+            forward ? copy : copy.descendingMap(),
+            from, to, forward, toInclusive
+        );
+    }
+
+    @Override
+    void flushToBase() {
+        for (final Map.Entry<WindowEntryKey, Optional<byte[]>> entry : pendingWrites.entrySet()) {
+            final long ts = entry.getKey().timestamp();
+            final Bytes key = entry.getKey().key();
+            if (entry.getValue().isPresent()) {
+                segmentMap.computeIfAbsent(ts, t -> new ConcurrentSkipListMap<>()).put(key, entry.getValue().get());
+            } else {
+                final ConcurrentNavigableMap<Bytes, byte[]> kvMap = segmentMap.get(ts);
+                if (kvMap != null) {
+                    kvMap.remove(key);
+                    if (kvMap.isEmpty()) {
+                        segmentMap.remove(ts);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    void discardPendingBatch() {
+        // no-op — no backend batch to discard
+    }
+
+    /**
+     * Iterator that flattens the two-level segmentMap structure into a stream of
+     * WindowEntryKey/byte[] pairs, respecting key bounds and direction.
+     */
+    private static class FlattenedSegmentIterator implements ManagedKeyValueIterator<WindowEntryKey, byte[]> {
+        private final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator;
+        private final WindowEntryKey from;
+        private final WindowEntryKey to;
+        private final boolean forward;
+        private final boolean toInclusive;
+
+        private Iterator<Map.Entry<Bytes, byte[]>> currentKeyIterator;
+        private long currentTimestamp;
+        private KeyValue<WindowEntryKey, byte[]> prefetched;
+        private boolean closed = false;
+        private Runnable closeCallback;
+
+        FlattenedSegmentIterator(
+                final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> timeRange,
+                final WindowEntryKey from,
+                final WindowEntryKey to,
+                final boolean forward,
+                final boolean toInclusive) {
+            this.from = from;
+            this.to = to;
+            this.forward = forward;
+            this.toInclusive = toInclusive;
+            this.segmentIterator = timeRange.entrySet().iterator();
+            advanceSegment();
+        }
+
+        private void advanceSegment() {
+            currentKeyIterator = null;
+            while (segmentIterator.hasNext()) {
+                final Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>> segment = segmentIterator.next();
+                currentTimestamp = segment.getKey();
+
+                final ConcurrentNavigableMap<Bytes, byte[]> subMap = boundKeyMap(segment.getValue());
+                final ConcurrentNavigableMap<Bytes, byte[]> orderedMap = forward ? subMap : subMap.descendingMap();
+                currentKeyIterator = orderedMap.entrySet().iterator();
+                if (currentKeyIterator.hasNext()) {
+                    return;
+                }
+            }
+        }
+
+        private ConcurrentNavigableMap<Bytes, byte[]> boundKeyMap(final ConcurrentNavigableMap<Bytes, byte[]> kvMap) {
+            final Bytes keyFrom = (from != null && currentTimestamp == from.timestamp()) ? from.key() : null;
+            final Bytes keyTo = (to != null && currentTimestamp == to.timestamp()) ? to.key() : null;
+            final boolean keyToInclusive = (to != null && currentTimestamp == to.timestamp()) ? toInclusive : true;
+
+            if (keyFrom != null && keyTo != null) {
+                return kvMap.subMap(keyFrom, true, keyTo, keyToInclusive);
+            } else if (keyFrom != null) {
+                return kvMap.tailMap(keyFrom, true);
+            } else if (keyTo != null) {
+                return kvMap.headMap(keyTo, keyToInclusive);
+            } else {
+                return kvMap;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (closed) {
+                throw new IllegalStateException("Iterator has already been closed.");
+            }
+            if (prefetched != null) {
+                return true;
+            }
+            prefetched = computeNext();
+            return prefetched != null;
+        }
+
+        @Override
+        public KeyValue<WindowEntryKey, byte[]> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            final KeyValue<WindowEntryKey, byte[]> result = prefetched;
+            prefetched = null;
+            return result;
+        }
+
+        @Override
+        public WindowEntryKey peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return prefetched.key;
+        }
+
+        @Override
+        public void onClose(final Runnable closeCallback) {
+            this.closeCallback = closeCallback;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            if (closeCallback != null) {
+                closeCallback.run();
+            }
+        }
+
+        private KeyValue<WindowEntryKey, byte[]> computeNext() {
+            while (currentKeyIterator != null) {
+                if (currentKeyIterator.hasNext()) {
+                    final Map.Entry<Bytes, byte[]> entry = currentKeyIterator.next();
+                    return new KeyValue<>(new WindowEntryKey(currentTimestamp, entry.getKey()), entry.getValue());
+                }
+                advanceSegment();
+            }
+            return null;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowTransactionBuffer.java
@@ -17,11 +17,8 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KeyValue;
 
-import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -34,10 +31,13 @@ import java.util.concurrent.ConcurrentSkipListMap;
 class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemoryWindowTransactionBuffer.WindowEntryKey> {
 
     private final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap;
+    private final boolean retainDuplicates;
 
     InMemoryWindowTransactionBuffer(
-            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap) {
+            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> segmentMap,
+            final boolean retainDuplicates) {
         this.segmentMap = segmentMap;
+        this.retainDuplicates = retainDuplicates;
     }
 
     /**
@@ -65,6 +65,11 @@ class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemory
             final int cmp = Long.compare(this.timestamp, other.timestamp);
             if (cmp != 0) {
                 return cmp;
+            }
+            // A null key is an unbounded upper-bound marker used only in range scans; it sorts after
+            // every real key at the same timestamp. (The lower bound uses empty bytes, the natural minimum.)
+            if (this.key == null || other.key == null) {
+                return Boolean.compare(this.key == null, other.key == null);
             }
             return this.key.compareTo(other.key);
         }
@@ -124,10 +129,7 @@ class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemory
             timeRange = segmentMap;
         }
 
-        return new FlattenedSegmentIterator(
-            forward ? timeRange : timeRange.descendingMap(),
-            from, to, forward, toInclusive
-        );
+        return baseIterator(forward ? timeRange : timeRange.descendingMap(), from, to, forward);
     }
 
     /**
@@ -154,10 +156,24 @@ class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemory
             copy.put(segment.getKey(), new ConcurrentSkipListMap<>(segment.getValue()));
         }
 
-        return new FlattenedSegmentIterator(
-            forward ? copy : copy.descendingMap(),
-            from, to, forward, toInclusive
-        );
+        return baseIterator(forward ? copy : copy.descendingMap(), from, to, forward);
+    }
+
+    /**
+     * Builds the committed-side base iterator by reusing the non-transactional segment iterator
+     * ({@link InMemoryWindowStore.WindowEntryKeyIterator}), which bounds keys at every timestamp and
+     * emits in the same (timestamp, stored-key) order as the staged map. A null from/to key (and the
+     * empty-bytes lower-bound placeholder) leaves that side of the key dimension open.
+     */
+    private ManagedKeyValueIterator<WindowEntryKey, byte[]> baseIterator(
+            final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> timeRange,
+            final WindowEntryKey from,
+            final WindowEntryKey to,
+            final boolean forward) {
+        final Bytes keyFrom = (from != null && from.key() != null && from.key().get().length > 0) ? from.key() : null;
+        final Bytes keyTo = (to != null) ? to.key() : null;
+        return new InMemoryWindowStore.WindowEntryKeyIterator(
+            keyFrom, keyTo, timeRange.entrySet().iterator(), retainDuplicates, forward);
     }
 
     @Override
@@ -184,120 +200,4 @@ class InMemoryWindowTransactionBuffer extends AbstractTransactionBuffer<InMemory
         // no-op — no backend batch to discard
     }
 
-    /**
-     * Iterator that flattens the two-level segmentMap structure into a stream of
-     * WindowEntryKey/byte[] pairs, respecting key bounds and direction.
-     */
-    private static class FlattenedSegmentIterator implements ManagedKeyValueIterator<WindowEntryKey, byte[]> {
-        private final Iterator<Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>>> segmentIterator;
-        private final WindowEntryKey from;
-        private final WindowEntryKey to;
-        private final boolean forward;
-        private final boolean toInclusive;
-
-        private Iterator<Map.Entry<Bytes, byte[]>> currentKeyIterator;
-        private long currentTimestamp;
-        private KeyValue<WindowEntryKey, byte[]> prefetched;
-        private boolean closed = false;
-        private Runnable closeCallback;
-
-        FlattenedSegmentIterator(
-                final ConcurrentNavigableMap<Long, ConcurrentNavigableMap<Bytes, byte[]>> timeRange,
-                final WindowEntryKey from,
-                final WindowEntryKey to,
-                final boolean forward,
-                final boolean toInclusive) {
-            this.from = from;
-            this.to = to;
-            this.forward = forward;
-            this.toInclusive = toInclusive;
-            this.segmentIterator = timeRange.entrySet().iterator();
-            advanceSegment();
-        }
-
-        private void advanceSegment() {
-            currentKeyIterator = null;
-            while (segmentIterator.hasNext()) {
-                final Map.Entry<Long, ConcurrentNavigableMap<Bytes, byte[]>> segment = segmentIterator.next();
-                currentTimestamp = segment.getKey();
-
-                final ConcurrentNavigableMap<Bytes, byte[]> subMap = boundKeyMap(segment.getValue());
-                final ConcurrentNavigableMap<Bytes, byte[]> orderedMap = forward ? subMap : subMap.descendingMap();
-                currentKeyIterator = orderedMap.entrySet().iterator();
-                if (currentKeyIterator.hasNext()) {
-                    return;
-                }
-            }
-        }
-
-        private ConcurrentNavigableMap<Bytes, byte[]> boundKeyMap(final ConcurrentNavigableMap<Bytes, byte[]> kvMap) {
-            final Bytes keyFrom = (from != null && currentTimestamp == from.timestamp()) ? from.key() : null;
-            final Bytes keyTo = (to != null && currentTimestamp == to.timestamp()) ? to.key() : null;
-            final boolean keyToInclusive = (to != null && currentTimestamp == to.timestamp()) ? toInclusive : true;
-
-            if (keyFrom != null && keyTo != null) {
-                return kvMap.subMap(keyFrom, true, keyTo, keyToInclusive);
-            } else if (keyFrom != null) {
-                return kvMap.tailMap(keyFrom, true);
-            } else if (keyTo != null) {
-                return kvMap.headMap(keyTo, keyToInclusive);
-            } else {
-                return kvMap;
-            }
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (closed) {
-                throw new IllegalStateException("Iterator has already been closed.");
-            }
-            if (prefetched != null) {
-                return true;
-            }
-            prefetched = computeNext();
-            return prefetched != null;
-        }
-
-        @Override
-        public KeyValue<WindowEntryKey, byte[]> next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            final KeyValue<WindowEntryKey, byte[]> result = prefetched;
-            prefetched = null;
-            return result;
-        }
-
-        @Override
-        public WindowEntryKey peekNextKey() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return prefetched.key;
-        }
-
-        @Override
-        public void onClose(final Runnable closeCallback) {
-            this.closeCallback = closeCallback;
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-            if (closeCallback != null) {
-                closeCallback.run();
-            }
-        }
-
-        private KeyValue<WindowEntryKey, byte[]> computeNext() {
-            while (currentKeyIterator != null) {
-                if (currentKeyIterator.hasNext()) {
-                    final Map.Entry<Bytes, byte[]> entry = currentKeyIterator.next();
-                    return new KeyValue<>(new WindowEntryKey(currentTimestamp, entry.getKey()), entry.getValue());
-                }
-                advanceSegment();
-            }
-            return null;
-        }
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -179,10 +179,19 @@ public abstract class AbstractSessionBytesStoreTest {
 
     abstract StoreType storeType();
 
+    /** Overridden by subclasses to exercise the transactional (staged-write) code path. */
+    boolean transactional() {
+        return false;
+    }
+
     @BeforeEach
     public void setUp() {
         sessionStore = buildSessionStore(RETENTION_PERIOD, Serdes.String(), Serdes.Long());
         recordCollector = new MockRecordCollector();
+        final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
+        if (transactional()) {
+            streamsConfig.put(StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG, true);
+        }
         context = new InternalMockProcessorContext<>(
             TestUtils.tempDirectory(),
             Serdes.String(),
@@ -191,7 +200,8 @@ public abstract class AbstractSessionBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics())));
+                new MockStreamsMetrics(new Metrics())),
+            new StreamsConfig(streamsConfig));
         context.setTime(1L);
 
         sessionStore.init(context, sessionStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -99,12 +99,21 @@ public abstract class AbstractWindowBytesStoreTest {
                                                        final boolean retainDuplicates,
                                                        final Serde<K> keySerde,
                                                        final Serde<V> valueSerde);
+    /** Overridden by subclasses to exercise the transactional (staged-write) code path. */
+    boolean transactional() {
+        return false;
+    }
+
     @BeforeEach
     protected void setup() {
-        
+
         windowStore = buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, false, Serdes.Integer(), Serdes.String());
 
         recordCollector = new MockRecordCollector();
+        final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
+        if (transactional()) {
+            streamsConfig.put(StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG, true);
+        }
         context = new InternalMockProcessorContext<>(
             baseDir,
             Serdes.String(),
@@ -113,7 +122,8 @@ public abstract class AbstractWindowBytesStoreTest {
             new ThreadCache(
                 new LogContext("testCache"),
                 0,
-                new MockStreamsMetrics(new Metrics())));
+                new MockStreamsMetrics(new Metrics())),
+            new StreamsConfig(streamsConfig));
         context.setTime(1L);
 
         windowStore.init(context, windowStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTransactionalSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTransactionalSessionStoreTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Runs the full {@link AbstractSessionBytesStoreTest} suite against the in-memory session store with
+ * transactional state stores enabled, so the staged-write/merge path is held to the same behavioural
+ * contract as the non-transactional store. Adds transactional-specific cases that the base suite (which
+ * only ever reads staged, un-committed writes) does not cover.
+ */
+public class InMemoryTransactionalSessionStoreTest extends AbstractSessionBytesStoreTest {
+
+    @Override
+    StoreType storeType() {
+        return StoreType.InMemoryStore;
+    }
+
+    @Override
+    boolean transactional() {
+        return true;
+    }
+
+    @Test
+    public void shouldReadAcrossCommitBoundaries() {
+        final Windowed<String> a0 = new Windowed<>("a", new SessionWindow(0, 0));
+        final Windowed<String> a1 = new Windowed<>("a", new SessionWindow(10, 20));
+
+        sessionStore.put(a0, 1L);                         // staged
+        sessionStore.commit(Collections.emptyMap());      // -> committed
+        sessionStore.put(a1, 2L);                         // staged on top of committed
+
+        // committed (a0) and staged (a1) are both visible before commit
+        try (final KeyValueIterator<Windowed<String>, Long> it = sessionStore.fetch("a")) {
+            assertEquals(Set.of(1L, 2L), valuesToSet(it));
+        }
+        sessionStore.commit(Collections.emptyMap());      // a1 -> committed; still visible
+        try (final KeyValueIterator<Windowed<String>, Long> it = sessionStore.fetch("a")) {
+            assertEquals(Set.of(1L, 2L), valuesToSet(it));
+        }
+
+        // a staged tombstone hides the committed session, and stays hidden after commit
+        sessionStore.remove(a0);
+        try (final KeyValueIterator<Windowed<String>, Long> it = sessionStore.fetch("a")) {
+            assertEquals(Set.of(2L), valuesToSet(it));
+        }
+        sessionStore.commit(Collections.emptyMap());
+        try (final KeyValueIterator<Windowed<String>, Long> it = sessionStore.fetch("a")) {
+            assertEquals(Set.of(2L), valuesToSet(it));
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTransactionalWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTransactionalWindowStoreTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static java.time.Duration.ofMillis;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Runs the full {@link AbstractWindowBytesStoreTest} suite against the in-memory window store with
+ * transactional state stores enabled, so the staged-write/merge path is held to the same behavioural
+ * contract as the non-transactional store.
+ */
+public class InMemoryTransactionalWindowStoreTest extends AbstractWindowBytesStoreTest {
+
+    private static final String STORE_NAME = "InMemoryTransactionalWindowStore";
+
+    @Override
+    <K, V> WindowStore<K, V> buildWindowStore(final long retentionPeriod,
+                                              final long windowSize,
+                                              final boolean retainDuplicates,
+                                              final Serde<K> keySerde,
+                                              final Serde<V> valueSerde) {
+        return Stores.windowStoreBuilder(
+            Stores.inMemoryWindowStore(
+                STORE_NAME,
+                ofMillis(retentionPeriod),
+                ofMillis(windowSize),
+                retainDuplicates),
+            keySerde,
+            valueSerde)
+            .build();
+    }
+
+    @Override
+    boolean transactional() {
+        return true;
+    }
+
+    /**
+     * Transactional reads are snapshot-isolated: an open iterator reflects the staged state as of when
+     * it was opened and does not observe records staged afterwards (the non-transactional store iterates
+     * the live map and does observe them). It must still not throw. This overrides the base test's
+     * live-iteration expectation accordingly.
+     */
+    @Test
+    @Override
+    public void shouldNotThrowConcurrentModificationException() {
+        long currentTime = 0;
+        windowStore.put(1, "one", currentTime);
+
+        currentTime += WINDOW_SIZE * 10;
+        windowStore.put(1, "two", currentTime);
+
+        try (final KeyValueIterator<Windowed<Integer>, String> iterator = windowStore.all()) {
+            currentTime += WINDOW_SIZE * 10;
+            windowStore.put(1, "three", currentTime);
+
+            currentTime += WINDOW_SIZE * 10;
+            windowStore.put(2, "four", currentTime);
+
+            assertEquals(windowedPair(1, "one", 0), iterator.next());
+            assertEquals(windowedPair(1, "two", WINDOW_SIZE * 10), iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Test
+    public void shouldReadAcrossCommitBoundaries() {
+        windowStore.put(1, "one", 0);                          // staged
+        windowStore.commit(Collections.emptyMap());            // -> committed
+        windowStore.put(1, "two", WINDOW_SIZE * 10);           // staged on top of committed
+
+        // committed (one) and staged (two) are both visible before commit, and after
+        try (final WindowStoreIterator<String> it = windowStore.fetch(1, 0, WINDOW_SIZE * 10)) {
+            assertEquals(new KeyValue<>(0L, "one"), it.next());
+            assertEquals(new KeyValue<>(WINDOW_SIZE * 10, "two"), it.next());
+            assertFalse(it.hasNext());
+        }
+        windowStore.commit(Collections.emptyMap());
+        try (final WindowStoreIterator<String> it = windowStore.fetch(1, 0, WINDOW_SIZE * 10)) {
+            assertEquals(new KeyValue<>(0L, "one"), it.next());
+            assertEquals(new KeyValue<>(WINDOW_SIZE * 10, "two"), it.next());
+            assertFalse(it.hasNext());
+        }
+
+        // a staged tombstone hides the committed record, and stays hidden after commit
+        windowStore.put(1, null, 0);
+        try (final WindowStoreIterator<String> it = windowStore.fetch(1, 0, WINDOW_SIZE * 10)) {
+            assertEquals(new KeyValue<>(WINDOW_SIZE * 10, "two"), it.next());
+            assertFalse(it.hasNext());
+        }
+        windowStore.commit(Collections.emptyMap());
+        try (final WindowStoreIterator<String> it = windowStore.fetch(1, 0, WINDOW_SIZE * 10)) {
+            assertEquals(new KeyValue<>(WINDOW_SIZE * 10, "two"), it.next());
+            assertFalse(it.hasNext());
+        }
+    }
+}


### PR DESCRIPTION
In-memory window and session stores need the same transactional,
isolation-aware behaviour KIP-892 introduced for the key-value store:
when transactional state stores are enabled (EOS), writes must be staged
in a transaction buffer and only applied to the store on commit, and
interactive queries must be able to read at `READ_COMMITTED` (ignoring
staged writes) or `READ_UNCOMMITTED`.

This adds `InMemoryWindowTransactionBuffer` and
`InMemorySessionTransactionBuffer`, each extending
`AbstractTransactionBuffer` with a composite key that encodes the
store's ordering — timestamp/key for windows, endTime/key/startTime for
sessions. `InMemoryWindowStore` and `InMemorySessionStore` route reads
and writes through their buffer when transactional state stores are
enabled, and report their staged size via
`approximateNumUncommittedBytes()`.

Each buffer implements `newBaseSnapshotIterator` so non-owner
(interactive-query) reads get a point-in-time view: the bounded range of
the backing segment map is eagerly deep-copied under the snapshot read
lock, isolating the returned iterator from concurrent owner mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewers: Bill Bejeck <bbejeck@apache.org>
