### PR TITLE
MINOR: Add logging for topology description push in streams group protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -572,6 +572,7 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
         streamsRebalanceData.setAcceptableRecoveryLag(data.acceptableRecoveryLag());
 
         if (data.topologyDescriptionRequired() && streamsRebalanceData.wireTopologyDescription() != null) {
+            logger.info("Broker requested topology description push");
             streamsRebalanceData.setTopologyPushRequired(true);
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupTopologyDescriptionRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupTopologyDescriptionRequestManager.java
@@ -72,6 +72,8 @@ public class StreamsGroupTopologyDescriptionRequestManager implements RequestMan
             .setTopologyEpoch(streamsRebalanceData.topologyEpoch())
             .setTopologyDescription(streamsRebalanceData.wireTopologyDescription());
 
+        logger.info("Sending topology description for group {}", data.groupId());
+
         final NetworkClientDelegate.UnsentRequest unsent = new NetworkClientDelegate.UnsentRequest(
             new StreamsGroupTopologyDescriptionUpdateRequest.Builder(data),
             coordinatorRequestManager.coordinator()
@@ -140,6 +142,7 @@ public class StreamsGroupTopologyDescriptionRequestManager implements RequestMan
             case NONE:
                 pushRequestState.onSuccessfulAttempt(responseTimeMs);
                 streamsRebalanceData.setTopologyPushRequired(false);
+                logger.info("Topology description pushed successfully");
                 break;
 
             case NOT_COORDINATOR:


### PR DESCRIPTION
Add INFO log lines for the topology description push flow in the streams
group protocol: when the broker requests a push via heartbeat response,
when the push request is sent, and when it completes successfully.

Reviewers: TengYao Chi <frankvicky@apache.org>, Alieh Saeedi
 <asaeedi@confluent.io>
