### PR TITLE
KAFKA-13976: Improve OpenAPI specs for Connect REST API

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.runtime.isolation.PluginUtils;
 import org.apache.kafka.connect.runtime.rest.RestRequestTimeout;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.entities.PluginInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.apache.kafka.connect.util.FutureCallback;
@@ -44,6 +45,12 @@ import java.util.concurrent.TimeoutException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
@@ -90,9 +97,45 @@ public class ConnectorPluginsResource {
 
     @PUT
     @Path("/{pluginName}/config/validate")
-    @Operation(summary = "Validate the provided configuration against the configuration definition for the specified pluginName")
+    @Operation(
+        summary = "Validate the provided configuration against the configuration definition for the specified pluginName",
+        requestBody = @RequestBody(
+            description = "The connector configuration properties to validate",
+            required = true,
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(type = "object", additionalPropertiesSchema = String.class)
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Configuration validation result returned successfully",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ConfigInfos.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid connector validation request",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ErrorMessage.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Configuration validation timed out or was interrupted",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ErrorMessage.class)
+            )
+        )
+    })
     public ConfigInfos validateConfigs(
-        final @PathParam("pluginName") String pluginName,
+        final @PathParam("pluginName") @Parameter(description = "The name of the connector plugin") String pluginName,
         final Map<String, String> connectorConfig
     ) throws Throwable {
         String includedConnType = connectorConfig.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
@@ -137,6 +180,14 @@ public class ConnectorPluginsResource {
 
     @GET
     @Operation(summary = "List all connector plugins installed")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Connector plugins retrieved successfully",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            array = @ArraySchema(schema = @Schema(implementation = PluginInfo.class))
+        )
+    )
     public List<PluginInfo> listConnectorPlugins(
             @DefaultValue("true") @QueryParam("connectorsOnly") @Parameter(description = "Whether to list only connectors instead of all plugins") boolean connectorsOnly
     ) {
@@ -154,8 +205,44 @@ public class ConnectorPluginsResource {
     @GET
     @Path("/{pluginName}/config")
     @Operation(summary = "Get the configuration definition for the specified pluginName")
-    public List<ConfigKeyInfo> getConnectorConfigDef(final @PathParam("pluginName") String pluginName,
-                                                     final @QueryParam("version") @DefaultValue("latest") String version) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector plugin configuration definition retrieved successfully",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                array = @ArraySchema(schema = @Schema(implementation = ConfigKeyInfo.class))
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid plugin version or type",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ErrorMessage.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector plugin not found",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ErrorMessage.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to load connector plugin class or dependencies",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(implementation = ErrorMessage.class)
+            )
+        )
+    })
+    public List<ConfigKeyInfo> getConnectorConfigDef(final @PathParam("pluginName") @Parameter(description = "The name of the connector plugin") String pluginName,
+                                                     final @QueryParam("version") @DefaultValue("latest")
+                                                     @Parameter(description = "The version requirement for the connector plugin")
+                                                     String version) {
 
         VersionRange range;
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -29,6 +29,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.CreateConnectorRequest;
+import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.entities.Message;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
@@ -47,6 +48,13 @@ import java.util.Map;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletContext;
 import jakarta.ws.rs.BadRequestException;
@@ -98,7 +106,23 @@ public class ConnectorsResource {
     }
 
     @GET
-    @Operation(summary = "List all active connectors")
+    @Operation(
+        summary = "List all active connectors",
+        parameters = @Parameter(
+            name = "expand",
+            in = ParameterIn.QUERY,
+            description = "Optional connector details to expand. Supported values are status and info. Repeat this parameter to include both",
+            array = @ArraySchema(schema = @Schema(type = "string", allowableValues = {"status", "info"}))
+        )
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Connector names retrieved successfully. When expand is supplied, connector details are returned keyed by connector name",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(oneOf = {String[].class, Object.class})
+        )
+    )
     public Response listConnectors(
         final @Context UriInfo uriInfo,
         final @Context HttpHeaders headers
@@ -135,7 +159,35 @@ public class ConnectorsResource {
     }
 
     @POST
-    @Operation(summary = "Create a new connector")
+    @Operation(
+        summary = "Create a new connector",
+        requestBody = @RequestBody(
+            required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = CreateConnectorRequest.class))
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "Connector created successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid connector creation request or configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Connector already exists or request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while creating the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
     public Response createConnector(final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
                                     final @Context HttpHeaders headers,
                                     final CreateConnectorRequest createRequest) throws Throwable {
@@ -159,7 +211,24 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}")
     @Operation(summary = "Get the details for the specified connector")
-    public ConnectorInfo getConnector(final @PathParam("connector") String connector) throws Throwable {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector details retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while retrieving connector details",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public ConnectorInfo getConnector(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) throws Throwable {
         FutureCallback<ConnectorInfo> cb = new FutureCallback<>();
         herder.connectorInfo(connector, cb);
         return requestHandler.completeRequest(cb);
@@ -168,7 +237,24 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}/config")
     @Operation(summary = "Get the configuration for the specified connector")
-    public Map<String, String> getConnectorConfig(final @PathParam("connector") String connector) throws Throwable {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector configuration retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = "object", additionalPropertiesSchema = String.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while retrieving the connector configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Map<String, String> getConnectorConfig(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) throws Throwable {
         FutureCallback<Map<String, String>> cb = new FutureCallback<>();
         herder.connectorConfig(connector, cb);
         return requestHandler.completeRequest(cb);
@@ -177,14 +263,41 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}/status")
     @Operation(summary = "Get the status for the specified connector")
-    public ConnectorStateInfo getConnectorStatus(final @PathParam("connector") String connector) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector status retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorStateInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public ConnectorStateInfo getConnectorStatus(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) {
         return herder.connectorStatus(connector);
     }
 
     @GET
     @Path("/{connector}/topics")
     @Operation(summary = "Get the list of topics actively used by the specified connector")
-    public Response getConnectorActiveTopics(final @PathParam("connector") String connector) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector active topics retrieved successfully",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(type = "object", additionalPropertiesSchema = ActiveTopicsInfo.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Topic tracking is disabled",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response getConnectorActiveTopics(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) {
         if (isTopicTrackingDisabled) {
             throw new ConnectRestException(Response.Status.FORBIDDEN.getStatusCode(),
                     "Topic tracking is disabled.");
@@ -196,7 +309,19 @@ public class ConnectorsResource {
     @PUT
     @Path("/{connector}/topics/reset")
     @Operation(summary = "Reset the list of topics actively used by the specified connector")
-    public Response resetConnectorActiveTopics(final @PathParam("connector") String connector, final @Context HttpHeaders headers) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "202",
+            description = "Connector active topics reset request accepted"
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Topic tracking or topic tracking reset is disabled",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response resetConnectorActiveTopics(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
+                                               final @Context HttpHeaders headers) {
         if (isTopicTrackingDisabled) {
             throw new ConnectRestException(Response.Status.FORBIDDEN.getStatusCode(),
                     "Topic tracking is disabled.");
@@ -211,8 +336,42 @@ public class ConnectorsResource {
 
     @PUT
     @Path("/{connector}/config")
-    @Operation(summary = "Create or reconfigure the specified connector")
-    public Response putConnectorConfig(final @PathParam("connector") String connector,
+    @Operation(
+        summary = "Create or reconfigure the specified connector",
+        requestBody = @RequestBody(
+            description = "The full connector configuration used to create the connector or replace its existing configuration",
+            required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = "object", additionalPropertiesSchema = String.class))
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector reconfigured successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "201",
+            description = "Connector created successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid connector configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while creating or updating the connector configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response putConnectorConfig(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                        final @Context HttpHeaders headers,
                                        final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
                                        final Map<String, String> connectorConfig) throws Throwable {
@@ -234,7 +393,46 @@ public class ConnectorsResource {
 
     @PATCH
     @Path("/{connector}/config")
-    public Response patchConnectorConfig(final @PathParam("connector") String connector,
+    @Operation(
+        summary = "Patch the configuration for the specified connector",
+        requestBody = @RequestBody(
+            description = "The connector configuration patch. Properties with non-null values are updated or added, and properties with null values are removed",
+            required = true,
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(type = "object"),
+                additionalPropertiesSchema = @Schema(type = "string", nullable = true)
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector configuration patched successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid connector configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while patching the connector configuration",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response patchConnectorConfig(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                          final @Context HttpHeaders headers,
                                          final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
                                          final Map<String, String> connectorConfigPatch) throws Throwable {
@@ -248,7 +446,33 @@ public class ConnectorsResource {
     @POST
     @Path("/{connector}/restart")
     @Operation(summary = "Restart the specified connector")
-    public Response restartConnector(final @PathParam("connector") String connector,
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "202",
+            description = "Restart request accepted when includeTasks or onlyFailed is true",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorStateInfo.class))
+        ),
+        @ApiResponse(
+            responseCode = "204",
+            description = "Connector restarted successfully when includeTasks and onlyFailed are false"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while restarting the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response restartConnector(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                  final @Context HttpHeaders headers,
                                  final @DefaultValue("false") @QueryParam("includeTasks") @Parameter(description = "Whether to also restart tasks") Boolean includeTasks,
                                  final @DefaultValue("false") @QueryParam("onlyFailed") @Parameter(description = "Whether to only restart failed tasks/connectors")Boolean onlyFailed,
@@ -278,8 +502,29 @@ public class ConnectorsResource {
     @Path("/{connector}/stop")
     @Operation(summary = "Stop the specified connector",
                description = "This operation is idempotent and has no effects if the connector is already stopped")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "Connector stopped successfully"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while stopping the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
     public void stopConnector(
-            @PathParam("connector") String connector,
+            @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
             final @Context HttpHeaders headers,
             final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
@@ -291,7 +536,24 @@ public class ConnectorsResource {
     @Path("/{connector}/pause")
     @Operation(summary = "Pause the specified connector",
                description = "This operation is idempotent and has no effects if the connector is already paused")
-    public Response pauseConnector(@PathParam("connector") String connector, final @Context HttpHeaders headers) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "202",
+            description = "Connector pause request accepted"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while pausing the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response pauseConnector(@PathParam("connector") @Parameter(description = "The name of the connector") String connector,
+                                   final @Context HttpHeaders headers) {
         herder.pauseConnector(connector);
         return Response.accepted().build();
     }
@@ -300,7 +562,23 @@ public class ConnectorsResource {
     @Path("/{connector}/resume")
     @Operation(summary = "Resume the specified connector",
                description = "This operation is idempotent and has no effects if the connector is already running")
-    public Response resumeConnector(@PathParam("connector") String connector) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "202",
+            description = "Connector resume request accepted"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while resuming the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response resumeConnector(@PathParam("connector") @Parameter(description = "The name of the connector") String connector) {
         herder.resumeConnector(connector);
         return Response.accepted().build();
     }
@@ -308,7 +586,24 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}/tasks")
     @Operation(summary = "List all tasks and their configurations for the specified connector")
-    public List<TaskInfo> getTaskConfigs(final @PathParam("connector") String connector) throws Throwable {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector task configurations retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = TaskInfo.class)))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while retrieving task configurations",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public List<TaskInfo> getTaskConfigs(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) throws Throwable {
         FutureCallback<List<TaskInfo>> cb = new FutureCallback<>();
         herder.taskConfigs(connector, cb);
         return requestHandler.completeRequest(cb);
@@ -317,17 +612,50 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}/tasks/{task}/status")
     @Operation(summary = "Get the state of the specified task for the specified connector")
-    public ConnectorStateInfo.TaskState getTaskStatus(final @PathParam("connector") String connector,
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Task status retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorStateInfo.TaskState.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector or task not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public ConnectorStateInfo.TaskState getTaskStatus(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                                       final @Context HttpHeaders headers,
-                                                      final @PathParam("task") Integer task) {
+                                                      final @PathParam("task") @Parameter(description = "The task ID") Integer task) {
         return herder.taskStatus(new ConnectorTaskId(connector, task));
     }
 
     @POST
     @Path("/{connector}/tasks/{task}/restart")
     @Operation(summary = "Restart the specified task for the specified connector")
-    public void restartTask(final @PathParam("connector") String connector,
-                            final @PathParam("task") Integer task,
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "Task restarted successfully"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector or task not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while restarting the task",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public void restartTask(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
+                            final @PathParam("task") @Parameter(description = "The task ID") Integer task,
                             final @Context HttpHeaders headers,
                             final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
@@ -339,7 +667,28 @@ public class ConnectorsResource {
     @DELETE
     @Path("/{connector}")
     @Operation(summary = "Delete the specified connector")
-    public void destroyConnector(final @PathParam("connector") String connector,
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "Connector deleted successfully"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while deleting the connector",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public void destroyConnector(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                  final @Context HttpHeaders headers,
                                  final @Parameter(hidden = true) @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
@@ -350,7 +699,24 @@ public class ConnectorsResource {
     @GET
     @Path("/{connector}/offsets")
     @Operation(summary = "Get the current offsets for the specified connector")
-    public ConnectorOffsets getOffsets(final @PathParam("connector") String connector) throws Throwable {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector offsets retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorOffsets.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while retrieving connector offsets",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public ConnectorOffsets getOffsets(final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) throws Throwable {
         FutureCallback<ConnectorOffsets> cb = new FutureCallback<>();
         herder.connectorOffsets(connector, cb);
         return requestHandler.completeRequest(cb);
@@ -358,9 +724,44 @@ public class ConnectorsResource {
 
     @PATCH
     @Path("/{connector}/offsets")
-    @Operation(summary = "Alter the offsets for the specified connector")
+    @Operation(
+        summary = "Alter the offsets for the specified connector",
+        requestBody = @RequestBody(
+            description = "The connector offsets to write. A null offset removes the offset for that partition",
+            required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorOffsets.class))
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector offsets altered successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Message.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid connector offsets or the connector is not in the STOPPED state",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while altering connector offsets",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
     public Response alterConnectorOffsets(final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
-                                          final @Context HttpHeaders headers, final @PathParam("connector") String connector,
+                                          final @Context HttpHeaders headers,
+                                          final @PathParam("connector") @Parameter(description = "The name of the connector") String connector,
                                           final ConnectorOffsets offsets) throws Throwable {
         if (offsets.offsets() == null || offsets.offsets().isEmpty()) {
             throw new BadRequestException("Partitions / offsets need to be provided for an alter offsets request");
@@ -376,8 +777,36 @@ public class ConnectorsResource {
     @DELETE
     @Path("/{connector}/offsets")
     @Operation(summary = "Reset the offsets for the specified connector")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Connector offsets reset successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Message.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Connector not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Connector is not in the STOPPED state",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Request cannot be completed while a rebalance is in progress",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while resetting connector offsets",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
     public Response resetConnectorOffsets(final @Parameter(hidden = true) @QueryParam("forward") Boolean forward,
-                                          final @Context HttpHeaders headers, final @PathParam("connector") String connector) throws Throwable {
+                                          final @Context HttpHeaders headers,
+                                          final @PathParam("connector") @Parameter(description = "The name of the connector") String connector) throws Throwable {
         FutureCallback<Message> cb = new FutureCallback<>();
         herder.resetConnectorOffsets(connector, cb);
         Message msg = requestHandler.completeOrForwardRequest(cb, "/connectors/" + connector + "/offsets", "DELETE", headers, null,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResource.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.rest.resources;
 
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.rest.entities.ErrorMessage;
 import org.apache.kafka.connect.runtime.rest.entities.LoggerLevel;
 import org.apache.kafka.connect.runtime.rest.errors.BadRequestException;
 
@@ -30,6 +31,13 @@ import java.util.Objects;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
@@ -69,6 +77,11 @@ public class LoggingResource {
      */
     @GET
     @Operation(summary = "List the current loggers that have their levels explicitly set and their log levels")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Logger levels retrieved successfully",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = "object", additionalPropertiesSchema = LoggerLevel.class))
+    )
     public Response listLoggers() {
         return Response.ok(herder.allLoggerLevels()).build();
     }
@@ -82,7 +95,19 @@ public class LoggingResource {
     @GET
     @Path("/{logger}")
     @Operation(summary = "Get the log level for the specified logger")
-    public Response getLogger(final @PathParam("logger") String namedLogger) {
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Logger level retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = LoggerLevel.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Logger not found",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
+    public Response getLogger(final @PathParam("logger") @Parameter(description = "The name of the logger") String namedLogger) {
         Objects.requireNonNull(namedLogger, "require non-null name");
 
         LoggerLevel loggerLevel = herder.loggerLevel(namedLogger);
@@ -102,9 +127,48 @@ public class LoggingResource {
      */
     @PUT
     @Path("/{logger}")
-    @Operation(summary = "Set the log level for the specified logger")
+    @Operation(
+        summary = "Set the log level for the specified logger",
+        requestBody = @RequestBody(
+            description = "The log level configuration",
+            required = true,
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                schema = @Schema(type = "object", requiredProperties = "level"),
+                schemaProperties = @SchemaProperty(name = "level", schema = @Schema(type = "string", description = "The log level to set"))
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Worker logger level set successfully",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON,
+                array = @ArraySchema(schema = @Schema(type = "string", description = "The names of loggers whose levels were changed")))
+        ),
+        @ApiResponse(
+            responseCode = "204",
+            description = "Cluster logger level set successfully"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Log level was not specified",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Invalid log level",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Request timed out or failed unexpectedly while setting the cluster logger level",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorMessage.class))
+        )
+    })
     @SuppressWarnings("fallthrough")
-    public Response setLevel(final @PathParam("logger") String namespace,
+    public Response setLevel(final @PathParam("logger") @Parameter(description = "The name of the logger") String namespace,
                              final Map<String, String> levelMap,
                              @DefaultValue("worker") @QueryParam("scope") @Parameter(description = "The scope for the logging modification (single-worker, cluster-wide, etc.)") String scope) {
         if (scope == null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/RootResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/RootResource.java
@@ -29,6 +29,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -58,6 +62,11 @@ public class RootResource {
 
     @GET
     @Operation(summary = "Get details about this Connect worker and the ID of the Kafka cluster it is connected to")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Connect worker details retrieved successfully",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ServerInfo.class))
+    )
     public ServerInfo serverInfo() {
         return new ServerInfo(herder.kafkaClusterId());
     }
@@ -65,6 +74,23 @@ public class RootResource {
     @GET
     @Path("/health")
     @Operation(summary = "Health check endpoint to verify worker readiness and liveness")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Worker has completed startup and is ready to handle requests",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = WorkerStatus.class))
+        ),
+        @ApiResponse(
+            responseCode = "503",
+            description = "Worker is still starting up",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = WorkerStatus.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Worker was unable to handle this request and may be unable to handle other requests",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = WorkerStatus.class))
+        )
+    })
     public Response healthCheck() throws Throwable {
         WorkerStatus workerStatus;
         int statusCode;


### PR DESCRIPTION
This PR improves response documentation in the generated OpenAPI specification by defining response schemas and documenting response codes for the public Kafka Connect REST endpoints.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
