### PR TITLE
KAFKA-19877: Clarify Deserializer ByteBuffer position/limit contract

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
@@ -97,6 +97,12 @@ public interface Deserializer<T> extends Closeable {
      * <p>Similarly, if this method is overridden, the implementation cannot make any assumptions about the
      * passed in {@link ByteBuffer} either.
      *
+     * <p>The serialized bytes are the buffer's {@link ByteBuffer#remaining() remaining} bytes, i.e. those
+     * between its current {@code position} and {@code limit}. An implementation should read the data without
+     * changing the buffer's {@code position}, {@code limit}, or {@code mark}: the caller retains ownership of
+     * the buffer and may read it again after this method returns (for example, to determine the serialized
+     * size of the value), so mutating the buffer's state can corrupt unrelated processing.
+     *
      * <p>It is recommended to deserialize a {@code null} {@link ByteBuffer} to a {@code null} object.
      *
      * <p>Note that the passed in {@link Headers} may be empty, but never {@code null}.


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-19877

The `deserialize(String, Headers, ByteBuffer)` Javadoc currently says only what callers and implementations *cannot* assume about the buffer (position, limit, capacity), but never what they *can* — which leaves the readable region and side-effect expectations unclear. The reporter hit a `serializedValueSize` regression after switching to this overload for zero-copy deserialization.

This adds a short clarification: the serialized bytes are the buffer's `remaining()` bytes (between `position` and `limit`), and implementations should not modify the buffer's `position`/`limit`/`mark`, since the caller retains ownership and may read the buffer again afterward.

I kept this to the actionable, non-controversial part and framed it conservatively. If the intended contract differs (e.g. on the exact `position` semantics — I noticed `Utils.toArray` and `Utils.readBytes` aren't fully consistent here), I'm happy to adjust; the goal is to close the documentation gap the issue describes.

Supersedes the stale #21371 (auto-closed for inactivity).

Docs-only change; no tests.

AI disclosure: drafted with Claude (Claude Code) and reviewed before submitting; the commit carries the `Co-Authored-By` trailer per the contributing guide.
