### PR TITLE
MINOR: fix DOAP metadata — git repo declared as SVNRepository; add Java to programming languages

### DIFF
--- a/doap_Kafka.rdf
+++ b/doap_Kafka.rdf
@@ -32,13 +32,14 @@
     <bug-database rdf:resource="https://issues.apache.org/jira/browse/KAFKA" />
     <mailing-list rdf:resource="https://kafka.apache.org/contact.html" />
     <download-page rdf:resource="https://kafka.apache.org/downloads.html" />
+    <programming-language>Java</programming-language>
     <programming-language>Scala</programming-language>
     <category rdf:resource="http://projects.apache.org/category/big-data" />
     <repository>
-      <SVNRepository>
+      <GitRepository>
         <location rdf:resource="https://gitbox.apache.org/repos/asf/kafka.git"/>
         <browse rdf:resource="https://github.com/apache/kafka"/>
-      </SVNRepository>
+      </GitRepository>
     </repository>
     <maintainer>
       <foaf:Person>


### PR DESCRIPTION
Small metadata fix to `doap_Kafka.rdf` (the file projects.apache.org reads):

1. The `<repository>` element wraps Kafka's **git** URL (`https://gitbox.apache.org/repos/asf/kafka.git`) in an `<SVNRepository>` element — it should be `<GitRepository>`. This is the error tracked in [KAFKA-14924](https://issues.apache.org/jira/browse/KAFKA-14924) (open since 2023).
2. `<programming-language>` lists only **Scala**, while the codebase is Java + Scala (AGENTS.md: "Gradle build in Java and Scala 2.13"; the repo's own `.asf.yaml` labels both). Added `Java` alongside `Scala`.

Deliberately did not touch anything else (aware #1378 removed `<release>` on purpose — not re-adding it).

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation
- [x] Verify test coverage and CI build status — metadata file, not built/tested by CI
- [x] Verify documentation (including upgrade notes)

Per the project's AI policy: AI assistance was used to prepare this change (disclosed via commit trailer); I verified the RDF content, the JIRA status, and prior DOAP PRs (#16472, #11423) myself and remain responsible for the change.
