### PR TITLE
MINOR: Code cleanups in coordinator-common runtime

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorLoaderImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorLoaderImpl.java
@@ -197,7 +197,7 @@ public class CoordinatorLoaderImpl<T> implements CoordinatorLoader<T> {
             int sizeInBytes = fileRecords.sizeInBytes();
             int bytesNeeded = Math.max(loadBufferSize, sizeInBytes);
 
-            // "minOneMessage = true in the above log.read() means that the buffer may need to
+            // minOneMessage = true in the above log.read() means that the buffer may need to
             // be grown to ensure progress can be made.
             if (buffer.capacity() < bytesNeeded) {
                 if (loadBufferSize < bytesNeeded) {

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -580,10 +580,10 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalStateException("Coordinator must be in loading state");
             }
 
-            loader.load(tp, coordinator).whenComplete((summary, exception) ->
+            loader.load(tp, coordinator).whenComplete((summary, exception) -> {
                 scheduleInternalOperation("CompleteLoad(tp=" + tp + ", epoch=" + epoch + ")", tp, () -> {
                     CoordinatorContext context = coordinators.get(tp);
-                    if (context != null)  {
+                    if (context != null) {
                         if (context.state != CoordinatorState.LOADING) {
                             log.info("Ignored load completion from {} because context is in {} state.",
                                 context.tp, context.state);
@@ -608,8 +608,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         log.debug("Failed to complete the loading of metadata for {} in epoch {} since the coordinator does not exist.",
                             tp, epoch);
                     }
-                })
-            );
+                });
+            });
         }
 
         /**
@@ -666,7 +666,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * @param expectedBatchEpoch The epoch of the batch to flush.
          */
         private void enqueueAdaptiveFlush(int expectedBatchEpoch) {
-            enqueueLast(new CoordinatorInternalEvent("FlushBatch", tp, () ->
+            enqueueLast(new CoordinatorInternalEvent("FlushBatch", tp, () -> {
                 withActiveContext(tp, context -> {
                     // The batch could have already been flushed because it reached the maximum
                     // batch size or a transactional write came in. When this happens, we want
@@ -682,8 +682,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                             log.debug("Failed to flush the pending records to {}: {}.", tp, t.getMessage());
                         }
                     }
-                })
-            ));
+                });
+            }));
         }
 
         /**
@@ -872,9 +872,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         }
 
         /**
-         * Completes the given event once all pending writes are completed. 
+         * Completes the given event once all pending writes are completed.
          *
-         * @param event             The event to complete once all pending 
+         * @param event             The event to complete once all pending
          *                          writes are completed.
          */
         private void waitForPendingWrites(DeferredEvent event) {
@@ -2463,7 +2463,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         metadataImage = newImage;
 
         // Push an event for each coordinator.
-        coordinators.keySet().forEach(tp ->
+        coordinators.keySet().forEach(tp -> {
             scheduleInternalOperation("UpdateImage(tp=" + tp + ", version=" + newImage.version() + ")", tp, () -> {
                 CoordinatorContext context = coordinators.get(tp);
                 if (context != null) {
@@ -2485,8 +2485,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     log.debug("Ignored new metadata image with version {} for {} because the coordinator does not exist.",
                         newImage.version(), tp);
                 }
-            })
-        );
+            });
+        });
     }
 
     /**

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -580,7 +580,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                 throw new IllegalStateException("Coordinator must be in loading state");
             }
 
-            loader.load(tp, coordinator).whenComplete((summary, exception) -> {
+            loader.load(tp, coordinator).whenComplete((summary, exception) ->
                 scheduleInternalOperation("CompleteLoad(tp=" + tp + ", epoch=" + epoch + ")", tp, () -> {
                     CoordinatorContext context = coordinators.get(tp);
                     if (context != null)  {
@@ -608,8 +608,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         log.debug("Failed to complete the loading of metadata for {} in epoch {} since the coordinator does not exist.",
                             tp, epoch);
                     }
-                });
-            });
+                })
+            );
         }
 
         /**
@@ -666,7 +666,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
          * @param expectedBatchEpoch The epoch of the batch to flush.
          */
         private void enqueueAdaptiveFlush(int expectedBatchEpoch) {
-            enqueueLast(new CoordinatorInternalEvent("FlushBatch", tp, () -> {
+            enqueueLast(new CoordinatorInternalEvent("FlushBatch", tp, () ->
                 withActiveContext(tp, context -> {
                     // The batch could have already been flushed because it reached the maximum
                     // batch size or a transactional write came in. When this happens, we want
@@ -682,8 +682,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                             log.debug("Failed to flush the pending records to {}: {}.", tp, t.getMessage());
                         }
                     }
-                });
-            }));
+                })
+            ));
         }
 
         /**
@@ -2463,7 +2463,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
         metadataImage = newImage;
 
         // Push an event for each coordinator.
-        coordinators.keySet().forEach(tp -> {
+        coordinators.keySet().forEach(tp ->
             scheduleInternalOperation("UpdateImage(tp=" + tp + ", version=" + newImage.version() + ")", tp, () -> {
                 CoordinatorContext context = coordinators.get(tp);
                 if (context != null) {
@@ -2485,8 +2485,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     log.debug("Ignored new metadata image with version {} for {} because the coordinator does not exist.",
                         newImage.version(), tp);
                 }
-            });
-        });
+            })
+        );
     }
 
     /**

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeMetricsImpl.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime.CoordinatorState;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -346,7 +346,7 @@ public class CoordinatorRuntimeMetricsImpl implements CoordinatorRuntimeMetrics 
 
     @Override
     public void close() {
-        Arrays.asList(
+        List.of(
             numPartitionsLoading,
             numPartitionsActive,
             numPartitionsFailed,

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorLoaderImplTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorLoaderImplTest.java
@@ -41,7 +41,6 @@ import org.mockito.invocation.InvocationOnMock;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,7 +138,7 @@ class CoordinatorLoaderImplTest {
             when(log.logStartOffset()).thenReturn(0L);
             when(log.highWatermark()).thenReturn(0L);
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -147,7 +146,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(0L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult1);
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())
@@ -156,7 +155,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(2L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult2);
 
-            FetchDataInfo readResult3 = logReadResult(5, 100L, (short) 5, Arrays.asList(
+            FetchDataInfo readResult3 = logReadResult(5, 100L, (short) 5, List.of(
                 new SimpleRecord("k6".getBytes(), "v6".getBytes()),
                 new SimpleRecord("k7".getBytes(), "v7".getBytes())
             ));
@@ -225,7 +224,7 @@ class CoordinatorLoaderImplTest {
         )) {
             when(log.logStartOffset()).thenReturn(0L);
 
-            FetchDataInfo readResult = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -271,7 +270,7 @@ class CoordinatorLoaderImplTest {
         )) {
             when(log.logStartOffset()).thenReturn(0L);
 
-            FetchDataInfo readResult = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -308,7 +307,7 @@ class CoordinatorLoaderImplTest {
         )) {
             when(log.logStartOffset()).thenReturn(0L);
 
-            FetchDataInfo readResult = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -378,7 +377,7 @@ class CoordinatorLoaderImplTest {
             long startTimeMs = time.milliseconds();
             when(log.logStartOffset()).thenReturn(0L);
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -389,7 +388,7 @@ class CoordinatorLoaderImplTest {
                     return readResult1;
                 });
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())
@@ -426,7 +425,7 @@ class CoordinatorLoaderImplTest {
             when(log.logStartOffset()).thenReturn(0L);
             when(log.highWatermark()).thenReturn(0L, 0L, 2L);
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -434,7 +433,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(0L, 1000, FetchIsolation.LOG_END, true))
                     .thenReturn(readResult1);
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())
@@ -443,7 +442,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(2L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult2);
 
-            FetchDataInfo readResult3 = logReadResult(5, Arrays.asList(
+            FetchDataInfo readResult3 = logReadResult(5, List.of(
                 new SimpleRecord("k6".getBytes(), "v6".getBytes()),
                 new SimpleRecord("k7".getBytes(), "v7".getBytes())
             ));
@@ -517,7 +516,7 @@ class CoordinatorLoaderImplTest {
             when(log.logStartOffset()).thenReturn(0L);
             when(log.highWatermark()).thenReturn(5L, 7L, 7L);
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -525,7 +524,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(0L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult1);
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())
@@ -534,7 +533,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(2L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult2);
 
-            FetchDataInfo readResult3 = logReadResult(5, Arrays.asList(
+            FetchDataInfo readResult3 = logReadResult(5, List.of(
                 new SimpleRecord("k6".getBytes(), "v6".getBytes()),
                 new SimpleRecord("k7".getBytes(), "v7".getBytes())
             ));
@@ -582,7 +581,7 @@ class CoordinatorLoaderImplTest {
             when(log.logStartOffset()).thenReturn(0L);
             when(log.highWatermark()).thenReturn(7L);
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -590,7 +589,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(0L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult1);
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())
@@ -599,14 +598,14 @@ class CoordinatorLoaderImplTest {
             when(log.read(2L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult2);
 
-            FetchDataInfo readResult3 = logReadResult(5, Arrays.asList(
+            FetchDataInfo readResult3 = logReadResult(5, List.of(
                 new SimpleRecord("k6".getBytes(), "v6".getBytes())
             ));
 
             when(log.read(5L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult3);
 
-            FetchDataInfo readResult4 = logReadResult(6, Arrays.asList(
+            FetchDataInfo readResult4 = logReadResult(6, List.of(
                 new SimpleRecord("k7".getBytes(), "v7".getBytes())
             ));
 
@@ -656,7 +655,7 @@ class CoordinatorLoaderImplTest {
             when(log.highWatermark()).thenReturn(0L);
             when(partitionLogEndOffsetSupplier.apply(tp)).thenReturn(Optional.of(5L)).thenReturn(Optional.of(-1L));
 
-            FetchDataInfo readResult1 = logReadResult(0, Arrays.asList(
+            FetchDataInfo readResult1 = logReadResult(0, List.of(
                 new SimpleRecord("k1".getBytes(), "v1".getBytes()),
                 new SimpleRecord("k2".getBytes(), "v2".getBytes())
             ));
@@ -664,7 +663,7 @@ class CoordinatorLoaderImplTest {
             when(log.read(0L, 1000, FetchIsolation.LOG_END, true))
                 .thenReturn(readResult1);
 
-            FetchDataInfo readResult2 = logReadResult(2, Arrays.asList(
+            FetchDataInfo readResult2 = logReadResult(2, List.of(
                 new SimpleRecord("k3".getBytes(), "v3".getBytes()),
                 new SimpleRecord("k4".getBytes(), "v4".getBytes()),
                 new SimpleRecord("k5".getBytes(), "v5".getBytes())

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/EventAccumulatorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/EventAccumulatorTest.java
@@ -82,7 +82,7 @@ public class EventAccumulatorTest {
         assertEquals(0, accumulator.size());
         assertNull(accumulator.poll());
 
-        List<MockEvent> events = Arrays.asList(
+        List<MockEvent> events = List.of(
             new MockEvent(1, 0),
             new MockEvent(1, 1),
             new MockEvent(1, 2),

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessorTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/MultiThreadedEventProcessorTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -178,7 +177,7 @@ public class MultiThreadedEventProcessorTest {
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
 
-            List<FutureEvent<Integer>> events = Arrays.asList(
+            List<FutureEvent<Integer>> events = List.of(
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),
@@ -215,7 +214,7 @@ public class MultiThreadedEventProcessorTest {
         )) {
             AtomicInteger numEventsExecuted = new AtomicInteger(0);
 
-            List<FutureEvent<Integer>> events = Arrays.asList(
+            List<FutureEvent<Integer>> events = List.of(
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet, true), // Event 0
                 new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet, true), // Event 1
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet, true), // Event 2
@@ -323,7 +322,7 @@ public class MultiThreadedEventProcessorTest {
                 true
             );
 
-            List<FutureEvent<Integer>> events = Arrays.asList(
+            List<FutureEvent<Integer>> events = List.of(
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
@@ -482,7 +481,7 @@ public class MultiThreadedEventProcessorTest {
                 return null;
             }).when(mockRuntimeMetrics).recordThreadIdleTime(idleTimeCaptured.capture());
 
-            List<FutureEvent<Integer>> events = Arrays.asList(
+            List<FutureEvent<Integer>> events = List.of(
                 new FutureEvent<>(new TopicPartition("foo", 0), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 1), numEventsExecuted::incrementAndGet),
                 new FutureEvent<>(new TopicPartition("foo", 2), numEventsExecuted::incrementAndGet),

--- a/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
+++ b/coordinator-common/src/testFixtures/java/org/apache/kafka/coordinator/common/runtime/MetadataImageBuilder.java
@@ -24,7 +24,7 @@ import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
 
-import java.util.Arrays;
+import java.util.List;
 
 public class MetadataImageBuilder {
     private final MetadataDelta delta;
@@ -52,7 +52,7 @@ public class MetadataImageBuilder {
             delta.replay(new PartitionRecord()
                 .setTopicId(topicId)
                 .setPartitionId(i)
-                .setReplicas(Arrays.asList(i % 4, (i + 1) % 4)));
+                .setReplicas(List.of(i % 4, (i + 1) % 4)));
         }
         return this;
     }


### PR DESCRIPTION
## Summary

Minor, behavior-preserving cleanups across the `coordinator-common`
runtime package. No functional changes.  The changes fall into three
categories:

1. **Replace `Arrays.asList(...)` with `List.of(...)`** in production
and test code where the list is only read. This is more idiomatic,
returns a truly immutable list, and lets us drop the `java.util.Arrays`
import in favor of `java.util.List`.

2. **Fix a stray quote** in a comment in `CoordinatorLoaderImpl`

Reviewers: Sean Quah <squah@confluent.io>
