### PR TITLE
KAFKA-20804: Cut lock contention in metadata add()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -29,19 +29,20 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ProducerMetadata extends Metadata {
     // If a topic hasn't been accessed for this many milliseconds, it is removed from the cache.
     private final long metadataIdleMs;
 
     /* Topics with expiry time */
-    private final Map<String, Long> topics = new HashMap<>();
+    private final Map<String, Long> topics = new ConcurrentHashMap<>();
     private final Set<String> newTopics = new HashSet<>();
     private final Logger log;
     private final Time time;
@@ -70,31 +71,59 @@ public class ProducerMetadata extends Metadata {
         return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
     }
 
-    public synchronized void add(String topic, long nowMs) {
+    /**
+     * Add a topic to the working set, refreshing its expiry. Already-known topics are updated
+     * lock-free via {@link ConcurrentHashMap#replace}; only topics that are new (or were concurrently
+     * evicted) fall back to a synchronized block so the map insert and {@code newTopics} bookkeeping
+     * happen atomically with {@link #retainTopic}. Called on every {@code send()}.
+     */
+    public void add(String topic, long nowMs) {
         Objects.requireNonNull(topic, "topic cannot be null");
-        if (topics.put(topic, nowMs + metadataIdleMs) == null) {
-            newTopics.add(topic);
-            requestUpdateForNewTopics();
+        // Fast path: topic already known - update expiry without acquiring the instance lock.
+        if (topics.replace(topic, nowMs + metadataIdleMs) != null) {
+            return;
+        }
+        // Slow path: topic is new (or was concurrently evicted). Enter the lock so the map
+        // insert and newTopics bookkeeping happen atomically with retainTopic().
+        synchronized (this) {
+            if (topics.put(topic, nowMs + metadataIdleMs) == null) {
+                newTopics.add(topic);
+                requestUpdateForNewTopics();
+            }
         }
     }
 
     /**
-     * Atomically add a batch of topics to the working set, refreshing the
-     * expiry for those already present. If any of the topics was newly added,
-     * a partial metadata refresh is requested and the current updateVersion is
-     * returned so the caller can pass it to {@link #awaitUpdate(int, long)} to
-     * wait for the next response. Returns an empty {@code OptionalInt} when no
-     * topic was newly added (no refresh requested, nothing to wait for).
+     * Add a batch of topics to the working set, refreshing the expiry for those already present.
+     * Already-known topics are updated lock-free via {@link ConcurrentHashMap#replace}; only topics
+     * that are new (or were concurrently evicted) fall back to a synchronized block so the map insert
+     * and {@code newTopics} bookkeeping happen atomically with {@link #retainTopic}.
+     * If any topic was newly added, a partial metadata refresh is requested and the current
+     * updateVersion is returned so the caller can pass it to {@link #awaitUpdate(int, long)} to
+     * wait for the next response. Returns an empty {@code OptionalInt} when no topic was newly added.
      */
-    public synchronized OptionalInt add(Collection<String> topics, long nowMs) {
-        boolean anyNew = false;
+    public OptionalInt add(Collection<String> topics, long nowMs) {
+        // Fast path: refresh expiry for all already-known topics without acquiring the lock.
+        List<String> newOrEvicted = null;
         for (String topic : topics) {
-            if (this.topics.put(topic, nowMs + metadataIdleMs) == null) {
-                newTopics.add(topic);
-                anyNew = true;
+            if (this.topics.replace(topic, nowMs + metadataIdleMs) == null) {
+                if (newOrEvicted == null) newOrEvicted = new ArrayList<>();
+                newOrEvicted.add(topic);
             }
         }
-        return anyNew ? OptionalInt.of(requestUpdateForNewTopics()) : OptionalInt.empty();
+        if (newOrEvicted == null) return OptionalInt.empty();
+
+        // Slow path: enter the lock once for the whole batch of truly-new topics.
+        synchronized (this) {
+            boolean anyNew = false;
+            for (String topic : newOrEvicted) {
+                if (this.topics.put(topic, nowMs + metadataIdleMs) == null) {
+                    newTopics.add(topic);
+                    anyNew = true;
+                }
+            }
+            return anyNew ? OptionalInt.of(requestUpdateForNewTopics()) : OptionalInt.empty();
+        }
     }
 
     public synchronized int requestUpdateForTopic(String topic) {
@@ -119,6 +148,11 @@ public class ProducerMetadata extends Metadata {
         return topics.containsKey(topic);
     }
 
+    /**
+     * Returns whether the given topic should be retained in the metadata cache. Idle topics
+     * (whose expiry has passed) are evicted via a conditional {@link ConcurrentHashMap#remove(Object, Object)}
+     * so that a concurrent {@link #add} that refreshed the expiry just before this call is not undone.
+     */
     @Override
     public synchronized boolean retainTopic(String topic, boolean isInternal, long nowMs) {
         Long expireMs = topics.get(topic);
@@ -128,7 +162,9 @@ public class ProducerMetadata extends Metadata {
             return true;
         } else if (expireMs <= nowMs) {
             log.debug("Removing unused topic {} from the metadata list, expiryMs {} now {}", topic, expireMs, nowMs);
-            topics.remove(topic);
+            // Use conditional remove so a concurrent add() that refreshed the expiry after
+            // our get() above is not accidentally undone.
+            topics.remove(topic, expireMs);
             return false;
         } else {
             return true;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
@@ -29,10 +29,15 @@ import org.apache.kafka.common.utils.internals.LogContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -302,6 +307,174 @@ public class ProducerMetadataTest {
         now += 1000;
         metadata.updateWithCurrentRequestVersion(responseWithTopics(Set.of(topic1, topic2)), false, now);
         assertFalse(metadata.updateRequested());
+    }
+
+    /**
+     * Verifies the fast path in {@code add(String, long)}: re-adding an already-known topic
+     * refreshes its expiry but does NOT add it to {@code newTopics} or trigger an update request.
+     */
+    @Test
+    public void testAddKnownTopicFastPathDoesNotAddToNewTopics() {
+        long now = 0;
+        String topic = "known-topic";
+
+        // First add: topic is new, update should be requested.
+        metadata.add(topic, now);
+        assertTrue(metadata.newTopics().contains(topic));
+        assertTrue(metadata.updateRequested());
+
+        // Simulate metadata response so the topic is no longer "new".
+        metadata.updateWithCurrentRequestVersion(responseWithTopics(Collections.singleton(topic)), true, now);
+        assertFalse(metadata.newTopics().contains(topic));
+        assertFalse(metadata.updateRequested());
+
+        // Second add: topic is already known — fast path via replace(), must not touch newTopics or request an update.
+        now += 1000;
+        metadata.add(topic, now);
+        assertFalse(metadata.newTopics().contains(topic), "Known topic must not be re-added to newTopics");
+        assertFalse(metadata.updateRequested(), "Re-adding a known topic must not trigger an update request");
+    }
+
+    /**
+     * Verifies that {@code add(Collection, long)} returns {@code OptionalInt.empty()} when all
+     * supplied topics are already known (fast path only, no lock contention).
+     */
+    @Test
+    public void testBatchAddAllKnownTopicsReturnsEmptyOptional() {
+        long now = 0;
+        List<String> topics = List.of("topic-a", "topic-b", "topic-c");
+
+        // Seed the topics as known.
+        for (String t : topics) metadata.add(t, now);
+        metadata.updateWithCurrentRequestVersion(responseWithTopics(Set.copyOf(topics)), true, now);
+        assertFalse(metadata.updateRequested());
+
+        // Batch-add with all known topics — no new topic, so OptionalInt must be empty.
+        now += 1000;
+        OptionalInt result = metadata.add(topics, now);
+        assertFalse(result.isPresent(), "Batch add of all-known topics must return OptionalInt.empty()");
+        assertFalse(metadata.updateRequested());
+    }
+
+    /**
+     * Verifies that {@code add(Collection, long)} returns a present {@code OptionalInt} and
+     * triggers an update request when at least one topic in the batch is new.
+     */
+    @Test
+    public void testBatchAddWithNewTopicReturnsPresentOptional() {
+        long now = 0;
+        String knownTopic = "known";
+        String newTopic = "new";
+
+        metadata.add(knownTopic, now);
+        metadata.updateWithCurrentRequestVersion(responseWithTopics(Collections.singleton(knownTopic)), true, now);
+        assertFalse(metadata.updateRequested());
+
+        now += 1000;
+        OptionalInt result = metadata.add(List.of(knownTopic, newTopic), now);
+        assertTrue(result.isPresent(), "Batch add with a new topic must return a present OptionalInt");
+        assertTrue(metadata.newTopics().contains(newTopic));
+        assertTrue(metadata.updateRequested());
+    }
+
+    /**
+     * Verifies that multiple threads racing to add the same brand-new topic result in the topic
+     * being recorded in {@code newTopics} exactly once. The synchronized slow path must ensure
+     * idempotent insertion even under high concurrency.
+     */
+    @Test
+    public void testConcurrentAddOfSameNewTopicIsIdempotent() throws InterruptedException {
+        int threadCount = 20;
+        String topic = "concurrent-topic";
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean error = new AtomicBoolean(false);
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    metadata.add(topic, 0);
+                } catch (Exception e) {
+                    error.set(true);
+                }
+            });
+            t.start();
+            threads.add(t);
+        }
+
+        ready.await();
+        start.countDown();
+        for (Thread t : threads) t.join();
+
+        assertFalse(error.get(), "No thread should throw during concurrent add");
+        assertTrue(metadata.topics().contains(topic));
+        assertEquals(1, metadata.newTopics().size(), "Topic must appear in newTopics exactly once");
+        assertTrue(metadata.newTopics().contains(topic));
+    }
+
+    /**
+     * Verifies that a concurrent {@code add()} refreshing a topic's expiry is not undone by a
+     * concurrent {@code retainTopic()} that decided to evict based on the old (stale) expiry.
+     * The conditional {@code remove(topic, expireMs)} in {@code retainTopic()} must lose the CAS
+     * when {@code add()} has already replaced the value, leaving the topic in the map.
+     */
+    @Test
+    public void testRetainTopicConditionalRemovePreservesRefreshedTopic() throws InterruptedException {
+        int iterations = 200;
+        for (int i = 0; i < iterations; i++) {
+            ProducerMetadata m = new ProducerMetadata(refreshBackoffMs, refreshBackoffMaxMs, metadataExpireMs,
+                    METADATA_IDLE_MS, new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
+            String topic = "topic";
+            m.add(topic, 0);
+            m.updateWithCurrentRequestVersion(responseWithTopics(Collections.singleton(topic)), false, 0);
+
+            // At nowMs = METADATA_IDLE_MS the topic is exactly at its expiry boundary.
+            long nowMs = METADATA_IDLE_MS;
+
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(2);
+            AtomicBoolean threadError = new AtomicBoolean(false);
+
+            // Thread 1: refresh the topic expiry (fast path — no lock).
+            Thread adder = new Thread(() -> {
+                try {
+                    start.await();
+                    m.add(topic, nowMs);  // replaces expiry to nowMs + METADATA_IDLE_MS
+                } catch (Exception e) {
+                    threadError.set(true);
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            // Thread 2: attempt to evict the topic at the same time.
+            Thread retainer = new Thread(() -> {
+                try {
+                    start.await();
+                    m.retainTopic(topic, false, nowMs);
+                } catch (Exception e) {
+                    threadError.set(true);
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            adder.start();
+            retainer.start();
+            start.countDown();
+            done.await();
+
+            assertFalse(threadError.get(), "No thread should throw");
+            // After add() refreshes the expiry, the topic must still be present regardless of
+            // which thread won the race: either retainTopic saw the new expiry and kept it, or
+            // its conditional remove(topic, oldExpiry) lost the CAS because add() had already
+            // replaced the value.
+            assertTrue(m.containsTopic(topic),
+                    "Topic must remain after concurrent add() refresh and retainTopic() eviction attempt (iteration " + i + ")");
+        }
     }
 
     private MetadataResponse responseWithCurrentTopics() {


### PR DESCRIPTION
## Summary
`ProducerMetadata.add()` is called on every `KafkaProducer.send()` via                                                                                                                                 
  `waitOnMetadata`. Because it was fully `synchronized`, all producer threads                                                                                                                          
  contended on the same instance lock even for topics already in the metadata                                                                                                                            
  cache.                                                                                                                                                                            
                                                                                                                                                                                                         
  ## Changes                                                                                                                                                                                             
   
  - `topics` map switched to `ConcurrentHashMap`. `add(String)` and                                                                                                                                      
    `add(Collection)` now take a lock-free fast path via                                                                                                                                               
    `ConcurrentHashMap.replace()` for already-known topics, covering the hot
    path on every `send()`. Only truly new (or concurrently evicted) topics                                                                                                                              
    fall back to a `synchronized` block, keeping the map insert and `newTopics`
    bookkeeping atomic with `retainTopic()`.                                                                                                                                                             
                                                                                                                                                                                                         
  - `retainTopic()` switches from a plain `topics.remove(topic)` to a
    conditional `topics.remove(topic, expireMs)`. This prevents a race where                                                                                                                             
    `retainTopic()` reads a stale (expired) expiry, `add()` concurrently                                                                                                                               
    refreshes it via `replace()`, and `retainTopic()` then removes the freshly                                                                                                                           
    refreshed entry. The conditional remove loses the CAS if the value has                                                                                                                               
    changed, leaving the refreshed entry intact.                                                                                                                                                         
                                                                                                                                                                                                         
  ## Testing                                                                                                                                                                                           

  - `testAddKnownTopicFastPathDoesNotAddToNewTopics`: verifies the fast path                                                                                                                             
    does not re-add a known topic to `newTopics` or trigger an update.
  - `testBatchAddAllKnownTopicsReturnsEmptyOptional` /                                                                                                                                                   
    `testBatchAddWithNewTopicReturnsPresentOptional`: verifies `add(Collection)`                                                                                                                       
    fast/slow path return values.                                                                                                                                                                        
  - `testConcurrentAddOfSameNewTopicIsIdempotent`: 20 threads racing to add the
    same new topic and asserts `newTopics` contains it exactly once.                                                                                                                                       
  - `testRetainTopicConditionalRemovePreservesRefreshedTopic`: 200 iterations of                                                                                                                       
    concurrent `add()` and `retainTopic()` racing at the expiry boundary and                                                                                                                               
    asserts the topic always survives when `add()` has refreshed its expiry.