### PR TITLE
KAFKA-19491 CONSUMER protocol metrics documentation

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -3455,7 +3455,7 @@ application-event-queue-size
 </td>
 <td>
 
-The current number of events in the queue to send from the application thread to the background thread(for CONSUMER Protocol,will be referred as 'CP' in the below metrics).
+The current number of events in the queue to send from the application thread to the background thread (consumer protocol).
 </td>
 <td>
 
@@ -3468,7 +3468,7 @@ application-event-queue-time-avg
 </td>
 <td>
 
-The average time, in ms, that application events are taking to be dequeued (for CP only).
+The average time, in ms, that application events are taking to be dequeued (consumer protocol).
 </td>
 <td>
 
@@ -3481,7 +3481,7 @@ application-event-queue-time-max
 </td>
 <td>
 
-The maximum time, in ms, that application events are taking to be dequeued (for CP only).
+The maximum time, in ms, that application events are taking to be dequeued (consumer protocol).
 </td>
 <td>
 
@@ -3494,7 +3494,7 @@ application-event-queue-processing-time-avg
 </td>
 <td>
 
-The average time, in ms,that the background thread took to process all available application events((for CP only).
+The average time, in ms, that the background thread took to process all available application events (consumer protocol).
 </td>
 <td>
 
@@ -3507,7 +3507,7 @@ application-event-queue-processing-time-max
 </td>
 <td>
 
-The maximum time, in ms,that the background thread took to process all available application events(for CP only).
+The maximum time, in ms, that the background thread took to process all available application events (consumer protocol).
 </td>
 <td>
 
@@ -3520,7 +3520,7 @@ application-events-expired-count
 </td>
 <td>
 
-The current number of expired application events (for CP only).
+The current number of expired application events (consumer protocol).
 </td>
 <td>
 
@@ -3533,7 +3533,7 @@ background-event-queue-size
 </td>
 <td>
 
-The current number of events in the queue to send from the background thread to the application thread (for CP only).
+The current number of events in the queue to send from the background thread to the application thread (consumer protocol).
 </td>
 
 <td>
@@ -3547,7 +3547,7 @@ background-event-queue-time-avg
 </td>
 <td>
 
-The average time, in ms, that background events are taking to be dequeued (for CP only).
+The average time, in ms, that background events are taking to be dequeued (consumer protocol).
 </td>
 <td>
 
@@ -3560,7 +3560,7 @@ background-event-queue-time-max
 </td>
 <td>
 
-The maximum time, in ms, that background events are taking to be dequeued (for CP only).
+The maximum time, in ms, that background events are taking to be dequeued (consumer protocol).
 </td>
 <td>
 
@@ -3573,7 +3573,7 @@ background-event-queue-processing-time-avg
 </td>
 <td>
 
-The average time, in ms, that the consumer took to process all available background events (for CP only).
+The average time, in ms, that the consumer took to process all available background events (consumer protocol).
 </td>
 <td>
 
@@ -3586,7 +3586,7 @@ background-event-queue-processing-time-max
 </td>
 <td>
 
-The maximum time, in ms, that the consumer took to process all available background events (for CP only).
+The maximum time, in ms, that the consumer took to process all available background events (consumer protocol).
 </td>
 <td>
 
@@ -3595,10 +3595,11 @@ kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 <tr>
 <td>
 
-time-between-network-thread-poll-max</td>
+time-between-network-thread-poll-max
+</td>
 <td>
 
-The maximum delay, in ms,between invocations of poll in the network thread (for CP only).
+The maximum delay, in ms,between invocations of poll in the network thread (consumer protocol).
 </td>
 <td>
 
@@ -3607,10 +3608,11 @@ kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 <tr>
 <td>
 
-time-between-network-thread-poll-avg</td>
+time-between-network-thread-poll-avg
+</td>
 <td>
 
-The average delay, in ms, between invocations of poll in the network thread (for CP only).
+The average delay, in ms, between invocations of poll in the network thread (consumer protocol).
 </td>
 <td>
 
@@ -3623,7 +3625,7 @@ unsent-requests-queue-size
 </td>
 <td>
 
-The current number of unsent requests in the background thread (for CP only).
+The current number of unsent requests in the background thread (consumer protocol).
 </td>
 <td>
 
@@ -3636,7 +3638,7 @@ unsent-requests-queue-time-max
 </td>
 <td>
 
-The maximum time, in ms, that a request remained unsent in the background thread(for CP only).
+The maximum time, in ms, that a request remained unsent in the background thread (consumer protocol).
 </td>
 <td>
 
@@ -3649,7 +3651,7 @@ unsent-requests-queue-time-avg
 </td>
 <td>
 
-The average time, in ms, that requests are taking to be sent in the background thread (for CP only).
+The average time, in ms, that requests are taking to be sent in the background thread (consumer protocol).
 </td>
 <td>
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -3447,18 +3447,6 @@ The total time the Consumer spent committing offsets in nanoseconds (for AOS).
 <td>
 
 kafka.consumer:type=consumer-metrics,client-id=([-.\w]+) 
-</td> </tr> 
-<tr>
-<td>
-
-time-between-network-thread-poll</td>
-<td>
-
-The average delay between invocations of poll (for CONSUMER protocol)
-</td>
-<td>
-
-kafka.consumer:type=consumer-metrics,client-id={clientId}
 </td> </tr>
 <tr>
 <td>
@@ -3467,11 +3455,11 @@ application-event-queue-size
 </td>
 <td>
 
-The current number of events in the consumer network application event queue (for CONSUMER protocol).
+The current number of events in the queue to send from the application thread to the background thread(for CONSUMER Protocol,will be referred as 'CP' in the below metrics).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3480,11 +3468,24 @@ application-event-queue-time-avg
 </td>
 <td>
 
-The average time, in milliseconds, that application events are taking to be dequeued (for CONSUMER protocol)
+The average time, in ms, that application events are taking to be dequeued (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td></tr>
+<tr>
+<td>
+
+application-event-queue-time-max
+</td>
+<td>
+
+The maximum time, in ms, that application events are taking to be dequeued (for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3493,11 +3494,24 @@ application-event-queue-processing-time-avg
 </td>
 <td>
 
-The maximum time, in milliseconds, that the consumer network took to process all available application events (for CONSUMER protocol)
+The average time, in ms,that the background thread took to process all available application events((for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td></tr>
+<tr>
+<td>
+
+application-event-queue-processing-time-max
+</td>
+<td>
+
+The maximum time, in ms,that the background thread took to process all available application events(for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3506,11 +3520,11 @@ application-events-expired-count
 </td>
 <td>
 
-The current number of expired application events (for CONSUMER protocol)
+The current number of expired application events (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3519,12 +3533,12 @@ background-event-queue-size
 </td>
 <td>
 
-The current number of events in the consumer background event queue (for CONSUMER protocol)
+The current number of events in the queue to send from the background thread to the application thread (for CP only).
 </td>
 
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3533,11 +3547,24 @@ background-event-queue-time-avg
 </td>
 <td>
 
-The average time, in milliseconds, that background events are taking to be dequeued (for CONSUMER protocol)
+The average time, in ms, that background events are taking to be dequeued (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td></tr>
+<tr>
+<td>
+
+background-event-queue-time-max
+</td>
+<td>
+
+The maximum time, in ms, that background events are taking to be dequeued (for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3546,12 +3573,49 @@ background-event-queue-processing-time-avg
 </td>
 <td>
 
-The average time, in milliseconds, that the consumer took to process all available background events (for CONSUMER protocol)
+The average time, in ms, that the consumer took to process all available background events (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
+<tr>
+<td>
+
+background-event-queue-processing-time-max
+</td>
+<td>
+
+The maximum time, in ms, that the consumer took to process all available background events (for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td></tr>
+<tr>
+<td>
+
+time-between-network-thread-poll-max</td>
+<td>
+
+The maximum delay, in ms,between invocations of poll in the network thread (for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td> </tr>
+<tr>
+<td>
+
+time-between-network-thread-poll-avg</td>
+<td>
+
+The average delay, in ms, between invocations of poll in the network thread (for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td> </tr>
 <tr>
 <td>
 
@@ -3559,11 +3623,24 @@ unsent-requests-queue-size
 </td>
 <td>
 
-The current number of unsent requests in the consumer network (for CONSUMER protocol)
+The current number of unsent requests in the background thread (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
+</td></tr>
+<tr>
+<td>
+
+unsent-requests-queue-time-max
+</td>
+<td>
+
+The maximum time, in ms, that a request remained unsent in the background thread(for CP only).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 <tr>
 <td>
@@ -3572,11 +3649,11 @@ unsent-requests-queue-time-avg
 </td>
 <td>
 
-The average time, in milliseconds, that requests are taking to be sent in the consumer network (for CONSUMER protocol)
+The average time, in ms, that requests are taking to be sent in the background thread (for CP only).
 </td>
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id={clientId}
+kafka.consumer:type=consumer-metrics,client-id=([-\.\w]+)
 </td></tr>
 </table>
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -3446,8 +3446,139 @@ The total time the Consumer spent committing offsets in nanoseconds (for AOS).
 </td>  
 <td>
 
-kafka.consumer:type=consumer-metrics,client-id=([-.\w]+)
-</td> </tr> </table>
+kafka.consumer:type=consumer-metrics,client-id=([-.\w]+) 
+</td> </tr> 
+<tr>
+<td>
+
+time-between-network-thread-poll</td>
+<td>
+
+The average delay between invocations of poll (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td> </tr>
+<tr>
+<td>
+
+application-event-queue-size
+</td>
+<td>
+
+The current number of events in the consumer network application event queue (for CONSUMER protocol).
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+application-event-queue-time-avg
+</td>
+<td>
+
+The average time, in milliseconds, that application events are taking to be dequeued (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+application-event-queue-processing-time-avg
+</td>
+<td>
+
+The maximum time, in milliseconds, that the consumer network took to process all available application events (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+application-events-expired-count
+</td>
+<td>
+
+The current number of expired application events (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+background-event-queue-size
+</td>
+<td>
+
+The current number of events in the consumer background event queue (for CONSUMER protocol)
+</td>
+
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+background-event-queue-time-avg
+</td>
+<td>
+
+The average time, in milliseconds, that background events are taking to be dequeued (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+background-event-queue-processing-time-avg
+</td>
+<td>
+
+The average time, in milliseconds, that the consumer took to process all available background events (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+unsent-requests-queue-size
+</td>
+<td>
+
+The current number of unsent requests in the consumer network (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+<tr>
+<td>
+
+unsent-requests-queue-time-avg
+</td>
+<td>
+
+The average time, in milliseconds, that requests are taking to be sent in the consumer network (for CONSUMER protocol)
+</td>
+<td>
+
+kafka.consumer:type=consumer-metrics,client-id={clientId}
+</td></tr>
+</table>
 
 ### Consumer Group Metrics  
   


### PR DESCRIPTION
Description   Added documentation for new consumer metrics related to
the CONSUMER protocol implementation

Below are metrics for which documentation has been added :

1. time-between-network-thread-poll
2. application-event-queue-size
3. application-event-queue-time-avg
4. application-event-queue-processing-time-avg
5. application-events-expired-count
6. background-event-queue-size
7. background-event-queue-time-avg
8. background-event-queue-processing-time-avg
9. unsent-requests-queue-size
10. unsent-requests-queue-time-avg

Testing :   Tested using javascript  wrapper in local for checking
indentation

<img width="1250" height="494" alt="image"
src="https://github.com/user-attachments/assets/bcfbecbe-fadb-4f5c-a289-c8b03e3b1f76"
/>

Reviewers: Sushant Mahajan <smahajan@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
