### PR TITLE
MINOR: Set StreamThread to non-daemon status

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1370,6 +1370,7 @@ public class KafkaStreams implements AutoCloseable {
     private ScheduledExecutorService setupStateDirCleaner() {
         return Executors.newSingleThreadScheduledExecutor(r -> {
             final Thread thread = new Thread(r, clientId + "-CleanupThread");
+            // daemon: background cleanup must not block JVM shutdown
             thread.setDaemon(true);
             return thread;
         });
@@ -1380,6 +1381,7 @@ public class KafkaStreams implements AutoCloseable {
         if (RecordingLevel.forName(config.getString(METRICS_RECORDING_LEVEL_CONFIG)) == RecordingLevel.DEBUG) {
             return Executors.newSingleThreadScheduledExecutor(r -> {
                 final Thread thread = new Thread(r, clientId + "-RocksDBMetricsRecordingTrigger");
+                // daemon: background metrics recording must not block JVM shutdown
                 thread.setDaemon(true);
                 return thread;
             });
@@ -1620,6 +1622,7 @@ public class KafkaStreams implements AutoCloseable {
 
         final Thread shutdownThread = shutdownHelper(false, timeoutMs, operation);
 
+        // daemon: the shutdown thread itself must not prevent JVM exit
         shutdownThread.setDaemon(true);
         shutdownThread.start();
 
@@ -1638,6 +1641,7 @@ public class KafkaStreams implements AutoCloseable {
         } else {
             final Thread shutdownThread = shutdownHelper(true, -1, org.apache.kafka.streams.CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP);
 
+            // daemon: the shutdown thread itself must not prevent JVM exit
             shutdownThread.setDaemon(true);
             shutdownThread.start();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -109,6 +109,7 @@ public class DefaultStateUpdater implements StateUpdater {
                                   final StreamsMetricsImpl metrics,
                                   final ChangelogReader changelogReader) {
             super(name);
+            setDaemon(true);
             this.changelogReader = changelogReader;
             this.updaterMetrics = new StateUpdaterMetrics(metrics, name);
             this.metricsConfig = metrics.metricsRegistry().config();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -109,6 +109,7 @@ public class DefaultStateUpdater implements StateUpdater {
                                   final StreamsMetricsImpl metrics,
                                   final ChangelogReader changelogReader) {
             super(name);
+            // daemon: internal helper thread must not block JVM shutdown on its own
             setDaemon(true);
             this.changelogReader = changelogReader;
             this.updaterMetrics = new StateUpdaterMetrics(metrics, name);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -198,6 +198,7 @@ public class GlobalStreamThread extends Thread {
         }
     }
 
+    @SuppressWarnings("this-escape")
     public GlobalStreamThread(final ProcessorTopology topology,
                               final StreamsConfig config,
                               final Consumer<byte[], byte[]> globalConsumer,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -211,6 +211,7 @@ public class GlobalStreamThread extends Thread {
                               final StateRestoreListener stateRestoreListener,
                               final java.util.function.Consumer<Throwable> streamsUncaughtExceptionHandler) {
         super(threadClientId);
+        // explicitly non-daemon so the JVM doesn't exit while this thread is still restoring/serving global state
         setDaemon(false);
         this.time = time;
         this.config = config;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -210,6 +210,7 @@ public class GlobalStreamThread extends Thread {
                               final StateRestoreListener stateRestoreListener,
                               final java.util.function.Consumer<Throwable> streamsUncaughtExceptionHandler) {
         super(threadClientId);
+        setDaemon(false);
         this.time = time;
         this.config = config;
         this.topology = topology;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -828,6 +828,7 @@ public class StreamThread extends Thread implements ProcessingThread {
                         final long maxUncommittedBytesPerThread
                         ) {
         super(threadId);
+        // explicitly non-daemon so the JVM doesn't exit while this thread is still processing
         setDaemon(false);
         this.stateLock = new Object();
         this.adminClient = adminClient;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -828,6 +828,7 @@ public class StreamThread extends Thread implements ProcessingThread {
                         final long maxUncommittedBytesPerThread
                         ) {
         super(threadId);
+        setDaemon(false);
         this.stateLock = new Object();
         this.adminClient = adminClient;
         this.streamsMetrics = streamsMetrics;


### PR DESCRIPTION
This PR sets

1. `StreamThread` `daemon=false`
2. `GlobalStreamThread` `daemon=false`
3. `StateUpdaterThread` `daemon=true`

Reviewers: Matthias J. Sax <matthias@confluent.io>
