### PR TITLE
KAFKA-20770: LocalLeaderEndPoint should return UNDEFINED_EPOCH when the leader epoch cannot be resolved

### DIFF
--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -119,21 +119,21 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val logStartOffset = partition.localLogOrException.logStartOffset
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(logStartOffset)
-    new OffsetAndEpoch(logStartOffset, epoch.orElse(0))
+    new OffsetAndEpoch(logStartOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchLatestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val logEndOffset = partition.localLogOrException.logEndOffset
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(logEndOffset)
-    new OffsetAndEpoch(logEndOffset, epoch.orElse(0))
+    new OffsetAndEpoch(logEndOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val localLogStartOffset = partition.localLogOrException.localLogStartOffset()
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(localLogStartOffset)
-    new OffsetAndEpoch(localLogStartOffset, epoch.orElse(0))
+    new OffsetAndEpoch(localLogStartOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchEarliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
@@ -159,7 +159,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
         case _ =>
           val earliestPendingUploadOffset = Math.max(highestRemoteOffset + 1, Math.max(logStartOffset.offset(), localLogStartOffset.offset()))
           val epoch = log.leaderEpochCache.epochForOffset(earliestPendingUploadOffset)
-          new OffsetAndEpoch(earliestPendingUploadOffset, epoch.orElse(0))
+          new OffsetAndEpoch(earliestPendingUploadOffset, epoch.orElse(UNDEFINED_EPOCH))
       }
     }
   }

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -276,15 +276,60 @@ class LocalLeaderEndPointTest extends Logging {
     appendRecords(replicaManager, topicIdPartition, records)
       .onFire(response => assertEquals(Errors.NONE, response.error))
 
-    // Highest remote is 1 => earliest pending should be max(1+1, logStart)
+    // Highest remote is 1 => earliest pending should be max(1+1, logStart) = 2,
+    // and all records were appended under leader epoch 0
     val log = replicaManager.getPartitionOrException(topicPartition).localLogOrException
     log.updateHighestOffsetInRemoteStorage(1)
 
-    val expectedOffset = Math.max(2L, log.logStartOffset())
-    val epoch = log.leaderEpochCache().epochForOffset(expectedOffset).orElse(0)
+    val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
+    assertEquals(new OffsetAndEpoch(2L, 0), result)
+  }
+
+  @Test
+  def testEarliestPendingUploadOffsetResolvesEpochOfPendingOffset(): Unit = {
+    // Append records under leader epoch 0 (offsets 0-2) and leader epoch 1 (offsets 3-5)
+    appendRecords(replicaManager, topicIdPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+    bumpLeaderEpoch()
+    appendRecords(replicaManager, topicIdPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    val log = replicaManager.getPartitionOrException(topicPartition).localLogOrException
+    log.updateHighestOffsetInRemoteStorage(3)
+
+    // Earliest pending upload offset is max(3 + 1, max(0, 0)) = 4, which was appended under epoch 1
+    val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 1)
+    assertEquals(new OffsetAndEpoch(4L, 1), result)
+  }
+
+  @Test
+  def testEarliestPendingUploadOffsetWhenEpochCannotBeResolved(): Unit = {
+    appendRecords(replicaManager, topicIdPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    val log = replicaManager.getPartitionOrException(topicPartition).localLogOrException
+    log.updateHighestOffsetInRemoteStorage(1)
+    // Wipe the epoch cache so the epoch of the pending upload offset cannot be resolved. The
+    // ListOffsets-based path (UnifiedLog#fetchEarliestPendingUploadOffset) leaves the epoch unset
+    // in this case, which serializes as -1, so the local path must report -1 as well instead of
+    // fabricating epoch 0.
+    log.leaderEpochCache().clearAndFlush()
 
     val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
-    assertEquals(new OffsetAndEpoch(expectedOffset, epoch), result)
+    assertEquals(new OffsetAndEpoch(2L, -1), result)
+  }
+
+  @Test
+  def testFetchOffsetsReturnUndefinedEpochWhenEpochCannotBeResolved(): Unit = {
+    appendRecords(replicaManager, topicIdPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    val log = replicaManager.getPartitionOrException(topicPartition).localLogOrException
+    log.leaderEpochCache().clearAndFlush()
+
+    assertEquals(new OffsetAndEpoch(0L, -1), endPoint.fetchEarliestOffset(topicPartition, 0))
+    assertEquals(new OffsetAndEpoch(3L, -1), endPoint.fetchLatestOffset(topicPartition, 0))
+    assertEquals(new OffsetAndEpoch(0L, -1), endPoint.fetchEarliestLocalOffset(topicPartition, 0))
   }
 
   @Test
@@ -302,12 +347,9 @@ class LocalLeaderEndPointTest extends Logging {
     log.updateLocalLogStartOffset(8)
 
     // Expected: max(highestRemoteOffset + 1, max(logStartOffset, localLogStartOffset))
-    //         = max(5 + 1, max(0, 8)) = max(6, 8) = 8
-    val expectedOffset = 8L
-    val epoch = log.leaderEpochCache().epochForOffset(expectedOffset).orElse(0)
-
+    //         = max(5 + 1, max(0, 8)) = max(6, 8) = 8, appended under leader epoch 0
     val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
-    assertEquals(new OffsetAndEpoch(expectedOffset, epoch), result)
+    assertEquals(new OffsetAndEpoch(8L, 0), result)
   }
 
   @Test
@@ -329,12 +371,9 @@ class LocalLeaderEndPointTest extends Logging {
     // Set highestRemoteOffset to 5 (less than logStartOffset)
     log.updateHighestOffsetInRemoteStorage(5)
 
-    // Expected: max(5+1, max(10, 3)) = max(6, 10) = 10
-    val expectedOffset = 10L
-    val epoch = log.leaderEpochCache().epochForOffset(expectedOffset).orElse(0)
-
+    // Expected: max(5+1, max(10, 3)) = max(6, 10) = 10, appended under leader epoch 0
     val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
-    assertEquals(new OffsetAndEpoch(expectedOffset, epoch), result)
+    assertEquals(new OffsetAndEpoch(10L, 0), result)
   }
 
   @Test
@@ -356,12 +395,9 @@ class LocalLeaderEndPointTest extends Logging {
     // Set highestRemoteOffset to 15 (greater than logStartOffset)
     log.updateHighestOffsetInRemoteStorage(15)
 
-    // Expected: max(15+1, max(10, 3)) = max(16, 10) = 16
-    val expectedOffset = 16L
-    val epoch = log.leaderEpochCache().epochForOffset(expectedOffset).orElse(0)
-
+    // Expected: max(15+1, max(10, 3)) = max(16, 10) = 16, appended under leader epoch 0
     val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
-    assertEquals(new OffsetAndEpoch(expectedOffset, epoch), result)
+    assertEquals(new OffsetAndEpoch(16L, 0), result)
   }
 
   @Test
@@ -384,12 +420,9 @@ class LocalLeaderEndPointTest extends Logging {
     // Set highestRemoteOffset to 5 (less than start offsets)
     log.updateHighestOffsetInRemoteStorage(5)
 
-    // Expected: max(5+1, max(10, 10)) = max(6, 10) = 10
-    val expectedOffset = 10L
-    val epoch = log.leaderEpochCache().epochForOffset(expectedOffset).orElse(0)
-
+    // Expected: max(5+1, max(10, 10)) = max(6, 10) = 10, appended under leader epoch 0
     val result = endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0)
-    assertEquals(new OffsetAndEpoch(expectedOffset, epoch), result)
+    assertEquals(new OffsetAndEpoch(10L, 0), result)
   }
 
   private class CallbackResult[T] {


### PR DESCRIPTION
LocalLeaderEndPoint (used by ReplicaAlterLogDirsThread) and
  RemoteLeaderEndPoint (used by ReplicaFetcherThread) implement the same
  LeaderEndPoint contract but disagree on the leader epoch reported when
  the epoch for an offset cannot be resolved from the leader epoch cache.
  The remote path goes through ListOffsets, where the epoch is left unset
  and serializes as -1 (NO_LEADER_EPOCH); LocalLeaderEndPoint instead
  fabricated epoch 0 via epoch.orElse(0) in fetchEarliestOffset,
  fetchLatestOffset, fetchEarliestLocalOffset and
  fetchEarliestPendingUploadOffset.

  This matters because the returned epoch is consumed by
  TierStateMachine#buildRemoteLogAuxState, which treats it as meaningful:
  epoch 0 short-circuits the earlier-epoch lookup, while other values drive
  an OffsetsForLeaderEpoch probe and an epoch-based remote log segment
  metadata lookup. A fabricated 0 claims the first leader epoch rather than
  admitting the epoch is unknown, so the two fetcher paths behaved
  differently for identical log state. The fallback is only reachable when
  the epoch cache is empty or truncated above the queried offset (for
  example after checkpoint loss), so this is a correctness/consistency fix
  rather than a data-loss fix.

  Replace the fallback with UNDEFINED_EPOCH (-1), matching the
  ListOffsets-based path. Behavior is unchanged whenever the epoch is
  resolvable.

  Testing: the existing LocalLeaderEndPointTest assertions computed the
  expected epoch with the same epochForOffset(...).orElse(0) expression as
  the production code, so they could not catch this; they now assert
  concrete values. Added tests covering a non-zero resolved epoch across
  leader epochs and the unresolvable-epoch case for all four methods; the
  new tests fail without the fix (epoch 0 returned) and pass with it.
  LocalLeaderEndPointTest and ReplicaAlterLogDirsThreadTest pass locally.

  Co-Authored-By: Claude Fable 5

Reviewers: Hyungmin Oh (github:haung921209)
