### PR TITLE
KAFKA-20786: Bound IntegrationTestUtils.readRecords on real elapsed time

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1212,10 +1212,9 @@ public class IntegrationTestUtils {
         consumer.subscribe(singletonList(topic));
         final int pollIntervalMs = 100;
         consumerRecords = new ArrayList<>();
-        int totalPollTimeMs = 0;
-        while (totalPollTimeMs < waitTime &&
+        final long deadline = System.currentTimeMillis() + waitTime;
+        while (System.currentTimeMillis() < deadline &&
             continueConsuming(consumerRecords.size(), maxMessages)) {
-            totalPollTimeMs += pollIntervalMs;
             final ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(pollIntervalMs));
 
             for (final ConsumerRecord<K, V> record : records) {


### PR DESCRIPTION
readRecords() polls up to `waitTime` by counting a fixed 100ms per
iteration rather than measuring the wall clock. A single consumer.poll()
can block longer than the requested 100ms interval, and thus
readReacord() can exceed the specified `waitTimeMs` by orders of
magnitude.

This PR bounds the loop on real elapsed time using a fixed deadline.
