### PR TITLE
Detect data loss and topic reset in MirrorMaker 2 source task

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown by {@link MirrorSourceTask} when it detects that records it was about to replicate
+ * are no longer available on the source cluster because they were purged by the source topic's
+ * retention policy before replication could catch up. This indicates an unrecoverable gap in the
+ * replicated data stream, so the task fails fast instead of silently skipping ahead to the next
+ * available offset.
+ */
+public class DataLossException extends ConnectException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DataLossException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 public class MirrorSourceConfig extends MirrorConnectorConfig {
@@ -116,6 +117,14 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
     public static final String OFFSET_SYNCS_TARGET_PRODUCER_ROLE = OFFSET_SYNCS_CLIENT_ROLE_PREFIX + "target-producer";
     public static final String OFFSET_SYNCS_SOURCE_ADMIN_ROLE = OFFSET_SYNCS_CLIENT_ROLE_PREFIX + "source-admin";
     public static final String OFFSET_SYNCS_TARGET_ADMIN_ROLE = OFFSET_SYNCS_CLIENT_ROLE_PREFIX + "target-admin";
+
+    public static final String DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED = "data.loss.and.topic.reset.detection" + ENABLED_SUFFIX;
+    private static final String DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED_DOC = "Whether to fail the task with a " +
+            "DataLossException or TopicResetException when the source consumer's requested offset is no longer " +
+            "available (e.g. due to retention-based log truncation or the source topic being deleted and recreated), " +
+            "instead of MirrorMaker 2's default behavior of silently resuming from the earliest available offset. " +
+            "When enabled, the source consumer is configured with " + AUTO_OFFSET_RESET_CONFIG + "=none.";
+    public static final boolean DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED_DEFAULT = false;
 
     public MirrorSourceConfig(Map<String, String> props) {
         super(CONNECTOR_CONFIG_DEF, props);
@@ -223,6 +232,10 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
 
     List<String> metricNamesFormats() {
         return getList(METRIC_NAMES_FORMAT);
+    }
+
+    boolean dataLossAndTopicResetDetectionEnabled() {
+        return getBoolean(DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED);
     }
 
     private static ConfigDef defineSourceConfig(ConfigDef baseConfig) {
@@ -348,6 +361,13 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
                         ConfigDef.ValidList.in(false, METRIC_NAMES_LEGACY, METRIC_NAMES_NEW),
                         ConfigDef.Importance.LOW,
                         METRIC_NAMES_FORMAT_DOC
+                )
+                .define(
+                        DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED,
+                        ConfigDef.Type.BOOLEAN,
+                        DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED_DOC
                 );
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -36,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +62,7 @@ public class MirrorSourceTask extends SourceTask {
     private boolean stopping = false;
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
+    private boolean failOnDataLossAndTopicReset = false;
 
     public MirrorSourceTask() {}
 
@@ -74,6 +78,14 @@ public class MirrorSourceTask extends SourceTask {
         this.offsetSyncWriter = offsetSyncWriter;
     }
 
+    // for testing
+    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+                     ReplicationPolicy replicationPolicy,
+                     OffsetSyncWriter offsetSyncWriter, boolean failOnDataLossAndTopicReset) {
+        this(consumer, metrics, sourceClusterAlias, replicationPolicy, offsetSyncWriter);
+        this.failOnDataLossAndTopicReset = failOnDataLossAndTopicReset;
+    }
+
     @Override
     public void start(Map<String, String> props) {
         MirrorSourceTaskConfig config = new MirrorSourceTaskConfig(props);
@@ -87,7 +99,14 @@ public class MirrorSourceTask extends SourceTask {
         if (config.emitOffsetSyncsEnabled()) {
             offsetSyncWriter = new OffsetSyncWriter(config);
         }
-        consumer = MirrorUtils.newConsumer(config.sourceConsumerConfig("replication-consumer"));
+        failOnDataLossAndTopicReset = config.dataLossAndTopicResetDetectionEnabled();
+        Map<String, Object> consumerConfig = config.sourceConsumerConfig("replication-consumer");
+        if (failOnDataLossAndTopicReset) {
+            // Without this, the underlying consumer silently resets to the earliest offset on
+            // truncation or topic reset, masking the very conditions this task needs to detect.
+            consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+        }
+        consumer = MirrorUtils.newConsumer(consumerConfig);
         Set<TopicPartition> taskTopicPartitions = config.taskTopicPartitions();
         initializeConsumer(taskTopicPartitions);
 
@@ -162,6 +181,12 @@ public class MirrorSourceTask extends SourceTask {
                 log.trace("Polled {} records from {}.", sourceRecords.size(), records.partitions());
                 return sourceRecords;
             }
+        } catch (OffsetOutOfRangeException e) {
+            if (failOnDataLossAndTopicReset) {
+                throw classifyOffsetOutOfRange(e);
+            }
+            log.warn("Failure during poll.", e);
+            return null;
         } catch (WakeupException e) {
             return null;
         } catch (KafkaException e) {
@@ -176,6 +201,36 @@ public class MirrorSourceTask extends SourceTask {
         }
     }
  
+    // visible for testing
+    RuntimeException classifyOffsetOutOfRange(OffsetOutOfRangeException e) {
+        Map<TopicPartition, Long> outOfRangeOffsets = e.offsetOutOfRangePartitions();
+        Map<TopicPartition, Long> earliestOffsets = consumer.beginningOffsets(outOfRangeOffsets.keySet());
+        boolean dataLossDetected = false;
+        for (Map.Entry<TopicPartition, Long> entry : outOfRangeOffsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            long requestedOffset = entry.getValue();
+            long earliestOffset = earliestOffsets.getOrDefault(topicPartition, 0L);
+            if (earliestOffset > 0) {
+                dataLossDetected = true;
+                log.error("Data loss detected replicating {}->{}: requested offset {} for {} is no longer " +
+                        "available (earliest available offset is {}). Records were likely purged by the " +
+                        "source topic's retention policy before they could be replicated.",
+                        sourceClusterAlias, topicPartition.topic(), requestedOffset, topicPartition, earliestOffset);
+            } else {
+                log.error("Topic reset detected replicating {}->{}: requested offset {} for {} is no longer " +
+                        "available and the earliest available offset is 0, indicating the source topic was " +
+                        "deleted and recreated.",
+                        sourceClusterAlias, topicPartition.topic(), requestedOffset, topicPartition);
+            }
+        }
+        if (dataLossDetected) {
+            return new DataLossException("Detected unreplicated data loss for partitions "
+                    + outOfRangeOffsets.keySet() + " while replicating from " + sourceClusterAlias, e);
+        }
+        return new TopicResetException("Detected topic reset for partitions "
+                + outOfRangeOffsets.keySet() + " while replicating from " + sourceClusterAlias, e);
+    }
+
     @Override
     public void commitRecord(SourceRecord record, RecordMetadata metadata) {
         if (stopping) {
@@ -228,9 +283,16 @@ public class MirrorSourceTask extends SourceTask {
                 .filter(this::isUncommitted).count());
 
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
-            // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {
-                log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                if (failOnDataLossAndTopicReset) {
+                    // auto.offset.reset is set to "none" in this mode, so the consumer won't pick a
+                    // starting position on its own; seek to earliest manually to preserve the same
+                    // starting behavior as the default configuration.
+                    log.trace("No committed offset for topicPartition: {}; seeking to earliest offset.", topicPartition);
+                    consumer.seekToBeginning(Collections.singletonList(topicPartition));
+                } else {
+                    log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                }
                 return;
             }
             long nextOffsetToCommittedOffset = offset + 1L;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown by {@link MirrorSourceTask} when it detects that the source topic-partition it was
+ * replicating has been deleted and recreated (its log end offset reset to the beginning) since
+ * the task last tracked an offset for it. This indicates the previously committed offset is no
+ * longer meaningful, so the task fails fast instead of silently resetting to the earliest offset.
+ */
+public class TopicResetException extends ConnectException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TopicResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
@@ -151,6 +151,20 @@ public class MirrorSourceConfigTest {
     }
 
     @Test
+    public void testDataLossAndTopicResetDetectionDefaultsToDisabled() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
+        assertFalse(config.dataLossAndTopicResetDetectionEnabled(),
+                "Data loss and topic reset detection should be disabled by default to preserve existing behavior");
+    }
+
+    @Test
+    public void testDataLossAndTopicResetDetectionCanBeEnabled() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps("data.loss.and.topic.reset.detection.enabled", "true"));
+        assertTrue(config.dataLossAndTopicResetDetectionEnabled());
+    }
+
+    @Test
     public void testAdminConfigsForOffsetSyncsTopic() {
         Map<String, String> connectorProps = makeProps(
                 "source.admin.request.timeout.ms", "1",

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
@@ -43,12 +44,16 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -265,6 +270,110 @@ public class MirrorSourceTaskTest {
                 .seek(new TopicPartition("previouslyReplicatedTopic1", 0), offsetToSeek);
 
         verifyNoMoreInteractions(mockConsumer);
+    }
+
+    @Test
+    public void testSeekToBeginningWhenDataLossAndTopicResetDetectionEnabled() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> mockConsumer = mock(KafkaConsumer.class);
+
+        SourceTaskContext mockSourceTaskContext = mock(SourceTaskContext.class);
+        OffsetStorageReader mockOffsetStorageReader = mock(OffsetStorageReader.class);
+        when(mockSourceTaskContext.offsetStorageReader()).thenReturn(mockOffsetStorageReader);
+        // No committed offset is returned for this partition (simulates a fresh start).
+        when(mockOffsetStorageReader.offset(anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TopicPartition newPartition = new TopicPartition("newTopicToReplicate", 0);
+        Set<TopicPartition> topicPartitions = Set.of(newPartition);
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(mockConsumer, null, null,
+                new DefaultReplicationPolicy(), null, true);
+        mirrorSourceTask.initialize(mockSourceTaskContext);
+
+        mirrorSourceTask.initializeConsumer(topicPartitions);
+
+        verify(mockConsumer, times(1)).assign(topicPartitions);
+        // With detection enabled, auto.offset.reset is "none", so we must seek to the beginning
+        // manually for partitions without a committed offset instead of relying on the consumer default.
+        verify(mockConsumer, times(1)).seekToBeginning(List.of(newPartition));
+        verifyNoMoreInteractions(mockConsumer);
+    }
+
+    @Test
+    public void testClassifyOffsetOutOfRangeAsDataLossWhenEarliestOffsetIsPositive() {
+        TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+        long requestedOffset = 1000L;
+        long earliestAvailableOffset = 500L;
+        OffsetOutOfRangeException offsetOutOfRangeException =
+                new OffsetOutOfRangeException(Map.of(topicPartition, requestedOffset));
+
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        when(consumer.beginningOffsets(Set.of(topicPartition)))
+                .thenReturn(Map.of(topicPartition, earliestAvailableOffset));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        RuntimeException classified = mirrorSourceTask.classifyOffsetOutOfRange(offsetOutOfRangeException);
+
+        assertInstanceOf(DataLossException.class, classified);
+    }
+
+    @Test
+    public void testClassifyOffsetOutOfRangeAsTopicResetWhenEarliestOffsetIsZero() {
+        TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+        long requestedOffset = 1000L;
+        OffsetOutOfRangeException offsetOutOfRangeException =
+                new OffsetOutOfRangeException(Map.of(topicPartition, requestedOffset));
+
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        when(consumer.beginningOffsets(Set.of(topicPartition)))
+                .thenReturn(Map.of(topicPartition, 0L));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        RuntimeException classified = mirrorSourceTask.classifyOffsetOutOfRange(offsetOutOfRangeException);
+
+        assertInstanceOf(TopicResetException.class, classified);
+    }
+
+    @Test
+    public void testPollPropagatesDataLossExceptionWhenDetectionEnabled() {
+        TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+        OffsetOutOfRangeException offsetOutOfRangeException =
+                new OffsetOutOfRangeException(Map.of(topicPartition, 1000L));
+
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        when(consumer.poll(any())).thenThrow(offsetOutOfRangeException);
+        when(consumer.beginningOffsets(Set.of(topicPartition))).thenReturn(Map.of(topicPartition, 500L));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        assertThrows(DataLossException.class, mirrorSourceTask::poll);
+    }
+
+    @Test
+    public void testPollSwallowsOffsetOutOfRangeWhenDetectionDisabled() {
+        TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+        OffsetOutOfRangeException offsetOutOfRangeException =
+                new OffsetOutOfRangeException(Map.of(topicPartition, 1000L));
+
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        when(consumer.poll(any())).thenThrow(offsetOutOfRangeException);
+
+        // Default (5-arg) constructor: data loss/topic reset detection is disabled,
+        // matching MirrorMaker 2's existing default behavior.
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null);
+
+        assertNull(mirrorSourceTask.poll());
+        verify(consumer, never()).beginningOffsets(any());
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DataLossAndTopicResetDetectionIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DataLossAndTopicResetDetectionIntegrationTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.integration;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.mirror.DataLossException;
+import org.apache.kafka.connect.mirror.MirrorMakerConfig;
+import org.apache.kafka.connect.mirror.MirrorSourceConfig;
+import org.apache.kafka.connect.mirror.MirrorSourceConnector;
+import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.mirror.TopicResetException;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for MirrorSourceTask's opt-in fail-fast detection of data loss (records
+ * purged by the source topic's retention policy before they could be replicated) and topic reset
+ * (source topic deleted and recreated), gated behind
+ * {@link MirrorSourceConfig#DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED}.
+ *
+ * <p>This suite sets up its own minimal, single-direction, single-connector two-cluster fixture
+ * rather than extending {@link MirrorConnectorsIntegrationBaseTest}: that shared fixture's
+ * default topics and its battery of unrelated inherited tests aren't compatible with running
+ * every replicated topic under strict ({@code auto.offset.reset=none}) semantics.
+ */
+@Tag("integration")
+public class DataLossAndTopicResetDetectionIntegrationTest {
+
+    private static final String PRIMARY_CLUSTER_ALIAS = "primary";
+    private static final String BACKUP_CLUSTER_ALIAS = "backup";
+    private static final String CONNECTOR_NAME = MirrorSourceConnector.class.getSimpleName();
+    private static final long RECORD_TRANSFER_DURATION_MS = 30_000;
+
+    private EmbeddedConnectCluster primary;
+    private EmbeddedConnectCluster backup;
+    private Producer<byte[], byte[]> primaryProducer;
+    private MirrorMakerConfig mm2Config;
+
+    @BeforeEach
+    public void startClusters() {
+        Map<String, String> mm2Props = new HashMap<>();
+        mm2Props.put("clusters", PRIMARY_CLUSTER_ALIAS + ", " + BACKUP_CLUSTER_ALIAS);
+        mm2Props.put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".enabled", "true");
+        mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
+        mm2Props.put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + ".topics", "test-topic-.*");
+        mm2Props.put(PRIMARY_CLUSTER_ALIAS + "->" + BACKUP_CLUSTER_ALIAS + "."
+                + MirrorSourceConfig.DATA_LOSS_AND_TOPIC_RESET_DETECTION_ENABLED, "true");
+        mm2Props.put("replication.factor", "1");
+        mm2Props.put("checkpoints.topic.replication.factor", "1");
+        mm2Props.put("heartbeats.topic.replication.factor", "1");
+        mm2Props.put("offset-syncs.topic.replication.factor", "1");
+        mm2Props.put("offset.storage.replication.factor", "1");
+        mm2Props.put("status.storage.replication.factor", "1");
+        mm2Props.put("config.storage.replication.factor", "1");
+
+        mm2Config = new MirrorMakerConfig(mm2Props);
+        Map<String, String> primaryWorkerProps = mm2Config.workerConfig(new SourceAndTarget(BACKUP_CLUSTER_ALIAS, PRIMARY_CLUSTER_ALIAS));
+        Map<String, String> backupWorkerProps = mm2Config.workerConfig(new SourceAndTarget(PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS));
+
+        Properties brokerProps = new Properties();
+        brokerProps.put("auto.create.topics.enable", "false");
+
+        primary = new EmbeddedConnectCluster.Builder()
+                .name(PRIMARY_CLUSTER_ALIAS + "-connect-cluster")
+                .numWorkers(1)
+                .numBrokers(1)
+                .brokerProps(brokerProps)
+                .workerProps(primaryWorkerProps)
+                .build();
+        backup = new EmbeddedConnectCluster.Builder()
+                .name(BACKUP_CLUSTER_ALIAS + "-connect-cluster")
+                .numWorkers(1)
+                .numBrokers(1)
+                .brokerProps(brokerProps)
+                .workerProps(backupWorkerProps)
+                .build();
+
+        primary.start();
+        backup.start();
+
+        primaryProducer = primary.kafka().createProducer(Map.of());
+
+        // The connector's tasks need each cluster's bootstrap.servers, which are only known once
+        // the embedded brokers have started; rebuild the config now that they're set.
+        mm2Props.put(PRIMARY_CLUSTER_ALIAS + ".bootstrap.servers", primary.kafka().bootstrapServers());
+        mm2Props.put(BACKUP_CLUSTER_ALIAS + ".bootstrap.servers", backup.kafka().bootstrapServers());
+        mm2Config = new MirrorMakerConfig(mm2Props);
+    }
+
+    @AfterEach
+    public void shutdownClusters() {
+        Utils.closeQuietly(primaryProducer, "primary producer");
+        if (primary != null) {
+            Utils.closeQuietly(primary::stop, "primary connect cluster");
+        }
+        if (backup != null) {
+            Utils.closeQuietly(backup::stop, "backup connect cluster");
+        }
+    }
+
+    @Test
+    public void testDataLossDetectedOnRetentionTruncation() throws Exception {
+        String topic = "test-topic-dataloss";
+        TopicPartition topicPartition = new TopicPartition(topic, 0);
+        primary.kafka().createTopic(topic, 1);
+
+        produce(topic, 10);
+
+        backup.configureConnector(CONNECTOR_NAME, mm2Config.connectorBaseConfig(
+                new SourceAndTarget(PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS), MirrorSourceConnector.class));
+        backup.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+                "Connector " + CONNECTOR_NAME + " tasks did not start in time");
+
+        String remoteTopic = PRIMARY_CLUSTER_ALIAS + "." + topic;
+        backup.kafka().consume(10, RECORD_TRANSFER_DURATION_MS, remoteTopic);
+
+        // Stop the task from polling so that the next few records it produces are purged before
+        // it has a chance to replicate them.
+        backup.pauseConnector(CONNECTOR_NAME);
+        backup.assertions().assertConnectorAndExactlyNumTasksArePaused(CONNECTOR_NAME, 1,
+                "Connector did not pause in time");
+
+        produce(topic, 5);
+
+        // Purge past the offset the paused task will resume from, simulating retention deleting
+        // records before they were replicated.
+        try (Admin admin = primary.kafka().createAdminClient()) {
+            admin.deleteRecords(Map.of(topicPartition, RecordsToDelete.beforeOffset(12L))).all().get();
+        }
+
+        backup.resumeConnector(CONNECTOR_NAME);
+
+        assertTaskFailedWithException(DataLossException.class);
+    }
+
+    @Test
+    public void testTopicResetDetectedOnTopicRecreation() throws Exception {
+        String topic = "test-topic-reset";
+        primary.kafka().createTopic(topic, 1);
+
+        produce(topic, 10);
+
+        backup.configureConnector(CONNECTOR_NAME, mm2Config.connectorBaseConfig(
+                new SourceAndTarget(PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS), MirrorSourceConnector.class));
+        backup.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, 1,
+                "Connector " + CONNECTOR_NAME + " tasks did not start in time");
+
+        String remoteTopic = PRIMARY_CLUSTER_ALIAS + "." + topic;
+        backup.kafka().consume(10, RECORD_TRANSFER_DURATION_MS, remoteTopic);
+
+        backup.pauseConnector(CONNECTOR_NAME);
+        backup.assertions().assertConnectorAndExactlyNumTasksArePaused(CONNECTOR_NAME, 1,
+                "Connector did not pause in time");
+
+        // Simulate an irregular system reset: the topic is deleted and recreated, so its log
+        // starts fresh at offset 0 while the paused task still expects to resume from offset 10.
+        primary.kafka().deleteTopic(topic);
+        primary.kafka().createTopic(topic, 1);
+
+        backup.resumeConnector(CONNECTOR_NAME);
+
+        assertTaskFailedWithException(TopicResetException.class);
+    }
+
+    private void produce(String topic, int numMessages) throws Exception {
+        for (int i = 0; i < numMessages; i++) {
+            String key = "key-" + i;
+            String value = "value-" + i;
+            primaryProducer.send(new ProducerRecord<>(topic, key.getBytes(), value.getBytes())).get();
+        }
+    }
+
+    private void assertTaskFailedWithException(Class<? extends Exception> expectedExceptionType) throws InterruptedException {
+        backup.assertions().assertConnectorIsRunningAndTasksHaveFailed(CONNECTOR_NAME, 1,
+                "Task should have failed with " + expectedExceptionType.getSimpleName());
+        ConnectorStateInfo status = backup.connectorStatus(CONNECTOR_NAME);
+        String trace = status.tasks().get(0).trace();
+        assertTrue(trace != null && trace.contains(expectedExceptionType.getSimpleName()),
+                "Expected task failure trace to contain " + expectedExceptionType.getSimpleName() + " but was: " + trace);
+    }
+}


### PR DESCRIPTION
## Design Rationale

### Problem

MirrorMaker 2's `MirrorSourceTask` consumes from the source cluster with `auto.offset.reset=earliest` (the consumer default). This masks two failure modes that matter for Primary/DR replication:

- **Silent data loss**: if the source topic's retention policy purges records before MM2 replicates them, the next `poll()` silently jumps to the next available offset instead of surfacing a gap.
- **Silent topic reset**: if a source topic is deleted and recreated, the previously tracked offset is no longer valid, and MM2 silently resets to the earliest offset of the new topic instead of surfacing the inconsistency.

Both cases currently only produce a debug/warn-level log line buried in `poll()`'s generic `KafkaException` handling, with no way for an operator or the Connect framework to detect or react to the condition.

### Files and classes modified

- `connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java` — new connector config `data.loss.and.topic.reset.detection.enabled` (boolean, default `false`) and accessor `dataLossAndTopicResetDetectionEnabled()`.
- `connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java` — core detection logic:
  - `start()`: when the new config is enabled, sets `auto.offset.reset=none` on the source consumer so `OffsetOutOfRangeException` is thrown instead of silently swallowed.
  - `initializeConsumer()`: since `auto.offset.reset=none` disables the consumer's own fallback, partitions with no committed offset are now seeked to the beginning manually, preserving MM2's existing startup behavior.
  - `poll()`: catches `OffsetOutOfRangeException` and, when detection is enabled, delegates to the new `classifyOffsetOutOfRange()` and rethrows its result; otherwise falls back to the existing warn-and-continue behavior.
  - `classifyOffsetOutOfRange()` (new, package-visible for testing): for each affected partition, compares the requested offset against `consumer.beginningOffsets()`. An earliest offset greater than 0 indicates purged records (data loss); an earliest offset of 0 indicates the topic was recreated (topic reset). Logs a detailed error per partition (source cluster, topic, partition, requested offset, earliest offset) before throwing.
- `connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java` (new) — thrown when purged records are detected; extends `ConnectException` so the Connect framework fails the task.
- `connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java` (new) — thrown when a topic reset is detected; same fail-fast mechanism.
- Corresponding test updates in `MirrorSourceConfigTest.java` and `MirrorSourceTaskTest.java`.

### Why this implementation strategy

- **Detection at the consumer boundary, not by polling metadata separately**: `OffsetOutOfRangeException` is the exact signal Kafka's consumer already raises when a requested offset is no longer valid, whether due to retention or topic recreation. Using it avoids adding a second, redundant mechanism (e.g. periodically comparing offsets against topic metadata) that could drift out of sync with what the consumer actually observes.
- **Distinguishing data loss from topic reset using `beginningOffsets()`**: a recreated topic's log starts at offset 0, while a topic that has simply been truncated by retention has an earliest offset greater than 0. This lets one exception type and one code path serve both detection scenarios cleanly.
- **Opt-in via config, defaulting to `false`**: this preserves MM2's existing default behavior (resume from earliest, log a warning) for existing deployments, while letting operators who need strict fail-fast semantics (e.g. mission-critical PR/DR setups) opt in explicitly.
- **Fail-fast via dedicated exception types rather than just logging**: a warning that's easy to miss in production logs does not stop a broken replication pipeline from continuing to run. Throwing `DataLossException`/`TopicResetException` (subclasses of `ConnectException`) causes the Connect framework to fail and surface the task, so the condition can't go unnoticed.

### Integration with the existing MM2 lifecycle

- No changes to `MirrorSourceConnector` or task lifecycle methods (`start()`/`stop()`/`commit()`/`commitRecord()`) beyond `start()` reading the new config and conditionally adjusting the consumer config map before the consumer is constructed — the rest of the startup sequence is untouched.
- `initializeConsumer()` already ran on task start to seek partitions to their committed offsets; the new branch only changes behavior for the previously-uncommitted-offset case, and only when detection is enabled, so default-mode task startup is unaffected.
- `poll()`'s existing exception hierarchy (`WakeupException`, generic `KafkaException`, `Throwable`) is preserved as-is; `OffsetOutOfRangeException` is caught ahead of the generic `KafkaException` handler so it can be special-cased without disturbing the other branches.
- When detection is disabled (the default), behavior is bit-for-bit identical to current MM2: same consumer config, same seek behavior, same warn-and-continue on `OffsetOutOfRangeException`.

### Testing

- `MirrorSourceConfigTest`: verifies the new config defaults to disabled and can be enabled.
- `MirrorSourceTaskTest`:
  - `testSeekToBeginningWhenDataLossAndTopicResetDetectionEnabled` — confirms manual `seekToBeginning` is invoked for uncommitted partitions when detection is on.
  - `testClassifyOffsetOutOfRangeAsDataLossWhenEarliestOffsetIsPositive` / `...AsTopicResetWhenEarliestOffsetIsZero` — confirm classification logic for both scenarios.
  - `testPollPropagatesDataLossExceptionWhenDetectionEnabled` — confirms `poll()` throws when detection is enabled.
  - `testPollSwallowsOffsetOutOfRangeWhenDetectionDisabled` — confirms default behavior (warn, return `null`, no call to `beginningOffsets()`) is unchanged when detection is disabled.
- `DataLossAndTopicResetDetectionIntegrationTest` (new, `@Tag("integration")`) — end-to-end coverage against real embedded clusters, since the unit tests above stub the consumer rather than exercising a real broker's offset semantics:
  - `testDataLossDetectedOnRetentionTruncation` — mirrors a topic, pauses the connector, produces more records and purges past the paused task's resume offset via `Admin.deleteRecords()`, then resumes and asserts the task fails with `DataLossException`.
  - `testTopicResetDetectedOnTopicRecreation` — mirrors a topic, pauses the connector, deletes and recreates the source topic so its log restarts at offset 0, then resumes and asserts the task fails with `TopicResetException`.
- All new and existing `connect:mirror` tests pass (`./gradlew :connect:mirror:test`).

