### PR TITLE
KAFKA-20655: Mark KIP-1331 RPCs stable before release

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupTopologyDescriptionUpdateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupTopologyDescriptionUpdateRequest.java
@@ -36,9 +36,7 @@ public class StreamsGroupTopologyDescriptionUpdateRequest extends AbstractReques
         private final StreamsGroupTopologyDescriptionUpdateRequestData data;
 
         public Builder(StreamsGroupTopologyDescriptionUpdateRequestData data) {
-            // The schema is marked latestVersionUnstable until the broker handler lands; opt in
-            // here so the Builder can still construct the only existing version.
-            super(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE, true);
+            super(ApiKeys.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_UPDATE);
             this.data = data;
         }
 

--- a/clients/src/main/resources/common/message/StreamsGroupDescribeRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupDescribeRequest.json
@@ -18,9 +18,7 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "StreamsGroupDescribeRequest",
-  // Version 1 adds IncludeTopologyDescription (KIP-1331). Marked unstable until the broker
-  // topology-description manager lands; flip to false before release.
-  "latestVersionUnstable": true,
+  // Version 1 adds IncludeTopologyDescription (KIP-1331).
   "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupHeartbeatRequest.json
@@ -20,9 +20,6 @@
   "name": "StreamsGroupHeartbeatRequest",
   // Version 1 is the same as version 0; bumped together with StreamsGroupHeartbeatResponse v1,
   // which adds TopologyDescriptionRequired (KIP-1331). Required so the response v1 is negotiated.
-  // Marked unstable until the broker topology-description manager lands (KIP-1331); flip to false
-  // before release.
-  "latestVersionUnstable": true,
   "validVersions": "0-1",
   "flexibleVersions": "0+",
   "fields": [

--- a/clients/src/main/resources/common/message/StreamsGroupTopologyDescriptionUpdateRequest.json
+++ b/clients/src/main/resources/common/message/StreamsGroupTopologyDescriptionUpdateRequest.json
@@ -18,9 +18,6 @@
   "type": "request",
   "listeners": ["broker"],
   "name": "StreamsGroupTopologyDescriptionUpdateRequest",
-  // The broker handler is a stub returning UNSUPPORTED_VERSION; the real handler lands in a
-  // later sub-task of KIP-1331. Flip to false before release.
-  "latestVersionUnstable": true,
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [


### PR DESCRIPTION
The broker-side topology-description handler has landed via KAFKA-20624,
so the KIP-1331 RPCs can be promoted from unstable to stable before
release.

This PR:
- Removes `"latestVersionUnstable": true` from the
`StreamsGroupHeartbeatRequest`, `StreamsGroupDescribeRequest`, and
`StreamsGroupTopologyDescriptionUpdateRequest` JSON schemas, along with
the now-stale "flip to false before release" comments.
- Reverts the `StreamsGroupTopologyDescriptionUpdateRequest` `Builder`
to drop the `enableUnstableLastVersion` opt-in, since the latest version
is now stable.

Reviewers: Matthias J. Sax <matthias@confluent.io>
