### PR TITLE
KAFKA-20802: Avoid NPE in thread leak reporting

### DIFF
--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/ClusterTestExtensions.java
@@ -182,11 +182,12 @@ public class ClusterTestExtensions implements TestTemplateInvocationContextProvi
             if (detectThreadLeak == null) {
                 return;
             }
+
             List<Thread> threads = detectThreadLeak.newThreads();
-            assertTrue(threads.isEmpty(), "Thread leak detected: " +
-                threads.stream().map(t -> {
-                    return t.getThreadGroup().getName() + "/" + t.getName();
-                }).collect(Collectors.joining(", ")));
+            assertTrue(threads.isEmpty(), "Thread leak detected: " + threads.stream()
+                .map(t -> Optional.ofNullable(t.getThreadGroup())
+                    .map(ThreadGroup::getName).orElse("<terminated>") + "/" + t.getName())
+                .collect(Collectors.joining(", ")));
         }
     }
 


### PR DESCRIPTION
## Summary

- handle a missing thread group while building thread-leak reports
- preserve the existing leak-detection behavior and label the group as
`<terminated>`

## Motivation

`ClusterTestExtensions#afterEach` formats detected threads with
`Thread#getThreadGroup().getName()`. A thread can terminate after
`DetectThreadLeak#newThreads()` captures it but before the message is
formatted. Since `Thread#getThreadGroup()` returns `null` for a
terminated thread, the reporting path throws an NPE instead of reporting
the detected thread.

CI failure:
https://github.com/apache/kafka/actions/runs/29228499012/job/86748625389#step:6:136310

Jira: https://issues.apache.org/jira/browse/KAFKA-20802

Related: https://issues.apache.org/jira/browse/KAFKA-17189

## Testing

- `./gradlew :test-common:test-common-runtime:test --tests
org.apache.kafka.common.test.junit.ClusterTestExtensionsUnitTest`
- `./gradlew :test-common:test-common-runtime:spotlessCheck`

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
