### PR TITLE
WIP: KAFKA-XXXX Fault injection proxy

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EndTxnFaultProxyPoCTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EndTxnFaultProxyPoCTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.FaultRule;
+import org.apache.kafka.streams.integration.utils.KafkaProtocolFaultProxy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * PROOF OF CONCEPT: validates the fault-proxy end-to-end — that a transactional client routed through
+ * {@link KafkaProtocolFaultProxy} (a) works normally through the proxy (routing via Metadata/FindCoordinator
+ * rewrite), and (b) observes an injected {@code EndTxn} error code that the real broker never returned,
+ * decoded and re-encoded through Kafka's own protocol classes.
+ *
+ * <p>Not a permanent test; it exercises the harness itself before wiring it to full KIP-892 Streams tests.
+ */
+@Timeout(120)
+@Tag("integration")
+public class EndTxnFaultProxyPoCTest {
+
+    private static final String TOPIC = "poc-topic";
+
+    private EmbeddedKafkaCluster cluster;
+    private KafkaProtocolFaultProxy proxy;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        cluster = new EmbeddedKafkaCluster(1);
+        cluster.start();
+        cluster.createTopic(TOPIC, 1, 1);
+        proxy = KafkaProtocolFaultProxy.inFrontOf(cluster.bootstrapServers());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (proxy != null) {
+            proxy.close();
+        }
+        if (cluster != null) {
+            cluster.stop();
+        }
+    }
+
+    private KafkaProducer<String, String> transactionalProducer(final String txnId) {
+        final Properties props = new Properties();
+        // Point the client at the PROXY, not the broker — this is what validates routing.
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, txnId);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 10_000);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 30_000);
+        return new KafkaProducer<>(props);
+    }
+
+    @Test
+    public void controlTransactionShouldCommitThroughProxy() {
+        // Proves routing: initTransactions (FindCoordinator), Produce, and EndTxn all flow through the
+        // proxy and succeed, i.e. the Metadata/FindCoordinator rewrites correctly point the client at us.
+        try (KafkaProducer<String, String> producer = transactionalProducer("poc-control")) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.send(new ProducerRecord<>(TOPIC, "k", "v"));
+            producer.commitTransaction();
+        }
+    }
+
+    @Test
+    public void injectedEndTxnErrorShouldSurfaceToClient() {
+        // Arm: the broker will really commit, but the proxy rewrites the EndTxn response error code to
+        // PRODUCER_FENCED (fatal). If routing/re-encode were wrong the client would instead throw a
+        // schema/correlation error — so a clean ProducerFenced proves the whole round-trip.
+        final FaultRule rule = proxy.injectError(ApiKeys.END_TXN, Errors.PRODUCER_FENCED).once();
+        try (KafkaProducer<String, String> producer = transactionalProducer("poc-inject")) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.send(new ProducerRecord<>(TOPIC, "k", "v"));
+
+            final KafkaException e = assertThrows(KafkaException.class, producer::commitTransaction);
+            System.out.println("[POC] commitTransaction threw: " + e.getClass().getName() + " -> " + e.getMessage());
+        }
+        assertEquals(1, rule.timesTriggered(), "exactly one EndTxn error should have been injected");
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FaultInjectingClientSupplierTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FaultInjectingClientSupplierTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.integration.utils.ClientFault;
+import org.apache.kafka.streams.integration.utils.FaultInjectingClientSupplier;
+import org.apache.kafka.streams.integration.utils.FaultInjectingClientSupplier.ProducerCall;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Fast, deterministic mechanics test for {@link FaultInjectingClientSupplier}: proves the DSL triggers
+ * ({@code once}/{@code onCall}/{@code times}), that only the targeted call throws, that other calls delegate,
+ * that consumers/admin pass through untouched, and that {@link ClientFault#remove()} disarms. No broker.
+ */
+public class FaultInjectingClientSupplierTest {
+
+    private FaultInjectingClientSupplier newSupplier(final Producer<byte[], byte[]> producer) {
+        final KafkaClientSupplier base = new KafkaClientSupplier() {
+            @Override
+            public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+                return producer;
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+                return new MockConsumer<>("earliest");
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+                return new MockConsumer<>("earliest");
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
+                return new MockConsumer<>("earliest");
+            }
+        };
+        return FaultInjectingClientSupplier.wrapping(base);
+    }
+
+    @Test
+    public void onceShouldThrowOnFirstCallThenDelegate() {
+        final MockProducer<byte[], byte[]> mock = new MockProducer<>();
+        final FaultInjectingClientSupplier supplier = newSupplier(mock);
+        final ClientFault fault = supplier.failOn(ProducerCall.COMMIT_TRANSACTION,
+            () -> new TimeoutException("injected")).once();
+
+        final Producer<byte[], byte[]> producer = supplier.getProducer(Map.of());
+        producer.initTransactions();
+        producer.beginTransaction();
+
+        // First commit throws the injected exception...
+        assertThrows(TimeoutException.class, producer::commitTransaction);
+        // ...and the real producer never saw it (transaction still open).
+        assertEquals(0, mock.commitCount());
+
+        // Retrying the commit passes through to the delegate (fault was one-shot).
+        assertDoesNotThrow(producer::commitTransaction);
+        assertEquals(1, mock.commitCount());
+
+        assertEquals(1, fault.timesTriggered());
+        assertEquals(2, fault.timesMatched());
+    }
+
+    @Test
+    public void onCallShouldThrowOnlyOnTheNthInvocation() {
+        final MockProducer<byte[], byte[]> mock = new MockProducer<>();
+        final FaultInjectingClientSupplier supplier = newSupplier(mock);
+        supplier.failOn(ProducerCall.COMMIT_TRANSACTION, () -> new TimeoutException("boom")).onCall(2);
+
+        final Producer<byte[], byte[]> producer = supplier.getProducer(Map.of());
+        producer.initTransactions();
+
+        producer.beginTransaction();
+        assertDoesNotThrow(producer::commitTransaction);       // invocation #1 ok (closes txn)
+        producer.beginTransaction();
+        assertThrows(TimeoutException.class, producer::commitTransaction); // #2 throws (txn stays open)
+        assertDoesNotThrow(producer::commitTransaction);       // #3 retry ok (closes txn)
+
+        assertEquals(2, mock.commitCount());
+    }
+
+    @Test
+    public void faultShouldTargetOnlyItsOwnCall() {
+        final MockProducer<byte[], byte[]> mock = new MockProducer<>();
+        final FaultInjectingClientSupplier supplier = newSupplier(mock);
+        supplier.failOn(ProducerCall.COMMIT_TRANSACTION, () -> new TimeoutException("only-commit")).everyTime();
+
+        final Producer<byte[], byte[]> producer = supplier.getProducer(Map.of());
+        // initTransactions / beginTransaction / abort are unaffected.
+        assertDoesNotThrow(() -> producer.initTransactions());
+        assertDoesNotThrow(producer::beginTransaction);
+        assertThrows(TimeoutException.class, producer::commitTransaction);
+        assertDoesNotThrow(producer::abortTransaction);
+    }
+
+    @Test
+    public void removeShouldDisarmTheFault() {
+        final MockProducer<byte[], byte[]> mock = new MockProducer<>();
+        final FaultInjectingClientSupplier supplier = newSupplier(mock);
+        final ClientFault fault = supplier.failOn(ProducerCall.COMMIT_TRANSACTION,
+            () -> new TimeoutException("boom")).everyTime();
+
+        final Producer<byte[], byte[]> producer = supplier.getProducer(Map.of());
+        producer.initTransactions();
+        producer.beginTransaction();
+        assertThrows(TimeoutException.class, producer::commitTransaction);
+
+        fault.remove();
+        // Retry on the still-open transaction now succeeds.
+        assertDoesNotThrow(producer::commitTransaction);
+        assertEquals(1, mock.commitCount());
+    }
+
+    @Test
+    public void consumersShouldPassThroughUntouched() {
+        final FaultInjectingClientSupplier supplier = newSupplier(new MockProducer<>());
+        // No exception configured for any consumer; they must be the delegate's instances.
+        assertSame(MockConsumer.class, supplier.getConsumer(Map.of()).getClass());
+        assertSame(MockConsumer.class, supplier.getRestoreConsumer(Map.of()).getClass());
+        assertSame(MockConsumer.class, supplier.getGlobalConsumer(Map.of()).getClass());
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProxyFaultAllErrorsSmokeTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProxyFaultAllErrorsSmokeTest.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
+import org.apache.kafka.common.message.AddOffsetsToTxnRequestData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
+import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
+import org.apache.kafka.common.requests.HeartbeatRequest;
+import org.apache.kafka.common.requests.HeartbeatResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.RequestUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.KafkaProtocolFaultProxy;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One smoke test per {@link KafkaProtocolFaultProxy} fault: every API registered in its {@code ERROR_SETTERS}
+ * (transactional producer, plain producer, and consumer paths), plus {@code disconnectOn}, {@code delayResponse},
+ * and {@code blackholeOn}. Each test arms exactly one fault and asserts the fault-specific, client-visible
+ * consequence (a thrown exception, a slowed-but-successful call, or a client-side timeout).
+ *
+ * <p>All client-side timeouts here (session/heartbeat/request/api timeouts) are configured far below their
+ * defaults so that the tests that legitimately wait for a timeout (the blackhole case) or a fixed delay (the
+ * delay case) do so in a couple of seconds rather than the default tens-of-seconds-to-minutes.
+ */
+@Tag("integration")
+@Timeout(60)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProxyFaultAllErrorsSmokeTest {
+
+    // Deliberately far below the client defaults (30s/60s/120s/45s/3s) so a test that has to wait out a real
+    // timeout (blackhole) or a fixed delay (delayResponse) still finishes in a couple of seconds.
+    private static final int SHORT_REQUEST_TIMEOUT_MS = 5_000;
+    private static final int SHORT_API_TIMEOUT_MS = 8_000;
+    private static final int VERY_SHORT_REQUEST_TIMEOUT_MS = 1_000;
+    private static final int VERY_SHORT_API_TIMEOUT_MS = 2_000;
+    private static final int SESSION_TIMEOUT_MS = 6_000; // the broker's group.min.session.timeout.ms floor
+    private static final int HEARTBEAT_INTERVAL_MS = 1_000;
+    private static final int MAX_BLOCK_MS = 5_000;
+    private static final int DELIVERY_TIMEOUT_MS = 10_000;
+    private static final int TRANSACTION_TIMEOUT_MS = 10_000;
+
+    private EmbeddedKafkaCluster cluster;
+    private KafkaProtocolFaultProxy proxy;
+
+    @BeforeAll
+    public void startClusterAndProxy() {
+        cluster = new EmbeddedKafkaCluster(1);
+        cluster.start();
+        proxy = KafkaProtocolFaultProxy.inFrontOf(cluster.bootstrapServers());
+    }
+
+    @AfterAll
+    public void stopClusterAndProxy() {
+        if (proxy != null) {
+            proxy.close();
+        }
+        if (cluster != null) {
+            cluster.stop();
+        }
+    }
+
+    @BeforeEach
+    public void resetFaults() {
+        proxy.clearFaults();
+    }
+
+    // ------------------------------------------------------------------
+    // injectError: plain producer / consumer data-plane APIs
+    // ------------------------------------------------------------------
+
+    @Test
+    public void produceErrorIsSurfacedToTheProducer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        proxy.injectError(ApiKeys.PRODUCE, Errors.TOPIC_AUTHORIZATION_FAILED).once();
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig())) {
+            final ExecutionException ex = assertThrows(ExecutionException.class,
+                () -> producer.send(new ProducerRecord<>(topic, "k", "v")).get());
+            assertInstanceOf(TopicAuthorizationException.class, ex.getCause(), "expected TopicAuthorizationException, got " + ex.getCause());
+        }
+    }
+
+    @Test
+    public void fetchErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        final TopicPartition tp = new TopicPartition(topic, 0);
+        proxy.injectError(ApiKeys.FETCH, Errors.TOPIC_AUTHORIZATION_FAILED).once();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            consumer.assign(singletonList(tp));
+            assertPollEventuallyThrows(consumer, TopicAuthorizationException.class);
+        }
+    }
+
+    @Test
+    public void offsetCommitErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        final TopicPartition tp = new TopicPartition(topic, 0);
+        proxy.injectError(ApiKeys.OFFSET_COMMIT, Errors.TOPIC_AUTHORIZATION_FAILED).once();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            consumer.assign(singletonList(tp));
+            assertThrows(TopicAuthorizationException.class,
+                () -> consumer.commitSync(Map.of(tp, new OffsetAndMetadata(0L))));
+        }
+    }
+
+    @Test
+    public void listOffsetsErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        final TopicPartition tp = new TopicPartition(topic, 0);
+        proxy.injectError(ApiKeys.LIST_OFFSETS, Errors.TOPIC_AUTHORIZATION_FAILED).once();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            assertThrows(TopicAuthorizationException.class,
+                () -> consumer.endOffsets(Collections.singleton(tp)));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // injectError: consumer group protocol (classic: JoinGroup/SyncGroup/Heartbeat)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void joinGroupErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        proxy.injectError(ApiKeys.JOIN_GROUP, Errors.GROUP_AUTHORIZATION_FAILED).once();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            consumer.subscribe(singletonList(topic));
+            assertPollEventuallyThrows(consumer, GroupAuthorizationException.class);
+        }
+    }
+
+    @Test
+    public void syncGroupErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        proxy.injectError(ApiKeys.SYNC_GROUP, Errors.GROUP_AUTHORIZATION_FAILED).once();
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            consumer.subscribe(singletonList(topic));
+            assertPollEventuallyThrows(consumer, GroupAuthorizationException.class);
+        }
+    }
+
+    @Test
+    public void heartbeatErrorIsSurfacedToTheConsumer(final TestInfo info) throws Exception {
+        // Unlike Join/SyncGroup, the classic consumer treats a failed Heartbeat response as retriable background
+        // noise (AbstractCoordinator.HeartbeatThread swallows it via heartbeat.failHeartbeat(), it never reaches
+        // the application as a thrown exception) - by design, so one bad heartbeat can't kill a healthy member.
+        // Observing its real consequence (persistent failures eventually forcing a session timeout + rebalance)
+        // takes several multiples of the broker's session-timeout floor, which is too slow/variable for a smoke
+        // test. Talk raw wire protocol instead, with a real group's memberId/generationId, to directly prove the
+        // fault-injection path itself (which is what this test is actually about) without waiting on it.
+        final String topic = newTopic(info);
+        final ConsumerGroupMetadata groupMetadata;
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig(uniqueGroupId(info)))) {
+            consumer.subscribe(singletonList(topic));
+            consumer.poll(Duration.ofSeconds(5)); // real join, so memberId/generationId below are valid
+            groupMetadata = consumer.groupMetadata();
+
+            final HeartbeatRequestData data = new HeartbeatRequestData()
+                .setGroupId(groupMetadata.groupId())
+                .setGenerationId(groupMetadata.generationId())
+                .setMemberId(groupMetadata.memberId());
+            final HeartbeatRequest request =
+                new HeartbeatRequest.Builder(data).build(ApiKeys.HEARTBEAT.latestVersion());
+
+            proxy.injectError(ApiKeys.HEARTBEAT, Errors.GROUP_AUTHORIZATION_FAILED).once();
+            final HeartbeatResponse response = (HeartbeatResponse) sendRawRequest(request);
+            assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code(), response.data().errorCode());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // injectError: transactional producer path
+    // ------------------------------------------------------------------
+
+    @Test
+    public void initProducerIdErrorIsSurfacedToTheProducer(final TestInfo info) {
+        proxy.injectError(ApiKeys.INIT_PRODUCER_ID, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED).once();
+
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(transactionalProducerConfig(info));
+        try {
+            assertThrows(TransactionalIdAuthorizationException.class, producer::initTransactions);
+        } finally {
+            closeQuietly(producer);
+        }
+    }
+
+    @Test
+    public void addOffsetsToTxnErrorIsSurfacedToTheProducer(final TestInfo info) throws Exception {
+        // Under Transaction Protocol V2 (the default here), TransactionManager.sendOffsetsToTransaction()
+        // skips AddOffsetsToTxn entirely and folds its purpose into TxnOffsetCommit - so a real producer never
+        // sends this request and can't exercise the fault. Talk raw wire protocol instead, straight through the
+        // proxy, to prove the fault-injection path itself (which is what this test is actually about).
+        final AddOffsetsToTxnRequestData data = new AddOffsetsToTxnRequestData()
+            .setTransactionalId("txn-" + safeUniqueTestName(info))
+            .setProducerId(1L)
+            .setProducerEpoch((short) 0)
+            .setGroupId("g-" + safeUniqueTestName(info));
+        final AddOffsetsToTxnRequest request =
+            new AddOffsetsToTxnRequest.Builder(data).build(ApiKeys.ADD_OFFSETS_TO_TXN.latestVersion());
+
+        proxy.injectError(ApiKeys.ADD_OFFSETS_TO_TXN, Errors.GROUP_AUTHORIZATION_FAILED).once();
+        final AddOffsetsToTxnResponse response = (AddOffsetsToTxnResponse) sendRawRequest(request);
+        assertEquals(Errors.GROUP_AUTHORIZATION_FAILED.code(), response.data().errorCode());
+    }
+
+    @Test
+    public void endTxnErrorIsSurfacedToTheProducer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(transactionalProducerConfig(info));
+        try {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.send(new ProducerRecord<>(topic, "k", "v")).get();
+
+            proxy.injectError(ApiKeys.END_TXN, Errors.INVALID_TXN_STATE).once();
+            assertThrows(InvalidTxnStateException.class, producer::commitTransaction);
+        } finally {
+            closeQuietly(producer);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // disconnectOn / delayResponse / blackholeOn
+    // ------------------------------------------------------------------
+
+    @Test
+    public void disconnectIsRetriedTransparentlyByAnIdempotentProducer(final TestInfo info) throws Exception {
+        final String topic = newTopic(info);
+        final var rule = proxy.disconnectOn(ApiKeys.PRODUCE).once();
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig())) {
+            // idempotence is on by default: the broker-side write already succeeded before the connection was
+            // dropped, so the retried send is deduplicated and this still completes successfully.
+            producer.send(new ProducerRecord<>(topic, "k", "v")).get();
+        }
+        assertTrue(rule.timesTriggered() >= 1, "expected the disconnect fault to have fired at least once");
+    }
+
+    @Test
+    public void delayResponseSlowsTheCallDownButItStillSucceeds() throws Exception {
+        final Duration delay = Duration.ofMillis(1_500);
+        proxy.delayResponse(ApiKeys.METADATA, delay).once();
+
+        try (Admin admin = Admin.create(adminConfig(SHORT_REQUEST_TIMEOUT_MS, SHORT_API_TIMEOUT_MS))) {
+            final long start = System.nanoTime();
+            admin.describeCluster().clusterId().get();
+            final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs >= delay.toMillis() - 100,
+                "expected the call to take at least ~" + delay.toMillis() + "ms, took " + elapsedMs + "ms");
+        }
+    }
+
+    @Test
+    public void blackholeCausesAClientSideTimeoutInsteadOfHanging() {
+        proxy.blackholeOn(ApiKeys.METADATA).everyTime();
+
+        try (Admin admin = Admin.create(adminConfig(VERY_SHORT_REQUEST_TIMEOUT_MS, VERY_SHORT_API_TIMEOUT_MS))) {
+            final long start = System.nanoTime();
+            final ExecutionException ex = assertThrows(ExecutionException.class,
+                () -> admin.describeCluster().clusterId().get());
+            final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            assertInstanceOf(TimeoutException.class, ex.getCause(), "expected a client-side TimeoutException, got " + ex.getCause());
+            assertTrue(elapsedMs < 10_000,
+                "expected the blackholed call to fail fast via its own (shortened) timeout, took " + elapsedMs + "ms");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private String newTopic(final TestInfo info) throws InterruptedException {
+        final String topic = "t-" + safeUniqueTestName(info);
+        cluster.createTopic(topic, 1, 1);
+        return topic;
+    }
+
+    private String uniqueGroupId(final TestInfo info) {
+        return "g-" + safeUniqueTestName(info);
+    }
+
+    private Properties adminConfig(final int requestTimeoutMs, final int apiTimeoutMs) {
+        final Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+        props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        props.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, apiTimeoutMs);
+        return props;
+    }
+
+    private Properties producerConfig() {
+        final Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, SHORT_REQUEST_TIMEOUT_MS);
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, DELIVERY_TIMEOUT_MS);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, MAX_BLOCK_MS);
+        return props;
+    }
+
+    private Properties transactionalProducerConfig(final TestInfo info) {
+        final Properties props = producerConfig();
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "txn-" + safeUniqueTestName(info));
+        props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, TRANSACTION_TIMEOUT_MS);
+        return props;
+    }
+
+    private Properties consumerConfig(final String groupId) {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.GROUP_PROTOCOL_CONFIG, "classic");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, SHORT_REQUEST_TIMEOUT_MS);
+        props.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, SHORT_API_TIMEOUT_MS);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
+        return props;
+    }
+
+    /** Polls in a bounded loop until either the expected exception is thrown or the deadline passes. */
+    private static <T extends RuntimeException> void assertPollEventuallyThrows(
+            final KafkaConsumer<?, ?> consumer, final Class<T> expected) throws InterruptedException {
+        final AtomicReference<RuntimeException> caught = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            try {
+                consumer.poll(Duration.ofMillis(200));
+                return false;
+            } catch (final RuntimeException e) {
+                caught.set(e);
+                return true;
+            }
+        }, 10_000, "expected a " + expected.getSimpleName() + " while polling");
+        assertNotNull(caught.get());
+        assertTrue(expected.isInstance(caught.get()), "expected " + expected.getSimpleName() + ", got " + caught.get());
+    }
+
+    /** Sends one request directly over the wire to the proxy and decodes its response, bypassing any client. */
+    private AbstractResponse sendRawRequest(final AbstractRequest request) throws Exception {
+        final String[] hostPort = proxy.bootstrapServers().split(":");
+        try (Socket socket = new Socket(hostPort[0], Integer.parseInt(hostPort[1]))) {
+            socket.setSoTimeout(SHORT_REQUEST_TIMEOUT_MS);
+            final RequestHeader header = new RequestHeader(request.apiKey(), request.version(), "smoke-test-raw", 1);
+            final ByteBuffer requestBuffer = RequestUtils.serialize(
+                    header.data(), header.headerVersion(), request.data(), request.version());
+            final byte[] payload = new byte[requestBuffer.remaining()];
+            requestBuffer.get(payload);
+            final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+            out.writeInt(payload.length);
+            out.write(payload);
+            out.flush();
+
+            final DataInputStream in = new DataInputStream(socket.getInputStream());
+            final byte[] frame = new byte[in.readInt()];
+            in.readFully(frame);
+            return AbstractResponse.parseResponse(ByteBuffer.wrap(frame), header);
+        }
+    }
+
+    private static void closeQuietly(final KafkaProducer<?, ?> producer) {
+        try {
+            producer.close(Duration.ofSeconds(5));
+        } catch (final RuntimeException ignored) {
+            // best-effort cleanup; the test's assertion already ran
+        }
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProxyFaultBasicIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ProxyFaultBasicIntegrationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.integration.utils.KafkaProtocolFaultProxy;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A basic smoke test that wires a real {@code source -> count -> sink} Kafka Streams app through the
+ * {@link KafkaProtocolFaultProxy} (no {@code FaultInjectingClientSupplier}). It processes 10 records
+ * cleanly through the proxy, then arms a fatal broker error on the commit boundary ({@code EndTxn}) so
+ * the next commit fails and the stream thread throws — captured via the uncaught-exception handler.
+ */
+@Tag("integration")
+@Timeout(120)
+public class ProxyFaultBasicIntegrationTest {
+
+    private static final int NUM_KEYS = 10;
+
+    private EmbeddedKafkaCluster cluster;
+    private KafkaProtocolFaultProxy proxy;
+    private KafkaStreams streams;
+    private String inputTopic;
+    private String outputTopic;
+    private String appId;
+    private final AtomicReference<Throwable> uncaught = new AtomicReference<>();
+
+    @BeforeEach
+    public void setUp(final TestInfo info) throws Exception {
+        cluster = new EmbeddedKafkaCluster(1);
+        cluster.start();
+        final String base = safeUniqueTestName(info);
+        appId = "proxy-fault-basic-" + base;
+        inputTopic = appId + "-in";
+        outputTopic = appId + "-out";
+        cluster.createTopic(inputTopic, 1, 1);
+        cluster.createTopic(outputTopic, 1, 1);
+        proxy = KafkaProtocolFaultProxy.inFrontOf(cluster.bootstrapServers());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (streams != null) {
+            streams.close();
+            streams.cleanUp();
+        }
+        if (proxy != null) {
+            proxy.close();
+        }
+        if (cluster != null) {
+            cluster.stop();
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenCommitFaultInjectedAfterTenRecords() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+            .count(Materialized.as("counts"))
+            .toStream()
+            .to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
+
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        // Route the whole app through the proxy.
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        props.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0); // emit every update -> 10 in, 10 out
+        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        streams = new KafkaStreams(builder.build(), props);
+        streams.setUncaughtExceptionHandler(t -> {
+            uncaught.compareAndSet(null, t);
+            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+        });
+        startApplicationAndWaitUntilRunning(streams);
+
+        // Phase 1: 10 distinct keys -> 10 output records, processed and committed cleanly through the proxy.
+        produce(NUM_KEYS);
+        waitUntilMinKeyValueRecordsReceived(consumerConfig(), outputTopic, NUM_KEYS, 60_000);
+
+        // Phase 2: arm a fatal commit-boundary fault. The next EndTxn the app issues gets a fatal error,
+        // so commitTransaction fails fatally and the stream thread throws.
+        proxy.injectError(ApiKeys.END_TXN, Errors.INVALID_TXN_STATE).everyTime();
+
+        // Nudge another processing+commit cycle.
+        produce(NUM_KEYS);
+
+        TestUtils.waitForCondition(
+            () -> uncaught.get() != null || streams.state() == KafkaStreams.State.ERROR,
+            60_000L,
+            () -> "expected the stream thread to throw after the injected EndTxn fault; state=" + streams.state());
+
+        assertNotNull(uncaught.get(), "an exception should have propagated to the uncaught-exception handler");
+        assertTrue(streams.state() == KafkaStreams.State.ERROR
+                || streams.state() == KafkaStreams.State.PENDING_ERROR
+                || streams.state() == KafkaStreams.State.NOT_RUNNING,
+            "app should have shut down after the fatal fault; state=" + streams.state());
+    }
+
+    private void produce(final int numKeys) {
+        final Properties p = new Properties();
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers()); // producer talks to broker directly
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        final List<KeyValue<String, String>> records = new ArrayList<>();
+        for (int i = 0; i < numKeys; i++) {
+            records.add(new KeyValue<>("k" + i, "v" + i));
+        }
+        IntegrationTestUtils.produceKeyValuesSynchronously(inputTopic, records, p, Time.SYSTEM);
+    }
+
+    private Properties consumerConfig() {
+        final Properties c = new Properties();
+        c.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        c.put(ConsumerConfig.GROUP_ID_CONFIG, "verify-" + appId);
+        c.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        c.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+        c.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        c.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        return c;
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/ClientFault.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/ClientFault.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration.utils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
+
+/**
+ * A single client-side exception fault applied to one {@link FaultInjectingClientSupplier.ProducerCall}.
+ * Built through the fluent DSL on {@link FaultInjectingClientSupplier}
+ * ({@code failOn(call, exceptionSupplier)} then a trigger) and returned to the caller as a handle so a test
+ * can inspect {@link #timesTriggered()} or {@link #remove()} it.
+ *
+ * <p>Unlike {@link FaultRule} (which rewrites a broker <em>response</em> on the wire), a {@code ClientFault}
+ * makes the wrapped producer throw a Java exception <em>before</em> the call reaches the network — modelling
+ * client-library failures (fenced producers, timeouts, invalid-txn-state) that never appear as a broker
+ * error code. This is the leaner, Streams-specific complement to {@link KafkaProtocolFaultProxy}.
+ */
+public final class ClientFault {
+
+    private final FaultInjectingClientSupplier owner;
+    private final FaultInjectingClientSupplier.ProducerCall call;
+    private final Supplier<? extends RuntimeException> exception;
+    private final IntPredicate trigger;
+    private final String description;
+
+    private final AtomicInteger matches = new AtomicInteger(0);
+    private final AtomicInteger triggered = new AtomicInteger(0);
+
+    ClientFault(final FaultInjectingClientSupplier owner,
+                final FaultInjectingClientSupplier.ProducerCall call,
+                final Supplier<? extends RuntimeException> exception,
+                final IntPredicate trigger,
+                final String description) {
+        this.owner = owner;
+        this.call = call;
+        this.exception = exception;
+        this.trigger = trigger;
+        this.description = description;
+    }
+
+    FaultInjectingClientSupplier.ProducerCall call() {
+        return call;
+    }
+
+    /**
+     * Called by the wrapped producer before it invokes {@code call}. If the trigger fires, returns the
+     * exception to throw; otherwise returns {@code null} and the real call proceeds.
+     */
+    RuntimeException maybeFail() {
+        final int n = matches.incrementAndGet();
+        if (trigger.test(n)) {
+            triggered.incrementAndGet();
+            return exception.get();
+        }
+        return null;
+    }
+
+    /** How many times this fault actually fired — for test assertions. */
+    public int timesTriggered() {
+        return triggered.get();
+    }
+
+    /** How many invocations of this call the fault has observed (whether or not it fired). */
+    public int timesMatched() {
+        return matches.get();
+    }
+
+    /** Deregister this fault from the supplier. */
+    public void remove() {
+        owner.removeFault(this);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientFault(" + description + ", triggered=" + triggered.get() + "/" + matches.get() + ")";
+    }
+
+    // ------------------------------------------------------------------
+    // Fluent trigger step: returned by failOn(...). Each terminal registers
+    // the built fault with the supplier and returns the handle.
+    // ------------------------------------------------------------------
+    public static final class Builder {
+        private final FaultInjectingClientSupplier owner;
+        private final FaultInjectingClientSupplier.ProducerCall call;
+        private final Supplier<? extends RuntimeException> exception;
+
+        Builder(final FaultInjectingClientSupplier owner,
+                final FaultInjectingClientSupplier.ProducerCall call,
+                final Supplier<? extends RuntimeException> exception) {
+            this.owner = owner;
+            this.call = call;
+            this.exception = exception;
+        }
+
+        private ClientFault register(final IntPredicate trigger, final String triggerDesc) {
+            final ClientFault fault = new ClientFault(owner, call, exception, trigger,
+                    "throw on " + call + " [" + triggerDesc + "]");
+            owner.addFault(fault);
+            return fault;
+        }
+
+        /** Throw on the first invocation only. */
+        public ClientFault once() {
+            return register(Occurrence.once(), "once");
+        }
+
+        /** Throw on exactly the {@code n}-th invocation (1-based). */
+        public ClientFault onCall(final int n) {
+            return register(Occurrence.call(n), "call #" + n);
+        }
+
+        /** Throw on the first {@code n} invocations. */
+        public ClientFault times(final int n) {
+            return register(Occurrence.first(n), "first " + n);
+        }
+
+        /** Throw on every invocation until removed. */
+        public ClientFault everyTime() {
+            return register(Occurrence.always(), "every time");
+        }
+
+        /** Throw on each invocation with the given probability (chaos mode; non-deterministic). */
+        public ClientFault withProbability(final double p) {
+            return register(Occurrence.withProbability(p), "p=" + p);
+        }
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultInjectingClientSupplier.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultInjectingClientSupplier.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration.utils;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.PreparedTxnState;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.streams.KafkaClientSupplier;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+/**
+ * A {@link KafkaClientSupplier} decorator that injects <em>client-side exceptions</em> into the transactional
+ * producer that Kafka Streams uses, without any broker round-trip. It is the leaner, Streams-specific
+ * complement to {@link KafkaProtocolFaultProxy}: the proxy rewrites broker responses on the wire (useful for
+ * any client and any language), while this makes the producer throw a Java exception directly — modelling
+ * client-library failures such as a fenced producer or a {@code commitTransaction} timeout that never surface
+ * as a broker error code.
+ *
+ * <p>Consumers and admin clients are passed through untouched; only the producer is decorated, because the
+ * KIP-892 commit path (send-offsets → commit/abort) lives entirely on the producer.
+ *
+ * <p>Usage mirrors the proxy DSL:
+ * <pre>{@code
+ * FaultInjectingClientSupplier supplier = FaultInjectingClientSupplier.wrapping(new DefaultKafkaClientSupplier());
+ * ClientFault fault = supplier.failOn(ProducerCall.COMMIT_TRANSACTION,
+ *                                     () -> new TimeoutException("injected")).onCall(2);
+ * props.put(StreamsConfig..., supplier); // pass to KafkaStreams(topology, props, supplier)
+ * // ... run, then:
+ * assertEquals(1, fault.timesTriggered());
+ * }</pre>
+ */
+public final class FaultInjectingClientSupplier implements KafkaClientSupplier {
+
+    /** The transactional producer entry points that can be made to throw. */
+    public enum ProducerCall {
+        INIT_TRANSACTIONS,
+        BEGIN_TRANSACTION,
+        SEND_OFFSETS_TO_TRANSACTION,
+        COMMIT_TRANSACTION,
+        ABORT_TRANSACTION,
+        SEND,
+        FLUSH
+    }
+
+    private final KafkaClientSupplier delegate;
+    private final CopyOnWriteArrayList<ClientFault> faults = new CopyOnWriteArrayList<>();
+
+    private FaultInjectingClientSupplier(final KafkaClientSupplier delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Wrap an existing supplier (e.g. {@code new DefaultKafkaClientSupplier()}). */
+    public static FaultInjectingClientSupplier wrapping(final KafkaClientSupplier delegate) {
+        return new FaultInjectingClientSupplier(delegate);
+    }
+
+    /** Begin defining a fault on {@code call}; the returned builder's terminal registers it and returns a handle. */
+    public ClientFault.Builder failOn(final ProducerCall call, final Supplier<? extends RuntimeException> exception) {
+        return new ClientFault.Builder(this, call, exception);
+    }
+
+    /** Remove all registered faults. */
+    public void clearFaults() {
+        faults.clear();
+    }
+
+    void addFault(final ClientFault fault) {
+        faults.add(fault);
+    }
+
+    void removeFault(final ClientFault fault) {
+        faults.remove(fault);
+    }
+
+    /** Consult the registered faults for {@code call}; returns the exception to throw, or {@code null}. */
+    private RuntimeException maybeFail(final ProducerCall call) {
+        for (final ClientFault fault : faults) {
+            if (fault.call() == call) {
+                final RuntimeException e = fault.maybeFail();
+                if (e != null) {
+                    return e;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+        return new FaultInjectingProducer(delegate.getProducer(config));
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+        return delegate.getConsumer(config);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+        return delegate.getRestoreConsumer(config);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
+        return delegate.getGlobalConsumer(config);
+    }
+
+    @Override
+    public Admin getAdmin(final Map<String, Object> config) {
+        return delegate.getAdmin(config);
+    }
+
+    /**
+     * Delegating producer that checks for a registered fault before each intercepted transactional call and,
+     * if one fires, throws instead of delegating. All other methods pass straight through.
+     */
+    private final class FaultInjectingProducer implements Producer<byte[], byte[]> {
+        private final Producer<byte[], byte[]> delegate;
+
+        FaultInjectingProducer(final Producer<byte[], byte[]> delegate) {
+            this.delegate = delegate;
+        }
+
+        private void checkFault(final ProducerCall call) {
+            final RuntimeException e = maybeFail(call);
+            if (e != null) {
+                throw e;
+            }
+        }
+
+        @Override
+        public void initTransactions() {
+            checkFault(ProducerCall.INIT_TRANSACTIONS);
+            delegate.initTransactions();
+        }
+
+        @Override
+        public void initTransactions(final boolean keepPreparedTxn) {
+            checkFault(ProducerCall.INIT_TRANSACTIONS);
+            delegate.initTransactions(keepPreparedTxn);
+        }
+
+        @Override
+        public void beginTransaction() throws ProducerFencedException {
+            checkFault(ProducerCall.BEGIN_TRANSACTION);
+            delegate.beginTransaction();
+        }
+
+        @Override
+        public void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                             final ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+            checkFault(ProducerCall.SEND_OFFSETS_TO_TRANSACTION);
+            delegate.sendOffsetsToTransaction(offsets, groupMetadata);
+        }
+
+        @Override
+        public void commitTransaction() throws ProducerFencedException {
+            checkFault(ProducerCall.COMMIT_TRANSACTION);
+            delegate.commitTransaction();
+        }
+
+        @Override
+        public void abortTransaction() throws ProducerFencedException {
+            checkFault(ProducerCall.ABORT_TRANSACTION);
+            delegate.abortTransaction();
+        }
+
+        @Override
+        public PreparedTxnState prepareTransaction() throws ProducerFencedException {
+            return delegate.prepareTransaction();
+        }
+
+        @Override
+        public void completeTransaction(final PreparedTxnState preparedTxnState) throws ProducerFencedException {
+            delegate.completeTransaction(preparedTxnState);
+        }
+
+        @Override
+        public Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record) {
+            checkFault(ProducerCall.SEND);
+            return delegate.send(record);
+        }
+
+        @Override
+        public Future<RecordMetadata> send(final ProducerRecord<byte[], byte[]> record, final Callback callback) {
+            checkFault(ProducerCall.SEND);
+            return delegate.send(record, callback);
+        }
+
+        @Override
+        public void flush() {
+            checkFault(ProducerCall.FLUSH);
+            delegate.flush();
+        }
+
+        // ---- pass-through (no fault injection) ----
+
+        @Override
+        public List<PartitionInfo> partitionsFor(final String topic) {
+            return delegate.partitionsFor(topic);
+        }
+
+        @Override
+        public Map<MetricName, ? extends Metric> metrics() {
+            return delegate.metrics();
+        }
+
+        @Override
+        public Uuid clientInstanceId(final Duration timeout) {
+            return delegate.clientInstanceId(timeout);
+        }
+
+        @Override
+        public void registerMetricForSubscription(final KafkaMetric metric) {
+            delegate.registerMetricForSubscription(metric);
+        }
+
+        @Override
+        public void unregisterMetricFromSubscription(final KafkaMetric metric) {
+            delegate.unregisterMetricFromSubscription(metric);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        @Override
+        public void close(final Duration timeout) {
+            delegate.close(timeout);
+        }
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration.utils;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntPredicate;
+
+/**
+ * A single fault to apply to responses of one {@link ApiKeys}. Built through the fluent DSL on
+ * {@link KafkaProtocolFaultProxy} ({@code injectError(...)} / {@code disconnectOn(...)} then a trigger),
+ * and returned to the caller as a handle so a test can inspect {@link #timesTriggered()} or
+ * {@link #remove()} it.
+ *
+ * <p>A rule counts every response of its API it sees ("matches"); the {@link IntPredicate} trigger decides,
+ * from the 1-based match count, whether the fault fires on that match — e.g. {@code n -> n == 1} is
+ * {@code once()}, {@code n -> n <= 3} is {@code times(3)}.
+ */
+public final class FaultRule {
+
+    enum Action { INJECT_ERROR, DISCONNECT }
+
+    private final KafkaProtocolFaultProxy owner;
+    private final ApiKeys apiKey;
+    private final Action action;
+    private final Errors error; // only for INJECT_ERROR
+    private final IntPredicate trigger;
+    private final String description;
+
+    private final AtomicInteger matches = new AtomicInteger(0);
+    private final AtomicInteger triggered = new AtomicInteger(0);
+
+    FaultRule(final KafkaProtocolFaultProxy owner,
+              final ApiKeys apiKey,
+              final Action action,
+              final Errors error,
+              final IntPredicate trigger,
+              final String description) {
+        this.owner = owner;
+        this.apiKey = apiKey;
+        this.action = action;
+        this.error = error;
+        this.trigger = trigger;
+        this.description = description;
+    }
+
+    ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    Action action() {
+        return action;
+    }
+
+    Errors error() {
+        return error;
+    }
+
+    /** Called by the proxy for each response of this rule's API; returns true if the fault should fire. */
+    boolean shouldFire() {
+        final int n = matches.incrementAndGet();
+        if (trigger.test(n)) {
+            triggered.incrementAndGet();
+            return true;
+        }
+        return false;
+    }
+
+    /** How many times this fault actually fired — for test assertions. */
+    public int timesTriggered() {
+        return triggered.get();
+    }
+
+    /** How many responses of this API the rule has observed (whether or not it fired). */
+    public int timesMatched() {
+        return matches.get();
+    }
+
+    /** Deregister this rule from the proxy. */
+    public void remove() {
+        owner.removeFault(this);
+    }
+
+    @Override
+    public String toString() {
+        return "FaultRule(" + description + ", triggered=" + triggered.get() + "/" + matches.get() + ")";
+    }
+
+    // ------------------------------------------------------------------
+    // Fluent trigger step: returned by injectError(...)/disconnectOn(...).
+    // Each terminal registers the built rule with the proxy and returns the handle.
+    // ------------------------------------------------------------------
+    public static final class Builder {
+        private final KafkaProtocolFaultProxy owner;
+        private final ApiKeys apiKey;
+        private final Action action;
+        private final Errors error;
+
+        Builder(final KafkaProtocolFaultProxy owner, final ApiKeys apiKey, final Action action, final Errors error) {
+            this.owner = owner;
+            this.apiKey = apiKey;
+            this.action = action;
+            this.error = error;
+        }
+
+        private FaultRule register(final IntPredicate trigger, final String triggerDesc) {
+            final String verb = action == Action.DISCONNECT ? "disconnect" : "inject " + error;
+            final FaultRule rule = new FaultRule(owner, apiKey, action, error, trigger,
+                    verb + " on " + apiKey + " [" + triggerDesc + "]");
+            owner.addFault(rule);
+            return rule;
+        }
+
+        /** Fire on the first matching response only. */
+        public FaultRule once() {
+            return register(Occurrence.once(), "once");
+        }
+
+        /** Fire on exactly the {@code n}-th matching response (1-based). */
+        public FaultRule onCall(final int n) {
+            return register(Occurrence.call(n), "call #" + n);
+        }
+
+        /** Fire on the first {@code n} matching responses. */
+        public FaultRule times(final int n) {
+            return register(Occurrence.first(n), "first " + n);
+        }
+
+        /** Fire on every matching response until removed. */
+        public FaultRule everyTime() {
+            return register(Occurrence.always(), "every time");
+        }
+
+        /** Fire on each matching response with the given probability (chaos mode; non-deterministic). */
+        public FaultRule withProbability(final double p) {
+            return register(Occurrence.withProbability(p), "p=" + p);
+        }
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
@@ -19,27 +19,29 @@ package org.apache.kafka.streams.integration.utils;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
 /**
- * A single fault to apply to responses of one {@link ApiKeys}. Built through the fluent DSL on
- * {@link KafkaProtocolFaultProxy} ({@code injectError(...)} / {@code disconnectOn(...)} then a trigger),
- * and returned to the caller as a handle so a test can inspect {@link #timesTriggered()} or
- * {@link #remove()} it.
+ * A single fault to apply to responses (or, for {@code BLACKHOLE}, requests) of one {@link ApiKeys}. Built
+ * through the fluent DSL on {@link KafkaProtocolFaultProxy} ({@code injectError(...)} / {@code disconnectOn(...)}
+ * / {@code delayResponse(...)} / {@code blackholeOn(...)} then a trigger), and returned to the caller as a
+ * handle so a test can inspect {@link #timesTriggered()} or {@link #remove()} it.
  *
- * <p>A rule counts every response of its API it sees ("matches"); the {@link IntPredicate} trigger decides,
- * from the 1-based match count, whether the fault fires on that match — e.g. {@code n -> n == 1} is
+ * <p>A rule counts every request/response of its API it sees ("matches"); the {@link IntPredicate} trigger
+ * decides, from the 1-based match count, whether the fault fires on that match — e.g. {@code n -> n == 1} is
  * {@code once()}, {@code n -> n <= 3} is {@code times(3)}.
  */
 public final class FaultRule {
 
-    enum Action { INJECT_ERROR, DISCONNECT }
+    enum Action { INJECT_ERROR, DISCONNECT, DELAY, BLACKHOLE }
 
     private final KafkaProtocolFaultProxy owner;
     private final ApiKeys apiKey;
     private final Action action;
     private final Errors error; // only for INJECT_ERROR
+    private final Duration delay; // only for DELAY
     private final IntPredicate trigger;
     private final String description;
 
@@ -50,12 +52,14 @@ public final class FaultRule {
               final ApiKeys apiKey,
               final Action action,
               final Errors error,
+              final Duration delay,
               final IntPredicate trigger,
               final String description) {
         this.owner = owner;
         this.apiKey = apiKey;
         this.action = action;
         this.error = error;
+        this.delay = delay;
         this.trigger = trigger;
         this.description = description;
     }
@@ -70,6 +74,10 @@ public final class FaultRule {
 
     Errors error() {
         return error;
+    }
+
+    Duration delay() {
+        return delay;
     }
 
     /** Called by the proxy for each response of this rule's API; returns true if the fault should fire. */
@@ -103,7 +111,7 @@ public final class FaultRule {
     }
 
     // ------------------------------------------------------------------
-    // Fluent trigger step: returned by injectError(...)/disconnectOn(...).
+    // Fluent trigger step: returned by injectError(...)/disconnectOn(...)/delayResponse(...)/blackholeOn(...).
     // Each terminal registers the built rule with the proxy and returns the handle.
     // ------------------------------------------------------------------
     public static final class Builder {
@@ -111,17 +119,33 @@ public final class FaultRule {
         private final ApiKeys apiKey;
         private final Action action;
         private final Errors error;
+        private final Duration delay;
 
-        Builder(final KafkaProtocolFaultProxy owner, final ApiKeys apiKey, final Action action, final Errors error) {
+        Builder(final KafkaProtocolFaultProxy owner, final ApiKeys apiKey, final Action action,
+                final Errors error, final Duration delay) {
             this.owner = owner;
             this.apiKey = apiKey;
             this.action = action;
             this.error = error;
+            this.delay = delay;
         }
 
         private FaultRule register(final IntPredicate trigger, final String triggerDesc) {
-            final String verb = action == Action.DISCONNECT ? "disconnect" : "inject " + error;
-            final FaultRule rule = new FaultRule(owner, apiKey, action, error, trigger,
+            final String verb;
+            switch (action) {
+                case DISCONNECT:
+                    verb = "disconnect";
+                    break;
+                case BLACKHOLE:
+                    verb = "blackhole (drop request before it reaches the broker)";
+                    break;
+                case DELAY:
+                    verb = "delay response by " + delay;
+                    break;
+                default:
+                    verb = "inject " + error;
+            }
+            final FaultRule rule = new FaultRule(owner, apiKey, action, error, delay, trigger,
                     verb + " on " + apiKey + " [" + triggerDesc + "]");
             owner.addFault(rule);
             return rule;

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/FaultRule.java
@@ -43,6 +43,7 @@ public final class FaultRule {
     private final Errors error; // only for INJECT_ERROR
     private final Duration delay; // only for DELAY
     private final IntPredicate trigger;
+    private final String clientIdFilter; // null = any client; otherwise the request clientId must contain it
     private final String description;
 
     private final AtomicInteger matches = new AtomicInteger(0);
@@ -54,6 +55,7 @@ public final class FaultRule {
               final Errors error,
               final Duration delay,
               final IntPredicate trigger,
+              final String clientIdFilter,
               final String description) {
         this.owner = owner;
         this.apiKey = apiKey;
@@ -61,6 +63,7 @@ public final class FaultRule {
         this.error = error;
         this.delay = delay;
         this.trigger = trigger;
+        this.clientIdFilter = clientIdFilter;
         this.description = description;
     }
 
@@ -78,6 +81,15 @@ public final class FaultRule {
 
     Duration delay() {
         return delay;
+    }
+
+    /**
+     * Whether this rule applies to a request from {@code clientId}. Lets a rule be scoped to a specific
+     * client — e.g. {@code forClient("restore")} to fault only the restore consumer's fetches, leaving the
+     * main consumer untouched. A null filter matches any client.
+     */
+    boolean matchesClient(final String clientId) {
+        return clientIdFilter == null || (clientId != null && clientId.contains(clientIdFilter));
     }
 
     /** Called by the proxy for each response of this rule's API; returns true if the fault should fire. */
@@ -120,6 +132,7 @@ public final class FaultRule {
         private final Action action;
         private final Errors error;
         private final Duration delay;
+        private String clientIdFilter; // null = any client
 
         Builder(final KafkaProtocolFaultProxy owner, final ApiKeys apiKey, final Action action,
                 final Errors error, final Duration delay) {
@@ -128,6 +141,16 @@ public final class FaultRule {
             this.action = action;
             this.error = error;
             this.delay = delay;
+        }
+
+        /**
+         * Scope this fault to requests whose clientId contains {@code substring} — e.g.
+         * {@code forClient("restore")} to fault only the restore consumer (leaving the main consumer and
+         * producer untouched). Without this, the rule matches any client.
+         */
+        public Builder forClient(final String substring) {
+            this.clientIdFilter = substring;
+            return this;
         }
 
         private FaultRule register(final IntPredicate trigger, final String triggerDesc) {
@@ -145,8 +168,9 @@ public final class FaultRule {
                 default:
                     verb = "inject " + error;
             }
-            final FaultRule rule = new FaultRule(owner, apiKey, action, error, delay, trigger,
-                    verb + " on " + apiKey + " [" + triggerDesc + "]");
+            final String scope = clientIdFilter == null ? "" : " client~" + clientIdFilter;
+            final FaultRule rule = new FaultRule(owner, apiKey, action, error, delay, trigger, clientIdFilter,
+                    verb + " on " + apiKey + scope + " [" + triggerDesc + "]");
             owner.addFault(rule);
             return rule;
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration.utils;
+
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
+import org.apache.kafka.common.requests.EndTxnResponse;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.InitProducerIdResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.RequestUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+/**
+ * A lightweight, client-agnostic Kafka wire-protocol fault-injection proxy for fast integration tests.
+ *
+ * <p>Sit it in front of a real (embedded) broker and point any client's {@code bootstrap.servers} at it;
+ * it decodes requests/responses with Kafka's own protocol classes ({@link RequestHeader},
+ * {@link AbstractResponse}, {@link RequestUtils#serialize}) — so it is correct across every wire version,
+ * including flexible/tagged-field ones, with no hand-rolled byte offsets.
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * try (var broker = new EmbeddedKafkaCluster(1)) {
+ *     broker.start();
+ *     try (var proxy = KafkaProtocolFaultProxy.inFrontOf(broker.bootstrapServers())) {
+ *         // point clients here:
+ *         props.put(BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
+ *
+ *         proxy.injectError(ApiKeys.END_TXN, Errors.CONCURRENT_TRANSACTIONS).once();
+ *         proxy.injectError(ApiKeys.PRODUCE, Errors.NOT_ENOUGH_REPLICAS).onCall(2);
+ *         proxy.disconnectOn(ApiKeys.END_TXN).once();      // the EOS "commit gap"
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Routing is transparent: the proxy rewrites {@code Metadata}/{@code FindCoordinator} responses so every
+ * advertised address points back at itself, so a single-broker embedded cluster needs no special config
+ * (its own ephemeral port is discovered from {@code bootstrapServers()}).
+ *
+ * <p>Determinism: {@code once()}/{@code onCall(n)}/{@code times(n)} are deterministic and safe for
+ * assertions; {@code withProbability(p)} is chaos-mode only. The proxy never closes sockets unless a
+ * {@code disconnectOn(...)} rule fires, so it is not itself a source of flakiness.
+ */
+public final class KafkaProtocolFaultProxy implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaProtocolFaultProxy.class);
+
+    /**
+     * Per-API setter that stamps an injected {@link Errors} onto a decoded response. Only APIs registered
+     * here support {@code injectError(...)}; anything else fails fast at rule registration.
+     */
+    private static final Map<ApiKeys, BiConsumer<AbstractResponse, Errors>> ERROR_SETTERS = new EnumMap<>(ApiKeys.class);
+    static {
+        ERROR_SETTERS.put(ApiKeys.END_TXN, (r, e) -> ((EndTxnResponse) r).data().setErrorCode(e.code()));
+        ERROR_SETTERS.put(ApiKeys.INIT_PRODUCER_ID, (r, e) -> ((InitProducerIdResponse) r).data().setErrorCode(e.code()));
+        ERROR_SETTERS.put(ApiKeys.ADD_OFFSETS_TO_TXN, (r, e) -> ((AddOffsetsToTxnResponse) r).data().setErrorCode(e.code()));
+        ERROR_SETTERS.put(ApiKeys.PRODUCE, (r, e) -> {
+            final ProduceResponseData data = ((org.apache.kafka.common.requests.ProduceResponse) r).data();
+            data.responses().forEach(topic ->
+                topic.partitionResponses().forEach(p -> p.setErrorCode(e.code())));
+        });
+    }
+
+    private final String targetHost;
+    private final int targetPort;
+    private final ExecutorService threadPool = Executors.newCachedThreadPool(r -> {
+        final Thread t = new Thread(r, "kafka-fault-proxy");
+        t.setDaemon(true);
+        return t;
+    });
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final CopyOnWriteArrayList<FaultRule> rules = new CopyOnWriteArrayList<>();
+    private ServerSocket serverSocket;
+    private volatile String proxyHost;
+    private volatile int proxyPort;
+
+    private KafkaProtocolFaultProxy(final String targetBootstrap) {
+        final String hostPort = targetBootstrap.split(",")[0].trim();
+        final int idx = hostPort.lastIndexOf(':');
+        this.targetHost = hostPort.substring(0, idx);
+        this.targetPort = Integer.parseInt(hostPort.substring(idx + 1));
+    }
+
+    /** Create and start a proxy in front of the given broker bootstrap address. */
+    public static KafkaProtocolFaultProxy inFrontOf(final String targetBootstrap) {
+        final KafkaProtocolFaultProxy proxy = new KafkaProtocolFaultProxy(targetBootstrap);
+        try {
+            proxy.start();
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to start fault proxy", e);
+        }
+        return proxy;
+    }
+
+    private void start() throws Exception {
+        serverSocket = new ServerSocket(0);
+        proxyPort = serverSocket.getLocalPort();
+        proxyHost = "localhost";
+        running.set(true);
+        threadPool.submit(this::acceptLoop);
+        LOG.info("Fault proxy listening on {}:{} -> broker {}:{}", proxyHost, proxyPort, targetHost, targetPort);
+    }
+
+    /** The address to hand to a client's {@code bootstrap.servers}. */
+    public String bootstrapServers() {
+        return proxyHost + ":" + proxyPort;
+    }
+
+    // ------------------------------------------------------------------
+    // DSL
+    // ------------------------------------------------------------------
+
+    /** Rewrite responses of {@code apiKey} to carry {@code error}. Follow with a trigger, e.g. {@code .once()}. */
+    public FaultRule.Builder injectError(final ApiKeys apiKey, final Errors error) {
+        if (!ERROR_SETTERS.containsKey(apiKey)) {
+            throw new IllegalArgumentException("Error injection is not supported for " + apiKey
+                    + " yet. Supported: " + ERROR_SETTERS.keySet()
+                    + " (add a setter to ERROR_SETTERS to extend).");
+        }
+        if (apiKey == ApiKeys.METADATA || apiKey == ApiKeys.FIND_COORDINATOR) {
+            throw new IllegalArgumentException(apiKey + " is reserved for routing and cannot carry injected errors.");
+        }
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.INJECT_ERROR, error);
+    }
+
+    /** Drop the connection when a response of {@code apiKey} would be returned (models the EOS commit gap). */
+    public FaultRule.Builder disconnectOn(final ApiKeys apiKey) {
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.DISCONNECT, null);
+    }
+
+    /** Remove all registered faults (routing rewrites are always on and unaffected). */
+    public void clearFaults() {
+        rules.clear();
+    }
+
+    void addFault(final FaultRule rule) {
+        rules.add(rule);
+    }
+
+    void removeFault(final FaultRule rule) {
+        rules.remove(rule);
+    }
+
+    // ------------------------------------------------------------------
+    // Proxy internals
+    // ------------------------------------------------------------------
+
+    private void acceptLoop() {
+        while (running.get()) {
+            try {
+                final Socket client = serverSocket.accept();
+                final Socket broker = new Socket(targetHost, targetPort);
+                final Connection conn = new Connection();
+                threadPool.submit(() -> pumpRequests(client, broker, conn));
+                threadPool.submit(() -> pumpResponses(broker, client, conn));
+            } catch (final Exception e) {
+                if (running.get()) {
+                    LOG.warn("accept loop error", e);
+                }
+            }
+        }
+    }
+
+    /** Per-connection state: correlationId -> request header, so responses can be decoded/matched. */
+    private static final class Connection {
+        private final Map<Integer, RequestHeader> inflight = new ConcurrentHashMap<>();
+    }
+
+    // client -> broker: forward verbatim, recording each request header for response decoding.
+    private void pumpRequests(final Socket client, final Socket broker, final Connection conn) {
+        try (client; broker;
+             DataInputStream in = new DataInputStream(client.getInputStream());
+             DataOutputStream out = new DataOutputStream(broker.getOutputStream())) {
+            byte[] frame;
+            while (running.get() && (frame = readFrame(in)) != null) {
+                try {
+                    final RequestHeader header = RequestHeader.parse(ByteBuffer.wrap(frame));
+                    conn.inflight.put(header.correlationId(), header);
+                } catch (final Exception parseErr) {
+                    LOG.debug("could not parse request header (forwarding anyway)", parseErr);
+                }
+                writeFrame(out, frame);
+            }
+        } catch (final Exception e) {
+            LOG.debug("request pump closed", e);
+        }
+    }
+
+    // broker -> client: rewrite for routing and/or apply a matching fault rule; otherwise forward verbatim.
+    private void pumpResponses(final Socket broker, final Socket client, final Connection conn) {
+        try (broker; client;
+             DataInputStream in = new DataInputStream(broker.getInputStream());
+             DataOutputStream out = new DataOutputStream(client.getOutputStream())) {
+            byte[] frame;
+            while (running.get() && (frame = readFrame(in)) != null) {
+                final int correlationId = ByteBuffer.wrap(frame).getInt(0);
+                final RequestHeader reqHeader = conn.inflight.remove(correlationId);
+
+                if (reqHeader == null) {
+                    writeFrame(out, frame);
+                    continue;
+                }
+
+                final ApiKeys apiKey = reqHeader.apiKey();
+                final boolean routing = apiKey == ApiKeys.METADATA || apiKey == ApiKeys.FIND_COORDINATOR;
+                final FaultRule fired = firstFiringRule(apiKey);
+
+                if (fired != null && fired.action() == FaultRule.Action.DISCONNECT) {
+                    LOG.info("Fault: dropping connection on {} response ({})", apiKey, fired);
+                    break; // closes both sockets via try-with-resources
+                }
+
+                if (!routing && fired == null) {
+                    writeFrame(out, frame);
+                    continue;
+                }
+
+                writeFrame(out, transform(reqHeader, frame, routing, fired));
+            }
+        } catch (final Exception e) {
+            LOG.debug("response pump closed", e);
+        }
+    }
+
+    // Decode -> (routing rewrite and/or error inject) -> re-encode. Falls back to the original bytes on error.
+    private byte[] transform(final RequestHeader reqHeader, final byte[] frame,
+                             final boolean routing, final FaultRule fired) {
+        final ApiKeys apiKey = reqHeader.apiKey();
+        final short version = reqHeader.apiVersion();
+        try {
+            final AbstractResponse response = AbstractResponse.parseResponse(ByteBuffer.wrap(frame), reqHeader);
+
+            if (routing) {
+                applyRouting(response);
+            }
+            if (fired != null && fired.action() == FaultRule.Action.INJECT_ERROR) {
+                ERROR_SETTERS.get(apiKey).accept(response, fired.error());
+                LOG.info("Fault: injected {} into {} response ({})", fired.error(), apiKey, fired);
+            }
+
+            final ResponseHeaderData headerData = new ResponseHeaderData().setCorrelationId(reqHeader.correlationId());
+            final ByteBuffer bb = RequestUtils.serialize(
+                    headerData, apiKey.responseHeaderVersion(version), response.data(), version);
+            final byte[] out = new byte[bb.remaining()];
+            bb.get(out);
+            return out;
+        } catch (final Exception e) {
+            LOG.warn("failed to transform {} v{} response; forwarding verbatim", apiKey, version, e);
+            return frame;
+        }
+    }
+
+    private void applyRouting(final AbstractResponse response) {
+        if (response instanceof MetadataResponse) {
+            ((MetadataResponse) response).data().brokers().forEach(b -> b.setHost(proxyHost).setPort(proxyPort));
+        } else if (response instanceof FindCoordinatorResponse) {
+            final FindCoordinatorResponse fc = (FindCoordinatorResponse) response;
+            fc.data().setHost(proxyHost).setPort(proxyPort);
+            fc.data().coordinators().forEach(c -> c.setHost(proxyHost).setPort(proxyPort));
+        }
+    }
+
+    private FaultRule firstFiringRule(final ApiKeys apiKey) {
+        FaultRule chosen = null;
+        for (final FaultRule rule : rules) {
+            if (rule.apiKey() == apiKey && rule.shouldFire() && chosen == null) {
+                chosen = rule; // keep evaluating so every same-API rule still counts its match
+            }
+        }
+        return chosen;
+    }
+
+    /** Reads one length-prefixed Kafka frame (without the 4-byte length). Returns null on clean EOF/close. */
+    private static byte[] readFrame(final DataInputStream in) {
+        try {
+            final int size = in.readInt();
+            final byte[] frame = new byte[size];
+            in.readFully(frame);
+            return frame;
+        } catch (final EOFException eof) {
+            return null;
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private static void writeFrame(final DataOutputStream out, final byte[] frame) throws Exception {
+        out.writeInt(frame.length);
+        out.write(frame);
+        out.flush();
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        try {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+        } catch (final Exception ignored) {
+            // closing
+        }
+        threadPool.shutdownNow();
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.streams.integration.utils;
 
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.ListOffsetsResponseData;
+import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -23,11 +26,17 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
 import org.apache.kafka.common.requests.EndTxnResponse;
+import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.requests.HeartbeatResponse;
 import org.apache.kafka.common.requests.InitProducerIdResponse;
+import org.apache.kafka.common.requests.JoinGroupResponse;
+import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.RequestUtils;
+import org.apache.kafka.common.requests.SyncGroupResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +47,7 @@ import java.io.EOFException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,7 +75,9 @@ import java.util.function.BiConsumer;
  *
  *         proxy.injectError(ApiKeys.END_TXN, Errors.CONCURRENT_TRANSACTIONS).once();
  *         proxy.injectError(ApiKeys.PRODUCE, Errors.NOT_ENOUGH_REPLICAS).onCall(2);
- *         proxy.disconnectOn(ApiKeys.END_TXN).once();      // the EOS "commit gap"
+ *         proxy.disconnectOn(ApiKeys.END_TXN).once();               // the EOS "commit gap"
+ *         proxy.delayResponse(ApiKeys.FETCH, Duration.ofSeconds(5)).everyTime(); // a slow/degraded broker
+ *         proxy.blackholeOn(ApiKeys.JOIN_GROUP).once();              // a silent network partition
  *     }
  * }
  * }</pre>
@@ -77,6 +89,17 @@ import java.util.function.BiConsumer;
  * <p>Determinism: {@code once()}/{@code onCall(n)}/{@code times(n)} are deterministic and safe for
  * assertions; {@code withProbability(p)} is chaos-mode only. The proxy never closes sockets unless a
  * {@code disconnectOn(...)} rule fires, so it is not itself a source of flakiness.
+ *
+ * <p>Fault actions differ in how "broken" they make the connection look to the client:
+ * <ul>
+ *   <li>{@code injectError(...)} — the broker-visible response arrives, carrying an application error code.</li>
+ *   <li>{@code disconnectOn(...)} — the TCP connection is reset; most clients treat this as an immediate,
+ *       unambiguous "reconnect now" signal.</li>
+ *   <li>{@code delayResponse(...)} — the response arrives, but only after a delay; exercises client-side
+ *       timeout paths ({@code request.timeout.ms}, session/heartbeat timeouts) that the above two can't reach.</li>
+ *   <li>{@code blackholeOn(...)} — the request is dropped before it ever reaches the broker: no response, no
+ *       reset. The client just waits until its own timeout fires, as with a real silent network partition.</li>
+ * </ul>
  */
 public final class KafkaProtocolFaultProxy implements AutoCloseable {
 
@@ -96,6 +119,25 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
             data.responses().forEach(topic ->
                 topic.partitionResponses().forEach(p -> p.setErrorCode(e.code())));
         });
+        // Common consumer-path errors.
+        ERROR_SETTERS.put(ApiKeys.FETCH, (r, e) -> {
+            final FetchResponseData data = ((FetchResponse) r).data();
+            data.responses().forEach(topic ->
+                topic.partitions().forEach(p -> p.setErrorCode(e.code())));
+        });
+        ERROR_SETTERS.put(ApiKeys.OFFSET_COMMIT, (r, e) -> {
+            final OffsetCommitResponseData data = ((OffsetCommitResponse) r).data();
+            data.topics().forEach(topic ->
+                topic.partitions().forEach(p -> p.setErrorCode(e.code())));
+        });
+        ERROR_SETTERS.put(ApiKeys.LIST_OFFSETS, (r, e) -> {
+            final ListOffsetsResponseData data = ((ListOffsetsResponse) r).data();
+            data.topics().forEach(topic ->
+                topic.partitions().forEach(p -> p.setErrorCode(e.code())));
+        });
+        ERROR_SETTERS.put(ApiKeys.JOIN_GROUP, (r, e) -> ((JoinGroupResponse) r).data().setErrorCode(e.code()));
+        ERROR_SETTERS.put(ApiKeys.SYNC_GROUP, (r, e) -> ((SyncGroupResponse) r).data().setErrorCode(e.code()));
+        ERROR_SETTERS.put(ApiKeys.HEARTBEAT, (r, e) -> ((HeartbeatResponse) r).data().setErrorCode(e.code()));
     }
 
     private final String targetHost;
@@ -157,12 +199,33 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
         if (apiKey == ApiKeys.METADATA || apiKey == ApiKeys.FIND_COORDINATOR) {
             throw new IllegalArgumentException(apiKey + " is reserved for routing and cannot carry injected errors.");
         }
-        return new FaultRule.Builder(this, apiKey, FaultRule.Action.INJECT_ERROR, error);
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.INJECT_ERROR, error, null);
     }
 
     /** Drop the connection when a response of {@code apiKey} would be returned (models the EOS commit gap). */
     public FaultRule.Builder disconnectOn(final ApiKeys apiKey) {
-        return new FaultRule.Builder(this, apiKey, FaultRule.Action.DISCONNECT, null);
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.DISCONNECT, null, null);
+    }
+
+    /**
+     * Delay responses of {@code apiKey} by {@code delay} before forwarding them (models a slow broker or a
+     * degraded network path). The delay runs on this connection's response-pump thread, so it also holds up
+     * forwarding of any later responses on the same connection ("head of line" — realistic for a single slow
+     * link, but worth knowing if the test also expects other in-flight requests on the same connection to
+     * complete promptly).
+     */
+    public FaultRule.Builder delayResponse(final ApiKeys apiKey, final Duration delay) {
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.DELAY, null, delay);
+    }
+
+    /**
+     * Silently drop requests of {@code apiKey} before they ever reach the broker: no response, no connection
+     * reset — the client just sits waiting until its own timeout (e.g. {@code request.timeout.ms}) fires.
+     * Models a network black hole (a firewall or partition silently dropping packets), as distinct from
+     * {@link #disconnectOn(ApiKeys)}'s immediate, unambiguous connection reset.
+     */
+    public FaultRule.Builder blackholeOn(final ApiKeys apiKey) {
+        return new FaultRule.Builder(this, apiKey, FaultRule.Action.BLACKHOLE, null, null);
     }
 
     /** Remove all registered faults (routing rewrites are always on and unaffected). */
@@ -204,17 +267,28 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
     }
 
     // client -> broker: forward verbatim, recording each request header for response decoding.
+    // Unless a BLACKHOLE rule fires for the request's API, in which case it is silently dropped here and
+    // never reaches the broker at all (the client just times out waiting for a response).
     private void pumpRequests(final Socket client, final Socket broker, final Connection conn) {
         try (client; broker;
              DataInputStream in = new DataInputStream(client.getInputStream());
              DataOutputStream out = new DataOutputStream(broker.getOutputStream())) {
             byte[] frame;
             while (running.get() && (frame = readFrame(in)) != null) {
+                RequestHeader header = null;
                 try {
-                    final RequestHeader header = RequestHeader.parse(ByteBuffer.wrap(frame));
-                    conn.inflight.put(header.correlationId(), header);
+                    header = RequestHeader.parse(ByteBuffer.wrap(frame));
                 } catch (final Exception parseErr) {
                     LOG.debug("could not parse request header (forwarding anyway)", parseErr);
+                }
+
+                if (header != null) {
+                    final FaultRule fired = firstFiringRequestRule(header.apiKey());
+                    if (fired != null) {
+                        LOG.info("Fault: blackholing {} request, never forwarded to the broker ({})", header.apiKey(), fired);
+                        continue;
+                    }
+                    conn.inflight.put(header.correlationId(), header);
                 }
                 writeFrame(out, frame);
             }
@@ -240,14 +314,24 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
 
                 final ApiKeys apiKey = reqHeader.apiKey();
                 final boolean routing = apiKey == ApiKeys.METADATA || apiKey == ApiKeys.FIND_COORDINATOR;
-                final FaultRule fired = firstFiringRule(apiKey);
+                final FaultRule fired = firstFiringResponseRule(apiKey);
 
                 if (fired != null && fired.action() == FaultRule.Action.DISCONNECT) {
                     LOG.info("Fault: dropping connection on {} response ({})", apiKey, fired);
                     break; // closes both sockets via try-with-resources
                 }
 
-                if (!routing && fired == null) {
+                if (fired != null && fired.action() == FaultRule.Action.DELAY) {
+                    LOG.info("Fault: delaying {} response by {} ({})", apiKey, fired.delay(), fired);
+                    try {
+                        Thread.sleep(fired.delay().toMillis());
+                    } catch (final InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return; // proxy is shutting down
+                    }
+                }
+
+                if (!routing && (fired == null || fired.action() == FaultRule.Action.DELAY)) {
                     writeFrame(out, frame);
                     continue;
                 }
@@ -268,7 +352,7 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
             final AbstractResponse response = AbstractResponse.parseResponse(ByteBuffer.wrap(frame), reqHeader);
 
             if (routing) {
-                applyRouting(response);
+                applyRouting(response, version);
             }
             if (fired != null && fired.action() == FaultRule.Action.INJECT_ERROR) {
                 ERROR_SETTERS.get(apiKey).accept(response, fired.error());
@@ -287,20 +371,42 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
         }
     }
 
-    private void applyRouting(final AbstractResponse response) {
+    // FindCoordinatorResponse's top-level Host/Port fields are only valid for versions 0-3; version 4+ (KIP-699)
+    // batches results into the Coordinators list instead, and the generated code rejects a non-default
+    // top-level Host/Port at those versions. Rewrite whichever half of the schema the negotiated version
+    // actually carries.
+    private static final short FIND_COORDINATOR_BATCHED_VERSION = 4;
+
+    private void applyRouting(final AbstractResponse response, final short version) {
         if (response instanceof MetadataResponse) {
             ((MetadataResponse) response).data().brokers().forEach(b -> b.setHost(proxyHost).setPort(proxyPort));
         } else if (response instanceof FindCoordinatorResponse) {
             final FindCoordinatorResponse fc = (FindCoordinatorResponse) response;
-            fc.data().setHost(proxyHost).setPort(proxyPort);
-            fc.data().coordinators().forEach(c -> c.setHost(proxyHost).setPort(proxyPort));
+            if (version >= FIND_COORDINATOR_BATCHED_VERSION) {
+                fc.data().coordinators().forEach(c -> c.setHost(proxyHost).setPort(proxyPort));
+            } else {
+                fc.data().setHost(proxyHost).setPort(proxyPort);
+            }
         }
     }
 
-    private FaultRule firstFiringRule(final ApiKeys apiKey) {
+    // Evaluated from pumpRequests: only BLACKHOLE rules match here, since that's the one action that must act
+    // before the request ever reaches the broker.
+    private FaultRule firstFiringRequestRule(final ApiKeys apiKey) {
         FaultRule chosen = null;
         for (final FaultRule rule : rules) {
-            if (rule.apiKey() == apiKey && rule.shouldFire() && chosen == null) {
+            if (rule.apiKey() == apiKey && rule.action() == FaultRule.Action.BLACKHOLE && rule.shouldFire() && chosen == null) {
+                chosen = rule; // keep evaluating so every same-API rule still counts its match
+            }
+        }
+        return chosen;
+    }
+
+    // Evaluated from pumpResponses: every other action (a response necessarily exists to act on).
+    private FaultRule firstFiringResponseRule(final ApiKeys apiKey) {
+        FaultRule chosen = null;
+        for (final FaultRule rule : rules) {
+            if (rule.apiKey() == apiKey && rule.action() != FaultRule.Action.BLACKHOLE && rule.shouldFire() && chosen == null) {
                 chosen = rule; // keep evaluating so every same-API rule still counts its match
             }
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/KafkaProtocolFaultProxy.java
@@ -50,6 +50,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
@@ -78,6 +79,8 @@ import java.util.function.BiConsumer;
  *         proxy.disconnectOn(ApiKeys.END_TXN).once();               // the EOS "commit gap"
  *         proxy.delayResponse(ApiKeys.FETCH, Duration.ofSeconds(5)).everyTime(); // a slow/degraded broker
  *         proxy.blackholeOn(ApiKeys.JOIN_GROUP).once();              // a silent network partition
+ *         proxy.injectError(ApiKeys.FETCH, Errors.OFFSET_OUT_OF_RANGE).forClient("restore").withProbability(0.3);
+ *         proxy.blackholeClient("streams-instance-1");               // evict one Streams instance entirely
  *     }
  * }
  * }</pre>
@@ -99,7 +102,15 @@ import java.util.function.BiConsumer;
  *       timeout paths ({@code request.timeout.ms}, session/heartbeat timeouts) that the above two can't reach.</li>
  *   <li>{@code blackholeOn(...)} — the request is dropped before it ever reaches the broker: no response, no
  *       reset. The client just waits until its own timeout fires, as with a real silent network partition.</li>
+ *   <li>{@code blackholeClient(...)} — like {@code blackholeOn(...)} but scoped to one client (by clientId
+ *       substring) instead of one API: drops every request from that client and closes its connection, an
+ *       ungraceful one-node network partition (e.g. to force a standby takeover).</li>
  * </ul>
+ *
+ * <p>Any {@code injectError(...)}/{@code disconnectOn(...)}/{@code delayResponse(...)}/{@code blackholeOn(...)}
+ * rule can be further scoped to one client via {@code .forClient(substring)} before the trigger, so it only
+ * matches requests whose clientId contains that substring (e.g. faulting only a Streams app's restore
+ * consumer, leaving its main consumer untouched).
  */
 public final class KafkaProtocolFaultProxy implements AutoCloseable {
 
@@ -149,6 +160,7 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
     });
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final CopyOnWriteArrayList<FaultRule> rules = new CopyOnWriteArrayList<>();
+    private final Set<String> blackholedClients = ConcurrentHashMap.newKeySet();
     private ServerSocket serverSocket;
     private volatile String proxyHost;
     private volatile int proxyPort;
@@ -228,9 +240,20 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
         return new FaultRule.Builder(this, apiKey, FaultRule.Action.BLACKHOLE, null, null);
     }
 
-    /** Remove all registered faults (routing rewrites are always on and unaffected). */
+    /**
+     * Blackhole every request from clients whose clientId contains {@code clientIdSubstring}: drop the request
+     * before it reaches the broker and close the connection. The broker stops hearing that instance's
+     * heartbeats and evicts it by session timeout — an ungraceful, reversible one-node network partition.
+     * Set a distinct {@code client.id} per Streams instance to target one instance. Undo via {@link #clearFaults()}.
+     */
+    public void blackholeClient(final String clientIdSubstring) {
+        blackholedClients.add(clientIdSubstring);
+    }
+
+    /** Remove all registered faults and client blackholes (routing rewrites are always on and unaffected). */
     public void clearFaults() {
         rules.clear();
+        blackholedClients.clear();
     }
 
     void addFault(final FaultRule rule) {
@@ -266,9 +289,10 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
         private final Map<Integer, RequestHeader> inflight = new ConcurrentHashMap<>();
     }
 
-    // client -> broker: forward verbatim, recording each request header for response decoding.
-    // Unless a BLACKHOLE rule fires for the request's API, in which case it is silently dropped here and
-    // never reaches the broker at all (the client just times out waiting for a response).
+    // client -> broker: forward verbatim, recording each request header for response decoding. If the whole
+    // client is blackholed (blackholeClient), the connection is dropped outright. Otherwise, unless a
+    // BLACKHOLE rule fires for the request's API (+ client, if scoped via forClient), the request is silently
+    // dropped here and never reaches the broker at all (the client just times out waiting for a response).
     private void pumpRequests(final Socket client, final Socket broker, final Connection conn) {
         try (client; broker;
              DataInputStream in = new DataInputStream(client.getInputStream());
@@ -283,7 +307,12 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
                 }
 
                 if (header != null) {
-                    final FaultRule fired = firstFiringRequestRule(header.apiKey());
+                    if (isBlackholed(header.clientId())) {
+                        LOG.info("Fault: blackholing request {} from client {} (dropping, not forwarding)",
+                                header.apiKey(), header.clientId());
+                        break; // closes both sockets via try-with-resources; broker never sees this request
+                    }
+                    final FaultRule fired = firstFiringRequestRule(header.apiKey(), header.clientId());
                     if (fired != null) {
                         LOG.info("Fault: blackholing {} request, never forwarded to the broker ({})", header.apiKey(), fired);
                         continue;
@@ -295,6 +324,18 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
         } catch (final Exception e) {
             LOG.debug("request pump closed", e);
         }
+    }
+
+    private boolean isBlackholed(final String clientId) {
+        if (clientId == null || blackholedClients.isEmpty()) {
+            return false;
+        }
+        for (final String substring : blackholedClients) {
+            if (clientId.contains(substring)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // broker -> client: rewrite for routing and/or apply a matching fault rule; otherwise forward verbatim.
@@ -314,7 +355,7 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
 
                 final ApiKeys apiKey = reqHeader.apiKey();
                 final boolean routing = apiKey == ApiKeys.METADATA || apiKey == ApiKeys.FIND_COORDINATOR;
-                final FaultRule fired = firstFiringResponseRule(apiKey);
+                final FaultRule fired = firstFiringResponseRule(apiKey, reqHeader.clientId());
 
                 if (fired != null && fired.action() == FaultRule.Action.DISCONNECT) {
                     LOG.info("Fault: dropping connection on {} response ({})", apiKey, fired);
@@ -392,10 +433,11 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
 
     // Evaluated from pumpRequests: only BLACKHOLE rules match here, since that's the one action that must act
     // before the request ever reaches the broker.
-    private FaultRule firstFiringRequestRule(final ApiKeys apiKey) {
+    private FaultRule firstFiringRequestRule(final ApiKeys apiKey, final String clientId) {
         FaultRule chosen = null;
         for (final FaultRule rule : rules) {
-            if (rule.apiKey() == apiKey && rule.action() == FaultRule.Action.BLACKHOLE && rule.shouldFire() && chosen == null) {
+            if (rule.apiKey() == apiKey && rule.action() == FaultRule.Action.BLACKHOLE
+                    && rule.matchesClient(clientId) && rule.shouldFire() && chosen == null) {
                 chosen = rule; // keep evaluating so every same-API rule still counts its match
             }
         }
@@ -403,10 +445,11 @@ public final class KafkaProtocolFaultProxy implements AutoCloseable {
     }
 
     // Evaluated from pumpResponses: every other action (a response necessarily exists to act on).
-    private FaultRule firstFiringResponseRule(final ApiKeys apiKey) {
+    private FaultRule firstFiringResponseRule(final ApiKeys apiKey, final String clientId) {
         FaultRule chosen = null;
         for (final FaultRule rule : rules) {
-            if (rule.apiKey() == apiKey && rule.action() != FaultRule.Action.BLACKHOLE && rule.shouldFire() && chosen == null) {
+            if (rule.apiKey() == apiKey && rule.action() != FaultRule.Action.BLACKHOLE
+                    && rule.matchesClient(clientId) && rule.shouldFire() && chosen == null) {
                 chosen = rule; // keep evaluating so every same-API rule still counts its match
             }
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/Occurrence.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/Occurrence.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration.utils;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.IntPredicate;
+
+/**
+ * Shared trigger predicates for the fault-injection DSLs. A trigger decides, from the 1-based count of
+ * matching events seen so far, whether the fault should fire on this one. Used by both
+ * {@link FaultRule.Builder} (wire-protocol faults) and {@link ClientFault.Builder} (client-exception faults)
+ * so the two DSLs read identically ({@code once()}, {@code onCall(n)}, {@code times(n)}, {@code everyTime()},
+ * {@code withProbability(p)}).
+ */
+final class Occurrence {
+
+    private Occurrence() {
+    }
+
+    /** Fire on the first matching event only. */
+    static IntPredicate once() {
+        return n -> n == 1;
+    }
+
+    /** Fire on exactly the {@code n}-th matching event (1-based). */
+    static IntPredicate call(final int n) {
+        return matchNo -> matchNo == n;
+    }
+
+    /** Fire on the first {@code n} matching events. */
+    static IntPredicate first(final int n) {
+        return matchNo -> matchNo <= n;
+    }
+
+    /** Fire on every matching event. */
+    static IntPredicate always() {
+        return n -> true;
+    }
+
+    /** Fire on each matching event with probability {@code p} (chaos mode; non-deterministic). */
+    static IntPredicate withProbability(final double p) {
+        if (p < 0.0 || p > 1.0) {
+            throw new IllegalArgumentException("probability must be in [0.0, 1.0], got " + p);
+        }
+        return n -> ThreadLocalRandom.current().nextDouble() < p;
+    }
+}


### PR DESCRIPTION
## What
  A lightweight, client-agnostic Kafka **wire-protocol fault-injection
proxy** for Streams
  integration tests. It sits between a client and an embedded broker —
point any
  `bootstrap.servers` at it — and decodes/re-encodes responses with
Kafka's own protocol classes
  (`RequestHeader`, `AbstractResponse`, `RequestUtils#serialize`), so
it's correct across all
  wire/flexible versions with no hand-rolled byte offsets.

  ## Why
This proxy lets a test deterministically inject broker-side faults — and
*drive lifecycle transitions*
(fault → rebalance / migrate / corrupt / revive) — to flush out that
class of bug before release.

  ## API
  ```java
  try (var proxy =
KafkaProtocolFaultProxy.inFrontOf(cluster.bootstrapServers())) {
      props.put(BOOTSTRAP_SERVERS_CONFIG, proxy.bootstrapServers());
      proxy.injectError(ApiKeys.END_TXN,
Errors.INVALID_TXN_STATE).once();
      proxy.disconnectOn(ApiKeys.END_TXN).everyTime();   // models the
EOS commit gap
  }
  ```

  Triggers: `once()` / `onCall(n)` / `times(n)` / `everyTime()` /
`withProbability(p)` — the first
three are deterministic and assertion-safe. Routing is transparent
(rewrites
`Metadata`/`FindCoordinator`); sockets are never dropped unless a
`disconnectOn` rule fires, so
the proxy isn't itself a flakiness source.
