### PR TITLE
KAFKA-20597: Fix prefixScan overflow for prefixes with no upper bound in in-memory state stores

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/internals/ByteUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/internals/ByteUtils.java
@@ -67,6 +67,23 @@ public final class ByteUtils {
     }
 
     /**
+     * Same as {@link #increment(Bytes)} but returns {@code null} instead of throwing
+     * {@code IndexOutOfBoundsException} when incrementing would overflow the byte array
+     * (i.e. every byte is {@code 0xFF}). A {@code null} result represents an unbounded
+     * upper range, which callers performing prefix scans should treat as "scan to the end".
+     *
+     * @param input the byte array to increment
+     * @return A new copy of the incremented byte array, or {@code null} if incrementing would overflow
+     */
+    public static Bytes incrementWithoutOverflow(final Bytes input) {
+        try {
+            return increment(input);
+        } catch (final IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    /**
      * A byte array comparator based on lexicographic ordering.
      */
     public static final ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();

--- a/clients/src/test/java/org/apache/kafka/common/utils/internals/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/internals/ByteUtilsTest.java
@@ -41,6 +41,7 @@ import java.util.function.LongFunction;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,6 +77,20 @@ public class ByteUtilsTest {
     public void testIncrementUpperBoundary() {
         byte[] input = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
         assertThrows(IndexOutOfBoundsException.class, () -> ByteUtils.increment(Bytes.wrap(input)));
+    }
+
+    @Test
+    public void testIncrementWithoutOverflow() {
+        byte[] input = new byte[]{(byte) 0xAB, (byte) 0xCD, (byte) 0xFF};
+        byte[] expected = new byte[]{(byte) 0xAB, (byte) 0xCE, (byte) 0x00};
+        Bytes output = ByteUtils.incrementWithoutOverflow(Bytes.wrap(input));
+        assertArrayEquals(expected, output.get());
+    }
+
+    @Test
+    public void testIncrementWithoutOverflowReturnsNullOnOverflow() {
+        byte[] input = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        assertNull(ByteUtils.incrementWithoutOverflow(Bytes.wrap(input)));
     }
     @Test
     public void testIncrementWithSubmap() {

--- a/clients/src/test/java/org/apache/kafka/common/utils/internals/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/internals/ByteUtilsTest.java
@@ -92,6 +92,7 @@ public class ByteUtilsTest {
         byte[] input = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
         assertNull(ByteUtils.incrementWithoutOverflow(Bytes.wrap(input)));
     }
+
     @Test
     public void testIncrementWithSubmap() {
         final NavigableMap<Bytes, byte[]> map = new TreeMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -439,7 +439,9 @@ public class CachingKeyValueStore
         validateStoreOpen();
         final KeyValueIterator<Bytes, byte[]> storeIterator = underlying.prefixScan(prefix, prefixKeySerializer);
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
+        // so the scan is unbounded and must run to the end of the keyspace.
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = internalContext.cache().range(cacheName, from, to, false);
         return new MergedSortedCacheKeyValueBytesStoreIterator(cacheIterator, storeIterator, true);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -439,8 +439,6 @@ public class CachingKeyValueStore
         validateStoreOpen();
         final KeyValueIterator<Bytes, byte[]> storeIterator = underlying.prefixScan(prefix, prefixKeySerializer);
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
-        // so the scan is unbounded and must run to the end of the keyspace.
         final Bytes to = ByteUtils.incrementWithoutOverflow(from);
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = internalContext.cache().range(cacheName, from, to, false);
         return new MergedSortedCacheKeyValueBytesStoreIterator(cacheIterator, storeIterator, true);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/DualColumnFamilyAccessor.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import static org.apache.kafka.streams.state.internals.RocksDBStore.incrementWithoutOverflow;
+import static org.apache.kafka.common.utils.internals.ByteUtils.incrementWithoutOverflow;
 
 /**
  * A generic implementation of {@link RocksDBStore.ColumnFamilyAccessor} that supports dual-column-family

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -239,13 +239,18 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer,
                                                                                      final IsolationLevel isolationLevel) {
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
+        // so the scan is unbounded and must run to the end of the keyspace.
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
         if (transactionBuffer != null) {
             return transactionBuffer.range(from, to, true, false, isolationLevel);
         }
         synchronized (this) {
-            return new InMemoryKeyValueIterator(map.subMap(from, true, to, false).keySet(), true);
+            final NavigableMap<Bytes, byte[]> subMap = to == null
+                ? map.tailMap(from, true)
+                : map.subMap(from, true, to, false);
+            return new InMemoryKeyValueIterator(subMap.keySet(), true);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -239,8 +239,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<Bytes, byte[]> {
     private <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer,
                                                                                      final IsolationLevel isolationLevel) {
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
-        // so the scan is unbounded and must run to the end of the keyspace.
         final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
         if (transactionBuffer != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegment.java
@@ -45,7 +45,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.kafka.streams.state.internals.RocksDBStore.incrementWithoutOverflow;
+import static org.apache.kafka.common.utils.internals.ByteUtils.incrementWithoutOverflow;
 
 /**
  * This "logical segment" is a segment which shares its underlying physical store with other

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -91,8 +91,6 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
     public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
 
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
-        // so the scan is unbounded and must run to the end of the keyspace.
         final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
         final TreeMap<Bytes, byte[]> treeMap = toTreeMap();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
 
@@ -90,13 +91,18 @@ public class MemoryNavigableLRUCache extends MemoryLRUCache {
     public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(final P prefix, final PS prefixKeySerializer) {
 
         final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
-        final Bytes to = ByteUtils.increment(from);
+        // A null upper bound means the prefix has no lexicographic successor (e.g. it is all 0xFF bytes),
+        // so the scan is unbounded and must run to the end of the keyspace.
+        final Bytes to = ByteUtils.incrementWithoutOverflow(from);
 
         final TreeMap<Bytes, byte[]> treeMap = toTreeMap();
+        final NavigableMap<Bytes, byte[]> subMap = to == null
+            ? treeMap.tailMap(from, true)
+            : treeMap.subMap(from, true, to, false);
 
         return new DelegatingPeekingKeyValueIterator<>(
             name(),
-            new MemoryNavigableLRUCache.CacheIterator(treeMap.subMap(from, true, to, false).keySet().iterator(), treeMap)
+            new MemoryNavigableLRUCache.CacheIterator(subMap.keySet().iterator(), treeMap)
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -1478,7 +1478,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         @Override
         public ManagedKeyValueIterator<Bytes, byte[]> prefixScan(final DBAccessor accessor, final Bytes prefix) {
-            final Bytes to = incrementWithoutOverflow(prefix);
+            final Bytes to = ByteUtils.incrementWithoutOverflow(prefix);
             return accessor.prefixScan(columnFamily, name, prefix, to);
         }
 
@@ -1552,19 +1552,4 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
     }
 
-    /**
-     * Same as {@link ByteUtils#increment(Bytes)} but {@code null} is returned instead of throwing
-     * {@code IndexOutOfBoundsException} in the event of overflow.
-     *
-     * @param input bytes to increment
-     * @return A new copy of the incremented byte array, or {@code null} if incrementing would
-     *         result in overflow.
-     */
-    static Bytes incrementWithoutOverflow(final Bytes input) {
-        try {
-            return ByteUtils.increment(input);
-        } catch (final IndexOutOfBoundsException e) {
-            return null;
-        }
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -1551,5 +1551,4 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
             return position.copy().merge(dbAccessor.uncommittedPositionDeltas());
         }
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -660,5 +660,27 @@ public abstract class AbstractKeyValueStoreTest {
                 iter.next();
             }
         }
-    }                  
+    }
+
+    @Test
+    public void prefixScanShouldReturnMatchesWhenPrefixHasNoUpperBound() {
+        // A prefix that serializes to all 0xFF bytes has no lexicographically larger successor,
+        // so incrementing it would overflow. The scan must treat this as an unbounded upper range
+        // and run to the end of the keyspace rather than throwing IndexOutOfBoundsException.
+        // IntegerSerializer encodes -1 as 0xFFFFFFFF, which reproduces the overflow case (KAFKA-20597).
+        store.put(0, "zero");
+        store.put(1, "one");
+        store.put(2, "two");
+        store.put(-1, "minus-one");
+
+        final List<KeyValue<Integer, String>> result = new ArrayList<>();
+        try (final KeyValueIterator<Integer, String> iter = store.prefixScan(-1, new IntegerSerializer())) {
+            while (iter.hasNext()) {
+                result.add(iter.next());
+            }
+        }
+
+        // Only the key whose bytes are 0xFFFFFFFF matches the prefix; the lower-valued keys are excluded.
+        assertEquals(Collections.singletonList(KeyValue.pair(-1, "minus-one")), result);
+    }
 }


### PR DESCRIPTION
## Problem

When a prefix has no lexicographically larger successor (e.g. it is all `0xFF` bytes), `prefixScan` computes the exclusive upper bound of its range by incrementing the prefix, which overflows. `RocksDBStore` already handles this by treating the overflow as an unbounded range, but `InMemoryKeyValueStore`, `MemoryNavigableLRUCache` and `CachingKeyValueStore` called `ByteUtils.increment()` directly and threw `IndexOutOfBoundsException`.

## Fix

- Centralize the overflow-safe increment as `ByteUtils.incrementWithoutOverflow()`, which returns `null` on overflow. The RocksDB code paths that previously defined a private copy now reuse it.
- The three in-memory stores treat a `null` upper bound as "scan to the end of the keyspace" (`tailMap`), matching the behaviour `RocksDBStore` already had.
- `ByteUtils.increment()` is left unchanged: `RocksDBStore.deleteRange()` intentionally relies on it throwing, since RocksDB's `deleteRange()` has no null-upper-bound form.

## Testing

- Added `prefixScanShouldReturnMatchesWhenPrefixHasNoUpperBound` to `AbstractKeyValueStoreTest`, so it runs against every `KeyValueStore` implementation. It uses `IntegerSerializer`'s encoding of `-1` (`0xFFFFFFFF`) to reproduce the overflow. Verified the test fails on the unpatched in-memory stores and passes with the fix, while the RocksDB-backed stores pass in both cases.
- Added unit tests for `ByteUtils.incrementWithoutOverflow()`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
