### PR TITLE
KAFKA-20741: Add ReadOnlyRecord IQv2 result type (KIP-1356)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
@@ -54,11 +54,9 @@ public interface ReadOnlyRecord<K, V> {
      *
      * <p>The returned {@link Headers} is part of a read-only view and must not be mutated by
      * callers.
-     *
-     * <p>TODO (KIP-1356 follow-up): once the IQv2 query types land, records served as IQv2
-     * results from a state store will have their headers frozen via
-     * {@code RecordHeaders.setReadOnly()}, so that any attempt to mutate them throws
-     * {@link IllegalStateException}.
      */
+    // TODO (KIP-1356 follow-up): once the IQv2 query types land, records served as IQv2
+    // results from a state store will have their headers frozen via RecordHeaders.setReadOnly(),
+    // so that any attempt to mutate them throws IllegalStateException.
     Headers headers();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.api;
 
+import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
 import org.apache.kafka.common.header.Headers;
 
 /**
@@ -30,6 +31,7 @@ import org.apache.kafka.common.header.Headers;
  * @param <K> The type of the key
  * @param <V> The type of the value
  */
+@Evolving
 public interface ReadOnlyRecord<K, V> {
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
@@ -24,8 +24,7 @@ import org.apache.kafka.common.header.Headers;
  * <p>This is the shared read surface of a record: the processing-layer {@link Record} extends it with
  * transform-and-forward builders ({@code withKey}/{@code withValue}/{@code withTimestamp}/{@code withHeaders}),
  * while an Interactive Query (IQv2) result is exactly this read-only snapshot and exposes nothing more.
- * It is the result type returned by the headers-aware IQv2 query types (e.g.
- * {@code TimestampedKeyWithHeadersQuery}), which surface the record headers
+ * It is the result type returned by the headers-aware IQv2 query types, which surface the record headers
  * persisted by header-aware state stores.
  *
  * @param <K> The type of the key
@@ -50,6 +49,14 @@ public interface ReadOnlyRecord<K, V> {
 
     /**
      * The headers of the record. Never null.
+     *
+     * <p>The returned {@link Headers} is part of a read-only view and must not be mutated by
+     * callers.
+     *
+     * <p>TODO (KIP-1356 follow-up): once the IQv2 query types land, records served as IQv2
+     * results from a state store will have their headers frozen via
+     * {@code RecordHeaders.setReadOnly()}, so that any attempt to mutate them throws
+     * {@link IllegalStateException}.
      */
     Headers headers();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/ReadOnlyRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.api;
+
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * A read-only view of a record's {@code key}, {@code value}, {@code timestamp}, and {@code headers}.
+ *
+ * <p>This is the shared read surface of a record: the processing-layer {@link Record} extends it with
+ * transform-and-forward builders ({@code withKey}/{@code withValue}/{@code withTimestamp}/{@code withHeaders}),
+ * while an Interactive Query (IQv2) result is exactly this read-only snapshot and exposes nothing more.
+ * It is the result type returned by the headers-aware IQv2 query types (e.g.
+ * {@code TimestampedKeyWithHeadersQuery}), which surface the record headers
+ * persisted by header-aware state stores.
+ *
+ * @param <K> The type of the key
+ * @param <V> The type of the value
+ */
+public interface ReadOnlyRecord<K, V> {
+
+    /**
+     * The key of the record. May be null.
+     */
+    K key();
+
+    /**
+     * The value of the record. May be null.
+     */
+    V value();
+
+    /**
+     * The timestamp of the record. Will never be negative.
+     */
+    long timestamp();
+
+    /**
+     * The headers of the record. Never null.
+     */
+    Headers headers();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/Record.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/Record.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  * @param <K> The type of the key
  * @param <V> The type of the value
  */
-public class Record<K, V> {
+public class Record<K, V> implements ReadOnlyRecord<K, V> {
     private final K key;
     private final V value;
     private final long timestamp;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/api/Record.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/api/Record.java
@@ -86,6 +86,7 @@ public class Record<K, V> implements ReadOnlyRecord<K, V> {
     /**
      * The key of the record. May be null.
      */
+    @Override
     public K key() {
         return key;
     }
@@ -93,6 +94,7 @@ public class Record<K, V> implements ReadOnlyRecord<K, V> {
     /**
      * The value of the record. May be null.
      */
+    @Override
     public V value() {
         return value;
     }
@@ -100,6 +102,7 @@ public class Record<K, V> implements ReadOnlyRecord<K, V> {
     /**
      * The timestamp of the record. Will never be negative.
      */
+    @Override
     public long timestamp() {
         return timestamp;
     }
@@ -107,6 +110,7 @@ public class Record<K, V> implements ReadOnlyRecord<K, V> {
     /**
      * The headers of the record. Never null.
      */
+    @Override
     public Headers headers() {
         return headers;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/api/ReadOnlyRecordTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/api/ReadOnlyRecordTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.api;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReadOnlyRecordTest {
+
+    private static Headers headers() {
+        return new RecordHeaders().add(new RecordHeader("k", "v".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void recordShouldBeAssignableToReadOnlyRecordAndExposeSameAccessors() {
+        final Headers headers = headers();
+        final Record<String, String> record = new Record<>("key", "value", 123L, headers);
+
+        // The assignment itself proves Record is a ReadOnlyRecord (source/binary compatible change).
+        final ReadOnlyRecord<String, String> readOnly = record;
+
+        assertEquals(record.key(), readOnly.key());
+        assertEquals(record.value(), readOnly.value());
+        assertEquals(record.timestamp(), readOnly.timestamp());
+        assertEquals(record.headers(), readOnly.headers());
+
+        assertEquals("key", readOnly.key());
+        assertEquals("value", readOnly.value());
+        assertEquals(123L, readOnly.timestamp());
+        assertEquals(headers, readOnly.headers());
+    }
+
+    @Test
+    public void readOnlyHeadersShouldBeNonNullAndEmptyWhenConstructedWithoutHeaders() {
+        final ReadOnlyRecord<String, String> readOnly = new Record<>("key", "value", 123L);
+        assertEquals(new RecordHeaders(), readOnly.headers());
+    }
+
+    @Test
+    public void readOnlyAccessorsShouldTolerateNullKeyAndValue() {
+        final ReadOnlyRecord<String, String> readOnly = new Record<>(null, null, 0L);
+        assertEquals(null, readOnly.key());
+        assertEquals(null, readOnly.value());
+        assertEquals(0L, readOnly.timestamp());
+        assertEquals(new RecordHeaders(), readOnly.headers());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/api/ReadOnlyRecordTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/api/ReadOnlyRecordTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ReadOnlyRecordTest {
 
@@ -39,11 +40,6 @@ public class ReadOnlyRecordTest {
 
         // The assignment itself proves Record is a ReadOnlyRecord (source/binary compatible change).
         final ReadOnlyRecord<String, String> readOnly = record;
-
-        assertEquals(record.key(), readOnly.key());
-        assertEquals(record.value(), readOnly.value());
-        assertEquals(record.timestamp(), readOnly.timestamp());
-        assertEquals(record.headers(), readOnly.headers());
 
         assertEquals("key", readOnly.key());
         assertEquals("value", readOnly.value());
@@ -60,8 +56,8 @@ public class ReadOnlyRecordTest {
     @Test
     public void readOnlyAccessorsShouldTolerateNullKeyAndValue() {
         final ReadOnlyRecord<String, String> readOnly = new Record<>(null, null, 0L);
-        assertEquals(null, readOnly.key());
-        assertEquals(null, readOnly.value());
+        assertNull(readOnly.key());
+        assertNull(readOnly.value());
         assertEquals(0L, readOnly.timestamp());
         assertEquals(new RecordHeaders(), readOnly.headers());
     }


### PR DESCRIPTION
Introduce a read-only view of a record (key/value/timestamp/headers);
prerequisite for the KIP-1356 headers-aware IQv2 query types.

- ReadOnlyRecord<K, V> (new, org.apache.kafka.streams.processor.api) — a
read-only view
exposing key() / value() / timestamp() / headers().
- Record now implements ReadOnlyRecord.
- ReadOnlyRecordTest — Record is assignable to ReadOnlyRecord and
exposes the same key/value/timestamp/headers; headers are non-null/empty
by default; null key/value tolerated.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, TengYao Chi
 <frankvicky@apache.org>
