### PR TITLE
KAFKA-20805: Check for last commit time by task vs. using directory mtime alone

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -128,6 +128,11 @@ public class StateDirectory implements AutoCloseable {
     private final StreamsConfig config;
     private final Set<TaskId> tasksInLocalState = new ConcurrentSkipListSet<>();
     private final Map<TaskId, Long> taskOffsetSums = new ConcurrentHashMap<>();
+    // Wall-clock time of the last committed changelog offsets per task. Used by the cleanup thread
+    // to decide directory obsolescence: with KIP-1035 (StateStore-managed changelog offsets) the
+    // per-commit .checkpoint file is no longer written, so the task directory's filesystem mtime is
+    // not refreshed during normal processing and cannot be relied upon to reflect recent activity.
+    private final Map<TaskId, Long> taskLastCommitMs = new ConcurrentHashMap<>();
 
     /**
      * Ensures that the state base directory as well as the application's sub-directory are created.
@@ -317,11 +322,13 @@ public class StateDirectory implements AutoCloseable {
     public void updateTaskOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
         if (!changelogOffsets.isEmpty()) {
             taskOffsetSums.put(taskId, sumOfChangelogOffsets(taskId, changelogOffsets));
+            taskLastCommitMs.put(taskId, time.milliseconds());
         }
     }
 
     public void removeTaskOffsets(final TaskId taskId) {
         taskOffsetSums.remove(taskId);
+        taskLastCommitMs.remove(taskId);
     }
 
     private long sumOfChangelogOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
@@ -547,6 +554,7 @@ public class StateDirectory implements AutoCloseable {
         if (hasPersistentStores) {
             unlockStartupStores();
             taskOffsetSums.clear();
+            taskLastCommitMs.clear();
             try {
                 stateDirLock.release();
                 stateDirLockChannel.close();
@@ -656,7 +664,15 @@ public class StateDirectory implements AutoCloseable {
                 try {
                     if (lock(id)) {
                         final long now = time.milliseconds();
-                        final long lastModifiedMs = taskDir.file().lastModified();
+                        // Prefer the last-commit time when known: under KIP-1035 the directory's
+                        // filesystem mtime is no longer refreshed on commit, so a directory can look
+                        // stale while its task is actively committing. Fall back to the file mtime for
+                        // orphan directories this instance has no in-memory record of (e.g. left over
+                        // from a previous run or a task that migrated away).
+                        final Long lastCommitMs = taskLastCommitMs.get(id);
+                        final long lastModifiedMs = lastCommitMs == null
+                            ? taskDir.file().lastModified()
+                            : Math.max(taskDir.file().lastModified(), lastCommitMs);
                         if (now - cleanupDelayMs > lastModifiedMs) {
                             removeTaskOffsets(id);
                             log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
@@ -793,6 +809,7 @@ public class StateDirectory implements AutoCloseable {
                 + "since Streams is not running any more these will be ignored to complete the cleanup");
         }
         taskOffsetSums.clear();
+        taskLastCommitMs.clear();
         final AtomicReference<Exception> firstException = new AtomicReference<>();
         for (final TaskDirectory taskDir : listAllTaskDirectories()) {
             final String dirName = taskDir.file().getName();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -394,6 +394,38 @@ public class StateDirectoryTest {
     }
 
     @Test
+    public void shouldNotCleanupTaskDirectoryThatRecentlyCommittedOffsets() {
+        // Reproduces the KIP-1035 regression with StateStore-managed changelog
+        // offsets, the per-commit .checkpoint file (a direct child of the task directory) is no
+        // longer written, so the task directory's filesystem mtime is not refreshed during normal
+        // processing - RocksDB writes land in subdirectories and do not bump the parent's mtime.
+        // The directory can therefore look arbitrarily stale even while the task is actively
+        // committing. When the owning thread dies and releases the lock, the cleanup thread must
+        // not treat such a directory as obsolete and delete the still-valid local state (which
+        // would force a from-scratch restore).
+        final TaskId task = new TaskId(1, 2);
+        final File dir = directory.getOrCreateDirectoryForTask(task);
+        assertTrue(new File(dir, "store").mkdir());
+
+        final int cleanupDelayMs = 60000;
+
+        // Simulate a stale directory mtime: a lot of time has elapsed since the directory was
+        // created (its file mtime was last set at creation time).
+        time.sleep(cleanupDelayMs * 10L);
+
+        // The task commits its changelog offsets "now" - well within the cleanup delay.
+        directory.updateTaskOffsets(task, Collections.singletonMap(new TopicPartition("changelog", 2), 100L));
+
+        // A short time later - still within the cleanup delay of the last commit - the owning
+        // thread dies (lock released) and the cleanup thread runs.
+        time.sleep(cleanupDelayMs / 2);
+        directory.cleanRemovedTasks(cleanupDelayMs);
+
+        assertTrue(dir.exists(), "state directory for a task that committed within the cleanup delay must not be deleted");
+        assertEquals(1, directory.listAllTaskDirectories().size());
+    }
+
+    @Test
     public void shouldNotRemoveNonTaskDirectoriesAndFiles() {
         final File otherDir = TestUtils.tempDirectory(stateDir.toPath(), "foo");
         directory.cleanRemovedTasks(0);


### PR DESCRIPTION
After a StreamThread failure (thread replaced, task reassigned to
another thread on the same instance), the background cleaner
(`StateDirectory.cleanRemovedTasks`) can delete the task's still-valid,
recently-committed state directory in the window between the failed
thread releasing its lock and the new thread re-acquiring it. The
reassigned task then finds no local offsets and restores its entire
changelog from scratch; for a compacted changelog whose head is being
removed by retention, the from-beginning restore can possibly be
overtaken mid-flight → `OffsetOutOfRangeException` →
`TaskCorruptedException`.

Applies when the dirty close does not wipe local state — i.e. ALOS, or
EOS with transactional state stores (KIP-892). (Under EOS with
non-transactional stores the dirty close wipes at close, so this path
isn't hit.)

The cleaner judges obsolescence by   `now - taskDir.lastModified() >
state.cleanup.delay.ms`.   Pre-KIP-1035 the per-commit `.checkpoint`
file  (a direct child of the task dir, written by rename) refreshed that
mtime  on every commit; KIP-1035 moved offsets into RocksDB and writes
`.checkpoint` only on downgrade, so nothing refreshes the task-dir mtime
during processing (RocksDB writes land in the `rocksdb/<store>/`
subdirectory, which doesn't bump the parent's mtime; per-task locking is
in-memory, so there's no `.lock` file either). The directory looks
arbitrarily stale while its task is actively committing, so the moment
its lock is released it is immediately eligible for deletion instead of
after the intended grace period.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Alieh Saeedi <asaeedi@confluent.io>, Nick Telford <nick.telford@gmail.com>
