### PR TITLE
KAFKA-20811: Add connector plugin version configuration and validation tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -40,9 +40,12 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.distributed.SampleConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
+import org.apache.kafka.connect.runtime.isolation.MultiVersionTest;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.PluginType;
+import org.apache.kafka.connect.runtime.isolation.PluginUtils;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.isolation.VersionedPluginBuilder;
 import org.apache.kafka.connect.runtime.isolation.VersionedPluginLoadingException;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
@@ -65,6 +68,7 @@ import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -76,11 +80,13 @@ import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -1328,6 +1334,250 @@ public class AbstractHerderTest {
                 Set.of()
         );
         assertTrue(AbstractHerder.taskConfigsChanged(snapshotWithDifferentAppliedConfig, CONN1, TASK_CONFIGS));
+    }
+
+    @Test
+    public void testConnectorPluginConfigUsesRequestedVersion() throws Exception {
+        when(worker.getPlugins()).thenReturn(MultiVersionTest.MULTI_VERSION_PLUGINS);
+        AbstractHerder herder = testHerder();
+
+        List<VersionedPluginBuilder.BuildInfo> pluginBuildInfos = MultiVersionTest.MULTI_VERSION_ARTIFACTS.values().stream()
+            .flatMap(Collection::stream)
+            .toList();
+
+        for (VersionedPluginBuilder.BuildInfo pluginBuildInfo : pluginBuildInfos) {
+            String pluginClass = pluginBuildInfo.plugin().className();
+            String pluginVersion = pluginBuildInfo.version();
+
+            List<ConfigKeyInfo> configs = herder.connectorPluginConfig(
+                pluginClass, PluginUtils.connectorVersionRequirement(pluginVersion)
+            );
+
+            // The versioned plugins have a specific config whose default value is set to the version of the plugin.
+            Optional<ConfigKeyInfo> versionSpecificConfig = configs.stream()
+                .filter(config -> config.name().equals(VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG))
+                .findFirst();
+
+            assertTrue(versionSpecificConfig.isPresent());
+            assertEquals(pluginVersion, versionSpecificConfig.get().defaultValue());
+        }
+    }
+
+    @Test
+    public void testConnectorPluginConfigRejectsUnavailableVersion() {
+        when(worker.getPlugins()).thenReturn(MultiVersionTest.MULTI_VERSION_PLUGINS);
+        AbstractHerder herder = testHerder();
+        VersionedPluginBuilder.VersionedTestPlugin plugin = VersionedPluginBuilder.VersionedTestPlugin.SOURCE_CONNECTOR;
+        String unavailableVersion = "99.0.0";
+
+        assertThrows(BadRequestException.class, () -> herder.connectorPluginConfig(
+            plugin.className(), PluginUtils.connectorVersionRequirement(unavailableVersion)
+        ));
+    }
+
+    @Test
+    public void testValidationIncludesAllPluginVersionConfigs() throws Exception {
+        AbstractHerder herder = testHerderWithMultiVersionPlugins();
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className());
+        connectorProps.put(ConnectorConfig.CONNECTOR_VERSION, MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION);
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG, "t");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG, "p");
+
+        ConfigInfos configInfos = herder.validateConnectorConfig(connectorProps, ignored -> null, false);
+        Set<String> versionConfigs = configInfos.configs().stream()
+            .map(ConfigInfo::configKey)
+            .filter(Objects::nonNull)
+            .map(ConfigKeyInfo::name)
+            .filter(name -> name.endsWith(WorkerConfig.PLUGIN_VERSION_SUFFIX))
+            .collect(Collectors.toSet());
+
+        assertEquals(Set.of(
+            ConnectorConfig.CONNECTOR_VERSION,
+            ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG,
+            ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG,
+            ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG,
+            ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX,
+            ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX
+        ), versionConfigs);
+    }
+
+    @Test
+    public void testValidationReportsAvailableVersionsForUnavailableConnectorVersion() {
+        when(worker.getPlugins()).thenReturn(MultiVersionTest.MULTI_VERSION_PLUGINS);
+        AbstractHerder herder = testHerder();
+
+        Map<String, String> connectorProps = Map.of(
+            ConnectorConfig.NAME_CONFIG, "connector-name",
+            ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SOURCE_CONNECTOR.className(),
+            ConnectorConfig.CONNECTOR_VERSION, "99.0.0"
+        );
+
+        ConfigInfos configInfos = herder.validateConnectorConfig(connectorProps, ignored -> null, false);
+
+        assertEquals(2, configInfos.errorCount());
+        assertErrorForKey(configInfos, ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.CONNECTOR_VERSION);
+
+        // Even when the connector cannot be loaded, validation should retain the latest default
+        // and recommend every available version.
+        ConfigInfo versionInfo = findInfo(configInfos, ConnectorConfig.CONNECTOR_VERSION);
+        assertEquals(MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION, versionInfo.configKey().defaultValue());
+
+        List<String> expectedRecommendedVersions = MultiVersionTest.MULTI_VERSION_ARTIFACTS.values().stream()
+            .flatMap(Collection::stream)
+            .filter(build -> build.plugin() == VersionedPluginBuilder.VersionedTestPlugin.SOURCE_CONNECTOR)
+            .map(VersionedPluginBuilder.BuildInfo::version)
+            .sorted(Comparator.comparing(DefaultArtifactVersion::new))
+            .toList();
+        assertEquals(expectedRecommendedVersions, versionInfo.configValue().recommendedValues());
+    }
+
+    @Test
+    public void testValidationReportsErrorsForUnavailableConverterTransformAndPredicateVersions() throws Exception {
+        AbstractHerder herder = testHerderWithMultiVersionPlugins();
+
+        Map<String, String> connectorProps = validMultiVersionConnectorProps();
+
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, "99.0.0");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, "99.0.0");
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, "99.0.0");
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX, "99.0.0");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX, "99.0.0");
+
+        ConfigInfos configInfos = herder.validateConnectorConfig(connectorProps, reportStage -> null, false);
+
+        // Each unavailable version reports errors on both the plugin class or type and its version field.
+        assertEquals(10, configInfos.errorCount());
+        assertErrorForKey(configInfos, ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.TRANSFORMS_CONFIG + ".t.type");
+        assertErrorForKey(configInfos, ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX);
+        assertErrorForKey(configInfos, ConnectorConfig.PREDICATES_CONFIG + ".p.type");
+        assertErrorForKey(configInfos, ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX);
+    }
+
+    @Test
+    public void testInvalidPluginClassesDoNotProduceVersionErrors() throws Exception {
+        AbstractHerder herder = testHerderWithMultiVersionPlugins();
+        // Use an available version so invalid classes and types do not also produce version errors.
+        String availableVersion = MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION;
+        Map<String, String> connectorProps = validMultiVersionConnectorProps();
+
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, "invalid-key-converter");
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, availableVersion);
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, "invalid-value-converter");
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, availableVersion);
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, "invalid-header-converter");
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, availableVersion);
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t.type", "invalid-transformation");
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX, availableVersion);
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p.type", "invalid-predicate");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX, availableVersion);
+
+        ConfigInfos configInfos = herder.validateConnectorConfig(connectorProps, ignored -> null, false);
+
+        assertEquals(5, configInfos.errorCount());
+        assertErrorForKey(configInfos, ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG);
+        assertErrorForKey(configInfos, ConnectorConfig.TRANSFORMS_CONFIG + ".t.type");
+        assertErrorForKey(configInfos, ConnectorConfig.PREDICATES_CONFIG + ".p.type");
+
+        assertNoErrorForKey(configInfos, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG);
+        assertNoErrorForKey(configInfos, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG);
+        assertNoErrorForKey(configInfos, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG);
+        assertNoErrorForKey(configInfos, ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX);
+        assertNoErrorForKey(configInfos, ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX);
+    }
+
+    @Test
+    public void testValidationUsesConfigFromEachRequestedPluginVersion() throws Exception {
+        AbstractHerder herder = testHerderWithMultiVersionPlugins();
+        // Distinct available versions ensure that each plugin version field is used independently.
+        String connectorVersion = "1.1.0";
+        String keyConverterVersion = "0.2.0";
+        String valueConverterVersion = "2.3.0";
+        String headerConverterVersion = "0.3.0";
+        String transformationVersion = "0.4.0";
+        String predicateVersion = "0.5.0";
+        Map<String, String> connectorProps = validMultiVersionConnectorProps();
+        connectorProps.put(ConnectorConfig.CONNECTOR_VERSION, connectorVersion);
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, keyConverterVersion);
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, valueConverterVersion);
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, headerConverterVersion);
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t." + WorkerConfig.PLUGIN_VERSION_SUFFIX, transformationVersion);
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p." + WorkerConfig.PLUGIN_VERSION_SUFFIX, predicateVersion);
+
+        ConfigInfos configInfos = herder.validateConnectorConfig(connectorProps, ignored -> null, false);
+
+        assertEquals(0, configInfos.errorCount());
+        // The versioned plugins have a specific config whose default value is set to the version of the plugin.
+        assertConfigDefault(configInfos,
+            VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            connectorVersion);
+        assertConfigDefault(configInfos,
+            ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG + "." + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            keyConverterVersion);
+        assertConfigDefault(configInfos,
+            ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG + "." + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            valueConverterVersion);
+        assertConfigDefault(configInfos,
+            ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG + "." + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            headerConverterVersion);
+        assertConfigDefault(configInfos,
+            ConnectorConfig.TRANSFORMS_CONFIG + ".t." + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            transformationVersion);
+        assertConfigDefault(configInfos,
+            ConnectorConfig.PREDICATES_CONFIG + ".p." + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            predicateVersion);
+    }
+
+    private AbstractHerder testHerderWithMultiVersionPlugins() throws ClassNotFoundException {
+        Map<String, String> workerProps = Map.of(
+            WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className(),
+            WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className(),
+            WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className()
+        );
+        Class<?> headerConverterClass = MultiVersionTest.MULTI_VERSION_PLUGINS.pluginClass(VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+
+        when(workerConfig.originalsStrings()).thenReturn(workerProps);
+        // Header converter has a worker default, so ConnectorConfig reads it through WorkerConfig#getClass.
+        Mockito.doReturn(headerConverterClass).when(workerConfig).getClass(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG);
+        when(worker.getPlugins()).thenReturn(MultiVersionTest.MULTI_VERSION_PLUGINS);
+        when(worker.config()).thenReturn(workerConfig);
+        return testHerder();
+    }
+
+    private Map<String, String> validMultiVersionConnectorProps() {
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "connector-name");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SOURCE_CONNECTOR.className());
+        connectorProps.put(ConnectorConfig.CONNECTOR_VERSION, MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION);
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG, "t");
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t.type", VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION.className());
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG, "p");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p.type", VersionedPluginBuilder.VersionedTestPlugin.PREDICATE.className());
+        return connectorProps;
+    }
+
+    private void assertNoErrorForKey(ConfigInfos configInfos, String key) {
+        ConfigInfo info = findInfo(configInfos, key);
+        assertNotNull(info);
+        assertTrue(info.configValue().errors().isEmpty());
+    }
+
+    private void assertConfigDefault(ConfigInfos configInfos, String key, String expectedDefault) {
+        ConfigInfo info = findInfo(configInfos, key);
+        assertNotNull(info);
+        assertEquals(expectedDefault, info.configKey().defaultValue());
     }
 
     protected void addConfigKey(Map<String, ConfigDef.ConfigKey> keys, String name, String group) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/CachedConnectorsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/CachedConnectorsTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.isolation.PluginUtils;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.isolation.VersionedPluginLoadingException;
 
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,9 +33,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,6 +47,78 @@ public class CachedConnectorsTest {
 
     @Mock
     private Plugins plugins;
+
+    @Test
+    public void testCachesConnectorsByClassAndVersion() throws InvalidVersionSpecificationException {
+        String sinkConnectorClass = SampleSinkConnector.class.getName();
+        String sourceConnectorClass = SampleSourceConnector.class.getName();
+        VersionRange firstVersion = VersionRange.createFromVersionSpec("1.0.0");
+        VersionRange secondVersion = VersionRange.createFromVersionSpec("2.0.0");
+        // Distinct instances verify that the cache separates entries by connector class and version.
+        Connector latestSinkConnector = new SampleSinkConnector();
+        Connector firstSinkConnector = new SampleSinkConnector();
+        Connector secondSinkConnector = new SampleSinkConnector();
+        Connector firstSourceConnector = new SampleSourceConnector();
+        when(plugins.newConnector(sinkConnectorClass, null)).thenReturn(latestSinkConnector);
+        when(plugins.newConnector(sinkConnectorClass, firstVersion)).thenReturn(firstSinkConnector);
+        when(plugins.newConnector(sinkConnectorClass, secondVersion)).thenReturn(secondSinkConnector);
+        when(plugins.newConnector(sourceConnectorClass, firstVersion)).thenReturn(firstSourceConnector);
+
+        CachedConnectors cachedConnectors = new CachedConnectors(plugins);
+
+        assertSame(latestSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, null));
+        assertSame(firstSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, firstVersion));
+        assertSame(secondSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, secondVersion));
+        assertSame(firstSourceConnector, cachedConnectors.getConnector(sourceConnectorClass, firstVersion));
+
+        assertSame(latestSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, null));
+        assertSame(firstSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, firstVersion));
+        assertSame(secondSinkConnector, cachedConnectors.getConnector(sinkConnectorClass, secondVersion));
+        assertSame(firstSourceConnector, cachedConnectors.getConnector(sourceConnectorClass, firstVersion));
+
+        verify(plugins, times(1)).newConnector(sinkConnectorClass, null);
+        verify(plugins, times(1)).newConnector(sinkConnectorClass, firstVersion);
+        verify(plugins, times(1)).newConnector(sinkConnectorClass, secondVersion);
+        verify(plugins, times(1)).newConnector(sourceConnectorClass, firstVersion);
+    }
+
+    @Test
+    public void testCachesInvalidConnectorAcrossVersions() throws InvalidVersionSpecificationException {
+        String connectorClass = "org.apache.kafka.connect.runtime.InvalidConnector";
+        VersionRange requestedVersion = VersionRange.createFromVersionSpec("1.0.0");
+        when(plugins.newConnector(connectorClass, null)).thenThrow(new ConnectException("unable to load connector"));
+
+        CachedConnectors cachedConnectors = new CachedConnectors(plugins);
+
+        // A loading failure that is not specific to a version is cached for the connector class and applies to all versions.
+        assertThrows(ConnectException.class, () -> cachedConnectors.getConnector(connectorClass, null));
+        assertThrows(ConnectException.class, () -> cachedConnectors.getConnector(connectorClass, requestedVersion));
+
+        verify(plugins, times(1)).newConnector(connectorClass, null);
+        verify(plugins, never()).newConnector(connectorClass, requestedVersion);
+    }
+
+    @Test
+    public void testVersionLoadingFailureDoesNotAffectOtherCachedVersions() throws InvalidVersionSpecificationException {
+        String connectorClass = SampleSinkConnector.class.getName();
+        VersionRange availableVersion = VersionRange.createFromVersionSpec("1.0.0");
+        VersionRange unavailableVersion = VersionRange.createFromVersionSpec("2.0.0");
+        Connector availableConnector = new SampleSinkConnector();
+        when(plugins.newConnector(connectorClass, availableVersion)).thenReturn(availableConnector);
+        when(plugins.newConnector(connectorClass, unavailableVersion)).thenThrow(new VersionedPluginLoadingException("unable to load connector version"));
+
+        CachedConnectors cachedConnectors = new CachedConnectors(plugins);
+
+        // Successful and failed version lookups are cached independently.
+        assertSame(availableConnector, cachedConnectors.getConnector(connectorClass, availableVersion));
+        assertThrows(VersionedPluginLoadingException.class, () -> cachedConnectors.getConnector(connectorClass, unavailableVersion));
+
+        assertSame(availableConnector, cachedConnectors.getConnector(connectorClass, availableVersion));
+        assertThrows(VersionedPluginLoadingException.class, () -> cachedConnectors.getConnector(connectorClass, unavailableVersion));
+
+        verify(plugins, times(1)).newConnector(connectorClass, availableVersion);
+        verify(plugins, times(1)).newConnector(connectorClass, unavailableVersion);
+    }
 
     @Test
     public void testCachedInvalidVersionFailurePreservesAvailableVersions() throws Exception {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -467,6 +467,48 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
     }
 
     @Test
+    public void testEachTransformationAndPredicateAliasUsesRequestedVersion() {
+        String firstTransformationPrefix = ConnectorConfig.TRANSFORMS_CONFIG + ".t1.";
+        String secondTransformationPrefix = ConnectorConfig.TRANSFORMS_CONFIG + ".t2.";
+        String firstPredicatePrefix = ConnectorConfig.PREDICATES_CONFIG + ".p1.";
+        String secondPredicatePrefix = ConnectorConfig.PREDICATES_CONFIG + ".p2.";
+        String firstTransformationVersion = "1.1.0";
+        String secondTransformationVersion = "2.3.0";
+        String firstPredicateVersion = "4.3.0";
+        String secondPredicateVersion = "0.5.0";
+
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "test");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className());
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG, "t1,t2");
+        connectorProps.put(firstTransformationPrefix + "type", VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION.className());
+        connectorProps.put(firstTransformationPrefix + WorkerConfig.PLUGIN_VERSION_SUFFIX, firstTransformationVersion);
+        connectorProps.put(secondTransformationPrefix + "type", VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION.className());
+        connectorProps.put(secondTransformationPrefix + WorkerConfig.PLUGIN_VERSION_SUFFIX, secondTransformationVersion);
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG, "p1,p2");
+        connectorProps.put(firstPredicatePrefix + "type", VersionedPluginBuilder.VersionedTestPlugin.PREDICATE.className());
+        connectorProps.put(firstPredicatePrefix + WorkerConfig.PLUGIN_VERSION_SUFFIX, firstPredicateVersion);
+        connectorProps.put(secondPredicatePrefix + "type", VersionedPluginBuilder.VersionedTestPlugin.PREDICATE.className());
+        connectorProps.put(secondPredicatePrefix + WorkerConfig.PLUGIN_VERSION_SUFFIX, secondPredicateVersion);
+
+        Plugins plugins = MultiVersionTest.MULTI_VERSION_PLUGINS;
+        ConfigDef configDef;
+        try (LoaderSwap ignored = plugins.withClassLoader(plugins.delegatingLoader())) {
+            configDef = ConnectorConfig.enrich(plugins, new ConfigDef(), connectorProps, true);
+        }
+
+        // Different defaults prove that each alias loaded the ConfigDef from its own requested plugin version.
+        assertConfigDefault(configDef, firstTransformationPrefix + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            firstTransformationVersion);
+        assertConfigDefault(configDef, secondTransformationPrefix + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            secondTransformationVersion);
+        assertConfigDefault(configDef, firstPredicatePrefix + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            firstPredicateVersion);
+        assertConfigDefault(configDef, secondPredicatePrefix + VersionedPluginBuilder.VERSION_SPECIFIC_CONFIG,
+            secondPredicateVersion);
+    }
+
+    @Test
     public void testHeaderConverterDefaultsUseWorkerDefault() {
         Map<String, String> connectorProps = Map.of(
             ConnectorConfig.NAME_CONFIG, "test",

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -18,11 +18,17 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.runtime.isolation.LoaderSwap;
+import org.apache.kafka.connect.runtime.isolation.MultiVersionTest;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.isolation.VersionedPluginBuilder;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.SimpleHeaderConverter;
+import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.util.ConnectorTaskId;
@@ -35,11 +41,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -368,6 +376,191 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         props.put("transforms.a.negate", "true");
         ConfigException e = assertThrows(ConfigException.class, () -> new ConnectorConfig(MOCK_PLUGINS, props));
         assertTrue(e.getMessage().contains("there is no config 'transforms.a.predicate' defining a predicate to be negated"));
+    }
+
+    @Test
+    public void testConverterDefaultsUseLatestVersionsWhenWorkerVersionsAreNotConfigured() throws ClassNotFoundException {
+        assertConverterDefaultsFromWorker(null, null, null);
+    }
+
+    @Test
+    public void testConverterDefaultsUseConfiguredWorkerVersions() throws ClassNotFoundException {
+        assertConverterDefaultsFromWorker("1.1.0", "2.3.0", "1.1.0");
+    }
+
+    @Test
+    public void testPluginVersionDefaultsFromCombinedConnectorArtifact() throws ClassNotFoundException {
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "test");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className());
+        // The combined artifact packages a different version of each plugin used here: sink connector 0.1.0,
+        // converter 0.2.0, header converter 0.3.0, transformation 0.4.0, and predicate 0.5.0.
+        // Selecting its connector makes these co-located plugin versions the defaults.
+        connectorProps.put(ConnectorConfig.CONNECTOR_VERSION, MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR));
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG, "t1");
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t1.type", VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION.className());
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG, "p1");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p1.type", VersionedPluginBuilder.VersionedTestPlugin.PREDICATE.className());
+
+        WorkerConfig workerConfig = workerConverterConfig(null, null, null);
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG,
+            MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.CONVERTER));
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG,
+            MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.CONVERTER));
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG,
+            MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER));
+        assertConfigDefault(configDef, ConnectorConfig.TRANSFORMS_CONFIG + ".t1." + WorkerConfig.PLUGIN_VERSION_SUFFIX,
+            MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION));
+        assertConfigDefault(configDef, ConnectorConfig.PREDICATES_CONFIG + ".p1." + WorkerConfig.PLUGIN_VERSION_SUFFIX,
+            MultiVersionTest.DEFAULT_COMBINED_ARTIFACT_VERSIONS.get(VersionedPluginBuilder.VersionedTestPlugin.PREDICATE));
+    }
+
+    @Test
+    public void testConnectorConverterVersionsDefaultToLatestWhenNotInConnectorArtifact() throws ClassNotFoundException {
+        String connectorVersion = "1.1.0";
+        String workerConverterVersion = "2.3.0";
+        String latestVersion = MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION;
+
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "test");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className());
+        connectorProps.put(ConnectorConfig.CONNECTOR_VERSION, connectorVersion);
+        connectorProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        connectorProps.put(ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+
+        // The isolated connector artifact contains no converters, so the connector-level converter
+        // defaults should use the latest installed versions instead of the worker versions.
+        WorkerConfig workerConfig = workerConverterConfig(
+            workerConverterVersion,
+            workerConverterVersion,
+            workerConverterVersion
+        );
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, latestVersion);
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, latestVersion);
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, latestVersion);
+    }
+
+    @Test
+    public void testConnectorTransformationAndPredicateVersionsDefaultToLatest() throws ClassNotFoundException {
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, "test");
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className());
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG, "t1");
+        connectorProps.put(ConnectorConfig.TRANSFORMS_CONFIG + ".t1.type", VersionedPluginBuilder.VersionedTestPlugin.TRANSFORMATION.className());
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG, "p1");
+        connectorProps.put(ConnectorConfig.PREDICATES_CONFIG + ".p1.type", VersionedPluginBuilder.VersionedTestPlugin.PREDICATE.className());
+        WorkerConfig workerConfig = workerConverterConfig(null, null, null);
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+
+        String latestVersion = MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION;
+        assertConfigDefault(configDef, ConnectorConfig.CONNECTOR_VERSION, latestVersion);
+        assertConfigDefault(configDef, ConnectorConfig.TRANSFORMS_CONFIG + ".t1." + WorkerConfig.PLUGIN_VERSION_SUFFIX, latestVersion);
+        assertConfigDefault(configDef, ConnectorConfig.PREDICATES_CONFIG + ".p1." + WorkerConfig.PLUGIN_VERSION_SUFFIX, latestVersion);
+    }
+
+    @Test
+    public void testHeaderConverterDefaultsUseWorkerDefault() {
+        Map<String, String> connectorProps = Map.of(
+            ConnectorConfig.NAME_CONFIG, "test",
+            ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className()
+        );
+        WorkerConfig workerConfig = new WorkerConfig(
+            WorkerConfig.baseConfigDef(),
+            Map.of(
+                WorkerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+                WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName(),
+                WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName()
+            )
+        );
+
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+
+        // Unlike the isolated versioned plugins, the built-in SimpleHeaderConverter reports the Kafka runtime version.
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, SimpleHeaderConverter.class.getName());
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, AppInfoParser.getVersion());
+    }
+
+    @Test
+    public void testKeyAndValueConverterDefaultsAreNullWhenClassesAreMissing() {
+        Map<String, String> connectorProps = Map.of(
+            ConnectorConfig.NAME_CONFIG, "test",
+            ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className()
+        );
+        WorkerConfig workerConfig = mock(WorkerConfig.class);
+        doReturn(SimpleHeaderConverter.class).when(workerConfig).getClass(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG);
+
+        // Neither connector nor worker properties provide key or value converter classes,
+        // so their class and version defaults cannot be determined.
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, null);
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, null);
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, null);
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, null);
+    }
+
+    private void assertConverterDefaultsFromWorker(String keyConverterVersion, String valueConverterVersion, String headerConverterVersion) throws ClassNotFoundException {
+        WorkerConfig workerConfig = workerConverterConfig(keyConverterVersion, valueConverterVersion, headerConverterVersion);
+        Map<String, String> connectorProps = Map.of(
+            ConnectorConfig.NAME_CONFIG, "test",
+            ConnectorConfig.CONNECTOR_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.SINK_CONNECTOR.className()
+        );
+        ConfigDef configDef = enrichedConfigDef(connectorProps, workerConfig);
+        String latestVersion = MultiVersionTest.DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION;
+
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        assertConfigDefault(configDef, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, keyConverterVersion == null ? latestVersion : keyConverterVersion);
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        assertConfigDefault(configDef, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, valueConverterVersion == null ? latestVersion : valueConverterVersion);
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+        assertConfigDefault(configDef, ConnectorConfig.HEADER_CONVERTER_VERSION_CONFIG, headerConverterVersion == null ? latestVersion : headerConverterVersion);
+    }
+
+    private WorkerConfig workerConverterConfig(String keyConverterVersion, String valueConverterVersion, String headerConverterVersion) throws ClassNotFoundException {
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        workerProps.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.CONVERTER.className());
+        workerProps.put(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+        if (keyConverterVersion != null) {
+            workerProps.put(WorkerConfig.KEY_CONVERTER_VERSION, keyConverterVersion);
+        }
+        if (valueConverterVersion != null) {
+            workerProps.put(WorkerConfig.VALUE_CONVERTER_VERSION, valueConverterVersion);
+        }
+        if (headerConverterVersion != null) {
+            workerProps.put(WorkerConfig.HEADER_CONVERTER_VERSION, headerConverterVersion);
+        }
+
+        WorkerConfig workerConfig = mock(WorkerConfig.class);
+        Class<?> headerConverterClass = MultiVersionTest.MULTI_VERSION_PLUGINS.pluginClass(VersionedPluginBuilder.VersionedTestPlugin.HEADER_CONVERTER.className());
+        when(workerConfig.originalsStrings()).thenReturn(workerProps);
+        doReturn(headerConverterClass).when(workerConfig).getClass(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG);
+        return workerConfig;
+    }
+
+    private ConfigDef enrichedConfigDef(Map<String, String> props, WorkerConfig workerConfig) {
+        Plugins plugins = MultiVersionTest.MULTI_VERSION_PLUGINS;
+        try (LoaderSwap ignored = plugins.withClassLoader(plugins.delegatingLoader())) {
+            return ConnectorConfig.enrich(plugins, ConnectorConfig.enrichedConfigDef(plugins, props, workerConfig), props, true);
+        }
+    }
+
+    private void assertConfigDefault(ConfigDef configDef, String key, String expectedDefault) {
+        ConfigDef.ConfigKey configKey = configDef.configKeys().get(key);
+        assertNotNull(configKey);
+        Object actualDefault = configKey.defaultValue;
+        if (configKey.type() == ConfigDef.Type.CLASS && actualDefault != null) {
+            actualDefault = assertInstanceOf(Class.class, actualDefault).getName();
+        }
+        assertEquals(expectedDefault, actualDefault);
     }
 
     public static class TestPredicate<R extends ConnectRecord<R>> implements Predicate<R>  {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/MultiVersionTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/MultiVersionTest.java
@@ -103,6 +103,7 @@ public class MultiVersionTest {
     public static final String DEFAULT_ISOLATED_ARTIFACTS_LATEST_VERSION;
     public static final Map<Path, List<VersionedPluginBuilder.BuildInfo>> DEFAULT_ISOLATED_ARTIFACTS;
     public static final Map<Path, List<VersionedPluginBuilder.BuildInfo>> DEFAULT_COMBINED_ARTIFACT;
+    public static final Map<Path, List<VersionedPluginBuilder.BuildInfo>> MULTI_VERSION_ARTIFACTS;
     public static final Plugins MULTI_VERSION_PLUGINS;
     public static final Map<VersionedPluginBuilder.VersionedTestPlugin, String> DEFAULT_COMBINED_ARTIFACT_VERSIONS;
 
@@ -134,7 +135,8 @@ public class MultiVersionTest {
             Map<Path, List<VersionedPluginBuilder.BuildInfo>> artifacts = new HashMap<>();
             artifacts.putAll(DEFAULT_COMBINED_ARTIFACT);
             artifacts.putAll(DEFAULT_ISOLATED_ARTIFACTS);
-            MULTI_VERSION_PLUGINS = setUpPlugins(artifacts, PluginDiscoveryMode.SERVICE_LOAD);
+            MULTI_VERSION_ARTIFACTS = Map.copyOf(artifacts);
+            MULTI_VERSION_PLUGINS = setUpPlugins(MULTI_VERSION_ARTIFACTS, PluginDiscoveryMode.SERVICE_LOAD);
 
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/VersionedPluginBuilder.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/VersionedPluginBuilder.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 public class VersionedPluginBuilder {
 
+    public static final String VERSION_SPECIFIC_CONFIG = "version-specific-config";
+
     private static final String VERSION_PLACEHOLDER = "PLACEHOLDER_FOR_VERSION";
 
     public enum VersionedTestPlugin {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -34,10 +34,12 @@ import org.apache.kafka.connect.runtime.SampleSinkConnector;
 import org.apache.kafka.connect.runtime.SampleSourceConnector;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoaderTest;
+import org.apache.kafka.connect.runtime.isolation.MultiVersionTest;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.PluginType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.isolation.VersionedPluginBuilder;
 import org.apache.kafka.connect.runtime.rest.RestRequestTimeout;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
@@ -455,6 +457,37 @@ public class ConnectorPluginsResourceTest {
             Optional<ConfigKeyInfo> cki = connectorConfigDef.stream().filter(c -> c.name().equals(config)).findFirst();
             assertTrue(cki.isPresent());
         }
+    }
+
+    @Test
+    public void testListAllVersionsOfMultiVersionPlugins() {
+        when(herder.plugins()).thenReturn(MultiVersionTest.MULTI_VERSION_PLUGINS);
+        RestRequestTimeout requestTimeout = RestRequestTimeout.constant(
+            DEFAULT_REST_REQUEST_TIMEOUT_MS, DEFAULT_HEALTH_CHECK_TIMEOUT_MS
+        );
+        ConnectorPluginsResource multiVersionResource = new ConnectorPluginsResource(herder, requestTimeout);
+
+        // Each BuildInfo describes a plugin class and version that the REST resource is expected to return.
+        List<VersionedPluginBuilder.BuildInfo> artifacts = MultiVersionTest.MULTI_VERSION_ARTIFACTS.values().stream()
+            .flatMap(Collection::stream)
+            .toList();
+
+        Map<String, Set<String>> expectedPluginVersions = new HashMap<>();
+        for (VersionedPluginBuilder.BuildInfo artifact : artifacts) {
+            expectedPluginVersions.computeIfAbsent(artifact.plugin().className(), versions -> new HashSet<>())
+                .add(artifact.version());
+        }
+
+        Map<String, Set<String>> listedPluginVersions = new HashMap<>();
+        // The registry also contains classpath plugins outside this multi-version fixture.
+        // Restrict the comparison to plugin classes declared by the fixture.
+        for (PluginInfo plugin : multiVersionResource.listConnectorPlugins(false)) {
+            if (expectedPluginVersions.containsKey(plugin.className())) {
+                listedPluginVersions.computeIfAbsent(plugin.className(), versions -> new HashSet<>()).add(plugin.version());
+            }
+        }
+
+        assertEquals(expectedPluginVersions, listedPluginVersions);
     }
 
     /* Name here needs to be unique as we are testing the aliasing mechanism */

--- a/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
+++ b/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/runtime/isolation/TestPlugins.java
@@ -522,7 +522,9 @@ public class TestPlugins {
             for (Map.Entry<String, String> entry : replacements.entrySet()) {
                 content = content.replace(entry.getKey(), entry.getValue());
             }
-            File tmpFile = new File(System.getProperty("java.io.tmpdir") + File.separator + source.getName());
+            Path tmpDir = Files.createTempDirectory("test-plugin-source.");
+            tmpDir.toFile().deleteOnExit();
+            File tmpFile = tmpDir.resolve(source.getName()).toFile();
             Files.writeString(tmpFile.toPath(), content);
             tmpFile.deleteOnExit();
             return tmpFile;


### PR DESCRIPTION
This PR follows up on #18326 and adds tests for KIP-891 connector plugin version configuration and validation.