### PR TITLE
KAFKA-18573: Close verification key resolver in BrokerJwtValidator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidator.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableV
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.SerializedJwt;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
+import org.apache.kafka.common.utils.Utils;
 
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -37,6 +38,7 @@ import org.jose4j.jwt.consumer.JwtContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +102,7 @@ public class BrokerJwtValidator implements JwtValidator {
     private static final Logger log = LoggerFactory.getLogger(BrokerJwtValidator.class);
 
     private final Optional<CloseableVerificationKeyResolver> verificationKeyResolverOpt;
+    private CloseableVerificationKeyResolver ownedVerificationKeyResolver;
 
     private JwtConsumer jwtConsumer;
 
@@ -154,9 +157,19 @@ public class BrokerJwtValidator implements JwtValidator {
                 SASL_OAUTHBEARER_EXPECTED_ISSUER, SASL_OAUTHBEARER_EXPECTED_ISSUER, SASL_OAUTHBEARER_ALLOW_UNVERIFIED_ISSUER));
         }
 
-        CloseableVerificationKeyResolver verificationKeyResolver = verificationKeyResolverOpt.orElseGet(
-            () -> VerificationKeyResolverFactory.get(configs, saslMechanism, jaasConfigEntries)
-        );
+        CloseableVerificationKeyResolver verificationKeyResolver;
+
+        if (verificationKeyResolverOpt.isPresent()) {
+            // The lifecycle of an injected resolver is managed by the code that supplied it.
+            verificationKeyResolver = verificationKeyResolverOpt.get();
+        } else {
+            // A resolver retrieved from the factory is owned by this validator, so it is configured here
+            // and released in close(). Otherwise its resources (e.g. the background JWKS refresh thread)
+            // would leak.
+            verificationKeyResolver = VerificationKeyResolverFactory.get(configs, saslMechanism, jaasConfigEntries);
+            ownedVerificationKeyResolver = verificationKeyResolver;
+            verificationKeyResolver.configure(configs, saslMechanism, jaasConfigEntries);
+        }
 
         final JwtConsumerBuilder jwtConsumerBuilder = new JwtConsumerBuilder();
 
@@ -192,6 +205,11 @@ public class BrokerJwtValidator implements JwtValidator {
             .build();
         this.scopeClaimName = scopeClaimName;
         this.subClaimName = subClaimName;
+    }
+
+    @Override
+    public void close() throws IOException {
+        Utils.closeQuietly(ownedVerificationKeyResolver, "JWT validator verification key resolver");
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactory.java
@@ -49,6 +49,11 @@ import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_E
  * HTTP(S) calls ({@link RefreshingHttpsJwksVerificationKeyResolver}), we only want to create
  * a new instance for each particular set of configuration. Because each set of configuration
  * may have multiple instances, we want to reuse the single instance.
+ *
+ * <p>The resolver returned from {@link #get(Map, String, List)} is reference counted: the caller
+ * must call {@link CloseableVerificationKeyResolver#configure(Map, String, List)} before use and
+ * {@link CloseableVerificationKeyResolver#close()} when finished with it so that the underlying
+ * resolver is initialized on first use and its resources are released when the last user closes it.
  */
 public class VerificationKeyResolverFactory {
 
@@ -65,9 +70,14 @@ public class VerificationKeyResolverFactory {
                     configs,
                     saslMechanism,
                     jaasConfigEntries
-                )
+                ),
+                k
             )
         );
+    }
+
+    private static synchronized void remove(VerificationKeyResolverKey cacheKey) {
+        CACHE.remove(cacheKey);
     }
 
     static CloseableVerificationKeyResolver create(Map<String, ?> configs,
@@ -75,10 +85,9 @@ public class VerificationKeyResolverFactory {
                                                    List<AppConfigurationEntry> jaasConfigEntries) {
         ConfigurationUtils cu = new ConfigurationUtils(configs, saslMechanism);
         URL jwksEndpointUrl = cu.validateUrl(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL);
-        CloseableVerificationKeyResolver resolver;
 
         if (jwksEndpointUrl.getProtocol().toLowerCase(Locale.ROOT).equals("file")) {
-            resolver = new JwksFileVerificationKeyResolver();
+            return new JwksFileVerificationKeyResolver();
         } else {
             long refreshIntervalMs = cu.validateLong(SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, true, 0L);
             JaasOptionsUtils jou = new JaasOptionsUtils(saslMechanism, jaasConfigEntries);
@@ -101,11 +110,8 @@ public class VerificationKeyResolverFactory {
                 refreshIntervalMs,
                 cu.validateLong(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS),
                 cu.validateLong(SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS));
-            resolver = new RefreshingHttpsJwksVerificationKeyResolver(refreshingHttpsJwks);
+            return new RefreshingHttpsJwksVerificationKeyResolver(refreshingHttpsJwks);
         }
-
-        resolver.configure(configs, saslMechanism, jaasConfigEntries);
-        return resolver;
     }
 
     /**
@@ -161,10 +167,13 @@ public class VerificationKeyResolverFactory {
 
         private final CloseableVerificationKeyResolver delegate;
 
+        private final VerificationKeyResolverKey cacheKey;
+
         private final AtomicInteger count = new AtomicInteger(0);
 
-        public RefCountingVerificationKeyResolver(CloseableVerificationKeyResolver delegate) {
+        public RefCountingVerificationKeyResolver(CloseableVerificationKeyResolver delegate, VerificationKeyResolverKey cacheKey) {
             this.delegate = delegate;
+            this.cacheKey = cacheKey;
         }
 
         @Override
@@ -180,8 +189,12 @@ public class VerificationKeyResolverFactory {
 
         @Override
         public void close() throws IOException {
-            if (count.decrementAndGet() == 0)
+            if (count.decrementAndGet() == 0) {
+                // Drop the cache entry so that a later get() with the same configuration builds a new
+                // resolver rather than resurrecting this closed one.
+                remove(cacheKey);
                 delegate.close();
+            }
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/BrokerJwtValidatorTest.java
@@ -21,20 +21,30 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.AccessTokenBuilder;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.CloseableVerificationKeyResolver;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 
 import org.apache.logging.log4j.Level;
 import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwx.JsonWebStructure;
 import org.jose4j.lang.InvalidAlgorithmException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.security.Key;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER;
+import static org.apache.kafka.common.config.internals.BrokerSecurityConfigs.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+import static org.apache.kafka.test.TestUtils.tempFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,10 +58,60 @@ public class BrokerJwtValidatorTest extends JwtValidatorTest {
 
     private static final String EXPECTED_AUDIENCE = "https://legit.example/other-service";
 
+    @AfterEach
+    public void tearDown() {
+        System.clearProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG);
+    }
+
     @Override
     protected JwtValidator createJwtValidator(AccessTokenBuilder builder) {
         CloseableVerificationKeyResolver resolver = (jws, nestingContext) -> builder.jwk().getKey();
         return new BrokerJwtValidator(resolver);
+    }
+
+    @Test
+    public void testCloseReleasesFactoryCreatedVerificationKeyResolver() throws Exception {
+        String file = tempFile("{\"keys\":[]}").toURI().toString();
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, file);
+        Map<String, ?> saslConfigs = getSaslConfigs(Map.of(
+                SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, file,
+                SASL_OAUTHBEARER_EXPECTED_ISSUER, EXPECTED_ISSUER,
+                SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, List.of(EXPECTED_AUDIENCE)));
+
+        CloseableVerificationKeyResolver cached = VerificationKeyResolverFactory.get(saslConfigs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+
+        BrokerJwtValidator validator = new BrokerJwtValidator();
+        validator.configure(saslConfigs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        validator.close();
+
+        // Closing the validator release the shared resolver. The factory should return a new one.
+        assertNotSame(cached, VerificationKeyResolverFactory.get(saslConfigs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()));
+    }
+
+    @Test
+    public void testCloseDoesNotCloseInjectedVerificationKeyResolver() throws Exception {
+        PublicJsonWebKey jwk = createRsaJwk();
+        AtomicBoolean closed = new AtomicBoolean();
+        CloseableVerificationKeyResolver resolver = new CloseableVerificationKeyResolver() {
+            @Override
+            public Key resolveKey(JsonWebSignature jws, List<JsonWebStructure> nestingContext) {
+                return jwk.getKey();
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        BrokerJwtValidator validator = new BrokerJwtValidator(resolver);
+        validator.configure(getSaslConfigs(Map.of(
+                        SASL_OAUTHBEARER_EXPECTED_ISSUER, EXPECTED_ISSUER,
+                        SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, List.of(EXPECTED_AUDIENCE))),
+                OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        validator.close();
+
+        // An injected resolver is owned by the code that supplied it; the validator must not close it.
+        assertFalse(closed.get());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/VerificationKeyResolverFactoryTest.java
@@ -30,6 +30,8 @@ import static org.apache.kafka.common.config.SaslConfigs.SASL_OAUTHBEARER_JWKS_E
 import static org.apache.kafka.common.config.internals.BrokerSecurityConfigs.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
 import static org.apache.kafka.test.TestUtils.tempFile;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class VerificationKeyResolverFactoryTest extends OAuthBearerTest {
 
@@ -43,7 +45,8 @@ public class VerificationKeyResolverFactoryTest extends OAuthBearerTest {
         String file = tempFile("{}").toURI().toString();
         System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, file);
         Map<String, ?> configs = Collections.singletonMap(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, file);
-        assertThrowsWithMessage(ConfigException.class, () -> VerificationKeyResolverFactory.create(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()), "The JSON JWKS content does not include the keys member");
+        CloseableVerificationKeyResolver verificationKeyResolver = VerificationKeyResolverFactory.create(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        assertThrowsWithMessage(ConfigException.class, () -> verificationKeyResolver.configure(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()), "The JSON JWKS content does not include the keys member");
     }
 
     @Test
@@ -52,7 +55,25 @@ public class VerificationKeyResolverFactoryTest extends OAuthBearerTest {
         String file = new File("/tmp/this-directory-does-not-exist/foo.json").toURI().toString();
         System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, file);
         Map<String, ?> configs = getSaslConfigs(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, file);
-        assertThrowsWithMessage(ConfigException.class, () -> VerificationKeyResolverFactory.create(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()), "that doesn't exist");
+        CloseableVerificationKeyResolver verificationKeyResolver = VerificationKeyResolverFactory.create(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        assertThrowsWithMessage(ConfigException.class, () -> verificationKeyResolver.configure(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()), "that doesn't exist");
+    }
+
+    @Test
+    public void testGetSharesResolverUntilLastClose() throws Exception {
+        String file = tempFile("{\"keys\":[]}").toURI().toString();
+        System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, file);
+        Map<String, ?> configs = Collections.singletonMap(SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, file);
+
+        CloseableVerificationKeyResolver resolver = VerificationKeyResolverFactory.get(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        assertSame(resolver, VerificationKeyResolverFactory.get(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()));
+
+        resolver.configure(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries());
+        resolver.close();
+
+        // Closing the last reference removes the cache entry, so the next get() creates a new resolver
+        // rather than returning the closed one.
+        assertNotSame(resolver, VerificationKeyResolverFactory.get(configs, OAUTHBEARER_MECHANISM, getJaasConfigEntries()));
     }
 
     @Test


### PR DESCRIPTION
### Why

`BrokerJwtValidator#configure` obtains a
`CloseableVerificationKeyResolver` from
`VerificationKeyResolverFactory.get()` but never closes it, so the JWKS
refresh thread of `RefreshingHttpsJwksVerificationKeyResolver` leaks.

### How

- `BrokerJwtValidator`
  - Keeps a reference to the resolver obtained from the factory,
configures it through the ref-counting wrapper, and releases it in
`close()`.
  - An injected resolver is not closed. Its lifecycle is managed by the
code that supplied it.
- `VerificationKeyResolverFactory`
  - `create()` no longer configures the resolver; initialization is
driven by the wrapper's `configure()`.
  - `RefCountingVerificationKeyResolver` removes its cache entry when
the last reference is closed, so a subsequent `get()` with the same
configuration builds a fresh resolver instead of returning the closed
one.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
