### PR TITLE
KAFKA-20731: Streams: transitToUpdateStandby is called without checking ACTIVE_RESTORING, crashing the state updater thread

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -434,9 +434,7 @@ public class DefaultStateUpdater implements StateUpdater {
             try {
                 exceptionsAndFailedTasks.add(exceptionAndTask);
                 updatingTasks.remove(exceptionAndTask.task().id());
-                if (exceptionAndTask.task().isActive()) {
-                    transitToUpdateStandbysIfOnlyStandbysLeft();
-                }
+                maybeTransitionChangelogReader();
             } finally {
                 exceptionsAndFailedTasksLock.unlock();
             }
@@ -448,7 +446,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 exceptionsAndFailedTasks.add(exceptionAndTask);
                 pausedTasks.remove(exceptionAndTask.task().id());
                 if (exceptionAndTask.task().isActive()) {
-                    transitToUpdateStandbysIfOnlyStandbysLeft();
+                    maybeTransitionChangelogReader();
                 }
             } finally {
                 exceptionsAndFailedTasksLock.unlock();
@@ -466,6 +464,7 @@ public class DefaultStateUpdater implements StateUpdater {
                     task -> exceptionsAndFailedTasks.add(new ExceptionAndTask(runtimeException, task))
                 );
                 pausedTasks.clear();
+                maybeTransitionChangelogReader();
             } finally {
                 exceptionsAndFailedTasksLock.unlock();
             }
@@ -597,9 +596,7 @@ public class DefaultStateUpdater implements StateUpdater {
                     changelogReader.enforceRestoreActive();
                 } else {
                     log.info("Standby task " + taskId + " was added to the state updater");
-                    if (updatingTasks.size() == 1) {
-                        changelogReader.transitToUpdateStandby();
-                    }
+                    maybeTransitionChangelogReader();
                 }
             }
         }
@@ -632,9 +629,7 @@ public class DefaultStateUpdater implements StateUpdater {
             final Task task = updatingTasks.get(taskId);
             prepareUpdatingTaskForRemoval(task, suspendReason);
             updatingTasks.remove(taskId);
-            if (task.isActive()) {
-                transitToUpdateStandbysIfOnlyStandbysLeft();
-            }
+            maybeTransitionChangelogReader();
             log.info((task.isActive() ? "Active" : "Standby")
                 + " task " + task.id() + " was removed from the updating tasks.");
             future.complete(new RemovedTaskResult(task));
@@ -722,9 +717,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 } finally {
                     tasksAndActionsLock.unlock();
                 }
-                if (task.isActive()) {
-                    transitToUpdateStandbysIfOnlyStandbysLeft();
-                }
+                maybeTransitionChangelogReader();
                 log.info((task.isActive() ? "Active" : "Standby")
                     + " task " + task.id() + " was paused from the updating tasks and added to the paused tasks.");
 
@@ -748,9 +741,7 @@ public class DefaultStateUpdater implements StateUpdater {
                 changelogReader.enforceRestoreActive();
             } else {
                 log.info("Standby task " + task.id() + " was resumed to the updating tasks of the state updater");
-                if (updatingTasks.size() == 1) {
-                    changelogReader.transitToUpdateStandby();
-                }
+                maybeTransitionChangelogReader();
             }
         }
 
@@ -767,15 +758,17 @@ public class DefaultStateUpdater implements StateUpdater {
                     changelogReader.unregister(changelogPartitions);
                     addToRestoredTasks(task);
                     log.info("Stateful active task " + task.id() + " completed restoration");
-                    transitToUpdateStandbysIfOnlyStandbysLeft();
+                    maybeTransitionChangelogReader();
                 } catch (final StreamsException streamsException) {
                     handleStreamsExceptionWithTask(streamsException, task.id());
                 }
             }
         }
 
-        private void transitToUpdateStandbysIfOnlyStandbysLeft() {
-            if (onlyStandbyTasksUpdating()) {
+        private void maybeTransitionChangelogReader() {
+            if (updatingTasks.isEmpty() && !changelogReader.isRestoringActive()) {
+                changelogReader.enforceRestoreActive();
+            } else if (onlyStandbyTasksUpdating() && changelogReader.isRestoringActive()) {
                 changelogReader.transitToUpdateStandby();
             }
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.test.TestUtils;
 
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
@@ -121,6 +122,23 @@ class DefaultStateUpdaterTest {
     private final TopologyMetadata topologyMetadata = unnamedTopology().build();
     private final DefaultStateUpdater stateUpdater =
         new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time);
+    private final AtomicBoolean restoringActive = new AtomicBoolean(true);
+
+    @BeforeEach
+    public void setUp() {
+        restoringActive.set(true);
+        when(changelogReader.isRestoringActive()).thenAnswer(invocation -> restoringActive.get());
+        doAnswer(invocation -> {
+            restoringActive.set(true);
+            return null;
+        }).when(changelogReader).enforceRestoreActive();
+        doAnswer(invocation -> {
+            if (!restoringActive.compareAndSet(true, false)) {
+                throw new IllegalStateException("Changelog reader is already updating standbys");
+            }
+            return null;
+        }).when(changelogReader).transitToUpdateStandby();
+    }
 
     @AfterEach
     public void tearDown() {
@@ -800,6 +818,21 @@ class DefaultStateUpdaterTest {
     }
 
     @Test
+    public void shouldRestoreActiveModeAfterLastStandbyTaskFailed() throws Exception {
+        final StandbyTask task = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
+        final TaskCorruptedException taskCorruptedException = new TaskCorruptedException(Set.of(task.id()));
+        final Map<TaskId, Task> updatingTasks = Map.of(task.id(), task);
+        when(changelogReader.allChangelogsCompleted()).thenReturn(false);
+        doThrow(taskCorruptedException).when(changelogReader).restore(updatingTasks);
+
+        stateUpdater.start();
+        stateUpdater.add(task);
+
+        verifyExceptionsAndFailedTasks(new ExceptionAndTask(taskCorruptedException, task));
+        verify(changelogReader).enforceRestoreActive();
+    }
+
+    @Test
     public void shouldUpdateStandbyTaskAfterAllActiveStatefulTasksRemoved() throws Exception {
         final StreamTask activeTask1 = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
         final StreamTask activeTask2 = statefulTask(TASK_0_1, Set.of(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
@@ -1265,12 +1298,12 @@ class DefaultStateUpdaterTest {
         verifyExceptionsAndFailedTasks();
         // shutdown ensures that the test does not end before changelog reader methods verified below are called
         stateUpdater.shutdown(Duration.ofMinutes(1));
-        verify(changelogReader, times(1)).enforceRestoreActive();
+        verify(changelogReader, times(2)).enforceRestoreActive();
         verify(changelogReader, times(1)).transitToUpdateStandby();
     }
 
     @Test
-    public void shouldPauseStandbyTaskAndNotTransitToRestoreActive() throws Exception {
+    public void shouldPauseStandbyTaskAndNotTransitToRestoreActiveIfAnotherStandbyIsUpdating() throws Exception {
         final StandbyTask task1 = standbyTask(TASK_A_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         final StandbyTask task2 = standbyTask(TASK_B_0_0, Set.of(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
 
@@ -1402,9 +1435,11 @@ class DefaultStateUpdaterTest {
     public void shouldResumeStandbyTask() throws Exception {
         final StandbyTask task = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         shouldResumeStatefulTask(task);
+        assertEquals(Optional.empty(), stateUpdater.fatalException());
         // shutdown ensures that the test does not end before changelog reader methods verified below are called
         stateUpdater.shutdown(Duration.ofMinutes(1));
         verify(changelogReader, times(2)).transitToUpdateStandby();
+        verify(changelogReader, times(2)).enforceRestoreActive();
     }
 
     private void shouldResumeStatefulTask(final Task task) throws Exception {
@@ -1490,7 +1525,7 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldAddFailedTasksToQueueWhenRestoreThrowsStreamsExceptionWithoutTask() throws Exception {
-        final StreamTask task1 = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final StandbyTask task1 = standbyTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RUNNING).build();
         final StandbyTask task2 = standbyTask(TASK_0_2, Set.of(TOPIC_PARTITION_B_0)).inState(State.RUNNING).build();
         final String exceptionMessage = "The Streams were crossed!";
         final StreamsException streamsException = new StreamsException(exceptionMessage);
@@ -1510,6 +1545,7 @@ class DefaultStateUpdaterTest {
         verifyPausedTasks();
         verifyUpdatingTasks();
         verifyRestoredActiveTasks();
+        verify(changelogReader).enforceRestoreActive();
         assertTrue(stateUpdater.isRunning());
     }
 


### PR DESCRIPTION
Fixes KAFKA-20731.

`DefaultStateUpdater` could call the non-idempotent `ChangelogReader#transitToUpdateStandby` method while the changelog reader was already in `STANDBY_UPDATING`. This could happen after all updating standby tasks were paused or removed because the empty-task state did not transition the reader back to `ACTIVE_RESTORING`. Adding or resuming a standby task afterward attempted the standby transition again, throwing an `IllegalStateException` and terminating the state updater thread.

This change centralizes changelog reader state transitions in `DefaultStateUpdater` and enforces the following invariants:

- When there are no updating tasks, the reader is in `ACTIVE_RESTORING`.
- When only standby tasks are updating, the reader transitions to `STANDBY_UPDATING` only if it is currently restoring active tasks.
- The existing non-idempotent contract and defensive exception in `StoreChangelogReader#transitToUpdateStandby` remain unchanged.

The transition helper is invoked after task additions, resumptions, pauses, removals, failures, and active restoration completion so that the reader state remains consistent with the updating task set.

The `DefaultStateUpdaterTest` changelog reader mock now models the actual reader state transitions. This allows the standby pause/resume regression test to fail if `transitToUpdateStandby` is invoked twice without an intervening transition back to active restoration.

Testing:

```
gradle streams:test \
  --tests org.apache.kafka.streams.processor.internals.DefaultStateUpdaterTest \
  --no-daemon \
  --console=plain
```

All 87 `DefaultStateUpdaterTest` tests passed. The test execution also completed `checkstyleMain`, `checkstyleTest`, and `spotbugsMain` successfully.

Reviewers: Nikita Shupletsov <nikita@shupletsov.ca>, Matthias J. Sax <matthias@confluent.io>
