### PR TITLE
KAFKA-20292 [5/N]: Fix UpdatedMembersAndTargetAssignmentView to handle instance id changes

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2262,7 +2262,6 @@ public class GroupMetadataManager {
         UpdateTargetAssignmentResult<TasksTuple> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
             group,
             groupEpoch,
-            Optional.of(member),
             Optional.of(updatedMember),
             updatedConfiguredTopology,
             metadataImage,
@@ -4162,9 +4161,10 @@ public class GroupMetadataManager {
                 new UpdatedMembersAndTargetAssignmentView<>(
                     group.members(),
                     group.staticMembers(),
-                    group.targetAssignment()
+                    group.targetAssignment(),
+                    ConsumerGroupMember::instanceId
                 );
-            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), member.instanceId(), updatedMember.instanceId(), updatedMember);
+            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), updatedMember);
 
             TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder assignmentResultBuilder =
                 new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(group.groupId(), groupEpoch, consumerGroupAssignors.get(preferredServerAssignor))
@@ -4245,9 +4245,10 @@ public class GroupMetadataManager {
                 new UpdatedMembersAndTargetAssignmentView<>(
                     group.members(),
                     Map.of(),
-                    group.targetAssignment()
+                    group.targetAssignment(),
+                    ShareGroupMember::instanceId
                 );
-            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), null, null, updatedMember);
+            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), updatedMember);
 
             TargetAssignmentBuilder.ShareTargetAssignmentBuilder assignmentResultBuilder =
                 new TargetAssignmentBuilder.ShareTargetAssignmentBuilder(group.groupId(), groupEpoch, shareGroupAssignor)
@@ -4293,7 +4294,6 @@ public class GroupMetadataManager {
      *
      * @param group                The StreamsGroup.
      * @param groupEpoch           The group epoch.
-     * @param member               The existing member (optional).
      * @param updatedMember        The updated member (optional).
      * @param metadataImage        The metadata image.
      * @param records              The list to accumulate any new records.
@@ -4303,7 +4303,6 @@ public class GroupMetadataManager {
     private UpdateTargetAssignmentResult<TasksTuple> maybeUpdateStreamsTargetAssignment(
         StreamsGroup group,
         int groupEpoch,
-        Optional<StreamsGroupMember> member,
         Optional<StreamsGroupMember> updatedMember,
         ConfiguredTopology configuredTopology,
         CoordinatorMetadataImage metadataImage,
@@ -4351,12 +4350,12 @@ public class GroupMetadataManager {
                 new UpdatedMembersAndTargetAssignmentView<>(
                     group.members(),
                     group.staticMembers(),
-                    group.targetAssignment()
+                    group.targetAssignment(),
+                    m -> m.instanceId().orElse(null)
                 );
-            updatedMember.ifPresent(updated -> {
-                String previousInstanceId = member.flatMap(StreamsGroupMember::instanceId).orElse(null);
-                updatedMembersAndTargetAssignment.addOrUpdateMember(updated.memberId(), previousInstanceId, updated.instanceId().orElse(null), updated);
-            });
+            updatedMember.ifPresent(member ->
+                updatedMembersAndTargetAssignment.addOrUpdateMember(member.memberId(), member)
+            );
 
             org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder assignmentResultBuilder =
                 new org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder(
@@ -4389,7 +4388,7 @@ public class GroupMetadataManager {
 
             return new UpdateTargetAssignmentResult<>(
                 groupEpoch,
-                updatedMember.map(updated -> assignmentResult.targetAssignment().get(updated.memberId()))
+                updatedMember.map(member -> assignmentResult.targetAssignment().get(member.memberId()))
                     .orElse(TasksTuple.EMPTY)
             );
         } catch (TaskAssignorException ex) {
@@ -4431,7 +4430,6 @@ public class GroupMetadataManager {
             maybeUpdateStreamsTargetAssignment(
                 group,
                 group.groupEpoch(),
-                Optional.empty(),
                 Optional.empty(),
                 group.configuredTopology().get(),
                 metadataImage,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -2262,6 +2262,7 @@ public class GroupMetadataManager {
         UpdateTargetAssignmentResult<TasksTuple> updateTargetAssignmentResult = maybeUpdateStreamsTargetAssignment(
             group,
             groupEpoch,
+            Optional.of(member),
             Optional.of(updatedMember),
             updatedConfiguredTopology,
             metadataImage,
@@ -4163,7 +4164,7 @@ public class GroupMetadataManager {
                     group.staticMembers(),
                     group.targetAssignment()
                 );
-            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), updatedMember.instanceId(), updatedMember);
+            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), member.instanceId(), updatedMember.instanceId(), updatedMember);
 
             TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder assignmentResultBuilder =
                 new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(group.groupId(), groupEpoch, consumerGroupAssignors.get(preferredServerAssignor))
@@ -4246,7 +4247,7 @@ public class GroupMetadataManager {
                     Map.of(),
                     group.targetAssignment()
                 );
-            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), updatedMember.instanceId(), updatedMember);
+            updatedMembersAndTargetAssignment.addOrUpdateMember(updatedMember.memberId(), null, null, updatedMember);
 
             TargetAssignmentBuilder.ShareTargetAssignmentBuilder assignmentResultBuilder =
                 new TargetAssignmentBuilder.ShareTargetAssignmentBuilder(group.groupId(), groupEpoch, shareGroupAssignor)
@@ -4292,6 +4293,7 @@ public class GroupMetadataManager {
      *
      * @param group                The StreamsGroup.
      * @param groupEpoch           The group epoch.
+     * @param member               The existing member (optional).
      * @param updatedMember        The updated member (optional).
      * @param metadataImage        The metadata image.
      * @param records              The list to accumulate any new records.
@@ -4301,6 +4303,7 @@ public class GroupMetadataManager {
     private UpdateTargetAssignmentResult<TasksTuple> maybeUpdateStreamsTargetAssignment(
         StreamsGroup group,
         int groupEpoch,
+        Optional<StreamsGroupMember> member,
         Optional<StreamsGroupMember> updatedMember,
         ConfiguredTopology configuredTopology,
         CoordinatorMetadataImage metadataImage,
@@ -4350,9 +4353,10 @@ public class GroupMetadataManager {
                     group.staticMembers(),
                     group.targetAssignment()
                 );
-            updatedMember.ifPresent(member ->
-                updatedMembersAndTargetAssignment.addOrUpdateMember(member.memberId(), member.instanceId().orElse(null), member)
-            );
+            updatedMember.ifPresent(updated -> {
+                String previousInstanceId = member.flatMap(StreamsGroupMember::instanceId).orElse(null);
+                updatedMembersAndTargetAssignment.addOrUpdateMember(updated.memberId(), previousInstanceId, updated.instanceId().orElse(null), updated);
+            });
 
             org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder assignmentResultBuilder =
                 new org.apache.kafka.coordinator.group.streams.TargetAssignmentBuilder(
@@ -4385,7 +4389,7 @@ public class GroupMetadataManager {
 
             return new UpdateTargetAssignmentResult<>(
                 groupEpoch,
-                updatedMember.map(member -> assignmentResult.targetAssignment().get(member.memberId()))
+                updatedMember.map(updated -> assignmentResult.targetAssignment().get(updated.memberId()))
                     .orElse(TasksTuple.EMPTY)
             );
         } catch (TaskAssignorException ex) {
@@ -4427,6 +4431,7 @@ public class GroupMetadataManager {
             maybeUpdateStreamsTargetAssignment(
                 group,
                 group.groupEpoch(),
+                Optional.empty(),
                 Optional.empty(),
                 group.configuredTopology().get(),
                 metadataImage,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentView.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentView.java
@@ -85,12 +85,28 @@ public class UpdatedMembersAndTargetAssignmentView<M, A> {
      * member for the same instance id, the previous static member's target assignment is moved to
      * the new member and the previous static member is removed from the view.
      *
-     * @param memberId   The member id.
-     * @param instanceId The instance id of the member, or {@code null} if the member is not static.
-     * @param member     The member to add or update.
+     * @param memberId           The member id.
+     * @param previousInstanceId The instance id the member had before the update, or {@code null}
+     *                           if the member was not static.
+     * @param instanceId         The instance id of the member, or {@code null} if the member is not
+     *                           static.
+     * @param member             The member to add or update.
      */
-    public void addOrUpdateMember(String memberId, String instanceId, M member) {
+    public void addOrUpdateMember(
+        String memberId,
+        String previousInstanceId,
+        String instanceId,
+        M member
+    ) {
         members.put(memberId, member);
+
+        // Remove the old static member mapping when the instance id has changed.
+        // We don't remove the mapping when the instance id has not changed, otherwise we won't
+        // detect static member replacement correctly below.
+        if (previousInstanceId != null && !previousInstanceId.equals(instanceId)) {
+            staticMembers.remove(previousInstanceId);
+        }
+
         if (instanceId != null) {
             String previousMemberId = staticMembers.put(instanceId, memberId);
             if (previousMemberId != null && !memberId.equals(previousMemberId)) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentView.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentView.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.group.util;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * A view of a group's members, static members, and target assignment after unwritten membership
@@ -45,18 +46,26 @@ public class UpdatedMembersAndTargetAssignmentView<M, A> {
     private final OverlayMap<String, A> targetAssignment;
 
     /**
+     * Gets a member's instance id, or {@code null} if the member is not static.
+     */
+    private final Function<M, String> getInstanceId;
+
+    /**
      * @param members          The group members. Must not be modified during the lifetime of the view.
      * @param staticMembers    The static group members. Must not be modified during the lifetime of the view.
      * @param targetAssignment The target assignment per member id. Must not be modified during the lifetime of the view.
+     * @param getInstanceId    Gets a member's instance id, or {@code null} if the member is not static.
      */
     public UpdatedMembersAndTargetAssignmentView(
         Map<String, M> members,
         Map<String, String> staticMembers,
-        Map<String, A> targetAssignment
+        Map<String, A> targetAssignment,
+        Function<M, String> getInstanceId
     ) {
         this.members = new OverlayMap<>(Objects.requireNonNull(members));
         this.staticMembers = new OverlayMap<>(Objects.requireNonNull(staticMembers));
         this.targetAssignment = new OverlayMap<>(Objects.requireNonNull(targetAssignment));
+        this.getInstanceId = Objects.requireNonNull(getInstanceId);
     }
 
     /**
@@ -85,20 +94,13 @@ public class UpdatedMembersAndTargetAssignmentView<M, A> {
      * member for the same instance id, the previous static member's target assignment is moved to
      * the new member and the previous static member is removed from the view.
      *
-     * @param memberId           The member id.
-     * @param previousInstanceId The instance id the member had before the update, or {@code null}
-     *                           if the member was not static.
-     * @param instanceId         The instance id of the member, or {@code null} if the member is not
-     *                           static.
-     * @param member             The member to add or update.
+     * @param memberId The member id.
+     * @param member   The member to add or update.
      */
-    public void addOrUpdateMember(
-        String memberId,
-        String previousInstanceId,
-        String instanceId,
-        M member
-    ) {
-        members.put(memberId, member);
+    public void addOrUpdateMember(String memberId, M member) {
+        M previousMember = members.put(memberId, member);
+        String previousInstanceId = previousMember != null ? getInstanceId.apply(previousMember) : null;
+        String instanceId = getInstanceId.apply(member);
 
         // Remove the old static member mapping when the instance id has changed.
         // We don't remove the mapping when the instance id has not changed, otherwise we won't
@@ -126,11 +128,11 @@ public class UpdatedMembersAndTargetAssignmentView<M, A> {
     /**
      * Removes a member.
      *
-     * @param memberId   The member id.
-     * @param instanceId The instance id of the member, or {@code null} if the member is not static.
+     * @param memberId The member id.
      */
-    public void removeMember(String memberId, String instanceId) {
-        members.remove(memberId);
+    public void removeMember(String memberId) {
+        M member = members.remove(memberId);
+        String instanceId = member != null ? getInstanceId.apply(member) : null;
         if (instanceId != null && memberId.equals(staticMembers.get(instanceId))) {
             staticMembers.remove(instanceId);
         }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentViewTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentViewTest.java
@@ -48,7 +48,7 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
     public void testAddMember() {
         UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
 
-        view.addOrUpdateMember("member-3", null, "Member3");
+        view.addOrUpdateMember("member-3", null, null, "Member3");
 
         assertEquals(Map.of(
             "member-1", "Member1",
@@ -68,7 +68,7 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
     public void testAddStaticMember() {
         UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
 
-        view.addOrUpdateMember("member-3", "instance-id-2", "Member3");
+        view.addOrUpdateMember("member-3", null, "instance-id-2", "Member3");
 
         assertEquals(Map.of(
             "member-1", "Member1",
@@ -89,7 +89,7 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
     public void testReplaceMember() {
         UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
 
-        view.addOrUpdateMember("member-1", null, "Member1-updated");
+        view.addOrUpdateMember("member-1", null, null, "Member1-updated");
 
         assertEquals(Map.of(
             "member-1", "Member1-updated",
@@ -108,7 +108,7 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
     public void testReplaceStaticMemberWithSameMemberId() {
         UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
 
-        view.addOrUpdateMember("member-2", "instance-id", "Member2-updated");
+        view.addOrUpdateMember("member-2", "instance-id", "instance-id", "Member2-updated");
 
         assertEquals(Map.of(
             "member-1", "Member1",
@@ -127,7 +127,7 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
     public void testReplaceStaticMemberWithDifferentMemberId() {
         UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
 
-        view.addOrUpdateMember("member-3", "instance-id", "Member3");
+        view.addOrUpdateMember("member-3", null, "instance-id", "Member3");
 
         assertEquals(Map.of(
             "member-1", "Member1",
@@ -154,6 +154,44 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
         assertEquals(Map.of(
             "member-1", "Assignment-member-1",
             "member-3", "Assignment-member-2"
+        ), view.targetAssignment());
+    }
+
+    @Test
+    public void testReplaceStaticMemberWithNullInstanceId() {
+        // This operation is currently not possible, since a heartbeat with a null instance id will
+        // keep any existing instance id.
+        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+
+        view.addOrUpdateMember("member-2", "instance-id", null, "Member2-updated");
+
+        assertEquals(Map.of(
+            "member-1", "Member1",
+            "member-2", "Member2-updated"
+        ), view.members());
+        assertEquals(Map.of(), view.staticMembers());
+        assertEquals(Map.of(
+            "member-1", "Assignment-member-1",
+            "member-2", "Assignment-member-2"
+        ), view.targetAssignment());
+    }
+
+    @Test
+    public void testReplaceStaticMemberWithDifferentInstanceId() {
+        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+
+        view.addOrUpdateMember("member-2", "instance-id", "instance-id-2", "Member2-updated");
+
+        assertEquals(Map.of(
+            "member-1", "Member1",
+            "member-2", "Member2-updated"
+        ), view.members());
+        assertEquals(Map.of(
+            "instance-id-2", "member-2"
+        ), view.staticMembers());
+        assertEquals(Map.of(
+            "member-1", "Assignment-member-1",
+            "member-2", "Assignment-member-2"
         ), view.targetAssignment());
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentViewTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/util/UpdatedMembersAndTargetAssignmentViewTest.java
@@ -25,14 +25,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UpdatedMembersAndTargetAssignmentViewTest {
 
     /**
+     * A test member.
+     */
+    private record Member(String name, String instanceId) { }
+
+    /**
      * Creates an {@link UpdatedMembersAndTargetAssignmentView} with two members, one static and one
      * non-static.
      */
-    private static UpdatedMembersAndTargetAssignmentView<String, String> createView() {
+    private static UpdatedMembersAndTargetAssignmentView<Member, String> createView() {
         return new UpdatedMembersAndTargetAssignmentView<>(
             Map.of(
-                "member-1", "Member1",
-                "member-2", "Member2"
+                "member-1", new Member("Member1", null),
+                "member-2", new Member("Member2", "instance-id")
             ),
             Map.of(
                 "instance-id", "member-2"
@@ -40,20 +45,21 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
             Map.of(
                 "member-1", "Assignment-member-1",
                 "member-2", "Assignment-member-2"
-            )
+            ),
+            Member::instanceId
         );
     }
 
     @Test
     public void testAddMember() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-3", null, null, "Member3");
+        view.addOrUpdateMember("member-3", new Member("Member3", null));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-2", "Member2",
-            "member-3", "Member3"
+            "member-1", new Member("Member1", null),
+            "member-2", new Member("Member2", "instance-id"),
+            "member-3", new Member("Member3", null)
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-2"
@@ -66,14 +72,14 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testAddStaticMember() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-3", null, "instance-id-2", "Member3");
+        view.addOrUpdateMember("member-3", new Member("Member3", "instance-id-2"));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-2", "Member2",
-            "member-3", "Member3"
+            "member-1", new Member("Member1", null),
+            "member-2", new Member("Member2", "instance-id"),
+            "member-3", new Member("Member3", "instance-id-2")
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-2",
@@ -87,13 +93,13 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testReplaceMember() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-1", null, null, "Member1-updated");
+        view.addOrUpdateMember("member-1", new Member("Member1-updated", null));
 
         assertEquals(Map.of(
-            "member-1", "Member1-updated",
-            "member-2", "Member2"
+            "member-1", new Member("Member1-updated", null),
+            "member-2", new Member("Member2", "instance-id")
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-2"
@@ -106,13 +112,13 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testReplaceStaticMemberWithSameMemberId() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-2", "instance-id", "instance-id", "Member2-updated");
+        view.addOrUpdateMember("member-2", new Member("Member2-updated", "instance-id"));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-2", "Member2-updated"
+            "member-1", new Member("Member1", null),
+            "member-2", new Member("Member2-updated", "instance-id")
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-2"
@@ -125,28 +131,13 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testReplaceStaticMemberWithDifferentMemberId() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-3", null, "instance-id", "Member3");
-
-        assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-3", "Member3"
-        ), view.members());
-        assertEquals(Map.of(
-            "instance-id", "member-3"
-        ), view.staticMembers());
-        assertEquals(Map.of(
-            "member-1", "Assignment-member-1",
-            "member-3", "Assignment-member-2"
-        ), view.targetAssignment());
-
-        // Removing the previous static member does not change the new static member's assignment.
-        view.removeMember("member-2", "instance-id");
+        view.addOrUpdateMember("member-3", new Member("Member3", "instance-id"));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-3", "Member3"
+            "member-1", new Member("Member1", null),
+            "member-3", new Member("Member3", "instance-id")
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-3"
@@ -159,15 +150,15 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testReplaceStaticMemberWithNullInstanceId() {
-        // This operation is currently not possible, since a heartbeat with a null instance id will
-        // keep any existing instance id.
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        // This operation is not possible, since a heartbeat with a null instance id will keep any
+        // existing instance id.
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-2", "instance-id", null, "Member2-updated");
+        view.addOrUpdateMember("member-2", new Member("Member2-updated", null));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-2", "Member2-updated"
+            "member-1", new Member("Member1", null),
+            "member-2", new Member("Member2-updated", null)
         ), view.members());
         assertEquals(Map.of(), view.staticMembers());
         assertEquals(Map.of(
@@ -178,13 +169,15 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testReplaceStaticMemberWithDifferentInstanceId() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        // This operation will never happen with the official Java client and may be forbidden in
+        // the future.
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.addOrUpdateMember("member-2", "instance-id", "instance-id-2", "Member2-updated");
+        view.addOrUpdateMember("member-2", new Member("Member2-updated", "instance-id-2"));
 
         assertEquals(Map.of(
-            "member-1", "Member1",
-            "member-2", "Member2-updated"
+            "member-1", new Member("Member1", null),
+            "member-2", new Member("Member2-updated", "instance-id-2")
         ), view.members());
         assertEquals(Map.of(
             "instance-id-2", "member-2"
@@ -197,12 +190,12 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testRemoveMember() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.removeMember("member-1", null);
+        view.removeMember("member-1");
 
         assertEquals(Map.of(
-            "member-2", "Member2"
+            "member-2", new Member("Member2", "instance-id")
         ), view.members());
         assertEquals(Map.of(
             "instance-id", "member-2"
@@ -214,12 +207,12 @@ public class UpdatedMembersAndTargetAssignmentViewTest {
 
     @Test
     public void testRemoveStaticMember() {
-        UpdatedMembersAndTargetAssignmentView<String, String> view = createView();
+        UpdatedMembersAndTargetAssignmentView<Member, String> view = createView();
 
-        view.removeMember("member-2", "instance-id");
+        view.removeMember("member-2");
 
         assertEquals(Map.of(
-            "member-1", "Member1"
+            "member-1", new Member("Member1", null)
         ), view.members());
         assertEquals(Map.of(), view.staticMembers());
         assertEquals(Map.of(

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
@@ -117,7 +117,7 @@ public class TargetAssignmentBuilderBenchmark {
             .build();
 
         updatedMembersAndTargetAssignment = new UpdatedMembersAndTargetAssignmentView<>(members, Map.of(), existingTargetAssignment);
-        updatedMembersAndTargetAssignment.addOrUpdateMember(newMember.memberId(), newMember.instanceId(), newMember);
+        updatedMembersAndTargetAssignment.addOrUpdateMember(newMember.memberId(), null, newMember.instanceId(), newMember);
 
         targetAssignmentBuilder = new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(GROUP_ID, GROUP_EPOCH, partitionAssignor)
             .withTime(Time.SYSTEM)

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/TargetAssignmentBuilderBenchmark.java
@@ -116,8 +116,8 @@ public class TargetAssignmentBuilderBenchmark {
             .setSubscribedTopicNames(allTopicNames)
             .build();
 
-        updatedMembersAndTargetAssignment = new UpdatedMembersAndTargetAssignmentView<>(members, Map.of(), existingTargetAssignment);
-        updatedMembersAndTargetAssignment.addOrUpdateMember(newMember.memberId(), null, newMember.instanceId(), newMember);
+        updatedMembersAndTargetAssignment = new UpdatedMembersAndTargetAssignmentView<>(members, Map.of(), existingTargetAssignment, ConsumerGroupMember::instanceId);
+        updatedMembersAndTargetAssignment.addOrUpdateMember(newMember.memberId(), newMember);
 
         targetAssignmentBuilder = new TargetAssignmentBuilder.ConsumerTargetAssignmentBuilder(GROUP_ID, GROUP_EPOCH, partitionAssignor)
             .withTime(Time.SYSTEM)


### PR DESCRIPTION
Fix addOrUpdateMember in UpdatedMembersAndTargetAssignmentView to remove
a member's previous instance id mapping when its instance id changes.
Previously, the method only added the new instanceId -> memberId
mapping, so when a static member rejoined with the same member id but a
different instance id, the old mapping was left behind.

Reviewers: David Jacot <david.jacot@gmail.com>
