### PR TITLE
KAFKA-20762 Add --zk-rollback-compatible flag to kafka-storage.sh format

### DIFF
--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -117,6 +117,7 @@ object StorageTool extends Logging {
       setClusterId(namespace.getString("cluster_id")).
       setUnstableFeatureVersionsEnabled(config.unstableFeatureVersionsEnabled).
       setIgnoreFormatted(namespace.getBoolean("ignore_formatted")).
+      setZkRollbackCompatible(namespace.getBoolean("zk_rollback_compatible")).
       setControllerListenerName(config.controllerListenerNames.head).
       setMetadataLogDirectory(config.metadataLogDir)
     Option(namespace.getString("release_version")) match {
@@ -205,6 +206,10 @@ object StorageTool extends Logging {
               |'SCRAM-SHA-256=[name=alice,password=alice-secret]'
               |'SCRAM-SHA-512=[name=alice,iterations=8192,salt="N3E=",saltedpassword="YCE="]'""".stripMargin)
     formatParser.addArgument("--ignore-formatted", "-g").
+      action(storeTrue())
+    formatParser.addArgument("--zk-rollback-compatible").
+      help("Format the node so that it remains compatible with rolling back an in-progress " +
+        "KRaft migration to ZooKeeper mode.").
       action(storeTrue())
     formatParser.addArgument("--release-version", "-r").
       action(store()).

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.metadata.UserScramCredentialRecord
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.common.Features
 import org.apache.kafka.metadata.bootstrap.BootstrapDirectory
-import org.apache.kafka.metadata.properties.{MetaPropertiesEnsemble, PropertiesUtils}
+import org.apache.kafka.metadata.properties.{MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
 import org.apache.kafka.metadata.storage.FormatterException
 import org.apache.kafka.raft.QuorumConfig
 import org.apache.kafka.server.config.{KRaftConfigs, ServerConfigs, ServerLogConfigs}
@@ -272,6 +272,38 @@ Found problem:
     properties.setProperty("log.dirs", availableDirs.mkString(","))
     val stream2 = new ByteArrayOutputStream()
     assertEquals(0, runFormatCommand(stream2, properties, Seq(), true))
+  }
+
+  @Test
+  def testFormatWithZkRollbackCompatibleWritesV0MetaProperties(): Unit = {
+    val availableDir = TestUtils.tempDir()
+    val properties = new Properties()
+    properties.putAll(defaultStaticQuorumProperties)
+    properties.setProperty("log.dirs", availableDir.toString)
+    val stream = new ByteArrayOutputStream()
+    assertEquals(0, runFormatCommand(stream, properties, Seq("--zk-rollback-compatible")))
+
+    val ensemble = new MetaPropertiesEnsemble.Loader().
+      addLogDirs(util.Collections.singletonList(availableDir.toString)).
+      load()
+    assertEquals(MetaPropertiesVersion.V0,
+      ensemble.logDirProps().get(availableDir.toString).version())
+  }
+
+  @Test
+  def testFormatWithoutZkRollbackCompatibleWritesV1MetaProperties(): Unit = {
+    val availableDir = TestUtils.tempDir()
+    val properties = new Properties()
+    properties.putAll(defaultStaticQuorumProperties)
+    properties.setProperty("log.dirs", availableDir.toString)
+    val stream = new ByteArrayOutputStream()
+    assertEquals(0, runFormatCommand(stream, properties))
+
+    val ensemble = new MetaPropertiesEnsemble.Loader().
+      addLogDirs(util.Collections.singletonList(availableDir.toString)).
+      load()
+    assertEquals(MetaPropertiesVersion.V1,
+      ensemble.logDirProps().get(availableDir.toString).version())
   }
 
   @Test

--- a/docs/operations/kraft.md
+++ b/docs/operations/kraft.md
@@ -102,6 +102,17 @@ When provisioning new broker and controller nodes that we want to add to an exis
     
     $ bin/kafka-storage.sh format --cluster-id <cluster-id> --config config/kraft/server.properties --no-initial-controllers
 
+### Formatting Nodes During a KRaft Migration
+
+During an ongoing migration, when scaling a cluster or replacing nodes, storage formatting must be done in a special way. In order for the formatted storage of a newly provisioned node to remain compatible with rollback of the KRaft migration, the `format` command must be invoked with the `--zk-rollback-compatible` flag. Unless this is done, newly provisioned brokers will fail to start when configured into migration mode during a rollback sequence.
+
+To produce a storage directory that's formatted in a rollback compatible way, pass `--zk-rollback-compatible`.
+
+    # Broker added during a migration
+    $ bin/kafka-storage.sh format --cluster-id <cluster-id> --config config/kraft/server.properties --no-initial-controllers --zk-rollback-compatible
+
+Once the migration has been finalized, rollback to ZooKeeper mode is no longer possible, and this flag should no longer be used when formatting nodes.
+
 ## Controller membership changes
 
 ### Static versus Dynamic KRaft Quorums
@@ -266,6 +277,8 @@ In general, the migration process passes through several phases.
   * In **hybrid phase** , some brokers are in ZK mode, but there is a KRaft controller.
   * In **dual-write phase** , all brokers are KRaft, but the KRaft controller is continuing to write to ZK.
   * When the migration has been **finalized** , we no longer write metadata to ZooKeeper.
+
+If you need to replace or add a node while the migration is still in progress, see [Formatting Nodes During a KRaft Migration](#formatting-nodes-during-a-kraft-migration).
 
 
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -135,6 +135,12 @@ public class Formatter {
     private Optional<DynamicVoters> initialControllers = Optional.empty();
     private boolean hasDynamicQuorum = false;
 
+    /**
+     * True if meta.properties should be written with version 0 so that the node stays
+     * compatible with rolling a KRaft migration back to ZooKeeper mode.
+     */
+    private boolean zkRollbackCompatible = false;
+
     public Formatter setPrintStream(PrintStream printStream) {
         this.printStream = printStream;
         return this;
@@ -212,6 +218,11 @@ public class Formatter {
 
     public Formatter setHasDynamicQuorum(boolean hasDynamicQuorum) {
         this.hasDynamicQuorum = hasDynamicQuorum;
+        return this;
+    }
+
+    public Formatter setZkRollbackCompatible(boolean zkRollbackCompatible) {
+        this.zkRollbackCompatible = zkRollbackCompatible;
         return this;
     }
 
@@ -386,8 +397,10 @@ public class Formatter {
     }
 
     void doFormat(BootstrapMetadata bootstrapMetadata) throws Exception {
+        MetaPropertiesVersion metaPropertiesVersion = zkRollbackCompatible ?
+            MetaPropertiesVersion.V0 : MetaPropertiesVersion.V1;
         MetaProperties metaProperties = new MetaProperties.Builder().
-                setVersion(MetaPropertiesVersion.V1).
+                setVersion(metaPropertiesVersion).
                 setClusterId(clusterId).
                 setNodeId(nodeId).
                 build();

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.metadata.bootstrap.BootstrapDirectory;
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
 import org.apache.kafka.metadata.properties.MetaProperties;
 import org.apache.kafka.metadata.properties.MetaPropertiesEnsemble;
+import org.apache.kafka.metadata.properties.MetaPropertiesVersion;
 import org.apache.kafka.raft.DynamicVoters;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.Features;
@@ -185,6 +186,34 @@ public class FormatterTest {
             formatter2.formatter.run();
             assertEquals("All of the log directories are already formatted.",
                 formatter2.output().trim());
+        }
+    }
+
+    @Test
+    public void testZkRollbackCompatibleWritesV0MetaProperties() throws Exception {
+        try (TestEnv testEnv = new TestEnv(1)) {
+            FormatterContext formatter1 = testEnv.newFormatter();
+            formatter1.formatter.setZkRollbackCompatible(true);
+            formatter1.formatter.run();
+            MetaPropertiesEnsemble ensemble = new MetaPropertiesEnsemble.Loader().
+                addLogDirs(testEnv.directories).
+                load();
+            MetaProperties metaProperties =
+                ensemble.logDirProps().get(testEnv.directory(0));
+            assertEquals(MetaPropertiesVersion.V0, metaProperties.version());
+        }
+    }
+
+    @Test
+    public void testDefaultWritesV1MetaProperties() throws Exception {
+        try (TestEnv testEnv = new TestEnv(1)) {
+            testEnv.newFormatter().formatter.run();
+            MetaPropertiesEnsemble ensemble = new MetaPropertiesEnsemble.Loader().
+                addLogDirs(testEnv.directories).
+                load();
+            MetaProperties metaProperties =
+                ensemble.logDirProps().get(testEnv.directory(0));
+            assertEquals(MetaPropertiesVersion.V1, metaProperties.version());
         }
     }
 


### PR DESCRIPTION
In order to support node replacements during KRaft migration, and for a cluster that has such replacements to remain possible to rollback, the storage formatting tool must be able to produce a storage directory that can be rolled back. Currently this is not the case, and the tool always produces a meta.properties file with version=1.

When rollback is triggered on such a cluster that has had node replacements, this results in a broker crash-loop with the below log.

```
Jul 02 14:56:32 kafka[25156]: [2026-07-02 14:56:32,647] ERROR Exiting Kafka due to fatal exception during startup. (kafka.Kafka$)
                              java.lang.RuntimeException: Found unexpected version in /srv/kafka/meta.properties. ZK-based brokers that are not migrating only support version 0 (which is implicit when the `version` field is missing).
                                      at org.apache.kafka.metadata.properties.MetaPropertiesEnsemble.verify(MetaPropertiesEnsemble.java:489)
                                      at kafka.server.KafkaServer.startup(KafkaServer.scala:258)
                                      at kafka.Kafka$.main(Kafka.scala:112)
                                      at kafka.Kafka.main(Kafka.scala)
Jul 02 14:56:32 kafka[25156]: [2026-07-02 14:56:32,650] INFO shutting down (kafka.server.KafkaServer)
```

This commit remedies this by introducing a new flag to the formatter tool that makes it create a meta.properties with version=0 and compatible with rollback. This matches what the broker itself does during a normal from-ZK migration.

Documentation is updated both in the KRaft migration section and in the generic section for provisioning nodes.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
