### PR TITLE
KAFKA-20278 : Refactor - Consolidate process-and-verify helpers, [2/N]

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -76,7 +76,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
 public class HeadersStoreUpgradeIntegrationTest {
@@ -847,7 +846,6 @@ public class HeadersStoreUpgradeIntegrationTest {
                 }
 
                 final ValueTimestampHeaders<String> actual = result.get().value;
-                assertNotNull(actual, "Stored value should not be null");
                 assertEquals(value, actual.value(), "Value should match");
                 assertEquals(expectedTimestamp, actual.timestamp(), "Timestamp should be " + expectedTimestamp);
                 assertEquals(expectedHeaders, actual.headers(), "Headers should match");
@@ -1384,6 +1382,27 @@ public class HeadersStoreUpgradeIntegrationTest {
     private void verifySessionValueWithEmptyHeaders(final String key,
                                                     final String value,
                                                     final long timestamp) throws Exception {
+        verifySessionValue(key, value, timestamp, new RecordHeaders());
+    }
+
+    private void processSessionKeyValueWithHeadersAndVerify(final String key,
+                                                            final String value,
+                                                            final long timestamp,
+                                                            final Headers headers,
+                                                            final Headers expectedHeaders) throws Exception {
+        produce(key, value, timestamp, headers);
+        verifySessionValue(key, value, timestamp, expectedHeaders);
+    }
+
+    /**
+     * Verifies the aggregation stored for {@code key} in the session bounded by {@code timestamp},
+     * expecting {@code value} and {@code expectedHeaders}. Pass an empty {@link RecordHeaders} for
+     * sessions migrated without headers.
+     */
+    private void verifySessionValue(final String key,
+                                    final String value,
+                                    final long timestamp,
+                                    final Headers expectedHeaders) throws Exception {
         awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
             store -> {
                 final Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> result =
@@ -1393,35 +1412,11 @@ public class HeadersStoreUpgradeIntegrationTest {
                 }
 
                 final AggregationWithHeaders<String> actual = result.get().value;
-                assertNotNull(actual, "Stored value should not be null");
                 assertEquals(value, actual.aggregation(), "Value should match");
-
-                // Verify headers exist but are empty (migrated from plain session store)
-                assertNotNull(actual.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, actual.headers().toArray().length, "Headers should be empty for migrated data");
-
+                assertEquals(expectedHeaders, actual.headers(), "Headers should match");
                 return true;
             },
-            "Could not verify legacy session value with empty headers in time.");
-    }
-
-    private void processSessionKeyValueWithHeadersAndVerify(final String key,
-                                                            final String value,
-                                                            final long timestamp,
-                                                            final Headers headers,
-                                                            final Headers expectedHeaders) throws Exception {
-        produce(key, value, timestamp, headers);
-
-        awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
-            store -> {
-                final Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> result =
-                    findSessionValue(store, key, timestamp);
-                return result.isPresent()
-                    && result.get().value != null
-                    && result.get().value.aggregation().equals(value)
-                    && result.get().value.headers().equals(expectedHeaders);
-            },
-            "Could not verify session value with headers in time.");
+            "Could not verify session value in time.");
     }
 
     private void setupAndPopulateSessionStoreWithHeaders(final Properties props) throws Exception {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -138,9 +138,10 @@ public class HeadersStoreUpgradeIntegrationTest {
     }
 
     /**
-     * Produces a single record (no explicit timestamp) into the input stream.
+     * Produces a single record (no explicit timestamp) into the input stream. Keys and values are
+     * always {@link String}, matching the {@link StringSerializer} used below.
      */
-    private <K, V> void produce(final K key, final V value) {
+    private void produce(final String key, final String value) {
         IntegrationTestUtils.produceKeyValuesSynchronously(
             inputStream,
             singletonList(KeyValue.pair(key, value)),
@@ -152,7 +153,7 @@ public class HeadersStoreUpgradeIntegrationTest {
     /**
      * Produces a single record with an explicit timestamp into the input stream.
      */
-    private <K, V> void produce(final K key, final V value, final long timestamp) {
+    private void produce(final String key, final String value, final long timestamp) {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             inputStream,
             singletonList(KeyValue.pair(key, value)),
@@ -164,7 +165,7 @@ public class HeadersStoreUpgradeIntegrationTest {
     /**
      * Produces a single record with an explicit timestamp and headers into the input stream.
      */
-    private <K, V> void produce(final K key, final V value, final long timestamp, final Headers headers) {
+    private void produce(final String key, final String value, final long timestamp, final Headers headers) {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             inputStream,
             singletonList(KeyValue.pair(key, value)),
@@ -187,11 +188,7 @@ public class HeadersStoreUpgradeIntegrationTest {
                                 final String message) throws Exception {
         TestUtils.waitForCondition(() -> {
             try {
-                final S store = IntegrationTestUtils.getStore(storeName, kafkaStreams, storeType);
-                if (store == null) {
-                    return false;
-                }
-                return condition.test(store);
+                return condition.test(IntegrationTestUtils.getStore(storeName, kafkaStreams, storeType));
             } catch (final Exception swallow) {
                 LOG.error("Error while checking store result", swallow);
                 return false;
@@ -208,10 +205,12 @@ public class HeadersStoreUpgradeIntegrationTest {
     }
 
     /**
-     * Finds the value stored for {@code key} in the window that {@code timestamp} falls into,
-     * by scanning {@link ReadOnlyWindowStore#all()} and matching on key and window start.
+     * Finds the entry stored for {@code key} in the window that {@code timestamp} falls into, by
+     * scanning {@link ReadOnlyWindowStore#all()} and matching on key and window start. Returns the
+     * matched {@link KeyValue} so an empty result means "no such entry" and is not conflated with a
+     * matched entry that happens to have a {@code null} value — callers can assert on the value.
      */
-    private static Optional<ValueTimestampHeaders<String>> findWindowedValue(
+    private static Optional<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> findWindowedValue(
         final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store,
         final String key,
         final long timestamp) {
@@ -220,7 +219,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             while (iterator.hasNext()) {
                 final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
                 if (kv.key.key().equals(key) && kv.key.window().start() == start) {
-                    return Optional.ofNullable(kv.value);
+                    return Optional.of(kv);
                 }
             }
         }
@@ -228,12 +227,13 @@ public class HeadersStoreUpgradeIntegrationTest {
     }
 
     /**
-     * Finds the aggregation stored for {@code key} in the session whose window starts at
-     * {@code timestamp}, by scanning {@link ReadOnlySessionStore#fetch(Object)}. Sessions in this
-     * test are always created as {@code SessionWindow(ts, ts)}, so matching on window start is
-     * equivalent to matching both start and end.
+     * Finds the entry stored for {@code key} in the session whose window starts at {@code timestamp},
+     * by scanning {@link ReadOnlySessionStore#fetch(Object)}. Sessions in this test are always
+     * created as {@code SessionWindow(ts, ts)}, so matching on window start is equivalent to matching
+     * both start and end. Returns the matched {@link KeyValue} so an empty result means "no such
+     * entry" and is not conflated with a matched entry that happens to have a {@code null} value.
      */
-    private static Optional<AggregationWithHeaders<String>> findSessionValue(
+    private static Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> findSessionValue(
         final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store,
         final String key,
         final long timestamp) {
@@ -241,7 +241,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             while (iterator.hasNext()) {
                 final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
                 if (kv.key.key().equals(key) && kv.key.window().start() == timestamp) {
-                    return Optional.ofNullable(kv.value);
+                    return Optional.of(kv);
                 }
             }
         }
@@ -479,81 +479,55 @@ public class HeadersStoreUpgradeIntegrationTest {
         kafkaStreams.close();
     }
 
-    private <K, V> void processKeyValueAndVerifyTimestampedValue(final K key,
-                                                                 final V value,
-                                                                 final long timestamp)
-        throws Exception {
-
+    private void processKeyValueAndVerifyTimestampedValue(final String key,
+                                                          final String value,
+                                                          final long timestamp) throws Exception {
         produce(key, value, timestamp);
-
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStore(),
-            store -> {
-                final ValueAndTimestamp<V> result = store.get(key);
-                return result != null && result.value().equals(value) && result.timestamp() == timestamp;
-            },
-            "Could not get expected result in time.");
+        verifyLegacyTimestampedValue(key, value, timestamp);
     }
 
-    private <K, V> void processKeyValueAndVerifyValue(final K key,
-                                                      final V value)
-        throws Exception {
-
+    private void processKeyValueAndVerifyValue(final String key,
+                                               final String value) throws Exception {
         produce(key, value);
 
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>keyValueStore(),
+        awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>keyValueStore(),
             store -> {
-                final V result = store.get(key);
+                final String result = store.get(key);
                 return result != null && result.equals(value);
             },
             "Could not get expected result in time.");
     }
 
-    private <K, V> void verifyLegacyTimestampedValue(final K key,
-                                                     final V value,
-                                                     final long timestamp)
-        throws Exception {
-
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStore(),
+    private void verifyLegacyTimestampedValue(final String key,
+                                              final String value,
+                                              final long timestamp) throws Exception {
+        awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>timestampedKeyValueStore(),
             store -> {
-                final ValueAndTimestamp<V> result = store.get(key);
+                final ValueAndTimestamp<String> result = store.get(key);
                 return result != null && result.value().equals(value) && result.timestamp() == timestamp;
             },
             "Could not get expected result in time.");
     }
 
-    private <K, V> void processKeyValueWithTimestampAndHeadersAndVerify(final K key,
-                                                                        final V value,
-                                                                        final long timestamp,
-                                                                        final Headers headers,
-                                                                        final Headers expectedHeaders)
-        throws Exception {
-
-        produce(key, value, timestamp, headers);
-
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
-            store -> {
-                final ValueTimestampHeaders<V> result = store.get(key);
-                return result != null
-                    && result.value().equals(value)
-                    && result.timestamp() == timestamp
-                    && result.headers().equals(expectedHeaders);
-            },
-            "Could not get expected result in time.");
+    private void processKeyValueWithTimestampAndHeadersAndVerify(final String key,
+                                                                 final String value,
+                                                                 final long timestamp,
+                                                                 final Headers headers,
+                                                                 final Headers expectedHeaders) throws Exception {
+        processKeyValueWithTimestampAndHeadersAndVerify(key, value, timestamp, timestamp, headers, expectedHeaders);
     }
 
-    private <K, V> void processKeyValueWithTimestampAndHeadersAndVerify(final K key,
-                                                                        final V value,
-                                                                        final long timestamp,
-                                                                        final long expectedTimestamp,
-                                                                        final Headers headers,
-                                                                        final Headers expectedHeaders)
-        throws Exception {
-
+    private void processKeyValueWithTimestampAndHeadersAndVerify(final String key,
+                                                                 final String value,
+                                                                 final long timestamp,
+                                                                 final long expectedTimestamp,
+                                                                 final Headers headers,
+                                                                 final Headers expectedHeaders) throws Exception {
         produce(key, value, timestamp, headers);
 
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
+        awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>timestampedKeyValueStoreWithHeaders(),
             store -> {
-                final ValueTimestampHeaders<V> result = store.get(key);
+                final ValueTimestampHeaders<String> result = store.get(key);
                 return result != null
                     && result.value().equals(value)
                     && result.timestamp() == expectedTimestamp
@@ -562,12 +536,12 @@ public class HeadersStoreUpgradeIntegrationTest {
             "Could not get expected result in time.");
     }
 
-    private <K, V> void verifyLegacyValuesWithEmptyHeaders(final K key,
-                                                           final V value,
-                                                           final long timestamp) throws Exception {
-        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
+    private void verifyLegacyValuesWithEmptyHeaders(final String key,
+                                                    final String value,
+                                                    final long timestamp) throws Exception {
+        awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>timestampedKeyValueStoreWithHeaders(),
             store -> {
-                final ValueTimestampHeaders<V> result = store.get(key);
+                final ValueTimestampHeaders<String> result = store.get(key);
                 return result != null
                     && result.value().equals(value)
                     && result.timestamp() == timestamp
@@ -711,8 +685,9 @@ public class HeadersStoreUpgradeIntegrationTest {
         // In proxy mode with plain store, headers and timestamps are not preserved
         final RecordHeaders expectedHeaders = new RecordHeaders();
 
-        processPlainWindowedKeyValueWithHeadersAndVerify("key3", "value3-updated", baseTime + 350, headers, expectedHeaders);
-        processPlainWindowedKeyValueWithHeadersAndVerify("key4", "value4", baseTime + 400, headers, expectedHeaders);
+        // Plain window store does not preserve timestamps, so the stored timestamp is -1.
+        processWindowedKeyValueWithHeadersAndVerify("key3", "value3-updated", baseTime + 350, -1L, headers, expectedHeaders);
+        processWindowedKeyValueWithHeadersAndVerify("key4", "value4", baseTime + 400, -1L, headers, expectedHeaders);
 
         kafkaStreams.close();
     }
@@ -761,9 +736,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyWindowValueWithEmptyHeaders("key1", "value1", baseTime + 100);
-        verifyWindowValueWithEmptyHeaders("key2", "value2", baseTime + 200);
-        verifyWindowValueWithEmptyHeaders("key3", "value3", baseTime + 300);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, baseTime + 100);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, baseTime + 200);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, baseTime + 300);
 
         final Headers headers = new RecordHeaders();
         headers.add("source", "migration-test".getBytes());
@@ -802,9 +777,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyWindowValueWithEmptyHeaders("key1", "value1", baseTime + 100);
-        verifyWindowValueWithEmptyHeaders("key2", "value2", baseTime + 200);
-        verifyWindowValueWithEmptyHeaders("key3", "value3", baseTime + 300);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, baseTime + 100);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, baseTime + 200);
+        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, baseTime + 300);
 
         final RecordHeaders headers = new RecordHeaders();
         headers.add("source", "proxy-test".getBytes());
@@ -838,42 +813,24 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                     final long expectedTimestamp) throws Exception {
         awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
             store -> {
-                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, windowTimestamp);
+                final Optional<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> result =
+                    findWindowedValue(store, key, windowTimestamp);
                 if (result.isEmpty()) {
                     return false;
                 }
 
-                final ValueTimestampHeaders<String> value0 = result.get();
-                assertNotNull(value0, "Result should not be null");
-                assertEquals(value, value0.value(), "Value should match");
-                assertEquals(expectedTimestamp, value0.timestamp(), "Timestamp should be " + expectedTimestamp + " for plain store migration");
+                final ValueTimestampHeaders<String> actual = result.get().value;
+                assertNotNull(actual, "Stored value should not be null");
+                assertEquals(value, actual.value(), "Value should match");
+                assertEquals(expectedTimestamp, actual.timestamp(), "Timestamp should be " + expectedTimestamp + " for plain store migration");
 
                 // Verify headers exist but are empty (migrated from plain store without headers or timestamps)
-                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
+                assertNotNull(actual.headers(), "Headers should not be null for migrated data");
+                assertEquals(0, actual.headers().toArray().length, "Headers should be empty for migrated data");
 
                 return true;
             },
             "Could not verify plain window value with empty headers and timestamp in time.");
-    }
-
-    private void processPlainWindowedKeyValueWithHeadersAndVerify(final String key,
-                                                                  final String value,
-                                                                  final long timestamp,
-                                                                  final Headers headers,
-                                                                  final Headers expectedHeaders) throws Exception {
-        produce(key, value, timestamp, headers);
-
-        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
-            store -> {
-                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
-                // For plain window stores, timestamp is always -1 since it's not preserved
-                return result.isPresent()
-                    && result.get().value().equals(value)
-                    && result.get().timestamp() == -1L
-                    && result.get().headers().equals(expectedHeaders);
-            },
-            "Could not verify plain windowed value with headers in time.");
     }
 
     private void processWindowedKeyValueAndVerifyTimestamped(final String key,
@@ -896,41 +853,33 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                              final long timestamp,
                                                              final Headers headers,
                                                              final Headers expectedHeaders) throws Exception {
+        processWindowedKeyValueWithHeadersAndVerify(key, value, timestamp, timestamp, headers, expectedHeaders);
+    }
+
+    /**
+     * Produces a windowed record with headers and verifies the stored value/headers, expecting
+     * {@code expectedTimestamp} in the store. For a plain window store (no timestamp preserved)
+     * pass {@code expectedTimestamp == -1L}; otherwise pass the produced {@code timestamp}.
+     */
+    private void processWindowedKeyValueWithHeadersAndVerify(final String key,
+                                                             final String value,
+                                                             final long timestamp,
+                                                             final long expectedTimestamp,
+                                                             final Headers headers,
+                                                             final Headers expectedHeaders) throws Exception {
         produce(key, value, timestamp, headers);
 
         awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
             store -> {
-                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
+                final Optional<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> result =
+                    findWindowedValue(store, key, timestamp);
                 return result.isPresent()
-                    && result.get().value().equals(value)
-                    && result.get().timestamp() == timestamp
-                    && result.get().headers().equals(expectedHeaders);
+                    && result.get().value != null
+                    && result.get().value.value().equals(value)
+                    && result.get().value.timestamp() == expectedTimestamp
+                    && result.get().value.headers().equals(expectedHeaders);
             },
             "Could not verify windowed value with headers in time.");
-    }
-
-    private void verifyWindowValueWithEmptyHeaders(final String key,
-                                                   final String value,
-                                                   final long timestamp) throws Exception {
-        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
-            store -> {
-                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
-                if (result.isEmpty()) {
-                    return false;
-                }
-
-                final ValueTimestampHeaders<String> value0 = result.get();
-                assertNotNull(value0, "Result should not be null");
-                assertEquals(value, value0.value(), "Value should match");
-                assertEquals(timestamp, value0.timestamp(), "Timestamp should match");
-
-                // Verify headers exist but are empty (migrated from timestamped store without headers)
-                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
-
-                return true;
-            },
-            "Could not verify legacy value with empty headers in time.");
     }
 
     /**
@@ -1152,17 +1101,6 @@ public class HeadersStoreUpgradeIntegrationTest {
         kafkaStreams.close();
     }
 
-    private boolean windowStoreContainsKey(final String key, final long timestamp) {
-        try {
-            final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
-                IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
-
-            return store != null && findWindowedValue(store, key, timestamp).isPresent();
-        } catch (final Exception e) {
-            return false;
-        }
-    }
-
     /**
      * Setup and populate a window store with headers.
      * @param props Streams properties
@@ -1179,18 +1117,10 @@ public class HeadersStoreUpgradeIntegrationTest {
         }
 
         // Wait for all records to be processed
-        TestUtils.waitForCondition(
-            () -> {
-                for (final KeyValue<String, Long> record : records) {
-                    if (!windowStoreContainsKey(record.key, baseTime + record.value)) {
-                        return false;
-                    }
-                }
-                return true;
-            },
-            30_000L,
-            "Store was not populated with expected data"
-        );
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
+            store -> records.stream()
+                .allMatch(record -> findWindowedValue(store, record.key, baseTime + record.value).isPresent()),
+            "Store was not populated with expected data");
 
         kafkaStreams.close();
     }
@@ -1436,7 +1366,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 try (final KeyValueIterator<Windowed<String>, String> iterator = store.fetch(key)) {
                     while (iterator.hasNext()) {
                         final KeyValue<Windowed<String>, String> kv = iterator.next();
-                        if (kv.key.key().equals(key) && kv.value.equals(value)) {
+                        if (kv.key.key().equals(key)
+                            && kv.key.window().start() == timestamp
+                            && kv.value.equals(value)) {
                             return true;
                         }
                     }
@@ -1451,18 +1383,19 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                     final long timestamp) throws Exception {
         awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
             store -> {
-                final Optional<AggregationWithHeaders<String>> result = findSessionValue(store, key, timestamp);
+                final Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> result =
+                    findSessionValue(store, key, timestamp);
                 if (result.isEmpty()) {
                     return false;
                 }
 
-                final AggregationWithHeaders<String> value0 = result.get();
-                assertNotNull(value0, "Result should not be null");
-                assertEquals(value, value0.aggregation(), "Value should match");
+                final AggregationWithHeaders<String> actual = result.get().value;
+                assertNotNull(actual, "Stored value should not be null");
+                assertEquals(value, actual.aggregation(), "Value should match");
 
                 // Verify headers exist but are empty (migrated from plain session store)
-                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
+                assertNotNull(actual.headers(), "Headers should not be null for migrated data");
+                assertEquals(0, actual.headers().toArray().length, "Headers should be empty for migrated data");
 
                 return true;
             },
@@ -1478,24 +1411,14 @@ public class HeadersStoreUpgradeIntegrationTest {
 
         awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
             store -> {
-                final Optional<AggregationWithHeaders<String>> result = findSessionValue(store, key, timestamp);
+                final Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> result =
+                    findSessionValue(store, key, timestamp);
                 return result.isPresent()
-                    && result.get().aggregation().equals(value)
-                    && result.get().headers().equals(expectedHeaders);
+                    && result.get().value != null
+                    && result.get().value.aggregation().equals(value)
+                    && result.get().value.headers().equals(expectedHeaders);
             },
             "Could not verify session value with headers in time.");
-    }
-
-    private boolean sessionStoreContainsKey(final String key,
-                                            final long timestamp) {
-        try {
-            final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store =
-                IntegrationTestUtils.getStore(SESSION_STORE_NAME, kafkaStreams, QueryableStoreTypes.sessionStoreWithHeaders());
-
-            return store != null && findSessionValue(store, key, timestamp).isPresent();
-        } catch (final Exception e) {
-            return false;
-        }
     }
 
     private void setupAndPopulateSessionStoreWithHeaders(final Properties props) throws Exception {
@@ -1515,19 +1438,11 @@ public class HeadersStoreUpgradeIntegrationTest {
         final Headers headers = new RecordHeaders();
         headers.add("source", "test".getBytes());
 
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair("key1", "value1")),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
-            headers,
-            baseTime + 100,
-            false);
+        produce("key1", "value1", baseTime + 100, headers);
 
-        TestUtils.waitForCondition(
-            () -> sessionStoreContainsKey("key1", baseTime + 100),
-            30_000L,
-            "Store was not populated with expected data"
-        );
+        awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
+            store -> findSessionValue(store, "key1", baseTime + 100).isPresent(),
+            "Store was not populated with expected data");
 
         kafkaStreams.close();
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -38,8 +38,8 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.AggregationWithHeaders;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
-import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.SessionStore;
@@ -67,9 +67,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -84,6 +85,7 @@ public class HeadersStoreUpgradeIntegrationTest {
     private static final String SESSION_STORE_NAME = "session-store";
     private static final long WINDOW_SIZE_MS = 1000L;
     private static final long RETENTION_MS = Duration.ofDays(1).toMillis();
+    private static final long DEFAULT_STORE_TIMEOUT_MS = 60_000L;
     private static final Logger LOG = LoggerFactory.getLogger(HeadersStoreUpgradeIntegrationTest.class);
     private String inputStream;
 
@@ -133,6 +135,117 @@ public class HeadersStoreUpgradeIntegrationTest {
             .process(processorSupplier, storeName);
         kafkaStreams = new KafkaStreams(builder.build(), props);
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+    }
+
+    /**
+     * Produces a single record (no explicit timestamp) into the input stream.
+     */
+    private <K, V> void produce(final K key, final V value) {
+        IntegrationTestUtils.produceKeyValuesSynchronously(
+            inputStream,
+            singletonList(KeyValue.pair(key, value)),
+            TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
+            CLUSTER.time,
+            false);
+    }
+
+    /**
+     * Produces a single record with an explicit timestamp into the input stream.
+     */
+    private <K, V> void produce(final K key, final V value, final long timestamp) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            inputStream,
+            singletonList(KeyValue.pair(key, value)),
+            TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
+            timestamp,
+            false);
+    }
+
+    /**
+     * Produces a single record with an explicit timestamp and headers into the input stream.
+     */
+    private <K, V> void produce(final K key, final V value, final long timestamp, final Headers headers) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            inputStream,
+            singletonList(KeyValue.pair(key, value)),
+            TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
+            headers,
+            timestamp,
+            false);
+    }
+
+    /**
+     * Shared skeleton for the process-and-verify / verify helpers: waits until the named store is
+     * queryable and the supplied condition holds. The store lookup is retried until the condition
+     * passes or the timeout elapses; transient query {@link Exception}s (e.g. store not yet ready)
+     * are swallowed and treated as "not ready". {@link AssertionError} thrown by a condition that
+     * uses {@code assertX(...)} is intentionally NOT caught here, so those helpers still fail fast.
+     */
+    private <S> void awaitStore(final String storeName,
+                                final QueryableStoreType<S> storeType,
+                                final Predicate<S> condition,
+                                final String message) throws Exception {
+        TestUtils.waitForCondition(() -> {
+            try {
+                final S store = IntegrationTestUtils.getStore(storeName, kafkaStreams, storeType);
+                if (store == null) {
+                    return false;
+                }
+                return condition.test(store);
+            } catch (final Exception swallow) {
+                LOG.error("Error while checking store result", swallow);
+                return false;
+            }
+        }, DEFAULT_STORE_TIMEOUT_MS, message);
+    }
+
+    /**
+     * Computes the start of the window that {@code timestamp} falls into for the fixed
+     * {@link #WINDOW_SIZE_MS} window size.
+     */
+    private static long windowStart(final long timestamp) {
+        return timestamp - (timestamp % WINDOW_SIZE_MS);
+    }
+
+    /**
+     * Finds the value stored for {@code key} in the window that {@code timestamp} falls into,
+     * by scanning {@link ReadOnlyWindowStore#all()} and matching on key and window start.
+     */
+    private static Optional<ValueTimestampHeaders<String>> findWindowedValue(
+        final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store,
+        final String key,
+        final long timestamp) {
+        final long start = windowStart(timestamp);
+        try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
+            while (iterator.hasNext()) {
+                final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
+                if (kv.key.key().equals(key) && kv.key.window().start() == start) {
+                    return Optional.ofNullable(kv.value);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Finds the aggregation stored for {@code key} in the session whose window starts at
+     * {@code timestamp}, by scanning {@link ReadOnlySessionStore#fetch(Object)}. Sessions in this
+     * test are always created as {@code SessionWindow(ts, ts)}, so matching on window start is
+     * equivalent to matching both start and end.
+     */
+    private static Optional<AggregationWithHeaders<String>> findSessionValue(
+        final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store,
+        final String key,
+        final long timestamp) {
+        try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(key)) {
+            while (iterator.hasNext()) {
+                final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
+                if (kv.key.key().equals(key) && kv.key.window().start() == timestamp) {
+                    return Optional.ofNullable(kv.value);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private void assertDowngradeThrowsProcessorStateException(
@@ -371,33 +484,13 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                  final long timestamp)
         throws Exception {
 
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            timestamp,
-            false);
+        produce(key, value, timestamp);
 
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                        IntegrationTestUtils.getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
-
-                    if (store == null) {
-                        return false;
-                    }
-
-                    final ValueAndTimestamp<V> result = store.get(key);
-                    return result != null && result.value().equals(value) && result.timestamp() == timestamp;
-                } catch (final Exception swallow) {
-                    LOG.error("Error while checking store result", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStore(),
+            store -> {
+                final ValueAndTimestamp<V> result = store.get(key);
+                return result != null && result.value().equals(value) && result.timestamp() == timestamp;
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
@@ -405,33 +498,13 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                       final V value)
         throws Exception {
 
-        IntegrationTestUtils.produceKeyValuesSynchronously(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            CLUSTER.time,
-            false);
+        produce(key, value);
 
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, V> store =
-                        IntegrationTestUtils.getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.keyValueStore());
-
-                    if (store == null) {
-                        return false;
-                    }
-
-                    final V result = store.get(key);
-                    return result != null && result.equals(value);
-                } catch (final Exception swallow) {
-                    LOG.error("Error while verifying legacy value", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>keyValueStore(),
+            store -> {
+                final V result = store.get(key);
+                return result != null && result.equals(value);
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
@@ -440,24 +513,11 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                      final long timestamp)
         throws Exception {
 
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, ValueAndTimestamp<V>> store =
-                        IntegrationTestUtils.getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
-
-                    if (store == null) {
-                        return false;
-                    }
-
-                    final ValueAndTimestamp<V> result = store.get(key);
-                    return result != null && result.value().equals(value) && result.timestamp() == timestamp;
-                } catch (final Exception swallow) {
-                    LOG.error("Error while waiting for expected result", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStore(),
+            store -> {
+                final ValueAndTimestamp<V> result = store.get(key);
+                return result != null && result.value().equals(value) && result.timestamp() == timestamp;
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
@@ -468,36 +528,16 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                         final Headers expectedHeaders)
         throws Exception {
 
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
 
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, ValueTimestampHeaders<V>> store = IntegrationTestUtils
-                        .getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders());
-
-                    if (store == null)
-                        return false;
-
-                    final ValueTimestampHeaders<V> result = store.get(key);
-                    return result != null
-                        && result.value().equals(value)
-                        && result.timestamp() == timestamp
-                        && result.headers().equals(expectedHeaders);
-                } catch (final Exception swallow) {
-                    LOG.error("Failed to retrieve expected result", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
+            store -> {
+                final ValueTimestampHeaders<V> result = store.get(key);
+                return result != null
+                    && result.value().equals(value)
+                    && result.timestamp() == timestamp
+                    && result.headers().equals(expectedHeaders);
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
@@ -509,62 +549,30 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                         final Headers expectedHeaders)
         throws Exception {
 
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
 
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, ValueTimestampHeaders<V>> store = IntegrationTestUtils
-                        .getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders());
-
-                    if (store == null)
-                        return false;
-
-                    final ValueTimestampHeaders<V> result = store.get(key);
-                    return result != null
-                        && result.value().equals(value)
-                        && result.timestamp() == expectedTimestamp
-                        && result.headers().equals(expectedHeaders);
-                } catch (final Exception swallow) {
-                    LOG.error("Failed to retrieve expected result", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
+            store -> {
+                final ValueTimestampHeaders<V> result = store.get(key);
+                return result != null
+                    && result.value().equals(value)
+                    && result.timestamp() == expectedTimestamp
+                    && result.headers().equals(expectedHeaders);
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
     private <K, V> void verifyLegacyValuesWithEmptyHeaders(final K key,
                                                            final V value,
                                                            final long timestamp) throws Exception {
-        TestUtils.waitForCondition(
-            () -> {
-                try {
-                    final ReadOnlyKeyValueStore<K, ValueTimestampHeaders<V>> store = IntegrationTestUtils
-                        .getStore(STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStoreWithHeaders());
-
-                    if (store == null)
-                        return false;
-
-                    final ValueTimestampHeaders<V> result = store.get(key);
-                    return result != null
-                        && result.value().equals(value)
-                        && result.timestamp() == timestamp
-                        && result.headers().toArray().length == 0;
-                } catch (final Exception swallow) {
-                    LOG.error("Failed to retrieve expected result", swallow);
-                    return false;
-                }
+        awaitStore(STORE_NAME, QueryableStoreTypes.<K, V>timestampedKeyValueStoreWithHeaders(),
+            store -> {
+                final ValueTimestampHeaders<V> result = store.get(key);
+                return result != null
+                    && result.value().equals(value)
+                    && result.timestamp() == timestamp
+                    && result.headers().toArray().length == 0;
             },
-            60_000L,
             "Could not get expected result in time.");
     }
 
@@ -814,78 +822,39 @@ public class HeadersStoreUpgradeIntegrationTest {
     private void processPlainWindowedKeyValueAndVerify(final String key,
                                                        final String value,
                                                        final long timestamp) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            List.of(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            timestamp,
-            false);
+        produce(key, value, timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, String> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.windowStore());
-
-                if (store == null) {
-                    return false;
-                }
-
-                final long windowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-                final String result = store.fetch(key, windowStart);
-
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>windowStore(),
+            store -> {
+                final String result = store.fetch(key, windowStart(timestamp));
                 return result != null && result.equals(value);
-            } catch (final Exception e) {
-                return false;
-            }
-        }, 60_000L, "Could not verify plain window value in time.");
+            },
+            "Could not verify plain window value in time.");
     }
 
     private void verifyPlainWindowValueWithEmptyHeadersAndTimestamp(final String key,
                                                                     final String value,
                                                                     final long windowTimestamp,
                                                                     final long expectedTimestamp) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
-
-                if (store == null) {
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
+            store -> {
+                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, windowTimestamp);
+                if (result.isEmpty()) {
                     return false;
                 }
 
-                final long windowStart = windowTimestamp - (windowTimestamp % WINDOW_SIZE_MS);
-
-                final List<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> results = new LinkedList<>();
-                try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key) && kv.key.window().start() == windowStart) {
-                            results.add(kv);
-                        }
-                    }
-                }
-
-                if (results.isEmpty()) {
-                    return false;
-                }
-
-                final ValueTimestampHeaders<String> result = results.get(0).value;
-                assertNotNull(result, "Result should not be null");
-                assertEquals(value, result.value(), "Value should match");
-                assertEquals(expectedTimestamp, result.timestamp(), "Timestamp should be " + expectedTimestamp + " for plain store migration");
+                final ValueTimestampHeaders<String> value0 = result.get();
+                assertNotNull(value0, "Result should not be null");
+                assertEquals(value, value0.value(), "Value should match");
+                assertEquals(expectedTimestamp, value0.timestamp(), "Timestamp should be " + expectedTimestamp + " for plain store migration");
 
                 // Verify headers exist but are empty (migrated from plain store without headers or timestamps)
-                assertNotNull(result.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, result.headers().toArray().length, "Headers should be empty for migrated data");
+                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
+                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
 
                 return true;
-            } catch (final Exception e) {
-                LOG.error("Error while verifying plain window value with empty headers and timestamp", e);
-                return false;
-            }
-        }, 60_000L, "Could not verify plain window value with empty headers and timestamp in time.");
+            },
+            "Could not verify plain window value with empty headers and timestamp in time.");
     }
 
     private void processPlainWindowedKeyValueWithHeadersAndVerify(final String key,
@@ -893,85 +862,33 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                   final long timestamp,
                                                                   final Headers headers,
                                                                   final Headers expectedHeaders) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            List.of(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
-
-                if (store == null) {
-                    return false;
-                }
-
-                final long windowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-
-                final List<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> results = new LinkedList<>();
-                try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key) && kv.key.window().start() == windowStart) {
-                            results.add(kv);
-                        }
-                    }
-                }
-
-                if (results.isEmpty()) {
-                    return false;
-                }
-
-                final ValueTimestampHeaders<String> result = results.get(0).value;
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
+            store -> {
+                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
                 // For plain window stores, timestamp is always -1 since it's not preserved
-                return result != null
-                    && result.value().equals(value)
-                    && result.timestamp() == -1L
-                    && result.headers().equals(expectedHeaders);
-            } catch (final Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-        }, 60_000L, "Could not verify plain windowed value with headers in time.");
+                return result.isPresent()
+                    && result.get().value().equals(value)
+                    && result.get().timestamp() == -1L
+                    && result.get().headers().equals(expectedHeaders);
+            },
+            "Could not verify plain windowed value with headers in time.");
     }
 
     private void processWindowedKeyValueAndVerifyTimestamped(final String key,
                                                              final String value,
                                                              final long timestamp) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            timestamp,
-            false);
+        produce(key, value, timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStore());
-
-                if (store == null) {
-                    return false;
-                }
-
-                final long windowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-                final ValueAndTimestamp<String> result = store.fetch(key, windowStart);
-
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStore(),
+            store -> {
+                final ValueAndTimestamp<String> result = store.fetch(key, windowStart(timestamp));
                 return result != null
                     && result.value().equals(value)
                     && result.timestamp() == timestamp;
-            } catch (final Exception e) {
-                return false;
-            }
-        }, 60_000L, "Could not verify timestamped value in time.");
+            },
+            "Could not verify timestamped value in time.");
     }
 
     private void processWindowedKeyValueWithHeadersAndVerify(final String key,
@@ -979,96 +896,41 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                              final long timestamp,
                                                              final Headers headers,
                                                              final Headers expectedHeaders) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
-
-                if (store == null) {
-                    return false;
-                }
-
-                final long windowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-
-                final List<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> results = new LinkedList<>();
-                try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key) && kv.key.window().start() == windowStart) {
-                            results.add(kv);
-                        }
-                    }
-                }
-
-                if (results.isEmpty()) {
-                    return false;
-                }
-
-                final ValueTimestampHeaders<String> result = results.get(0).value;
-                return result != null
-                    && result.value().equals(value)
-                    && result.timestamp() == timestamp
-                    && result.headers().equals(expectedHeaders);
-            } catch (final Exception e) {
-                LOG.error("Error while verifying windowed value with headers", e);
-                return false;
-            }
-        }, 60_000L, "Could not verify windowed value with headers in time.");
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
+            store -> {
+                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
+                return result.isPresent()
+                    && result.get().value().equals(value)
+                    && result.get().timestamp() == timestamp
+                    && result.get().headers().equals(expectedHeaders);
+            },
+            "Could not verify windowed value with headers in time.");
     }
 
     private void verifyWindowValueWithEmptyHeaders(final String key,
                                                    final String value,
                                                    final long timestamp) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
-                    IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
-
-                if (store == null) {
+        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
+            store -> {
+                final Optional<ValueTimestampHeaders<String>> result = findWindowedValue(store, key, timestamp);
+                if (result.isEmpty()) {
                     return false;
                 }
 
-                final long windowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-
-                final List<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> results = new LinkedList<>();
-                try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key) && kv.key.window().start() == windowStart) {
-                            results.add(kv);
-                        }
-                    }
-                }
-
-                if (results.isEmpty()) {
-                    return false;
-                }
-
-                final ValueTimestampHeaders<String> result = results.get(0).value;
-                assertNotNull(result, "Result should not be null");
-                assertEquals(value, result.value(), "Value should match");
-                assertEquals(timestamp, result.timestamp(), "Timestamp should match");
+                final ValueTimestampHeaders<String> value0 = result.get();
+                assertNotNull(value0, "Result should not be null");
+                assertEquals(value, value0.value(), "Value should match");
+                assertEquals(timestamp, value0.timestamp(), "Timestamp should match");
 
                 // Verify headers exist but are empty (migrated from timestamped store without headers)
-                assertNotNull(result.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, result.headers().toArray().length, "Headers should be empty for migrated data");
+                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
+                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
 
                 return true;
-            } catch (final Exception e) {
-                LOG.error("Error while verifying legacy value with empty headers", e);
-                return false;
-            }
-        }, 60_000L, "Could not verify legacy value with empty headers in time.");
+            },
+            "Could not verify legacy value with empty headers in time.");
     }
 
     /**
@@ -1295,20 +1157,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store =
                 IntegrationTestUtils.getStore(WINDOW_STORE_NAME, kafkaStreams, QueryableStoreTypes.timestampedWindowStoreWithHeaders());
 
-            if (store == null) {
-                return false;
-            }
-
-            final long expectedWindowStart = timestamp - (timestamp % WINDOW_SIZE_MS);
-            try (final KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-                while (iterator.hasNext()) {
-                    final KeyValue<Windowed<String>, ValueTimestampHeaders<String>> kv = iterator.next();
-                    if (kv.key.key().equals(key) && kv.key.window().start() == expectedWindowStart) {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            return store != null && findWindowedValue(store, key, timestamp).isPresent();
         } catch (final Exception e) {
             return false;
         }
@@ -1364,13 +1213,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         final Headers headers = new RecordHeaders();
         headers.add("source", "test".getBytes());
 
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(), StringSerializer.class, StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
     }
 
     private void setupAndPopulateKeyValueStoreWithHeaders(final Properties props) throws Exception {
@@ -1586,24 +1429,10 @@ public class HeadersStoreUpgradeIntegrationTest {
     private void processSessionKeyValueAndVerify(final String key,
                                                   final String value,
                                                   final long timestamp) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            timestamp,
-            false);
+        produce(key, value, timestamp);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlySessionStore<String, String> store =
-                    IntegrationTestUtils.getStore(SESSION_STORE_NAME, kafkaStreams, QueryableStoreTypes.sessionStore());
-
-                if (store == null) {
-                    return false;
-                }
-
+        awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStore(),
+            store -> {
                 try (final KeyValueIterator<Windowed<String>, String> iterator = store.fetch(key)) {
                     while (iterator.hasNext()) {
                         final KeyValue<Windowed<String>, String> kv = iterator.next();
@@ -1613,49 +1442,31 @@ public class HeadersStoreUpgradeIntegrationTest {
                     }
                 }
                 return false;
-            } catch (final Exception e) {
-                return false;
-            }
-        }, 60_000L, "Could not verify session value in time.");
+            },
+            "Could not verify session value in time.");
     }
 
     private void verifySessionValueWithEmptyHeaders(final String key,
                                                     final String value,
                                                     final long timestamp) throws Exception {
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store =
-                    IntegrationTestUtils.getStore(SESSION_STORE_NAME, kafkaStreams, QueryableStoreTypes.sessionStoreWithHeaders());
-
-                if (store == null) {
+        awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
+            store -> {
+                final Optional<AggregationWithHeaders<String>> result = findSessionValue(store, key, timestamp);
+                if (result.isEmpty()) {
                     return false;
                 }
 
-                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(key)) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key)
-                            && kv.key.window().start() == timestamp
-                            && kv.key.window().end() == timestamp) {
+                final AggregationWithHeaders<String> value0 = result.get();
+                assertNotNull(value0, "Result should not be null");
+                assertEquals(value, value0.aggregation(), "Value should match");
 
-                            final AggregationWithHeaders<String> result = kv.value;
-                            assertNotNull(result, "Result should not be null");
-                            assertEquals(value, result.aggregation(), "Value should match");
+                // Verify headers exist but are empty (migrated from plain session store)
+                assertNotNull(value0.headers(), "Headers should not be null for migrated data");
+                assertEquals(0, value0.headers().toArray().length, "Headers should be empty for migrated data");
 
-                            // Verify headers exist but are empty (migrated from plain session store)
-                            assertNotNull(result.headers(), "Headers should not be null for migrated data");
-                            assertEquals(0, result.headers().toArray().length, "Headers should be empty for migrated data");
-
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            } catch (final Exception e) {
-                LOG.error("Error verifying legacy session value with empty headers", e);
-                return false;
-            }
-        }, 60_000L, "Could not verify legacy session value with empty headers in time.");
+                return true;
+            },
+            "Could not verify legacy session value with empty headers in time.");
     }
 
     private void processSessionKeyValueWithHeadersAndVerify(final String key,
@@ -1663,45 +1474,16 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                             final long timestamp,
                                                             final Headers headers,
                                                             final Headers expectedHeaders) throws Exception {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
-            inputStream,
-            singletonList(KeyValue.pair(key, value)),
-            TestUtils.producerConfig(CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class),
-            headers,
-            timestamp,
-            false);
+        produce(key, value, timestamp, headers);
 
-        TestUtils.waitForCondition(() -> {
-            try {
-                final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store =
-                    IntegrationTestUtils.getStore(SESSION_STORE_NAME, kafkaStreams, QueryableStoreTypes.sessionStoreWithHeaders());
-
-                if (store == null) {
-                    return false;
-                }
-
-                try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(key)) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
-                        if (kv.key.key().equals(key)
-                            && kv.key.window().start() == timestamp
-                            && kv.key.window().end() == timestamp) {
-
-                            final AggregationWithHeaders<String> result = kv.value;
-                            return result != null
-                                && result.aggregation().equals(value)
-                                && result.headers().equals(expectedHeaders);
-                        }
-                    }
-                }
-                return false;
-            } catch (final Exception e) {
-                LOG.error("Error verifying session value with headers", e);
-                return false;
-            }
-        }, 60_000L, "Could not verify session value with headers in time.");
+        awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStoreWithHeaders(),
+            store -> {
+                final Optional<AggregationWithHeaders<String>> result = findSessionValue(store, key, timestamp);
+                return result.isPresent()
+                    && result.get().aggregation().equals(value)
+                    && result.get().headers().equals(expectedHeaders);
+            },
+            "Could not verify session value with headers in time.");
     }
 
     private boolean sessionStoreContainsKey(final String key,
@@ -1710,19 +1492,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store =
                 IntegrationTestUtils.getStore(SESSION_STORE_NAME, kafkaStreams, QueryableStoreTypes.sessionStoreWithHeaders());
 
-            if (store == null) {
-                return false;
-            }
-
-            try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(key)) {
-                while (iterator.hasNext()) {
-                    final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
-                    if (kv.key.key().equals(key) && kv.key.window().start() == timestamp) {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            return store != null && findSessionValue(store, key, timestamp).isPresent();
         } catch (final Exception e) {
             return false;
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -179,8 +179,12 @@ public class HeadersStoreUpgradeIntegrationTest {
      * Shared skeleton for the process-and-verify / verify helpers: waits until the named store is
      * queryable and the supplied condition holds. The store lookup is retried until the condition
      * passes or the timeout elapses; transient query {@link Exception}s (e.g. store not yet ready)
-     * are swallowed and treated as "not ready". {@link AssertionError} thrown by a condition that
-     * uses {@code assertX(...)} is intentionally NOT caught here, so those helpers still fail fast.
+     * are swallowed and treated as "not ready".
+     *
+     * <p>A condition that uses {@code assertX(...)} does not fail fast: {@link TestUtils#waitForCondition}
+     * retries on {@link AssertionError} until the timeout, then rethrows the last assertion failure
+     * (with its specific message). Returning {@code false} and throwing an assertion therefore differ
+     * only in the message reported once the timeout is hit.
      */
     private <S> void awaitStore(final String storeName,
                                 final QueryableStoreType<S> storeType,
@@ -190,7 +194,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             try {
                 return condition.test(IntegrationTestUtils.getStore(storeName, kafkaStreams, storeType));
             } catch (final Exception swallow) {
-                LOG.error("Error while checking store result", swallow);
+                LOG.error("Error while checking result for store {}", storeName, swallow);
                 return false;
             }
         }, DEFAULT_STORE_TIMEOUT_MS, message);
@@ -227,20 +231,23 @@ public class HeadersStoreUpgradeIntegrationTest {
     }
 
     /**
-     * Finds the entry stored for {@code key} in the session whose window starts at {@code timestamp},
-     * by scanning {@link ReadOnlySessionStore#fetch(Object)}. Sessions in this test are always
-     * created as {@code SessionWindow(ts, ts)}, so matching on window start is equivalent to matching
-     * both start and end. Returns the matched {@link KeyValue} so an empty result means "no such
-     * entry" and is not conflated with a matched entry that happens to have a {@code null} value.
+     * Finds the entry stored for {@code key} in the session bounded by {@code timestamp}, by scanning
+     * {@link ReadOnlySessionStore#fetch(Object)} and matching on key and an exact session window
+     * ({@code SessionWindow(timestamp, timestamp)}). Both window start and end must equal
+     * {@code timestamp}, so a migration bug that mangles either boundary fails the match. Returns the
+     * matched {@link KeyValue} so an empty result means "no such entry" and is not conflated with a
+     * matched entry that happens to have a {@code null} value.
      */
-    private static Optional<KeyValue<Windowed<String>, AggregationWithHeaders<String>>> findSessionValue(
-        final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store,
+    private static <V> Optional<KeyValue<Windowed<String>, V>> findSessionValue(
+        final ReadOnlySessionStore<String, V> store,
         final String key,
         final long timestamp) {
-        try (final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(key)) {
+        try (final KeyValueIterator<Windowed<String>, V> iterator = store.fetch(key)) {
             while (iterator.hasNext()) {
-                final KeyValue<Windowed<String>, AggregationWithHeaders<String>> kv = iterator.next();
-                if (kv.key.key().equals(key) && kv.key.window().start() == timestamp) {
+                final KeyValue<Windowed<String>, V> kv = iterator.next();
+                if (kv.key.key().equals(key)
+                    && kv.key.window().start() == timestamp
+                    && kv.key.window().end() == timestamp) {
                     return Optional.of(kv);
                 }
             }
@@ -524,7 +531,24 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                                  final Headers headers,
                                                                  final Headers expectedHeaders) throws Exception {
         produce(key, value, timestamp, headers);
+        verifyKeyValueWithHeaders(key, value, expectedTimestamp, expectedHeaders);
+    }
 
+    private void verifyLegacyValuesWithEmptyHeaders(final String key,
+                                                    final String value,
+                                                    final long timestamp) throws Exception {
+        verifyKeyValueWithHeaders(key, value, timestamp, new RecordHeaders());
+    }
+
+    /**
+     * Verifies the value stored for {@code key} in the timestamped-with-headers key-value store,
+     * expecting {@code expectedTimestamp} and {@code expectedHeaders}. Pass an empty
+     * {@link RecordHeaders} for stores migrated without headers.
+     */
+    private void verifyKeyValueWithHeaders(final String key,
+                                           final String value,
+                                           final long expectedTimestamp,
+                                           final Headers expectedHeaders) throws Exception {
         awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>timestampedKeyValueStoreWithHeaders(),
             store -> {
                 final ValueTimestampHeaders<String> result = store.get(key);
@@ -532,20 +556,6 @@ public class HeadersStoreUpgradeIntegrationTest {
                     && result.value().equals(value)
                     && result.timestamp() == expectedTimestamp
                     && result.headers().equals(expectedHeaders);
-            },
-            "Could not get expected result in time.");
-    }
-
-    private void verifyLegacyValuesWithEmptyHeaders(final String key,
-                                                    final String value,
-                                                    final long timestamp) throws Exception {
-        awaitStore(STORE_NAME, QueryableStoreTypes.<String, String>timestampedKeyValueStoreWithHeaders(),
-            store -> {
-                final ValueTimestampHeaders<String> result = store.get(key);
-                return result != null
-                    && result.value().equals(value)
-                    && result.timestamp() == timestamp
-                    && result.headers().toArray().length == 0;
             },
             "Could not get expected result in time.");
     }
@@ -633,9 +643,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, persistentStore ? -1L : baseTime + 100);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, persistentStore ? -1L : baseTime + 200);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, persistentStore ? -1L : baseTime + 300);
+        verifyWindowValue("key1", "value1", baseTime + 100, persistentStore ? -1L : baseTime + 100);
+        verifyWindowValue("key2", "value2", baseTime + 200, persistentStore ? -1L : baseTime + 200);
+        verifyWindowValue("key3", "value3", baseTime + 300, persistentStore ? -1L : baseTime + 300);
 
         final Headers headers = new RecordHeaders();
         headers.add("source", "migration-test".getBytes());
@@ -674,9 +684,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, -1L);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, -1L);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, -1L);
+        verifyWindowValue("key1", "value1", baseTime + 100, -1L);
+        verifyWindowValue("key2", "value2", baseTime + 200, -1L);
+        verifyWindowValue("key3", "value3", baseTime + 300, -1L);
 
         final RecordHeaders headers = new RecordHeaders();
         headers.add("source", "proxy-test".getBytes());
@@ -736,9 +746,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, baseTime + 100);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, baseTime + 200);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, baseTime + 300);
+        verifyWindowValue("key1", "value1", baseTime + 100, baseTime + 100);
+        verifyWindowValue("key2", "value2", baseTime + 200, baseTime + 200);
+        verifyWindowValue("key3", "value3", baseTime + 300, baseTime + 300);
 
         final Headers headers = new RecordHeaders();
         headers.add("source", "migration-test".getBytes());
@@ -777,9 +787,9 @@ public class HeadersStoreUpgradeIntegrationTest {
                 Serdes.String()),
             TimestampedWindowedWithHeadersProcessor::new, WINDOW_STORE_NAME, props);
 
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key1", "value1", baseTime + 100, baseTime + 100);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key2", "value2", baseTime + 200, baseTime + 200);
-        verifyPlainWindowValueWithEmptyHeadersAndTimestamp("key3", "value3", baseTime + 300, baseTime + 300);
+        verifyWindowValue("key1", "value1", baseTime + 100, baseTime + 100);
+        verifyWindowValue("key2", "value2", baseTime + 200, baseTime + 200);
+        verifyWindowValue("key3", "value3", baseTime + 300, baseTime + 300);
 
         final RecordHeaders headers = new RecordHeaders();
         headers.add("source", "proxy-test".getBytes());
@@ -807,10 +817,27 @@ public class HeadersStoreUpgradeIntegrationTest {
             "Could not verify plain window value in time.");
     }
 
-    private void verifyPlainWindowValueWithEmptyHeadersAndTimestamp(final String key,
-                                                                    final String value,
-                                                                    final long windowTimestamp,
-                                                                    final long expectedTimestamp) throws Exception {
+    /**
+     * Verifies the value stored for {@code key} in the window that {@code windowTimestamp} falls into,
+     * expecting {@code expectedTimestamp} and empty headers (i.e. a store migrated without headers).
+     */
+    private void verifyWindowValue(final String key,
+                                   final String value,
+                                   final long windowTimestamp,
+                                   final long expectedTimestamp) throws Exception {
+        verifyWindowValue(key, value, windowTimestamp, expectedTimestamp, new RecordHeaders());
+    }
+
+    /**
+     * Verifies the value stored for {@code key} in the window that {@code windowTimestamp} falls into,
+     * expecting {@code expectedTimestamp} and {@code expectedHeaders} in the store. Pass an empty
+     * {@link RecordHeaders} for stores migrated without headers.
+     */
+    private void verifyWindowValue(final String key,
+                                   final String value,
+                                   final long windowTimestamp,
+                                   final long expectedTimestamp,
+                                   final Headers expectedHeaders) throws Exception {
         awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
             store -> {
                 final Optional<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> result =
@@ -822,15 +849,11 @@ public class HeadersStoreUpgradeIntegrationTest {
                 final ValueTimestampHeaders<String> actual = result.get().value;
                 assertNotNull(actual, "Stored value should not be null");
                 assertEquals(value, actual.value(), "Value should match");
-                assertEquals(expectedTimestamp, actual.timestamp(), "Timestamp should be " + expectedTimestamp + " for plain store migration");
-
-                // Verify headers exist but are empty (migrated from plain store without headers or timestamps)
-                assertNotNull(actual.headers(), "Headers should not be null for migrated data");
-                assertEquals(0, actual.headers().toArray().length, "Headers should be empty for migrated data");
-
+                assertEquals(expectedTimestamp, actual.timestamp(), "Timestamp should be " + expectedTimestamp);
+                assertEquals(expectedHeaders, actual.headers(), "Headers should match");
                 return true;
             },
-            "Could not verify plain window value with empty headers and timestamp in time.");
+            "Could not verify window value in time.");
     }
 
     private void processWindowedKeyValueAndVerifyTimestamped(final String key,
@@ -868,18 +891,7 @@ public class HeadersStoreUpgradeIntegrationTest {
                                                              final Headers headers,
                                                              final Headers expectedHeaders) throws Exception {
         produce(key, value, timestamp, headers);
-
-        awaitStore(WINDOW_STORE_NAME, QueryableStoreTypes.<String, String>timestampedWindowStoreWithHeaders(),
-            store -> {
-                final Optional<KeyValue<Windowed<String>, ValueTimestampHeaders<String>>> result =
-                    findWindowedValue(store, key, timestamp);
-                return result.isPresent()
-                    && result.get().value != null
-                    && result.get().value.value().equals(value)
-                    && result.get().value.timestamp() == expectedTimestamp
-                    && result.get().value.headers().equals(expectedHeaders);
-            },
-            "Could not verify windowed value with headers in time.");
+        verifyWindowValue(key, value, timestamp, expectedTimestamp, expectedHeaders);
     }
 
     /**
@@ -1363,17 +1375,8 @@ public class HeadersStoreUpgradeIntegrationTest {
 
         awaitStore(SESSION_STORE_NAME, QueryableStoreTypes.<String, String>sessionStore(),
             store -> {
-                try (final KeyValueIterator<Windowed<String>, String> iterator = store.fetch(key)) {
-                    while (iterator.hasNext()) {
-                        final KeyValue<Windowed<String>, String> kv = iterator.next();
-                        if (kv.key.key().equals(key)
-                            && kv.key.window().start() == timestamp
-                            && kv.value.equals(value)) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
+                final Optional<KeyValue<Windowed<String>, String>> result = findSessionValue(store, key, timestamp);
+                return result.isPresent() && value.equals(result.get().value);
             },
             "Could not verify session value in time.");
     }


### PR DESCRIPTION
Note: This PR is part 2 of
[KAFKA-20278](https://issues.apache.org/jira/browse/KAFKA-20278)
(continues #21754).

Consolidates the duplicated process-and-verify test helpers in
HeadersStoreUpgradeIntegrationTest. Covers three co-located items from
the ticket that touch the same code and can't be split cleanly:

- 2 Similar Process-and-Verify Helper Methods
- 3 Duplicated Verification Logic
- 9 TestUtils.waitForCondition wrapper

also introduces reusable helpers

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
