### PR TITLE
MINOR: Correct the deprecated console share consumer option in the 4.3 upgrade notes

### DIFF
--- a/docs/getting-started/upgrade.md
+++ b/docs/getting-started/upgrade.md
@@ -122,7 +122,8 @@ Note: Apache Kafka 4.2 only supports KRaft mode - ZooKeeper mode has been remove
       * `kafka-consumer-perf-test.sh` and `kafka-share-consumer-perf-test.sh` gain the `--command-property` option to bring all performance testing tools in line 
     * The option `--command-config` is used for all command-line tools which accept a file of configuration properties. The tools affected are: 
       * `kafka-cluster.sh` (`--config` is deprecated in favor of `--command-config`) 
-      * `kafka-console-consumer.sh`, `kafka-console-producer.sh` and `kafka-console-share-consumer.sh` (`--consumer.config` and `--producer.config` are deprecated in favor of `--command-config`) 
+      * `kafka-console-consumer.sh` and `kafka-console-producer.sh` (`--consumer.config` and `--producer.config` are deprecated in favor of `--command-config`)
+      * `kafka-console-share-consumer.sh` (`--consumer-config` is deprecated in favor of `--command-config`)
       * `kafka-consumer-perf-test.sh`, `kafka-producer-perf-test.sh` and `kafka-share-consumer-perf-test.sh` (`--consumer.config` and `--producer.config` are deprecated in favor of `--command-config`) 
       * `kafka-verifiable-consumer.sh` and `kafka-verifiable-producer.sh` (`--consumer.config` and `--producer.config` are deprecated in favor of `--command-config`) 
       * `kafka-leader-election.sh` (`--admin.config` is deprecated in favor of `--command-config`) 


### PR DESCRIPTION
The 4.3 upgrade notes incorrectly list `--consumer.config` as the deprecated configuration-file option for `kafka-console-share-consumer.sh`. That tool uses `--consumer-config`, while `--consumer.config` remains the correct deprecated option for the regular console consumer.

This change gives the share consumer its own entry and documents that `--consumer-config` is deprecated in favor of `--command-config`. The spelling was cross-checked against `ConsoleShareConsumerOptions` and its focused option tests.

No tests were run because this is a documentation-only correction.

Reviewers: Andrew Schofield <aschofield@confluent.io>
