### PR TITLE
KAFKA-20821: DeleteRecordsCommand exits non-zero on per-partition errors

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
@@ -143,13 +143,23 @@ public class DeleteRecordsCommand {
         DeleteRecordsResult deleteRecordsResult = adminClient.deleteRecords(recordsToDelete);
         out.println("Records delete operation completed:");
 
+        Map<TopicPartition, String> failures = new HashMap<>();
         deleteRecordsResult.lowWatermarks().forEach((tp, partitionResult) -> {
             try {
                 out.printf("partition: %s\tlow_watermark: %s%n", tp, partitionResult.get().lowWatermark());
             } catch (InterruptedException | ExecutionException e) {
                 out.printf("partition: %s\terror: %s%n", tp, e.getMessage());
+                failures.put(tp, e.getMessage());
             }
         });
+
+        if (!failures.isEmpty()) {
+            StringJoiner failed = new StringJoiner(", ");
+            failures.forEach((tp, message) -> failed.add(tp + ": " + message));
+            throw new AdminCommandFailedException(
+                String.format("Failed to delete records for %d partition(s): %s", failures.size(), failed)
+            );
+        }
     }
 
     private static Admin createAdminClient(DeleteRecordsCommandOptions opts) throws IOException {

--- a/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
@@ -81,11 +81,13 @@ public class DeleteRecordsCommandTest {
                 admin
             );
 
-            executeAndAssertOutput(
-                "{\"partitions\":[{\"topic\":\"t\", \"partition\":42, \"offset\":42}]}",
-                "partition: t-42\terror",
-                admin
-            );
+            String errorOutput = ToolsTestUtils.captureStandardOut(() ->
+                assertThrows(
+                    AdminCommandFailedException.class,
+                    () -> DeleteRecordsCommand.execute(admin,
+                        "{\"partitions\":[{\"topic\":\"t\", \"partition\":42, \"offset\":42}]}", System.out)
+                ));
+            assertTrue(errorOutput.contains("partition: t-42\terror"));
         }
     }
 


### PR DESCRIPTION
`kafka-delete-records.sh` previously exited 0 even when individual
partitions failed, hiding errors from callers/tests. It now returns a
non-zero status when any partition result carries an error.

Disclaimer: returning 1 instead of 0 is a behavior change for the tool,
however the current behavior isn't entirely consistent across other
tools (like LeaderElectionCommand), therefore I think we can consider
this as a bug.
