### PR TITLE
MINOR: Fix regex escaping in Kafka Streams WordCount examples

### DIFF
--- a/docs/streams/developer-guide/processor-api.md
+++ b/docs/streams/developer-guide/processor-api.md
@@ -92,7 +92,7 @@ The following example `Processor` defines a simple word-count algorithm and the 
     
         @Override
         public void process(final Record<String, String> record) {
-            final String[] words = record.value().toLowerCase(Locale.getDefault()).split("\W+");
+            final String[] words = record.value().toLowerCase(Locale.getDefault()).split("\\W+");
     
             for (final String word : words) {
                 final Integer oldValue = kvStore.get(word);
@@ -429,5 +429,4 @@ Now that you have fully defined your processor topology in your application, you
   * [Documentation](/documentation)
   * [Kafka Streams](/documentation/streams)
   * [Developer Guide](/documentation/streams/developer-guide/)
-
 

--- a/docs/streams/introduction.md
+++ b/docs/streams/introduction.md
@@ -118,7 +118,7 @@ public class WordCountApplication {
        StreamsBuilder builder = new StreamsBuilder();
        KStream<String, String> textLines = builder.stream("TextLinesTopic");
        KTable<String, Long> wordCounts = textLines
-           .flatMapValues(textLine -> Arrays.asList(textLine.toLowerCase().split("\W+")))
+           .flatMapValues(textLine -> Arrays.asList(textLine.toLowerCase().split("\\W+")))
            .groupBy((key, word) -> word)
            .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("counts-store"));
        wordCounts.toStream().to("WordsWithCountsTopic", Produced.with(Serdes.String(), Serdes.Long()));
@@ -154,7 +154,7 @@ object WordCountApplication extends App {
   val builder: StreamsBuilder = new StreamsBuilder
   val textLines: KStream[String, String] = builder.stream[String, String]("TextLinesTopic")
   val wordCounts: KTable[String, Long] = textLines
-    .flatMapValues(textLine => textLine.toLowerCase.split("\W+"))
+    .flatMapValues(textLine => textLine.toLowerCase.split("\\W+"))
     .groupBy((_, word) => word)
     .count()(Materialized.as("counts-store"))
   wordCounts.toStream.to("WordsWithCountsTopic")
@@ -169,4 +169,3 @@ object WordCountApplication extends App {
 ```
 {{% /tab %}}
 {{< /tabpane >}}
-

--- a/docs/streams/quickstart.md
+++ b/docs/streams/quickstart.md
@@ -49,7 +49,7 @@ This quickstart example will demonstrate how to run a streaming application code
     
     KTable<String, Long> wordCounts = textLines
         // Split each text line, by whitespace, into words.
-        .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\W+")))
+        .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
     
         // Group the text words as message keys
         .groupBy((key, value) -> value)
@@ -257,5 +257,4 @@ You can now stop the console consumer, the console producer, the Wordcount appli
 
   * [Documentation](/documentation)
   * [Kafka Streams](/documentation/streams)
-
 

--- a/docs/streams/tutorial.md
+++ b/docs/streams/tutorial.md
@@ -255,7 +255,7 @@ Since each of the source stream's record is a `String` typed key-value pair, let
     KStream<String, String> words = source.flatMapValues(new ValueMapper<String, Iterable<String>>() {
                 @Override
                 public Iterable<String> apply(String value) {
-                    return Arrays.asList(value.split("\W+"));
+                    return Arrays.asList(value.split("\\W+"));
                 }
             });
 
@@ -263,13 +263,13 @@ The operator will take the `source` stream as its input, and generate a new stre
     
     
     KStream<String, String> source = builder.stream("streams-plaintext-input");
-    KStream<String, String> words = source.flatMapValues(value -> Arrays.asList(value.split("\W+")));
+    KStream<String, String> words = source.flatMapValues(value -> Arrays.asList(value.split("\\W+")));
 
 And finally we can write the word stream back into another Kafka topic, say `streams-linesplit-output`. Again, these two steps can be concatenated as the following (assuming lambda expression is used): 
     
     
     KStream<String, String> source = builder.stream("streams-plaintext-input");
-    source.flatMapValues(value -> Arrays.asList(value.split("\W+")))
+    source.flatMapValues(value -> Arrays.asList(value.split("\\W+")))
           .to("streams-linesplit-output");
 
 If we now describe this augmented topology as `System.out.println(topology.describe())`, we will get the following: 
@@ -315,7 +315,7 @@ The complete code looks like this (assuming lambda expression is used):
             final StreamsBuilder builder = new StreamsBuilder();
     
             KStream<String, String> source = builder.stream("streams-plaintext-input");
-            source.flatMapValues(value -> Arrays.asList(value.split("\W+")))
+            source.flatMapValues(value -> Arrays.asList(value.split("\\W+")))
                   .to("streams-linesplit-output");
     
             final Topology topology = builder.build();
@@ -346,7 +346,7 @@ In order to count the words we can first modify the `flatMapValues` operator to 
     source.flatMapValues(new ValueMapper<String, Iterable<String>>() {
         @Override
         public Iterable<String> apply(String value) {
-            return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\W+"));
+            return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
         }
     });
 
@@ -357,7 +357,7 @@ In order to do the counting aggregation we have to first specify that we want to
     source.flatMapValues(new ValueMapper<String, Iterable<String>>() {
                 @Override
                 public Iterable<String> apply(String value) {
-                    return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\W+"));
+                    return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
                 }
             })
           .groupBy(new KeyValueMapper<String, String, String>() {
@@ -381,7 +381,7 @@ Note that in order to read the changelog stream from topic `streams-wordcount-ou
     
     
     KStream<String, String> source = builder.stream("streams-plaintext-input");
-    source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\W+")))
+    source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
           .groupBy((key, value) -> value)
           .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("counts-store"))
           .toStream()
@@ -444,7 +444,7 @@ The complete code looks like this (assuming lambda expression is used):
             final StreamsBuilder builder = new StreamsBuilder();
     
             KStream<String, String> source = builder.stream("streams-plaintext-input");
-            source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\W+")))
+            source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
                   .groupBy((key, value) -> value)
                   .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("counts-store"))
                   .toStream()
@@ -460,5 +460,4 @@ The complete code looks like this (assuming lambda expression is used):
 
   * [Documentation](/documentation)
   * [Kafka Streams](/documentation/streams)
-
 


### PR DESCRIPTION
Several Kafka Streams WordCount and line-splitting examples use `\W+` directly in Java or Scala string literals. Because the regular-expression backslash is not escaped at the source-language level, the snippets contain an illegal string escape and cannot be compiled as shown.

This change uses `\\W+` in the Processor API guide, introduction, quickstart, and tutorial so that the examples pass `\W+` to the regular-expression engine. No Kafka build or tests were run because the changes only correct string literals in documentation snippets; `git diff --check` passed.
