### PR TITLE
KAFKA-16262: Add IQv2 to Kafka Streams documentation

### DIFF
--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -753,7 +753,7 @@ Issuing an IQv2 query follows four steps:
 
   1. **Build a query.** Create a `Query` object that describes what you want to read, for example a [KeyQuery](/{version}/javadoc/org/apache/kafka/streams/query/KeyQuery.html) for a single-key lookup or a [RangeQuery](/{version}/javadoc/org/apache/kafka/streams/query/RangeQuery.html) for a scan.
   2. **Build a request.** Wrap the query in a [StateQueryRequest](/{version}/javadoc/org/apache/kafka/streams/query/StateQueryRequest.html) that names the store to query: `StateQueryRequest.inStore(storeName).withQuery(query)`. Optionally configure the request (partitions, position bound, isolation level, and so on).
-  3. **Execute the request.** Call `streams.query(request)`, which runs the query against every locally available partition of the store (or just the partitions you requested) and returns a `StateQueryResult`.
+  3. **Execute the request.** Call `streams.query(request)`, which runs the query against every locally available partition of the store (or just the partitions you requested) and returns a `StateQueryResult`. Like the original API, `query(...)` reads only the state hosted locally on this instance; to discover which instance holds a given key, use the same metadata APIs as IQv1 (see [Querying remote state stores for the entire app](#querying-remote-state-stores-for-the-entire-app)).
   4. **Read the results.** For a query that targets a single partition, use `getOnlyPartitionResult()`. For a query that may span multiple partitions, use `getPartitionResults()` to get a `Map` from partition number to `QueryResult`. Each `QueryResult` reports whether the query succeeded on that partition and holds either the result value or a typed failure reason.
 
 ## Building and executing a query
@@ -804,11 +804,14 @@ Kafka Streams ships with a set of query types covering the standard store types.
 | `RangeQuery<K, V>` | `KeyValueIterator<K, V>` | `withRange(lower, upper)`, `withLowerBound(lower)`, `withUpperBound(upper)`, `withNoBounds()`; `.withAscendingKeys()` / `.withDescendingKeys()` |
 | `TimestampedRangeQuery<K, V>` | `KeyValueIterator<K, ValueAndTimestamp<V>>` | `withRange(lower, upper)`, `withLowerBound(lower)`, `withUpperBound(upper)`, `withNoBounds()`; `.withAscendingKeys()` / `.withDescendingKeys()` |
 | `WindowKeyQuery<K, V>` | `WindowStoreIterator<V>` | `withKeyAndWindowStartRange(key, timeFrom, timeTo)` |
-| `WindowRangeQuery<K, V>` | `KeyValueIterator<Windowed<K>, V>` | `withKey(key)`, `withWindowStartRange(timeFrom, timeTo)` |
+| `WindowRangeQuery<K, V>` (window store) | `KeyValueIterator<Windowed<K>, V>` | `withWindowStartRange(timeFrom, timeTo)` |
+| `WindowRangeQuery<K, V>` (session store) | `KeyValueIterator<Windowed<K>, V>` | `withKey(key)` |
 | `VersionedKeyQuery<K, V>` | `VersionedRecord<V>` | `withKey(key)`; `.asOf(instant)` |
 | `MultiVersionedKeyQuery<K, V>` | `VersionedRecordIterator<V>` | `withKey(key)`; `.fromTime(instant)`, `.toTime(instant)`, `.withAscendingTimestamps()` / `.withDescendingTimestamps()` |
 
 For range and scan queries (`RangeQuery`, `TimestampedRangeQuery`), passing no bounds performs a full scan, and result ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
+
+The two `WindowRangeQuery` forms are store-specific: window stores accept only `withWindowStartRange`, and session stores only `withKey` — submitting the wrong form fails with `UNKNOWN_QUERY_TYPE`. `WindowRangeQuery.withKey` is how a session store is queried through IQv2.
 
 Versioned key-value stores are queryable **only** through IQv2 — use `VersionedKeyQuery` for a single version (latest, or as of a timestamp) and `MultiVersionedKeyQuery` for a range of versions. The original `KafkaStreams#store(...)` API has no queryable store type for versioned stores.
 
@@ -826,10 +829,13 @@ Which accessor to use is determined by the *query type* you chose, not by inspec
 The accessors are:
 
   * `getPartitionResults()` returns a `Map<Integer, QueryResult<R>>`, keyed by partition number — one entry per partition that ran the query. This is the general form and works for any query.
-  * `getOnlyPartitionResult()` is a convenience that filters to the single partition that produced a value and returns it (or `null` if none did). It throws `IllegalArgumentException` if more than one partition produced a value, so only use it when you know the query matches at most one partition.
+  * `getOnlyPartitionResult()` is a convenience that returns the single partition result that is either a non-`null` value or a failure, or `null` if there is none. It throws `IllegalArgumentException` if more than one partition returned a value **or a failure** — failures count toward that limit, so avoid it when a query may fan out across partitions (for example a `KeyQuery` issued with `requireActive()`, where non-active partitions come back as `NOT_ACTIVE` failures). Use it only when you know the query matches at most one partition.
+  * `getGlobalResult()` returns the `QueryResult` for a global-store query, or `null` for a partitioned store (conversely, `getPartitionResults()` is empty for a global-store query). Global stores are not yet supported by `query(...)`, so this is where that rejection surfaces — as a failed result with `UNKNOWN_QUERY_TYPE`.
   * `getPosition()` returns the merged `Position` observed across the partition results.
 
 Each `QueryResult` reports the outcome for one partition. Use `isSuccess()` / `isFailure()` before reading: `getResult()` returns the value on success (which may itself be `null`, for example when a key is not found), while `getFailureReason()` and `getFailureMessage()` describe a failure. Results are always **per-partition** — a query may succeed on some partitions and fail on others (for example, if one partition has migrated off this instance).
+
+These `FailureReason`s describe per-partition outcomes. Problems with the request itself still raise exceptions from `query()`: `UnknownStateStoreException` if the named store is not registered in the topology, `StreamsNotStartedException` if the instance has not been started yet, and `StreamsStoppedException` once it is shutting down or has stopped.
 
 When a query returns an iterator (`RangeQuery`, `WindowKeyQuery`, `MultiVersionedKeyQuery`, and so on), the iterator must be closed after use. Iterate over every partition's result and use a try-with-resources block:
 
@@ -875,20 +881,20 @@ A failed `QueryResult` carries one of the [FailureReason](/{version}/javadoc/org
 | `NOT_ACTIVE` | `requireActive()` was set, but the partition is a standby or an active task that is not yet in the `RUNNING` state. | Retry later or query a different replica. |
 | `NOT_UP_TO_BOUND` | The partition has not yet caught up to the requested `PositionBound`. | Retry later or query a different replica. |
 | `NOT_PRESENT` | The requested partition is not present on this instance (for example, it migrated during a rebalance). | Query a different replica. |
-| `DOES_NOT_EXIST` | The requested partition does not exist for this store. | Correct the requested set of partitions. |
+| `DOES_NOT_EXIST` | Defined for store implementations to signal a partition that does not exist, but **not currently emitted by the Streams runtime** — a missing or non-existent partition comes back as `NOT_PRESENT` instead. | n/a (not produced by `query()` today). |
 | `STORE_EXCEPTION` | The store threw an exception while executing the query. | Depending on the exception, retry this instance or a different one. |
 
 ## Controlling consistency and availability
 
 A `StateQueryRequest` is immutable; each configuration method returns a new request. Beyond `inStore(...).withQuery(...)`, the following options let you trade off consistency, availability, and cost:
 
-  * `withPartitions(Set<Integer>)` / `withAllPartitions()`: run against a specific set of partitions or against all locally available partitions (the default). Partitions that are missing return `NOT_PRESENT`; partitions that do not exist return `DOES_NOT_EXIST`.
+  * `withPartitions(Set<Integer>)` / `withAllPartitions()`: run against a specific set of partitions or against all locally available partitions (the default). Any requested partition that is not present on this instance returns `NOT_PRESENT`, whether it migrated away or does not exist for the store at all — the runtime does not currently distinguish the two.
   * `requireActive()`: run only on active (leader) partitions. Non-active partitions return `NOT_ACTIVE`. Use this when you need the most up-to-date data and want to avoid reading from standby replicas.
-  * `withPositionBound(PositionBound)`: by default a request is `PositionBound.unbounded()`. Use `PositionBound.at(position)` to require that each queried partition has consumed up to a given `Position` before serving the query; a partition that is behind returns `NOT_UP_TO_BOUND`. Combined with the `Position` returned by `StateQueryResult#getPosition()`, this lets you implement read-your-writes / monotonic reads: feed the position from one query into the bound of the next so repeated queries never appear to move backwards in time, while still allowing reads to be served from any replica that is caught up.
-  * `withIsolationLevel(IsolationLevel)`: override the isolation level for this query. When not set, the effective level falls back to the `default.interactive.query.isolation.level` configuration.
+  * `withPositionBound(PositionBound)`: by default a request is `PositionBound.unbounded()`. Use `PositionBound.at(position)` to require that each queried partition has consumed up to a given `Position` before serving the query; a partition that is behind returns `NOT_UP_TO_BOUND`. Combined with the `Position` returned by `StateQueryResult#getPosition()`, this lets you implement read-your-writes / monotonic reads: feed the position from one query into the bound of the next so repeated queries never appear to move backwards in time, while still allowing reads to be served from any replica that is caught up. Note that `withPositionBound(...)` is ignored when `requireActive()` is also set: an active, running task is always served without a bound check, so it never returns `NOT_UP_TO_BOUND`.
+  * `withIsolationLevel(IsolationLevel)`: override the isolation level for this query. When not set, the effective level falls back to the `default.interactive.query.isolation.level` configuration (default `READ_UNCOMMITTED`). The isolation level is only meaningful when `enable.transactional.statestores` is `true`: `READ_UNCOMMITTED` reads include writes staged in the transaction buffer since the last commit, while `READ_COMMITTED` skips the buffer and returns only committed data.
   * `enableExecutionInfo()`: ask stores and the runtime to record details about how the query executed, retrievable via `QueryResult#getExecutionInfo()`.
 
-For example, the following request reads the latest committed value for a key from the active replica, but only for partitions 0 and 1, and only once the store has caught up to a known input position:
+For example, the following request reads a key from the active replica only, and only for partitions 0 and 1:
 
 ```java
 KeyQuery<String, Long> query = KeyQuery.withKey("alice");
@@ -896,8 +902,19 @@ StateQueryRequest<Long> request =
     inStore("CountsKeyValueStore")
         .withQuery(query)
         .requireActive()
-        .withPartitions(Set.of(0, 1))
-        .withPositionBound(PositionBound.at(inputPosition));
+        .withPartitions(Set.of(0, 1));
+
+StateQueryResult<Long> result = streams.query(request);
+```
+
+For monotonic reads, bound the query on a `Position` instead of requiring an active task — the two do not combine, since `requireActive()` discards the position bound. Feed the `Position` returned by one query into the bound of the next so repeated reads never appear to move backwards, while still letting any caught-up replica serve them:
+
+```java
+KeyQuery<String, Long> query = KeyQuery.withKey("alice");
+StateQueryRequest<Long> request =
+    inStore("CountsKeyValueStore")
+        .withQuery(query)
+        .withPositionBound(PositionBound.at(knownPosition));
 
 StateQueryResult<Long> result = streams.query(request);
 Position position = result.getPosition(); // pass into a later query for monotonic reads

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -809,7 +809,7 @@ Kafka Streams ships with a set of query types covering the standard store types.
 
 For range and scan queries (`RangeQuery`, `TimestampedRangeQuery`), passing no bounds performs a full scan, and result ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
 
-There are also headers-aware variants (`TimestampedKeyWithHeadersQuery`, `TimestampedRangeWithHeadersQuery`, `TimestampedWindowKeyWithHeadersQuery`, and `TimestampedWindowRangeWithHeadersQuery`, added by KIP-1271 and KIP-1356) that return the record headers alongside the value. These require a headers-aware store supplier (for example `Stores.persistentTimestampedKeyValueStoreWithHeaders`); querying a plain store with them fails with `UNKNOWN_QUERY_TYPE`.
+There are also headers-aware variants (`TimestampedKeyWithHeadersQuery`, `TimestampedRangeWithHeadersQuery`, and `TimestampedWindowKeyWithHeadersQuery`, added by KIP-1356 building on the header-storage support from KIP-1271) that return the record headers alongside the value. These require a headers-aware store supplier (for example `Stores.persistentTimestampedKeyValueStoreWithHeaders`); querying a plain store with them fails with `UNKNOWN_QUERY_TYPE`.
 
 Because IQv2 is extensible, a custom state store may implement additional query types of its own. When a store does not know how to handle a query, it does not throw; instead it returns a failed `QueryResult` with `FailureReason.UNKNOWN_QUERY_TYPE`.
 

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -731,6 +731,190 @@ At this point the full state of the application is interactively queryable:
 
 
 
+# Interactive Queries v2 (IQv2) {#interactive-queries-v2}
+
+The sections above describe the original interactive queries API (informally, "IQv1"), where you obtain a read-only store facade from [KafkaStreams#store(...)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) and call methods such as `get(key)` or `range(from, to)` on it. Interactive Queries v2 (IQv2), introduced in [KIP-796](https://cwiki.apache.org/confluence/x/34xnCw), is an alternative, more flexible API for the same purpose: querying the local state of a running Kafka Streams application.
+
+Instead of a fixed store facade, IQv2 models every query as a first-class [Query](/{version}/javadoc/org/apache/kafka/streams/query/Query.html) object that you submit through a single [KafkaStreams#query(StateQueryRequest)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) method. The response is a [StateQueryResult](/{version}/javadoc/org/apache/kafka/streams/query/StateQueryResult.html) that contains a separate [QueryResult](/{version}/javadoc/org/apache/kafka/streams/query/QueryResult.html) for each partition that executed the query, along with metadata such as each partition's [Position](/{version}/javadoc/org/apache/kafka/streams/query/Position.html).
+
+IQv2 offers several advantages over the original API:
+
+  * A single, uniform entry point for every kind of query.
+  * Extensibility: custom state stores can define their own `Query` types, and the runtime forwards unknown queries straight through to the underlying byte store.
+  * Rich, per-partition results with typed failure reasons instead of exceptions.
+  * Fine-grained consistency control through `Position` and `PositionBound`.
+  * The ability to target specific partitions, require active (leader) tasks, override the isolation level, and collect execution information.
+
+Both APIs are fully supported and can be used side by side. Note that IQv2 is marked as an evolving API, so it may change between releases, and global stores are not yet supported by `query(...)` (see [Limitations](#limitations-of-iqv2) below).
+
+## How Interactive Queries v2 works
+
+Issuing an IQv2 query follows four steps:
+
+  1. **Build a query.** Create a `Query` object that describes what you want to read, for example a [KeyQuery](/{version}/javadoc/org/apache/kafka/streams/query/KeyQuery.html) for a single-key lookup or a [RangeQuery](/{version}/javadoc/org/apache/kafka/streams/query/RangeQuery.html) for a scan.
+  2. **Build a request.** Wrap the query in a [StateQueryRequest](/{version}/javadoc/org/apache/kafka/streams/query/StateQueryRequest.html) that names the store to query: `StateQueryRequest.inStore(storeName).withQuery(query)`. Optionally configure the request (partitions, position bound, isolation level, and so on).
+  3. **Execute the request.** Call `streams.query(request)`, which runs the query against every locally available partition of the store (or just the partitions you requested) and returns a `StateQueryResult`.
+  4. **Read the results.** For a query that targets a single partition, use `getOnlyPartitionResult()`. For a query that may span multiple partitions, use `getPartitionResults()` to get a `Map` from partition number to `QueryResult`. Each `QueryResult` reports whether the query succeeded on that partition and holds either the result value or a typed failure reason.
+
+## Building and executing a query
+
+The following example looks up a single key in the `CountsKeyValueStore` state store from the word-count example used earlier on this page:
+
+```java
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.query.KeyQuery;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+
+import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
+
+KafkaStreams streams = ...;
+
+// 1. Build the query: retrieve the value for a single key.
+KeyQuery<String, Long> query = KeyQuery.withKey("alice");
+
+// 2. Build the request, naming the store to run the query against.
+//    A KeyQuery<String, Long> is a Query<Long>, so the request is a StateQueryRequest<Long>.
+StateQueryRequest<Long> request = inStore("CountsKeyValueStore").withQuery(query);
+
+// 3. Execute the query.
+StateQueryResult<Long> result = streams.query(request);
+
+// 4. Read the result. A key lookup targets a single partition, so getOnlyPartitionResult()
+//    returns that partition's result (or null if no locally available partition holds the key).
+QueryResult<Long> partitionResult = result.getOnlyPartitionResult();
+if (partitionResult != null && partitionResult.isSuccess()) {
+    Long count = partitionResult.getResult();
+    System.out.println("Count for alice: " + count);
+}
+```
+
+Note that the type parameter of `StateQueryRequest` (and of `StateQueryResult` and `QueryResult`) is the query's *result* type, not the query type: a `KeyQuery<String, Long>` implements `Query<Long>`, so the request is a `StateQueryRequest<Long>`.
+
+## Built-in query types
+
+Kafka Streams ships with a set of query types covering the standard store types. All of them live in the [org.apache.kafka.streams.query](/{version}/javadoc/org/apache/kafka/streams/query/package-summary.html) package.
+
+| Query | Result type (`R`) | Key factory / builder methods |
+| --- | --- | --- |
+| `KeyQuery<K, V>` | `V` | `withKey(key)`; `.skipCache()` |
+| `TimestampedKeyQuery<K, V>` | `ValueAndTimestamp<V>` | `withKey(key)`; `.skipCache()` |
+| `RangeQuery<K, V>` | `KeyValueIterator<K, V>` | `withRange(lower, upper)`, `withLowerBound(lower)`, `withUpperBound(upper)`, `withNoBounds()`; `.withAscendingKeys()` / `.withDescendingKeys()` |
+| `TimestampedRangeQuery<K, V>` | `KeyValueIterator<K, ValueAndTimestamp<V>>` | `withRange(lower, upper)`, `withLowerBound(lower)`, `withUpperBound(upper)`, `withNoBounds()`; `.withAscendingKeys()` / `.withDescendingKeys()` |
+| `WindowKeyQuery<K, V>` | `WindowStoreIterator<V>` | `withKeyAndWindowStartRange(key, timeFrom, timeTo)` |
+| `WindowRangeQuery<K, V>` | `KeyValueIterator<Windowed<K>, V>` | `withKey(key)`, `withWindowStartRange(timeFrom, timeTo)` |
+| `VersionedKeyQuery<K, V>` | `VersionedRecord<V>` | `withKey(key)`; `.asOf(instant)` |
+| `MultiVersionedKeyQuery<K, V>` | `VersionedRecordIterator<V>` | `withKey(key)`; `.fromTime(instant)`, `.toTime(instant)`, `.withAscendingTimestamps()` / `.withDescendingTimestamps()` |
+
+For range and scan queries (`RangeQuery`, `TimestampedRangeQuery`), passing no bounds performs a full scan, and result ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
+
+There are also headers-aware variants (`TimestampedKeyWithHeadersQuery`, `TimestampedRangeWithHeadersQuery`, `TimestampedWindowKeyWithHeadersQuery`, and `TimestampedWindowRangeWithHeadersQuery`, added by KIP-1271 and KIP-1356) that return the record headers alongside the value. These require a headers-aware store supplier (for example `Stores.persistentTimestampedKeyValueStoreWithHeaders`); querying a plain store with them fails with `UNKNOWN_QUERY_TYPE`.
+
+Because IQv2 is extensible, a custom state store may implement additional query types of its own. When a store does not know how to handle a query, it does not throw; instead it returns a failed `QueryResult` with `FailureReason.UNKNOWN_QUERY_TYPE`.
+
+## Handling query results
+
+A `StateQueryResult` aggregates one `QueryResult` per partition that ran the query:
+
+  * `getPartitionResults()` returns a `Map<Integer, QueryResult<R>>`, keyed by partition number.
+  * `getOnlyPartitionResult()` is a convenience for queries that are expected to match a single partition (such as a key lookup). It returns that partition's result, or throws `IllegalArgumentException` if more than one partition returned a result.
+  * `getPosition()` returns the merged `Position` observed across the partition results.
+
+Each `QueryResult` reports the outcome for one partition. Use `isSuccess()` / `isFailure()` before reading: `getResult()` returns the value on success (which may itself be `null`, for example when a key is not found), while `getFailureReason()` and `getFailureMessage()` describe a failure. Results are always **per-partition** — a query may succeed on some partitions and fail on others (for example, if one partition has migrated off this instance).
+
+When a query returns an iterator (`RangeQuery`, `WindowKeyQuery`, `MultiVersionedKeyQuery`, and so on), the iterator must be closed after use. Iterate over every partition's result and use a try-with-resources block:
+
+```java
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.RangeQuery;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import java.util.Map;
+
+import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
+
+RangeQuery<String, Long> query = RangeQuery.withRange("a", "n");
+StateQueryRequest<KeyValueIterator<String, Long>> request =
+    inStore("CountsKeyValueStore").withQuery(query);
+StateQueryResult<KeyValueIterator<String, Long>> result = streams.query(request);
+
+for (Map.Entry<Integer, QueryResult<KeyValueIterator<String, Long>>> entry
+        : result.getPartitionResults().entrySet()) {
+    QueryResult<KeyValueIterator<String, Long>> partitionResult = entry.getValue();
+    if (partitionResult.isFailure()) {
+        System.out.println("Partition " + entry.getKey() + " failed: "
+            + partitionResult.getFailureReason() + " - " + partitionResult.getFailureMessage());
+        continue;
+    }
+    try (KeyValueIterator<String, Long> iterator = partitionResult.getResult()) {
+        while (iterator.hasNext()) {
+            KeyValue<String, Long> record = iterator.next();
+            System.out.println(record.key + ": " + record.value);
+        }
+    }
+}
+```
+
+A failed `QueryResult` carries one of the [FailureReason](/{version}/javadoc/org/apache/kafka/streams/query/FailureReason.html) values:
+
+| `FailureReason` | Meaning | Recommended action |
+| --- | --- | --- |
+| `UNKNOWN_QUERY_TYPE` | The store does not know how to execute this query. | Verify the query is supported by that store type; for custom queries, contact the store maintainer. |
+| `NOT_ACTIVE` | `requireActive()` was set, but the partition is a standby or an active task that is not yet in the `RUNNING` state. | Retry later or query a different replica. |
+| `NOT_UP_TO_BOUND` | The partition has not yet caught up to the requested `PositionBound`. | Retry later or query a different replica. |
+| `NOT_PRESENT` | The requested partition is not present on this instance (for example, it migrated during a rebalance). | Query a different replica. |
+| `DOES_NOT_EXIST` | The requested partition does not exist for this store. | Correct the requested set of partitions. |
+| `STORE_EXCEPTION` | The store threw an exception while executing the query. | Depending on the exception, retry this instance or a different one. |
+
+## Controlling consistency and availability
+
+A `StateQueryRequest` is immutable; each configuration method returns a new request. Beyond `inStore(...).withQuery(...)`, the following options let you trade off consistency, availability, and cost:
+
+  * `withPartitions(Set<Integer>)` / `withAllPartitions()`: run against a specific set of partitions or against all locally available partitions (the default). Partitions that are missing return `NOT_PRESENT`; partitions that do not exist return `DOES_NOT_EXIST`.
+  * `requireActive()`: run only on active (leader) partitions. Non-active partitions return `NOT_ACTIVE`. Use this when you need the most up-to-date data and want to avoid reading from standby replicas.
+  * `withPositionBound(PositionBound)`: by default a request is `PositionBound.unbounded()`. Use `PositionBound.at(position)` to require that each queried partition has consumed up to a given `Position` before serving the query; a partition that is behind returns `NOT_UP_TO_BOUND`. Combined with the `Position` returned by `StateQueryResult#getPosition()`, this lets you implement read-your-writes / monotonic reads: feed the position from one query into the bound of the next so repeated queries never appear to move backwards in time, while still allowing reads to be served from any replica that is caught up.
+  * `withIsolationLevel(IsolationLevel)`: override the isolation level for this query. When not set, the effective level falls back to the `default.interactive.query.isolation.level` configuration.
+  * `enableExecutionInfo()`: ask stores and the runtime to record details about how the query executed, retrievable via `QueryResult#getExecutionInfo()`.
+
+For example, the following request reads the latest committed value for a key from the active replica, but only for partitions 0 and 1, and only once the store has caught up to a known input position:
+
+```java
+KeyQuery<String, Long> query = KeyQuery.withKey("alice");
+StateQueryRequest<Long> request =
+    inStore("CountsKeyValueStore")
+        .withQuery(query)
+        .requireActive()
+        .withPartitions(Set.of(0, 1))
+        .withPositionBound(PositionBound.at(inputPosition));
+
+StateQueryResult<Long> result = streams.query(request);
+Position position = result.getPosition(); // pass into a later query for monotonic reads
+```
+
+## Comparison of IQv1 and IQv2
+
+| Aspect | IQv1 (`KafkaStreams#store`) | IQv2 (`KafkaStreams#query`) |
+| --- | --- | --- |
+| Entry point | `store(StoreQueryParameters)` returns a typed, read-only store facade | `query(StateQueryRequest)` returns a `StateQueryResult` |
+| Query surface | Fixed methods on the store facade (`get`, `range`, ...) | First-class `Query` objects |
+| Extensibility | Not extensible | Custom stores can define custom `Query` types |
+| Result granularity | Values from the store facade | A `QueryResult` per partition |
+| Failure reporting | Exceptions (for example, `InvalidStateStoreException`) | Typed `FailureReason` per partition |
+| Consistency control | `enableStaleStores()` toggle | `PositionBound` plus the returned `Position` |
+| Partition targeting | `.withPartition(int)` | `.withPartitions(Set)` / `.withAllPartitions()` |
+| Global stores | Supported | Not yet supported |
+| Maturity | Stable | Evolving |
+
+## Limitations of IQv2 {#limitations-of-iqv2}
+
+  * Global stores are not yet supported by `query(...)`. Use [KafkaStreams#store(...)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) to query global stores.
+  * The IQv2 API is still evolving and may change in future releases.
+  * For range and scan queries, ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
+
 To see an end-to-end application with interactive queries, review the demo applications.
 
   * [Documentation](/documentation)

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -740,7 +740,7 @@ Instead of a fixed store facade, IQv2 models every query as a first-class [Query
 IQv2 offers several advantages over the original API:
 
   * A single, uniform entry point for every kind of query.
-  * Extensibility: custom state stores can define their own `Query` types, and the runtime forwards unknown queries straight through to the underlying byte store.
+  * Query-level extensibility: custom state stores can handle their own `Query` types (the runtime forwards unknown queries straight through to the underlying byte store), rather than requiring a custom `QueryableStoreType` store facade as the original API does.
   * Rich, per-partition results with typed failure reasons instead of exceptions.
   * Fine-grained consistency control through `Position` and `PositionBound`.
   * The ability to target specific partitions, require active (leader) tasks, override the isolation level, and collect execution information.
@@ -901,7 +901,7 @@ Position position = result.getPosition(); // pass into a later query for monoton
 | --- | --- | --- |
 | Entry point | `store(StoreQueryParameters)` returns a typed, read-only store facade | `query(StateQueryRequest)` returns a `StateQueryResult` |
 | Query surface | Fixed methods on the store facade (`get`, `range`, ...) | First-class `Query` objects |
-| Extensibility | Not extensible | Custom stores can define custom `Query` types |
+| Extensibility | Custom `QueryableStoreType` store facades | Custom `Query` types forwarded to the store |
 | Result granularity | Values from the store facade | A `QueryResult` per partition |
 | Failure reporting | Exceptions (for example, `InvalidStateStoreException`) | Typed `FailureReason` per partition |
 | Consistency control | `enableStaleStores()` toggle | `PositionBound` plus the returned `Position` |

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -781,8 +781,9 @@ StateQueryRequest<Long> request = inStore("CountsKeyValueStore").withQuery(query
 // 3. Execute the query.
 StateQueryResult<Long> result = streams.query(request);
 
-// 4. Read the result. A key lookup targets a single partition, so getOnlyPartitionResult()
-//    returns that partition's result (or null if no locally available partition holds the key).
+// 4. Read the result. A given key lives in exactly one partition, so at most one partition
+//    returns a value. getOnlyPartitionResult() returns that partition's result, or null if
+//    no locally available partition holds the key.
 QueryResult<Long> partitionResult = result.getOnlyPartitionResult();
 if (partitionResult != null && partitionResult.isSuccess()) {
     Long count = partitionResult.getResult();
@@ -809,16 +810,23 @@ Kafka Streams ships with a set of query types covering the standard store types.
 
 For range and scan queries (`RangeQuery`, `TimestampedRangeQuery`), passing no bounds performs a full scan, and result ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
 
-There are also headers-aware variants (`TimestampedKeyWithHeadersQuery`, `TimestampedRangeWithHeadersQuery`, and `TimestampedWindowKeyWithHeadersQuery`, added by KIP-1356 building on the header-storage support from KIP-1271) that return the record headers alongside the value. These require a headers-aware store supplier (for example `Stores.persistentTimestampedKeyValueStoreWithHeaders`); querying a plain store with them fails with `UNKNOWN_QUERY_TYPE`.
+Versioned key-value stores are queryable **only** through IQv2 — use `VersionedKeyQuery` for a single version (latest, or as of a timestamp) and `MultiVersionedKeyQuery` for a range of versions. The original `KafkaStreams#store(...)` API has no queryable store type for versioned stores.
 
 Because IQv2 is extensible, a custom state store may implement additional query types of its own. When a store does not know how to handle a query, it does not throw; instead it returns a failed `QueryResult` with `FailureReason.UNKNOWN_QUERY_TYPE`.
 
 ## Handling query results
 
-A `StateQueryResult` aggregates one `QueryResult` per partition that ran the query:
+A `StateQueryResult` aggregates one `QueryResult` per partition that ran the query. By default a request runs against all locally available partitions of the store (unless you narrow it with `withPartitions(...)`), so `getPartitionResults()` may contain an entry for every one of those partitions.
 
-  * `getPartitionResults()` returns a `Map<Integer, QueryResult<R>>`, keyed by partition number.
-  * `getOnlyPartitionResult()` is a convenience for queries that are expected to match a single partition (such as a key lookup). It returns that partition's result, or throws `IllegalArgumentException` if more than one partition returned a result.
+Which accessor to use is determined by the *query type* you chose, not by inspecting the result at runtime:
+
+  * **Point lookups** (`KeyQuery`, `TimestampedKeyQuery`, `VersionedKeyQuery`) can only match in the single partition that owns the key, so at most one partition returns a value (the other queried partitions return a successful result with `null`). Use `getOnlyPartitionResult()`.
+  * **Range, scan, and window queries** (`RangeQuery`, `WindowRangeQuery`, `MultiVersionedKeyQuery`, and so on) can match records in every queried partition, so results are spread across partitions. Use `getPartitionResults()` and iterate.
+
+The accessors are:
+
+  * `getPartitionResults()` returns a `Map<Integer, QueryResult<R>>`, keyed by partition number — one entry per partition that ran the query. This is the general form and works for any query.
+  * `getOnlyPartitionResult()` is a convenience that filters to the single partition that produced a value and returns it (or `null` if none did). It throws `IllegalArgumentException` if more than one partition produced a value, so only use it when you know the query matches at most one partition.
   * `getPosition()` returns the merged `Position` observed across the partition results.
 
 Each `QueryResult` reports the outcome for one partition. Use `isSuccess()` / `isFailure()` before reading: `getResult()` returns the value on success (which may itself be `null`, for example when a key is not found), while `getFailureReason()` and `getFailureMessage()` describe a failure. Results are always **per-partition** — a query may succeed on some partitions and fail on others (for example, if one partition has migrated off this instance).
@@ -906,6 +914,7 @@ Position position = result.getPosition(); // pass into a later query for monoton
 | Failure reporting | Exceptions (for example, `InvalidStateStoreException`) | Typed `FailureReason` per partition |
 | Consistency control | `enableStaleStores()` toggle | `PositionBound` plus the returned `Position` |
 | Partition targeting | `.withPartition(int)` | `.withPartitions(Set)` / `.withAllPartitions()` |
+| Versioned stores | Not queryable | `VersionedKeyQuery` / `MultiVersionedKeyQuery` |
 | Global stores | Supported | Not yet supported |
 | Maturity | Stable | Evolving |
 
@@ -913,7 +922,6 @@ Position position = result.getPosition(); // pass into a later query for monoton
 
   * Global stores are not yet supported by `query(...)`. Use [KafkaStreams#store(...)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) to query global stores.
   * The IQv2 API is still evolving and may change in future releases.
-  * For range and scan queries, ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
 
 To see an end-to-end application with interactive queries, review the demo applications.
 

--- a/docs/streams/developer-guide/interactive-queries.md
+++ b/docs/streams/developer-guide/interactive-queries.md
@@ -606,131 +606,6 @@ You can now find and query your custom store:
     // Query the store
     String value = store.read("key");
 
-# Querying remote state stores for the entire app
-
-To query remote states for the entire app, you must expose the application's full state to other applications, including applications that are running on different machines.
-
-For example, you have a Kafka Streams application that processes user events in a multi-player video game, and you want to retrieve the latest status of each user directly and display it in a mobile app. Here are the required steps to make the full state of your application queryable:
-
-  1. Add an RPC layer to your application so that the instances of your application can be interacted with via the network (e.g., a REST API, Thrift, a custom protocol, and so on). The instances must respond to interactive queries. You can follow the reference examples provided to get started.
-  2. Expose the RPC endpoints of your application's instances via the `application.server` configuration setting of Kafka Streams. Because RPC endpoints must be unique within a network, each instance has its own value for this configuration setting. This makes an application instance discoverable by other instances.
-  3. In the RPC layer, discover remote application instances and their state stores and query locally available state stores to make the full state of your application queryable. The remote application instances can forward queries to other app instances if a particular instance lacks the local data to respond to a query. The locally available state stores can directly respond to queries.
-
-
-
-![](/43/images/streams-interactive-queries-api-02.png)
-
-Discover any running instances of the same application as well as the respective RPC endpoints they expose for interactive queries
-
-## Adding an RPC layer to your application
-
-There are many ways to add an RPC layer. The only requirements are that the RPC layer is embedded within the Kafka Streams application and that it exposes an endpoint that other application instances and applications can connect to.
-
-## Exposing the RPC endpoints of your application
-
-To enable remote state store discovery in a distributed Kafka Streams application, you must set the [configuration property](../config-streams#streams-developer-guide-required-configs) in the config properties. The `application.server` property defines a unique `host:port` pair that points to the RPC endpoint of the respective instance of a Kafka Streams application. The value of this configuration property will vary across the instances of your application. When this property is set, Kafka Streams will keep track of the RPC endpoint information for every instance of an application, its state stores, and assigned stream partitions through instances of [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html).
-
-**Tip**
-
-Consider leveraging the exposed RPC endpoints of your application for further functionality, such as piggybacking additional inter-application communication that goes beyond interactive queries.
-
-This example shows how to configure and run a Kafka Streams application that supports the discovery of its state stores.
-    
-    
-    Properties props = new Properties();
-    // Set the unique RPC endpoint of this application instance through which it
-    // can be interactively queried.  In a real application, the value would most
-    // probably not be hardcoded but derived dynamically.
-    String rpcEndpoint = "host1:4460";
-    props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, rpcEndpoint);
-    // ... further settings may follow here ...
-    
-    StreamsBuilder builder = new StreamsBuilder();
-    
-    KStream<String, String> textLines = builder.stream(stringSerde, stringSerde, "word-count-input");
-    
-    final KGroupedStream<String, String> groupedByWord = textLines
-        .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\W+")))
-        .groupBy((key, word) -> word, Grouped.with(stringSerde, stringSerde));
-    
-    // This call to `count()` creates a state store named "word-count".
-    // The state store is discoverable and can be queried interactively.
-    groupedByWord.count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>as("word-count"));
-    
-    // Start an instance of the topology
-    KafkaStreams streams = new KafkaStreams(builder, props);
-    streams.start();
-    
-    // Then, create and start the actual RPC service for remote access to this
-    // application instance's local state stores.
-    //
-    // This service should be started on the same host and port as defined above by
-    // the property `StreamsConfig.APPLICATION_SERVER_CONFIG`.  The example below is
-    // fictitious, but we provide end-to-end demo applications (such as KafkaMusicExample)
-    // that showcase how to implement such a service to get you started.
-    MyRPCService rpcService = ...;
-    rpcService.listenAt(rpcEndpoint);
-
-## Discovering and accessing application instances and their local state stores
-
-The following methods return [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html) objects, which provide meta-information about application instances such as their RPC endpoint and locally available state stores.
-
-  * `KafkaStreams#allMetadata()`: find all instances of this application
-  * `KafkaStreams#allMetadataForStore(String storeName)`: find those applications instances that manage local instances of the state store "storeName"
-  * `KafkaStreams#metadataForKey(String storeName, K key, Serializer<K> keySerializer)`: using the default stream partitioning strategy, find the one application instance that holds the data for the given key in the given state store
-  * `KafkaStreams#metadataForKey(String storeName, K key, StreamPartitioner<K, ?> partitioner)`: using `partitioner`, find the one application instance that holds the data for the given key in the given state store
-
-
-
-Attention
-
-If `application.server` is not configured for an application instance, then the above methods will not find any [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html) for it.
-
-For example, we can now find the `StreamsMetadata` for the state store named "word-count" that we defined in the code example shown in the previous section:
-    
-    
-    KafkaStreams streams = ...;
-    // Find all the locations of local instances of the state store named "word-count"
-    Collection<StreamsMetadata> wordCountHosts = streams.allMetadataForStore("word-count");
-    
-    // For illustrative purposes, we assume using an HTTP client to talk to remote app instances.
-    HttpClient http = ...;
-    
-    // Get the word count for word (aka key) 'alice': Approach 1
-    //
-    // We first find the one app instance that manages the count for 'alice' in its local state stores.
-    StreamsMetadata metadata = streams.metadataForKey("word-count", "alice", Serdes.String().serializer());
-    // Then, we query only that single app instance for the latest count of 'alice'.
-    // Note: The RPC URL shown below is fictitious and only serves to illustrate the idea.  Ultimately,
-    // the URL (or, in general, the method of communication) will depend on the RPC layer you opted to
-    // implement.  Again, we provide end-to-end demo applications (such as KafkaMusicExample) that showcase
-    // how to implement such an RPC layer.
-    Long result = http.getLong("http://" + metadata.host() + ":" + metadata.port() + "/word-count/alice");
-    
-    // Get the word count for word (aka key) 'alice': Approach 2
-    //
-    // Alternatively, we could also choose (say) a brute-force approach where we query every app instance
-    // until we find the one that happens to know about 'alice'.
-    Optional<Long> result = streams.allMetadataForStore("word-count")
-        .stream()
-        .map(streamsMetadata -> {
-            // Construct the (fictituous) full endpoint URL to query the current remote application instance
-            String url = "http://" + streamsMetadata.host() + ":" + streamsMetadata.port() + "/word-count/alice";
-            // Read and return the count for 'alice', if any.
-            return http.getLong(url);
-        })
-        .filter(s -> s != null)
-        .findFirst();
-
-At this point the full state of the application is interactively queryable:
-
-  * You can discover the running instances of the application and the state stores they manage locally.
-  * Through the RPC layer that was added to the application, you can communicate with these application instances over the network and query them for locally available state.
-  * The application instances are able to serve such queries because they can directly query their own local state stores and respond via the RPC layer.
-  * Collectively, this allows us to query the full state of the entire application.
-
-
-
 # Interactive Queries v2 (IQv2) {#interactive-queries-v2}
 
 The sections above describe the original interactive queries API (informally, "IQv1"), where you obtain a read-only store facade from [KafkaStreams#store(...)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) and call methods such as `get(key)` or `range(from, to)` on it. Interactive Queries v2 (IQv2), introduced in [KIP-796](https://cwiki.apache.org/confluence/x/34xnCw), is an alternative, more flexible API for the same purpose: querying the local state of a running Kafka Streams application.
@@ -808,10 +683,17 @@ Kafka Streams ships with a set of query types covering the standard store types.
 | `WindowRangeQuery<K, V>` (session store) | `KeyValueIterator<Windowed<K>, V>` | `withKey(key)` |
 | `VersionedKeyQuery<K, V>` | `VersionedRecord<V>` | `withKey(key)`; `.asOf(instant)` |
 | `MultiVersionedKeyQuery<K, V>` | `VersionedRecordIterator<V>` | `withKey(key)`; `.fromTime(instant)`, `.toTime(instant)`, `.withAscendingTimestamps()` / `.withDescendingTimestamps()` |
+| `TimestampedKeyWithHeadersQuery<K, V>` | `ReadOnlyRecord<K, V>` | `withKey(key)`; `.skipCache()` |
+| `TimestampedRangeWithHeadersQuery<K, V>` | `ReadOnlyRecordIterator<K, V>` | `withRange(lower, upper)`, `withLowerBound(lower)`, `withUpperBound(upper)`, `withNoBounds()`; `.withAscendingKeys()` / `.withDescendingKeys()` |
+| `TimestampedWindowKeyWithHeadersQuery<K, V>` | `ReadOnlyRecordIterator<Windowed<K>, V>` | `withKeyAndWindowStartRange(key, timeFrom, timeTo)` |
+| `TimestampedWindowRangeWithHeadersQuery<K, V>` (window store) | `ReadOnlyRecordIterator<Windowed<K>, V>` | `withWindowStartRange(timeFrom, timeTo)` |
+| `TimestampedWindowRangeWithHeadersQuery<K, V>` (session store) | `ReadOnlyRecordIterator<Windowed<K>, V>` | `withKey(key)` |
 
 For range and scan queries (`RangeQuery`, `TimestampedRangeQuery`), passing no bounds performs a full scan, and result ordering is based on the serialized `byte[]` of the keys, not on the logical key order.
 
 The two `WindowRangeQuery` forms are store-specific: window stores accept only `withWindowStartRange`, and session stores only `withKey` — submitting the wrong form fails with `UNKNOWN_QUERY_TYPE`. `WindowRangeQuery.withKey` is how a session store is queried through IQv2.
+
+The `*WithHeaders` query types return records that carry their headers and require a store built with a headers-aware (`*WithHeaders`) supplier; against any other store they fail with `UNKNOWN_QUERY_TYPE`. See [Header-aware stores and interactive queries](#header-aware-stores-interactive-queries) for their result semantics, examples, and store-build requirements.
 
 Versioned key-value stores are queryable **only** through IQv2 — use `VersionedKeyQuery` for a single version (latest, or as of a timestamp) and `MultiVersionedKeyQuery` for a range of versions. The original `KafkaStreams#store(...)` API has no queryable store type for versioned stores.
 
@@ -939,6 +821,129 @@ Position position = result.getPosition(); // pass into a later query for monoton
 
   * Global stores are not yet supported by `query(...)`. Use [KafkaStreams#store(...)](/{version}/javadoc/org/apache/kafka/streams/KafkaStreams.html) to query global stores.
   * The IQv2 API is still evolving and may change in future releases.
+
+# Querying remote state stores for the entire app
+
+To query remote states for the entire app, you must expose the application's full state to other applications, including applications that are running on different machines.
+
+For example, you have a Kafka Streams application that processes user events in a multi-player video game, and you want to retrieve the latest status of each user directly and display it in a mobile app. Here are the required steps to make the full state of your application queryable:
+
+  1. Add an RPC layer to your application so that the instances of your application can be interacted with via the network (e.g., a REST API, Thrift, a custom protocol, and so on). The instances must respond to interactive queries. You can follow the reference examples provided to get started.
+  2. Expose the RPC endpoints of your application's instances via the `application.server` configuration setting of Kafka Streams. Because RPC endpoints must be unique within a network, each instance has its own value for this configuration setting. This makes an application instance discoverable by other instances.
+  3. In the RPC layer, discover remote application instances and their state stores and query locally available state stores to make the full state of your application queryable. The remote application instances can forward queries to other app instances if a particular instance lacks the local data to respond to a query. The locally available state stores can directly respond to queries.
+
+
+
+![](/43/images/streams-interactive-queries-api-02.png)
+
+Discover any running instances of the same application as well as the respective RPC endpoints they expose for interactive queries
+
+## Adding an RPC layer to your application
+
+There are many ways to add an RPC layer. The only requirements are that the RPC layer is embedded within the Kafka Streams application and that it exposes an endpoint that other application instances and applications can connect to.
+
+## Exposing the RPC endpoints of your application
+
+To enable remote state store discovery in a distributed Kafka Streams application, you must set the [configuration property](../config-streams#streams-developer-guide-required-configs) in the config properties. The `application.server` property defines a unique `host:port` pair that points to the RPC endpoint of the respective instance of a Kafka Streams application. The value of this configuration property will vary across the instances of your application. When this property is set, Kafka Streams will keep track of the RPC endpoint information for every instance of an application, its state stores, and assigned stream partitions through instances of [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html).
+
+**Tip**
+
+Consider leveraging the exposed RPC endpoints of your application for further functionality, such as piggybacking additional inter-application communication that goes beyond interactive queries.
+
+This example shows how to configure and run a Kafka Streams application that supports the discovery of its state stores.
+    
+    
+    Properties props = new Properties();
+    // Set the unique RPC endpoint of this application instance through which it
+    // can be interactively queried.  In a real application, the value would most
+    // probably not be hardcoded but derived dynamically.
+    String rpcEndpoint = "host1:4460";
+    props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, rpcEndpoint);
+    // ... further settings may follow here ...
+    
+    StreamsBuilder builder = new StreamsBuilder();
+    
+    KStream<String, String> textLines = builder.stream(stringSerde, stringSerde, "word-count-input");
+    
+    final KGroupedStream<String, String> groupedByWord = textLines
+        .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\W+")))
+        .groupBy((key, word) -> word, Grouped.with(stringSerde, stringSerde));
+    
+    // This call to `count()` creates a state store named "word-count".
+    // The state store is discoverable and can be queried interactively.
+    groupedByWord.count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>as("word-count"));
+    
+    // Start an instance of the topology
+    KafkaStreams streams = new KafkaStreams(builder, props);
+    streams.start();
+    
+    // Then, create and start the actual RPC service for remote access to this
+    // application instance's local state stores.
+    //
+    // This service should be started on the same host and port as defined above by
+    // the property `StreamsConfig.APPLICATION_SERVER_CONFIG`.  The example below is
+    // fictitious, but we provide end-to-end demo applications (such as KafkaMusicExample)
+    // that showcase how to implement such a service to get you started.
+    MyRPCService rpcService = ...;
+    rpcService.listenAt(rpcEndpoint);
+
+## Discovering and accessing application instances and their local state stores
+
+The following methods return [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html) objects, which provide meta-information about application instances such as their RPC endpoint and locally available state stores.
+
+  * `KafkaStreams#allMetadata()`: find all instances of this application
+  * `KafkaStreams#allMetadataForStore(String storeName)`: find those applications instances that manage local instances of the state store "storeName"
+  * `KafkaStreams#metadataForKey(String storeName, K key, Serializer<K> keySerializer)`: using the default stream partitioning strategy, find the one application instance that holds the data for the given key in the given state store
+  * `KafkaStreams#metadataForKey(String storeName, K key, StreamPartitioner<K, ?> partitioner)`: using `partitioner`, find the one application instance that holds the data for the given key in the given state store
+
+
+
+Attention
+
+If `application.server` is not configured for an application instance, then the above methods will not find any [StreamsMetadata](/{version}/javadoc/org/apache/kafka/streams/state/StreamsMetadata.html) for it.
+
+For example, we can now find the `StreamsMetadata` for the state store named "word-count" that we defined in the code example shown in the previous section:
+    
+    
+    KafkaStreams streams = ...;
+    // Find all the locations of local instances of the state store named "word-count"
+    Collection<StreamsMetadata> wordCountHosts = streams.allMetadataForStore("word-count");
+    
+    // For illustrative purposes, we assume using an HTTP client to talk to remote app instances.
+    HttpClient http = ...;
+    
+    // Get the word count for word (aka key) 'alice': Approach 1
+    //
+    // We first find the one app instance that manages the count for 'alice' in its local state stores.
+    StreamsMetadata metadata = streams.metadataForKey("word-count", "alice", Serdes.String().serializer());
+    // Then, we query only that single app instance for the latest count of 'alice'.
+    // Note: The RPC URL shown below is fictitious and only serves to illustrate the idea.  Ultimately,
+    // the URL (or, in general, the method of communication) will depend on the RPC layer you opted to
+    // implement.  Again, we provide end-to-end demo applications (such as KafkaMusicExample) that showcase
+    // how to implement such an RPC layer.
+    Long result = http.getLong("http://" + metadata.host() + ":" + metadata.port() + "/word-count/alice");
+    
+    // Get the word count for word (aka key) 'alice': Approach 2
+    //
+    // Alternatively, we could also choose (say) a brute-force approach where we query every app instance
+    // until we find the one that happens to know about 'alice'.
+    Optional<Long> result = streams.allMetadataForStore("word-count")
+        .stream()
+        .map(streamsMetadata -> {
+            // Construct the (fictituous) full endpoint URL to query the current remote application instance
+            String url = "http://" + streamsMetadata.host() + ":" + streamsMetadata.port() + "/word-count/alice";
+            // Read and return the count for 'alice', if any.
+            return http.getLong(url);
+        })
+        .filter(s -> s != null)
+        .findFirst();
+
+At this point the full state of the application is interactively queryable:
+
+  * You can discover the running instances of the application and the state stores they manage locally.
+  * Through the RPC layer that was added to the application, you can communicate with these application instances over the network and query them for locally available state.
+  * The application instances are able to serve such queries because they can directly query their own local state stores and respond via the RPC layer.
+  * Collectively, this allows us to query the full state of the entire application.
 
 To see an end-to-end application with interactive queries, review the demo applications.
 


### PR DESCRIPTION
Add IQv2 to Kafka Streams documentation

The IQv2 API (KIP-796) has been available for several releases but was
absent from the [Interactive Queries developer
guide](https://kafka.apache.org/documentation/streams/developer-guide/interactive-queries.html).
Users had no doc-level pointer to the newer API, making it hard to
discover, try out, and give feedback on. This PR adds an "Interactive
Queries v2 (IQv2)" section to
docs/streams/developer-guide/interactive-queries.md, positioning it as
the new API alongside the existing IQv1 content (both remain fully
supported).

> The built-in-types table's *WithHeaders query types cross-link into
the Header-aware stores and interactive queries section, which landed in
trunk via #22882. This PR is rebased on top of that; its diff now
contains only the general IQv2 section.

The new section covers:
- An overview of IQv2 and how it differs from IQv1, with the current
evolving-API/feature-completeness caveats.
- The four-step query flow (build query → build request → execute → read
per-partition results), with runnable `KeyQuery` and `RangeQuery`
examples (the latter closing iterators via try-with-resources).
- A table of the built-in `Query` types with their result types and
builder methods.
- Result and failure handling, including a table of all `FailureReason`
values and recommended actions.
- Consistency/availability controls
(`withPartitions`/`withAllPartitions`, `requireActive`,
`withPositionBound`, `withIsolationLevel`, `enableExecutionInfo`) and a
read-your-writes / monotonic-reads example.
- An IQv1-vs-IQv2 comparison table and a list of current limitations
(e.g. global stores are not yet supported by `query(...)`).

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, TengYao Chi
 <frankvicky@apache.org>
