### PR TITLE
MINOR: Fix KStream leftJoin doc and test param naming for KStream-GlobalKTable 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1433,8 +1433,10 @@ public interface KStream<K, V> {
      * or the {@code KStreams} input record's key for a left-join result.
      * If you need read access to the {@code KStream} key or the {@link GlobalKTable} key (which is the same as the
      * join key extracted by {@code keySelector}), use {@link #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithStreamAndMappedKey)}.
-     * If a {@code KStream} input record's value is {@code null} or if the provided {@link KeyValueMapper keySelector}
-     * returns {@code null}, the input record will be dropped, and no join computation is triggered.
+     * If a {@code KStream} input record's value is {@code null}, the input record will be dropped,
+     * and no join computation is triggered.
+     * If the provided {@link KeyValueMapper keySelector} returns {@code null}, the record will be treated as a non-match
+     * and {@link ValueJoiner} will be called with a {@code null} value for the global table record.
      * Note, that {@code null} keys for {@code KStream} input records are supported (in contrast to
      * {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner join}) resulting in a left join result.
      * If a {@link GlobalKTable} input record's key is {@code null} the input record will be dropped, and the table

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoinTest.java
@@ -437,7 +437,7 @@ public class KStreamGlobalKTableJoinTest {
             table,
             (KeyValueMapper<Integer, String, String>) (k, v) -> v,
             (ValueJoinerWithStreamAndMappedKey<Integer, String, String, String, String>)
-                (mk, sk, v1, v2) -> v1 + v2,
+                (streamKey, mappedKey, v1, v2) -> v1 + v2,
             Named.as("join-table"));
         assertThat(builder.build().describe().toString(), containsString("Processor: join-table"));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableLeftJoinTest.java
@@ -505,7 +505,7 @@ public class KStreamGlobalKTableLeftJoinTest {
         stream.leftJoin(
             table,
             (KeyValueMapper<Integer, String, String>) (k, v) -> v,
-            (ValueJoinerWithStreamAndMappedKey<Integer, String, String, String, String>) (mk, sk, v1, v2) -> v1 + v2,
+            (ValueJoinerWithStreamAndMappedKey<Integer, String, String, String, String>) (streamKey, mappedKey, v1, v2) -> v1 + v2,
             Named.as("left-join-table"));
 
         assertThat(builder.build().describe().toString(), containsString("Processor: left-join-table"));


### PR DESCRIPTION
This PR fixes:
- Wrong description regarding leftJoin(GlobalKTable, ...) Javadoc when
keySelector is null
- Wrong param ordering for ValueJoinerWithStreamAndMappedKey for 2 unit
tests

Reviewers: Matthias J. Sax <matthias@confluent.io>
