### PR TITLE
MINOR: fix flakey SwallowUnknownTopicErrorIntegrationTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SwallowUnknownTopicErrorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SwallowUnknownTopicErrorIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.integration;
 
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -144,6 +145,9 @@ public class SwallowUnknownTopicErrorIntegrationTest {
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1);
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.IntegerSerde.class);
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        // Lower max.block.ms (default 60s) so the producer does not block on metadata for the
+        // non-existing topic long enough to race the 60s test timeout (cf. timeoutMs).
+        streamsConfiguration.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10_000);
         streamsConfiguration.put(StreamsConfig.PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, TestHandler.class);
         return streamsConfiguration;
     }


### PR DESCRIPTION
This PR reduces `max.block.ms` to avoid hitting the test timeout. The
same fix was added via https://github.com/apache/kafka/pull/16710 in the
past (the test was rename from `CustomHandlerIntegrationTest` to
`SwallowUnknownTopicErrorIntegrationTest` later), but the fix was
dropped via https://github.com/apache/kafka/pull/17163 (unclear why).

Reviewers: Bill Bejeck <bbejeck@apache.org>, TengYao Chi
 <frankvicky@apache.org>
