### PR TITLE
KAFKA-20662: Throw `INCONSISTENT_GROUP_PROTOCOL` for malformed request during online migration

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -1905,7 +1905,7 @@ public class GroupMetadataManager {
                 ByteBuffer.wrap(protocols.iterator().next().metadata())
             );
         } catch (SchemaException e) {
-            throw new IllegalStateException("Malformed embedded consumer protocol in subscription deserialization.");
+            throw Errors.INCONSISTENT_GROUP_PROTOCOL.exception("Malformed embedded consumer protocol in subscription deserialization.");
         }
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -12097,7 +12097,7 @@ public class GroupMetadataManagerTest {
             .setSessionTimeoutMs(5000)
             .setRebalanceTimeoutMs(45000);
 
-        IllegalStateException ex = assertThrows(IllegalStateException.class,
+        InconsistentGroupProtocolException ex = assertThrows(InconsistentGroupProtocolException.class,
             () -> context.sendClassicGroupJoin(joinRequest));
         assertEquals("Malformed embedded consumer protocol in subscription deserialization.", ex.getMessage());
     }


### PR DESCRIPTION
When the subscription deserialization fails, we throw an
IllegalStateException
```
private static ConsumerProtocolSubscription deserializeSubscription(
  JoinGroupRequestProtocolCollection protocols
) {
  try {
  return ConsumerProtocol.deserializeConsumerProtocolSubscription(
    ByteBuffer.wrap(protocols.iterator().next().metadata()));
  }
  catch (SchemaException e) {
  throw new IllegalStateException("Malformed embedded consumer protocol
in subscription deserialization.");
  }
}
```
which will be translated to UNKNOWN_SERVER_ERROR. This is a bit
confusing to the client. We throw a fatal `INCONSISTENT_GROUP_PROTOCOL`
here instead.

Reviewers: David Jacot <david.jacot@gmail.com>
