### PR TITLE
KAFKA-20709: Add HeaderRouter SMT

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Filter;
 import org.apache.kafka.connect.transforms.Flatten;
 import org.apache.kafka.connect.transforms.HeaderFrom;
+import org.apache.kafka.connect.transforms.HeaderRouter;
 import org.apache.kafka.connect.transforms.HoistField;
 import org.apache.kafka.connect.transforms.InsertField;
 import org.apache.kafka.connect.transforms.InsertHeader;
@@ -48,6 +49,7 @@ public class TransformationDoc {
             new DocInfo(Filter.class.getName(), Filter.OVERVIEW_DOC, Filter.CONFIG_DEF),
             new DocInfo(Flatten.class.getName(), Flatten.OVERVIEW_DOC, Flatten.CONFIG_DEF),
             new DocInfo(HeaderFrom.class.getName(), HeaderFrom.OVERVIEW_DOC, HeaderFrom.CONFIG_DEF),
+            new DocInfo(HeaderRouter.class.getName(), HeaderRouter.OVERVIEW_DOC, HeaderRouter.CONFIG_DEF),
             new DocInfo(HoistField.class.getName(), HoistField.OVERVIEW_DOC, HoistField.CONFIG_DEF),
             new DocInfo(InsertField.class.getName(), InsertField.OVERVIEW_DOC, InsertField.CONFIG_DEF),
             new DocInfo(InsertHeader.class.getName(), InsertHeader.OVERVIEW_DOC, InsertHeader.CONFIG_DEF),

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderRouter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderRouter.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.transforms.util.NonEmptyListValidator;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Routes records to a destination topic based on the value of a Kafka record header.
+ * Multiple header names can be specified in priority order; the first header found on
+ * the record determines the destination topic. An optional fallback topic can be
+ * configured for records with none of the specified headers present.
+ */
+public class HeaderRouter<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final Logger log = LoggerFactory.getLogger(HeaderRouter.class);
+
+    public static final String OVERVIEW_DOC =
+            "Route records to a destination topic based on the value of a Kafka record header. " +
+            "Multiple header names can be specified in priority order via <code>" + ConfigName.HEADER_NAMES + "</code>; " +
+            "the first header found on the record determines the destination topic. " +
+            "An optional <code>" + ConfigName.FALLBACK_TOPIC + "</code> can be configured for records " +
+            "with none of the specified headers present. If no header matches and no fallback is set, " +
+            "the record passes through with its original topic unchanged.";
+
+    private interface ConfigName {
+        String HEADER_NAMES = "header.names";
+        String FALLBACK_TOPIC = "fallback.topic";
+    }
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(ConfigName.HEADER_NAMES, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE,
+                    new NonEmptyListValidator(), ConfigDef.Importance.HIGH,
+                    "Priority-ordered list of header names to inspect. The value of the first header " +
+                    "found on the record is used as the destination topic name.")
+            .define(ConfigName.FALLBACK_TOPIC, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
+                    "Topic to route records to when none of the configured headers are present. " +
+                    "If not set, the record's original topic is preserved.");
+
+    private List<String> headerNames;
+    private String fallbackTopic;
+
+    @Override
+    public String version() {
+        return AppInfoParser.getVersion();
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        headerNames = config.getList(ConfigName.HEADER_NAMES);
+        final String fallback = config.getString(ConfigName.FALLBACK_TOPIC);
+        fallbackTopic = (fallback != null && !fallback.isBlank()) ? fallback : null;
+    }
+
+    @Override
+    public R apply(R record) {
+        for (String name : headerNames) {
+            final Header header = record.headers().lastWithName(name);
+            if (header != null && header.value() != null && !headerValueAsString(header).isEmpty()) {
+                final String newTopic = headerValueAsString(header);
+                log.trace("Rerouting record from topic '{}' to '{}' via header '{}'",
+                        record.topic(), newTopic, name);
+                return record.newRecord(newTopic, record.kafkaPartition(),
+                        record.keySchema(), record.key(),
+                        record.valueSchema(), record.value(),
+                        record.timestamp());
+            }
+        }
+        if (fallbackTopic != null) {
+            log.trace("No matching header found on record from topic '{}'; routing to fallback topic '{}'",
+                    record.topic(), fallbackTopic);
+            return record.newRecord(fallbackTopic, record.kafkaPartition(),
+                    record.keySchema(), record.key(),
+                    record.valueSchema(), record.value(),
+                    record.timestamp());
+        }
+        log.trace("No matching header found on record from topic '{}' and no fallback configured; passing through",
+                record.topic());
+        return record;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    private static String headerValueAsString(Header header) {
+        final Object value = header.value();
+        if (value instanceof String) return (String) value;
+        if (value instanceof byte[]) return new String((byte[]) value, StandardCharsets.UTF_8);
+        return value.toString();
+    }
+}

--- a/connect/transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/connect/transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -23,6 +23,7 @@ org.apache.kafka.connect.transforms.Flatten$Key
 org.apache.kafka.connect.transforms.Flatten$Value
 org.apache.kafka.connect.transforms.HeaderFrom$Key
 org.apache.kafka.connect.transforms.HeaderFrom$Value
+org.apache.kafka.connect.transforms.HeaderRouter
 org.apache.kafka.connect.transforms.HoistField$Key
 org.apache.kafka.connect.transforms.HoistField$Value
 org.apache.kafka.connect.transforms.InsertField$Key

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderRouterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderRouterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HeaderRouterTest {
+
+    private final HeaderRouter<SourceRecord> router = new HeaderRouter<>();
+
+    @AfterEach
+    public void tearDown() {
+        router.close();
+    }
+
+    private SourceRecord sourceRecord(String topic, ConnectHeaders headers) {
+        return new SourceRecord(Map.of("p", "v"), Map.of("o", "v"),
+                topic, 0, null, "key", null, "value", 0L, headers);
+    }
+
+    @Test
+    public void singleHeaderMatch() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("x-dest-topic", "target-topic");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("target-topic", result.topic());
+    }
+
+    @Test
+    public void priorityOrderingFirstHeaderWins() {
+        router.configure(Map.of("header.names", "tenant-id, classification"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("tenant-id", "acme");
+        headers.addString("classification", "sensitive");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("acme", result.topic());
+    }
+
+    @Test
+    public void priorityOrderingFallsToSecondHeader() {
+        router.configure(Map.of("header.names", "tenant-id, classification"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("classification", "sensitive");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("sensitive", result.topic());
+    }
+
+    @Test
+    public void fallbackTopicUsedWhenNoHeaderMatches() {
+        router.configure(Map.of("header.names", "x-dest-topic", "fallback.topic", "default-topic"));
+        SourceRecord result = router.apply(sourceRecord("source-topic", new ConnectHeaders()));
+        assertEquals("default-topic", result.topic());
+    }
+
+    @Test
+    public void passThroughWhenNoHeaderMatchesAndNoFallback() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        SourceRecord result = router.apply(sourceRecord("source-topic", new ConnectHeaders()));
+        assertEquals("source-topic", result.topic());
+    }
+
+    @Test
+    public void nullHeaderValueIsSkipped() {
+        router.configure(Map.of("header.names", "first, second"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.add("first", null, null);
+        headers.addString("second", "second-topic");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("second-topic", result.topic());
+    }
+
+    @Test
+    public void bytesHeaderValueDecodedAsUtf8() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addBytes("x-dest-topic", "bytes-topic".getBytes(StandardCharsets.UTF_8));
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("bytes-topic", result.topic());
+    }
+
+    @Test
+    public void stringHeaderValueUsedDirectly() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("x-dest-topic", "string-topic");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("string-topic", result.topic());
+    }
+
+    @Test
+    public void lastHeaderWithNameIsUsedWhenDuplicatesExist() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("x-dest-topic", "first-value");
+        headers.addString("x-dest-topic", "last-value");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("last-value", result.topic());
+    }
+
+    @Test
+    public void emptyStringHeaderValueIsSkipped() {
+        router.configure(Map.of("header.names", "first, second"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("first", "");
+        headers.addString("second", "second-topic");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("second-topic", result.topic());
+    }
+
+    @Test
+    public void blankFallbackTopicTreatedAsPassThrough() {
+        router.configure(Map.of("header.names", "x-dest-topic", "fallback.topic", "   "));
+        SourceRecord result = router.apply(sourceRecord("source-topic", new ConnectHeaders()));
+        assertEquals("source-topic", result.topic());
+    }
+
+    @Test
+    public void missingRequiredHeaderNamesConfigThrows() {
+        assertThrows(ConfigException.class, () -> router.configure(Map.of()));
+    }
+
+    @Test
+    public void emptyHeaderNamesListThrows() {
+        assertThrows(ConfigException.class, () -> router.configure(Map.of("header.names", "")));
+    }
+
+    @Test
+    public void headersArePreservedAfterRerouting() {
+        router.configure(Map.of("header.names", "x-dest-topic"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("x-dest-topic", "target-topic");
+        headers.addString("x-keep", "preserved");
+        SourceRecord result = router.apply(sourceRecord("source-topic", headers));
+        assertEquals("target-topic", result.topic());
+        assertEquals(headers, result.headers());
+    }
+
+    @Test
+    public void versionMatchesAppInfoParser() {
+        assertEquals(AppInfoParser.getVersion(), router.version());
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                             
                                                                                                                                                                                                       
This PR adds a new built-in Single Message Transformation, `HeaderRouter`, that routes records to a destination topic based on the value of a Kafka record header. This addresses a gap in Kafka Connect's built-in transforms where no native mechanism existed to route records using header metadata.                                                                                                                   
                                                                                                                                                                                                         
The transform accepts an ordered list of header names (`header.names`). On each record, headers are checked in priority order and the value of the first matching header is used as the destination topic name.

An optional `fallback.topic` can be configured for records where none of the specified headers are present; if omitted, such records pass through with their original topic unchanged.
                                                                                                                                                                                                         
  ## Changes                                                                                                                                                                                           

  - **`connect/transforms/.../HeaderRouter.java`**: New SMT implementation. Iterates `header.names` in priority order, resolves header values as `String`, `byte[]` (decoded as UTF-8), or any other type via `toString()`. Skips headers with `null` or empty string values. Normalizes a blank `fallback.topic` to absent at `configure()` time to prevent routing records to an invalid empty topic name.
  - **`connect/transforms/.../META-INF/services/org.apache.kafka.connect.transforms.Transformation`**: Registers `HeaderRouter` for automatic plugin discovery by the Connect runtime.                  
  - **`connect/runtime/.../tools/TransformationDoc.java`**: Adds `HeaderRouter` to the doc generation tool so it appears in the generated HTML reference documentation (`docs/generated/connect_transforms.html`).                                                                                                                                                            
                                                                                                                                                                                                         
  ## Testing                                                                                                                                                                                             
                                                                                                                                                                                                       
  Unit tests added in `HeaderRouterTest.java` covering:

  - Single header match routes record to header value as topic                                                                                                                                           
  - Priority ordering: first header in list wins when multiple are present
  - Priority ordering: falls through to second header when first is absent                                                                                                                           
  - `fallback.topic` used when no configured header is present on the record                                                                                                                           
  - Pass-through when no header matches and no fallback is configured
  - `null` header value is skipped; next header in list is tried                                                                                                                                         
  - Empty string header value is skipped; next header in list is tried
  - Blank `fallback.topic` config is treated as absent (pass-through)                                                                                                                                    
  - `byte[]` header values are decoded as UTF-8 for the topic name                                                                                                                                       
  - Duplicate header keys: last value wins, per the Connect API contract
  - Record headers are preserved unchanged after rerouting                                                                                                                                               
  - `ConfigException` thrown when `header.names` is missing or empty