### PR TITLE
KAFKA-20777: Make a closed StagedMergeIterator throw InvalidStateStoreException

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StagedMergeIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StagedMergeIterator.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import java.util.Iterator;
@@ -77,7 +78,7 @@ class StagedMergeIterator<K extends Comparable<K>, V> implements ManagedKeyValue
     @Override
     public boolean hasNext() {
         if (closed) {
-            throw new IllegalStateException("Iterator has already been closed.");
+            throw new InvalidStateStoreException("Store iterator for this transaction buffer has already been closed.");
         }
         if (prefetched != null) {
             return true;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StagedMergeIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StagedMergeIterator.java
@@ -78,7 +78,7 @@ class StagedMergeIterator<K extends Comparable<K>, V> implements ManagedKeyValue
     @Override
     public boolean hasNext() {
         if (closed) {
-            throw new InvalidStateStoreException("Store iterator for this transaction buffer has already been closed.");
+            throw new InvalidStateStoreException("Iterator has already been closed.");
         }
         if (prefetched != null) {
             return true;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StagedMergeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StagedMergeIteratorTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 import org.junit.jupiter.api.Test;
@@ -85,6 +86,23 @@ public class StagedMergeIteratorTest {
             assertEquals("staged-a", str(entry.value));
             assertFalse(iter.hasNext());
         }
+    }
+
+    @Test
+    public void shouldThrowInvalidStateStoreExceptionOnHasNextAfterClose() {
+        final NavigableMap<Bytes, Optional<byte[]>> staging = new TreeMap<>();
+        staging.put(key("a"), Optional.of(val("staged-a")));
+
+        final KeyValueIterator<Bytes, byte[]> iter =
+            new StagedMergeIterator(staging, new ListIterator(List.of()));
+        iter.close();
+
+        // A closed store iterator must signal via InvalidStateStoreException -- the type
+        // SegmentIterator catches to close open iterators gracefully -- not a bare
+        // IllegalStateException, which would escape that handling.
+        assertThrows(InvalidStateStoreException.class, iter::hasNext);
+        assertThrows(InvalidStateStoreException.class, iter::next);
+        assertThrows(InvalidStateStoreException.class, iter::peekNextKey);
     }
 
     @Test


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-20777

When transactional state stores are enabled
(enable.transactional.statestores=true), an open StagedMergeIterator
that is used after the store is closed throws
java.lang.IllegalStateException("Iterator has already been closed.")
from StagedMergeIterator.hasNext(), for consistency with the other
managed store iterators (e.g. RocksDbIterator), it should throw
InvalidStateStoreException.

Reviewers: Bill Bejeck <bbejeck@apache.org>
