### PR TITLE
KAFKA-20686: Reduce share heartbeat timeout in DLQ integ tests. [3/N]

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerDLQTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerDLQTest.java
@@ -63,7 +63,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         @ClusterConfigProperty(key = "offsets.topic.replication.factor", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.min.isr", value = "1"),
         @ClusterConfigProperty(key = "share.coordinator.state.topic.num.partitions", value = "3"),
-        @ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1")
+        @ClusterConfigProperty(key = "share.coordinator.state.topic.replication.factor", value = "1"),
+        @ClusterConfigProperty(key = "group.share.min.heartbeat.interval.ms", value = "1500"),
+        @ClusterConfigProperty(key = "group.share.heartbeat.interval.ms", value = "1500")
     }
 )
 public class ShareConsumerDLQTest extends ShareConsumerTestBase {


### PR DESCRIPTION
Currently we are using default 5 sec timeout for share consumer
heartbeats which in a timed scenario like a test could cause flakiness.
This PR aims to improve the overall hygiene by setting it to more
reasonable 1.5 sec.

Reviewers: Shivsundar R <shr@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
