### PR TITLE
KAFKA-18951: Correct topic name in client example docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 This module contains some Kafka client examples.
 
 1. Start a local single-broker Kafka cluster with a plain listener configured on port 9092.
-2. Run `examples/bin/java-producer-consumer-demo.sh 10000` to asynchronously send 10k records to topic1 and consume them.
-3. Run `examples/bin/java-producer-consumer-demo.sh 10000 sync` to synchronous send 10k records to topic1 and consume them.
+2. Run `examples/bin/java-producer-consumer-demo.sh 10000` to asynchronously send 10k records to `my-topic` and consume them.
+3. Run `examples/bin/java-producer-consumer-demo.sh 10000 sync` to synchronously send 10k records to `my-topic` and consume them.
 4. Run `examples/bin/exactly-once-demo.sh 6 3 10000` to create input-topic and output-topic with 6 partitions each,
    start 3 transactional application instances and process 10k records.

--- a/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit;
  * This example can be decomposed into the following stages:
  * <p>
  * 1. Clean any topics left from previous runs.
- * 2. Create a producer thread to send a set of records to topic1.
- * 3. Create a consumer thread to fetch all previously sent records from topic1.
+ * 2. Create a producer thread to send a set of records to my-topic.
+ * 3. Create a consumer thread to fetch all previously sent records from my-topic.
  * <p>
  * If you are using IntelliJ IDEA, the above arguments should be put in `Modify Run Configuration - Program Arguments`.
  * You can also set an output log file in `Modify Run Configuration - Modify options - Save console output to file` to
@@ -51,12 +51,12 @@ public class KafkaConsumerProducerDemo {
             Utils.recreateTopics(KafkaProperties.BOOTSTRAP_SERVERS, -1, TOPIC_NAME);
             CountDownLatch latch = new CountDownLatch(2);
 
-            // stage 2: produce records to topic1
+            // stage 2: produce records to my-topic
             Producer producerThread = new Producer(
                 "producer", KafkaProperties.BOOTSTRAP_SERVERS, TOPIC_NAME, isAsync, null, false, numRecords, -1, latch);
             producerThread.start();
 
-            // stage 3: consume records from topic1
+            // stage 3: consume records from my-topic
             Consumer consumerThread = new Consumer(
                 "consumer", KafkaProperties.BOOTSTRAP_SERVERS, TOPIC_NAME, GROUP_NAME, Optional.empty(), false, numRecords, latch);
             consumerThread.start();


### PR DESCRIPTION
## What changed

- replace stale `topic1` references with the demo's actual `my-topic`
topic name
- correct the README wording from "to synchronous send" to "to
synchronously send"
- keep the Java example comments consistent with the README and
`TOPIC_NAME`

## Why

The producer/consumer example uses `my-topic`, but its documentation
still referred to `topic1`. This mismatch could confuse users following
the example.

## Validation

- `./gradlew :examples:compileJava :examples:checkstyleMain
spotlessCheck`
- `git diff --check`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
