### PR TITLE
KAFKA-20568: Unify DSL store accessor and header-aware builder naming

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -557,13 +557,15 @@ public class StreamsConfig extends AbstractConfig {
     static final String DSL_STORE_SUPPLIERS_CLASS_DOC = "Defines which store implementations to plug in to DSL operators. Must implement the <code>org.apache.kafka.streams.state.DslStoreSuppliers</code> interface.";
     static final Class<?> DSL_STORE_SUPPLIERS_CLASS_DEFAULT = BuiltInDslStoreSuppliers.RocksDBDslStoreSuppliers.class;
 
-    /** {@code dsl.store.suppliers.class } */
+    /** {@code dsl.store.format} */
     public static final String DSL_STORE_FORMAT_CONFIG = "dsl.store.format";
     public static final String DSL_STORE_FORMAT_DEFAULT = "DEFAULT";
     public static final String DSL_STORE_FORMAT_HEADERS = "HEADERS";
     private static final String DSL_STORE_FORMAT_DOC = "Specifies the state store format for DSL operators. " +
         "'DEFAULT' creates either timestamped or plain state stores, depending on context. " +
-        "'HEADERS' creates headers-aware stores that preserve record headers.";
+        "'HEADERS' creates headers-aware stores that preserve record headers. " +
+        "Custom DslStoreSuppliers implementations receive the format via dslStoreFormat() on DslKeyValueParams, " +
+        "DslWindowParams, and DslSessionParams.";
 
     /** {@code default key.serde} */
     @SuppressWarnings("WeakerAccess")

--- a/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/BuiltInDslStoreSuppliers.java
@@ -109,7 +109,7 @@ public class BuiltInDslStoreSuppliers {
         @Override
         public SessionBytesStoreSupplier sessionStore(final DslSessionParams params) {
             if (params.emitStrategy().type() == EmitStrategy.StrategyType.ON_WINDOW_CLOSE) {
-                if (params.storeFormat() == DslStoreFormat.HEADERS) {
+                if (params.dslStoreFormat() == DslStoreFormat.HEADERS) {
                     return new RocksDbTimeOrderedSessionHeadersBytesStoreSupplier(
                         params.name(),
                         params.retentionPeriod().toMillis(),
@@ -124,7 +124,7 @@ public class BuiltInDslStoreSuppliers {
                 }
             }
 
-            if (params.storeFormat() == DslStoreFormat.HEADERS) {
+            if (params.dslStoreFormat() == DslStoreFormat.HEADERS) {
                 return Stores.persistentSessionStoreWithHeaders(params.name(), params.retentionPeriod());
             }
             return Stores.persistentSessionStore(params.name(), params.retentionPeriod());

--- a/streams/src/main/java/org/apache/kafka/streams/state/DslSessionParams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/DslSessionParams.java
@@ -26,6 +26,9 @@ import java.util.Objects;
 /**
  * {@code DslSessionParams} is a wrapper class for all parameters that function
  * as inputs to {@link DslStoreSuppliers#sessionStore(DslSessionParams)}.
+ *
+ * <p>The store format is exposed via {@link #dslStoreFormat()}, consistent with
+ * {@link DslKeyValueParams} and {@link DslWindowParams}.
  */
 @InterfaceAudience.Public
 public class DslSessionParams {
@@ -33,7 +36,7 @@ public class DslSessionParams {
     private final String name;
     private final Duration retentionPeriod;
     private final EmitStrategy emitStrategy;
-    private final DslStoreFormat storeFormat;
+    private final DslStoreFormat dslStoreFormat;
 
     /**
      * @param name              name of the store (cannot be {@code null})
@@ -54,12 +57,12 @@ public class DslSessionParams {
     public DslSessionParams(final String name,
                             final Duration retentionPeriod,
                             final EmitStrategy emitStrategy,
-                            final DslStoreFormat storeFormat) {
+                            final DslStoreFormat dslStoreFormat) {
         Objects.requireNonNull(name);
         this.name = name;
         this.retentionPeriod = retentionPeriod;
         this.emitStrategy = emitStrategy;
-        this.storeFormat = storeFormat;
+        this.dslStoreFormat = dslStoreFormat;
     }
 
     public String name() {
@@ -74,8 +77,17 @@ public class DslSessionParams {
         return emitStrategy;
     }
 
+    public DslStoreFormat dslStoreFormat() {
+        return dslStoreFormat;
+    }
+
+    /**
+     * @deprecated Since 4.4. Use {@link #dslStoreFormat()} instead, consistent with
+     *             {@link DslKeyValueParams} and {@link DslWindowParams}.
+     */
+    @Deprecated
     public DslStoreFormat storeFormat() {
-        return storeFormat;
+        return dslStoreFormat();
     }
 
     @Override
@@ -90,12 +102,12 @@ public class DslSessionParams {
         return Objects.equals(name, that.name)
                 && Objects.equals(retentionPeriod, that.retentionPeriod)
                 && Objects.equals(emitStrategy, that.emitStrategy)
-                && Objects.equals(storeFormat, that.storeFormat);
+                && Objects.equals(dslStoreFormat, that.dslStoreFormat);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, retentionPeriod, emitStrategy, storeFormat);
+        return Objects.hash(name, retentionPeriod, emitStrategy, dslStoreFormat);
     }
 
     @Override
@@ -104,7 +116,7 @@ public class DslSessionParams {
                 "name='" + name + '\'' +
                 ", retentionPeriod=" + retentionPeriod +
                 ", emitStrategy=" + emitStrategy +
-                ", storeFormat=" + storeFormat +
+                ", dslStoreFormat=" + dslStoreFormat +
                 '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -35,7 +35,7 @@ import org.apache.kafka.streams.state.internals.RocksDbWindowHeadersBytesStoreSu
 import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
 import org.apache.kafka.streams.state.internals.SessionStoreWithHeadersBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
-import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilderWithHeaders;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreWithHeadersBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
 import org.apache.kafka.streams.state.internals.TimestampedWindowStoreWithHeadersBuilder;
 import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
@@ -605,7 +605,7 @@ public final class Stores {
         final Serde<V> valueSerde
     ) {
         Objects.requireNonNull(supplier, "supplier cannot be null");
-        return new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, keySerde, valueSerde, Time.SYSTEM);
+        return new TimestampedKeyValueStoreWithHeadersBuilder<>(supplier, keySerde, valueSerde, Time.SYSTEM);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreWithHeadersBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreWithHeadersBuilder.java
@@ -36,16 +36,18 @@ import java.util.Objects;
 /**
  * Builder for {@link TimestampedKeyValueStoreWithHeaders} instances.
  *
- * This is analogous to {@link TimestampedKeyValueStoreBuilder}, but uses
+ * <p>This is analogous to {@link TimestampedKeyValueStoreBuilder}, but uses
  * {@link ValueTimestampHeaders} as the value wrapper and wires up the
  * header-aware store stack (change-logging, caching, metering).
+ * The naming follows the {@code *WithHeadersBuilder} pattern used by
+ * {@link TimestampedWindowStoreWithHeadersBuilder} and {@link SessionStoreWithHeadersBuilder}.
  */
-public class TimestampedKeyValueStoreBuilderWithHeaders<K, V>
+public class TimestampedKeyValueStoreWithHeadersBuilder<K, V>
     extends AbstractStoreBuilder<K, ValueTimestampHeaders<V>, TimestampedKeyValueStoreWithHeaders<K, V>> {
 
     private final KeyValueBytesStoreSupplier storeSupplier;
 
-    public TimestampedKeyValueStoreBuilderWithHeaders(final KeyValueBytesStoreSupplier storeSupplier,
+    public TimestampedKeyValueStoreWithHeadersBuilder(final KeyValueBytesStoreSupplier storeSupplier,
                                                       final Serde<K> keySerde,
                                                       final Serde<V> valueSerde,
                                                       final Time time) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreWithHeadersBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreWithHeadersBuilderTest.java
@@ -77,19 +77,19 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
-public class TimestampedKeyValueStoreBuilderWithHeadersTest {
+public class TimestampedKeyValueStoreWithHeadersBuilderTest {
 
     @Mock
     private KeyValueBytesStoreSupplier supplier;
     @Mock
     private RocksDBTimestampedStoreWithHeaders inner;
-    private TimestampedKeyValueStoreBuilderWithHeaders<String, String> builder;
+    private TimestampedKeyValueStoreWithHeadersBuilder<String, String> builder;
 
     private void setUpWithoutInner() {
         when(supplier.name()).thenReturn("name");
         when(supplier.metricsScope()).thenReturn("metricScope");
 
-        builder = new TimestampedKeyValueStoreBuilderWithHeaders<>(
+        builder = new TimestampedKeyValueStoreWithHeadersBuilder<>(
             supplier,
             Serdes.String(),
             Serdes.String(),
@@ -190,28 +190,28 @@ public class TimestampedKeyValueStoreBuilderWithHeadersTest {
     public void shouldThrowNullPointerIfInnerIsNull() {
         setUpWithoutInner();
         assertThrows(NullPointerException.class, () ->
-            new TimestampedKeyValueStoreBuilderWithHeaders<>(null, Serdes.String(), Serdes.String(), new MockTime()));
+            new TimestampedKeyValueStoreWithHeadersBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime()));
     }
 
     @Test
     public void shouldNotThrowNullPointerIfKeySerdeIsNull() {
         setUpWithoutInner();
         // does not throw
-        new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, null, Serdes.String(), new MockTime());
+        new TimestampedKeyValueStoreWithHeadersBuilder<>(supplier, null, Serdes.String(), new MockTime());
     }
 
     @Test
     public void shouldNotThrowNullPointerIfValueSerdeIsNull() {
         setUpWithoutInner();
         // does not throw
-        new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, Serdes.String(), null, new MockTime());
+        new TimestampedKeyValueStoreWithHeadersBuilder<>(supplier, Serdes.String(), null, new MockTime());
     }
 
     @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
         setUpWithoutInner();
         assertThrows(NullPointerException.class, () ->
-            new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, Serdes.String(), Serdes.String(), null));
+            new TimestampedKeyValueStoreWithHeadersBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
     @Test
@@ -220,7 +220,7 @@ public class TimestampedKeyValueStoreBuilderWithHeadersTest {
         when(supplier.metricsScope()).thenReturn(null);
 
         final Exception e = assertThrows(NullPointerException.class,
-            () -> new TimestampedKeyValueStoreBuilderWithHeaders<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
+            () -> new TimestampedKeyValueStoreWithHeadersBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
         assertTrue(e.getMessage().contains("storeSupplier's metricsScope can't be null"));
     }
 
@@ -266,7 +266,7 @@ public class TimestampedKeyValueStoreBuilderWithHeadersTest {
         lenient().when(supplier.metricsScope()).thenReturn("metricScope");
         lenient().when(supplier.get()).thenReturn(innerStore(storeType));
 
-        builder = new TimestampedKeyValueStoreBuilderWithHeaders<>(
+        builder = new TimestampedKeyValueStoreWithHeadersBuilder<>(
             supplier, Serdes.String(), Serdes.String(), new MockTime());
         final TimestampedKeyValueStoreWithHeaders<String, String> store =
             (cachingEnabled


### PR DESCRIPTION
Aligns two naming inconsistencies in the Streams DSL store APIs:

* DslSessionParams now exposes dslStoreFormat(), matching DslKeyValueParams and DslWindowParams. The prior storeFormat() is retained as a @Deprecated alias delegating to dslStoreFormat().
* The internal header-aware key-value builder is renamed to TimestampedKeyValueStoreWithHeadersBuilder, matching the *WithHeadersBuilder pattern used by the window and session builders.

Also corrects a stale dsl.store.suppliers.class Javadoc tag on the dsl.store.format config in StreamsConfig.

Reviewer-  @aliehsaeedii

Reviewers: Priyanshu Vishwkarma <pv254424@gmail.com>
