### PR TITLE
KAFKA-20761: Add client logs for consumer group configs defined on the broker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -350,8 +350,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
             // The heartbeat interval is a group config owned by the broker, so log it when it changes to give
             // visibility into the value the coordinator is applying (it is not derivable from client config).
             if (heartbeatIntervalMs != previousHeartbeatIntervalMs) {
-                logger.info("{} received heartbeat interval {}ms from the group coordinator (was {}ms)",
-                    heartbeatRequestName(), heartbeatIntervalMs, previousHeartbeatIntervalMs);
+                logger.info("Received heartbeat interval {}ms from the group coordinator", heartbeatIntervalMs);
             }
             heartbeatRequestState.updateHeartbeatIntervalMs(heartbeatIntervalMs);
             heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -350,7 +350,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
             // The heartbeat interval is a group config owned by the broker, so log it when it changes to give
             // visibility into the value the coordinator is applying (it is not derivable from client config).
             if (heartbeatIntervalMs != previousHeartbeatIntervalMs) {
-                logger.info("Member {} received heartbeat interval {}ms from the group coordinator", membershipManager().memberId, heartbeatIntervalMs);
+                logger.info("Member {} received heartbeat interval {}ms from the group coordinator", membershipManager().memberId(), heartbeatIntervalMs);
             }
             heartbeatRequestState.updateHeartbeatIntervalMs(heartbeatIntervalMs);
             heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -345,7 +345,15 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
 
     private void onResponse(final R response, final long currentTimeMs) {
         if (errorForResponse(response) == Errors.NONE) {
-            heartbeatRequestState.updateHeartbeatIntervalMs(heartbeatIntervalForResponse(response));
+            long previousHeartbeatIntervalMs = heartbeatRequestState.heartbeatIntervalMs();
+            long heartbeatIntervalMs = heartbeatIntervalForResponse(response);
+            // The heartbeat interval is a group config owned by the broker, so log it when it changes to give
+            // visibility into the value the coordinator is applying (it is not derivable from client config).
+            if (heartbeatIntervalMs != previousHeartbeatIntervalMs) {
+                logger.info("{} received heartbeat interval {}ms from the group coordinator (was {}ms)",
+                    heartbeatRequestName(), heartbeatIntervalMs, previousHeartbeatIntervalMs);
+            }
+            heartbeatRequestState.updateHeartbeatIntervalMs(heartbeatIntervalMs);
             heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);
             membershipManager().onHeartbeatSuccess(response);
             return;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManager.java
@@ -350,7 +350,7 @@ public abstract class AbstractHeartbeatRequestManager<R extends AbstractResponse
             // The heartbeat interval is a group config owned by the broker, so log it when it changes to give
             // visibility into the value the coordinator is applying (it is not derivable from client config).
             if (heartbeatIntervalMs != previousHeartbeatIntervalMs) {
-                logger.info("Received heartbeat interval {}ms from the group coordinator", heartbeatIntervalMs);
+                logger.info("Member {} received heartbeat interval {}ms from the group coordinator", membershipManager().memberId, heartbeatIntervalMs);
             }
             heartbeatRequestState.updateHeartbeatIntervalMs(heartbeatIntervalMs);
             heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -206,7 +206,7 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
 
     private static long countHeartbeatIntervalLogs(final LogCaptureAppender logAppender) {
         return logAppender.getMessages().stream()
-            .filter(message -> message.contains("Received heartbeat interval"))
+            .filter(message -> message.contains("received heartbeat interval"))
             .count();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -178,6 +178,7 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
         try (LogCaptureAppender logAppender =
                  LogCaptureAppender.createAndRegister(heartbeatRequestManager.getClass())) {
             logAppender.setClassLogger(heartbeatRequestManager.getClass(), Level.INFO);
+            when(membershipManager.memberId()).thenReturn(DEFAULT_MEMBER_ID);
 
             int changedIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS + 500;
 
@@ -191,6 +192,9 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
             assertEquals(changedIntervalMs, heartbeatRequestState.heartbeatIntervalMs());
             assertEquals(1, countHeartbeatIntervalLogs(logAppender),
                 "The heartbeat interval received from the coordinator should be logged when it changes.");
+            assertTrue(logAppender.getMessages().stream().anyMatch(message -> message.contains(
+                    "Member " + DEFAULT_MEMBER_ID + " received heartbeat interval " + changedIntervalMs + "ms")),
+                "The logged message should contain the member id and the received interval.");
 
             // A subsequent heartbeat carrying the same interval must not be logged again.
             time.sleep(changedIntervalMs);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -21,9 +21,11 @@ import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 
+import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -78,6 +80,9 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
 
     protected abstract ClientResponse createHeartbeatResponse(
         NetworkClientDelegate.UnsentRequest request, Errors error);
+
+    protected abstract ClientResponse createHeartbeatResponse(
+        NetworkClientDelegate.UnsentRequest request, Errors error, int heartbeatIntervalMs);
 
     @Test
     public void testTimerNotDue() {
@@ -166,6 +171,43 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
 
         inflightReq.handler().onComplete(createHeartbeatResponse(inflightReq, Errors.NONE));
         assertNextHeartbeatTiming(DEFAULT_HEARTBEAT_INTERVAL_MS - partOfInterval);
+    }
+
+    @Test
+    public void testLogsHeartbeatIntervalReceivedFromCoordinatorOnlyWhenChanged() {
+        try (LogCaptureAppender logAppender =
+                 LogCaptureAppender.createAndRegister(heartbeatRequestManager.getClass())) {
+            logAppender.setClassLogger(heartbeatRequestManager.getClass(), Level.INFO);
+
+            int changedIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS + 500;
+
+            // A successful heartbeat whose interval differs from the current one is applied and logged.
+            time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
+            NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+            assertEquals(1, result.unsentRequests.size());
+            result.unsentRequests.get(0).handler().onComplete(
+                createHeartbeatResponse(result.unsentRequests.get(0), Errors.NONE, changedIntervalMs));
+
+            assertEquals(changedIntervalMs, heartbeatRequestState.heartbeatIntervalMs());
+            assertEquals(1, countHeartbeatIntervalLogs(logAppender),
+                "The heartbeat interval received from the coordinator should be logged when it changes.");
+
+            // A subsequent heartbeat carrying the same interval must not be logged again.
+            time.sleep(changedIntervalMs);
+            result = heartbeatRequestManager.poll(time.milliseconds());
+            assertEquals(1, result.unsentRequests.size());
+            result.unsentRequests.get(0).handler().onComplete(
+                createHeartbeatResponse(result.unsentRequests.get(0), Errors.NONE, changedIntervalMs));
+
+            assertEquals(1, countHeartbeatIntervalLogs(logAppender),
+                "An unchanged heartbeat interval must not be logged again.");
+        }
+    }
+
+    private static long countHeartbeatIntervalLogs(final LogCaptureAppender logAppender) {
+        return logAppender.getMessages().stream()
+            .filter(message -> message.contains("received heartbeat interval"))
+            .count();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractHeartbeatRequestManagerTest.java
@@ -206,7 +206,7 @@ abstract class AbstractHeartbeatRequestManagerTest<R extends AbstractResponse> {
 
     private static long countHeartbeatIntervalLogs(final LogCaptureAppender logAppender) {
         return logAppender.getMessages().stream()
-            .filter(message -> message.contains("received heartbeat interval"))
+            .filter(message -> message.contains("Received heartbeat interval"))
             .count();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -907,17 +907,25 @@ public class ConsumerHeartbeatRequestManagerTest
     @Override
     protected ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,
                                                      Errors error) {
-        return createHeartbeatResponse(request, error, "stubbed error message");
+        return createHeartbeatResponse(request, error, DEFAULT_HEARTBEAT_INTERVAL_MS, "stubbed error message");
+    }
+
+    @Override
+    protected ClientResponse createHeartbeatResponse(NetworkClientDelegate.UnsentRequest request,
+                                                     Errors error,
+                                                     int heartbeatIntervalMs) {
+        return createHeartbeatResponse(request, error, heartbeatIntervalMs, "stubbed error message");
     }
 
     private ClientResponse createHeartbeatResponse(
         final NetworkClientDelegate.UnsentRequest request,
         final Errors error,
+        final int heartbeatIntervalMs,
         final String msg
     ) {
         ConsumerGroupHeartbeatResponseData data = new ConsumerGroupHeartbeatResponseData()
             .setErrorCode(error.code())
-            .setHeartbeatIntervalMs(DEFAULT_HEARTBEAT_INTERVAL_MS)
+            .setHeartbeatIntervalMs(heartbeatIntervalMs)
             .setMemberId(DEFAULT_MEMBER_ID)
             .setMemberEpoch(DEFAULT_MEMBER_EPOCH);
         if (error != Errors.NONE) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -461,9 +461,17 @@ public class ShareHeartbeatRequestManagerTest
     protected ClientResponse createHeartbeatResponse(
             final NetworkClientDelegate.UnsentRequest request,
             final Errors error) {
+        return createHeartbeatResponse(request, error, DEFAULT_HEARTBEAT_INTERVAL_MS);
+    }
+
+    @Override
+    protected ClientResponse createHeartbeatResponse(
+            final NetworkClientDelegate.UnsentRequest request,
+            final Errors error,
+            final int heartbeatIntervalMs) {
         ShareGroupHeartbeatResponseData data = new ShareGroupHeartbeatResponseData()
                 .setErrorCode(error.code())
-                .setHeartbeatIntervalMs(DEFAULT_HEARTBEAT_INTERVAL_MS)
+                .setHeartbeatIntervalMs(heartbeatIntervalMs)
                 .setMemberId(DEFAULT_MEMBER_ID)
                 .setMemberEpoch(DEFAULT_MEMBER_EPOCH);
         if (error != Errors.NONE) {


### PR DESCRIPTION
Inspired by https://github.com/apache/kafka/pull/22730.
`heartbeat.internal.ms` for async/shared consumer has been  migrated
from client to broker side after KIP 848/932. It should be  logged on
client-side for better visibility.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
