### PR TITLE
MINOR: Correct broker dynamic configuration names in the documentation

### DIFF
--- a/docs/configuration/broker-configs.md
+++ b/docs/configuration/broker-configs.md
@@ -137,7 +137,7 @@ Default topic configuration options used by brokers may be updated without broke
   * `log.segment.delete.delay.ms`
   * `unclean.leader.election.enable`
   * `min.insync.replicas`
-  * `max.message.bytes`
+  * `message.max.bytes`
   * `compression.type`
   * `log.preallocate`
   * `log.message.timestamp.type`
@@ -192,7 +192,6 @@ In Kafka version 1.1.x, the listener used by the inter-broker listener may not b
 In addition to all the security configs of new listeners, the following configs may be updated dynamically at per-broker level: 
 
   * `listeners`
-  * `advertised.listeners`
   * `listener.security.protocol.map`
 
 Inter-broker listener must be configured using the static broker configuration `inter.broker.listener.name` or `security.inter.broker.protocol`. 


### PR DESCRIPTION
The broker configuration documentation incorrectly uses the topic-level name `max.message.bytes` in its list of dynamically updateable default topic settings. This changes it to the corresponding broker configuration name, `message.max.bytes`.

The same documentation also lists `advertised.listeners` as dynamically updateable, although it is not included in the authoritative dynamic broker configuration set and alter requests for it are rejected. This removes it from the per-broker dynamic listener configuration list.

No tests or builds were run because this is a documentation-only change. The updates were checked against `ServerTopicConfigSynonyms`, the dynamic broker configuration definitions, and the existing unit and Admin integration tests.
