### PR TITLE
KAFKA-20812: Move Admin tests from KRaftClusterTest

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ClientQuotasTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ClientQuotasTest.java
@@ -60,6 +60,7 @@ public class ClientQuotasTest {
                 new ClientQuotaAlteration.Op("consumer_byte_rate", value.doubleValue())))
         )).all().get();
     }
+
     private Map<ClientQuotaEntity, Long> getConsumerByteRates(Admin admin) throws Exception {
         return admin.describeClientQuotas(ClientQuotaFilter.contains(List.of()))
             .entities().get()
@@ -70,6 +71,7 @@ public class ClientQuotasTest {
                 entry -> entry.getValue().get("consumer_byte_rate").longValue()
             ));
     }
+    
     @ClusterTest
     public void testClientQuotas(ClusterInstance cluster) throws Exception {
         try (Admin admin = cluster.admin()) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ClientQuotasTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/ClientQuotasTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.test.TestUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ClusterTestDefaults(types = {Type.KRAFT})
+public class ClientQuotasTest {
+
+    private Map<ClientQuotaEntity, Map<String, Double>> alterThenDescribe(
+        Admin admin,
+        ClientQuotaEntity entity,
+        List<ClientQuotaAlteration.Op> quotas,
+        ClientQuotaFilter filter,
+        int expectCount
+    ) throws Exception {
+        AlterClientQuotasResult alterResult = admin.alterClientQuotas(List.of(new ClientQuotaAlteration(entity, quotas)));
+        alterResult.all().get();
+
+        TestUtils.waitForCondition(() -> {
+            Map<ClientQuotaEntity, Map<String, Double>> results = admin.describeClientQuotas(filter).entities().get();
+            return results.getOrDefault(entity, Map.of()).size() == expectCount;
+        }, "Broker never saw new client quotas");
+
+        return admin.describeClientQuotas(filter).entities().get();
+    }
+
+    private void setConsumerByteRate(Admin admin, ClientQuotaEntity entity, Long value) throws Exception {
+        admin.alterClientQuotas(List.of(
+            new ClientQuotaAlteration(entity, List.of(
+                new ClientQuotaAlteration.Op("consumer_byte_rate", value.doubleValue())))
+        )).all().get();
+    }
+    private Map<ClientQuotaEntity, Long> getConsumerByteRates(Admin admin) throws Exception {
+        return admin.describeClientQuotas(ClientQuotaFilter.contains(List.of()))
+            .entities().get()
+            .entrySet().stream()
+            .filter(entry -> entry.getValue().containsKey("consumer_byte_rate"))
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().get("consumer_byte_rate").longValue()
+            ));
+    }
+    @ClusterTest
+    public void testClientQuotas(ClusterInstance cluster) throws Exception {
+        try (Admin admin = cluster.admin()) {
+            ClientQuotaEntity entity = new ClientQuotaEntity(Map.of("user", "testkit"));
+            ClientQuotaFilter filter = ClientQuotaFilter.containsOnly(
+                List.of(ClientQuotaFilterComponent.ofEntity("user", "testkit")));
+
+            Map<ClientQuotaEntity, Map<String, Double>> describeResult = alterThenDescribe(admin, entity,
+                List.of(new ClientQuotaAlteration.Op("request_percentage", 0.99)), filter, 1);
+            assertEquals(0.99, describeResult.get(entity).get("request_percentage"), 1e-6);
+
+            describeResult = alterThenDescribe(admin, entity, List.of(
+                new ClientQuotaAlteration.Op("request_percentage", 0.97),
+                new ClientQuotaAlteration.Op("producer_byte_rate", 10000.0),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", 10001.0)
+            ), filter, 3);
+            assertEquals(0.97, describeResult.get(entity).get("request_percentage"), 1e-6);
+            assertEquals(10000.0, describeResult.get(entity).get("producer_byte_rate"), 1e-6);
+            assertEquals(10001.0, describeResult.get(entity).get("consumer_byte_rate"), 1e-6);
+
+            describeResult = alterThenDescribe(admin, entity, List.of(
+                new ClientQuotaAlteration.Op("request_percentage", 0.95),
+                new ClientQuotaAlteration.Op("producer_byte_rate", null),
+                new ClientQuotaAlteration.Op("consumer_byte_rate", null)
+            ), filter, 1);
+            assertEquals(0.95, describeResult.get(entity).get("request_percentage"), 1e-6);
+
+            alterThenDescribe(admin, entity, List.of(
+                new ClientQuotaAlteration.Op("request_percentage", null)), filter, 0);
+
+            describeResult = alterThenDescribe(admin, entity,
+                List.of(new ClientQuotaAlteration.Op("producer_byte_rate", 9999.0)), filter, 1);
+            assertEquals(9999.0, describeResult.get(entity).get("producer_byte_rate"), 1e-6);
+
+            ClientQuotaEntity entity2 = new ClientQuotaEntity(Map.of("user", "testkit", "client-id", "some-client"));
+            filter = ClientQuotaFilter.containsOnly(
+                List.of(
+                    ClientQuotaFilterComponent.ofEntity("user", "testkit"),
+                    ClientQuotaFilterComponent.ofEntity("client-id", "some-client")
+                ));
+            describeResult = alterThenDescribe(admin, entity2,
+                List.of(new ClientQuotaAlteration.Op("producer_byte_rate", 9998.0)), filter, 1);
+            assertEquals(9998.0, describeResult.get(entity2).get("producer_byte_rate"), 1e-6);
+
+            final ClientQuotaFilter finalFilter = ClientQuotaFilter.contains(
+                List.of(ClientQuotaFilterComponent.ofEntity("user", "testkit")));
+
+            TestUtils.waitForCondition(() -> {
+                Map<ClientQuotaEntity, Map<String, Double>> results = admin.describeClientQuotas(finalFilter).entities().get();
+                if (results.size() != 2) {
+                    return false;
+                }
+                assertEquals(9999.0, results.get(entity).get("producer_byte_rate"), 1e-6);
+                assertEquals(9998.0, results.get(entity2).get("producer_byte_rate"), 1e-6);
+                return true;
+            }, "Broker did not see two client quotas");
+        }
+    }
+
+    @ClusterTest
+    public void testDefaultClientQuotas(ClusterInstance cluster) throws Exception {
+        try (Admin admin = cluster.admin()) {
+            ClientQuotaEntity defaultUser = new ClientQuotaEntity(Collections.singletonMap("user", null));
+            ClientQuotaEntity bobUser = new ClientQuotaEntity(Map.of("user", "bob"));
+
+            TestUtils.waitForCondition(
+                () -> getConsumerByteRates(admin).isEmpty(),
+                "Initial consumer byte rates should be empty");
+
+            setConsumerByteRate(admin, defaultUser, 100L);
+            TestUtils.waitForCondition(() -> {
+                Map<ClientQuotaEntity, Long> rates = getConsumerByteRates(admin);
+                return rates.size() == 1 &&
+                    rates.get(defaultUser) == 100L;
+            }, "Default user rate should be 100");
+
+            setConsumerByteRate(admin, bobUser, 1000L);
+            TestUtils.waitForCondition(() -> {
+                Map<ClientQuotaEntity, Long> rates = getConsumerByteRates(admin);
+                return rates.size() == 2 &&
+                    rates.get(defaultUser) == 100L &&
+                    rates.get(bobUser) == 1000L;
+            }, "Should have both default and bob user rates");
+        }
+    }
+}

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
@@ -29,7 +29,7 @@ import java.util.Set;
 @ClusterTestDefaults(types = {Type.KRAFT})
 public class CreateTopicsTest {
 
-    @ClusterTest(brokers = 3, controllers = 3)
+    @ClusterTest(brokers = 3)
     public void testCreateClusterAndCreateAndManyTopics(ClusterInstance cluster) throws Exception {
         try (Admin admin = cluster.admin()) {
             // Create many topics

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class CreateTopicsTest {
 
     @ClusterTest(brokers = 3)
-    public void testCreateClusterAndCreateAndManyTopics(ClusterInstance cluster) throws Exception {
+    public void testCreateManyTopics(ClusterInstance cluster) throws Exception {
         try (Admin admin = cluster.admin()) {
             // Create many topics
             List<NewTopic> newTopics = List.of(

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/CreateTopicsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.test.TestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+@ClusterTestDefaults(types = {Type.KRAFT})
+public class CreateTopicsTest {
+
+    @ClusterTest(brokers = 3, controllers = 3)
+    public void testCreateClusterAndCreateAndManyTopics(ClusterInstance cluster) throws Exception {
+        try (Admin admin = cluster.admin()) {
+            // Create many topics
+            List<NewTopic> newTopics = List.of(
+                new NewTopic("test-topic-1", 2, (short) 3),
+                new NewTopic("test-topic-2", 2, (short) 3),
+                new NewTopic("test-topic-3", 2, (short) 3)
+            );
+            CreateTopicsResult createTopicResult = admin.createTopics(newTopics);
+            createTopicResult.all().get();
+
+            // List created topics
+            Set<String> expectedTopics = Set.of(
+                "test-topic-1",
+                "test-topic-2",
+                "test-topic-3"
+            );
+
+            TestUtils.waitForCondition(
+                () -> admin.listTopics().names().get().containsAll(expectedTopics),
+                "Failed to find topics " + expectedTopics
+            );
+        }
+    }
+}

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
@@ -67,7 +67,7 @@ public class DeleteTopicTest {
     private final Map<Integer, List<Integer>> expectedReplicaAssignment = Map.of(0, List.of(0, 1, 2));
 
     @ClusterTest
-    public void testCreateClusterAndCreateListDeleteTopic(ClusterInstance cluster) throws Exception {
+    public void testCreateAndDeleteTopic(ClusterInstance cluster) throws Exception {
         String testTopic = "test-topic";
         try (Admin admin = cluster.admin()) {
             // Create a test topic

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
@@ -71,8 +71,8 @@ public class DeleteTopicTest {
         String testTopic = "test-topic";
         try (Admin admin = cluster.admin()) {
             // Create a test topic
-            List<NewTopic> newTopic = List.of(new NewTopic(testTopic, 1, (short) 3));
-            CreateTopicsResult createTopicResult = admin.createTopics(newTopic);
+            List<NewTopic> newTopics = List.of(new NewTopic(testTopic, 1, (short) 3));
+            CreateTopicsResult createTopicResult = admin.createTopics(newTopics);
             createTopicResult.all().get();
             TestUtils.waitForCondition(
                 () -> admin.listTopics().names().get().contains(testTopic),

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
@@ -66,6 +66,31 @@ public class DeleteTopicTest {
     private static final String DEFAULT_TOPIC = "topic";
     private final Map<Integer, List<Integer>> expectedReplicaAssignment = Map.of(0, List.of(0, 1, 2));
 
+    @ClusterTest(controllers = 3)
+    public void testCreateClusterAndCreateListDeleteTopic(ClusterInstance cluster) throws Exception {
+        String testTopic = "test-topic";
+        try (Admin admin = cluster.admin()) {
+            // Create a test topic
+            List<NewTopic> newTopic = List.of(new NewTopic(testTopic, 1, (short) 3));
+            CreateTopicsResult createTopicResult = admin.createTopics(newTopic);
+            createTopicResult.all().get();
+            TestUtils.waitForCondition(
+                () -> admin.listTopics().names().get().contains(testTopic),
+                "Failed to find topic " + testTopic
+            );
+
+            // Delete topic
+            DeleteTopicsResult deleteResult = admin.deleteTopics(List.of(testTopic));
+            deleteResult.all().get();
+
+            // List again
+            TestUtils.waitForCondition(
+                () -> !admin.listTopics().names().get().contains(testTopic),
+                "Topic " + testTopic + " was not deleted"
+            );
+        }
+    }
+
     @ClusterTest
     public void testDeleteTopicWithAllAliveReplicas(ClusterInstance cluster) throws Exception {
         try (Admin admin = cluster.admin()) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DeleteTopicTest.java
@@ -66,7 +66,7 @@ public class DeleteTopicTest {
     private static final String DEFAULT_TOPIC = "topic";
     private final Map<Integer, List<Integer>> expectedReplicaAssignment = Map.of(0, List.of(0, 1, 2));
 
-    @ClusterTest(controllers = 3)
+    @ClusterTest
     public void testCreateClusterAndCreateListDeleteTopic(ClusterInstance cluster) throws Exception {
         String testTopic = "test-topic";
         try (Admin admin = cluster.admin()) {

--- a/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
+++ b/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.server;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.AlterClientQuotasResult;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -52,10 +51,6 @@ import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.quota.ClientQuotaAlteration;
-import org.apache.kafka.common.quota.ClientQuotaEntity;
-import org.apache.kafka.common.quota.ClientQuotaFilter;
-import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.DescribeClusterRequest;
 import org.apache.kafka.common.requests.DescribeClusterResponse;
@@ -105,7 +100,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -335,214 +329,6 @@ public class KRaftClusterTest {
                 .authorizerPlugin().get().get();
             assertEquals(expected, ((FakeConfigurableAuthorizer) brokerAuthorizer).foobar.get());
         });
-    }
-
-    @Test
-    public void testCreateClusterAndCreateListDeleteTopic() throws Exception {
-        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
-            new TestKitNodes.Builder()
-                .setNumBrokerNodes(3)
-                .setNumControllerNodes(3)
-                .build()).build()) {
-            cluster.format();
-            cluster.startup();
-            cluster.waitForReadyBrokers();
-            TestUtils.waitForCondition(() -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
-                "Broker never made it to RUNNING state.");
-            TestUtils.waitForCondition(() -> cluster.raftManagers().get(0).client().leaderAndEpoch().leaderId().isPresent(),
-                "RaftManager was not initialized.");
-
-            String testTopic = "test-topic";
-            try (Admin admin = cluster.admin()) {
-                // Create a test topic
-                List<NewTopic> newTopic = List.of(new NewTopic(testTopic, 1, (short) 3));
-                CreateTopicsResult createTopicResult = admin.createTopics(newTopic);
-                createTopicResult.all().get();
-                waitForTopicListing(admin, List.of(testTopic), List.of());
-
-                // Delete topic
-                DeleteTopicsResult deleteResult = admin.deleteTopics(List.of(testTopic));
-                deleteResult.all().get();
-
-                // List again
-                waitForTopicListing(admin, List.of(), List.of(testTopic));
-            }
-        }
-    }
-
-    @Test
-    public void testCreateClusterAndCreateAndManyTopics() throws Exception {
-        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
-            new TestKitNodes.Builder()
-                .setNumBrokerNodes(3)
-                .setNumControllerNodes(3)
-                .build()).build()) {
-            cluster.format();
-            cluster.startup();
-            cluster.waitForReadyBrokers();
-            TestUtils.waitForCondition(() -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
-                "Broker never made it to RUNNING state.");
-            TestUtils.waitForCondition(() -> cluster.raftManagers().get(0).client().leaderAndEpoch().leaderId().isPresent(),
-                "RaftManager was not initialized.");
-
-            try (Admin admin = cluster.admin()) {
-                // Create many topics
-                List<NewTopic> newTopics = List.of(
-                    new NewTopic("test-topic-1", 2, (short) 3),
-                    new NewTopic("test-topic-2", 2, (short) 3),
-                    new NewTopic("test-topic-3", 2, (short) 3)
-                );
-                CreateTopicsResult createTopicResult = admin.createTopics(newTopics);
-                createTopicResult.all().get();
-
-                // List created topics
-                waitForTopicListing(admin, List.of("test-topic-1", "test-topic-2", "test-topic-3"), List.of());
-            }
-        }
-    }
-
-    private Map<ClientQuotaEntity, Map<String, Double>> alterThenDescribe(
-        Admin admin,
-        ClientQuotaEntity entity,
-        List<ClientQuotaAlteration.Op> quotas,
-        ClientQuotaFilter filter,
-        int expectCount
-    ) throws Exception {
-        AlterClientQuotasResult alterResult = admin.alterClientQuotas(List.of(new ClientQuotaAlteration(entity, quotas)));
-        alterResult.all().get();
-
-        TestUtils.waitForCondition(() -> {
-            Map<ClientQuotaEntity, Map<String, Double>> results = admin.describeClientQuotas(filter).entities().get();
-            return results.getOrDefault(entity, Map.of()).size() == expectCount;
-        }, "Broker never saw new client quotas");
-
-        return admin.describeClientQuotas(filter).entities().get();
-    }
-
-    @Test
-    public void testClientQuotas() throws Exception {
-        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
-            new TestKitNodes.Builder()
-                .setNumBrokerNodes(1)
-                .setNumControllerNodes(1)
-                .build()).build()) {
-            cluster.format();
-            cluster.startup();
-            TestUtils.waitForCondition(() -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
-                "Broker never made it to RUNNING state.");
-
-            try (Admin admin = cluster.admin()) {
-                ClientQuotaEntity entity = new ClientQuotaEntity(Map.of("user", "testkit"));
-                ClientQuotaFilter filter = ClientQuotaFilter.containsOnly(
-                    List.of(ClientQuotaFilterComponent.ofEntity("user", "testkit")));
-
-                Map<ClientQuotaEntity, Map<String, Double>> describeResult = alterThenDescribe(admin, entity,
-                    List.of(new ClientQuotaAlteration.Op("request_percentage", 0.99)), filter, 1);
-                assertEquals(0.99, describeResult.get(entity).get("request_percentage"), 1e-6);
-
-                describeResult = alterThenDescribe(admin, entity, List.of(
-                    new ClientQuotaAlteration.Op("request_percentage", 0.97),
-                    new ClientQuotaAlteration.Op("producer_byte_rate", 10000.0),
-                    new ClientQuotaAlteration.Op("consumer_byte_rate", 10001.0)
-                ), filter, 3);
-                assertEquals(0.97, describeResult.get(entity).get("request_percentage"), 1e-6);
-                assertEquals(10000.0, describeResult.get(entity).get("producer_byte_rate"), 1e-6);
-                assertEquals(10001.0, describeResult.get(entity).get("consumer_byte_rate"), 1e-6);
-
-                describeResult = alterThenDescribe(admin, entity, List.of(
-                    new ClientQuotaAlteration.Op("request_percentage", 0.95),
-                    new ClientQuotaAlteration.Op("producer_byte_rate", null),
-                    new ClientQuotaAlteration.Op("consumer_byte_rate", null)
-                ), filter, 1);
-                assertEquals(0.95, describeResult.get(entity).get("request_percentage"), 1e-6);
-
-                alterThenDescribe(admin, entity, List.of(
-                    new ClientQuotaAlteration.Op("request_percentage", null)), filter, 0);
-
-                describeResult = alterThenDescribe(admin, entity,
-                    List.of(new ClientQuotaAlteration.Op("producer_byte_rate", 9999.0)), filter, 1);
-                assertEquals(9999.0, describeResult.get(entity).get("producer_byte_rate"), 1e-6);
-
-                ClientQuotaEntity entity2 = new ClientQuotaEntity(Map.of("user", "testkit", "client-id", "some-client"));
-                filter = ClientQuotaFilter.containsOnly(
-                    List.of(
-                        ClientQuotaFilterComponent.ofEntity("user", "testkit"),
-                        ClientQuotaFilterComponent.ofEntity("client-id", "some-client")
-                    ));
-                describeResult = alterThenDescribe(admin, entity2,
-                    List.of(new ClientQuotaAlteration.Op("producer_byte_rate", 9998.0)), filter, 1);
-                assertEquals(9998.0, describeResult.get(entity2).get("producer_byte_rate"), 1e-6);
-
-                final ClientQuotaFilter finalFilter = ClientQuotaFilter.contains(
-                    List.of(ClientQuotaFilterComponent.ofEntity("user", "testkit")));
-
-                TestUtils.waitForCondition(() -> {
-                    Map<ClientQuotaEntity, Map<String, Double>> results = admin.describeClientQuotas(finalFilter).entities().get();
-                    if (results.size() != 2) {
-                        return false;
-                    }
-                    assertEquals(9999.0, results.get(entity).get("producer_byte_rate"), 1e-6);
-                    assertEquals(9998.0, results.get(entity2).get("producer_byte_rate"), 1e-6);
-                    return true;
-                }, "Broker did not see two client quotas");
-            }
-        }
-    }
-
-    private void setConsumerByteRate(Admin admin, ClientQuotaEntity entity, Long value) throws Exception {
-        admin.alterClientQuotas(List.of(
-            new ClientQuotaAlteration(entity, List.of(
-                new ClientQuotaAlteration.Op("consumer_byte_rate", value.doubleValue())))
-        )).all().get();
-    }
-
-    private Map<ClientQuotaEntity, Long> getConsumerByteRates(Admin admin) throws Exception {
-        return admin.describeClientQuotas(ClientQuotaFilter.contains(List.of()))
-            .entities().get()
-            .entrySet().stream()
-            .filter(entry -> entry.getValue().containsKey("consumer_byte_rate"))
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> entry.getValue().get("consumer_byte_rate").longValue()
-            ));
-    }
-
-    @Test
-    public void testDefaultClientQuotas() throws Exception {
-        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
-            new TestKitNodes.Builder()
-                .setNumBrokerNodes(1)
-                .setNumControllerNodes(1)
-                .build()).build()) {
-            cluster.format();
-            cluster.startup();
-            TestUtils.waitForCondition(() -> cluster.brokers().get(0).brokerState() == BrokerState.RUNNING,
-                "Broker never made it to RUNNING state.");
-
-            try (Admin admin = cluster.admin()) {
-                ClientQuotaEntity defaultUser = new ClientQuotaEntity(Collections.singletonMap("user", null));
-                ClientQuotaEntity bobUser = new ClientQuotaEntity(Map.of("user", "bob"));
-
-                TestUtils.waitForCondition(
-                    () -> getConsumerByteRates(admin).isEmpty(),
-                    "Initial consumer byte rates should be empty");
-
-                setConsumerByteRate(admin, defaultUser, 100L);
-                TestUtils.waitForCondition(() -> {
-                    Map<ClientQuotaEntity, Long> rates = getConsumerByteRates(admin);
-                    return rates.size() == 1 &&
-                        rates.get(defaultUser) == 100L;
-                }, "Default user rate should be 100");
-
-                setConsumerByteRate(admin, bobUser, 1000L);
-                TestUtils.waitForCondition(() -> {
-                    Map<ClientQuotaEntity, Long> rates = getConsumerByteRates(admin);
-                    return rates.size() == 2 &&
-                        rates.get(defaultUser) == 100L &&
-                        rates.get(bobUser) == 1000L;
-                }, "Should have both default and bob user rates");
-            }
-        }
     }
 
     @Test


### PR DESCRIPTION
This PR moves several AdminClient-focused tests out of
`KRaftClusterTest` and into the `clients-integration-tests` module.

### Changes

- Move topic creation and deletion tests to the corresponding
AdminClient integration test classes.
- Move client quota tests to a new `ClientQuotasTest`.
- Rewrite the moved tests to use `ClusterInstance` and `@ClusterTest`.
- Remove the corresponding tests, helpers, and unused imports from
`KRaftClusterTest`.

### Testing
```shell
./gradlew :clients:clients-integration-tests:test \
  --tests '*ClientQuotasTest' \
  --tests '*CreateTopicsTest' \
  --tests '*DeleteTopicTest.testCreateClusterAndCreateListDeleteTopic'
  ```

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>, Ming-Yen Chung <mingyen066@gmail.com>
