### PR TITLE
MINOR: Clarify controller bootstrap support in admin CLI documentation

### DIFF
--- a/docs/getting-started/compatibility.md
+++ b/docs/getting-started/compatibility.md
@@ -347,4 +347,4 @@ More details in the [Connect](/40/documentation.html#upgrade_400_notable_connect
   </tr>
 </table>
 
-Note: Starting with Kafka 4.0, the `--zookeeper` option in AdminClient commands has been removed. Users must use the `--bootstrap-server` option to interact with the Kafka cluster. This change aligns with the transition to KRaft mode. 
+Note: Starting with Kafka 4.0, the `--zookeeper` option in AdminClient commands has been removed. Users must instead use a bootstrap option supported by the command, such as `--bootstrap-server` or, where available, `--bootstrap-controller`, to interact with the Kafka cluster. This change aligns with the transition to KRaft mode.

--- a/docs/security/authorization-and-acls.md
+++ b/docs/security/authorization-and-acls.md
@@ -220,7 +220,7 @@ Configuration
 </td>  
 <td>
 
-A property file containing configs to be passed to Admin Client. This option can only be used with --bootstrap-server option.
+A property file containing configs to be passed to Admin Client. This option can be used with either --bootstrap-server or --bootstrap-controller.
 </td>  
 <td>
 


### PR DESCRIPTION
Kafka 4.0 compatibility documentation currently presents `--bootstrap-server` as the only replacement for the removed `--zookeeper` option in AdminClient commands. Some commands, including `ConfigCommand` and `AclCommand`, also support direct controller connections through `--bootstrap-controller`.

This change makes the compatibility note command-dependent and corrects the `kafka-acls.sh` option reference to state that `--command-config` can be used with either `--bootstrap-server` or `--bootstrap-controller`.

No tests were run because these are documentation-only changes. The wording was checked against the current command option handling and existing `ConfigCommand` and `AclCommand` tests; `git diff --check` also completed successfully.
