### PR TITLE
KAFKA-20759 testUnsubscribeDoesNotCommitOffsetsEvenWithAutoCommitEnabled hangs in closing

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -2203,6 +2203,10 @@ public class AsyncKafkaConsumerTest {
         verify(applicationEventHandler, never()).add(ArgumentMatchers.isA(SyncCommitEvent.class));
         verify(applicationEventHandler, never()).add(ArgumentMatchers.isA(AsyncCommitEvent.class));
         verify(applicationEventHandler, never()).add(ArgumentMatchers.isA(CommitOnCloseEvent.class));
+
+        // Auto-commit is enabled, so close() will send a commit-on-close event and wait for it to
+        // complete. Mock the handler to complete the commit event so close() does not hang.
+        completeCommitSyncApplicationEventSuccessfully();
     }
 
     private static Stream<CompletableBackgroundEvent<?>> assignmentEventsSource() {


### PR DESCRIPTION
Since `testUnsubscribeDoesNotCommitOffsetsEvenWithAutoCommitEnabled`
enables    auto-commit, closing the consumer in the `@AfterEach`
teardown triggers    `autoCommitOnClose()`, which calls
`commitSyncAllConsumed()` and blocks waiting    on the resulting
`SyncCommitEvent` future:

  ```java
  private void autoCommitOnClose(final Timer timer) {
      if (groupMetadata.get().isEmpty() || applicationEventHandler ==
null)
          return;

      if (autoCommitEnabled)            commitSyncAllConsumed(timer); //
sends a blocking SyncCommitEvent

      applicationEventHandler.add(new CommitOnCloseEvent());
  }
```
  Because the test mocks applicationEventHandler and never completes
this event,
  close() blocks until the timeout.

  This patch completes the commit event during close by calling
completeCommitSyncApplicationEventSuccessfully() at the end of the test

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
