### PR TITLE
MINOR: Correct configuration property names in the Kafka Connect ACL tables

### DIFF
--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -618,7 +618,7 @@ Offsets topic used by the connector
 
 This is the value of the `offsets.storage.topic` property in the connector’s configuration if provided,
 
-or the value of the `offsets.storage.topic` property in the worker’s configuration if not.
+or the value of the `offset.storage.topic` property in the worker’s configuration if not.
 </td>
 <td>
 
@@ -686,7 +686,7 @@ the name of the connector
 
 or the value of `consumer.group.id` if present in the Connect configuration,
 
-or the value of `consumer.overrides.group.id` if present in the Connector configuration
+or the value of `consumer.override.group.id` if present in the Connector configuration
 </td><td> </td></tr>
 <tr><td>Read</td><td>Topic</td><td>sink topic(s) that the connector will consume from</td><td>
 


### PR DESCRIPTION
The Kafka Connect ACL tables referenced two invalid configuration
property names. The Source connector table used the connector-level
`offsets.storage.topic` name for the worker fallback, whose actual
property is `offset.storage.topic`. The Sink connector table also
misspelled the connector client override `consumer.override.group.id` as
`consumer.overrides.group.id`.

This change corrects both references so that the ACL guidance matches
the worker configuration and connector override names used elsewhere in
the guide and in the Connect configuration classes.

No tests were run because this is a documentation-only change. `git diff
--check` completed successfully.

Reviewers: Andrew Schofield <aschofield@confluent.io>
