### PR TITLE
KAFKA-20828: Derive client throttling from response schema

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -304,7 +304,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
      * quota violation, sends out responses before throttling.
      */
     public boolean shouldClientThrottle(short version) {
-        return false;
+        return apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null;
     }
 
     public ApiKeys apiKey() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionReassignmentsResponse.java
@@ -45,11 +45,6 @@ public class AlterPartitionReassignmentsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterUserScramCredentialsResponse.java
@@ -38,11 +38,6 @@ public class AlterUserScramCredentialsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerHeartbeatResponse.java
@@ -59,8 +59,4 @@ public class BrokerHeartbeatResponse extends AbstractResponse {
         return new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/BrokerRegistrationResponse.java
@@ -60,11 +60,6 @@ public class BrokerRegistrationResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public String toString() {
         return data.toString();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTopicPartitionsResponse.java
@@ -52,11 +52,6 @@ public class DescribeTopicPartitionsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new EnumMap<>(Errors.class);
         data.topics().forEach(topicResponse -> {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeUserScramCredentialsResponse.java
@@ -38,11 +38,6 @@ public class DescribeUserScramCredentialsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersResponse.java
@@ -83,11 +83,6 @@ public class ElectLeadersResponse extends AbstractResponse {
         return new ElectLeadersResponse(new ElectLeadersResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
     public static Map<TopicPartition, Optional<Throwable>> electLeadersResult(ElectLeadersResponseData data) {
         Map<TopicPartition, Optional<Throwable>> map = new HashMap<>();
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListPartitionReassignmentsResponse.java
@@ -43,11 +43,6 @@ public class ListPartitionReassignmentsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UnregisterBrokerResponse.java
@@ -61,8 +61,4 @@ public class UnregisterBrokerResponse extends AbstractResponse {
         return new UnregisterBrokerResponse(new UnregisterBrokerResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return true;
-    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -359,6 +359,21 @@ public class RequestResponseTest {
         }
     }
 
+    @Test
+    public void testClientThrottlesResponsesWithThrottleTime() {
+        List<ApiKeys> apiKeys = List.of(
+            ApiKeys.CONSUMER_GROUP_HEARTBEAT,
+            ApiKeys.SHARE_GROUP_HEARTBEAT,
+            ApiKeys.STREAMS_GROUP_HEARTBEAT
+        );
+
+        for (ApiKeys apiKey : apiKeys) {
+            for (short version : apiKey.allVersions()) {
+                assertTrue(getResponse(apiKey, version).shouldClientThrottle(version));
+            }
+        }
+    }
+
     // This test validates special cases that are not checked in testSerialization
     @Test
     public void testSerializationSpecialCases() {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -403,10 +403,13 @@ public class RequestResponseTest {
             for (short version : apiKey.allVersions()) {
                 boolean responseHasThrottleTime =
                     apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null;
+                short firstPostKip219Version = postKip219Version.getOrDefault(apiKey, apiKey.oldestVersion());
                 boolean shouldClientThrottle = responseHasThrottleTime &&
-                    version >= postKip219Version.getOrDefault(apiKey, apiKey.oldestVersion());
+                    version >= firstPostKip219Version;
                 assertEquals(shouldClientThrottle, getResponse(apiKey, version).shouldClientThrottle(version),
-                    apiKey + " version " + version);
+                    "Unexpected shouldClientThrottle result for " + apiKey + " version " + version +
+                        ": responseHasThrottleTime=" + responseHasThrottleTime +
+                        ", firstPostKip219Version=" + firstPostKip219Version);
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -361,24 +361,52 @@ public class RequestResponseTest {
 
     @Test
     public void testClientThrottlesResponsesWithThrottleTime() {
-        List<ApiKeys> apiKeys = List.of(
-            ApiKeys.ALTER_PARTITION_REASSIGNMENTS,
-            ApiKeys.ALTER_USER_SCRAM_CREDENTIALS,
-            ApiKeys.BROKER_HEARTBEAT,
-            ApiKeys.BROKER_REGISTRATION,
-            ApiKeys.CONSUMER_GROUP_HEARTBEAT,
-            ApiKeys.DESCRIBE_TOPIC_PARTITIONS,
-            ApiKeys.DESCRIBE_USER_SCRAM_CREDENTIALS,
-            ApiKeys.ELECT_LEADERS,
-            ApiKeys.LIST_PARTITION_REASSIGNMENTS,
-            ApiKeys.SHARE_GROUP_HEARTBEAT,
-            ApiKeys.STREAMS_GROUP_HEARTBEAT,
-            ApiKeys.UNREGISTER_BROKER
+        Map<ApiKeys, Short> postKip219Version = Map.ofEntries(
+            Map.entry(ApiKeys.PRODUCE, (short) 6),
+            Map.entry(ApiKeys.FETCH, (short) 8),
+            Map.entry(ApiKeys.LIST_OFFSETS, (short) 3),
+            Map.entry(ApiKeys.METADATA, (short) 6),
+            Map.entry(ApiKeys.OFFSET_COMMIT, (short) 4),
+            Map.entry(ApiKeys.OFFSET_FETCH, (short) 4),
+            Map.entry(ApiKeys.FIND_COORDINATOR, (short) 2),
+            Map.entry(ApiKeys.JOIN_GROUP, (short) 3),
+            Map.entry(ApiKeys.HEARTBEAT, (short) 2),
+            Map.entry(ApiKeys.LEAVE_GROUP, (short) 2),
+            Map.entry(ApiKeys.SYNC_GROUP, (short) 2),
+            Map.entry(ApiKeys.DESCRIBE_GROUPS, (short) 2),
+            Map.entry(ApiKeys.LIST_GROUPS, (short) 2),
+            Map.entry(ApiKeys.API_VERSIONS, (short) 2),
+            Map.entry(ApiKeys.CREATE_TOPICS, (short) 3),
+            Map.entry(ApiKeys.DELETE_TOPICS, (short) 2),
+            Map.entry(ApiKeys.DELETE_RECORDS, (short) 1),
+            Map.entry(ApiKeys.INIT_PRODUCER_ID, (short) 1),
+            Map.entry(ApiKeys.ADD_PARTITIONS_TO_TXN, (short) 1),
+            Map.entry(ApiKeys.ADD_OFFSETS_TO_TXN, (short) 1),
+            Map.entry(ApiKeys.END_TXN, (short) 1),
+            Map.entry(ApiKeys.TXN_OFFSET_COMMIT, (short) 1),
+            Map.entry(ApiKeys.DESCRIBE_ACLS, (short) 1),
+            Map.entry(ApiKeys.CREATE_ACLS, (short) 1),
+            Map.entry(ApiKeys.DELETE_ACLS, (short) 1),
+            Map.entry(ApiKeys.DESCRIBE_CONFIGS, (short) 2),
+            Map.entry(ApiKeys.ALTER_CONFIGS, (short) 1),
+            Map.entry(ApiKeys.ALTER_REPLICA_LOG_DIRS, (short) 1),
+            Map.entry(ApiKeys.DESCRIBE_LOG_DIRS, (short) 1),
+            Map.entry(ApiKeys.CREATE_PARTITIONS, (short) 1),
+            Map.entry(ApiKeys.CREATE_DELEGATION_TOKEN, (short) 1),
+            Map.entry(ApiKeys.RENEW_DELEGATION_TOKEN, (short) 1),
+            Map.entry(ApiKeys.EXPIRE_DELEGATION_TOKEN, (short) 1),
+            Map.entry(ApiKeys.DESCRIBE_DELEGATION_TOKEN, (short) 1),
+            Map.entry(ApiKeys.DELETE_GROUPS, (short) 1)
         );
 
-        for (ApiKeys apiKey : apiKeys) {
+        for (ApiKeys apiKey : ApiKeys.values()) {
             for (short version : apiKey.allVersions()) {
-                assertTrue(getResponse(apiKey, version).shouldClientThrottle(version));
+                boolean responseHasThrottleTime =
+                    apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null;
+                boolean shouldClientThrottle = responseHasThrottleTime &&
+                    version >= postKip219Version.getOrDefault(apiKey, apiKey.oldestVersion());
+                assertEquals(shouldClientThrottle, getResponse(apiKey, version).shouldClientThrottle(version),
+                    apiKey + " version " + version);
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -362,9 +362,18 @@ public class RequestResponseTest {
     @Test
     public void testClientThrottlesResponsesWithThrottleTime() {
         List<ApiKeys> apiKeys = List.of(
+            ApiKeys.ALTER_PARTITION_REASSIGNMENTS,
+            ApiKeys.ALTER_USER_SCRAM_CREDENTIALS,
+            ApiKeys.BROKER_HEARTBEAT,
+            ApiKeys.BROKER_REGISTRATION,
             ApiKeys.CONSUMER_GROUP_HEARTBEAT,
+            ApiKeys.DESCRIBE_TOPIC_PARTITIONS,
+            ApiKeys.DESCRIBE_USER_SCRAM_CREDENTIALS,
+            ApiKeys.ELECT_LEADERS,
+            ApiKeys.LIST_PARTITION_REASSIGNMENTS,
             ApiKeys.SHARE_GROUP_HEARTBEAT,
-            ApiKeys.STREAMS_GROUP_HEARTBEAT
+            ApiKeys.STREAMS_GROUP_HEARTBEAT,
+            ApiKeys.UNREGISTER_BROKER
         );
 
         for (ApiKeys apiKey : apiKeys) {


### PR DESCRIPTION
## Description

`AbstractResponse.shouldClientThrottle()` previously defaulted to
`false`. As a result, newer response types containing a `throttleTimeMs`
field did not enable client-side throttling unless they explicitly
overrode this method.

This change derives the default behavior from the response schema. A
client now throttles when the response schema for the negotiated API
version contains the `throttle_time_ms` field.

Existing overrides remain unchanged to preserve historical
version-specific throttling behavior for older APIs.

This fixes client-side throttling for:

- `ConsumerGroupHeartbeatResponse`
- `ShareGroupHeartbeatResponse`
- `StreamsGroupHeartbeatResponse`

It also prevents newly added response types with a throttle-time field
from accidentally omitting the required behavior.

## Testing

Added regression coverage for every supported version of the affected
heartbeat APIs, verifying that `shouldClientThrottle()` returns `true`.

The following checks passed:

- `clients:test --tests
org.apache.kafka.common.requests.RequestResponseTest`
- `clients:checkstyleMain`
- `clients:checkstyleTest`
- `spotlessCheck`

Reviewers: Jun Rao <junrao@gmail.com>, Hardanish Singh
 (github:Hardanish-Singh)
