### PR TITLE
MINOR: Fix "does not exists" grammatical typos in messages and Javadoc

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/TransactionIndex.java
@@ -193,7 +193,7 @@ public class TransactionIndex implements Closeable {
 
     /**
      * Check if the index is empty.
-     * @return `true` if the index is empty (or) when underlying file doesn't exists, `false` otherwise.
+     * @return `true` if the index is empty (or) when underlying file doesn't exist, `false` otherwise.
      */
     public boolean isEmpty() {
         return !iterable().iterator().hasNext();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -475,7 +475,7 @@ public class StateDirectory implements AutoCloseable {
     /**
      * Get or create the directory for the global stores.
      * @return directory for the global stores
-     * @throws ProcessorStateException if the global store directory does not exists and could not be created
+     * @throws ProcessorStateException if the global store directory does not exist and could not be created
      */
     public File globalStateDir() {
         final File dir = new File(stateDir, "global");

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -168,7 +168,7 @@ public class MetadataQuorumCommand {
             return new Properties();
         } else {
             if (!optionalCommandConfig.exists())
-                throw new TerseException("Properties file " + optionalCommandConfig.getPath() + " does not exists!");
+                throw new TerseException("Properties file " + optionalCommandConfig.getPath() + " does not exist!");
             return Utils.loadProps(optionalCommandConfig.getPath());
         }
     }

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -168,7 +168,7 @@ public class MetadataQuorumCommand {
             return new Properties();
         } else {
             if (!optionalCommandConfig.exists())
-                throw new TerseException("Properties file " + optionalCommandConfig.getPath() + " does not exist!");
+                throw new TerseException("Properties file " + optionalCommandConfig.getPath() + " does not exist.");
             return Utils.loadProps(optionalCommandConfig.getPath());
         }
     }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -35,7 +35,7 @@ public class MetadataQuorumCommandErrorTest {
     public void testPropertiesFileDoesNotExist() {
         assertEquals(1,
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", "localhost:9092", "--command-config", "admin.properties", "describe"));
-        assertEquals("Properties file admin.properties does not exist!",
+        assertEquals("Properties file admin.properties does not exist.",
             ToolsTestUtils.captureStandardErr(() ->
                 MetadataQuorumCommand.mainNoExit("--bootstrap-server", "localhost:9092", "--command-config", "admin.properties", "describe")));
     }

--- a/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/MetadataQuorumCommandErrorTest.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MetadataQuorumCommandErrorTest {
 
     @Test
-    public void testPropertiesFileDoesNotExists() {
+    public void testPropertiesFileDoesNotExist() {
         assertEquals(1,
             MetadataQuorumCommand.mainNoExit("--bootstrap-server", "localhost:9092", "--command-config", "admin.properties", "describe"));
-        assertEquals("Properties file admin.properties does not exists!",
+        assertEquals("Properties file admin.properties does not exist!",
             ToolsTestUtils.captureStandardErr(() ->
                 MetadataQuorumCommand.mainNoExit("--bootstrap-server", "localhost:9092", "--command-config", "admin.properties", "describe")));
     }


### PR DESCRIPTION
Follow-up to #22544, fixing a few more occurrences of the same class of
typo found in a repo-wide sweep.

Fixes subject-verb agreement typos ("does not exists" → "does not
exist") in user-facing diagnostic messages and Javadoc:

- `StateDirectory` — `@throws` Javadoc: `"does not exists"` → `"does not
exist"`
- `TransactionIndex` — `@return` Javadoc: `"doesn't exists"` → `"doesn't
exist"`
- `MetadataQuorumCommand` — exception message: `"Properties file ...
does not exists!"` → `"...does not exist."`

Javadoc and string-literal changes only, with no behavior change. The
`MetadataQuorumCommandErrorTest` assertion and its test method name are
updated to match the corrected message.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Mickael Maison
 <mickael.maison@gmail.com>
