### PR TITLE
MINOR: Fix RandomAccessFile leak in FileRecords.openChannel

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
@@ -487,8 +487,13 @@ public class FileRecords extends AbstractRecords implements Closeable {
                         StandardOpenOption.WRITE);
             } else {
                 RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
-                randomAccessFile.setLength(initFileSize);
-                return randomAccessFile.getChannel();
+                try {
+                    randomAccessFile.setLength(initFileSize);
+                    return randomAccessFile.getChannel();
+                } catch (IOException e) {
+                    randomAccessFile.close();
+                    throw e;
+                }
             }
         } else {
             return FileChannel.open(file.toPath());


### PR DESCRIPTION
`randomAccessFile` is leaked when `setLength` throws. This change wraps
the call in a try-catch that closes the file before re-throwing.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
