### PR TITLE
KAFKA-20728: Post-Quantum Cryptography (PQC) TLS Readiness: Add setNamedGroups() and ssl.named.groups configuration (ref: CAMEL-23154)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -48,6 +48,11 @@ public class SslConfigs {
     public static final String SSL_CIPHER_SUITES_DOC = "A list of cipher suites. This is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. "
             + "By default all the available cipher suites are supported.";
 
+    public static final String SSL_NAMED_GROUPS_CONFIG = "ssl.named.groups";
+    public static final String SSL_NAMED_GROUPS_DOC = "An ordered list of key exchange named groups to use for SSL connections, with the most preferred group first. "
+        + "The supported values depend on the SSL provider and Java runtime. By default, the SSL provider's default named groups are used. "
+        + "If this configuration is set to an empty list, no named groups are used.";
+
     public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
     public static final String SSL_ENABLED_PROTOCOLS_DOC = "The list of protocols enabled for SSL connections. "
         + "The default is 'TLSv1.2,TLSv1.3'. This means that clients and servers will prefer TLSv1.3 if both support it "
@@ -129,6 +134,7 @@ public class SslConfigs {
         config.define(SslConfigs.SSL_PROTOCOL_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_PROTOCOL, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROTOCOL_DOC)
                 .define(SslConfigs.SSL_PROVIDER_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROVIDER_DOC)
                 .define(SslConfigs.SSL_CIPHER_SUITES_CONFIG, ConfigDef.Type.LIST, List.of(), ConfigDef.ValidList.anyNonDuplicateValues(true, false), ConfigDef.Importance.LOW, SslConfigs.SSL_CIPHER_SUITES_DOC)
+                .define(SslConfigs.SSL_NAMED_GROUPS_CONFIG, ConfigDef.Type.LIST, null, ConfigDef.ValidList.anyNonDuplicateValues(true, true), ConfigDef.Importance.LOW, SslConfigs.SSL_NAMED_GROUPS_DOC)
                 .define(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, ConfigDef.Type.LIST, SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS, ConfigDef.ValidList.anyNonDuplicateValues(true, false), ConfigDef.Importance.MEDIUM, SslConfigs.SSL_ENABLED_PROTOCOLS_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_KEYSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_LOCATION_DOC)
@@ -164,6 +170,7 @@ public class SslConfigs {
             SslConfigs.SSL_PROTOCOL_CONFIG,
             SslConfigs.SSL_PROVIDER_CONFIG,
             SslConfigs.SSL_CIPHER_SUITES_CONFIG,
+            SslConfigs.SSL_NAMED_GROUPS_CONFIG,
             SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
             SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG,
             SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/internals/BrokerSecurityConfigs.java
@@ -155,6 +155,7 @@ public class BrokerSecurityConfigs {
             .define(SslConfigs.SSL_PROTOCOL_CONFIG, STRING, SslConfigs.DEFAULT_SSL_PROTOCOL, MEDIUM, SslConfigs.SSL_PROTOCOL_DOC)
             .define(SslConfigs.SSL_PROVIDER_CONFIG, STRING, null, MEDIUM, SslConfigs.SSL_PROVIDER_DOC)
             .define(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, LIST, SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS, ConfigDef.ValidList.anyNonDuplicateValues(true, false), MEDIUM, SslConfigs.SSL_ENABLED_PROTOCOLS_DOC)
+            .define(SslConfigs.SSL_NAMED_GROUPS_CONFIG, LIST, null, ConfigDef.ValidList.anyNonDuplicateValues(true, true), LOW, SslConfigs.SSL_NAMED_GROUPS_DOC)
             .define(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, STRING, SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE, MEDIUM, SslConfigs.SSL_KEYSTORE_TYPE_DOC)
             .define(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, STRING, null, MEDIUM, SslConfigs.SSL_KEYSTORE_LOCATION_DOC)
             .define(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, PASSWORD, null, MEDIUM, SslConfigs.SSL_KEYSTORE_PASSWORD_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -33,6 +33,8 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
@@ -76,6 +78,7 @@ import javax.net.ssl.TrustManagerFactory;
 public class DefaultSslEngineFactory implements SslEngineFactory {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSslEngineFactory.class);
+    private static final Method SET_NAMED_GROUPS_METHOD = findSetNamedGroupsMethod();
     public static final String PEM_TYPE = "PEM";
 
     private Map<String, ?> configs;
@@ -86,6 +89,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
     private SecurityStore keystore;
     private SecurityStore truststore;
     private String[] cipherSuites;
+    private String[] namedGroups;
     private String[] enabledProtocols;
     private SecureRandom secureRandomImplementation;
     private SSLContext sslContext;
@@ -150,6 +154,9 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
             this.enabledProtocols = null;
         }
 
+        List<String> namedGroupsList = (List<String>) configs.get(SslConfigs.SSL_NAMED_GROUPS_CONFIG);
+        this.namedGroups = namedGroupsList == null ? null : namedGroupsList.toArray(new String[0]);
+
         this.secureRandomImplementation = createSecureRandom((String)
                 configs.get(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG));
 
@@ -189,8 +196,16 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
         if (cipherSuites != null) sslEngine.setEnabledCipherSuites(cipherSuites);
         if (enabledProtocols != null) sslEngine.setEnabledProtocols(enabledProtocols);
 
+        SSLParameters sslParams = sslEngine.getSSLParameters();
+        if (namedGroups != null) {
+            setNamedGroups(sslParams, namedGroups);
+        }
+
         if (connectionMode == ConnectionMode.SERVER) {
             sslEngine.setUseClientMode(false);
+            if (namedGroups != null) {
+                sslEngine.setSSLParameters(sslParams);
+            }
             switch (sslClientAuth) {
                 case REQUIRED:
                     sslEngine.setNeedClientAuth(true);
@@ -203,13 +218,37 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
             }
         } else {
             sslEngine.setUseClientMode(true);
-            SSLParameters sslParams = sslEngine.getSSLParameters();
             // SSLParameters#setEndpointIdentificationAlgorithm enables endpoint validation
             // only in client mode. Hence, validation is enabled only for clients.
             sslParams.setEndpointIdentificationAlgorithm(endpointIdentification);
             sslEngine.setSSLParameters(sslParams);
         }
         return sslEngine;
+    }
+
+    private static void setNamedGroups(SSLParameters sslParameters, String[] namedGroups) {
+        if (SET_NAMED_GROUPS_METHOD == null) {
+            throw new InvalidConfigurationException(
+                    "The configuration " + SslConfigs.SSL_NAMED_GROUPS_CONFIG + " requires Java 20 or later");
+        }
+
+        try {
+            SET_NAMED_GROUPS_METHOD.invoke(sslParameters, (Object) namedGroups);
+        } catch (IllegalAccessException e) {
+            throw new InvalidConfigurationException(
+                    "Unable to configure " + SslConfigs.SSL_NAMED_GROUPS_CONFIG, e);
+        } catch (InvocationTargetException e) {
+            throw new InvalidConfigurationException(
+                    "Invalid value for " + SslConfigs.SSL_NAMED_GROUPS_CONFIG, e.getCause());
+        }
+    }
+
+    private static Method findSetNamedGroupsMethod() {
+        try {
+            return SSLParameters.class.getMethod("setNamedGroups", String[].class);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
     }
     private static SslClientAuth createSslClientAuth(String key) {
         SslClientAuth auth = SslClientAuth.forConfig(key);

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -17,12 +17,14 @@
 package org.apache.kafka.common.security.ssl;
 
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,9 +32,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SSLEngine;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class DefaultSslEngineFactoryTest {
 
@@ -208,6 +215,43 @@ public class DefaultSslEngineFactoryTest {
 
     protected DefaultSslEngineFactory sslEngineFactory() {
         return new DefaultSslEngineFactory();
+    }
+
+    @Test
+    public void testNamedGroupsAreAppliedToClientAndServerSslEngines() throws Exception {
+        assumeTrue(Runtime.version().feature() >= 20);
+        String[] namedGroups = {"secp256r1", "secp384r1"};
+        configs.put(SslConfigs.SSL_NAMED_GROUPS_CONFIG, Arrays.asList(namedGroups));
+        configs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        factory.configure(configs);
+
+        assertArrayEquals(namedGroups, namedGroups(factory.createClientSslEngine("localhost", 0, "HTTPS")));
+        SSLEngine serverSslEngine = factory.createServerSslEngine("localhost", 0);
+        assertArrayEquals(namedGroups, namedGroups(serverSslEngine));
+        assertTrue(serverSslEngine.getNeedClientAuth());
+    }
+
+    @Test
+    public void testUnsetNamedGroupsUseSslProviderDefaults() throws Exception {
+        assumeTrue(Runtime.version().feature() >= 20);
+        factory.configure(configs);
+
+        String[] providerDefaults = namedGroups(factory.sslContext().createSSLEngine("localhost", 0));
+        assertArrayEquals(providerDefaults, namedGroups(factory.createClientSslEngine("localhost", 0, "HTTPS")));
+    }
+
+    @Test
+    public void testEmptyNamedGroupsDisableNamedGroups() throws Exception {
+        assumeTrue(Runtime.version().feature() >= 20);
+        configs.put(SslConfigs.SSL_NAMED_GROUPS_CONFIG, List.of());
+        factory.configure(configs);
+
+        assertArrayEquals(new String[0], namedGroups(factory.createClientSslEngine("localhost", 0, "HTTPS")));
+    }
+
+    private String[] namedGroups(SSLEngine sslEngine) throws Exception {
+        Method getNamedGroups = sslEngine.getSSLParameters().getClass().getMethod("getNamedGroups");
+        return (String[]) getNamedGroups.invoke(sslEngine.getSSLParameters());
     }
 
     @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -930,6 +930,7 @@ class KafkaConfigTest {
         case SslConfigs.SSL_PROTOCOL_CONFIG => // ignore string
         case SslConfigs.SSL_PROVIDER_CONFIG => // ignore string
         case SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG =>
+        case SslConfigs.SSL_NAMED_GROUPS_CONFIG => // ignore list
         case SslConfigs.SSL_KEYSTORE_TYPE_CONFIG => // ignore string
         case SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG => // ignore string
         case SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG => // ignore string

--- a/docs/security/encryption-and-authentication-using-ssl.md
+++ b/docs/security/encryption-and-authentication-using-ssl.md
@@ -270,10 +270,11 @@ ssl.truststore.password=test1234
 Note: ssl.truststore.password is technically optional but highly recommended. If a password is not set access to the truststore is still available, but integrity checking is disabled. Optional settings that are worth considering: 
 1. ssl.client.auth=none ("required" => client authentication is required, "requested" => client authentication is requested and client without certs can still connect. The usage of "requested" is discouraged as it provides a false sense of security and misconfigured clients will still connect successfully.)
 2. ssl.cipher.suites (Optional). A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. (Default is an empty list)
-3. ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1 (list out the SSL protocols that you are going to accept from clients. Do note that SSL is deprecated in favor of TLS and using SSL in production is not recommended)
-4. ssl.keystore.type=JKS
-5. ssl.truststore.type=JKS
-6. ssl.secure.random.implementation=SHA1PRNG
+3. ssl.named.groups (Optional). An ordered list of key exchange named groups, with the most preferred group first. By default, the SSL provider's default named groups are used. An explicitly empty list disables named groups.
+4. ssl.enabled.protocols=TLSv1.2,TLSv1.3 (list out the TLS protocols that you are going to accept from clients)
+5. ssl.keystore.type=JKS
+6. ssl.truststore.type=JKS
+7. ssl.secure.random.implementation=SHA1PRNG
 If you want to enable SSL for inter-broker communication, add the following to the server.properties file (it defaults to PLAINTEXT):
 
 ```java-properties
@@ -330,9 +331,18 @@ ssl.key.password=test1234
 Other configuration settings that may also be needed depending on our requirements and the broker configuration: 
 1. ssl.provider (Optional). The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.
 2. ssl.cipher.suites (Optional). A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol.
-3. ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1. It should list at least one of the protocols configured on the broker side
-4. ssl.truststore.type=JKS
-5. ssl.keystore.type=JKS
+3. ssl.named.groups (Optional). An ordered list of key exchange named groups, with the most preferred group first. By default, the SSL provider's default named groups are used. An explicitly empty list disables named groups.
+4. ssl.enabled.protocols=TLSv1.2,TLSv1.3. It should list at least one of the protocols configured on the broker side
+5. ssl.truststore.type=JKS
+6. ssl.keystore.type=JKS
+
+The available named groups depend on the SSL provider and Java runtime. Configuring `ssl.named.groups` requires Java 20 or later. An explicit list overrides the provider defaults, so deployments should include any required fallback groups. For example, a Java runtime that supports post-quantum hybrid TLS key exchange can be configured with:
+
+```java-properties
+ssl.named.groups=X25519MLKEM768,x25519,secp256r1
+```
+
+On JDK 27, the default JSSE configuration already prefers `X25519MLKEM768`, so this setting is typically not required. Post-quantum hybrid key exchange requires TLS 1.3 and support from the SSL provider; support for the ML-KEM cryptographic algorithm alone does not imply support for ML-KEM TLS named groups.
   
 Examples using console-producer and console-consumer: 
 
@@ -340,6 +350,4 @@ Examples using console-producer and console-consumer:
 $ bin/kafka-console-producer.sh --bootstrap-server localhost:9093 --topic test --command-config client-ssl.properties
 $ bin/kafka-console-consumer.sh --bootstrap-server localhost:9093 --topic test --command-config client-ssl.properties
 ```
-
-
 

--- a/docs/security/security-model.md
+++ b/docs/security/security-model.md
@@ -95,7 +95,7 @@ ACLs are managed with `kafka-acls.sh` or the AdminClient `createAcls`/`deleteAcl
 
 ## Encryption in Transit
 
-TLS is configured per-listener via the standard `ssl.*` properties (`ssl.keystore.*`, `ssl.truststore.*`, `ssl.protocol`, `ssl.cipher.suites`, `ssl.enabled.protocols`). Recommendations:
+TLS is configured per-listener via the standard `ssl.*` properties (`ssl.keystore.*`, `ssl.truststore.*`, `ssl.protocol`, `ssl.cipher.suites`, `ssl.named.groups`, `ssl.enabled.protocols`). Recommendations:
 
 - Disable TLS versions below 1.2; prefer 1.3 where the JDK supports it.
 - Use distinct keystores for the inter-broker listener and any client-facing listener so that a leaked client-facing key cannot impersonate a broker.


### PR DESCRIPTION
## Summary

[KAFKA-20728](https://issues.apache.org/jira/browse/KAFKA-20728) Add an `ssl.named.groups` configuration for Kafka clients and brokers. This allows users to specify an ordered list of TLS key-exchange named groups, including post-quantum hybrid groups such as `X25519MLKEM768` when supported by the configured Java runtime and SSL provider.

The configuration follows the existing `ssl.cipher.suites` and `ssl.enabled.protocols` flows:

- It is available to both clients and brokers.
- Values are ordered by preference.
- Duplicate and blank values are rejected.
- The default is an empty list, which preserves the SSL provider’s defaults.
- The configuration is classified as non-reconfigurable, consistent with cipher suites and enabled protocols.

`SSLParameters.setNamedGroups()` was added in Java 20, while Kafka clients continue to support Java 11. The implementation therefore resolves and invokes the method reflectively. Configuring a non-empty list on a runtime older than Java 20 produces an `InvalidConfigurationException`. When the configuration is empty, Kafka does not call the method and remains compatible with existing supported runtimes.

Named groups are applied to both client and server `SSLEngine` instances. The server-side ordering ensures applying `SSLParameters` does not reset the configured client-authentication mode.

The SSL documentation now describes:

- Runtime and SSL-provider dependencies.
- The Java 20 requirement for explicit configuration.
- The need to retain appropriate fallback groups during migration.
- The TLS 1.3 requirement for post-quantum hybrid key exchange.
- JDK 27’s default preference for `X25519MLKEM768`, meaning explicit configuration is normally unnecessary on that runtime.

Kafka Connect’s REST SSL configuration is not changed because it uses a separate Jetty SSL configuration path.

## Testing

The following targeted tests were run on Java 21:

- `DefaultSslEngineFactoryTest`
  - Verifies configured named groups are applied in order to client and server engines.
  - Verifies an empty configuration preserves the SSL provider defaults.
  - Verifies applying named groups does not reset required server-side client authentication.
  - All 12 tests passed.
- `KafkaConfigTest`
  - Verifies the new broker configuration integrates with the complete broker configuration definition.
  - All tests passed.
- `:clients:spotlessJavaApply`
- Client checkstyle and SpotBugs tasks executed successfully as dependencies of the targeted client test build.
- `git diff --check` passed.

A JDK 27-specific integration test for an actual `X25519MLKEM768` TLS 1.3 handshake is not included because the current Kafka build and CI environment use Java 17/21 for these paths. The unit tests use classical named groups supported by Java 21 to validate Kafka’s configuration and `SSLEngine` behavior independently of JDK 27’s PQC implementation.

Reviewers: Netan Mangal, Michael Edgar <michael@xlate.io>
