### PR TITLE
KAFKA-20808: StreamThread dies with fatal InvalidStateStoreException after TaskCorruptedException

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractSegments.java
@@ -96,7 +96,12 @@ public abstract class AbstractSegments<S extends Segment> implements Segments<S>
                 throw new IllegalStateException(newSegment.getClass().getSimpleName() + " already exists. Possible concurrent access.");
             }
 
-            openSegmentDB(newSegment, context);
+            try {
+                openSegmentDB(newSegment, context);
+            } catch (final Exception openException) {
+                segments.remove(segmentId);
+                throw openException;
+            }
             return newSegment;
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSegmentsTest.java
@@ -112,6 +112,30 @@ abstract class AbstractSegmentsTest<S extends Segments> {
         assertEquals("Tasks [0_0] are corrupted and hence need to be re-initialized", thrown.getMessage());
     }
 
+    @Test
+    public void shouldNotRetainFailedSegmentSoRecoveryStaysRecoverable() throws Exception {
+        context = getEOSProcessorContext();
+        segments = getSegments();
+        segments.openExisting(context, 0L);
+        final Segment segment = segments.getOrCreateSegmentIfLive(0, context, 1L);
+
+        assertTrue(segment.isOpen());
+        segments.close();
+
+        simulateUncleanShutdownForAllSegments();
+        segments = getSegments();
+
+        // The first open fails with a (recoverable) TaskCorruptedException because the on-disk state is dirty.
+        assertThrows(TaskCorruptedException.class, () -> segments.openExisting(context, 0L));
+
+        // A segment that failed to open must not be retained in the segments map. Otherwise a subsequent
+        // open would return the stale, unopened segment instead of retrying to open it, and querying its
+        // committed offset during task re-initialization would then fail with a fatal
+        // InvalidStateStoreException. Re-opening must instead stay recoverable, i.e. keep throwing
+        // TaskCorruptedException until the dirty local state is wiped.
+        assertThrows(TaskCorruptedException.class, () -> segments.openExisting(context, 0L));
+    }
+
     private void simulateUncleanShutdownForAllSegments() throws Exception {
         for (final File dbDir : Objects.requireNonNull(context.stateDir().listFiles())) {
             for (final File storeDir : Objects.requireNonNull(dbDir.listFiles())) {


### PR DESCRIPTION
This PR ensures that an unsuccessfully opened segment is remove from the
in-memory cache for open segments.

Reviewers: Nick Telford <nick.telford@gmail.com>, Bill Bejeck
 <bbejeck@apache.org>
