### PR TITLE
KAFKA-20793: Bump latest production ShareVersion to 2 (SV_2).

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -131,8 +131,7 @@ public enum MetadataVersion {
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
 
-    // IBP_4_4_IV0 enables dead-letter queue support for share groups (KIP-1191). When this version
-    // is finalized, so will the DLQ support.
+    // IBP_4_4_IV0 enables dead-letter queue support for share groups (KIP-1191).
     IBP_4_4_IV0(31, "4.4", "IV0", false),
 
     // Add support for CIDR-based ACL host patterns (KIP-1276).

--- a/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/ShareVersion.java
@@ -32,7 +32,7 @@ public enum ShareVersion implements FeatureVersion {
 
     public static final String FEATURE_NAME = "share.version";
 
-    public static final ShareVersion LATEST_PRODUCTION = SV_1;
+    public static final ShareVersion LATEST_PRODUCTION = SV_2;
 
     private final short featureLevel;
     private final MetadataVersion bootstrapMetadataVersion;

--- a/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/FeatureCommandTest.java
@@ -203,7 +203,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithoutUnstable.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithoutUnstable.get(4))
         );
         assertFeatureOutput(
@@ -296,7 +296,7 @@ public class FeatureCommandTest {
                 outputWithoutEpoch(featuresWithoutUnstable.get(3))
         );
         assertFeatureOutput(
-                "share.version", "0", "1", "0",
+                "share.version", "0", "2", "0",
                 outputWithoutEpoch(featuresWithoutUnstable.get(4))
         );
         assertFeatureOutput(


### PR DESCRIPTION
Bump latest production version for share.version config to `SV_2` so
that  `share.version` feature can be upgraded to 2 without the unstable
feature  config.

Reviewers: Andrew Schofield <aschofield@confluent.io>
