### PR TITLE
KAFKA-10025: guard RocksDBMetricsRecorder value provider reads against store close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -107,6 +107,10 @@ public class RocksDBMetricsRecorder {
     private Sensor numberOfFileErrorsSensor;
 
     private final Map<String, DbAndCacheAndStatistics> storeToValueProviders = new ConcurrentHashMap<>();
+    // Guards value-provider reads against removeValueProviders(), which runs just before
+    // RocksDBStore.close() frees the native RocksDB/Statistics, so a read never dereferences
+    // a freed handle.
+    private final Object valueProvidersLock = new Object();
     private final String metricsScope;
     private final String storeName;
     private TaskId taskId;
@@ -157,17 +161,19 @@ public class RocksDBMetricsRecorder {
                                   final RocksDB db,
                                   final Cache cache,
                                   final Statistics statistics) {
-        if (storeToValueProviders.isEmpty()) {
-            logger.debug("Adding metrics recorder of task {} to metrics recording trigger", taskId);
-            streamsMetrics.rocksDBMetricsRecordingTrigger().addMetricsRecorder(this);
-        } else if (storeToValueProviders.containsKey(segmentName)) {
-            throw new IllegalStateException("Value providers for store " + segmentName + " of task " + taskId +
-                " has been already added. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues");
+        synchronized (valueProvidersLock) {
+            if (storeToValueProviders.isEmpty()) {
+                logger.debug("Adding metrics recorder of task {} to metrics recording trigger", taskId);
+                streamsMetrics.rocksDBMetricsRecordingTrigger().addMetricsRecorder(this);
+            } else if (storeToValueProviders.containsKey(segmentName)) {
+                throw new IllegalStateException("Value providers for store " + segmentName + " of task " + taskId +
+                    " has been already added. This is a bug in Kafka Streams. " +
+                    "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues");
+            }
+            verifyDbAndCacheAndStatistics(segmentName, db, cache, statistics);
+            logger.debug("Adding value providers for store {} of task {}", segmentName, taskId);
+            storeToValueProviders.put(segmentName, new DbAndCacheAndStatistics(db, cache, statistics));
         }
-        verifyDbAndCacheAndStatistics(segmentName, db, cache, statistics);
-        logger.debug("Adding value providers for store {} of task {}", segmentName, taskId);
-        storeToValueProviders.put(segmentName, new DbAndCacheAndStatistics(db, cache, statistics));
     }
 
     private void verifyDbAndCacheAndStatistics(final String segmentName,
@@ -350,15 +356,18 @@ public class RocksDBMetricsRecorder {
     private Gauge<BigInteger> gaugeToComputeSumOfProperties(final String propertyName) {
         return (metricsConfig, now) -> {
             BigInteger result = BigInteger.valueOf(0);
-            for (final DbAndCacheAndStatistics valueProvider : storeToValueProviders.values()) {
-                try {
-                    // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
-                    // BigInteger and construct the object from the byte representation of the value
-                    result = result.add(new BigInteger(1, longToBytes(
-                        valueProvider.db.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
-                    )));
-                } catch (final RocksDBException e) {
-                    throw new ProcessorStateException("Error recording RocksDB metric " + propertyName, e);
+            // Acquiring the lock so the store's native RocksDB cannot be freed mid-read.
+            synchronized (valueProvidersLock) {
+                for (final DbAndCacheAndStatistics valueProvider : storeToValueProviders.values()) {
+                    try {
+                        // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
+                        // BigInteger and construct the object from the byte representation of the value
+                        result = result.add(new BigInteger(1, longToBytes(
+                            valueProvider.db.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
+                        )));
+                    } catch (final RocksDBException e) {
+                        throw new ProcessorStateException("Error recording RocksDB metric " + propertyName, e);
+                    }
                 }
             }
             return result;
@@ -368,24 +377,27 @@ public class RocksDBMetricsRecorder {
     private Gauge<BigInteger> gaugeToComputeBlockCacheMetrics(final String propertyName) {
         return (metricsConfig, now) -> {
             BigInteger result = BigInteger.valueOf(0);
-            for (final DbAndCacheAndStatistics valueProvider : storeToValueProviders.values()) {
-                try {
-                    if (singleCache) {
-                        // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
-                        // BigInteger and construct the object from the byte representation of the value
-                        result = new BigInteger(1, longToBytes(
-                            valueProvider.db.getLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
-                        ));
-                        break;
-                    } else {
-                        // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
-                        // BigInteger and construct the object from the byte representation of the value
-                        result = result.add(new BigInteger(1, longToBytes(
-                            valueProvider.db.getLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
-                        )));
+            // Acquiring the lock so the store's native RocksDB cannot be freed mid-read.
+            synchronized (valueProvidersLock) {
+                for (final DbAndCacheAndStatistics valueProvider : storeToValueProviders.values()) {
+                    try {
+                        if (singleCache) {
+                            // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
+                            // BigInteger and construct the object from the byte representation of the value
+                            result = new BigInteger(1, longToBytes(
+                                valueProvider.db.getLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
+                            ));
+                            break;
+                        } else {
+                            // values of RocksDB properties are of type unsigned long in C++, i.e., in Java we need to use
+                            // BigInteger and construct the object from the byte representation of the value
+                            result = result.add(new BigInteger(1, longToBytes(
+                                valueProvider.db.getLongProperty(ROCKSDB_PROPERTIES_PREFIX + propertyName)
+                            )));
+                        }
+                    } catch (final RocksDBException e) {
+                        throw new ProcessorStateException("Error recording RocksDB metric " + propertyName, e);
                     }
-                } catch (final RocksDBException e) {
-                    throw new ProcessorStateException("Error recording RocksDB metric " + propertyName, e);
                 }
             }
             return result;
@@ -399,20 +411,24 @@ public class RocksDBMetricsRecorder {
     }
 
     public void removeValueProviders(final String segmentName) {
-        logger.debug("Removing value providers for store {} of task {}", segmentName, taskId);
-        final DbAndCacheAndStatistics removedValueProviders = storeToValueProviders.remove(segmentName);
-        if (removedValueProviders == null) {
-            throw new IllegalStateException("No value providers for store \"" + segmentName + "\" of task " + taskId +
-                " could be found. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues");
-        }
-        if (storeToValueProviders.isEmpty()) {
-            logger.debug(
-                "Removing metrics recorder for store {} of task {} from metrics recording trigger",
-                storeName,
-                taskId
-            );
-            streamsMetrics.rocksDBMetricsRecordingTrigger().removeMetricsRecorder(this);
+        // Acquiring the lock so any in-flight read finishes before the caller (RocksDBStore.close())
+        // frees the native handles, and no later read sees the removed segment.
+        synchronized (valueProvidersLock) {
+            logger.debug("Removing value providers for store {} of task {}", segmentName, taskId);
+            final DbAndCacheAndStatistics removedValueProviders = storeToValueProviders.remove(segmentName);
+            if (removedValueProviders == null) {
+                throw new IllegalStateException("No value providers for store \"" + segmentName + "\" of task " + taskId +
+                    " could be found. This is a bug in Kafka Streams. " +
+                    "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues");
+            }
+            if (storeToValueProviders.isEmpty()) {
+                logger.debug(
+                    "Removing metrics recorder for store {} of task {} from metrics recording trigger",
+                    storeName,
+                    taskId
+                );
+                streamsMetrics.rocksDBMetricsRecordingTrigger().removeMetricsRecorder(this);
+            }
         }
     }
 
@@ -443,37 +459,40 @@ public class RocksDBMetricsRecorder {
         double compactionTimeMin = Double.MAX_VALUE;
         double compactionTimeMax = 0.0;
         boolean shouldRecord = true;
-        for (final DbAndCacheAndStatistics valueProviders : storeToValueProviders.values()) {
-            if (valueProviders.statistics == null) {
-                shouldRecord = false;
-                break;
+        // Acquiring the lock so the store's native Statistics cannot be freed mid-read.
+        synchronized (valueProvidersLock) {
+            for (final DbAndCacheAndStatistics valueProviders : storeToValueProviders.values()) {
+                if (valueProviders.statistics == null) {
+                    shouldRecord = false;
+                    break;
+                }
+                bytesWrittenToDatabase += valueProviders.statistics.getAndResetTickerCount(TickerType.BYTES_WRITTEN);
+                bytesReadFromDatabase += valueProviders.statistics.getAndResetTickerCount(TickerType.BYTES_READ);
+                memtableBytesFlushed += valueProviders.statistics.getAndResetTickerCount(TickerType.FLUSH_WRITE_BYTES);
+                memtableHits += valueProviders.statistics.getAndResetTickerCount(TickerType.MEMTABLE_HIT);
+                memtableMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.MEMTABLE_MISS);
+                blockCacheDataHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_HIT);
+                blockCacheDataMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_MISS);
+                blockCacheIndexHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_HIT);
+                blockCacheIndexMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_MISS);
+                blockCacheFilterHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_HIT);
+                blockCacheFilterMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_MISS);
+                writeStallDuration += valueProviders.statistics.getAndResetTickerCount(TickerType.STALL_MICROS);
+                bytesWrittenDuringCompaction += valueProviders.statistics.getAndResetTickerCount(TickerType.COMPACT_WRITE_BYTES);
+                bytesReadDuringCompaction += valueProviders.statistics.getAndResetTickerCount(TickerType.COMPACT_READ_BYTES);
+                numberOfOpenFiles = -1;
+                numberOfFileErrors += valueProviders.statistics.getAndResetTickerCount(TickerType.NO_FILE_ERRORS);
+                final HistogramData memtableFlushTimeData = valueProviders.statistics.getHistogramData(HistogramType.FLUSH_TIME);
+                memtableFlushTimeSum += memtableFlushTimeData.getSum();
+                memtableFlushTimeCount += memtableFlushTimeData.getCount();
+                memtableFlushTimeMin = Double.min(memtableFlushTimeMin, memtableFlushTimeData.getMin());
+                memtableFlushTimeMax = Double.max(memtableFlushTimeMax, memtableFlushTimeData.getMax());
+                final HistogramData compactionTimeData = valueProviders.statistics.getHistogramData(HistogramType.COMPACTION_TIME);
+                compactionTimeSum += compactionTimeData.getSum();
+                compactionTimeCount += compactionTimeData.getCount();
+                compactionTimeMin = Double.min(compactionTimeMin, compactionTimeData.getMin());
+                compactionTimeMax = Double.max(compactionTimeMax, compactionTimeData.getMax());
             }
-            bytesWrittenToDatabase += valueProviders.statistics.getAndResetTickerCount(TickerType.BYTES_WRITTEN);
-            bytesReadFromDatabase += valueProviders.statistics.getAndResetTickerCount(TickerType.BYTES_READ);
-            memtableBytesFlushed += valueProviders.statistics.getAndResetTickerCount(TickerType.FLUSH_WRITE_BYTES);
-            memtableHits += valueProviders.statistics.getAndResetTickerCount(TickerType.MEMTABLE_HIT);
-            memtableMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.MEMTABLE_MISS);
-            blockCacheDataHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_HIT);
-            blockCacheDataMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_DATA_MISS);
-            blockCacheIndexHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_HIT);
-            blockCacheIndexMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_INDEX_MISS);
-            blockCacheFilterHits += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_HIT);
-            blockCacheFilterMisses += valueProviders.statistics.getAndResetTickerCount(TickerType.BLOCK_CACHE_FILTER_MISS);
-            writeStallDuration += valueProviders.statistics.getAndResetTickerCount(TickerType.STALL_MICROS);
-            bytesWrittenDuringCompaction += valueProviders.statistics.getAndResetTickerCount(TickerType.COMPACT_WRITE_BYTES);
-            bytesReadDuringCompaction += valueProviders.statistics.getAndResetTickerCount(TickerType.COMPACT_READ_BYTES);
-            numberOfOpenFiles = -1;
-            numberOfFileErrors += valueProviders.statistics.getAndResetTickerCount(TickerType.NO_FILE_ERRORS);
-            final HistogramData memtableFlushTimeData = valueProviders.statistics.getHistogramData(HistogramType.FLUSH_TIME);
-            memtableFlushTimeSum += memtableFlushTimeData.getSum();
-            memtableFlushTimeCount += memtableFlushTimeData.getCount();
-            memtableFlushTimeMin = Double.min(memtableFlushTimeMin, memtableFlushTimeData.getMin());
-            memtableFlushTimeMax = Double.max(memtableFlushTimeMax, memtableFlushTimeData.getMax());
-            final HistogramData compactionTimeData = valueProviders.statistics.getHistogramData(HistogramType.COMPACTION_TIME);
-            compactionTimeSum += compactionTimeData.getSum();
-            compactionTimeCount += compactionTimeData.getCount();
-            compactionTimeMin = Double.min(compactionTimeMin, compactionTimeData.getMin());
-            compactionTimeMax = Double.max(compactionTimeMax, compactionTimeData.getMax());
         }
         if (shouldRecord) {
             bytesWrittenToDatabaseSensor.record(bytesWrittenToDatabase, now);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.state.internals.metrics;
 
-import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
@@ -25,12 +24,15 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.rocksdb.Cache;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 
 import java.math.BigInteger;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -254,20 +256,82 @@ public class RocksDBMetricsRecorderGaugesTest {
                                final String propertyName,
                                final long expectedValue) {
 
-        final Map<MetricName, ? extends Metric> metrics = streamsMetrics.metrics();
+        final KafkaMetric metric = getMetric(streamsMetrics, propertyName);
+
+        assertThat(metric, notNullValue());
+        assertThat(metric.metricValue(), is(BigInteger.valueOf(expectedValue)));
+    }
+
+    private KafkaMetric getMetric(final StreamsMetricsImpl streamsMetrics, final String propertyName) {
         final Map<String, String> tagMap = mkMap(
             mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()),
             mkEntry(TASK_ID_TAG, TASK_ID.toString()),
             mkEntry(METRICS_SCOPE + "-" + STORE_ID_TAG, STORE_NAME)
         );
-        final KafkaMetric metric = (KafkaMetric) metrics.get(new MetricName(
+        return (KafkaMetric) streamsMetrics.metrics().get(new MetricName(
             propertyName,
             STATE_STORE_LEVEL_GROUP,
             "description is ignored",
             tagMap
         ));
+    }
 
+    /**
+     * A gauge read and value-provider removal must be mutually exclusive: {@code RocksDBStore.close()}
+     * calls {@code removeValueProviders(...)} and then frees the native RocksDB, so removal must not
+     * return while a gauge is still reading, or it would free a handle the gauge is dereferencing.
+     */
+    @Test
+    @Timeout(30)
+    public void shouldNotRemoveValueProvidersWhileGaugeIsReadingThem() throws Exception {
+        final StreamsMetricsImpl streamsMetrics =
+            new StreamsMetricsImpl(new Metrics(), "test-client", new MockTime());
+        final RocksDBMetricsRecorder recorder = new RocksDBMetricsRecorder(METRICS_SCOPE, STORE_NAME);
+        recorder.init(streamsMetrics, TASK_ID);
+        recorder.addValueProviders(SEGMENT_STORE_NAME_1, dbToAdd1, cacheToAdd1, statisticsToAdd1);
+
+        final CountDownLatch gaugeReadInProgress = new CountDownLatch(1);
+        final CountDownLatch allowGaugeReadToComplete = new CountDownLatch(1);
+        when(dbToAdd1.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + ESTIMATED_NUMBER_OF_KEYS))
+            .thenAnswer(invocation -> {
+                gaugeReadInProgress.countDown();
+                allowGaugeReadToComplete.await(10, TimeUnit.SECONDS);
+                return 5L;
+            });
+
+        final KafkaMetric metric = getMetric(streamsMetrics, ESTIMATED_NUMBER_OF_KEYS);
         assertThat(metric, notNullValue());
-        assertThat(metric.metricValue(), is(BigInteger.valueOf(expectedValue)));
+
+        // Evaluate the gauge on a separate thread; it blocks inside getAggregatedLongProperty
+        // while holding the recorder's value-providers lock.
+        final Thread gaugeReader = new Thread(metric::metricValue, "gauge-reader");
+        gaugeReader.start();
+        assertThat("gauge read did not start", gaugeReadInProgress.await(10, TimeUnit.SECONDS), is(true));
+
+        // While the gauge read is in progress, removeValueProviders() (called by
+        // RocksDBStore.close() before it frees the native db) must not be able to proceed.
+        final CountDownLatch removeReturned = new CountDownLatch(1);
+        final Thread storeCloser = new Thread(() -> {
+            recorder.removeValueProviders(SEGMENT_STORE_NAME_1);
+            removeReturned.countDown();
+        }, "store-closer");
+        storeCloser.start();
+
+        assertThat(
+            "removeValueProviders() returned while a gauge read was in progress - the use-after-free window is open",
+            removeReturned.await(500, TimeUnit.MILLISECONDS),
+            is(false)
+        );
+
+        // Once the gauge read completes, removeValueProviders() must be able to proceed.
+        allowGaugeReadToComplete.countDown();
+        assertThat(
+            "removeValueProviders() did not proceed after the gauge read finished",
+            removeReturned.await(10, TimeUnit.SECONDS),
+            is(true)
+        );
+
+        gaugeReader.join(TimeUnit.SECONDS.toMillis(10));
+        storeCloser.join(TimeUnit.SECONDS.toMillis(10));
     }
 }


### PR DESCRIPTION
## What

`RocksDBMetricsRecorder` reads native RocksDB value providers (`RocksDB` and `Statistics`) in three places:

- `record()`: `statistics.getAndResetTickerCount(...)` / `getHistogramData(...)`
- the property gauges (`gaugeToComputeSumOfProperties`): `db.getAggregatedLongProperty(...)`
- the block-cache gauges (`gaugeToComputeBlockCacheMetrics`): `db.getLongProperty(...)`

These run with no mutual exclusion against `removeValueProviders(...)`. `RocksDBStore.close()` calls `removeValueProviders(name)` and then closes (frees) the native RocksDB and Statistics. So a metrics read that is in flight when a store is closed (during a rebalance / task migration) can dereference a native handle that `close()` is concurrently freeing: a native use-after-free / SIGSEGV.

Two observed crash frames, same root cause:

- `record()` path, `Statistics::getAndResetTickerCount`: this is KAFKA-10025 (open since 2020).
- gauge path, `rocksdb::DBImpl::GetAggregatedIntProperty`: observed in production under a from-zero state rebuild, where warmup/probing rebalances close stores continuously while a metrics reporter / JMX scrape evaluates the (INFO-level) RocksDB property gauges.

The gauge metrics are registered at `RecordingLevel.INFO`, so they are scraped even at `metrics.recording.level=INFO`; only the `record()` path is gated to DEBUG. The crash is therefore reachable at INFO.

## Why the current code is unsafe

`storeToValueProviders` is a `ConcurrentHashMap`, so the map operations are thread-safe, but that does not stop a reader that has already obtained a `DbAndCacheAndStatistics` from calling a native method on its `db`/`statistics` after `RocksDBStore.close()` frees them. There is no happens-before between "recorder reads the provider" and "store closes the provider".

## Fix

Add a single lock (`valueProvidersLock`) in `RocksDBMetricsRecorder`, held around every read of the value providers (`record()`, both gauge lambdas) and around the map mutations (`addValueProviders`, `removeValueProviders`). Since `RocksDBStore.close()` calls `removeValueProviders(...)` before it frees the native db/statistics, having `removeValueProviders(...)` acquire the lock guarantees:

- any in-flight read completes before the segment is removed and the native handles freed, and
- any read that starts after removal no longer sees the segment,

so no read can dereference a freed handle.

No lock-ordering risk: `RocksDBMetricsRecordingTrigger` holds no lock while calling `record()`, and the guarded reads never call back into `RocksDBStore`. `RocksDBStore.close()` takes the store monitor then this lock, and opens take the same order, so there is no cycle.

## Testing

- New test `RocksDBMetricsRecorderGaugesTest#shouldNotRemoveValueProvidersWhileGaugeIsReadingThem`: blocks a gauge evaluation inside `getAggregatedLongProperty` (holding the lock) and asserts `removeValueProviders(...)` cannot return until the read completes. Verified it fails without the fix and passes with it.
- Existing `RocksDBMetricsRecorderTest` / `RocksDBMetricsRecorderGaugesTest`, checkstyle and spotbugs all pass.

End-to-end confirmation (outside this PR, in a standalone Docker harness): a real Kafka Streams app on the released `kafka-streams 8.2.1-ce`, at `metrics.recording.level=INFO`, with a JMX-style metrics scrape plus forced rebalances, SIGSEGVs in `rocksdb::DBImpl::GetAggregatedIntProperty` on a scrape thread after ~27M gauge reads. The same binary with only `RocksDBMetricsRecorder` replaced by the patched class survived 600s / ~336M gauge reads / 25 rebalances with zero crashes. The same native crash was also reproduced in a standalone `rocksdbjni` harness by racing `getAggregatedLongProperty` against a concurrent DB close/reopen.
