### PR TITLE
MINOR: Replace deprecated TopologyTestDriver constructor in TestTopicsTest

### DIFF
--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -76,7 +76,7 @@ public class TestTopicsTest {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);
         properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);
-        testDriver = new TopologyTestDriver(builder.build(), properties);
+        testDriver = new TopologyTestDriverBuilder(builder.build()).withConfig(properties).build();
     }
 
     @AfterEach


### PR DESCRIPTION
This patch updates `TestTopicsTest` to use `TopologyTestDriverBuilder`
instead of the deprecated `TopologyTestDriver` constructor.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
