### PR TITLE
MINOR: Clean up SSL support for ClusterTestExtensions

### DIFF
--- a/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/TestKitNodes.java
+++ b/test-common/test-common-runtime/src/main/java/org/apache/kafka/common/test/TestKitNodes.java
@@ -162,17 +162,6 @@ public class TestKitNodes {
             if (numDisksPerBroker <= 0) {
                 throw new IllegalArgumentException("Invalid value for numDisksPerBroker");
             }
-            var supportedProtocols = List.of(
-                    SecurityProtocol.PLAINTEXT,
-                    SecurityProtocol.SASL_PLAINTEXT,
-                    SecurityProtocol.SASL_SSL,
-                    SecurityProtocol.SSL
-            );
-            if (!supportedProtocols.contains(brokerSecurityProtocol) || !supportedProtocols.contains(controllerSecurityProtocol)) {
-                throw new IllegalArgumentException(String.format("Currently only support %s security protocol",
-                        supportedProtocols.stream().map(sp -> sp.name).collect(Collectors.joining(" / ")))
-                );
-            }
             if ((brokerSecurityProtocol == SecurityProtocol.SSL) != (controllerSecurityProtocol == SecurityProtocol.SSL)) {
                 throw new IllegalArgumentException("Mixed broker and controller SSL security protocol configurations are not yet supported");
             }

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
@@ -69,7 +69,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -612,7 +611,7 @@ public class ClusterTestExtensionsTest {
     public void testSsl(ClusterInstance clusterInstance) throws InterruptedException, ExecutionException {
         KafkaBroker broker = clusterInstance.brokers().values().iterator().next();
         ControllerServer controller = clusterInstance.controllers().values().iterator().next();
-        Function<SocketServer, String> endpoints = socketServer -> Collections.list(socketServer.dataPlaneAcceptors().keys())
+        Function<SocketServer, String> endpoints = socketServer -> socketServer.dataPlaneAcceptors().keySet()
                 .stream().map(endpoint -> String.format("%s:%s", endpoint.listener(), endpoint.securityProtocol())).collect(Collectors.joining(","));
         assertEquals("EXTERNAL:SSL", endpoints.apply(broker.socketServer()));
         assertEquals("CONTROLLER:SSL", endpoints.apply(controller.socketServer()));


### PR DESCRIPTION
This PR addresses two follow-up review comments from #22184:

- Remove the redundant security protocol allowlist, which enumerated
every `SecurityProtocol` value.
- Simplify SSL endpoint collection by using
`dataPlaneAcceptors().keySet()` directly.

Mixed broker and controller security protocol handling remains unchanged
and can be addressed separately.

### Testing

```bash
./gradlew :test-common:test-common-runtime:test \
  --tests org.apache.kafka.common.test.TestKitNodeTest \
  --tests
org.apache.kafka.common.test.junit.ClusterTestExtensionsTest.testSsl

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
