### PR TITLE
KAFKA-20730: Remove scalafmt from streams-scala Spotless config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3032,7 +3032,7 @@ project(':streams:streams-scala') {
   spotless {
     scala {
       target '**/*.scala'
-      scalafmt("$versions.scalafmt").configFile('../../checkstyle/.scalafmt.conf').scalaMajorVersion(versions.baseScala)
+      // Skip scalafmt while Spotless is affected by https://github.com/diffplug/spotless/issues/2850.
       licenseHeaderFile '../../checkstyle/java.header', 'package'
     }
   }


### PR DESCRIPTION
The `:streams:streams-scala:spotlessScalaCheck` task currently fails
with    scalafmt-related `NoClassDefFoundError` errors. This is caused
by    diffplug/spotless#2850.

  Since the `streams-scala` module is already deprecated, this patch
removes    the scalafmt Spotless step for that module. This should not
affect active    development, and the existing license header check is
kept in place.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
