### PR TITLE
KAFKA-10369: Add TimestampAndOffset value type of deduplication store (1/N)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffset.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffset.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import java.util.Optional;
+
+class TimestampAndOffset {
+
+    final long timestamp;
+    final Optional<Long> offset; // for punctuated records
+
+    TimestampAndOffset(final long timestamp, final Optional<Long> offset) {
+        this.timestamp = timestamp;
+        this.offset = offset;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffsetSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampAndOffsetSerde.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+class TimestampAndOffsetSerde implements Serde<TimestampAndOffset> {
+
+    private static final int SIZE = 8 + 1 + 8; // timestamp + hasOffset flag + offset
+
+    @Override
+    public Serializer<TimestampAndOffset> serializer() {
+        return (topic, data) -> {
+            if (data == null) return null;
+            final ByteBuffer buf = ByteBuffer.allocate(SIZE);
+            buf.putLong(data.timestamp);
+            if (data.offset.isPresent()) {
+                buf.put((byte) 0x01);
+                buf.putLong(data.offset.get());
+            } else {
+                buf.put((byte) 0x00);
+                buf.putLong(0L); // padding
+            }
+            return buf.array();
+        };
+    }
+
+    @Override
+    public Deserializer<TimestampAndOffset> deserializer() {
+        return (topic, data) -> {
+            if (data == null) return null;
+            final ByteBuffer buf = ByteBuffer.wrap(data);
+            final long timestamp = buf.getLong();
+            final boolean hasOffset = buf.get() == 0x01;
+            final long offsetValue = buf.getLong();
+            final Optional<Long> offset = hasOffset ? Optional.of(offsetValue) : Optional.empty();
+            return new TimestampAndOffset(timestamp, offset);
+        };
+    }
+}


### PR DESCRIPTION
### Summary

This is a first PR for adding deduplication operator to Streams DSL. See this global PR draft for reference https://github.com/apache/kafka/pull/22189

This PR adds the _TimestampAndOffset_ class which will be used as a the value type of the deduplication store. The store keeps track of the records seen so far, and will be used by the processor to deduplicate records. See [wiki](https://cwiki.apache.org/confluence/display/KAFKA/KIP-655%3A+Windowed+Distinct+Operation+for+Kafka+Streams+API) and [mail thread discussion](https://lists.apache.org/thread/8qd0mopvromwr3y0wvw9v3kzf9vkb5z0) for the reason we need the timestamp and offset.

In brief:
- Deduplication is bounded in time and the store doesn't keep records forever - old records should be evicted from the store => Hence _Timestamp_

- Records may be processed twice in case of a failure - we need to track records that have been saved in the store and still not committed => Hence _Offset_

### JIRA
[KAFKA-10369](https://issues.apache.org/jira/browse/KAFKA-10369)



