### PR TITLE
KAFKA-20760: Fix for PositionRestartIntegrationTest and persisting Position object

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
@@ -250,6 +250,17 @@ public class PositionRestartIntegrationTest {
         }
     }
 
+    // Persistent stores that we additionally exercise with transactional state stores
+    // (KIP-892). Transactional state stores are only supported for persistent stores, so
+    // we pick one representative persistent store per store type (key-value, window,
+    // session) to keep the matrix sparse rather than multiplying every combination.
+    private static final Set<StoresToTest> TRANSACTIONAL_STORES = Set.of(
+        StoresToTest.ROCKS_KV,
+        StoresToTest.TIME_ROCKS_KV,
+        StoresToTest.ROCKS_WINDOW,
+        StoresToTest.ROCKS_SESSION
+    );
+
     public static Stream<Arguments> data() {
         LOG.info("Generating test cases according to random seed: {}", SEED);
         final List<Arguments> values = new ArrayList<>();
@@ -260,12 +271,26 @@ public class PositionRestartIntegrationTest {
                     // survive restarts, since those are by definition not durable.
                     if (logEnabled || toTest.supplier().get().persistent()) {
                         for (final String kind : Arrays.asList("DSL", "PAPI")) {
-                            values.add(Arguments.of(cacheEnabled, logEnabled, toTest, kind));
+                            // Non-transactional case (existing coverage, works under both
+                            // at-least-once and exactly-once, but here at-least-once).
+                            values.add(Arguments.of(cacheEnabled, logEnabled, toTest, kind, false));
                         }
                     }
                 }
             }
         }
+
+        // Add a sparse set of transactional-state-store cases (KIP-892). Transactional
+        // state stores require exactly-once-v2 and only apply to persistent stores. To
+        // avoid multiplying the whole matrix we add a single representative combination
+        // (caching disabled, logging enabled) per representative persistent store and
+        // both DSL and PAPI. This exercises the transactional Position-across-restart path.
+        for (final StoresToTest toTest : TRANSACTIONAL_STORES) {
+            for (final String kind : Arrays.asList("DSL", "PAPI")) {
+                values.add(Arguments.of(false, true, toTest, kind, true));
+            }
+        }
+
         return values.stream();
     }
 
@@ -361,8 +386,8 @@ public class PositionRestartIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void verifyStore(final boolean cache, final boolean log, final StoresToTest storeToTest, final String kind) {
-        final Properties streamsConfig = streamsConfiguration(cache, log, storeToTest.name(), kind);
+    public void verifyStore(final boolean cache, final boolean log, final StoresToTest storeToTest, final String kind, final boolean transactional) {
+        final Properties streamsConfig = streamsConfiguration(cache, log, storeToTest.name(), kind, transactional);
         final StreamsBuilder streamsBuilder = getStreamBuilder(cache, log, storeToTest, kind);
         kafkaStreams = IntegrationTestUtils.getStartedStreams(streamsConfig, streamsBuilder, true);
 
@@ -649,10 +674,11 @@ public class PositionRestartIntegrationTest {
     private static Properties streamsConfiguration(final boolean cache,
                                             final boolean log,
                                             final String supplier,
-                                            final String kind) {
+                                            final String kind,
+                                            final boolean transactional) {
         final String safeTestName =
             PositionRestartIntegrationTest.class.getName() + "-" + cache + "-" + log + "-"
-                + supplier + "-" + kind;
+                + supplier + "-" + kind + "-" + transactional;
         final Properties config = new Properties();
         config.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         config.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
@@ -668,6 +694,11 @@ public class PositionRestartIntegrationTest {
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         config.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
         config.put(InternalConfig.IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        if (transactional) {
+            // Transactional state stores (KIP-892) are only supported under exactly-once-v2.
+            config.put(StreamsConfig.TRANSACTIONAL_STATE_STORES_CONFIG, true);
+            config.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        }
         return config;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/KeyValueToTimestampedKeyValueByteStoreAdapter.java
@@ -156,8 +156,8 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
                 final byte[] valueWithTimestamp = convertToTimestampedFormat(plainValue);
                 result = (QueryResult<R>) InternalQueryResultUtil.copyAndSubstituteDeserializedResult(result, valueWithTimestamp);
             } else if (query instanceof RangeQuery || query instanceof TimestampedRangeQuery) {
-                final KeyValueToTimestampedKeyValueAdapterIterator wrappedRocksDBRangeIterator = new KeyValueToTimestampedKeyValueAdapterIterator((RocksDbIterator) result.getResult());
-                result = (QueryResult<R>) InternalQueryResultUtil.copyAndSubstituteDeserializedResult(result, wrappedRocksDBRangeIterator);
+                final KeyValueToTimestampedKeyValueAdapterIterator wrappedRangeIterator = new KeyValueToTimestampedKeyValueAdapterIterator((ManagedKeyValueIterator<Bytes, byte[]>) result.getResult());
+                result = (QueryResult<R>) InternalQueryResultUtil.copyAndSubstituteDeserializedResult(result, wrappedRangeIterator);
             } else {
                 throw new IllegalArgumentException("Unsupported query type: " + query.getClass());
             }
@@ -218,35 +218,35 @@ public class KeyValueToTimestampedKeyValueByteStoreAdapter implements KeyValueSt
 
     private static class KeyValueToTimestampedKeyValueAdapterIterator implements ManagedKeyValueIterator<Bytes, byte[]> {
 
-        private final RocksDbIterator rocksDbIterator;
+        private final ManagedKeyValueIterator<Bytes, byte[]> delegate;
 
-        public KeyValueToTimestampedKeyValueAdapterIterator(final RocksDbIterator rocksDbIterator) {
-            this.rocksDbIterator = rocksDbIterator;
+        public KeyValueToTimestampedKeyValueAdapterIterator(final ManagedKeyValueIterator<Bytes, byte[]> delegate) {
+            this.delegate = delegate;
         }
 
         @Override
         public void close() {
-            rocksDbIterator.close();
+            delegate.close();
         }
 
         @Override
         public Bytes peekNextKey() {
-            return rocksDbIterator.peekNextKey();
+            return delegate.peekNextKey();
         }
 
         @Override
         public void onClose(final Runnable closeCallback) {
-            rocksDbIterator.onClose(closeCallback);
+            delegate.onClose(closeCallback);
         }
 
         @Override
         public boolean hasNext() {
-            return rocksDbIterator.hasNext();
+            return delegate.hasNext();
         }
 
         @Override
         public KeyValue<Bytes, byte[]> next() {
-            final KeyValue<Bytes, byte[]> next = rocksDbIterator.next();
+            final KeyValue<Bytes, byte[]> next = delegate.next();
             if (next == null) {
                 return null;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -916,8 +916,14 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
         try {
             synchronized (position) {
+                if (isTransactional) {
+                    // Merge the buffer's pending position deltas into the committed position and stage
+                    // the committed position into the same write batch as the staged data and changelog
+                    // offsets, so it is flushed atomically by the commitStagedWrites triggered below.
+                    dbAccessor.mergeUncommittedPositionInto(position);
+                    cfAccessor.commit(dbAccessor, position);
+                }
                 cfAccessor.commit(dbAccessor, changelogOffsets);
-                dbAccessor.mergeUncommittedPositionInto(position);
             }
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error while executing commit from store " + name, e);


### PR DESCRIPTION
Two defects surfaced when parameterizing the
PositionRestartIntegrationTest for transactional state stores

  1. ClassCastException on IQv2 RangeQuery/TimestampedRangeQuery

  An IQv2 `RangeQuery` or `TimestampedRangeQuery` against a
transactional    store threw:

      java.lang.ClassCastException: class StagedMergeIterator cannot be
cast        to class RocksDbIterator            at
KeyValueToTimestampedKeyValueByteStoreAdapter.query(...)

  `KeyValueToTimestampedKeyValueByteStoreAdapter.query` cast the range
result to `RocksDbIterator`; a transactional store returns a
StagedMergeIterator

2. Committed Position not restored after restart

  After a clean close and reopen, a position-bound IQv2 query against a
transactional store timed out with `NOT_UP_TO_BOUND` because the
persisted    Position came back empty/stale:

      current position Position{position={}} is not yet up to the bound
...

  The committed Position was staged into the transaction buffer's write
batch by the `writePosition()` checkpoint callback but never flushed,
and    the batch is discarded on close.

Reviewers: Nick Telford <nick.telford@gmail.com>
