### PR TITLE
KAFKA-20820: make symlinked log.dirs possible when on JDK17

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java
@@ -37,7 +37,9 @@ import org.apache.kafka.snapshot.Snapshots;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -449,7 +451,7 @@ public class Formatter {
                 printStream.printf("Formatting %s %s with %s %s.%n",
                     directoryType.description(), writeLogDir,
                     MetadataVersion.FEATURE_NAME, releaseVersion);
-                Files.createDirectories(Paths.get(writeLogDir));
+                createLogDirectory(Paths.get(writeLogDir));
                 if (writeBootstrapSnapshot && directoryType.isMetadataDirectory()) {
                     writeBoostrapSnapshot(writeLogDir,
                         bootstrapMetadata,
@@ -463,6 +465,18 @@ public class Formatter {
                         errorLogDir + ": " + e);
             });
             copier.writeLogDirChanges();
+        }
+    }
+
+    // On JDK < 20, Files.createDirectories throws FileAlreadyExistsException when the
+    // path is a symbolic link to an existing directory (JDK-8294193).
+    static void createLogDirectory(Path dir) throws java.io.IOException {
+        try {
+            Files.createDirectories(dir);
+        } catch (FileAlreadyExistsException e) {
+            if (!Files.isDirectory(dir)) {
+                throw e;
+            }
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -53,6 +53,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -606,6 +608,68 @@ public class FormatterTest {
             assertNotNull(logDirProps0);
             MetaProperties logDirProps1 = ensemble.logDirProps().get(testEnv.directory(1));
             assertNotNull(logDirProps1);
+        }
+    }
+
+    @Test
+    public void testFormatWithSymbolicLinkLogDir() throws Exception {
+        Path tempDir = Files.createTempDirectory("kafka-symlink-test");
+        Path realDir = tempDir.resolve("real-log-dir");
+        Files.createDirectory(realDir);
+        Path symlinkDir = tempDir.resolve("symlink-log-dir");
+        Files.createSymbolicLink(symlinkDir, realDir);
+
+        try {
+            String symlinkPath = symlinkDir.toAbsolutePath().toString();
+            Formatter formatter = new Formatter()
+                .setNodeId(DEFAULT_NODE_ID)
+                .setClusterId(DEFAULT_CLUSTER_ID.toString());
+            formatter.addDirectory(symlinkPath);
+            formatter.setMetadataLogDirectory(symlinkPath);
+            FormatterContext context = new FormatterContext(formatter);
+            context.formatter.run();
+
+            MetaPropertiesEnsemble ensemble = new MetaPropertiesEnsemble.Loader()
+                .addLogDirs(List.of(symlinkPath))
+                .load();
+            assertEquals(OptionalInt.of(DEFAULT_NODE_ID), ensemble.nodeId());
+            assertEquals(Optional.of(DEFAULT_CLUSTER_ID.toString()), ensemble.clusterId());
+            assertTrue(ensemble.logDirProps().containsKey(symlinkPath));
+        } finally {
+            Utils.delete(tempDir.toFile());
+        }
+    }
+
+    @Test
+    public void testCreateLogDirectoryWithSymlink() throws Exception {
+        Path tempDir = Files.createTempDirectory("kafka-symlink-test");
+        Path realDir = tempDir.resolve("real-log-dir");
+        Files.createDirectory(realDir);
+        Path symlinkDir = tempDir.resolve("symlink-log-dir");
+        Files.createSymbolicLink(symlinkDir, realDir);
+
+        try {
+            // Should succeed on a symlink to an existing directory
+            assertDoesNotThrow(() -> Formatter.createLogDirectory(symlinkDir));
+            assertTrue(Files.isDirectory(symlinkDir));
+
+            // Should succeed on a regular directory
+            assertDoesNotThrow(() -> Formatter.createLogDirectory(realDir));
+
+            // Should succeed on a non-existent path (creates it)
+            Path newDir = tempDir.resolve("new-dir");
+            assertDoesNotThrow(() -> Formatter.createLogDirectory(newDir));
+            assertTrue(Files.isDirectory(newDir));
+
+            // Should throw on a symlink to a regular file
+            Path regularFile = tempDir.resolve("regular-file");
+            Files.createFile(regularFile);
+            Path symlinkToFile = tempDir.resolve("symlink-to-file");
+            Files.createSymbolicLink(symlinkToFile, regularFile);
+            assertThrows(java.nio.file.FileAlreadyExistsException.class,
+                () -> Formatter.createLogDirectory(symlinkToFile));
+        } finally {
+            Utils.delete(tempDir.toFile());
         }
     }
 }


### PR DESCRIPTION
The issue already came up earlier on the mailing list https://lists.apache.org/thread/ro8mbk70xstywz5yw7mlm4yoswcfqlp5

The bug can be reproduced by pointing log.dirs to a symlinked path, e.g.:

/kafka/1/dd -> /navencrypt/1/kafka/kafka/1/dd

The storage format step attempts to write the required meta.properties file to the configured log directory and fails with:

Error while writing meta.properties file /kafka/3/dd:
java.nio.file.FileAlreadyExistsException: /kafka/3/dd

The broker later exits with:

java.lang.RuntimeException: No readable meta.properties files found.

Based on my research the root cause is  a bug in JDK's Files.createDirectories which was addressed in https://bugs.openjdk.org/browse/JDK-8294193 and shipped in JDK 20.

Specific code location in Kafka https://github.com/apache/kafka/blob/8fc539cb383c34e44bdb31721e0643faf453b8e6/metadata/src/main/java/org/apache/kafka/metadata/storage/Formatter.java#L452

To conclude, Kafka 4.x is committed to use JDK17 and there is no real restriction on why symlinked paths could not be used for log dirs. Also this bug prevents to use certain tools like NavEncrypt which could handle encryption at rest.

I would propose a simple fix to also make symlinked log.dirs possible when on JDK17.

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>
