### PR TITLE
KAFKA-20831: Cache SASL principal per authentication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -139,6 +139,9 @@ public class SaslServerAuthenticator implements Authenticator {
     private AuthenticationException pendingException = null;
     private SaslServer saslServer;
     private String saslMechanism;
+    // The authenticated principal is connection-scoped. Cache it after the first build since principal() is invoked
+    // for every request. Re-authentication installs a new SaslServerAuthenticator, and therefore a fresh cache.
+    private KafkaPrincipal principal;
 
     // buffers used in `authenticate`
     private Integer saslAuthRequestMaxReceiveSize;
@@ -305,14 +308,18 @@ public class SaslServerAuthenticator implements Authenticator {
 
     @Override
     public KafkaPrincipal principal() {
+        if (principal != null)
+            return principal;
+
         Optional<SSLSession> sslSession = transportLayer instanceof SslTransportLayer ?
                 Optional.of(((SslTransportLayer) transportLayer).sslSession()) : Optional.empty();
         SaslAuthenticationContext context = new SaslAuthenticationContext(saslServer, securityProtocol,
                 clientAddress(), listenerName.value(), sslSession);
-        KafkaPrincipal principal = principalBuilder.build(context);
+        KafkaPrincipal builtPrincipal = principalBuilder.build(context);
         if (ScramMechanism.isScram(saslMechanism) && Boolean.parseBoolean((String) saslServer.getNegotiatedProperty(ScramLoginModule.TOKEN_AUTH_CONFIG))) {
-            principal.tokenAuthenticated(true);
+            builtPrincipal.tokenAuthenticated(true);
         }
+        principal = builtPrincipal;
         return principal;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -140,7 +140,8 @@ public class SaslServerAuthenticator implements Authenticator {
     private SaslServer saslServer;
     private String saslMechanism;
     // The authenticated principal is connection-scoped. Cache it after the first build since principal() is invoked
-    // for every request. Re-authentication installs a new SaslServerAuthenticator, and therefore a fresh cache.
+    // for every request. It is only accessed by the Processor thread, so no synchronization is needed.
+    // Re-authentication installs a new SaslServerAuthenticator, and therefore a fresh cache.
     private KafkaPrincipal principal;
 
     // buffers used in `authenticate`

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -217,6 +217,32 @@ public class SaslAuthenticatorTest {
         checkAuthenticationAndReauthentication(securityProtocol, node);
     }
 
+    @Test
+    public void testPrincipalBuiltOncePerAuthentication() throws Exception {
+        String node = "0";
+        time = new MockTime();
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_PLAINTEXT;
+        configureMechanisms("PLAIN", Collections.singletonList("PLAIN"));
+        saslServerConfigs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG,
+                CountingKafkaPrincipalBuilder.class);
+        CountingKafkaPrincipalBuilder.BUILD_COUNT.set(0);
+
+        server = createEchoServer(securityProtocol);
+        createClientConnection(securityProtocol, node);
+        checkClientConnection(node);
+        server.selector().channels().get(0).principal();
+        server.selector().channels().get(0).principal();
+        assertEquals(1, CountingKafkaPrincipalBuilder.BUILD_COUNT.get(),
+                "Principal should be built only once for repeated access on a connection");
+
+        time.sleep((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
+        checkClientConnection(node);
+        server.verifyReauthenticationMetrics(1, 0);
+        server.selector().channels().get(0).principal();
+        assertEquals(2, CountingKafkaPrincipalBuilder.BUILD_COUNT.get(),
+                "A successful re-authentication should build and cache a new principal");
+    }
+
     /**
      * Test SASL/PLAIN with sasl.authentication.max.receive.size config
      */
@@ -2761,6 +2787,27 @@ public class SaslAuthenticatorTest {
 
         static KafkaPrincipal saslSslPrincipal(String saslPrincipal, String sslPrincipal) {
             return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslPrincipal + ":" + sslPrincipal);
+        }
+
+        @Override
+        public byte[] serialize(KafkaPrincipal principal) {
+            return new byte[0];
+        }
+
+        @Override
+        public KafkaPrincipal deserialize(byte[] bytes) {
+            return null;
+        }
+    }
+
+    public static class CountingKafkaPrincipalBuilder implements KafkaPrincipalBuilder {
+        private static final AtomicInteger BUILD_COUNT = new AtomicInteger();
+
+        @Override
+        public KafkaPrincipal build(AuthenticationContext context) {
+            SaslAuthenticationContext saslContext = (SaslAuthenticationContext) context;
+            BUILD_COUNT.incrementAndGet();
+            return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslContext.server().getAuthorizationID());
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -178,6 +178,7 @@ public class SaslAuthenticatorTest {
         saslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         credentialCache = new CredentialCache();
         TestLogin.loginCount.set(0);
+        CountingKafkaPrincipalBuilder.buildCount = 0;
     }
 
     @AfterEach
@@ -225,21 +226,20 @@ public class SaslAuthenticatorTest {
         configureMechanisms("PLAIN", Collections.singletonList("PLAIN"));
         saslServerConfigs.put(BrokerSecurityConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG,
                 CountingKafkaPrincipalBuilder.class);
-        CountingKafkaPrincipalBuilder.BUILD_COUNT.set(0);
 
         server = createEchoServer(securityProtocol);
         createClientConnection(securityProtocol, node);
         checkClientConnection(node);
         server.selector().channels().get(0).principal();
         server.selector().channels().get(0).principal();
-        assertEquals(1, CountingKafkaPrincipalBuilder.BUILD_COUNT.get(),
+        assertEquals(1, CountingKafkaPrincipalBuilder.buildCount,
                 "Principal should be built only once for repeated access on a connection");
 
         time.sleep((long) (CONNECTIONS_MAX_REAUTH_MS_VALUE * 1.1));
         checkClientConnection(node);
         server.verifyReauthenticationMetrics(1, 0);
         server.selector().channels().get(0).principal();
-        assertEquals(2, CountingKafkaPrincipalBuilder.BUILD_COUNT.get(),
+        assertEquals(2, CountingKafkaPrincipalBuilder.buildCount,
                 "A successful re-authentication should build and cache a new principal");
     }
 
@@ -2801,12 +2801,12 @@ public class SaslAuthenticatorTest {
     }
 
     public static class CountingKafkaPrincipalBuilder implements KafkaPrincipalBuilder {
-        private static final AtomicInteger BUILD_COUNT = new AtomicInteger();
+        private static int buildCount;
 
         @Override
         public KafkaPrincipal build(AuthenticationContext context) {
             SaslAuthenticationContext saslContext = (SaslAuthenticationContext) context;
-            BUILD_COUNT.incrementAndGet();
+            buildCount++;
             return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslContext.server().getAuthorizationID());
         }
 


### PR DESCRIPTION
## Summary

- Cache the `KafkaPrincipal` built by `SaslServerAuthenticator` for the
lifetime of an authenticated connection.
- Continue to build a new principal after successful SASL
re-authentication, which installs a new authenticator.
- Add regression coverage for repeated principal access and
re-authentication.

## Motivation

`KafkaChannel.principal()` is consulted while request contexts are
constructed. The current SASL implementation creates a new
`SaslAuthenticationContext` and invokes the configured
`KafkaPrincipalBuilder` on every call, even though the authenticated
identity is connection-scoped.

Custom principal builders may perform non-trivial work or have side
effects. Reusing the principal produced for the authenticated session
avoids redundant work and ensures repeated access observes the same
principal instance.

## Compatibility

This change introduces no public API or configuration changes. Initial
authentication behavior is unchanged. During re-authentication Kafka
installs a new `SaslServerAuthenticator`, so the new authenticated
session receives a fresh principal.

## Validation

```text
./gradlew :clients:test --tests
'org.apache.kafka.common.security.authenticator.SaslAuthenticatorTest'
./gradlew spotlessCheck :clients:checkstyleMain :clients:checkstyleTest
:clients:spotbugsMain -x test
```

The test suite covers PLAIN, SCRAM, OAuth bearer, SSL, token
authentication, and SASL re-authentication paths.

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>, Luke Chen
 <showuon@gmail.com>
