### PR TITLE
KAFKA-20490: Track committed and uncommitted RocksDB Positions

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -497,7 +497,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         synchronized (position) {
             cfAccessor.put(dbAccessor, key.get(), value);
-            StoreQueryUtils.updatePosition(position, context);
+            dbAccessor.updatePosition(position, context);
         }
     }
 
@@ -518,7 +518,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             try (final WriteBatch batch = new WriteBatch()) {
                 cfAccessor.prepareBatch(entries, batch);
                 write(batch);
-                StoreQueryUtils.updatePosition(position, context);
+                dbAccessor.updatePosition(position, context);
             } catch (final RocksDBException e) {
                 throw new ProcessorStateException("Error while batch writing to store " + name, e);
             }
@@ -531,12 +531,20 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         final PositionBound positionBound,
         final QueryConfig config) {
 
+        final Position queryPosition;
+        synchronized (position) {
+            if (config.getIsolationLevel() == IsolationLevel.READ_COMMITTED) {
+                queryPosition = position.copy();
+            } else {
+                queryPosition = position.copy().merge(dbAccessor.uncommittedPositionDeltas());
+            }
+        }
         return StoreQueryUtils.handleBasicQueries(
             query,
             positionBound,
             config,
             this,
-            position,
+            queryPosition,
             context
         );
     }
@@ -893,6 +901,9 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
         try {
             cfAccessor.commit(dbAccessor, changelogOffsets);
+            synchronized (position) {
+                dbAccessor.mergeUncommittedPositionInto(position);
+            }
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error while executing commit from store " + name, e);
         }
@@ -1081,6 +1092,21 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         default void rollbackStagedWrites() {
             // no-op for non-transactional accessors
         }
+
+        // Position tracking. A non-transactional accessor writes straight to the store's committed
+        // position and has no uncommitted deltas; the transactional accessor stages them in its
+        // buffer until commit. (committedPosition is unused by the transactional override.)
+        default void updatePosition(final Position committedPosition, final StateStoreContext context) {
+            StoreQueryUtils.updatePosition(committedPosition, context);
+        }
+
+        default Position uncommittedPositionDeltas() {
+            return Position.emptyPosition();
+        }
+
+        default void mergeUncommittedPositionInto(final Position committedPosition) {
+            // no-op for non-transactional accessors
+        }
     }
 
     static class DirectDBAccessor implements DBAccessor {
@@ -1257,6 +1283,21 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         @Override
         public void rollbackStagedWrites() {
             buffer.rollback();
+        }
+
+        @Override
+        public void updatePosition(final Position committedPosition, final StateStoreContext context) {
+            buffer.updatePosition(context);
+        }
+
+        @Override
+        public Position uncommittedPositionDeltas() {
+            return buffer.pendingPosition();
+        }
+
+        @Override
+        public void mergeUncommittedPositionInto(final Position committedPosition) {
+            buffer.mergePendingPositionInto(committedPosition);
         }
 
     }
@@ -1457,6 +1498,9 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         synchronized (position) {
             try (final WriteBatch batch = new WriteBatch()) {
                 for (final ConsumerRecord<byte[], byte[]> record : records) {
+                    // Restore writes go straight to the base store (write(batch) below bypasses the
+                    // transaction buffer), so the restored data is already committed — its position
+                    // updates `position` directly, never the buffer's pending deltas.
                     ChangelogRecordDeserializationHelper.applyChecksAndUpdatePosition(
                         record,
                         consistencyEnabled,
@@ -1479,7 +1523,21 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
     @Override
     public Position getPosition() {
-        return position;
+        synchronized (position) {
+            return position.copy().merge(dbAccessor.uncommittedPositionDeltas());
+        }
+    }
+
+    // Visible for testing. Returns a snapshot of the committed Position only (no pending writes).
+    Position committedPositionForTest() {
+        synchronized (position) {
+            return position.copy();
+        }
+    }
+
+    // Visible for testing. Returns a snapshot of the pending-only Position deltas.
+    Position pendingPositionForTest() {
+        return dbAccessor.uncommittedPositionDeltas();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -532,22 +532,22 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         final PositionBound positionBound,
         final QueryConfig config) {
 
-        final Position queryPosition;
         synchronized (position) {
+            final Position queryPosition;
             if (config.getIsolationLevel() == IsolationLevel.READ_COMMITTED) {
-                queryPosition = position.copy();
+                queryPosition = position;
             } else {
                 queryPosition = position.copy().merge(dbAccessor.uncommittedPositionDeltas());
             }
+            return StoreQueryUtils.handleBasicQueries(
+                query,
+                positionBound,
+                config,
+                this,
+                queryPosition,
+                context
+            );
         }
-        return StoreQueryUtils.handleBasicQueries(
-            query,
-            positionBound,
-            config,
-            this,
-            queryPosition,
-            context
-        );
     }
 
     @Override
@@ -901,8 +901,8 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             return;
         }
         try {
-            cfAccessor.commit(dbAccessor, changelogOffsets);
             synchronized (position) {
+                cfAccessor.commit(dbAccessor, changelogOffsets);
                 dbAccessor.mergeUncommittedPositionInto(position);
             }
         } catch (final RocksDBException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -144,7 +144,8 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
 
     protected StateStoreContext context;
-    protected Position position;
+    // VisibleForTesting
+    Position position;
     private TaskId taskId;
 
     public RocksDBStore(final String name,
@@ -1526,18 +1527,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         synchronized (position) {
             return position.copy().merge(dbAccessor.uncommittedPositionDeltas());
         }
-    }
-
-    // Visible for testing. Returns a snapshot of the committed Position only (no pending writes).
-    Position committedPositionForTest() {
-        synchronized (position) {
-            return position.copy();
-        }
-    }
-
-    // Visible for testing. Returns a snapshot of the pending-only Position deltas.
-    Position pendingPositionForTest() {
-        return dbAccessor.uncommittedPositionDeltas();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
@@ -279,14 +279,11 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
 
     @Override
     void discardPendingBatch() {
-        // Called from rollback() under the snapshotLock write lock: discard the staged position
-        // alongside the staged writes and range tombstones.
         writeBatch.clear();
         rangeTombstones = Collections.emptyNavigableMap();
         pendingPosition = Position.emptyPosition();
     }
 
-    /** Stage the current record's position into the uncommitted transaction (owner write path). */
     void updatePosition(final StateStoreContext stateStoreContext) {
         snapshotLock.writeLock().lock();
         try {
@@ -296,7 +293,6 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
         }
     }
 
-    /** A point-in-time copy of the uncommitted position deltas, for isolation-aware (IQ) reads. */
     Position pendingPosition() {
         snapshotLock.readLock().lock();
         try {
@@ -306,7 +302,6 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
         }
     }
 
-    /** Merge the uncommitted position deltas into {@code committed} and clear them (commit path). */
     void mergePendingPositionInto(final Position committed) {
         snapshotLock.writeLock().lock();
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.query.Position;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
@@ -58,6 +60,11 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
     private final String storeName;
     private WriteBatch writeBatch;
     private volatile NavigableMap<Bytes, List<Bytes>> rangeTombstones = Collections.emptyNavigableMap();
+    // Position deltas for writes staged in the current (uncommitted) transaction. Merged into the
+    // store's committed Position and cleared on commit; discarded on rollback. Guarded by
+    // snapshotLock (the same lock that guards the staging map), so reads from IQ threads and
+    // owner mutations stay consistent with the staged writes they correspond to.
+    private Position pendingPosition = Position.emptyPosition();
 
     RocksDBTransactionBuffer(final RocksDB db,
                              final ColumnFamilyHandle cfHandle,
@@ -272,8 +279,42 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
 
     @Override
     void discardPendingBatch() {
+        // Called from rollback() under the snapshotLock write lock: discard the staged position
+        // alongside the staged writes and range tombstones.
         writeBatch.clear();
         rangeTombstones = Collections.emptyNavigableMap();
+        pendingPosition = Position.emptyPosition();
+    }
+
+    /** Stage the current record's position into the uncommitted transaction (owner write path). */
+    void updatePosition(final StateStoreContext stateStoreContext) {
+        snapshotLock.writeLock().lock();
+        try {
+            StoreQueryUtils.updatePosition(pendingPosition, stateStoreContext);
+        } finally {
+            snapshotLock.writeLock().unlock();
+        }
+    }
+
+    /** A point-in-time copy of the uncommitted position deltas, for isolation-aware (IQ) reads. */
+    Position pendingPosition() {
+        snapshotLock.readLock().lock();
+        try {
+            return pendingPosition.copy();
+        } finally {
+            snapshotLock.readLock().unlock();
+        }
+    }
+
+    /** Merge the uncommitted position deltas into {@code committed} and clear them (commit path). */
+    void mergePendingPositionInto(final Position committed) {
+        snapshotLock.writeLock().lock();
+        try {
+            committed.merge(pendingPosition);
+            pendingPosition = Position.emptyPosition();
+        } finally {
+            snapshotLock.writeLock().unlock();
+        }
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1533,8 +1533,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         eosContext.setRecordContext(new ProcessorRecordContext(0, 5L, 0, "input", new RecordHeaders()));
         rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k2")), stringSerializer.serialize(null, "v2"));
 
-        assertEquals(Map.of(0, 1L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
-        assertEquals(Map.of(0, 5L), rocksDBStore.pendingPositionForTest().getPartitionPositions("input"));
+        assertEquals(Map.of(0, 1L), rocksDBStore.position.getPartitionPositions("input"));
+        assertEquals(Map.of(0, 5L), rocksDBStore.dbAccessor.uncommittedPositionDeltas().getPartitionPositions("input"));
         assertEquals(Map.of(0, 5L), rocksDBStore.getPosition().getPartitionPositions("input"));
     }
 
@@ -1553,8 +1553,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k2")), stringSerializer.serialize(null, "v2"));
         rocksDBStore.commit(Map.of());
 
-        assertEquals(Map.of(0, 9L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
-        assertTrue(rocksDBStore.pendingPositionForTest().getTopics().isEmpty());
+        assertEquals(Map.of(0, 9L), rocksDBStore.position.getPartitionPositions("input"));
+        assertTrue(rocksDBStore.dbAccessor.uncommittedPositionDeltas().getTopics().isEmpty());
     }
 
     @Test
@@ -1564,8 +1564,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         context.setRecordContext(new ProcessorRecordContext(0, 7L, 0, "input", new RecordHeaders()));
         rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k")), stringSerializer.serialize(null, "v"));
 
-        assertEquals(Map.of(0, 7L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
-        assertTrue(rocksDBStore.pendingPositionForTest().getTopics().isEmpty());
+        assertEquals(Map.of(0, 7L), rocksDBStore.position.getPartitionPositions("input"));
+        assertTrue(rocksDBStore.dbAccessor.uncommittedPositionDeltas().getTopics().isEmpty());
     }
 
     public static class TestingBloomFilterRocksDBConfigSetter implements RocksDBConfigSetter {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1519,6 +1519,55 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED).get(key)));
     }
 
+    @Test
+    public void committedPositionShouldExcludeStagedWritesUntilCommit() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 1L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k1")), stringSerializer.serialize(null, "v1"));
+        rocksDBStore.commit(Map.of());
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 5L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k2")), stringSerializer.serialize(null, "v2"));
+
+        assertEquals(Map.of(0, 1L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
+        assertEquals(Map.of(0, 5L), rocksDBStore.pendingPositionForTest().getPartitionPositions("input"));
+        assertEquals(Map.of(0, 5L), rocksDBStore.getPosition().getPartitionPositions("input"));
+    }
+
+    @Test
+    public void commitShouldMergePendingIntoCommittedPosition() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 1L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k1")), stringSerializer.serialize(null, "v1"));
+        rocksDBStore.commit(Map.of());
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 9L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k2")), stringSerializer.serialize(null, "v2"));
+        rocksDBStore.commit(Map.of());
+
+        assertEquals(Map.of(0, 9L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
+        assertTrue(rocksDBStore.pendingPositionForTest().getTopics().isEmpty());
+    }
+
+    @Test
+    public void nonTransactionalStoreShouldUpdateCommittedPositionDirectly() {
+        rocksDBStore.init(context, rocksDBStore);
+
+        context.setRecordContext(new ProcessorRecordContext(0, 7L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k")), stringSerializer.serialize(null, "v"));
+
+        assertEquals(Map.of(0, 7L), rocksDBStore.committedPositionForTest().getPartitionPositions("input"));
+        assertTrue(rocksDBStore.pendingPositionForTest().getTopics().isEmpty());
+    }
+
     public static class TestingBloomFilterRocksDBConfigSetter implements RocksDBConfigSetter {
 
         static boolean bloomFiltersSet;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1568,6 +1568,54 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         assertTrue(rocksDBStore.dbAccessor.uncommittedPositionDeltas().getTopics().isEmpty());
     }
 
+    @Test
+    public void rollbackShouldDiscardPendingPositionDeltas() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 1L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k1")), stringSerializer.serialize(null, "v1"));
+        rocksDBStore.commit(Map.of());
+
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 5L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "k2")), stringSerializer.serialize(null, "v2"));
+
+        // sanity: the staged write advanced the pending position past the committed one
+        assertEquals(Map.of(0, 5L), rocksDBStore.dbAccessor.uncommittedPositionDeltas().getPartitionPositions("input"));
+
+        rocksDBStore.dbAccessor.rollbackStagedWrites();
+
+        // committed position is untouched; the pending delta is discarded
+        assertEquals(Map.of(0, 1L), rocksDBStore.position.getPartitionPositions("input"));
+        assertTrue(rocksDBStore.dbAccessor.uncommittedPositionDeltas().getTopics().isEmpty());
+        assertEquals(Map.of(0, 1L), rocksDBStore.getPosition().getPartitionPositions("input"));
+    }
+
+    @Test
+    public void rollbackShouldDiscardStagedWritesAndPendingPositionWithoutPriorCommit() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        final Bytes key = new Bytes(stringSerializer.serialize(null, "k"));
+        eosContext.setRecordContext(new ProcessorRecordContext(0, 3L, 0, "input", new RecordHeaders()));
+        rocksDBStore.put(key, stringSerializer.serialize(null, "v"));
+
+        // sanity: nothing committed yet; the write is only staged
+        assertEquals(Map.of(0, 3L), rocksDBStore.dbAccessor.uncommittedPositionDeltas().getPartitionPositions("input"));
+
+        rocksDBStore.dbAccessor.rollbackStagedWrites();
+
+        // the staged write and its pending position delta are both gone
+        assertNull(rocksDBStore.get(key));
+        assertTrue(rocksDBStore.position.getTopics().isEmpty());
+        assertTrue(rocksDBStore.dbAccessor.uncommittedPositionDeltas().getTopics().isEmpty());
+        assertTrue(rocksDBStore.getPosition().getTopics().isEmpty());
+    }
+
     public static class TestingBloomFilterRocksDBConfigSetter implements RocksDBConfigSetter {
 
         static boolean bloomFiltersSet;


### PR DESCRIPTION
Part of the KIP-892 interactive-query isolation-level series. KIP-892
specifies that a transactional state store tracks its committed
`Position` separately from the position deltas of the current
(uncommitted) transaction, so `READ_COMMITTED` interactive queries do
not observe positions for writes that are still only in the transaction
buffer.

The committed `Position` stays on `RocksDBStore`; the uncommitted deltas
live in `RocksDBTransactionBuffer` alongside the staged writes they
correspond to, under the same lock, so they are merged into the
committed `Position` on commit and discarded on rollback (an aborted
transaction no longer leaks position deltas). `RocksDBStore` routes
position handling through the `DBAccessor` interface rather than
`instanceof` checks: `DirectDBAccessor` writes straight to the committed
`Position` and reports no uncommitted deltas, while
`TransactionalDBAccessor` routes through the buffer. `READ_COMMITTED`
sees only the committed `Position`, `READ_UNCOMMITTED` merges in the
buffer's deltas, and `getPosition()` merges both for backwards
compatibility. Restore writes bypass the buffer and update the committed
`Position` directly.

This builds on the `RocksDBTransactionBuffer` redesign (now on trunk)
and is filed under the same KAFKA-20490; it now applies directly to
trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewers: Bill Bejeck <bbejeck@apache.org>
