### PR TITLE
test: cover subscription state validation paths

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,6 +72,8 @@ public class SubscriptionStateTest {
         state.seek(tp0, 1);
         assertTrue(state.isFetchable(tp0));
         assertEquals(1L, state.position(tp0).offset);
+        assertEquals(Optional.of(new OffsetAndMetadata(1L, Optional.empty(), "")),
+                Optional.ofNullable(state.allConsumed().get(tp0)));
         state.assignFromUser(Set.of());
         assertTrue(state.assignedPartitions().isEmpty());
         assertEquals(0, state.numAssignedPartitions());
@@ -259,6 +262,12 @@ public class SubscriptionStateTest {
     @Test
     public void partitionReset() {
         state.assignFromUser(Set.of(tp0));
+        assertFalse(state.isFetchable(tp0), "Should not be fetchable without a valid position");
+
+        state.resetInitializingPositions();
+        assertEquals(Set.of(tp0), state.partitionsNeedingReset(0L));
+        assertFalse(state.isFetchable(tp0));
+
         state.seek(tp0, 5);
         assertEquals(5L, state.position(tp0).offset);
         state.requestOffsetReset(tp0);
@@ -920,6 +929,8 @@ public class SubscriptionStateTest {
         assertEquals(Optional.of(new OffsetAndMetadata(divergentOffset, Optional.of(divergentOffsetEpoch), "")),
                 truncation.divergentOffsetOpt);
         assertEquals(initialPosition, truncation.fetchPosition);
+        assertEquals("(partition=test-0, fetchOffset=10, fetchEpoch=Optional[5], divergentOffset=5, divergentEpoch=Optional[7])",
+                truncation.toString());
         assertTrue(state.awaitingValidation(tp0));
     }
 
@@ -972,6 +983,8 @@ public class SubscriptionStateTest {
 
         assertEquals(Optional.empty(), truncation.divergentOffsetOpt);
         assertEquals(initialPosition, truncation.fetchPosition);
+        assertEquals("(partition=test-0, fetchOffset=10, fetchEpoch=Optional[5], divergentOffset=unknown, divergentEpoch=unknown)",
+                truncation.toString());
         assertTrue(state.awaitingValidation(tp0));
     }
 
@@ -1158,4 +1171,55 @@ public class SubscriptionStateTest {
         assertTrue(predicateEvaluated.get());
         assertEquals(tp0, fetchablePartitions.get(0));
     }
+
+    @Test
+    public void testMaybeSeekUnvalidatedOnlyUpdatesPartitionsAwaitingReset() {
+        Node broker1 = new Node(1, "localhost", 9092);
+        SubscriptionState.FetchPosition position = new SubscriptionState.FetchPosition(10L, Optional.of(5),
+            new Metadata.LeaderAndEpoch(Optional.of(broker1), Optional.of(10)));
+        TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+        state.assignFromUser(Set.of(tp0));
+
+        state.maybeSeekUnvalidated(unassignedPartition, position, AutoOffsetResetStrategy.EARLIEST);
+        state.maybeSeekUnvalidated(tp0, position, AutoOffsetResetStrategy.EARLIEST);
+        assertNull(state.position(tp0));
+
+        state.requestOffsetReset(tp0, AutoOffsetResetStrategy.EARLIEST);
+        state.maybeSeekUnvalidated(tp0, position, AutoOffsetResetStrategy.LATEST);
+        assertTrue(state.isOffsetResetNeeded(tp0));
+        assertNull(state.position(tp0));
+
+        state.maybeSeekUnvalidated(tp0, position, AutoOffsetResetStrategy.EARLIEST);
+        assertEquals(position, state.position(tp0));
+        assertTrue(state.awaitingValidation(tp0));
+    }
+
+    @Test
+    public void testPartitionsNeedingValidationRespectsRetryBackoff() {
+        Node broker1 = new Node(1, "localhost", 9092);
+        SubscriptionState.FetchPosition position0 = new SubscriptionState.FetchPosition(10L, Optional.of(5),
+            new Metadata.LeaderAndEpoch(Optional.of(broker1), Optional.of(10)));
+        SubscriptionState.FetchPosition position1 = new SubscriptionState.FetchPosition(20L, Optional.of(6),
+            new Metadata.LeaderAndEpoch(Optional.of(broker1), Optional.of(10)));
+        TopicPartition unassignedPartition = new TopicPartition("unassigned", 0);
+        state.assignFromUser(Set.of(tp0, tp1));
+
+        state.seekUnvalidated(tp0, position0);
+        state.seekUnvalidated(tp1, position1);
+        assertEquals(Map.of(tp0, position0, tp1, position1), state.partitionsNeedingValidation(0L));
+        assertTrue(state.hasPartitionsNeedingValidation(0L));
+
+        state.requestFailed(Set.of(tp0, unassignedPartition), 10L);
+        assertEquals(Map.of(tp1, position1), state.partitionsNeedingValidation(9L));
+        assertTrue(state.hasPartitionsNeedingValidation(9L));
+
+        state.setNextAllowedRetry(Set.of(tp1), 20L);
+        assertTrue(state.partitionsNeedingValidation(9L).isEmpty());
+        assertFalse(state.hasPartitionsNeedingValidation(9L));
+        assertEquals(Map.of(tp0, position0), state.partitionsNeedingValidation(19L));
+        assertTrue(state.hasPartitionsNeedingValidation(19L));
+        assertEquals(Map.of(tp0, position0, tp1, position1), state.partitionsNeedingValidation(20L));
+        assertTrue(state.hasPartitionsNeedingValidation(20L));
+    }
+
 }


### PR DESCRIPTION
Hi,

I added focused regression coverage for offset reset and validation retry behavior. I also tightened the existing truncation tests with assertions for the string description.

Impact on coverage:

* Covers the relevant SubscriptionState logic, including the `maybeSeekUnvalidated` [reset guards](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java#L449-L461) and the [validation retry paths](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java#L893-L913)
* Branch coverage for SubscriptionState increases by around 15%.

Why:

These checks make sure partitions only become eligible for validation/reset at the right time and that truncation details stay visible when they are reported.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
