### PR TITLE
KAFKA-20803: Demultiplex batched persister responses once (WriteStateHandler)

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -181,25 +181,57 @@ public class PersisterStateManager {
         return nodeRPCMap;
     }
 
+    // test visibility
+    Collection<RequestAndCompletionHandler> generateRequests() {
+        return sender.generateRequests();
+    }
+
     public void setGenerateCallback(Runnable generateCallback) {
         this.generateCallback = generateCallback;
     }
 
-    // Groups a combined response's results into topicId -> partition -> result for O(1) per-partition lookup.
-    private static <T, P> Map<Uuid, Map<Integer, P>> indexByTopicPartition(
-        List<T> results,
-        Function<T, Uuid> topicId,
-        Function<T, List<P>> partitions,
-        ToIntFunction<P> partition
-    ) {
-        Map<Uuid, Map<Integer, P>> index = new HashMap<>();
-        for (T result : results) {
-            Map<Integer, P> byPartition = index.computeIfAbsent(topicId.apply(result), t -> new HashMap<>());
-            for (P p : partitions.apply(result)) {
-                byPartition.put(partition.applyAsInt(p), p);
-            }
+    /**
+     * Demultiplexes a combined RPC response into topicId -> partition -> per-partition result, so that
+     * each handler of a coalesced request finds its own slice in O(1) rather than rescanning the whole
+     * response (which costs O(N) per handler, hence O(N^2) per batch).
+     *
+     * @param <P> per-partition result type of the RPC, e.g. {@link WriteShareGroupStateResponseData.PartitionResult}
+     */
+    static final class PartitionResultIndex<P> {
+        private final Map<Uuid, Map<Integer, P>> index;
+
+        private PartitionResultIndex(Map<Uuid, Map<Integer, P>> index) {
+            this.index = index;
         }
-        return index;
+
+        /**
+         * @param results    per-topic results of the combined response
+         * @param topicId    extracts the topic id from a per-topic result
+         * @param partitions extracts the per-partition results of a per-topic result
+         * @param partition  extracts the partition number from a per-partition result
+         * @param <T>        per-topic result type of the RPC, e.g. {@link WriteShareGroupStateResponseData.WriteStateResult}
+         * @param <P>        per-partition result type of the RPC
+         */
+        static <T, P> PartitionResultIndex<P> build(
+            List<T> results,
+            Function<T, Uuid> topicId,
+            Function<T, List<P>> partitions,
+            ToIntFunction<P> partition
+        ) {
+            Map<Uuid, Map<Integer, P>> index = new HashMap<>();
+            for (T result : results) {
+                Map<Integer, P> byPartition = index.computeIfAbsent(topicId.apply(result), t -> new HashMap<>());
+                for (P p : partitions.apply(result)) {
+                    byPartition.put(partition.applyAsInt(p), p);
+                }
+            }
+            return new PartitionResultIndex<>(index);
+        }
+
+        P get(SharePartitionKey key) {
+            Map<Integer, P> byPartition = index.get(key.topicId());
+            return byPartition == null ? null : byPartition.get(key.partition());
+        }
     }
 
     /**
@@ -215,8 +247,9 @@ public class PersisterStateManager {
         private final ExponentialBackoffManager findCoordBackoff;
         private Consumer<ClientResponse> onCompleteCallback;
         protected final SharePartitionKey partitionKey;
-        // Combined-response index shared across handlers; set before onComplete, read-and-cleared in lookupPartitionResult (KAFKA-20803).
-        protected Object sharedResultIndex;
+        // Index of the combined response, shared across the handlers of one coalesced request; assigned
+        // before onComplete and read-and-cleared by lookupPartitionResult (KAFKA-20803).
+        private PartitionResultIndex<?> sharedResultIndex;
 
         public PersisterStateManagerHandler(
             String groupId,
@@ -259,22 +292,33 @@ public class PersisterStateManager {
          */
         protected abstract void handleRequestResponse(ClientResponse response);
 
-        // Overridden per RPC to index the combined response as topicId -> partition -> result; null when no usable body.
-        protected Object buildResultIndex(ClientResponse response) {
+        /**
+         * Indexes a combined response so every handler of the batch can look up its own slice. Overridden
+         * per RPC type; the base implementation leaves the O(1) path disabled. Implementations must tolerate
+         * a null or bodyless response and return null for it.
+         *
+         * @param response - Client response, possibly null
+         * @return index of the combined response, or null when there is no usable body
+         */
+        protected PartitionResultIndex<?> buildResultIndex(ClientResponse response) {
             return null;
         }
 
+        /**
+         * Returns this handler's per-partition result from the combined response in O(1), preferring the
+         * index built once for the whole batch and otherwise indexing the response on its own.
+         *
+         * @param response - Client response
+         * @return the per-partition result, or null when the response carries none for this partition
+         */
         @SuppressWarnings("unchecked")
         protected final <R> R lookupPartitionResult(ClientResponse response) {
-            Object index = sharedResultIndex;
+            PartitionResultIndex<?> index = sharedResultIndex;
             sharedResultIndex = null;
-            Map<Uuid, Map<Integer, R>> resultIndex =
-                (Map<Uuid, Map<Integer, R>>) (index != null ? index : buildResultIndex(response));
-            if (resultIndex == null) {
-                return null;
+            if (index == null) {
+                index = buildResultIndex(response);
             }
-            Map<Integer, R> byPartition = resultIndex.get(partitionKey().topicId());
-            return byPartition == null ? null : byPartition.get(partitionKey().partition());
+            return index == null ? null : ((PartitionResultIndex<R>) index).get(partitionKey());
         }
 
         /**
@@ -815,11 +859,11 @@ public class PersisterStateManager {
         }
 
         @Override
-        protected Object buildResultIndex(ClientResponse response) {
-            if (!response.hasResponse()) {
+        protected PartitionResultIndex<WriteShareGroupStateResponseData.PartitionResult> buildResultIndex(ClientResponse response) {
+            if (response == null || !response.hasResponse()) {
                 return null;
             }
-            return indexByTopicPartition(
+            return PartitionResultIndex.build(
                 ((WriteShareGroupStateResponse) response.responseBody()).data().results(),
                 WriteShareGroupStateResponseData.WriteStateResult::topicId,
                 WriteShareGroupStateResponseData.WriteStateResult::partitions,
@@ -1593,14 +1637,15 @@ public class PersisterStateManager {
                                             oldVal.remove(coordNode);
                                             return oldVal;
                                         });
-                                        // Demux the combined response once and share it across handlers (KAFKA-20803).
-                                        Object sharedResultIndex = handlersPerGroup.isEmpty()
-                                            ? null
-                                            : handlersPerGroup.get(0).buildResultIndex(response);
-                                        handlersPerGroup.forEach(handler1 -> {
-                                            handler1.sharedResultIndex = sharedResultIndex;
-                                            handler1.onComplete(response);
-                                        });
+                                        // Demux the combined response once and share it across the handlers
+                                        // which composed the combined request (KAFKA-20803).
+                                        if (!handlersPerGroup.isEmpty()) {
+                                            PartitionResultIndex<?> sharedResultIndex = handlersPerGroup.get(0).buildResultIndex(response);
+                                            handlersPerGroup.forEach(handler1 -> {
+                                                handler1.sharedResultIndex = sharedResultIndex;
+                                                handler1.onComplete(response);
+                                            });
+                                        }
                                         wakeup();
                                     }));
                                 sending.computeIfAbsent(rpcType, key -> new HashSet<>()).add(coordNode);
@@ -1649,7 +1694,10 @@ public class PersisterStateManager {
      * batching requests.
      */
     private static class RequestCoalescerHelper {
+        private static final Logger LOG = LoggerFactory.getLogger(RequestCoalescerHelper.class);
+
         public static AbstractRequest.Builder<? extends AbstractRequest> coalesceRequests(String groupId, RPCType rpcType, List<? extends PersisterStateManagerHandler> handlers) {
+            LOG.trace("Received coalesce request for {} handlers of RPC type {}", handlers.size(), rpcType);
             return switch (rpcType) {
                 case WRITE -> coalesceWrites(groupId, handlers);
                 case READ -> coalesceReads(groupId, handlers);

--- a/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
+++ b/server-common/src/main/java/org/apache/kafka/server/share/persister/PersisterStateManager.java
@@ -78,6 +78,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -183,6 +185,23 @@ public class PersisterStateManager {
         this.generateCallback = generateCallback;
     }
 
+    // Groups a combined response's results into topicId -> partition -> result for O(1) per-partition lookup.
+    private static <T, P> Map<Uuid, Map<Integer, P>> indexByTopicPartition(
+        List<T> results,
+        Function<T, Uuid> topicId,
+        Function<T, List<P>> partitions,
+        ToIntFunction<P> partition
+    ) {
+        Map<Uuid, Map<Integer, P>> index = new HashMap<>();
+        for (T result : results) {
+            Map<Integer, P> byPartition = index.computeIfAbsent(topicId.apply(result), t -> new HashMap<>());
+            for (P p : partitions.apply(result)) {
+                byPartition.put(partition.applyAsInt(p), p);
+            }
+        }
+        return index;
+    }
+
     /**
      * Parent class of all RPCs. Uses template pattern to implement core methods.
      * Various child classes can extend this class to define how to handle RPC specific
@@ -196,6 +215,8 @@ public class PersisterStateManager {
         private final ExponentialBackoffManager findCoordBackoff;
         private Consumer<ClientResponse> onCompleteCallback;
         protected final SharePartitionKey partitionKey;
+        // Combined-response index shared across handlers; set before onComplete, read-and-cleared in lookupPartitionResult (KAFKA-20803).
+        protected Object sharedResultIndex;
 
         public PersisterStateManagerHandler(
             String groupId,
@@ -237,6 +258,24 @@ public class PersisterStateManager {
          * @param response - Client response
          */
         protected abstract void handleRequestResponse(ClientResponse response);
+
+        // Overridden per RPC to index the combined response as topicId -> partition -> result; null when no usable body.
+        protected Object buildResultIndex(ClientResponse response) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        protected final <R> R lookupPartitionResult(ClientResponse response) {
+            Object index = sharedResultIndex;
+            sharedResultIndex = null;
+            Map<Uuid, Map<Integer, R>> resultIndex =
+                (Map<Uuid, Map<Integer, R>>) (index != null ? index : buildResultIndex(response));
+            if (resultIndex == null) {
+                return null;
+            }
+            Map<Integer, R> byPartition = resultIndex.get(partitionKey().topicId());
+            return byPartition == null ? null : byPartition.get(partitionKey().partition());
+        }
 
         /**
          * Returns true if the response is valid for the respective child class.
@@ -776,6 +815,18 @@ public class PersisterStateManager {
         }
 
         @Override
+        protected Object buildResultIndex(ClientResponse response) {
+            if (!response.hasResponse()) {
+                return null;
+            }
+            return indexByTopicPartition(
+                ((WriteShareGroupStateResponse) response.responseBody()).data().results(),
+                WriteShareGroupStateResponseData.WriteStateResult::topicId,
+                WriteShareGroupStateResponseData.WriteStateResult::partitions,
+                WriteShareGroupStateResponseData.PartitionResult::partition);
+        }
+
+        @Override
         protected void handleRequestResponse(ClientResponse response) {
             log().debug("Write state response received - {}", response);
             writeStateBackoff.incrementAttempt();
@@ -783,55 +834,44 @@ public class PersisterStateManager {
             String clientResponseErrorMessage = clientResponseError.message();
             switch (clientResponseError) {
                 case NONE:
-                    // response can be a combined one for large number of requests
-                    // we need to deconstruct it
-                    WriteShareGroupStateResponse combinedResponse = (WriteShareGroupStateResponse) response.responseBody();
+                    WriteShareGroupStateResponseData.PartitionResult partitionResult = lookupPartitionResult(response);
+                    if (partitionResult != null) {
+                        Errors error = Errors.forCode(partitionResult.errorCode());
+                        String errorMessage = partitionResult.errorMessage();
+                        if (errorMessage == null || errorMessage.isEmpty()) {
+                            errorMessage = error.message();
+                        }
 
-                    for (WriteShareGroupStateResponseData.WriteStateResult writeStateResult : combinedResponse.data().results()) {
-                        if (writeStateResult.topicId().equals(partitionKey().topicId())) {
-                            Optional<WriteShareGroupStateResponseData.PartitionResult> partitionStateData =
-                                writeStateResult.partitions().stream().filter(partitionResult -> partitionResult.partition() == partitionKey().partition())
-                                    .findFirst();
+                        switch (error) {
+                            case NONE:
+                                writeStateBackoff.resetAttempts();
+                                WriteShareGroupStateResponseData.WriteStateResult result = WriteShareGroupStateResponse.toResponseWriteStateResult(
+                                    partitionKey().topicId(),
+                                    List.of(partitionResult)
+                                );
+                                this.result.complete(new WriteShareGroupStateResponse(
+                                    new WriteShareGroupStateResponseData().setResults(List.of(result))));
+                                return;
 
-                            if (partitionStateData.isPresent()) {
-                                Errors error = Errors.forCode(partitionStateData.get().errorCode());
-                                String errorMessage = partitionStateData.get().errorMessage();
-                                if (errorMessage == null || errorMessage.isEmpty()) {
-                                    errorMessage = error.message();
+                            // check retriable errors
+                            case COORDINATOR_NOT_AVAILABLE:
+                            case COORDINATOR_LOAD_IN_PROGRESS:
+                            case NOT_COORDINATOR:
+                            case UNKNOWN_TOPIC_OR_PARTITION:
+                                log().debug("Received retriable error in write state RPC for key {}: {}", partitionKey(), errorMessage);
+                                if (!writeStateBackoff.canAttempt()) {
+                                    log().error("Exhausted max retries for write state RPC for key {} without success.", partitionKey());
+                                    requestErrorResponse(error, new Exception("Exhausted max retries to complete write state RPC without success."));
+                                    return;
                                 }
+                                super.resetCoordinatorNode();
+                                timer.add(new PersisterTimerTask(writeStateBackoff.backOff(), this));
+                                return;
 
-                                switch (error) {
-                                    case NONE:
-                                        writeStateBackoff.resetAttempts();
-                                        WriteShareGroupStateResponseData.WriteStateResult result = WriteShareGroupStateResponse.toResponseWriteStateResult(
-                                            partitionKey().topicId(),
-                                            List.of(partitionStateData.get())
-                                        );
-                                        this.result.complete(new WriteShareGroupStateResponse(
-                                            new WriteShareGroupStateResponseData().setResults(List.of(result))));
-                                        return;
-
-                                    // check retriable errors
-                                    case COORDINATOR_NOT_AVAILABLE:
-                                    case COORDINATOR_LOAD_IN_PROGRESS:
-                                    case NOT_COORDINATOR:
-                                    case UNKNOWN_TOPIC_OR_PARTITION:
-                                        log().debug("Received retriable error in write state RPC for key {}: {}", partitionKey(), errorMessage);
-                                        if (!writeStateBackoff.canAttempt()) {
-                                            log().error("Exhausted max retries for write state RPC for key {} without success.", partitionKey());
-                                            requestErrorResponse(error, new Exception("Exhausted max retries to complete write state RPC without success."));
-                                            return;
-                                        }
-                                        super.resetCoordinatorNode();
-                                        timer.add(new PersisterTimerTask(writeStateBackoff.backOff(), this));
-                                        return;
-
-                                    default:
-                                        log().error("Unable to perform write state RPC for key {}: {}", partitionKey(), errorMessage);
-                                        requestErrorResponse(error, new Exception(errorMessage));
-                                        return;
-                                }
-                            }
+                            default:
+                                log().error("Unable to perform write state RPC for key {}: {}", partitionKey(), errorMessage);
+                                requestErrorResponse(error, new Exception(errorMessage));
+                                return;
                         }
                     }
 
@@ -1553,10 +1593,14 @@ public class PersisterStateManager {
                                             oldVal.remove(coordNode);
                                             return oldVal;
                                         });
-                                        // now the combined request has completed
-                                        // we need to create responses for individual
-                                        // requests which composed the combined request
-                                        handlersPerGroup.forEach(handler1 -> handler1.onComplete(response));
+                                        // Demux the combined response once and share it across handlers (KAFKA-20803).
+                                        Object sharedResultIndex = handlersPerGroup.isEmpty()
+                                            ? null
+                                            : handlersPerGroup.get(0).buildResultIndex(response);
+                                        handlersPerGroup.forEach(handler1 -> {
+                                            handler1.sharedResultIndex = sharedResultIndex;
+                                            handler1.onComplete(response);
+                                        });
                                         wakeup();
                                     }));
                                 sending.computeIfAbsent(rpcType, key -> new HashSet<>()).add(coordNode);

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.message.InitializeShareGroupStateResponseData;
 import org.apache.kafka.common.message.ReadShareGroupStateResponseData;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryResponseData;
 import org.apache.kafka.common.message.WriteShareGroupStateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.DeleteShareGroupStateRequest;
@@ -43,12 +44,14 @@ import org.apache.kafka.common.requests.ReadShareGroupStateRequest;
 import org.apache.kafka.common.requests.ReadShareGroupStateResponse;
 import org.apache.kafka.common.requests.ReadShareGroupStateSummaryRequest;
 import org.apache.kafka.common.requests.ReadShareGroupStateSummaryResponse;
+import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.WriteShareGroupStateRequest;
 import org.apache.kafka.common.requests.WriteShareGroupStateResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.share.SharePartitionKey;
 import org.apache.kafka.server.util.MockTime;
+import org.apache.kafka.server.util.RequestAndCompletionHandler;
 import org.apache.kafka.server.util.timer.MockTimer;
 import org.apache.kafka.server.util.timer.SystemTimer;
 import org.apache.kafka.server.util.timer.SystemTimerReaper;
@@ -64,6 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +76,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -1532,6 +1537,168 @@ class PersisterStateManagerTest {
             .map(PersisterStateManager.WriteStateHandler::result).toArray(CompletableFuture[]::new)).get();
 
         TestUtils.waitForCondition(isBatchingSuccess::get, TestUtils.DEFAULT_MAX_WAIT_MS, 10L, () -> "unable to verify batching");
+    }
+
+    private static WriteShareGroupStateResponseData.PartitionResult writePartitionResult(int partition, Errors error) {
+        return new WriteShareGroupStateResponseData.PartitionResult()
+            .setPartition(partition)
+            .setErrorCode(error.code())
+            .setErrorMessage(error.message());
+    }
+
+    private static WriteShareGroupStateResponseData.WriteStateResult writeStateResult(
+        Uuid topicId,
+        WriteShareGroupStateResponseData.PartitionResult... partitions
+    ) {
+        return new WriteShareGroupStateResponseData.WriteStateResult()
+            .setTopicId(topicId)
+            .setPartitions(List.of(partitions));
+    }
+
+    private static ClientResponse writeStateClientResponse(WriteShareGroupStateResponseData data) {
+        return new ClientResponse(
+            new RequestHeader(ApiKeys.WRITE_SHARE_GROUP_STATE, ApiKeys.WRITE_SHARE_GROUP_STATE.latestVersion(), "client-id", 0),
+            null,
+            HOST,
+            MOCK_TIME.milliseconds(),
+            MOCK_TIME.milliseconds(),
+            false,
+            null,
+            null,
+            new WriteShareGroupStateResponse(data)
+        );
+    }
+
+    // Places a write handler straight into the batching map, bypassing coordinator lookup, so that a
+    // single generateRequests() call yields one coalesced request covering every handler.
+    private PersisterStateManager.WriteStateHandler batchedWriteHandler(
+        PersisterStateManager stateManager,
+        Node coordinatorNode,
+        String groupId,
+        Uuid topicId,
+        int partition
+    ) {
+        PersisterStateManager.WriteStateHandler handler = stateManager.new WriteStateHandler(
+            groupId,
+            topicId,
+            partition,
+            0,
+            0,
+            0,
+            0,
+            List.of(),
+            new CompletableFuture<>(),
+            REQUEST_BACKOFF_MS,
+            REQUEST_BACKOFF_MAX_MS,
+            MAX_RPC_RETRY_ATTEMPTS
+        );
+        handler.addRequestToNodeMap(coordinatorNode, handler);
+        return handler;
+    }
+
+    private static void assertWriteStateResult(
+        PersisterStateManager.WriteStateHandler handler,
+        Uuid expectedTopicId,
+        int expectedPartition,
+        Errors expectedError
+    ) {
+        WriteShareGroupStateResponse response = assertDoesNotThrow(() -> handler.result().get());
+        assertEquals(1, response.data().results().size());
+        WriteShareGroupStateResponseData.WriteStateResult result = response.data().results().get(0);
+        assertEquals(expectedTopicId, result.topicId());
+        assertEquals(1, result.partitions().size());
+        assertEquals(expectedPartition, result.partitions().get(0).partition());
+        assertEquals(expectedError.code(), result.partitions().get(0).errorCode());
+    }
+
+    @Test
+    public void testWriteStateCombinedResponseDemultiplexedPerTopicPartition() {
+        String groupId = "group1";
+        Uuid topicId1 = Uuid.randomUuid();
+        Uuid topicId2 = Uuid.randomUuid();
+        Node coordinatorNode = new Node(1, HOST, PORT);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(new MockClient(MOCK_TIME))
+            .withTimer(mockTimer)
+            .withCacheHelper(getCoordinatorCacheHelper(coordinatorNode))
+            .build();
+
+        // the same partition numbers appear under both topics, so a topicId-blind lookup cannot pass
+        PersisterStateManager.WriteStateHandler topic1Partition0 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId1, 0);
+        PersisterStateManager.WriteStateHandler topic1Partition1 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId1, 1);
+        PersisterStateManager.WriteStateHandler topic2Partition0 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId2, 0);
+        PersisterStateManager.WriteStateHandler topic2Partition1 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId2, 1);
+
+        Collection<RequestAndCompletionHandler> requests = stateManager.generateRequests();
+        assertEquals(1, requests.size());
+
+        // a distinct error per (topic, partition) makes any mixed-up slice observable
+        requests.iterator().next().handler.onComplete(writeStateClientResponse(
+            new WriteShareGroupStateResponseData().setResults(List.of(
+                writeStateResult(topicId1,
+                    writePartitionResult(0, Errors.NONE),
+                    writePartitionResult(1, Errors.INVALID_REQUEST)),
+                writeStateResult(topicId2,
+                    writePartitionResult(0, Errors.FENCED_STATE_EPOCH),
+                    writePartitionResult(1, Errors.NONE))))));
+
+        assertWriteStateResult(topic1Partition0, topicId1, 0, Errors.NONE);
+        assertWriteStateResult(topic1Partition1, topicId1, 1, Errors.INVALID_REQUEST);
+        assertWriteStateResult(topic2Partition0, topicId2, 0, Errors.FENCED_STATE_EPOCH);
+        assertWriteStateResult(topic2Partition1, topicId2, 1, Errors.NONE);
+    }
+
+    @Test
+    public void testWriteStateCombinedResponseMissingPartitionFailsOnlyThatHandler() {
+        String groupId = "group1";
+        Uuid topicId = Uuid.randomUuid();
+        Node coordinatorNode = new Node(1, HOST, PORT);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(new MockClient(MOCK_TIME))
+            .withTimer(mockTimer)
+            .withCacheHelper(getCoordinatorCacheHelper(coordinatorNode))
+            .build();
+
+        PersisterStateManager.WriteStateHandler present = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId, 0);
+        PersisterStateManager.WriteStateHandler missing = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId, 1);
+
+        Collection<RequestAndCompletionHandler> requests = stateManager.generateRequests();
+        assertEquals(1, requests.size());
+
+        // partition 1 is absent from the combined response
+        requests.iterator().next().handler.onComplete(writeStateClientResponse(
+            new WriteShareGroupStateResponseData().setResults(List.of(
+                writeStateResult(topicId, writePartitionResult(0, Errors.NONE))))));
+
+        assertWriteStateResult(present, topicId, 0, Errors.NONE);
+        assertWriteStateResult(missing, topicId, 1, Errors.UNKNOWN_SERVER_ERROR);
+    }
+
+    @Test
+    public void testWriteStateCombinedResponseNullClientResponseCompletesAllHandlers() {
+        String groupId = "group1";
+        Uuid topicId = Uuid.randomUuid();
+        Node coordinatorNode = new Node(1, HOST, PORT);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(new MockClient(MOCK_TIME))
+            .withTimer(mockTimer)
+            .withCacheHelper(getCoordinatorCacheHelper(coordinatorNode))
+            .build();
+
+        PersisterStateManager.WriteStateHandler partition0 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId, 0);
+        PersisterStateManager.WriteStateHandler partition1 = batchedWriteHandler(stateManager, coordinatorNode, groupId, topicId, 1);
+
+        Collection<RequestAndCompletionHandler> requests = stateManager.generateRequests();
+        assertEquals(1, requests.size());
+
+        // a null response must still fail every handler in the batch rather than throwing
+        assertDoesNotThrow(() -> requests.iterator().next().handler.onComplete(null));
+
+        assertWriteStateResult(partition0, topicId, 0, Errors.UNKNOWN_SERVER_ERROR);
+        assertWriteStateResult(partition1, topicId, 1, Errors.UNKNOWN_SERVER_ERROR);
     }
 
     @Test

--- a/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/share/persister/PersisterStateManagerTest.java
@@ -81,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1647,6 +1648,61 @@ class PersisterStateManagerTest {
         assertWriteStateResult(topic1Partition1, topicId1, 1, Errors.INVALID_REQUEST);
         assertWriteStateResult(topic2Partition0, topicId2, 0, Errors.FENCED_STATE_EPOCH);
         assertWriteStateResult(topic2Partition1, topicId2, 1, Errors.NONE);
+    }
+
+    @Test
+    public void testWriteStateCombinedResponseIndexedOncePerBatch() {
+        String groupId = "group1";
+        Uuid topicId = Uuid.randomUuid();
+        Node coordinatorNode = new Node(1, HOST, PORT);
+
+        PersisterStateManager stateManager = PersisterStateManagerBuilder.builder()
+            .withKafkaClient(new MockClient(MOCK_TIME))
+            .withTimer(mockTimer)
+            .withCacheHelper(getCoordinatorCacheHelper(coordinatorNode))
+            .build();
+
+        List<PersisterStateManager.WriteStateHandler> handlers = new ArrayList<>();
+        for (int partition = 0; partition < 4; partition++) {
+            PersisterStateManager.WriteStateHandler handler = spy(stateManager.new WriteStateHandler(
+                groupId,
+                topicId,
+                partition,
+                0,
+                0,
+                0,
+                0,
+                List.of(),
+                new CompletableFuture<>(),
+                REQUEST_BACKOFF_MS,
+                REQUEST_BACKOFF_MAX_MS,
+                MAX_RPC_RETRY_ATTEMPTS
+            ));
+            handler.addRequestToNodeMap(coordinatorNode, handler);
+            handlers.add(handler);
+        }
+
+        Collection<RequestAndCompletionHandler> requests = stateManager.generateRequests();
+        assertEquals(1, requests.size());
+
+        requests.iterator().next().handler.onComplete(writeStateClientResponse(
+            new WriteShareGroupStateResponseData().setResults(List.of(
+                writeStateResult(topicId,
+                    writePartitionResult(0, Errors.NONE),
+                    writePartitionResult(1, Errors.NONE),
+                    writePartitionResult(2, Errors.NONE),
+                    writePartitionResult(3, Errors.NONE))))));
+
+        // the combined response is indexed once for the whole batch, and every other handler reuses
+        // that index rather than rescanning the response
+        verify(handlers.get(0), times(1)).buildResultIndex(any());
+        for (int i = 1; i < handlers.size(); i++) {
+            verify(handlers.get(i), never()).buildResultIndex(any());
+        }
+
+        for (int partition = 0; partition < handlers.size(); partition++) {
+            assertWriteStateResult(handlers.get(partition), topicId, partition, Errors.NONE);
+        }
     }
 
     @Test


### PR DESCRIPTION
fix: https://issues.apache.org/jira/browse/KAFKA-20803

PersisterStateManager coalesces many partitions into a single
WRITE_SHARE_GROUP_STATE RPC. On completion, every per-partition handler
re-scanned the full combined response to find its own slice — N handlers
*  O(N) scan = O(N ^ 2 ), all on the single send thread, stalling the
send loop.

This PR demultiplexes the combined response once into a topicId ->
partition -> result index (PartitionResultIndex, built in the send loop
and shared across the handlers of one coalesced request) and  converts
WriteStateHandler to an O(1) lookup.

Scope is deliberately limited to WRITE: it is the hot path, since every
acknowledgement/commit drives a write. readState runs once per
SharePartition lifetime, initializeState once per group-topic-partition,
and delete/read-summary are admin-invoked — for those, building an index
would cost more than the lookup it saves, so they keep the existing
scan.

Reviewers: Sushant Mahajan <smahajan@confluent.io>, Andrew Schofield
 <aschofield@confluent.io>
