### PR TITLE
MINOR: Unify ClusterInstance client security configuration

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ConcurrentListOffsetsRequestTest.java
@@ -76,7 +76,7 @@ public class ConcurrentListOffsetsRequestTest {
                 "default.api.timeout.ms", TIMEOUT,
                 "request.timeout.ms", TIMEOUT,
                 CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
-        adminClient = KafkaAdminClient.createInternal(new AdminClientConfig(clusterInstance.setClientSaslConfig(props), true),
+        adminClient = KafkaAdminClient.createInternal(new AdminClientConfig(clusterInstance.createClientSecurityConfig(props), true),
                 null, new TestHostResolver());
 
         networkClient = TestUtils.fieldValue(adminClient, KafkaAdminClient.class, "client");

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/ClusterInstance.java
@@ -38,9 +38,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBindingFilter;
-import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -146,7 +144,7 @@ public interface ClusterInstance {
         props.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         props.putIfAbsent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-        return new KafkaProducer<>(setClientSaslConfig(setClientSslConfig(props)));
+        return new KafkaProducer<>(createClientSecurityConfig(props));
     }
 
     default <K, V> Producer<K, V> producer() {
@@ -160,7 +158,7 @@ public interface ClusterInstance {
         props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, "group_" + TestUtils.randomString(5));
         props.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-        return new KafkaConsumer<>(setClientSaslConfig(setClientSslConfig(props)));
+        return new KafkaConsumer<>(createClientSecurityConfig(props));
     }
 
     default <K, V> Consumer<K, V> consumer() {
@@ -185,7 +183,7 @@ public interface ClusterInstance {
         }
         props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, "group_" + TestUtils.randomString(5));
         props.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-        return new KafkaShareConsumer<>(setClientSaslConfig(setClientSslConfig(props)), keyDeserializer, valueDeserializer);
+        return new KafkaShareConsumer<>(createClientSecurityConfig(props), keyDeserializer, valueDeserializer);
     }
 
     default Admin admin(Map<String, Object> configs, boolean usingBootstrapControllers) {
@@ -197,26 +195,10 @@ public interface ClusterInstance {
             props.putIfAbsent(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
             props.remove(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG);
         }
-        return Admin.create(setClientSaslConfig(setClientSslConfig(props)));
+        return Admin.create(createClientSecurityConfig(props));
     }
 
-    default Map<String, Object> setClientSaslConfig(Map<String, Object> configs) {
-        Map<String, Object> props = new HashMap<>(configs);
-        if (config().brokerSecurityProtocol() == SecurityProtocol.SASL_PLAINTEXT) {
-            props.putIfAbsent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_PLAINTEXT.name);
-            props.putIfAbsent(SaslConfigs.SASL_MECHANISM, "PLAIN");
-            props.putIfAbsent(
-                SaslConfigs.SASL_JAAS_CONFIG,
-                String.format(
-                    "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";",
-                    JaasUtils.KAFKA_PLAIN_ADMIN, JaasUtils.KAFKA_PLAIN_ADMIN_PASSWORD
-                )
-            );
-        }
-        return props;
-    }
-
-    Map<String, Object> setClientSslConfig(Map<String, Object> configs);
+    Map<String, Object> createClientSecurityConfig(Map<String, Object> configs);
 
     default Admin admin(Map<String, Object> configs) {
         return admin(configs, false);

--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/RaftClusterInvocationContext.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/junit/RaftClusterInvocationContext.java
@@ -183,10 +183,15 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
         }
 
         @Override
-        public Map<String, Object> setClientSslConfig(Map<String, Object> configs) {
+        public Map<String, Object> createClientSecurityConfig(Map<String, Object> configs) {
             Map<String, Object> props = new HashMap<>(configs);
-            if (config().brokerSecurityProtocol() == SecurityProtocol.SASL_SSL) {
-                props.putIfAbsent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name);
+            SecurityProtocol protocol = clusterConfig.brokerSecurityProtocol();
+            props.putIfAbsent(
+                CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                protocol.name
+            );
+            if (protocol == SecurityProtocol.SASL_PLAINTEXT ||
+                protocol == SecurityProtocol.SASL_SSL) {
                 props.putIfAbsent(SaslConfigs.SASL_MECHANISM, "PLAIN");
                 props.putIfAbsent(
                     SaslConfigs.SASL_JAAS_CONFIG,
@@ -195,12 +200,10 @@ public class RaftClusterInvocationContext implements TestTemplateInvocationConte
                         JaasUtils.KAFKA_PLAIN_ADMIN, JaasUtils.KAFKA_PLAIN_ADMIN_PASSWORD
                     )
                 );
-                if (clusterTestKit.sslManager() != null) {
-                    props.putAll(clusterTestKit.sslManager().createClientSslConfig());
-                    props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
-                }
-            } else if (config().brokerSecurityProtocol() == SecurityProtocol.SSL) {
-                props.putIfAbsent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name);
+            }
+
+            if (protocol == SecurityProtocol.SSL ||
+                protocol == SecurityProtocol.SASL_SSL) {
                 if (clusterTestKit.sslManager() != null) {
                     props.putAll(clusterTestKit.sslManager().createClientSslConfig());
                     props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");


### PR DESCRIPTION
This follow-up addresses review feedback from #20376.

The client security configuration was previously split between
`setClientSaslConfig` and `setClientSslConfig`, resulting in nested and
counterintuitive call chains.

This change:

- Introduces `createClientSecurityConfig` as the unified client security configuration API.
- Centralizes PLAINTEXT, SSL, SASL_PLAINTEXT, and SASL_SSL handling in `RaftClusterInstance`.
- Updates producer, consumer, share consumer, and admin client creation.
- Updates the direct client integration test caller.
- Removes the obsolete SASL- and SSL-specific methods from `ClusterInstance`.

Testing:

- `./gradlew :test-common:test-common-runtime:spotlessCheck`
- `./gradlew :test-common:test-common-runtime:checkstyleMain`
- `./gradlew :test-common:test-common-runtime:compileJava`
- `./gradlew :test-common:test-common-runtime:test --tests org.apache.kafka.common.test.junit.ClusterTestExtensionsTest --rerun-tasks`
- `./gradlew :clients:clients-integration-tests:test --tests org.apache.kafka.clients.admin.ConcurrentListOffsetsRequestTest`

Reviewers: Ken Huang <s7133700@gmail.com>
