### PR TITLE
KAFKA-20796: Fix num-open-iterators metric for timestamped range queries

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-import java.util.Set;
+import java.util.NavigableSet;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -47,8 +47,7 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
     private final Sensor operationSensor;
     private final Sensor iteratorSensor;
     private final Time time;
-    private final LongAdder numOpenIterators;
-    private final Set<MeteredIterator> openIterators;
+    private final MeteredIteratorTracker iteratorTracker;
     private final long startNs;
     private final long startTimestampMs;
 
@@ -57,20 +56,32 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
                             final Sensor iteratorSensor,
                             final Time time,
                             final LongAdder numOpenIterators,
-                            final Set<MeteredIterator> openIterators) {
+                            final NavigableSet<MeteredIterator> openIterators) {
+        this(
+            iter,
+            operationSensor,
+            iteratorSensor,
+            time,
+            new MeteredIteratorTracker(numOpenIterators, openIterators)
+        );
+    }
+
+    AbstractMeteredIterator(final KeyValueIterator<RawKey, byte[]> iter,
+                            final Sensor operationSensor,
+                            final Sensor iteratorSensor,
+                            final Time time,
+                            final MeteredIteratorTracker iteratorTracker) {
         this.iter = iter;
         this.operationSensor = operationSensor;
         this.iteratorSensor = iteratorSensor;
         this.time = time;
-        this.numOpenIterators = numOpenIterators;
-        this.openIterators = openIterators;
+        this.iteratorTracker = iteratorTracker;
         this.startNs = time.nanoseconds();
         this.startTimestampMs = time.milliseconds();
-        numOpenIterators.increment();
-        openIterators.add(this);
+        iteratorTracker.add(this);
     }
 
-    // Final: the constructor's openIterators.add(this) sorts through this via the set's
+    // Final: the constructor's iteratorTracker.add(this) sorts through this via the set's
     // startTimestamp comparator, i.e. on a not-yet-fully-constructed object. Keeping it final stops a
     // subclass from overriding it with something that reads its own not-yet-assigned state.
     @Override
@@ -96,8 +107,7 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
             final long duration = time.nanoseconds() - startNs;
             operationSensor.record(duration);
             iteratorSensor.record(duration);
-            numOpenIterators.decrement();
-            openIterators.remove(this);
+            iteratorTracker.remove(this);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIteratorTracker.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIteratorTracker.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.LongAdder;
+
+final class MeteredIteratorTracker {
+
+    private final LongAdder numOpenIterators;
+    private final NavigableSet<MeteredIterator> openIterators;
+
+    MeteredIteratorTracker() {
+        this(
+            new LongAdder(),
+            new ConcurrentSkipListSet<>(Comparator.comparingLong(MeteredIterator::startTimestamp))
+        );
+    }
+
+    MeteredIteratorTracker(final LongAdder numOpenIterators,
+                           final NavigableSet<MeteredIterator> openIterators) {
+        this.numOpenIterators = numOpenIterators;
+        this.openIterators = openIterators;
+    }
+
+    void add(final MeteredIterator iterator) {
+        numOpenIterators.increment();
+        openIterators.add(iterator);
+    }
+
+    void remove(final MeteredIterator iterator) {
+        numOpenIterators.decrement();
+        openIterators.remove(iterator);
+    }
+
+    long numOpenIterators() {
+        return numOpenIterators.sum();
+    }
+
+    long oldestIteratorStartTimestamp() {
+        try {
+            final Iterator<MeteredIterator> iterator = openIterators.iterator();
+            return iterator.hasNext() ? iterator.next().startTimestamp() : 0L;
+        } catch (final NoSuchElementException e) {
+            return 0L;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -52,15 +52,9 @@ import org.apache.kafka.streams.state.internals.StoreQueryUtils.QueryHandler;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
-import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -104,9 +98,7 @@ public class MeteredKeyValueStore<K, V>
     private TaskId taskId;
     private Sensor restoreSensor;
 
-    protected LongAdder numOpenIterators = new LongAdder();
-    protected NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(Comparator.comparingLong(MeteredIterator::startTimestamp));
-
+    protected final MeteredIteratorTracker iteratorTracker = new MeteredIteratorTracker();
 
     private final Map<Class<?>, QueryHandler<?>> queryHandlers =
         mkMap(
@@ -169,21 +161,14 @@ public class MeteredKeyValueStore<K, V>
             metricsScope,
             name(),
             streamsMetrics,
-            (config, now) -> numOpenIterators.sum()
+            (config, now) -> iteratorTracker.numOpenIterators()
         );
         StateStoreMetrics.addOldestOpenIteratorGauge(
             taskId.toString(),
             metricsScope,
             name(),
             streamsMetrics,
-            (config, now) -> {
-                try {
-                    final Iterator<MeteredIterator> iter = openIterators.iterator();
-                    return iter.hasNext() ? iter.next().startTimestamp() : 0L;
-                } catch (final NoSuchElementException e) {
-                    return 0L;
-                }
-            }
+            (config, now) -> iteratorTracker.oldestIteratorStartTimestamp()
         );
         if (!persistent()) {
             StateStoreMetrics.addNumKeysGauge(taskId.toString(), metricsScope, name(), streamsMetrics,
@@ -576,8 +561,7 @@ public class MeteredKeyValueStore<K, V>
             this.sensor = sensor;
             this.startTimestamp = time.milliseconds();
             this.startNs = time.nanoseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
+            iteratorTracker.add(this);
         }
 
         @Override
@@ -609,8 +593,7 @@ public class MeteredKeyValueStore<K, V>
                 final long duration = time.nanoseconds() - startNs;
                 sensor.record(duration);
                 iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
+                iteratorTracker.remove(this);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -21,8 +21,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.state.VersionedRecord;
 import org.apache.kafka.streams.state.VersionedRecordIterator;
 
-import java.util.Set;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 
 class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterator<V>, MeteredIterator {
@@ -33,25 +31,21 @@ class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterato
     private final Time time;
     private final long startNs;
     private final long startTimestampMs;
-    private final Set<MeteredIterator> openIterators;
-    private final LongAdder numOpenIterators;
+    private final MeteredIteratorTracker iteratorTracker;
 
     public MeteredMultiVersionedKeyQueryIterator(final VersionedRecordIterator<byte[]> iterator,
                                                  final Sensor sensor,
                                                  final Time time,
                                                  final Function<VersionedRecord<byte[]>, VersionedRecord<V>> deserializeValue,
-                                                 final LongAdder numOpenIterators,
-                                                 final Set<MeteredIterator> openIterators) {
+                                                 final MeteredIteratorTracker iteratorTracker) {
         this.iterator = iterator;
         this.deserializeValue = deserializeValue;
-        this.numOpenIterators = numOpenIterators;
-        this.openIterators = openIterators;
+        this.iteratorTracker = iteratorTracker;
         this.sensor = sensor;
         this.time = time;
         this.startNs = time.nanoseconds();
         this.startTimestampMs = time.milliseconds();
-        numOpenIterators.increment();
-        openIterators.add(this);
+        iteratorTracker.add(this);
     }
 
     @Override
@@ -65,8 +59,7 @@ class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterato
             iterator.close();
         } finally {
             sensor.record(time.nanoseconds() - startNs);
-            numOpenIterators.decrement();
-            openIterators.remove(this);
+            iteratorTracker.remove(this);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -318,8 +318,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
             this.startNs = time.nanoseconds();
             this.startTimestampMs = time.milliseconds();
             this.returnPlainValue = returnPlainValue;
-            numOpenIterators.increment();
-            openIterators.add(this);
+            iteratorTracker.add(this);
         }
 
         @Override
@@ -352,8 +351,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
                 final long duration = time.nanoseconds() - startNs;
                 sensor.record(duration);
                 iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
+                iteratorTracker.remove(this);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -318,6 +318,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
             this.startNs = time.nanoseconds();
             this.startTimestampMs = time.milliseconds();
             this.returnPlainValue = returnPlainValue;
+            numOpenIterators.increment();
             openIterators.add(this);
         }
 
@@ -351,6 +352,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
                 final long duration = time.nanoseconds() - startNs;
                 sensor.record(duration);
                 iteratorDurationSensor.record(duration);
+                numOpenIterators.decrement();
                 openIterators.remove(this);
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -672,7 +672,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer,
             final boolean returnPlainValue
         ) {
-            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
+            super(iter, sensor, iteratorDurationSensor, time, iteratorTracker);
             this.valueTimestampHeadersDeserializer = valueTimestampHeadersDeserializer;
             this.returnPlainValue = returnPlainValue;
         }
@@ -747,7 +747,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final Sensor sensor,
             final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer
         ) {
-            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
+            super(iter, sensor, iteratorDurationSensor, time, iteratorTracker);
             this.valueTimestampHeadersDeserializer = valueTimestampHeadersDeserializer;
         }
 
@@ -781,7 +781,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final KeyValueIterator<Bytes, byte[]> iter,
             final Sensor sensor
         ) {
-            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
+            super(iter, sensor, iteratorDurationSensor, time, iteratorTracker);
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStore.java
@@ -292,8 +292,7 @@ public class MeteredVersionedKeyValueStore<K, V>
                         iteratorDurationSensor,
                         time,
                         StoreQueryUtils.deserializeValue(plainValueSerdes),
-                        numOpenIterators,
-                        openIterators
+                        iteratorTracker
                     );
                 final QueryResult<MeteredMultiVersionedKeyQueryIterator<V>> typedQueryResult =
                     InternalQueryResultUtil.copyAndSubstituteDeserializedResult(rawResult, typedResult);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -505,7 +506,73 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
     }
-    
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    public void shouldDecrementOpenIteratorsTwiceWhenClosedTwiceForRangeQuery() {
+        setUp();
+
+        when(inner.query(
+            any(),
+            any(PositionBound.class),
+            any(QueryConfig.class)
+        )).thenReturn((QueryResult) QueryResult.forResult(
+            KeyValueIterators.emptyIterator()
+        ));
+
+        init();
+
+        final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
+        final QueryResult<?> result = metered.query(
+            RangeQuery.<String, String>withNoBounds(),
+            PositionBound.unbounded(),
+            new QueryConfig(false)
+        );
+        final KeyValueIterator<?, ?> iterator =
+            (KeyValueIterator<?, ?>) result.getResult();
+
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+
+        iterator.close();
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+
+        iterator.close();
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(-1L));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    public void shouldLeaveIteratorOpenWhenNextThrowsAndNotClosedForRangeQuery() {
+        setUp();
+
+        final KeyValueIterator<Bytes, byte[]> rawIterator =
+            mock(KeyValueIterator.class);
+        when(rawIterator.next())
+            .thenThrow(new IllegalStateException("boom"));
+
+        when(inner.query(
+            any(),
+            any(PositionBound.class),
+            any(QueryConfig.class)
+        )).thenReturn((QueryResult) QueryResult.forResult(rawIterator));
+
+        init();
+
+        final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
+        final QueryResult<?> result = metered.query(
+            RangeQuery.<String, String>withNoBounds(),
+            PositionBound.unbounded(),
+            new QueryConfig(false)
+        );
+        final KeyValueIterator<?, ?> iterator =
+            (KeyValueIterator<?, ?>) result.getResult();
+
+        assertThrows(IllegalStateException.class, iterator::next);
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+
+        iterator.close();
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+    }
 
     @SuppressWarnings("unused")
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -37,6 +37,12 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryConfig;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.TimestampedRangeQuery;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
@@ -450,6 +456,56 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
     }
+
+    @Test
+    public void shouldTrackOpenIteratorsMetricForRangeQuery() {
+        assertTracksOpenIteratorsMetricForQuery(
+            RangeQuery.<String, String>withNoBounds()
+        );
+    }
+
+    @Test
+    public void shouldTrackOpenIteratorsMetricForTimestampedRangeQuery() {
+        assertTracksOpenIteratorsMetricForQuery(
+            TimestampedRangeQuery.<String, String>withNoBounds()
+        );
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void assertTracksOpenIteratorsMetricForQuery(final Query<?> query) {
+        setUp();
+
+        final QueryResult<KeyValueIterator<Bytes, byte[]>> rawResult =
+            QueryResult.forResult(KeyValueIterators.emptyIterator());
+
+        when(inner.query(
+            any(),
+            any(PositionBound.class),
+            any(QueryConfig.class)
+        )).thenReturn((QueryResult) rawResult);
+
+        init();
+
+        final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
+        assertThat(openIteratorsMetric, not(nullValue()));
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+
+        final QueryResult<?> result = metered.query(
+            query,
+            PositionBound.unbounded(),
+            new QueryConfig(false)
+        );
+
+        assertTrue(result.isSuccess());
+
+        try (final KeyValueIterator<?, ?> unused =
+                (KeyValueIterator<?, ?>) result.getResult()) {
+            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+        }
+
+        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+    }
+    
 
     @SuppressWarnings("unused")
     @Test


### PR DESCRIPTION
`MeteredTimestampedKeyValueStoreIterator` registered itself in
`openIterators`, but did not update `numOpenIterators`. As a result,
iterators created by IQv2 `RangeQuery` and `TimestampedRangeQuery`  were
not included in the `num-open-iterators` metric.

This change increments the counter when the iterator is created and
decrements it when the iterator is closed.

Regression tests verify that the metric transitions from 0 to 1 while
the iterator is open and returns to 0 after it is closed for both query
types.

Testing:
- `./gradlew :streams:spotlessJavaCheck`
- `./gradlew :streams:checkstyleMain :streams:checkstyleTest`
- `./gradlew :streams:test`

Reviewers: Matthias J. Sax <matthias@confluent.io>, Alieh Saeedi <asaeedi@confluent.io>
