### PR TITLE
KAFKA-20783: LogReader interface cleanup (2/N)

### DIFF
--- a/core/src/main/java/kafka/server/share/ReplicaManagerLogReader.java
+++ b/core/src/main/java/kafka/server/share/ReplicaManagerLogReader.java
@@ -62,47 +62,6 @@ public class ReplicaManagerLogReader implements LogReader {
     }
 
     @Override
-    public LinkedHashMap<TopicIdPartition, LogReadResult> read(
-            FetchParams fetchParams,
-            Set<TopicIdPartition> partitionsToFetch,
-            LinkedHashMap<TopicIdPartition, Long> topicPartitionFetchOffsets,
-            LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes) {
-
-        if (partitionsToFetch.isEmpty()) {
-            return new LinkedHashMap<>();
-        }
-
-        LinkedHashMap<TopicIdPartition, FetchRequest.PartitionData> topicPartitionData = new LinkedHashMap<>();
-        topicPartitionFetchOffsets.forEach((topicIdPartition, fetchOffset) ->
-            topicPartitionData.put(topicIdPartition,
-                new FetchRequest.PartitionData(
-                    topicIdPartition.topicId(),
-                    fetchOffset,
-                    0,
-                    partitionMaxBytes.get(topicIdPartition),
-                    Optional.empty())
-            ));
-
-        Seq<Tuple2<TopicIdPartition, LogReadResult>> responseLogResult = replicaManager.readFromLog(
-            fetchParams,
-            CollectionConverters.asScala(
-                partitionsToFetch.stream().map(topicIdPartition ->
-                    new Tuple2<>(topicIdPartition, topicPartitionData.get(topicIdPartition))).collect(Collectors.toList())
-            ),
-            QuotaFactory.UNBOUNDED_QUOTA,
-            true);
-
-        LinkedHashMap<TopicIdPartition, LogReadResult> responseData = new LinkedHashMap<>();
-        responseLogResult.foreach(tpLogResult -> {
-            responseData.put(tpLogResult._1(), tpLogResult._2());
-            return BoxedUnit.UNIT;
-        });
-
-        log.trace("Data successfully retrieved by replica manager: {}", responseData);
-        return responseData;
-    }
-
-    @Override
     public CompletableFuture<LinkedHashMap<TopicIdPartition, LogReadResult>> readAsync(
             FetchParams fetchParams,
             Set<TopicIdPartition> partitionsToFetch,
@@ -160,6 +119,47 @@ public class ReplicaManagerLogReader implements LogReader {
                 futures.forEach((topicIdPartition, future) -> results.put(topicIdPartition, future.getNow(null)));
                 return results;
             });
+    }
+
+    // Visible for testing
+    LinkedHashMap<TopicIdPartition, LogReadResult> read(
+        FetchParams fetchParams,
+        Set<TopicIdPartition> partitionsToFetch,
+        LinkedHashMap<TopicIdPartition, Long> topicPartitionFetchOffsets,
+        LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes
+    ) {
+        if (partitionsToFetch.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        LinkedHashMap<TopicIdPartition, FetchRequest.PartitionData> topicPartitionData = new LinkedHashMap<>();
+        topicPartitionFetchOffsets.forEach((topicIdPartition, fetchOffset) ->
+            topicPartitionData.put(topicIdPartition,
+                new FetchRequest.PartitionData(
+                    topicIdPartition.topicId(),
+                    fetchOffset,
+                    0,
+                    partitionMaxBytes.get(topicIdPartition),
+                    Optional.empty())
+            ));
+
+        Seq<Tuple2<TopicIdPartition, LogReadResult>> responseLogResult = replicaManager.readFromLog(
+            fetchParams,
+            CollectionConverters.asScala(
+                partitionsToFetch.stream().map(topicIdPartition ->
+                    new Tuple2<>(topicIdPartition, topicPartitionData.get(topicIdPartition))).collect(Collectors.toList())
+            ),
+            QuotaFactory.UNBOUNDED_QUOTA,
+            true);
+
+        LinkedHashMap<TopicIdPartition, LogReadResult> responseData = new LinkedHashMap<>();
+        responseLogResult.foreach(tpLogResult -> {
+            responseData.put(tpLogResult._1(), tpLogResult._2());
+            return BoxedUnit.UNIT;
+        });
+
+        log.trace("Data successfully retrieved by replica manager: {}", responseData);
+        return responseData;
     }
 
     /**

--- a/server/src/main/java/org/apache/kafka/server/share/LogReader.java
+++ b/server/src/main/java/org/apache/kafka/server/share/LogReader.java
@@ -30,21 +30,6 @@ import java.util.concurrent.CompletableFuture;
 public interface LogReader {
 
     /**
-     * Read records for the given partitions starting at the specified offsets.
-     *
-     * @param fetchParams             The fetch parameters (isolation level, maxBytes, etc.)
-     * @param partitionsToFetch       The set of partitions to actually fetch (after filtering erroneous ones)
-     * @param topicPartitionFetchOffsets The fetch offset per partition
-     * @param partitionMaxBytes       The max bytes per partition
-     * @return A map of partition to log read result
-     */
-    LinkedHashMap<TopicIdPartition, LogReadResult> read(
-        FetchParams fetchParams,
-        Set<TopicIdPartition> partitionsToFetch,
-        LinkedHashMap<TopicIdPartition, Long> topicPartitionFetchOffsets,
-        LinkedHashMap<TopicIdPartition, Integer> partitionMaxBytes);
-
-    /**
      * Read records for the given partitions starting at the specified offsets, combining the local read
      * and - when {@code readRemote} is true and the requested data has been tiered off the local log - the
      * follow-up remote read into a single call.


### PR DESCRIPTION
Minor PR to cleanup LogReader interface as now DleayedShareFetch is
moved to async handling of reads.

Reviewers: Abhinav Dixit <adixit@confluent.io>, Andrew Schofield <aschofield@confluent.io>
