### PR TITLE
KAFKA-20750: Add divide-by-zero error check in KafkaConsumerMetrics/KafkaShareConsumerMetrics.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaConsumerMetrics.java
@@ -102,7 +102,8 @@ public class KafkaConsumerMetrics extends AbstractConsumerMetricsManager {
 
     public void recordPollEnd(long pollEndMs) {
         long pollTimeMs = pollEndMs - pollStartMs;
-        double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+        long pollCycleTimeMs = pollTimeMs + timeSinceLastPollMs;
+        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / pollCycleTimeMs;
         this.pollIdleSensor.record(pollIdleRatio);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaConsumerMetrics.java
@@ -103,7 +103,7 @@ public class KafkaConsumerMetrics extends AbstractConsumerMetricsManager {
     public void recordPollEnd(long pollEndMs) {
         long pollTimeMs = pollEndMs - pollStartMs;
         long pollCycleTimeMs = pollTimeMs + timeSinceLastPollMs;
-        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / pollCycleTimeMs;
+        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : (pollTimeMs * 1.0 / pollCycleTimeMs);
         this.pollIdleSensor.record(pollIdleRatio);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaShareConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaShareConsumerMetrics.java
@@ -79,7 +79,8 @@ public class KafkaShareConsumerMetrics extends AbstractConsumerMetricsManager {
 
     public void recordPollEnd(long pollEndMs) {
         long pollTimeMs = pollEndMs - pollStartMs;
-        double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
+        long pollCycleTimeMs = pollTimeMs + timeSinceLastPollMs;
+        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / pollCycleTimeMs;
         this.pollIdleSensor.record(pollIdleRatio);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaShareConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/metrics/KafkaShareConsumerMetrics.java
@@ -80,7 +80,7 @@ public class KafkaShareConsumerMetrics extends AbstractConsumerMetricsManager {
     public void recordPollEnd(long pollEndMs) {
         long pollTimeMs = pollEndMs - pollStartMs;
         long pollCycleTimeMs = pollTimeMs + timeSinceLastPollMs;
-        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : pollTimeMs * 1.0 / pollCycleTimeMs;
+        double pollIdleRatio = pollCycleTimeMs == 0 ? 0.0 : (pollTimeMs * 1.0 / pollCycleTimeMs);
         this.pollIdleSensor.record(pollIdleRatio);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -3775,6 +3775,26 @@ public void testPollIdleRatio(GroupProtocol groupProtocol) {
         assertEquals((1.0d + 0.0d + 0.5d) / 3, consumer.metrics().get(pollIdleRatio).metricValue());
     }
 
+    @ParameterizedTest
+    @EnumSource(GroupProtocol.class)
+    public void testPollIdleRatioZero(GroupProtocol groupProtocol) {
+        ConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Map.of(topic, 1));
+
+        KafkaConsumer<String, String> consumer = newConsumer(groupProtocol, time, client, subscription, metadata, assignor, true, groupInstanceId);
+        // MetricName object to check
+        Metrics metrics = consumer.metricsRegistry();
+        MetricName pollIdleRatio = metrics.metricName("poll-idle-ratio-avg", "consumer-metrics");
+        // Test default value
+        assertEquals(Double.NaN, consumer.metrics().get(pollIdleRatio).metricValue());
+
+        // Poll starts and ends within the same millisecond, so the metric should be 0.
+        consumer.kafkaConsumerMetrics().recordPollStart(time.milliseconds());
+        consumer.kafkaConsumerMetrics().recordPollEnd(time.milliseconds());
+        assertEquals(0.0d, consumer.metrics().get(pollIdleRatio).metricValue());
+    }
+
     private static boolean consumerMetricPresent(KafkaConsumer<String, String> consumer, String name) {
         MetricName metricName = new MetricName(name, "consumer-metrics", "", Collections.emptyMap());
         return consumer.metricsRegistry().metrics().containsKey(metricName);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerMetricsTest.java
@@ -165,6 +165,25 @@ public class KafkaShareConsumerMetricsTest {
         assertEquals((1.0d + 0.0d + 0.5d) / 3, consumer.metrics().get(pollIdleRatio).metricValue());
     }
 
+    @Test
+    public void testPollIdleRatioZero() {
+        ShareConsumerMetadata metadata = createMetadata(subscription);
+        MockClient client = new MockClient(time, metadata);
+        initMetadata(client, Map.of(topic, 1));
+
+        KafkaShareConsumer<String, String> consumer = newShareConsumer(time, client, subscription, metadata);
+        // MetricName object to check
+        Metrics metrics = consumer.metricsRegistry();
+        MetricName pollIdleRatio = metrics.metricName("poll-idle-ratio-avg", CONSUMER_SHARE_METRIC_GROUP_PREFIX + "-metrics");
+        // Test default value
+        assertEquals(Double.NaN, consumer.metrics().get(pollIdleRatio).metricValue());
+
+        // Poll starts and ends within the same millisecond, so the metric should be 0.
+        consumer.kafkaShareConsumerMetrics().recordPollStart(time.milliseconds());
+        consumer.kafkaShareConsumerMetrics().recordPollEnd(time.milliseconds());
+        assertEquals(0.0d, consumer.metrics().get(pollIdleRatio).metricValue());
+    }
+
     private static boolean consumerMetricPresent(KafkaShareConsumer<String, String> consumer, String name) {
         MetricName metricName = new MetricName(name, CONSUMER_SHARE_METRIC_GROUP_PREFIX + "-metrics", "", Map.of());
         return consumer.metricsRegistry().metrics().containsKey(metricName);


### PR DESCRIPTION
*What*
https://issues.apache.org/jira/browse/KAFKA-20750

During testing it was observed that the poll idle ratio metric was
showing NaN even when the fetches were happening successfully. This was
a case when there were fast polls (sub-millisecond values) leading to a
divide by zero error.  PR adds a check and sets the value to 0 in such
cases.

Reviewers: Andrew Schofield <aschofield@confluent.io>
