### PR TITLE
KAFKA-20722: Upgrade JLine to 3.30.14

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -307,7 +307,7 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-3.30.4, see: licenses/jline-BSD-3-clause
+- jline-3.30.14, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ versions += [
   jetty: "12.0.34",
   jersey: "3.1.10",
   jgit: "7.6.0.202603022253-r",
-  jline: "3.30.4",
+  jline: "3.30.14",
   jmh: "1.37",
   hamcrest: "3.0",
   scalaLogging: "3.9.6",


### PR DESCRIPTION
## Summary

- Upgrade JLine from 3.30.4 to 3.30.14, the public 3.x release containing backports for GHSA-47qp-hqvx-6r3f and GHSA-2r2c-cx56-8933.
- Update the matching JLine entry in `LICENSE-binary`.

Jira: https://issues.apache.org/jira/browse/KAFKA-20722

Public advisories:
- https://github.com/advisories/GHSA-47qp-hqvx-6r3f
- https://github.com/advisories/GHSA-2r2c-cx56-8933

## Rationale

Kafka currently packages the JLine 3.30.4 aggregate jar in the shell runtime. JLine 3.30.14 is the patch-line update that publicly backports both telnet denial-of-service mitigations, avoiding a JLine 4.x migration.

## Testing

- `./gradlew :shell:dependencyInsight --dependency org.jline:jline --configuration runtimeClasspath`
- `./gradlew :shell:copyDependantLibs :shell:test`
- Confirmed the copied runtime artifact is `jline-3.30.14.jar`.
- `git diff --check` and exact two-file scope verification.

Generated-by: OpenAI Codex (GPT-5.6)
Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
