### PR TITLE
KAFKA-20813 Add Podman support to Docker image build tests

### DIFF
--- a/docker/common.py
+++ b/docker/common.py
@@ -45,7 +45,7 @@ def build_docker_image_runner(command, image_type, kafka_archive=None):
     try:
         execute(command.split())
     except:
-        raise SystemError("Docker Image Build failed")
+        raise SystemError(f"{container_runtime.capitalize()} image build failed")
     finally:
         shutil.rmtree(temp_dir_path)
 

--- a/docker/common.py
+++ b/docker/common.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 import subprocess
 import tempfile
 import os
@@ -38,14 +39,20 @@ def build_docker_image_runner(command, image_type, kafka_archive=None):
     shutil.copytree(f"{current_dir}/{image_type}", f"{temp_dir_path}/{image_type}", dirs_exist_ok=True)
     shutil.copytree(f"{current_dir}/resources", f"{temp_dir_path}/{image_type}/resources", dirs_exist_ok=True)
     shutil.copy(f"{current_dir}/server.properties", f"{temp_dir_path}/{image_type}")
+
+    kafka_archive_path = Path(temp_dir_path) / image_type / "kafka.tgz"
     if kafka_archive:
-        shutil.copy(kafka_archive, f"{temp_dir_path}/{image_type}/kafka.tgz")
+        shutil.copy(kafka_archive, kafka_archive_path)
+    else:
+        # Podman requires the COPY source to exist before kafka_url is
+        # downloaded by the Dockerfile.
+        kafka_archive_path.touch()
     command = command.replace("$DOCKER_FILE", f"{temp_dir_path}/{image_type}/Dockerfile")
     command = command.replace("$DOCKER_DIR", f"{temp_dir_path}/{image_type}")
     try:
         execute(command.split())
-    except:
-        raise SystemError(f"{container_runtime.capitalize()} image build failed")
+    except Exception as e:
+        raise SystemError("Container image build failed") from e
     finally:
         shutil.rmtree(temp_dir_path)
 

--- a/docker/common.py
+++ b/docker/common.py
@@ -20,6 +20,8 @@ import tempfile
 import os
 import shutil
 
+SUPPORTED_CONTAINER_RUNTIMES = ("docker", "podman")
+
 def execute(command):
     if subprocess.run(command).returncode != 0:
         raise SystemError("Failure in executing following command:- ", " ".join(command))
@@ -46,3 +48,27 @@ def build_docker_image_runner(command, image_type, kafka_archive=None):
         raise SystemError("Docker Image Build failed")
     finally:
         shutil.rmtree(temp_dir_path)
+
+def detect_container_runtime():
+    configured_runtime = os.environ.get("CONTAINER_RUNTIME")
+
+    if configured_runtime:
+        if configured_runtime not in SUPPORTED_CONTAINER_RUNTIMES:
+            raise ValueError(
+                f"Unsupported container runtime: {configured_runtime}. "
+                f"Supported runtimes: {', '.join(SUPPORTED_CONTAINER_RUNTIMES)}"
+            )
+        if shutil.which(configured_runtime) is None:
+            raise RuntimeError(
+                f"Container runtime '{configured_runtime}' was not found"
+            )
+        return configured_runtime
+
+    for runtime in SUPPORTED_CONTAINER_RUNTIMES:
+        if shutil.which(runtime):
+            return runtime
+
+    raise RuntimeError(
+        "No supported container runtime found. "
+        "Please install Docker or Podman, or set CONTAINER_RUNTIME."
+    )

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         if args.kafka_url:
             build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url={args.kafka_url} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type)
         elif args.kafka_archive:
-            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type, args.kafka_archive)
+            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url= --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type, args.kafka_archive)
 
     if args.test_only or not (args.build_only or args.test_only):
         run_docker_tests(args.image, args.tag, args.kafka_url, args.image_type, container_runtime)

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -43,6 +43,13 @@ import tempfile
 import os
 
 def run_docker_tests(image, tag, kafka_url, image_type, container_runtime="docker"):
+    compose_command = f"{container_runtime}-compose"
+    if shutil.which(compose_command) is None:
+        raise RuntimeError(
+            f"Required Compose command '{compose_command}' was not found. "
+            "Please install it and ensure it is available on PATH."
+        )
+
     temp_dir_path = tempfile.mkdtemp()
     try:
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -81,7 +88,7 @@ if __name__ == '__main__':
         if args.kafka_url:
             build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url={args.kafka_url} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type)
         elif args.kafka_archive:
-            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url= --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type, args.kafka_archive)
+            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type, args.kafka_archive)
 
     if args.test_only or not (args.build_only or args.test_only):
         run_docker_tests(args.image, args.tag, args.kafka_url, args.image_type, container_runtime)

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -77,34 +77,11 @@ if __name__ == '__main__':
 
     container_runtime = detect_container_runtime()
 
-    progress_option = (
-        "--progress=plain"
-        if container_runtime == "docker"
-        else ""
-    )
-
     if args.build_only or not (args.build_only or args.test_only):
-        kafka_build_arg = (
-            f"--build-arg kafka_url={args.kafka_url}"
-            if args.kafka_url
-            else ""
-        )
-
-        command = (
-            f"{container_runtime} build "
-            f"-f $DOCKER_FILE "
-            f"-t {args.image}:{args.tag} "
-            f"{kafka_build_arg} "
-            f"--build-arg build_date={date.today()} "
-            f"--no-cache {progress_option} "
-            f"$DOCKER_DIR"
-        )
-
-        build_docker_image_runner(
-            command,
-            args.image_type,
-            args.kafka_archive,
-        )
+        if args.kafka_url:
+            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url={args.kafka_url} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type)
+        elif args.kafka_archive:
+            build_docker_image_runner(f"{container_runtime} build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg build_date={date.today()} --no-cache $DOCKER_DIR", args.image_type, args.kafka_archive)
 
     if args.test_only or not (args.build_only or args.test_only):
         run_docker_tests(args.image, args.tag, args.kafka_url, args.image_type, container_runtime)

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -38,11 +38,11 @@ from datetime import date
 import argparse
 import shutil
 from test.docker_sanity_test import run_tests
-from common import execute, build_docker_image_runner
+from common import execute, build_docker_image_runner, detect_container_runtime
 import tempfile
 import os
 
-def run_docker_tests(image, tag, kafka_url, image_type):
+def run_docker_tests(image, tag, kafka_url, image_type, container_runtime="docker"):
     temp_dir_path = tempfile.mkdtemp()
     try:
         current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -50,7 +50,7 @@ def run_docker_tests(image, tag, kafka_url, image_type):
         execute(["wget", "-nv", "-O", f"{temp_dir_path}/kafka.tgz", kafka_url])
         execute(["mkdir", f"{temp_dir_path}/fixtures/kafka"])
         execute(["tar", "xfz", f"{temp_dir_path}/kafka.tgz", "-C", f"{temp_dir_path}/fixtures/kafka", "--strip-components", "1"])
-        failure_count = run_tests(f"{image}:{tag}", image_type, temp_dir_path)
+        failure_count = run_tests(f"{image}:{tag}", image_type, temp_dir_path, container_runtime)
     except:
         raise SystemError("Failed to run the tests")
     finally:
@@ -75,11 +75,36 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    container_runtime = detect_container_runtime()
+
+    progress_option = (
+        "--progress=plain"
+        if container_runtime == "docker"
+        else ""
+    )
+
     if args.build_only or not (args.build_only or args.test_only):
-        if args.kafka_url:
-            build_docker_image_runner(f"docker build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg kafka_url={args.kafka_url} --build-arg build_date={date.today()} --no-cache --progress=plain $DOCKER_DIR", args.image_type)
-        elif args.kafka_archive:
-            build_docker_image_runner(f"docker build -f $DOCKER_FILE -t {args.image}:{args.tag} --build-arg build_date={date.today()} --no-cache --progress=plain $DOCKER_DIR", args.image_type, args.kafka_archive)
-    
+        kafka_build_arg = (
+            f"--build-arg kafka_url={args.kafka_url}"
+            if args.kafka_url
+            else ""
+        )
+
+        command = (
+            f"{container_runtime} build "
+            f"-f $DOCKER_FILE "
+            f"-t {args.image}:{args.tag} "
+            f"{kafka_build_arg} "
+            f"--build-arg build_date={date.today()} "
+            f"--no-cache {progress_option} "
+            f"$DOCKER_DIR"
+        )
+
+        build_docker_image_runner(
+            command,
+            args.image_type,
+            args.kafka_archive,
+        )
+
     if args.test_only or not (args.build_only or args.test_only):
-        run_docker_tests(args.image, args.tag, args.kafka_url, args.image_type)
+        run_docker_tests(args.image, args.tag, args.kafka_url, args.image_type, container_runtime)

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -28,9 +28,7 @@ class DockerSanityTest(unittest.TestCase):
     CONTAINER_RUNTIME="docker"
 
     def compose_command(self):
-        if self.CONTAINER_RUNTIME == "podman":
-            return ["podman", "compose"]
-        return ["docker-compose"]
+        return [f"{self.CONTAINER_RUNTIME}-compose"]
 
     def resume_container(self):
         subprocess.run([self.CONTAINER_RUNTIME, "start", constants.BROKER_CONTAINER])

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -25,12 +25,18 @@ class DockerSanityTest(unittest.TestCase):
     IMAGE="apache/kafka"
     FIXTURES_DIR="."
     MODE="jvm"
-    
+    CONTAINER_RUNTIME="docker"
+
+    def compose_command(self):
+        if self.CONTAINER_RUNTIME == "podman":
+            return ["podman", "compose"]
+        return ["docker-compose"]
+
     def resume_container(self):
-        subprocess.run(["docker", "start", constants.BROKER_CONTAINER])
+        subprocess.run([self.CONTAINER_RUNTIME, "start", constants.BROKER_CONTAINER])
 
     def stop_container(self) -> None:
-        subprocess.run(["docker", "stop", constants.BROKER_CONTAINER])
+        subprocess.run([self.CONTAINER_RUNTIME, "stop", constants.BROKER_CONTAINER])
 
     def update_file(self, filename, old_string, new_string):
         with open(filename) as f:
@@ -42,10 +48,10 @@ class DockerSanityTest(unittest.TestCase):
     def start_compose(self, filename) -> None:
         self.update_file(filename, "image: {$IMAGE}", f"image: {self.IMAGE}")
         self.update_file(f"{self.FIXTURES_DIR}/{constants.SSL_CLIENT_CONFIG}", "{$DIR}", self.FIXTURES_DIR)
-        subprocess.run(["docker-compose", "-f", filename, "up", "-d"])
-    
+        subprocess.run(self.compose_command() + ["-f", filename, "up", "-d"])
+
     def destroy_compose(self, filename) -> None:
-        subprocess.run(["docker-compose", "-f", filename, "down"])
+        subprocess.run(self.compose_command() + ["-f", filename, "down"])
         self.update_file(filename, f"image: {self.IMAGE}", "image: {$IMAGE}")
         self.update_file(f"{self.FIXTURES_DIR}/{constants.SSL_CLIENT_CONFIG}", self.FIXTURES_DIR, "{$DIR}")
 
@@ -221,10 +227,11 @@ class DockerSanityTestIsolatedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
-def run_tests(image, mode, fixtures_dir):
+def run_tests(image, mode, fixtures_dir, container_runtime="docker"):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
     DockerSanityTest.MODE = mode
+    DockerSanityTest.CONTAINER_RUNTIME = container_runtime
 
     test_classes_to_run = []
     if mode == "jvm" or mode == "native":


### PR DESCRIPTION
This PR adds Podman support to the Docker image build and sanity-test
scripts.

The container runtime can be selected through `CONTAINER_RUNTIME`. When
it is  not specified, Docker is preferred and Podman is used as a
fallback, following  the behavior used by the system-test scripts.

The selected runtime is used throughout the build and test flow. Podman
builds  images with `podman build`, runs Compose through `podman
compose`, and uses  `podman start/stop` for the broker restart test.
Docker continues to use the  existing `docker-compose` workflow. The
Docker-specific `--progress=plain`  option is omitted when building with
Podman.

Testing performed:

- Verified runtime detection and build command generation.
- Verified Python syntax and formatting.
- Tested Podman build, Compose up/down, and container start/stop.
- Tested the combined and isolated Kafka Compose fixtures using
  `podman-compose`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Maros Orsak
 <maros.orsak159@gmail.com>
