### PR TITLE
KAFKA-20815: Remove unnecessary jline deps and bump to latest 3.x

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -307,7 +307,9 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-3.30.15, see: licenses/jline-BSD-3-clause
+- jline-native-3.30.15, see: licenses/jline-BSD-3-clause
+- jline-reader-3.30.15, see: licenses/jline-BSD-3-clause
+- jline-terminal-3.30.15, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -307,7 +307,7 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-3.30.4, see: licenses/jline-BSD-3-clause
+- jline-3.30.15, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ versions += [
   jetty: "12.0.34",
   jersey: "3.1.10",
   jgit: "7.6.0.202603022253-r",
-  jline: "3.30.4",
+  jline: "3.30.15",
   jmh: "1.37",
   hamcrest: "3.0",
   scalaLogging: "3.9.6",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -185,7 +185,7 @@ libs += [
   jgitSshApache: "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit",
   // GPG support for JGit based on BouncyCastle (commit signing)
   jgitGpgBc: "org.eclipse.jgit:org.eclipse.jgit.gpg.bc:$versions.jgit",
-  jline: "org.jline:jline:$versions.jline",
+  jline: "org.jline:jline-reader:$versions.jline",
   jmhCore: "org.openjdk.jmh:jmh-core:$versions.jmh",
   jmhCoreBenchmarks: "org.openjdk.jmh:jmh-core-benchmarks:$versions.jmh",
   jmhGeneratorAnnProcess: "org.openjdk.jmh:jmh-generator-annprocess:$versions.jmh",


### PR DESCRIPTION
KAFKA-20815 reported a security vulnerability on `jline-remote-telnet`
3.30.4. Kafka does not have a dependency on the mentioned package but
actually uses the whole jline bundle which includes telnet related
binaries too. Jline is only used for the metadata shell module which in
turn only needs it for basic terminal functionality, there are no remote
capabilities. This PR aims to remove the unnecessary jline dependencies
and prevent false positive security vulnerability scan results about
jline telnet/ssh.

The shell module only needs the `jline-reader` dependency which also
pulls in transitive dependencies `jline-terminal` and `jline -native`.

As an additional benefit the change reduces binary size going from jline
bunde (1.40 MB) to jline-reader + jline-terminal + jline-native (650 KB)
~ 55% saved

While at it the dependency version has been updated to the latest 3.x
release

Reviewers: Mickael Maison <mickael.maison@gmail.com>, Apoorv Mittal <apoorvmittal10@gmail.com>
