### PR TITLE
KAFKA-20719: "Streams" group sticky assignor not sticky at startup

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -46,6 +46,17 @@ public class StickyTaskAssignor implements TaskAssignor {
     private static final String STICKY_ASSIGNOR_NAME = "sticky";
     private static final Logger log = LoggerFactory.getLogger(StickyTaskAssignor.class);
 
+    /** Offset sum for a task whose state the member does not hold, or does not report an offset for. */
+    private static final long UNKNOWN_OFFSET_SUM = -1L;
+
+    /**
+     * Standbys from the target assignment rank ahead of members only known to hold state through their reported
+     * offsets; within each group, the most caught-up state comes first.
+     */
+    private static final Comparator<StandbyCandidate> STANDBY_CANDIDATE_ORDER =
+        Comparator.comparingInt((StandbyCandidate candidate) -> candidate.isPrevStandby() ? 0 : 1)
+            .thenComparing(Comparator.comparingLong(StandbyCandidate::offsetSum).reversed());
+
     @Override
     public String name() {
         return STICKY_ASSIGNOR_NAME;
@@ -117,7 +128,9 @@ public class StickyTaskAssignor implements TaskAssignor {
 
         localState.processIdToState = new HashMap<>(localState.totalMembersWithActiveTaskCapacity);
         localState.activeTaskToPrevMember = new HashMap<>(localState.totalActiveTasks);
-        localState.standbyTaskToPrevMember = new HashMap<>(localState.numStandbyReplicas > 0 ? (localState.totalTasks - localState.totalActiveTasks) / localState.numStandbyReplicas : 0);
+
+        // Standby-strength candidates per task, gathered in a single pass over the members and ranked below.
+        final Map<TaskId, ArrayList<StandbyCandidate>> standbyCandidates = new HashMap<>();
         for (final String memberId : groupSpec.memberIds()) {
             final MemberAssignmentState memberAssignmentState = groupSpec.memberAssignmentState(memberId);
             final String processId = groupSpec.memberMetadata(memberId).processId();
@@ -134,55 +147,73 @@ public class StickyTaskAssignor implements TaskAssignor {
                 }
             }
 
-            // prev standby tasks
-            for (final Map.Entry<String, Set<Integer>> entry : memberAssignmentState.standbyTasks().entrySet()) {
-                final Set<Integer> partitionNoSet = entry.getValue();
-                for (final int partitionNo : partitionNoSet) {
-                    final TaskId taskId = new TaskId(entry.getKey(), partitionNo);
-                    localState.standbyTaskToPrevMember.putIfAbsent(taskId, new ArrayList<>(localState.numStandbyReplicas));
-                    localState.standbyTaskToPrevMember.get(taskId).add(member);
-                }
-            }
+            collectStandbyCandidates(standbyCandidates, memberAssignmentState, member);
         }
 
-        maybeAddOffsetBasedPrevMembers(localState, groupSpec);
+        localState.standbyTaskToPrevMember = rankStandbyCandidates(standbyCandidates);
         return localState;
     }
 
-    /**
-     * A member that rejoins after a restart gets a fresh member ID and an empty target assignment, so the previous
-     * ownership maps cannot capture that it owned any tasks before the restart. Such members report cumulative
-     * offsets for tasks with state on local disk; treat them like previous standbys of those tasks, so that the
-     * stickiness phases assign the tasks back to the local state, most caught-up state first. Members already known
-     * as previous standbys keep precedence over offset-based candidates.
-     */
-    private static void maybeAddOffsetBasedPrevMembers(final LocalState localState, final GroupSpec groupSpec) {
-        final Map<TaskId, ArrayList<MemberAndOffsetSum>> tasksWithReportedOffsets = new HashMap<>();
-        for (final String memberId : groupSpec.memberIds()) {
-            final Member member = new Member(groupSpec.memberMetadata(memberId).processId(), memberId);
-            for (final Map.Entry<String, Map<Integer, Long>> subtopologyOffsets : groupSpec.memberAssignmentState(memberId).taskOffsets().entrySet()) {
-                for (final Map.Entry<Integer, Long> partitionOffset : subtopologyOffsets.getValue().entrySet()) {
-                    if (partitionOffset.getValue() < 0) {
-                        continue;
-                    }
-                    tasksWithReportedOffsets
-                        .computeIfAbsent(new TaskId(subtopologyOffsets.getKey(), partitionOffset.getKey()), task -> new ArrayList<>())
-                        .add(new MemberAndOffsetSum(member, partitionOffset.getValue()));
-                }
+    private static void collectStandbyCandidates(final Map<TaskId, ArrayList<StandbyCandidate>> standbyCandidates,
+                                                 final MemberAssignmentState memberAssignmentState,
+                                                 final Member member) {
+        // prev standby tasks, carrying any reported offset sum so the most caught-up standby ranks first
+        for (final Map.Entry<String, Set<Integer>> entry : memberAssignmentState.standbyTasks().entrySet()) {
+            final String subtopologyId = entry.getKey();
+            final Set<Integer> partitionNoSet = entry.getValue();
+            for (final int partitionNo : partitionNoSet) {
+                standbyCandidates
+                    .computeIfAbsent(new TaskId(subtopologyId, partitionNo), task -> new ArrayList<>())
+                    .add(new StandbyCandidate(member, true, reportedOffsetSum(memberAssignmentState, subtopologyId, partitionNo)));
             }
         }
 
-        for (final Map.Entry<TaskId, ArrayList<MemberAndOffsetSum>> entry : tasksWithReportedOffsets.entrySet()) {
-            final ArrayList<Member> candidates =
-                localState.standbyTaskToPrevMember.computeIfAbsent(entry.getKey(), task -> new ArrayList<>());
-            final Set<String> knownMemberIds = candidates.stream().map(candidate -> candidate.memberId).collect(Collectors.toSet());
-            entry.getValue().sort(Comparator.comparingLong(MemberAndOffsetSum::offsetSum).reversed());
-            for (final MemberAndOffsetSum memberAndOffsetSum : entry.getValue()) {
-                if (knownMemberIds.add(memberAndOffsetSum.member().memberId)) {
-                    candidates.add(memberAndOffsetSum.member());
+        // A member that rejoins after a restart gets a fresh member ID and an empty target assignment, so the maps
+        // above cannot capture what it owned before. Offsets reported for tasks with state on local disk make it a
+        // weaker standby candidate, so stickiness can still hand those tasks back to the local state.
+        for (final Map.Entry<String, Map<Integer, Long>> entry : memberAssignmentState.taskOffsets().entrySet()) {
+            final String subtopologyId = entry.getKey();
+            for (final Map.Entry<Integer, Long> partitionOffset : entry.getValue().entrySet()) {
+                final int partitionNo = partitionOffset.getKey();
+                if (partitionOffset.getValue() < 0 || isStandbyTask(memberAssignmentState, subtopologyId, partitionNo)) {
+                    continue;
                 }
+                standbyCandidates
+                    .computeIfAbsent(new TaskId(subtopologyId, partitionNo), task -> new ArrayList<>())
+                    .add(new StandbyCandidate(member, false, partitionOffset.getValue()));
             }
         }
+    }
+
+    private static Map<TaskId, ArrayList<Member>> rankStandbyCandidates(final Map<TaskId, ArrayList<StandbyCandidate>> standbyCandidates) {
+        final Map<TaskId, ArrayList<Member>> standbyTaskToPrevMember = new HashMap<>(standbyCandidates.size());
+        standbyCandidates.forEach((taskId, candidates) -> {
+            candidates.sort(STANDBY_CANDIDATE_ORDER);
+            final ArrayList<Member> prevMembers = new ArrayList<>(candidates.size());
+            for (final StandbyCandidate candidate : candidates) {
+                prevMembers.add(candidate.member());
+            }
+            standbyTaskToPrevMember.put(taskId, prevMembers);
+        });
+        return standbyTaskToPrevMember;
+    }
+
+    private static long reportedOffsetSum(final MemberAssignmentState memberAssignmentState,
+                                          final String subtopologyId,
+                                          final int partitionNo) {
+        final Map<Integer, Long> subtopologyOffsets = memberAssignmentState.taskOffsets().get(subtopologyId);
+        if (subtopologyOffsets == null) {
+            return UNKNOWN_OFFSET_SUM;
+        }
+        final Long offsetSum = subtopologyOffsets.get(partitionNo);
+        return offsetSum == null || offsetSum < 0 ? UNKNOWN_OFFSET_SUM : offsetSum;
+    }
+
+    private static boolean isStandbyTask(final MemberAssignmentState memberAssignmentState,
+                                         final String subtopologyId,
+                                         final int partitionNo) {
+        final Set<Integer> partitionNoSet = memberAssignmentState.standbyTasks().get(subtopologyId);
+        return partitionNoSet != null && partitionNoSet.contains(partitionNo);
     }
 
     private static GroupAssignment buildGroupAssignment(final LocalState localState, final Collection<String> members) {
@@ -221,8 +252,8 @@ public class StickyTaskAssignor implements TaskAssignor {
     private static Map<String, Set<Integer>> toCompactedTaskIds(final Set<TaskId> taskIds) {
         final Map<String, Set<Integer>> ret = new HashMap<>();
         for (final TaskId taskId : taskIds) {
-            ret.putIfAbsent(taskId.subtopologyId(), new HashSet<>());
-            ret.get(taskId.subtopologyId()).add(taskId.partition());
+            ret.computeIfAbsent(taskId.subtopologyId(), subtopologyId -> new HashSet<>())
+                .add(taskId.partition());
         }
         return ret;
     }
@@ -476,7 +507,7 @@ public class StickyTaskAssignor implements TaskAssignor {
         }
     }
 
-    private record MemberAndOffsetSum(Member member, long offsetSum) {
+    private record StandbyCandidate(Member member, boolean isPrevStandby, long offsetSum) {
     }
 
     private static class LocalState {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -133,8 +133,8 @@ public class StickyTaskAssignor implements TaskAssignor {
             final String processId = groupSpec.memberMetadata(memberId).processId();
             final Member member = new Member(processId, memberId);
 
-            localState.processIdToState.putIfAbsent(processId, new ProcessState(processId));
-            localState.processIdToState.get(processId).addMember(memberId);
+            localState.processIdToState.computeIfAbsent(processId, ProcessState::new)
+                .addMember(memberId);
 
             // prev active tasks
             for (final Map.Entry<String, Set<Integer>> entry : memberAssignmentState.activeTasks().entrySet()) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -46,9 +46,6 @@ public class StickyTaskAssignor implements TaskAssignor {
     private static final String STICKY_ASSIGNOR_NAME = "sticky";
     private static final Logger log = LoggerFactory.getLogger(StickyTaskAssignor.class);
 
-    /** Offset sum for a task whose state the member does not hold, or does not report an offset for. */
-    private static final long UNKNOWN_OFFSET_SUM = -1L;
-
     /**
      * Standbys from the target assignment rank ahead of members only known to hold state through their reported
      * offsets; within each group, the most caught-up state comes first.
@@ -175,7 +172,7 @@ public class StickyTaskAssignor implements TaskAssignor {
             final String subtopologyId = entry.getKey();
             for (final Map.Entry<Integer, Long> partitionOffset : entry.getValue().entrySet()) {
                 final int partitionNo = partitionOffset.getKey();
-                if (partitionOffset.getValue() < 0 || isStandbyTask(memberAssignmentState, subtopologyId, partitionNo)) {
+                if (isStandbyTask(memberAssignmentState, subtopologyId, partitionNo)) {
                     continue;
                 }
                 standbyCandidates
@@ -198,15 +195,13 @@ public class StickyTaskAssignor implements TaskAssignor {
         return standbyTaskToPrevMember;
     }
 
+    /** Falls back to {@code 0} when no offset is reported, the conservative bound implying maximum lag. */
     private static long reportedOffsetSum(final MemberAssignmentState memberAssignmentState,
                                           final String subtopologyId,
                                           final int partitionNo) {
-        final Map<Integer, Long> subtopologyOffsets = memberAssignmentState.taskOffsets().get(subtopologyId);
-        if (subtopologyOffsets == null) {
-            return UNKNOWN_OFFSET_SUM;
-        }
-        final Long offsetSum = subtopologyOffsets.get(partitionNo);
-        return offsetSum == null || offsetSum < 0 ? UNKNOWN_OFFSET_SUM : offsetSum;
+        return memberAssignmentState.taskOffsets()
+            .getOrDefault(subtopologyId, Map.of())
+            .getOrDefault(partitionNo, 0L);
     }
 
     private static boolean isStandbyTask(final MemberAssignmentState memberAssignmentState,

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -144,7 +144,45 @@ public class StickyTaskAssignor implements TaskAssignor {
                 }
             }
         }
+
+        maybeAddOffsetBasedPrevMembers(localState, groupSpec);
         return localState;
+    }
+
+    /**
+     * A member that rejoins after a restart gets a fresh member ID and an empty target assignment, so the previous
+     * ownership maps cannot capture that it owned any tasks before the restart. Such members report cumulative
+     * offsets for tasks with state on local disk; treat them like previous standbys of those tasks, so that the
+     * stickiness phases assign the tasks back to the local state, most caught-up state first. Members already known
+     * as previous standbys keep precedence over offset-based candidates.
+     */
+    private static void maybeAddOffsetBasedPrevMembers(final LocalState localState, final GroupSpec groupSpec) {
+        final Map<TaskId, ArrayList<MemberAndOffsetSum>> tasksWithReportedOffsets = new HashMap<>();
+        for (final String memberId : groupSpec.memberIds()) {
+            final Member member = new Member(groupSpec.memberMetadata(memberId).processId(), memberId);
+            for (final Map.Entry<String, Map<Integer, Long>> subtopologyOffsets : groupSpec.memberAssignmentState(memberId).taskOffsets().entrySet()) {
+                for (final Map.Entry<Integer, Long> partitionOffset : subtopologyOffsets.getValue().entrySet()) {
+                    if (partitionOffset.getValue() < 0) {
+                        continue;
+                    }
+                    tasksWithReportedOffsets
+                        .computeIfAbsent(new TaskId(subtopologyOffsets.getKey(), partitionOffset.getKey()), task -> new ArrayList<>())
+                        .add(new MemberAndOffsetSum(member, partitionOffset.getValue()));
+                }
+            }
+        }
+
+        for (final Map.Entry<TaskId, ArrayList<MemberAndOffsetSum>> entry : tasksWithReportedOffsets.entrySet()) {
+            final ArrayList<Member> candidates =
+                localState.standbyTaskToPrevMember.computeIfAbsent(entry.getKey(), task -> new ArrayList<>());
+            final Set<String> knownMemberIds = candidates.stream().map(candidate -> candidate.memberId).collect(Collectors.toSet());
+            entry.getValue().sort(Comparator.comparingLong(MemberAndOffsetSum::offsetSum).reversed());
+            for (final MemberAndOffsetSum memberAndOffsetSum : entry.getValue()) {
+                if (knownMemberIds.add(memberAndOffsetSum.member().memberId)) {
+                    candidates.add(memberAndOffsetSum.member());
+                }
+            }
+        }
     }
 
     private static GroupAssignment buildGroupAssignment(final LocalState localState, final Collection<String> members) {
@@ -436,6 +474,9 @@ public class StickyTaskAssignor implements TaskAssignor {
             this.processId = processId;
             this.memberId = memberId;
         }
+    }
+
+    private record MemberAndOffsetSum(Member member, long offsetSum) {
     }
 
     private static class LocalState {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -172,7 +172,7 @@ public class StickyTaskAssignor implements TaskAssignor {
             final String subtopologyId = entry.getKey();
             for (final Map.Entry<Integer, Long> partitionOffset : entry.getValue().entrySet()) {
                 final int partitionNo = partitionOffset.getKey();
-                if (isStandbyTask(memberAssignmentState, subtopologyId, partitionNo)) {
+                if (isCurrentlyAssignedStandbyTask(memberAssignmentState, subtopologyId, partitionNo)) {
                     continue;
                 }
                 standbyCandidates
@@ -204,9 +204,9 @@ public class StickyTaskAssignor implements TaskAssignor {
             .getOrDefault(partitionNo, 0L);
     }
 
-    private static boolean isStandbyTask(final MemberAssignmentState memberAssignmentState,
-                                         final String subtopologyId,
-                                         final int partitionNo) {
+    private static boolean isCurrentlyAssignedStandbyTask(final MemberAssignmentState memberAssignmentState,
+                                                          final String subtopologyId,
+                                                          final int partitionNo) {
         final Set<Integer> partitionNoSet = memberAssignmentState.standbyTasks().get(subtopologyId);
         return partitionNoSet != null && partitionNoSet.contains(partitionNo);
     }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1454,6 +1454,49 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
+    public void shouldPreferPreviousStandbyWithHigherReportedTaskOffsetSum() {
+        // Several previous standbys of the same task: the one reporting the most caught-up state is promoted to
+        // active, rather than whichever one the member iteration order happened to visit first.
+        final Map<String, Set<Integer>> standbyForTask0 = mkMap(mkEntry("test-subtopology", Set.of(0)));
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithStandbysAndOffsets("process1",
+            standbyForTask0, mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 50L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithStandbysAndOffsets("process2",
+            standbyForTask0, mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
+    }
+
+    @Test
+    public void shouldPreferPreviousStandbyWithoutReportedOffsetsOverOffsetOnlyCandidate() {
+        // Upgrade case: a previous standby on an old client that does not report offsets yet must still outrank a
+        // member that is only known to hold state through its reported offsets.
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadata("process1",
+            Map.of(), mkMap(mkEntry("test-subtopology", Set.of(0))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
     public void shouldPreferMemberReportingHigherTaskOffsetSum() {
         // When several processes hold state for the same task, the most caught-up one wins.
         final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
@@ -1667,6 +1710,23 @@ public class StickyTaskAssignorTest {
             Map.of(),
             Map.of(),
             Map.of(),
+            Map.of());
+    }
+
+    private MemberMetadataAndStateImpl createMemberMetadataWithStandbysAndOffsets(
+        final String processId,
+        final Map<String, Set<Integer>> prevStandbyTasks,
+        final Map<String, Map<Integer, Long>> taskOffsets
+    ) {
+        return new MemberMetadataAndStateImpl(
+            Optional.empty(),
+            Optional.empty(),
+            processId,
+            Map.of(),
+            Map.of(),
+            prevStandbyTasks,
+            Map.of(),
+            taskOffsets,
             Map.of());
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1319,7 +1319,8 @@ public class StickyTaskAssignorTest {
         // -> it should not go to member2/process2 due to load balancing of active tasks
         // standby 2 should stay on member2/process2 -> no reason to move it (load of member2 stays within capacity)
         // standby 0,1: one *must* go to member4/process4 due to load balancing
-        // -> the other one can go anywhere but member2/process2 due to load balancing
+        // -> standby 0 can go anywhere but member2/process2 due to load balancing
+        // -> standby 1 can not go to member3, so only member 1 is left for this case, due to load balancing
         //
         // expected new assignment [active] [standby]
         // ("expected" here means, based on the concrete implementation -- if this test fails with a different but
@@ -1342,20 +1343,47 @@ public class StickyTaskAssignorTest {
             new TopologyDescriberImpl(3, true, List.of("test-subtopology"))
         );
 
-        assertEquals(Set.of(2), getActiveTasks(result, "test-subtopology", "member1"));
-        // if this is not empty, but only hold standby 0 or 1, still correct
-        assertEquals(List.of(), getAllStandbyTaskIds(result, "member1"));
+        @SuppressWarnings("unchecked")
+        final HashMap<String, List<Integer>>[] resultInvariants = new HashMap[3];
+        resultInvariants[0] = new HashMap<>();
+        resultInvariants[0].put("member1", List.of()); // may be empty
+        resultInvariants[0].put("member2", List.of(2)); // standby-2 should always be on member2
+        resultInvariants[0].put("member3", List.of(0)); // can never hold standby-1
+        resultInvariants[0].put("member4", List.of(1));
 
+        resultInvariants[1] = new HashMap<>();
+        resultInvariants[1].put("member1", List.of(1));
+        resultInvariants[1].put("member2", List.of(2)); // standby-2 should always be on member2
+        resultInvariants[1].put("member3", List.of()); // may be empty
+        resultInvariants[1].put("member4", List.of(0)); // should either hold 0 or 1
+
+        resultInvariants[2] = new HashMap<>();
+        resultInvariants[2].put("member1", List.of(0));
+        resultInvariants[2].put("member2", List.of(2)); // standby-2 should always be on member2
+        resultInvariants[2].put("member3", List.of()); // may be empty
+        resultInvariants[2].put("member4", List.of(1)); // should either hold 0 or 1
+
+        assertEquals(Set.of(2), getActiveTasks(result, "test-subtopology", "member1"));
         assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member3"));
+        assertEquals(Set.of(), getActiveTasks(result, "test-subtopology", "member4"));
+
+        // verify standbys
+
+        // member2 must always host standby-2
         assertEquals(List.of(2), getAllStandbyTaskIds(result, "member2"));
 
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member3"));
-        // if this is empty, or hold standby 1 instead, still correct
-        assertEquals(List.of(0), getAllStandbyTaskIds(result, "member3"));
-
-        assertEquals(Set.of(), getActiveTasks(result, "test-subtopology", "member4"));
-        // if this hold standby 0, or both standby 0 and 1, still correct
-        assertEquals(List.of(1), getAllStandbyTaskIds(result, "member4"));
+        if (getAllStandbyTaskIds(result, "member1").equals(resultInvariants[0].get("member1"))) {
+            assertEquals(resultInvariants[0].get("member3"), getAllStandbyTaskIds(result, "member3"));
+            assertEquals(resultInvariants[0].get("member4"), getAllStandbyTaskIds(result, "member4"));
+        } else if (getAllStandbyTaskIds(result, "member1").equals(resultInvariants[1].get("member1"))) {
+            assertEquals(resultInvariants[1].get("member3"), getAllStandbyTaskIds(result, "member3"));
+            assertEquals(resultInvariants[1].get("member4"), getAllStandbyTaskIds(result, "member4"));
+        } else {
+            assertEquals(resultInvariants[2].get("member1"), getAllStandbyTaskIds(result, "member1"));
+            assertEquals(resultInvariants[2].get("member3"), getAllStandbyTaskIds(result, "member3"));
+            assertEquals(resultInvariants[2].get("member4"), getAllStandbyTaskIds(result, "member4"));
+        }
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1306,7 +1306,6 @@ public class StickyTaskAssignorTest {
         assertTrue(member1TotalTasks <= 2, "Member1 should have <= 2 total tasks (quota), but has " + member1TotalTasks);
     }
 
-
     @Test
     public void shouldAssignStandbyToPreviousStandbyThatDoesNotHoldTheActiveTask() {
         // starting assignment [active] [standby]:
@@ -1359,6 +1358,165 @@ public class StickyTaskAssignorTest {
         assertEquals(List.of(1), getAllStandbyTaskIds(result, "member4"));
     }
 
+    @Test
+    public void shouldAssignTasksToMembersReportingTaskOffsetsOnColdStart() {
+        // Cold start (KAFKA-20719): all members have fresh member IDs and empty target assignments, but report
+        // cumulative offsets for the tasks whose state they hold on local disk.
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L), mkEntry(1, 100L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(2, 100L), mkEntry(3, 100L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(4, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Sets.newSet(0, 1), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Sets.newSet(2, 3), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
+    public void shouldAssignTasksToProcessesReportingTaskOffsetsOnColdStartWithMultipleMembersPerProcess() {
+        // Members of the same process share the state directory and report the same offsets; tasks should stay
+        // on the process holding the state, spread across its members.
+        final Map<String, Map<Integer, Long>> process1Offsets = mkMap(
+            mkEntry("test-subtopology", mkMap(mkEntry(0, 100L), mkEntry(1, 100L))));
+        final Map<String, Map<Integer, Long>> process2Offsets = mkMap(
+            mkEntry("test-subtopology", mkMap(mkEntry(2, 100L), mkEntry(3, 100L))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1_1", createMemberMetadataWithOffsets("process1", process1Offsets)),
+            mkEntry("member1_2", createMemberMetadataWithOffsets("process1", process1Offsets)),
+            mkEntry("member2_1", createMemberMetadataWithOffsets("process2", process2Offsets)),
+            mkEntry("member2_2", createMemberMetadataWithOffsets("process2", process2Offsets)));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(4, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(mkMap(mkEntry("test-subtopology", Sets.newSet(0, 1))),
+            mergeAllActiveTasks(result, "member1_1", "member1_2"));
+        assertEquals(mkMap(mkEntry("test-subtopology", Sets.newSet(2, 3))),
+            mergeAllActiveTasks(result, "member2_1", "member2_2"));
+    }
+
+    @Test
+    public void shouldPreferPreviousActiveOwnerOverReportedTaskOffsets() {
+        // A live member owning the task in the current target assignment beats any reported on-disk offsets.
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadata("process1",
+            mkMap(mkEntry("test-subtopology", Set.of(0))), Map.of());
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
+    public void shouldPreferPreviousStandbyOverReportedTaskOffsets() {
+        // A member that is standby in the current target assignment beats an offset-based candidate, even if the
+        // standby member also reports offsets for the task (which must not register it as a duplicate candidate).
+        final MemberMetadataAndStateImpl memberMetadata1 = new MemberMetadataAndStateImpl(
+            Optional.empty(),
+            Optional.empty(),
+            "process1",
+            Map.of(),
+            Map.of(),
+            mkMap(mkEntry("test-subtopology", Set.of(0))),
+            Map.of(),
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 500L)))),
+            Map.of());
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
+    public void shouldPreferMemberReportingHigherTaskOffsetSum() {
+        // When several processes hold state for the same task, the most caught-up one wins.
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 50L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
+    public void shouldIgnoreNegativeReportedTaskOffsetSums() {
+        // Negative offset sums are sentinel/unknown values and must not grant stickiness over a valid report.
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, -2L), mkEntry(1, 100L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, new HashMap<>()),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
+    }
+
+    @Test
+    public void shouldAssignStandbysAwayFromProcessHoldingStateOnColdStart() {
+        // On cold start with standbys enabled, actives follow the reported state and standbys land on the
+        // other process (a standby may not be co-located with its active).
+        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(1, 100L)))));
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberMetadata1),
+            mkEntry("member2", memberMetadata2));
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, mkMap(mkEntry(NUM_STANDBY_REPLICAS_CONFIG, "1"))),
+            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+        );
+
+        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
+        assertEquals(Set.of(1), getStandbyTasks(result, "test-subtopology", "member1"));
+        assertEquals(Set.of(0), getStandbyTasks(result, "test-subtopology", "member2"));
+    }
+
+
     private int getAllActiveTaskCount(GroupAssignment result, String... memberIds) {
         int size = 0;
         for (String memberId : memberIds) {
@@ -1382,6 +1540,19 @@ public class StickyTaskAssignorTest {
             assertNotNull(testMember.activeTasks());
             if (testMember.activeTasks().get(topologyId) != null) {
                 res.addAll(testMember.activeTasks().get(topologyId));
+            }
+        }
+        return res;
+    }
+
+    private Set<Integer> getStandbyTasks(GroupAssignment result, final String topologyId, String... memberIds) {
+        Set<Integer> res = new HashSet<>();
+        for (String memberId : memberIds) {
+            final MemberAssignment testMember = result.members().get(memberId);
+            assertNotNull(testMember);
+            assertNotNull(testMember.standbyTasks());
+            if (testMember.standbyTasks().get(topologyId) != null) {
+                res.addAll(testMember.standbyTasks().get(topologyId));
             }
         }
         return res;
@@ -1496,6 +1667,22 @@ public class StickyTaskAssignorTest {
             Map.of(),
             Map.of(),
             Map.of(),
+            Map.of());
+    }
+
+    private MemberMetadataAndStateImpl createMemberMetadataWithOffsets(
+        final String processId,
+        final Map<String, Map<Integer, Long>> taskOffsets
+    ) {
+        return new MemberMetadataAndStateImpl(
+            Optional.empty(),
+            Optional.empty(),
+            processId,
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            taskOffsets,
             Map.of());
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1405,135 +1405,35 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldPreferPreviousActiveOwnerOverReportedTaskOffsets() {
-        // A live member owning the task in the current target assignment beats any reported on-disk offsets.
+    public void shouldRankCurrentOwnersAheadOfReportedTaskOffsetsAndMostCaughtUpFirst() {
+        // All previous-ownership signals compete at once. member3 reports the largest possible offset sums for
+        // tasks 0 and 1, but loses both: the current active owner keeps task 0 and the current standby is promoted
+        // to active for task 1. Among the two members only known through their offsets, task 2 goes to the more
+        // caught-up one, leaving task 3 for the other.
         final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadata("process1",
             mkMap(mkEntry("test-subtopology", Set.of(0))), Map.of());
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
+        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadata("process2",
+            Map.of(), mkMap(mkEntry("test-subtopology", Set.of(0, 1))));
+        final MemberMetadataAndStateImpl memberMetadata3 = createMemberMetadataWithOffsets("process3",
+            mkMap(mkEntry("test-subtopology",
+                mkMap(mkEntry(0, 1_000_000L), mkEntry(1, 1_000_000L), mkEntry(2, 100L)))));
+        final MemberMetadataAndStateImpl memberMetadata4 = createMemberMetadataWithOffsets("process4",
+            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(2, 50L)))));
         final Map<String, MemberMetadataAndStateImpl> members = mkMap(
             mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
+            mkEntry("member2", memberMetadata2),
+            mkEntry("member3", memberMetadata3),
+            mkEntry("member4", memberMetadata4));
 
         final GroupAssignment result = assignor.assign(
             new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
+            new TopologyDescriberImpl(4, true, List.of("test-subtopology"))
         );
 
         assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
         assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
-    }
-
-    @Test
-    public void shouldPreferPreviousStandbyOverReportedTaskOffsets() {
-        // A member that is standby in the current target assignment beats an offset-based candidate, even if the
-        // standby member also reports offsets for the task (which must not register it as a duplicate candidate).
-        final MemberMetadataAndStateImpl memberMetadata1 = new MemberMetadataAndStateImpl(
-            Optional.empty(),
-            Optional.empty(),
-            "process1",
-            Map.of(),
-            Map.of(),
-            mkMap(mkEntry("test-subtopology", Set.of(0))),
-            Map.of(),
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 500L)))),
-            Map.of());
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
-        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
-            mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
-
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
-        );
-
-        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
-    }
-
-    @Test
-    public void shouldPreferPreviousStandbyWithHigherReportedTaskOffsetSum() {
-        // Several previous standbys of the same task: the one reporting the most caught-up state is promoted to
-        // active, rather than whichever one the member iteration order happened to visit first.
-        final Map<String, Set<Integer>> standbyForTask0 = mkMap(mkEntry("test-subtopology", Set.of(0)));
-        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithStandbysAndOffsets("process1",
-            standbyForTask0, mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 50L)))));
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithStandbysAndOffsets("process2",
-            standbyForTask0, mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
-        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
-            mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
-
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
-        );
-
-        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
-    }
-
-    @Test
-    public void shouldPreferPreviousStandbyWithoutReportedOffsetsOverOffsetOnlyCandidate() {
-        // Upgrade case: a previous standby on an old client that does not report offsets yet must still outrank a
-        // member that is only known to hold state through its reported offsets.
-        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadata("process1",
-            Map.of(), mkMap(mkEntry("test-subtopology", Set.of(0))));
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 1_000_000L)))));
-        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
-            mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
-
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
-        );
-
-        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member1"));
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member2"));
-    }
-
-    @Test
-    public void shouldPreferMemberReportingHigherTaskOffsetSum() {
-        // When several processes hold state for the same task, the most caught-up one wins.
-        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 50L)))));
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
-        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
-            mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
-
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
-        );
-
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
-        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
-    }
-
-    @Test
-    public void shouldRankNegativeReportedTaskOffsetSumsLast() {
-        // A negative offset sum reads as more lag than any valid report, so it must not grant stickiness over one.
-        final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, -2L), mkEntry(1, 100L)))));
-        final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",
-            mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, 100L)))));
-        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
-            mkEntry("member1", memberMetadata1),
-            mkEntry("member2", memberMetadata2));
-
-        final GroupAssignment result = assignor.assign(
-            new GroupSpecImpl(members, new HashMap<>()),
-            new TopologyDescriberImpl(2, true, List.of("test-subtopology"))
-        );
-
-        assertEquals(Set.of(1), getActiveTasks(result, "test-subtopology", "member1"));
-        assertEquals(Set.of(0), getActiveTasks(result, "test-subtopology", "member2"));
+        assertEquals(Set.of(2), getActiveTasks(result, "test-subtopology", "member3"));
+        assertEquals(Set.of(3), getActiveTasks(result, "test-subtopology", "member4"));
     }
 
     @Test
@@ -1710,23 +1610,6 @@ public class StickyTaskAssignorTest {
             Map.of(),
             Map.of(),
             Map.of(),
-            Map.of());
-    }
-
-    private MemberMetadataAndStateImpl createMemberMetadataWithStandbysAndOffsets(
-        final String processId,
-        final Map<String, Set<Integer>> prevStandbyTasks,
-        final Map<String, Map<Integer, Long>> taskOffsets
-    ) {
-        return new MemberMetadataAndStateImpl(
-            Optional.empty(),
-            Optional.empty(),
-            processId,
-            Map.of(),
-            Map.of(),
-            prevStandbyTasks,
-            Map.of(),
-            taskOffsets,
             Map.of());
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -1517,8 +1517,8 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldIgnoreNegativeReportedTaskOffsetSums() {
-        // Negative offset sums are sentinel/unknown values and must not grant stickiness over a valid report.
+    public void shouldRankNegativeReportedTaskOffsetSumsLast() {
+        // A negative offset sum reads as more lag than any valid report, so it must not grant stickiness over one.
         final MemberMetadataAndStateImpl memberMetadata1 = createMemberMetadataWithOffsets("process1",
             mkMap(mkEntry("test-subtopology", mkMap(mkEntry(0, -2L), mkEntry(1, 100L)))));
         final MemberMetadataAndStateImpl memberMetadata2 = createMemberMetadataWithOffsets("process2",

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsAssignorBenchmarkUtils.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsAssignorBenchmarkUtils.java
@@ -39,12 +39,14 @@ public class StreamsAssignorBenchmarkUtils {
      *
      * @param members               The StreamsGroupMembers.
      * @param assignmentConfigs     The assignment configs.
+     * @param taskOffsets           The reported offset sums per member, empty for members reporting none.
      *
      * @return The new GroupSpec.
      */
     public static GroupSpec createGroupSpec(
         Map<String, StreamsGroupMember> members,
-        Map<String, String> assignmentConfigs
+        Map<String, String> assignmentConfigs,
+        Map<String, Map<String, Map<Integer, Long>>> taskOffsets
     ) {
         Map<String, MemberMetadataAndStateImpl> memberSpecs = new HashMap<>();
 
@@ -61,7 +63,7 @@ public class StreamsAssignorBenchmarkUtils {
                 Map.of(),
                 Map.of(),
                 Map.of(),
-                Map.of(),
+                taskOffsets.getOrDefault(memberId, Map.of()),
                 Map.of()
             ));
         }
@@ -70,6 +72,52 @@ public class StreamsAssignorBenchmarkUtils {
             memberSpecs,
             assignmentConfigs
         );
+    }
+
+    /**
+     * Creates the offset sums the members report for the state they hold on local disk.
+     *
+     * Tasks of stateful subtopologies are spread round-robin over the members, so every member reports the tasks
+     * it would have owned in an earlier generation. Each dormant replica makes a following member report the same
+     * task with a lower offset sum, so several members compete as candidates for it and the candidate ranking
+     * actually has something to sort.
+     *
+     * @param memberIds         The members to spread the tasks over, in a stable order.
+     * @param subtopologyMap    The subtopologies; only the stateful ones get offsets.
+     * @param dormantReplicas   The number of members reporting a task on top of the one owning it.
+     *
+     * @return The reported offset sums, per member.
+     */
+    public static Map<String, Map<String, Map<Integer, Long>>> createTaskOffsets(
+        List<String> memberIds,
+        SortedMap<String, ConfiguredSubtopology> subtopologyMap,
+        int dormantReplicas
+    ) {
+        Map<String, Map<String, Map<Integer, Long>>> taskOffsets = new HashMap<>();
+
+        int taskIndex = 0;
+        for (Map.Entry<String, ConfiguredSubtopology> subtopologyEntry : subtopologyMap.entrySet()) {
+            ConfiguredSubtopology subtopology = subtopologyEntry.getValue();
+            if (subtopology.stateChangelogTopics().isEmpty()) {
+                continue;
+            }
+
+            for (int partition = 0; partition < subtopology.numberOfTasks(); partition++) {
+                for (int replica = 0; replica <= dormantReplicas; replica++) {
+                    String memberId = memberIds.get((taskIndex + replica) % memberIds.size());
+                    // The owner holds the most caught-up state, every dormant copy a little less.
+                    long offsetSum = (long) (dormantReplicas + 1 - replica) * 1_000_000L + taskIndex;
+
+                    taskOffsets
+                        .computeIfAbsent(memberId, id -> new HashMap<>())
+                        .computeIfAbsent(subtopologyEntry.getKey(), id -> new HashMap<>())
+                        .put(partition, offsetSum);
+                }
+                taskIndex++;
+            }
+        }
+
+        return taskOffsets;
     }
 
     /**

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
@@ -44,6 +44,8 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +69,20 @@ public class StreamsStickyAssignorBenchmark {
         FULL, INCREMENTAL
     }
 
+    /**
+     * Whether the members report offset sums for the state they hold on local disk. NONE is the behaviour of a
+     * group whose clients do not report offsets, OWNED_AND_DORMANT also reports state left behind by earlier
+     * assignments, so several members compete as candidates for the same task.
+     */
+    public enum ReportedOffsets {
+        NONE, OWNED_AND_DORMANT
+    }
+
+    /**
+     * The number of members reporting a task on top of the one owning it, under OWNED_AND_DORMANT.
+     */
+    private static final int DORMANT_REPLICAS = 1;
+
     @Param({"100", "1000"})
     private int memberCount;
 
@@ -85,6 +101,9 @@ public class StreamsStickyAssignorBenchmark {
     @Param({"FULL", "INCREMENTAL"})
     private AssignmentType assignmentType;
 
+    @Param({"NONE", "OWNED_AND_DORMANT"})
+    private ReportedOffsets reportedOffsets;
+
     private TaskAssignor taskAssignor;
 
     private GroupSpec groupSpec;
@@ -92,6 +111,8 @@ public class StreamsStickyAssignorBenchmark {
     private TopologyDescriber topologyDescriber;
 
     private Map<String, String> assignmentConfigs;
+
+    private Map<String, Map<String, Map<Integer, Long>>> taskOffsets;
 
     @Setup(Level.Trial)
     public void setup() {
@@ -110,10 +131,20 @@ public class StreamsStickyAssignorBenchmark {
             "num.standby.replicas",
             Integer.toString(standbyReplicas)
         );
-        this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs);
+
+        List<String> memberIds = new ArrayList<>(members.keySet());
+        Collections.sort(memberIds);
+        this.taskOffsets = reportedOffsets == ReportedOffsets.NONE
+            ? Map.of()
+            : StreamsAssignorBenchmarkUtils.createTaskOffsets(memberIds, subtopologyMap, DORMANT_REPLICAS);
 
         if (assignmentType == AssignmentType.INCREMENTAL) {
+            // The setup assignment is only fixture for the measured one, so it is left offset-free. The offsets
+            // go into the member spec it produces, which is what the measured assignment sees.
+            this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs, Map.of());
             simulateIncrementalRebalance();
+        } else {
+            this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs, taskOffsets);
         }
     }
 
@@ -149,7 +180,7 @@ public class StreamsStickyAssignorBenchmark {
                 memberAssignment.standbyTasks(),
                 // Warm-up tasks are not assigned by the assignor; they are decided during reconciliation.
                 Map.of(),
-                Map.of(),
+                taskOffsets.getOrDefault(memberId, Map.of()),
                 Map.of()
             ));
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ColdStartStickinessIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ColdStartStickinessIntegrationTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -129,7 +128,6 @@ public class ColdStartStickinessIntegrationTest {
         CLUSTER.deleteAllTopics();
     }
 
-    @Disabled("Reproduces KAFKA-20719; enable once fixed")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldStickToLocalStateOnColdStart(final boolean streamsProtocol) throws Exception {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -2277,7 +2277,7 @@ public class StreamsConfig extends AbstractConfig {
     }
 
     protected boolean isStreamsProtocolEnabled() {
-        return getString(GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name());
+        return StreamsConfigUtils.streamsProtocolEnabled(this);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/StreamsConfigUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.internals;
 
+import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.StreamsConfig;
 
 import org.slf4j.Logger;
@@ -55,6 +56,10 @@ public class StreamsConfigUtils {
 
     public static boolean eosEnabled(final StreamsConfig config) {
         return processingMode(config) == ProcessingMode.EXACTLY_ONCE_V2;
+    }
+
+    public static boolean streamsProtocolEnabled(final StreamsConfig config) {
+        return config.getString(StreamsConfig.GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name);
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -52,7 +52,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.LogContext;
-import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -106,6 +105,7 @@ import static org.apache.kafka.clients.consumer.CloseOptions.GroupMembershipOper
 import static org.apache.kafka.clients.consumer.CloseOptions.GroupMembershipOperation.LEAVE_GROUP;
 import static org.apache.kafka.clients.consumer.CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.eosEnabled;
+import static org.apache.kafka.streams.internals.StreamsConfigUtils.streamsProtocolEnabled;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.adminClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.consumerClientId;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.restoreConsumerClientId;
@@ -569,7 +569,7 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                        final Map<String, Object> consumerConfigs,
                                                        final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskOffsetSum,
                                                        final Supplier<Map<StreamsRebalanceData.TaskId, Long>> taskEndOffsetSum) {
-        if (config.getString(StreamsConfig.GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name)) {
+        if (streamsProtocolEnabled(config)) {
             if (topologyMetadata.hasNamedTopologies()) {
                 throw new IllegalStateException("Named topologies and the STREAMS protocol cannot be used at the same time.");
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -972,7 +972,9 @@ public class StreamThread extends Thread implements ProcessingThread {
     boolean runLoop() {
         // Populate the task-offset-sum snapshot before subscribing: subscribing triggers the join heartbeat,
         // which must already carry the offset sums of tasks discovered in the local state directory, so that
-        // the broker-side sticky assignor can assign those tasks back to this client on a cold start.
+        // the broker-side sticky assignor can assign those tasks back to this client on a cold start. The sums
+        // are available this early because StateDirectory#initializeStartupStores runs during KafkaStreams#start,
+        // before any stream thread is started.
         taskManager.maybeUpdateTaskOffsetSumSnapshot();
         subscribeConsumer();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -970,6 +970,10 @@ public class StreamThread extends Thread implements ProcessingThread {
      * @throws StreamsException      if the store's change log does not contain the partition
      */
     boolean runLoop() {
+        // Populate the task-offset-sum snapshot before subscribing: subscribing triggers the join heartbeat,
+        // which must already carry the offset sums of tasks discovered in the local state directory, so that
+        // the broker-side sticky assignor can assign those tasks back to this client on a cold start.
+        taskManager.maybeUpdateTaskOffsetSumSnapshot();
         subscribeConsumer();
 
         // if the thread is still in the middle of a rebalance, we should keep polling

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -91,6 +91,7 @@ public class TaskManager {
     private final Admin adminClient;
     private final StateDirectory stateDirectory;
     private final ProcessingMode processingMode;
+    private final boolean streamsProtocolEnabled;
     private final ChangelogReader changelogReader;
     private final TopologyMetadata topologyMetadata;
 
@@ -139,6 +140,7 @@ public class TaskManager {
         this.activeTaskCreator = activeTaskCreator;
         this.standbyTaskCreator = standbyTaskCreator;
         this.processingMode = topologyMetadata.processingMode();
+        this.streamsProtocolEnabled = topologyMetadata.streamsProtocolEnabled();
 
         final LogContext logContext = new LogContext(logPrefix);
         this.log = logContext.logger(getClass());
@@ -1277,8 +1279,15 @@ public class TaskManager {
      * For all other assigned tasks this thread owns, we overwrite the (potentially) state offset-sum from the
      * state directory with the latest changelog offset information. This step also add offset-sums for in-memory
      * state stores.
+     *
+     * <p>No-op under the classic protocol, which reports offset sums through {@link #taskOffsetSums()} instead and
+     * never reads this snapshot.
      */
     public void maybeUpdateTaskOffsetSumSnapshot() {
+        if (!streamsProtocolEnabled) {
+            return;
+        }
+
         final Map<TaskId, Long> offsetSums = new HashMap<>(stateDirectory.taskOffsetSums());
         for (final Task task : allTasks().values()) {
             if (task.isActive() && task.state() == State.RUNNING) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig.TaskConfig;
 import org.apache.kafka.streams.errors.TopologyException;
@@ -138,6 +139,10 @@ public class TopologyMetadata {
     
     public ProcessingMode processingMode() {
         return processingMode;
+    }
+
+    public boolean streamsProtocolEnabled() {
+        return config.getString(StreamsConfig.GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name);
     }
 
     public long topologyVersion() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.internals.LogContext;
-import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyConfig.TaskConfig;
 import org.apache.kafka.streams.errors.TopologyException;
@@ -142,7 +141,7 @@ public class TopologyMetadata {
     }
 
     public boolean streamsProtocolEnabled() {
-        return config.getString(StreamsConfig.GROUP_PROTOCOL_CONFIG).equalsIgnoreCase(GroupProtocol.STREAMS.name);
+        return StreamsConfigUtils.streamsProtocolEnabled(config);
     }
 
     public long topologyVersion() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -217,7 +217,14 @@ public class TaskManagerTest {
     private TaskManager setUpTaskManager(final ProcessingMode processingMode,
                                          final TasksRegistry tasks,
                                          final boolean processingThreadsEnabled) {
-        topologyMetadata = new TopologyMetadata(topologyBuilder, new DummyStreamsConfig(processingMode));
+        return setUpTaskManager(processingMode, tasks, processingThreadsEnabled, false);
+    }
+
+    private TaskManager setUpTaskManager(final ProcessingMode processingMode,
+                                         final TasksRegistry tasks,
+                                         final boolean processingThreadsEnabled,
+                                         final boolean streamsProtocolEnabled) {
+        topologyMetadata = new TopologyMetadata(topologyBuilder, new DummyStreamsConfig(processingMode, streamsProtocolEnabled));
         final TaskManager taskManager = new TaskManager(
             time,
             changeLogReader,
@@ -2003,13 +2010,26 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void shouldNotPublishTaskOffsetSumSnapshotUnderClassicProtocol() {
+        final TasksRegistry tasks = mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+
+        taskManager.maybeUpdateTaskOffsetSumSnapshot();
+
+        // the classic protocol reports offset sums through taskOffsetSums() instead, so the state directory is
+        // never consulted for the snapshot
+        assertThat(taskManager.taskOffsetSumSnapshot(), is(Collections.emptyMap()));
+        verify(stateDirectory, never()).taskOffsetSums();
+    }
+
+    @Test
     public void shouldPublishTaskOffsetSumSnapshotFromStateDirectoryExcludingRunningActiveTasks() {
         final StreamTask runningActiveTask = statefulTask(taskId00, taskId00ChangelogPartitions).inState(State.RUNNING).build();
         final StreamTask restoringActiveTask = statefulTask(taskId01, taskId01ChangelogPartitions).inState(State.RESTORING).build();
         final StandbyTask standbyTask = standbyTask(taskId02, taskId02ChangelogPartitions).inState(State.RUNNING).build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, false, true);
         // running-active tasks are owned by the stream thread; restoring-active and standby tasks live in the state updater
         when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningActiveTask)));
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringActiveTask, standbyTask));
@@ -2038,7 +2058,7 @@ public class TaskManagerTest {
         when(ownStandbyTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p2changelog, 90L)));
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
-        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks, false, true);
         when(tasks.allInitializedTasksPerId()).thenReturn(Collections.emptyMap());
         when(stateUpdater.tasks()).thenReturn(Set.of(ownStandbyTask));
         // the shared sums only cover what is recoverable from disk, so they can trail an open task's in-memory stores

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/DummyStreamsConfig.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/DummyStreamsConfig.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals.testutil;
 
+import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode;
 
@@ -24,18 +25,25 @@ import java.util.Properties;
 public class DummyStreamsConfig extends StreamsConfig {
 
     public DummyStreamsConfig() {
-        super(dummyProps(ProcessingMode.AT_LEAST_ONCE));
+        super(dummyProps(ProcessingMode.AT_LEAST_ONCE, false));
     }
 
     public DummyStreamsConfig(final ProcessingMode processingMode) {
-        super(dummyProps(processingMode));
+        super(dummyProps(processingMode, false));
     }
 
-    private static Properties dummyProps(final ProcessingMode processingMode) {
+    public DummyStreamsConfig(final ProcessingMode processingMode, final boolean streamsProtocolEnabled) {
+        super(dummyProps(processingMode, streamsProtocolEnabled));
+    }
+
+    private static Properties dummyProps(final ProcessingMode processingMode, final boolean streamsProtocolEnabled) {
         final Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "dummy-application");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171");
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, processingMode.toString());
+        if (streamsProtocolEnabled) {
+            props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.name);
+        }
         return props;
     }
 }


### PR DESCRIPTION
StickyTaskAssignor is supposed to avoid task movements. However, at
application startup there is no previous assignment the assignor can
rely on. Previously, clients did not yet report the task offsets from
the local state directory when "stream" protocol is enabled (in contrast
to "classic"). Thus, stickiness at startup could not be provided,
resulting in unexpected task shuffling.

This PR fixes this issue by taking the now reported task offsets from
the client side local state directory (reported via the heartbeat) into
account. For backwards compatibility, information from a previous
assignment takes precedence over "cold start" offset information.

This PR also ensures, that the task offsets information is reported
correctly with the very first "join group" heartbeat.

Reviewers: Matthias J. Sax <matthias@confluent.io>
