### PR TITLE
MINOR: Remove redundant bcpkix test dependency from tools module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2700,7 +2700,6 @@ project(':tools') {
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
-    testImplementation libs.bcpkix // required by the clients test module, but we have to specify it explicitly as gradle does not include the transitive test dependency automatically
     testImplementation(libs.jfreechart) {
       exclude group: 'junit', module: 'junit'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2501,7 +2501,6 @@ project(':storage') {
     testImplementation libs.jacksonDataformatYaml
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
-    testImplementation libs.bcpkix
     testImplementation testLog4j2Libs
 
     testRuntimeOnly runtimeTestLibs
@@ -2861,7 +2860,6 @@ project(':streams') {
     testImplementation testFixtures(project(':clients'))
     testImplementation libs.jacksonDataformatYaml
     testImplementation libs.junitJupiter
-    testImplementation libs.bcpkix
     testImplementation libs.hamcrest
     testImplementation libs.mockitoCore
     testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
@@ -3064,7 +3062,6 @@ project(':streams:integration-tests') {
     testImplementation project(':test-common:test-common-runtime')
     testImplementation project(':tools')
     testImplementation project(':transaction-coordinator')
-    testImplementation libs.bcpkix
     testImplementation libs.hamcrest
     testImplementation libs.junitJupiter
     testImplementation libs.junitPlatformSuiteEngine // supports suite test
@@ -3983,7 +3980,6 @@ project(':connect:basic-auth-extension') {
     implementation libs.jakartaRsApi
     implementation libs.jakartaAnnotationApi
 
-    testImplementation libs.bcpkix
     testImplementation libs.mockitoCore
     testImplementation libs.junitJupiter
     testImplementation testLog4j2Libs


### PR DESCRIPTION
Since tools depends on `testFixtures(project(':clients'))`, which declares testFixturesImplementation libs.bcpkix, bcpkix is already provided transitively on the test classpath. The explicit testImplementation libs.bcpkix in tools is therefore redundant and can be removed.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>
