### PR TITLE
MINOR: increase build timeout to 3.5 hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           test-task: test
-          timeout-minutes: 180  # 3 hours
+          timeout-minutes: 210  # 3.5 hours -- capped at 6 hours
           test-catalog-path: ${{ steps.load-test-catalog.outputs.download-path }}/combined-test-catalog.txt
           build-scan-artifact-name: build-scan-${{ env.job-variation }}
           run-new-tests: ${{ matrix.run-new }}


### PR DESCRIPTION
Current p95 build time is about 2:50h, and we did see an increased
number of PR build failures due do hitting the current 3h limit.

As a short term solution, this PR increases the timeout to 3.5h. We
should work with INFRA to maybe get better hardward to reducee the
runtime.

Reviewers: Bill Bejeck<bbejeck@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
