### PR TITLE
MINOR: Enhance MirrorMaker 2 fault tolerance for topic truncation and reset scenarios

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+/**
+ * Thrown by {@link MirrorSourceTask} when a previously-unreplicated offset has been
+ * purged by log retention. Always fails the task.
+ */
+public class DataLossException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DataLossException(String message) {
+        super(message);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -16,12 +16,18 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Utils;
@@ -35,10 +41,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
@@ -50,9 +61,9 @@ public class MirrorSourceTask extends SourceTask {
 
     private static final Logger log = LoggerFactory.getLogger(MirrorSourceTask.class);
 
-    private KafkaConsumer<byte[], byte[]> consumer;
+    private Consumer<byte[], byte[]> consumer;
     private String sourceClusterAlias;
-    private Duration pollTimeout;
+    private Duration pollTimeout = Duration.ofMillis(100);
     private ReplicationPolicy replicationPolicy;
     private MirrorSourceLegacyMetrics legacyMetrics;
     private MirrorSourceMetrics metrics;
@@ -60,10 +71,21 @@ public class MirrorSourceTask extends SourceTask {
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
 
+    private Admin sourceAdmin;
+    private final Map<String, Uuid> knownTopicIds = new HashMap<>();
+    private final ReplicationFailureClassifier failureClassifier = new ReplicationFailureClassifier();
+    private static final String TOPIC_ID_OFFSET_KEY = "mm2_fault_tolerance_topic_id";
+
+    // Configurable via the "topic.reset.behavior" task property (fail-fast default, self-heal opt-in).
+    static final String RESET_BEHAVIOR_CONFIG = "topic.reset.behavior";
+    static final String RESET_BEHAVIOR_FAIL_FAST = "fail-fast";
+    static final String RESET_BEHAVIOR_SELF_HEAL = "self-heal";
+    private String resetBehavior = RESET_BEHAVIOR_FAIL_FAST;
+
     public MirrorSourceTask() {}
 
     // for testing
-    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+    MirrorSourceTask(Consumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
                      ReplicationPolicy replicationPolicy,
                      OffsetSyncWriter offsetSyncWriter) {
         this.consumer = consumer;
@@ -74,8 +96,27 @@ public class MirrorSourceTask extends SourceTask {
         this.offsetSyncWriter = offsetSyncWriter;
     }
 
+    // for testing
+    MirrorSourceTask(Consumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+                     ReplicationPolicy replicationPolicy, OffsetSyncWriter offsetSyncWriter, Admin sourceAdmin) {
+        this(consumer, metrics, sourceClusterAlias, replicationPolicy, offsetSyncWriter);
+        this.sourceAdmin = sourceAdmin;
+    }
+
+    // visible for testing -- seeds the topic-ID cache directly, bypassing start()/primeKnownTopicIdsAndDetectResets
+    void seedKnownTopicId(String topic, Uuid topicId) {
+        knownTopicIds.put(topic, topicId);
+    }
+
+    // visible for testing -- sets resetBehavior directly, bypassing start()/resolveResetBehavior
+    void setResetBehaviorForTesting(String resetBehavior) {
+        this.resetBehavior = resetBehavior;
+    }
+
     @Override
     public void start(Map<String, String> props) {
+        resetBehavior = resolveResetBehavior(props);
+
         MirrorSourceTaskConfig config = new MirrorSourceTaskConfig(props);
         consumerAccess = new Semaphore(1);  // let one thread at a time access the consumer
         sourceClusterAlias = config.sourceClusterAlias();
@@ -87,12 +128,24 @@ public class MirrorSourceTask extends SourceTask {
         if (config.emitOffsetSyncsEnabled()) {
             offsetSyncWriter = new OffsetSyncWriter(config);
         }
-        consumer = MirrorUtils.newConsumer(config.sourceConsumerConfig("replication-consumer"));
-        Set<TopicPartition> taskTopicPartitions = config.taskTopicPartitions();
-        initializeConsumer(taskTopicPartitions);
 
-        log.info("{} replicating {} topic-partitions {}->{}: {}.", Thread.currentThread().getName(),
-            taskTopicPartitions.size(), sourceClusterAlias, config.targetClusterAlias(), taskTopicPartitions);
+        // "earliest" would silently skip purged offsets; "none" makes that throw instead.
+        Map<String, Object> consumerConfig = config.sourceConsumerConfig("replication-consumer");
+        consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+        consumer = MirrorUtils.newConsumer(consumerConfig);
+
+        if (sourceAdmin == null) {
+            sourceAdmin = Admin.create(config.sourceAdminConfig("fault-tolerance-admin"));
+        }
+
+        Set<TopicPartition> taskTopicPartitions = config.taskTopicPartitions();
+        // Check topic identity before seeking to any stored offset, not only reactively
+        // on exception -- otherwise a coincidental offset match after a reset never throws.
+        Set<TopicPartition> preexistingResets = primeKnownTopicIdsAndDetectResets(taskTopicPartitions);
+        initializeConsumer(taskTopicPartitions, preexistingResets);
+
+        log.info("{} replicating {} topic-partitions {}->{}: {}. Reset behavior: {}.", Thread.currentThread().getName(),
+                taskTopicPartitions.size(), sourceClusterAlias, config.targetClusterAlias(), taskTopicPartitions, resetBehavior);
     }
 
     @Override
@@ -116,14 +169,15 @@ public class MirrorSourceTask extends SourceTask {
         try {
             consumerAccess.acquire();
         } catch (InterruptedException e) {
-            log.warn("Interrupted waiting for access to consumer. Will try closing anyway."); 
+            log.warn("Interrupted waiting for access to consumer. Will try closing anyway.");
         }
         Utils.closeQuietly(consumer, "source consumer");
+        Utils.closeQuietly(sourceAdmin, "source admin client");
         Utils.closeQuietly(offsetSyncWriter, "offset sync writer");
         Utils.closeQuietly(legacyMetrics, "metrics");
         log.info("Stopping {} took {} ms.", Thread.currentThread().getName(), System.currentTimeMillis() - start);
     }
-   
+
     @Override
     public String version() {
         return new MirrorSourceConnector().version();
@@ -162,6 +216,18 @@ public class MirrorSourceTask extends SourceTask {
                 log.trace("Polled {} records from {}.", sourceRecords.size(), records.partitions());
                 return sourceRecords;
             }
+        } catch (NoOffsetForPartitionException e) {
+            // First-ever run for this partition, not data loss -- start from the beginning.
+            log.info("No previously committed offset for {} -- first replication run for "
+                    + "these partitions. Starting from the beginning.", e.partitions());
+            consumer.seekToBeginning(e.partitions());
+            return null;
+        } catch (OffsetOutOfRangeException e) {
+            // handleOffsetOutOfRange tells truncation and reset apart, and either throws
+            // (DataLossException always; TopicResetException if resetBehavior is fail-fast)
+            // or resubscribes from the beginning (reset, only if resetBehavior is self-heal).
+            handleOffsetOutOfRange(e);
+            return null;
         } catch (WakeupException e) {
             return null;
         } catch (KafkaException e) {
@@ -175,7 +241,7 @@ public class MirrorSourceTask extends SourceTask {
             consumerAccess.release();
         }
     }
- 
+
     @Override
     public void commitRecord(SourceRecord record, RecordMetadata metadata) {
         if (stopping) {
@@ -209,7 +275,136 @@ public class MirrorSourceTask extends SourceTask {
             offsetSyncWriter.firePendingOffsetSyncs();
         }
     }
- 
+
+    /**
+     * Runs at startup, before seeking. Compares each partition's durable topic ID
+     * against a fresh one; throws or flags for reset-seeking depending on resetBehavior.
+     */
+    private Set<TopicPartition> primeKnownTopicIdsAndDetectResets(Set<TopicPartition> topicPartitions) {
+        Set<String> allTopics = topicPartitions.stream().map(TopicPartition::topic).collect(Collectors.toSet());
+        Map<String, Uuid> currentIds = fetchTopicIds(allTopics);
+
+        Set<TopicPartition> resetPartitions = new HashSet<>();
+        for (TopicPartition tp : topicPartitions) {
+            Uuid durable = loadKnownTopicId(tp);
+            Uuid current = currentIds.get(tp.topic());
+
+            if (durable != null
+                    && failureClassifier.classify(durable, current) == ReplicationFailureClassifier.Decision.TOPIC_RESET) {
+                if (RESET_BEHAVIOR_SELF_HEAL.equals(resetBehavior)) {
+                    log.warn("Detected topic reset for {} at startup: topic ID changed from {} to {}. "
+                            + "Resubscribing from the beginning (self-heal mode).", tp, durable, current);
+                    resetPartitions.add(tp);
+                } else {
+                    log.error("Detected topic reset for {} at startup: topic ID changed from {} to {}. "
+                                    + "Failing fast (set {}={} to auto-recover instead).",
+                            tp, durable, current, RESET_BEHAVIOR_CONFIG, RESET_BEHAVIOR_SELF_HEAL);
+                    throw new TopicResetException(String.format(
+                            "Topic reset detected on %s at startup: topic ID changed from %s to %s.",
+                            tp, durable, current));
+                }
+            }
+            Uuid toCache = current != null ? current : durable;
+            if (toCache != null) {
+                knownTopicIds.put(tp.topic(), toCache);
+            }
+        }
+        return resetPartitions;
+    }
+
+    /** Resolves the topic.reset.behavior property, defaulting to fail-fast. */
+    static String resolveResetBehavior(Map<String, String> props) {
+        String value = props.getOrDefault(RESET_BEHAVIOR_CONFIG, RESET_BEHAVIOR_FAIL_FAST);
+        if (!RESET_BEHAVIOR_FAIL_FAST.equals(value) && !RESET_BEHAVIOR_SELF_HEAL.equals(value)) {
+            log.warn("Unrecognized {}='{}', defaulting to '{}'.", RESET_BEHAVIOR_CONFIG, value, RESET_BEHAVIOR_FAIL_FAST);
+            return RESET_BEHAVIOR_FAIL_FAST;
+        }
+        return value;
+    }
+
+    private Map<String, Uuid> fetchTopicIds(Set<String> topics) {
+        Map<String, Uuid> result = new HashMap<>();
+        if (topics.isEmpty()) {
+            return result;
+        }
+        try {
+            Map<String, org.apache.kafka.common.KafkaFuture<TopicDescription>> futures =
+                    sourceAdmin.describeTopics(topics).topicNameValues();
+            for (Map.Entry<String, org.apache.kafka.common.KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
+                try {
+                    result.put(entry.getKey(), entry.getValue().get().topicId());
+                } catch (ExecutionException | InterruptedException e) {
+                    log.warn("Could not fetch topic ID for {} while checking for topic reset.", entry.getKey(), e);
+                }
+            }
+        } catch (KafkaException e) {
+            log.warn("Could not describe topics {} while checking for topic reset.", topics, e);
+        }
+        return result;
+    }
+
+    /**
+     * Distinguishes truncation from topic reset. Truncation always throws
+     * {@link DataLossException}. Reset throws {@link TopicResetException} (fail-fast,
+     * default) or resubscribes from the beginning (self-heal, opt-in).
+     */
+    private void handleOffsetOutOfRange(OffsetOutOfRangeException e) {
+        Set<TopicPartition> affected = e.offsetOutOfRangePartitions().keySet();
+        Set<String> affectedTopics = affected.stream().map(TopicPartition::topic).collect(Collectors.toSet());
+        Map<String, Uuid> currentTopicIds = fetchTopicIds(affectedTopics);
+
+        List<TopicPartition> resetPartitions = new ArrayList<>();
+
+        for (TopicPartition tp : affected) {
+            long requestedOffset = e.offsetOutOfRangePartitions().get(tp);
+            Uuid previousId = knownTopicIds.get(tp.topic());
+            Uuid currentId = currentTopicIds.get(tp.topic());
+
+            ReplicationFailureClassifier.Decision decision = failureClassifier.classify(previousId, currentId);
+
+            if (decision == ReplicationFailureClassifier.Decision.TOPIC_RESET) {
+                if (RESET_BEHAVIOR_SELF_HEAL.equals(resetBehavior)) {
+                    log.warn("Detected topic reset for {}-{}: topic ID changed from {} to {} at {}. "
+                                    + "Resubscribing from the beginning offset (self-heal mode).",
+                            tp.topic(), tp.partition(), previousId, currentId, Instant.now());
+                    resetPartitions.add(tp);
+                    knownTopicIds.put(tp.topic(), currentId);
+                } else {
+                    log.error("Detected topic reset for {}-{}: topic ID changed from {} to {}. "
+                                    + "Failing fast (set {}={} to auto-recover instead).",
+                            tp.topic(), tp.partition(), previousId, currentId, RESET_BEHAVIOR_CONFIG, RESET_BEHAVIOR_SELF_HEAL);
+                    throw new TopicResetException(String.format(
+                            "Topic reset detected on %s-%s: topic ID changed from %s to %s.",
+                            tp.topic(), tp.partition(), previousId, currentId));
+                }
+            } else {
+                long earliest = safeBeginningOffset(tp);
+                log.error("Detected unrecoverable data loss for {}-{}: next required offset {} is no longer "
+                                + "available on the source cluster (earliest available offset is now {}). Failing fast.",
+                        tp.topic(), tp.partition(), requestedOffset, earliest);
+                throw new DataLossException(String.format(
+                        "Data loss detected on %s-%s: required offset %d but earliest available is %d. "
+                                + "Data was purged by retention before MirrorMaker 2 replicated it.",
+                        tp.topic(), tp.partition(), requestedOffset, earliest));
+            }
+        }
+
+        if (!resetPartitions.isEmpty()) {
+            consumer.seekToBeginning(resetPartitions);
+        }
+    }
+
+    private long safeBeginningOffset(TopicPartition tp) {
+        try {
+            Map<TopicPartition, Long> beginning = consumer.beginningOffsets(Collections.singletonList(tp));
+            Long offset = beginning.get(tp);
+            return offset == null ? -1L : offset;
+        } catch (KafkaException e) {
+            log.warn("Could not fetch beginning offset for {} while reporting data loss.", tp, e);
+            return -1L;
+        }
+    }
+
     private Map<TopicPartition, Long> loadOffsets(Set<TopicPartition> topicPartitions) {
         return topicPartitions.stream().collect(Collectors.toMap(x -> x, this::loadOffset));
     }
@@ -220,14 +415,43 @@ public class MirrorSourceTask extends SourceTask {
         return MirrorUtils.unwrapOffset(wrappedOffset);
     }
 
-    // visible for testing
+    /** Reads the topic UUID stamped on the last committed offset, if any -- survives restarts unlike {@link #knownTopicIds}. */
+    private Uuid loadKnownTopicId(TopicPartition topicPartition) {
+        Map<String, Object> wrappedPartition = MirrorUtils.wrapPartition(topicPartition, sourceClusterAlias);
+        Map<String, Object> wrappedOffset = context.offsetStorageReader().offset(wrappedPartition);
+        if (wrappedOffset == null) {
+            return null;
+        }
+        Object stored = wrappedOffset.get(TOPIC_ID_OFFSET_KEY);
+        if (stored == null) {
+            return null;
+        }
+        try {
+            return Uuid.fromString(stored.toString());
+        } catch (IllegalArgumentException e) {
+            log.warn("Could not parse stored topic ID '{}' for {}; treating as unknown.", stored, topicPartition, e);
+            return null;
+        }
+    }
+
+    // visible for testing -- kept for Kafka's own MirrorSourceTaskTest#testSeekBehaviorDuringStart
     void initializeConsumer(Set<TopicPartition> taskTopicPartitions) {
+        initializeConsumer(taskTopicPartitions, Collections.emptySet());
+    }
+
+    // visible for testing
+    void initializeConsumer(Set<TopicPartition> taskTopicPartitions, Set<TopicPartition> resetPartitions) {
         Map<TopicPartition, Long> topicPartitionOffsets = loadOffsets(taskTopicPartitions);
         consumer.assign(topicPartitionOffsets.keySet());
         log.info("Starting with {} previously uncommitted partitions.", topicPartitionOffsets.values().stream()
                 .filter(this::isUncommitted).count());
 
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
+            if (resetPartitions.contains(topicPartition)) {
+                log.trace("Seeking {} to the beginning due to a topic reset detected at startup.", topicPartition);
+                consumer.seekToBeginning(Collections.singletonList(topicPartition));
+                return;
+            }
             // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {
                 log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
@@ -239,13 +463,21 @@ public class MirrorSourceTask extends SourceTask {
         });
     }
 
-    // visible for testing 
+    // visible for testing
     SourceRecord convertRecord(ConsumerRecord<byte[], byte[]> record) {
         String targetTopic = formatRemoteTopic(record.topic());
         Headers headers = convertHeaders(record);
+
+        // Stamp the current topic ID onto the committed offset so it survives restarts.
+        Map<String, Object> sourceOffset = new HashMap<>(MirrorUtils.wrapOffset(record.offset()));
+        Uuid currentTopicId = knownTopicIds.get(record.topic());
+        if (currentTopicId != null) {
+            sourceOffset.put(TOPIC_ID_OFFSET_KEY, currentTopicId.toString());
+        }
+
         return new SourceRecord(
                 MirrorUtils.wrapPartition(new TopicPartition(record.topic(), record.partition()), sourceClusterAlias),
-                MirrorUtils.wrapOffset(record.offset()),
+                sourceOffset,
                 targetTopic, record.partition(),
                 Schema.OPTIONAL_BYTES_SCHEMA, record.key(),
                 Schema.BYTES_SCHEMA, record.value(),

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/ReplicationFailureClassifier.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/ReplicationFailureClassifier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.Uuid;
+
+/**
+ * Decides whether an {@code OffsetOutOfRangeException} means genuine data loss or a
+ * benign topic reset, based on whether the topic's UUID has changed.
+ *
+ * <p>Deliberately free of any Connect/consumer/AdminClient dependency, so it's
+ * unit-testable without a broker; all I/O stays in {@link MirrorSourceTask}.
+ */
+public class ReplicationFailureClassifier {
+
+    public enum Decision {
+        TOPIC_RESET,
+        DATA_LOSS
+    }
+
+    /**
+     * @param previousTopicId last-cached UUID, or null if never observed
+     * @param currentTopicId  freshly-fetched UUID, or null if the fetch failed
+     */
+    public Decision classify(Uuid previousTopicId, Uuid currentTopicId) {
+        boolean bothKnownAndDifferent = previousTopicId != null
+                && currentTopicId != null
+                && !previousTopicId.equals(currentTopicId);
+
+        if (bothKnownAndDifferent) {
+            return Decision.TOPIC_RESET;
+        }
+        // Fail safe: same ID, or either ID unknown -> treat as data loss.
+        return Decision.DATA_LOSS;
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+/**
+ * Thrown by {@link MirrorSourceTask} when a source topic reset (delete+recreate) is
+ * detected and {@code topic.reset.behavior} is "fail-fast" (the default).
+ */
+public class TopicResetException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TopicResetException(String message) {
+        super(message);
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskFaultToleranceTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskFaultToleranceTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Simulates a real OffsetOutOfRangeException during poll() and checks the right exception (or none) comes out. */
+class MirrorSourceTaskFaultToleranceTest {
+
+    private static final String TOPIC = "commit-log";
+    private static final TopicPartition TP = new TopicPartition(TOPIC, 0);
+
+    @Test
+    void sameTopicIdThrowsDataLossException() {
+        Uuid sameId = Uuid.randomUuid();
+        MockConsumer<byte[], byte[]> consumer = newAssignedConsumer();
+        Admin admin = mockAdminReturning(sameId);
+
+        MirrorSourceTask task = new MirrorSourceTask(consumer, null, "primary", null, null, admin);
+        task.seedKnownTopicId(TOPIC, sameId);
+        scheduleOffsetOutOfRange(consumer);
+
+        assertThrows(DataLossException.class, task::poll);
+    }
+
+    @Test
+    void differentTopicIdInFailFastModeThrowsTopicResetException() {
+        MockConsumer<byte[], byte[]> consumer = newAssignedConsumer();
+        Admin admin = mockAdminReturning(Uuid.randomUuid());
+
+        MirrorSourceTask task = new MirrorSourceTask(consumer, null, "primary", null, null, admin);
+        task.seedKnownTopicId(TOPIC, Uuid.randomUuid()); // different from the mocked current ID
+        task.setResetBehaviorForTesting("fail-fast");
+        scheduleOffsetOutOfRange(consumer);
+
+        assertThrows(TopicResetException.class, task::poll);
+    }
+
+    @Test
+    void differentTopicIdInSelfHealModeDoesNotThrow() {
+        MockConsumer<byte[], byte[]> consumer = newAssignedConsumer();
+        Admin admin = mockAdminReturning(Uuid.randomUuid());
+
+        MirrorSourceTask task = new MirrorSourceTask(consumer, null, "primary", null, null, admin);
+        task.seedKnownTopicId(TOPIC, Uuid.randomUuid());
+        task.setResetBehaviorForTesting("self-heal");
+        scheduleOffsetOutOfRange(consumer);
+
+        assertDoesNotThrow(task::poll);
+    }
+
+    private static MockConsumer<byte[], byte[]> newAssignedConsumer() {
+        MockConsumer<byte[], byte[]> consumer = new MockConsumer<>("none");
+        consumer.assign(Collections.singletonList(TP));
+        consumer.updateBeginningOffsets(Collections.singletonMap(TP, 0L));
+        return consumer;
+    }
+
+    private static void scheduleOffsetOutOfRange(MockConsumer<byte[], byte[]> consumer) {
+        Map<TopicPartition, Long> outOfRange = Collections.singletonMap(TP, 100L);
+        consumer.schedulePollTask(() -> {
+            throw new OffsetOutOfRangeException(outOfRange);
+        });
+    }
+
+    private static Admin mockAdminReturning(Uuid currentTopicId) {
+        Admin admin = mock(Admin.class);
+        TopicDescription description = mock(TopicDescription.class);
+        when(description.topicId()).thenReturn(currentTopicId);
+        DescribeTopicsResult result = mock(DescribeTopicsResult.class);
+        when(result.topicNameValues()).thenReturn(
+                Collections.singletonMap(TOPIC, KafkaFuture.completedFuture(description)));
+        when(admin.describeTopics(anyCollection())).thenReturn(result);
+        return admin;
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskResetBehaviorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskResetBehaviorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MirrorSourceTaskResetBehaviorTest {
+
+    @Test
+    void defaultsToFailFastWhenNotSet() {
+        assertEquals("fail-fast", MirrorSourceTask.resolveResetBehavior(Collections.emptyMap()));
+    }
+
+    @Test
+    void respectsExplicitFailFast() {
+        Map<String, String> props = Collections.singletonMap("topic.reset.behavior", "fail-fast");
+        assertEquals("fail-fast", MirrorSourceTask.resolveResetBehavior(props));
+    }
+
+    @Test
+    void respectsExplicitSelfHeal() {
+        Map<String, String> props = Collections.singletonMap("topic.reset.behavior", "self-heal");
+        assertEquals("self-heal", MirrorSourceTask.resolveResetBehavior(props));
+    }
+
+    @Test
+    void fallsBackToFailFastOnUnrecognizedValue() {
+        Map<String, String> props = Collections.singletonMap("topic.reset.behavior", "bogus");
+        assertEquals("fail-fast", MirrorSourceTask.resolveResetBehavior(props));
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/ReplicationFailureClassifierTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/ReplicationFailureClassifierTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.kafka.connect.mirror.ReplicationFailureClassifier.Decision.DATA_LOSS;
+import static org.apache.kafka.connect.mirror.ReplicationFailureClassifier.Decision.TOPIC_RESET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReplicationFailureClassifierTest {
+
+    private final ReplicationFailureClassifier classifier = new ReplicationFailureClassifier();
+
+    @Test
+    void classifiesAsTopicResetWhenTopicIdChanged() {
+        Uuid oldId = Uuid.randomUuid();
+        Uuid newId = Uuid.randomUuid();
+        assertEquals(TOPIC_RESET, classifier.classify(oldId, newId));
+    }
+
+    @Test
+    void classifiesAsDataLossWhenTopicIdUnchanged() {
+        Uuid sameId = Uuid.randomUuid();
+        assertEquals(DATA_LOSS, classifier.classify(sameId, sameId));
+    }
+
+    @Test
+    void classifiesAsDataLossWhenCurrentIdCouldNotBeFetched() {
+        Uuid oldId = Uuid.randomUuid();
+        assertEquals(DATA_LOSS, classifier.classify(oldId, null));
+    }
+
+    @Test
+    void classifiesAsDataLossWhenNoPreviousIdWasEverCached() {
+        Uuid currentId = Uuid.randomUuid();
+        assertEquals(DATA_LOSS, classifier.classify(null, currentId));
+    }
+
+    @Test
+    void classifiesAsDataLossWhenBothIdsUnknown() {
+        assertEquals(DATA_LOSS, classifier.classify(null, null));
+    }
+}


### PR DESCRIPTION

## Summary

Part of a broader effort to make MirrorMaker 2 suitable for mission-critical
replication between a primary cluster and a disaster-recovery cluster,
beyond what vanilla MM2 offers. Adds two fault-tolerance behaviors to
`MirrorSourceTask`:

1. **Fail-fast on silent data loss.** If the source cluster's retention
   purges data before MM2 replicates it, MM2 currently jumps ahead
   silently with no signal. This detects the gap, logs the topic,
   partition, and problematic offset, and throws `DataLossException`.
2. **Fail-fast on topic reset, with an opt-in self-heal mode.** If the
   source topic is deleted and recreated, MM2 currently stalls or throws
   an unhandled error. By default, this detects the reset and throws
   `TopicResetException`, stopping the task for manual intervention. A
   task property, `topic.reset.behavior=self-heal`, is available to
   instead auto-resubscribe from the beginning -- off by default.

## Problem

MM2's consumer defaults to `auto.offset.reset=earliest`. If the next
offset it needs has been purged by retention, it silently resets to
whatever data is left -- no exception, no log, no signal anything was
lost. A topic delete+recreate produces the same underlying symptom
(`OffsetOutOfRangeException`), so telling the two apart needs more than
just catching the exception.

## Changes

- `MirrorSourceTask.java`:
  - `auto.offset.reset=none` on the replication consumer, turning the
    silent-skip into a catchable `OffsetOutOfRangeException`.
  - Dedicated catch for `NoOffsetForPartitionException` -- a brand-new
    partition's first-ever run is not data loss.
  - `primeKnownTopicIdsAndDetectResets()` checks each partition's topic
    UUID *before* seeking to any stored offset, so a reset is caught even
    if the old numeric offset happens to still be valid in the recreated
    topic.
  - The current topic UUID is stamped onto each record's committed offset
    (`convertRecord`) so identity survives task/container restarts, not
    just in-memory state.
  - `handleOffsetOutOfRange()` remains as a secondary, reactive check for
    truncation or a reset that happens mid-run without a restart.
  - New `topic.reset.behavior` task property (`fail-fast` default,
    `self-heal` opt-in), read from task properties and resolved via the
    new `resolveResetBehavior()` static method.
  - Consumer field widened from the concrete `KafkaConsumer` class to the
    `Consumer` interface, so it can be exercised with `MockConsumer` in
    tests without changing any runtime behavior.
- `ReplicationFailureClassifier.java`: pure decision logic -- compares two
  topic UUIDs, returns `TOPIC_RESET` or `DATA_LOSS`. No Connect/consumer/
  admin dependency, unit-tested in isolation. Defaults to `DATA_LOSS` if
  either UUID can't be established.
- `DataLossException.java` (new): thrown on genuine data loss, fails the
  Connect task with a clear, greppable cause.
- `TopicResetException.java` (new): thrown on a detected topic reset when
  `topic.reset.behavior` is `fail-fast` (the default).

## Test Strategy

- `ReplicationFailureClassifierTest` -- 5 unit tests for the pure
  UUID-comparison decision, no broker.
- `MirrorSourceTaskResetBehaviorTest` -- 4 unit tests for the
  `topic.reset.behavior` property parsing (default, both explicit values,
  fallback on an unrecognized value), no broker.
- `MirrorSourceTaskFaultToleranceTest` -- 3 tests that simulate a real
  `OffsetOutOfRangeException` firing mid-`poll()` via
  `MockConsumer#schedulePollTask`, with a mocked `Admin` controlling which
  topic ID comes back, asserting: same topic ID throws
  `DataLossException`; different topic ID in fail-fast mode throws
  `TopicResetException`; different topic ID in self-heal mode throws
  nothing and resubscribes instead.
- Kafka's pre-existing `MirrorSourceTaskTest` suite passes unchanged (7/7),
  including `testSeekBehaviorDuringStart` -- the original
  `initializeConsumer(Set<TopicPartition>)` signature is preserved via an
  overload rather than changed.
- Full manual verification was also run against a real two-cluster Docker
  stack in an earlier iteration of this change (normal replication,
  truncation, topic-reset recovery, including a back-to-back double-reset
  edge case) -- superseded here by the in-fork `MockConsumer`-based tests
  above, which don't require standing up a real cluster to run.

Full design reasoning, including real bugs found and fixed along the way,
is in `docs/DESIGN.md` of my submission repo:
https://github.com/ankita10r/kafka-dr-replication

## Scope

Contained to `connect/mirror` -- one modified file plus two new small
exception classes, one new pure decision class, and their tests. No
changes to `MirrorUtils`, `MirrorConnectorConfig`, or any other connector
(checkpoint, heartbeat). `topic.reset.behavior` is read directly from task
properties rather than registered in `MirrorConnectorConfig`'s shared
`ConfigDef`, to avoid touching a file used by every MM2 connector for a
property that only affects this fault-tolerance behavior.

## AI Usage Documentation

I used Claude (Anthropic) to help design and implement this change, and
cross-checked design tradeoffs with Gemini separately rather than trusting
one tool's output as final. Specifically:
- Helped structure the two-scenario detection logic and identify the
  topic-UUID comparison as the reliable signal (as opposed to offset-value
  comparison, which can't actually distinguish the two scenarios, since
  both always present as "requested offset below what's available").
- Wrote the initial implementation of `MirrorSourceTask`'s changes and the
  new exception/classifier classes; I verified correctness by compiling
  and running the full test suite myself, not by reading the code alone.
- Helped write the `MockConsumer`/Mockito-based test simulating the real
  failure scenario, verifying the exact API (constructor signatures,
  `Admin.describeTopics` overloads) against this repository's actual
  source before relying on it.
- Helped debug real issues found only by running tests and the build
  locally, not caught by code review alone.