### PR TITLE
MINOR: Document top-level-only field casting limitation in Cast SMT

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -62,7 +62,8 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     public static final String OVERVIEW_DOC =
             "Cast fields or the entire key or value to a specific type, e.g. to force an integer field to a smaller "
                     + "width. Cast from integers, floats, boolean and string to any other type, "
-                    + "and cast binary to string (base64 encoded)."
+                    + "and cast binary to string (base64 encoded). "
+                    + "Only top-level fields are supported; nested field casting via dotted notation is not currently available."
                     + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
@@ -83,7 +84,8 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             ConfigDef.Importance.HIGH,
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
-                    + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.")
+                    + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string. "
+                    + "Only top-level fields are supported; nested fields cannot be addressed using dotted notation.")
             .define(REPLACE_NULL_WITH_DEFAULT_CONFIG,
                     ConfigDef.Type.BOOLEAN,
                     true,


### PR DESCRIPTION
### Motivation

The `Cast` SMT only supports top-level fields. Nested field casting via
dotted notation (e.g. `outer.inner:int32`) is not supported. This was
noted in an internal TODO comment but never surfaced to users.

### Changes

`connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java`

- **`OVERVIEW_DOC`**: note that only top-level fields are supported
- **`spec` ConfigDef description**: same clarification

Documentation strings only. No logic, behaviour, or API change.

### Committer checklist

- [x] No new public API or behaviour change
- [x] No new tests required (doc-only change)
- [x] Internal TODO comment preserved for future nested-field support
