### PR TITLE
KAFKA-19738: Add unit tests for OffsetsRequestManager ListOffsets request building

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -471,8 +471,9 @@ public class OffsetsRequestManagerTest {
         verifyRequestSuccessfullyCompleted(fetchOffsetsFuture, expectedOffsets);
     }
 
-    @Test
-    public void testListOffsetsRetriedToNewLeaderAfterMetadataUpdate() throws ExecutionException,
+    @ParameterizedTest
+    @MethodSource("retriableErrors")
+    public void testListOffsetsRetriedToNewLeaderAfterMetadataUpdate(Errors error) throws ExecutionException,
             InterruptedException {
         Map<TopicPartition, Long> timestampsToSearch = Collections.singletonMap(TEST_PARTITION_1,
                 ListOffsetsRequest.EARLIEST_TIMESTAMP);
@@ -490,7 +491,7 @@ public class OffsetsRequestManagerTest {
 
         // Original leader returns a retriable error, so the partition queued for retry and metadata update
         ClientResponse errorResponse = buildClientResponseWithErrors(firstRequest,
-                Collections.singletonMap(TEST_PARTITION_1, Errors.NOT_LEADER_OR_FOLLOWER));
+                Collections.singletonMap(TEST_PARTITION_1, error));
         errorResponse.onComplete();
         assertFalse(fetchOffsetsFuture.isDone());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManagerTest.java
@@ -47,7 +47,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -470,6 +472,52 @@ public class OffsetsRequestManagerTest {
     }
 
     @Test
+    public void testListOffsetsRetriedToNewLeaderAfterMetadataUpdate() throws ExecutionException,
+            InterruptedException {
+        Map<TopicPartition, Long> timestampsToSearch = Collections.singletonMap(TEST_PARTITION_1,
+                ListOffsetsRequest.EARLIEST_TIMESTAMP);
+
+        mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        CompletableFuture<Map<TopicPartition, OffsetAndTimestampInternal>> fetchOffsetsFuture =
+                requestManager.fetchOffsets(timestampsToSearch, false);
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        NetworkClientDelegate.PollResult res = requestManager.poll(time.milliseconds());
+        verifySuccessfulPollAwaitingResponse(res);
+        NetworkClientDelegate.UnsentRequest firstRequest = res.unsentRequests.get(0);
+        assertEquals(Optional.of(LEADER_1), firstRequest.node());
+
+        // Original leader returns a retriable error, so the partition queued for retry and metadata update
+        ClientResponse errorResponse = buildClientResponseWithErrors(firstRequest,
+                Collections.singletonMap(TEST_PARTITION_1, Errors.NOT_LEADER_OR_FOLLOWER));
+        errorResponse.onComplete();
+        assertFalse(fetchOffsetsFuture.isDone());
+
+        assertEquals(0, requestManager.requestsToSend());
+        assertEquals(1, requestManager.requestsToRetry());
+        verify(metadata).requestUpdate(false);
+
+        // Metadata update moves leadership of the partition to LEADER_2
+        mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_2));
+        requestManager.onUpdate(new ClusterResource(""));
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        // The retry must be routed to the new leader, not the stale one
+        NetworkClientDelegate.PollResult retriedPoll = requestManager.poll(time.milliseconds());
+        verifySuccessfulPollAwaitingResponse(retriedPoll);
+        NetworkClientDelegate.UnsentRequest retryRequest = retriedPoll.unsentRequests.get(0);
+        assertEquals(Optional.of(LEADER_2), retryRequest.node());
+
+        Map<TopicPartition, OffsetAndTimestampInternal> expectedOffsets = Collections.singletonMap(
+                TEST_PARTITION_1, new OffsetAndTimestampInternal(5L, -1, Optional.empty()));
+        ClientResponse successResponse = buildClientResponse(retryRequest, expectedOffsets);
+        successResponse.onComplete();
+        verifyRequestSuccessfullyCompleted(fetchOffsetsFuture, expectedOffsets);
+    }
+
+    @Test
     public void testRequestFailedResponse_NonRetriableAuthError() {
         Map<TopicPartition, Long> timestampsToSearch = Collections.singletonMap(TEST_PARTITION_1,
                 ListOffsetsRequest.EARLIEST_TIMESTAMP);
@@ -887,6 +935,63 @@ public class OffsetsRequestManagerTest {
         assertInstanceOf(ListOffsetsRequest.class, abstractRequest);
         ListOffsetsRequest offsetFetchRequest = (ListOffsetsRequest) abstractRequest;
         assertEquals(requestTimeoutMs, offsetFetchRequest.timeoutMs());
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsolationLevel.class)
+    public void testListOffsetsRequestSendsIsolationLevel(IsolationLevel isolationLevel) {
+        requestManager = new OffsetsRequestManager(
+                subscriptionState,
+                metadata,
+                isolationLevel,
+                time,
+                RETRY_BACKOFF_MS,
+                REQUEST_TIMEOUT_MS,
+                DEFAULT_API_TIMEOUT_MS,
+                apiVersions,
+                mock(NetworkClientDelegate.class),
+                commitRequestManager,
+                new PositionsValidator(new LogContext(), time, subscriptionState, metadata),
+                new LogContext()
+        );
+
+        Map<TopicPartition, Long> timestampsToSearch =
+                Collections.singletonMap(TEST_PARTITION_1, ListOffsetsRequest.EARLIEST_TIMESTAMP);
+        mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        requestManager.fetchOffsets(timestampsToSearch, false);
+        assertEquals(1, requestManager.requestsToSend());
+        assertEquals(0, requestManager.requestsToRetry());
+
+        NetworkClientDelegate.PollResult pollResult = requestManager.poll(time.milliseconds());
+        NetworkClientDelegate.UnsentRequest unsentRequest = pollResult.unsentRequests.get(0);
+
+        AbstractRequest abstractRequest = unsentRequest.requestBuilder().build();
+        assertInstanceOf(ListOffsetsRequest.class, abstractRequest);
+        ListOffsetsRequest listOffsetsRequest = (ListOffsetsRequest) abstractRequest;
+
+        assertEquals(isolationLevel, listOffsetsRequest.isolationLevel());
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {ListOffsetsRequest.EARLIEST_TIMESTAMP, ListOffsetsRequest.LATEST_TIMESTAMP})
+    public void testListOffsetsRequestSendsTargetTimestamp(long timestamp) {
+        Map<TopicPartition, Long> timestampsToSearch =
+                Collections.singletonMap(TEST_PARTITION_1, timestamp);
+        mockSuccessfulRequest(Collections.singletonMap(TEST_PARTITION_1, LEADER_1));
+        requestManager.fetchOffsets(timestampsToSearch, false);
+        assertEquals(1, requestManager.requestsToSend());
+
+        NetworkClientDelegate.PollResult pollResult = requestManager.poll(time.milliseconds());
+        NetworkClientDelegate.UnsentRequest unsentRequest = pollResult.unsentRequests.get(0);
+
+        AbstractRequest abstractRequest = unsentRequest.requestBuilder().build();
+        assertInstanceOf(ListOffsetsRequest.class, abstractRequest);
+        ListOffsetsRequest listOffsetsRequest = (ListOffsetsRequest) abstractRequest;
+
+        // The target timestamp requested by the caller must be carried on the wire request
+        assertEquals(TEST_PARTITION_1.topic(), listOffsetsRequest.topics().get(0).name());
+        assertEquals(timestamp,
+                listOffsetsRequest.topics().get(0).partitions().get(0).timestamp());
     }
 
     private void mockAssignedPartitionsMissingPositions(Set<TopicPartition> assignedPartitions,


### PR DESCRIPTION
KAFKA-19738 asks to improve `OffsetsRequestManager` test coverage to
better  match `OffsetFetcher`. This is part 1 of 5, covering ListOffsets
request  construction and retry routing, which were previously untested:

- `testListOffsetsRequestSendsIsolationLevel` verifies the configured
  `IsolationLevel` is carried on the outgoing `ListOffsetsRequest`.
Parameterized
  over both `READ_COMMITTED` and `READ_UNCOMMITTED`.

- `testListOffsetsRequestSendsTargetTimestamp` verifies the caller's
target
  timestamp is carried on the request. Parameterized over
`EARLIEST_TIMESTAMP`
  and `LATEST_TIMESTAMP`.

- `testListOffsetsRetriedToNewLeaderAfterMetadataUpdate` verifies that
when a
  partition's leader changes after a retriable error triggers a metadata
update,
  the retried request is routed to the new leader rather than the stale
one.
  Parameterized over all retriable errors, matching
`OffsetFetcherTest.testGetOffsetByTimeWithPartitionsRetryCouldTriggerMetadataUpdate`.

Reviewers: Evan Zhou, Evan Zhou <ezhou@confluent.io>, Lianet Magrans
 <lmagrans@confluent.io>
