### PR TITLE
MINOR: Correct the documented default for automatic ConfigProviders

### DIFF
--- a/docs/configuration/system-properties.md
+++ b/docs/configuration/system-properties.md
@@ -158,7 +158,7 @@ Default Value:
 
   * #### org.apache.kafka.automatic.config.providers
 
-This system property controls the automatic loading of ConfigProvider implementations in Apache Kafka. ConfigProviders are used to dynamically supply configuration values from sources such as files, directories, or environment variables. This property accepts a comma-separated list of ConfigProvider names. By default, all built-in ConfigProviders are enabled, including **FileConfigProvider** , **DirectoryConfigProvider** , and **EnvVarConfigProvider**.
+This system property controls the automatic loading of ConfigProvider implementations in Apache Kafka. ConfigProviders are used to dynamically supply configuration values from sources such as files, directories, or environment variables. This property accepts a comma-separated list of ConfigProvider names. By default, all configured ConfigProvider implementations are enabled, including non-built-in implementations. Built-in implementations include **FileConfigProvider** , **DirectoryConfigProvider** , and **EnvVarConfigProvider**.
 
 If users want to disable all automatic ConfigProviders, they need to explicitly set the system property as shown below. Disabling automatic ConfigProviders is recommended in environments where configuration data comes from untrusted sources or where increased security is required. For more details, see [CVE-2024-31141](/community/cve-list/#CVE-2024-31141).
 
@@ -195,7 +195,6 @@ Default Value:
 </th>  
 <td>
 
-All built-in ConfigProviders are enabled
+All configured ConfigProvider implementations are enabled, including non-built-in implementations
 </td></tr> </table>
-
 


### PR DESCRIPTION
The documentation for `org.apache.kafka.automatic.config.providers` currently implies that its unset default enables only Kafka's built-in ConfigProvider implementations. In practice, `AbstractConfig` allows every configured provider class when the property is absent, including custom implementations.

Update both the property description and its default-value table to state that all configured ConfigProvider implementations are enabled by default, while retaining the built-in providers as examples.

No tests were run because this is a documentation-only change. The wording was cross-checked against `AbstractConfig` and the existing `AbstractConfigTest` coverage for non-built-in providers and fully qualified provider class names.
