### PR TITLE
KAFKA-20781: Fix flaky testConsumerGroupHeartbeatWithRegexWithDifferentMemberAcls

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -3196,9 +3196,13 @@ class AuthorizerIntegrationTest extends AbstractAuthorizerIntegrationTest {
     val allowAllOpsAcl = new AccessControlEntry(clientPrincipalString, WILDCARD_HOST, ALL, ALLOW)
     addAndVerifyAcls(Set(allowAllOpsAcl), groupResource)
 
-    // Member on inter-broker listener has all access and is assigned the matching topic
+    // Member on inter-broker listener has all access and is assigned the matching topic.
+    // The first heartbeat only schedules the asynchronous regex resolution, so retry until
+    // the resolution completes and the assignment is available.
     var member1Response = sendAndReceiveFirstRegexHeartbeat("memberWithAllAccess", interBrokerListenerName)
-    member1Response = sendAndReceiveRegexHeartbeat(member1Response, interBrokerListenerName, Some(2))
+    TestUtils.tryUntilNoAssertionError() {
+      member1Response = sendAndReceiveRegexHeartbeat(member1Response, interBrokerListenerName, Some(2))
+    }
 
     // Member on client listener has no topic describe access, but is assigned a partition of the
     // unauthorized topic. This is leaking unauthorized topic metadata to member2. Simply filtering out


### PR DESCRIPTION
## Cause
`testConsumerGroupHeartbeatWithRegexWithDifferentMemberAcls` drives a
regex-based (`^top.*`) consumer group heartbeat. Regex resolution on the
broker is asynchronous: the first heartbeat only *schedules* the
resolution, so the follow-up heartbeat that asserts member1 has a
2-partition assignment can run before resolution completes. On
slower/loaded CI hosts the assignment is still empty and
`assertEquals(2, ...)` fails intermittently .
## Change
Wrap the first `sendAndReceiveRegexHeartbeat(..., Some(2))` for member1
in `TestUtils.tryUntilNoAssertionError`, so the test retries the
heartbeat/assertion until the asynchronous regex resolution completes
and the assignment is available. This mirrors the pattern already used
elsewhere in the same test (`tryUntilNoAssertionError`) and
`TestUtils.retry` for the later regex refreshes.

Test-only change; no production code affected.

Jira: https://issues.apache.org/jira/browse/KAFKA-20781

Reviewers - @lianetm

Reviewers: Lianet Magrans <lmagrans@confluent.io>
