### PR TITLE
KAFKA-20698: Remove deprecated ConsumerRecords(Map) constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -20,17 +20,12 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 import org.apache.kafka.common.utils.internals.AbstractIterator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A container that holds the list {@link ConsumerRecord} per partition for a
@@ -39,27 +34,10 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 @InterfaceAudience.Public
 public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
-    private static final Logger log = LoggerFactory.getLogger(ConsumerRecords.class);
-
     public static final ConsumerRecords<Object, Object> EMPTY = new ConsumerRecords<>(Map.of(), Map.of());
 
     private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
     private final Map<TopicPartition, OffsetAndMetadata> nextOffsets;
-
-    // Flag to detect if legacy ConsumerRecords(Map) constructor is used. See KAFKA-20660 for more details.
-    private final boolean tainted;
-    // Visible for testing
-    static final long TAINT_LOG_INTERVAL_NS = TimeUnit.MINUTES.toNanos(5);
-    // Visible for testing
-    static final AtomicLong TAINTED_NEXT_OFFSETS_LAST_LOG_NS = new AtomicLong(System.nanoTime() - TAINT_LOG_INTERVAL_NS);
-
-    /**
-     * @deprecated Since 4.0. Use {@link #ConsumerRecords(Map, Map)} instead.
-     */
-    @Deprecated(since = "4.0", forRemoval = true)
-    public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
-        this(records, Map.of(), true);
-    }
 
     /**
      * Constructs a new ConsumerRecords with the given records and next offsets.
@@ -70,13 +48,8 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
      *                    start reading from on the next poll.
      */
     public ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records, final Map<TopicPartition, OffsetAndMetadata> nextOffsets) {
-        this(records, nextOffsets, false);
-    }
-
-    private ConsumerRecords(Map<TopicPartition, List<ConsumerRecord<K, V>>> records, final Map<TopicPartition, OffsetAndMetadata> nextOffsets, boolean tainted) {
         this.records = records;
         this.nextOffsets = Map.copyOf(nextOffsets);
-        this.tainted = tainted;
     }
 
     /**
@@ -97,20 +70,6 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
      * @return The next offsets that the consumer will consume
      */
     public Map<TopicPartition, OffsetAndMetadata> nextOffsets() {
-        if (this.tainted) {
-            final long now = System.nanoTime();
-            final long lastLog = TAINTED_NEXT_OFFSETS_LAST_LOG_NS.get();
-            // nextOffsets() is called on every poll, so a tainted instance would otherwise log the deprecation error log on
-            // every call. A time based approach is used to avoid this. See KAFKA-20660 for more details.
-            if (now - lastLog >= TAINT_LOG_INTERVAL_NS && TAINTED_NEXT_OFFSETS_LAST_LOG_NS.compareAndSet(lastLog, now)) {
-                log.error("ConsumerRecords#nextOffsets() returned empty because this instance was built with the " +
-                        "deprecated ConsumerRecords(Map) constructor (see KIP-1094), which does not supply next offsets. " +
-                        "Downstream logic that relies on these offsets to advance the consumer's committed position " +
-                        "(for example, Kafka Streams under exactly-once semantics) will be unable to commit, leading to " +
-                        "reprocessing. Update the interceptor or wrapper that constructed it to use the " +
-                        "ConsumerRecords(Map, Map) constructor that supplies next offsets.");
-            }
-        }
         return nextOffsets;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.common.utils.LogCaptureAppender;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -183,66 +181,20 @@ public class ConsumerRecordsTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
-    public void testNextOffsetsLogsErrorPeriodicallyWhenConstructedWithDeprecatedConstructor() {
-        TopicPartition tp = new TopicPartition("topic", 0);
-        Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
-            Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
-
-        // Capture the global throttle state so it can be restored, to avoid leaking into other tests.
-        final long previousLastLogNs = ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.get();
-        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
-            // Force the rate-limit window to have elapsed so the next tainted call logs.
-            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(
-                System.nanoTime() - ConsumerRecords.TAINT_LOG_INTERVAL_NS - 1);
-
-            ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
-
-            // deprecated constructor does not supply next offsets, so the map is empty
-            assertTrue(consumerRecords.nextOffsets().isEmpty());
-
-            List<String> errors = appender.getMessages("ERROR");
-            assertEquals(1, errors.size());
-            assertTrue(errors.get(0).contains("deprecated ConsumerRecords(Map) constructor"),
-                "Unexpected error message: " + errors.get(0));
-
-            // Within the rate-limit window, neither repeated calls nor new tainted instances log again.
-            assertTrue(consumerRecords.nextOffsets().isEmpty());
-            assertTrue(new ConsumerRecords<>(records).nextOffsets().isEmpty());
-            assertEquals(1, appender.getMessages("ERROR").size());
-
-            // Once the window has elapsed, the error is logged again.
-            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(
-                System.nanoTime() - ConsumerRecords.TAINT_LOG_INTERVAL_NS - 1);
-            assertTrue(consumerRecords.nextOffsets().isEmpty());
-            assertEquals(2, appender.getMessages("ERROR").size());
-        } finally {
-            ConsumerRecords.TAINTED_NEXT_OFFSETS_LAST_LOG_NS.set(previousLastLogNs);
-        }
-    }
-
-    @Test
-    public void testNextOffsetsDoesNotLogErrorWhenConstructedWithNextOffsets() {
+    public void testNextOffsets() {
         TopicPartition tp = new TopicPartition("topic", 0);
         Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records =
             Map.of(tp, List.of(new ConsumerRecord<>("topic", 0, 0L, 0, "value")));
         Map<TopicPartition, OffsetAndMetadata> nextOffsets = Map.of(tp, new OffsetAndMetadata(1L));
 
-        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
-            ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, nextOffsets);
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, nextOffsets);
 
-            assertFalse(consumerRecords.nextOffsets().isEmpty());
-            assertEquals(nextOffsets, consumerRecords.nextOffsets());
-            assertTrue(appender.getMessages("ERROR").isEmpty());
-        }
+        assertEquals(nextOffsets, consumerRecords.nextOffsets());
     }
 
     @Test
-    public void testNextOffsetsDoesNotLogErrorForEmptyRecords() {
-        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(ConsumerRecords.class)) {
-            assertTrue(ConsumerRecords.empty().nextOffsets().isEmpty());
-            assertTrue(appender.getMessages("ERROR").isEmpty());
-        }
+    public void testNextOffsetsForEmptyRecords() {
+        assertTrue(ConsumerRecords.empty().nextOffsets().isEmpty());
     }
 
     private ConsumerRecords<Integer, String> buildTopicTestRecords(int recordSize,


### PR DESCRIPTION
The `ConsumerRecords(Map)` constructor was deprecated in 4.0 by KIP-1094
with `forRemoval = true` and is scheduled for removal in 5.0
(KAFKA-20660).

Remove the constructor together with the taint-tracking machinery that
existed only to warn when it was used: the `tainted` flag, the
rate-limited error log in `nextOffsets()`, the `TAINT_LOG_INTERVAL_NS`
and `TAINTED_NEXT_OFFSETS_LAST_LOG_NS` statics, and the now-unused
logger and imports. The private three-argument constructor is folded
into the public two-argument one.

Update `ConsumerRecordsTest` accordingly: drop the test that exercised
the deprecated constructor's logging behavior, and simplify the two
remaining `nextOffsets()` tests that only asserted the absence of that
logging (also removing the now-unused `LogCaptureAppender` and
`assertFalse` imports).

Testing: no remaining usages of the removed constructor or javadoc
references to it across the code base (checked Java and Scala sources).
Verified locally on both JDK 17 and JDK 25 with the
`ConsumerRecordsTest` unit tests and checkstyle, plus spotbugs; the
constructor that remains is covered by the existing tests.

Reviewers: Andrew Schofield <aschofield@confluent.io>
