### PR TITLE
MINOR: Clarify SerializationException Javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.errors;
 import org.apache.kafka.common.KafkaException;
 
 /**
- *  Any exception during serialization in the producer
+ * Any exception during serialization or deserialization.
  */
 public class SerializationException extends KafkaException {
 


### PR DESCRIPTION
SerializationException is currently documented as applying to producer
serialization only, but Kafka also uses it for deserialization failures.

For example, RecordDeserializationException extends
SerializationException,  and built-in deserializers such as
BooleanDeserializer throw  SerializationException for invalid input.

This updates the Javadoc to describe both serialization and
deserialization  failures. No behavior is changed.

Reviewers: Andrew Schofield <aschofield@confluent.io>
