### PR TITLE
KAFKA-20819: Fail requests when state updater thread dies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -169,6 +169,8 @@ public class DefaultStateUpdater implements StateUpdater {
                 handleRuntimeException(anyOtherException);
             } catch (final Error fatalError) {
                 log.error("A fatal error occurred within the state updater thread", fatalError);
+                DefaultStateUpdater.this.fatalError.compareAndSet(null, fatalError);
+                streamThreadWakeup.run();
                 throw fatalError;
             } finally {
                 isRunning.set(false);
@@ -347,7 +349,6 @@ public class DefaultStateUpdater implements StateUpdater {
         private void handleRuntimeException(final RuntimeException runtimeException) {
             log.error("An unexpected error occurred within the state updater thread: {}", String.valueOf(runtimeException));
             addToExceptionsAndFailedTasksThenClearUpdatingAndPausedTasks(runtimeException);
-            isRunning.set(false);
         }
 
         private void handleTaskCorruptedException(final TaskCorruptedException taskCorruptedException) {
@@ -854,6 +855,7 @@ public class DefaultStateUpdater implements StateUpdater {
     private final Consumer<byte[], byte[]> restoreConsumer;
     private final ChangelogReader changelogReader;
     private final TopologyMetadata topologyMetadata;
+    private final Runnable streamThreadWakeup;
     private final Queue<TaskAndAction> tasksAndActions = new LinkedList<>();
     private final Lock tasksAndActionsLock = new ReentrantLock();
     private final Condition tasksAndActionsCondition = tasksAndActionsLock.newCondition();
@@ -869,6 +871,7 @@ public class DefaultStateUpdater implements StateUpdater {
     private long lastCommitMs;
 
     private final AtomicReference<Map<StreamsRebalanceData.TaskId, Long>> taskEndOffsetSumSnapshot = new AtomicReference<>(Map.of());
+    private final AtomicReference<Error> fatalError = new AtomicReference<>();
 
     private StateUpdaterThread stateUpdaterThread = null;
 
@@ -878,13 +881,15 @@ public class DefaultStateUpdater implements StateUpdater {
                                final Consumer<byte[], byte[]> restoreConsumer,
                                final ChangelogReader changelogReader,
                                final TopologyMetadata topologyMetadata,
-                               final Time time) {
+                               final Time time,
+                               final Runnable streamThreadWakeup) {
         this.time = time;
         this.name = name;
         this.metrics = metrics;
         this.restoreConsumer = restoreConsumer;
         this.changelogReader = changelogReader;
         this.topologyMetadata = topologyMetadata;
+        this.streamThreadWakeup = streamThreadWakeup;
         this.commitIntervalMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
 
         final String logPrefix = String.format("state-updater [%s] ", name);
@@ -933,6 +938,14 @@ public class DefaultStateUpdater implements StateUpdater {
                 Thread.currentThread().interrupt();
                 log.warn("Interrupted while waiting for state updater thread to shut down");
             }
+        }
+    }
+
+    @Override
+    public void maybeThrowFatalError() {
+        final Error error = fatalError.get();
+        if (error != null) {
+            throw error;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -167,7 +167,11 @@ public class DefaultStateUpdater implements StateUpdater {
                 }
             } catch (final RuntimeException anyOtherException) {
                 handleRuntimeException(anyOtherException);
+            } catch (final Error fatalError) {
+                log.error("A fatal error occurred within the state updater thread", fatalError);
+                throw fatalError;
             } finally {
+                isRunning.set(false);
                 clearInputQueue();
                 clearUpdatingAndPausedTasks();
                 updaterMetrics.clear();
@@ -178,6 +182,10 @@ public class DefaultStateUpdater implements StateUpdater {
         private void clearInputQueue() {
             tasksAndActionsLock.lock();
             try {
+                final StreamsException exception = new StreamsException("State updater thread stopped before the request was processed");
+                tasksAndActions.stream()
+                    .filter(taskAndAction -> taskAndAction.action() == Action.REMOVE)
+                    .forEach(taskAndAction -> taskAndAction.futureForRemove().completeExceptionally(exception));
                 tasksAndActions.clear();
             } finally {
                 tasksAndActionsLock.unlock();
@@ -934,6 +942,7 @@ public class DefaultStateUpdater implements StateUpdater {
 
         tasksAndActionsLock.lock();
         try {
+            ensureStateUpdaterIsRunningIfStarted();
             tasksAndActions.add(TaskAndAction.createAddTask(task));
             tasksAndActionsCondition.signalAll();
         } finally {
@@ -956,12 +965,26 @@ public class DefaultStateUpdater implements StateUpdater {
         final CompletableFuture<RemovedTaskResult> future = new CompletableFuture<>();
         tasksAndActionsLock.lock();
         try {
-            tasksAndActions.add(TaskAndAction.createRemoveTask(taskId, future, suspendReason));
-            tasksAndActionsCondition.signalAll();
+            if (stateUpdaterThread != null && !stateUpdaterThread.isRunning.get()) {
+                future.completeExceptionally(stateUpdaterNotRunningException());
+            } else {
+                tasksAndActions.add(TaskAndAction.createRemoveTask(taskId, future, suspendReason));
+                tasksAndActionsCondition.signalAll();
+            }
         } finally {
             tasksAndActionsLock.unlock();
         }
         return future;
+    }
+
+    private void ensureStateUpdaterIsRunningIfStarted() {
+        if (stateUpdaterThread != null && !stateUpdaterThread.isRunning.get()) {
+            throw stateUpdaterNotRunningException();
+        }
+    }
+
+    private StreamsException stateUpdaterNotRunningException() {
+        return new StreamsException("State updater thread is not running");
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateUpdater.java
@@ -131,6 +131,11 @@ public interface StateUpdater {
     void shutdown(final Duration timeout);
 
     /**
+     * Throws the fatal error that terminated the state updater thread, if any.
+     */
+    void maybeThrowFatalError();
+
+    /**
      * Adds a task (active or standby) to the state updater.
      *
      * This method does not block until the task is added to the state updater.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -486,7 +487,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                 topologyMetadata,
                 time,
                 clientId,
-                threadIdx
+                threadIdx,
+                () -> referenceContainer.mainConsumer.wakeup()
             );
 
         final TaskManager taskManager = new TaskManager(
@@ -672,7 +674,8 @@ public class StreamThread extends Thread implements ProcessingThread {
                                                         final TopologyMetadata topologyMetadata,
                                                         final Time time,
                                                         final String clientId,
-                                                        final int threadIdx) {
+                                                        final int threadIdx,
+                                                        final Runnable streamThreadWakeup) {
         final String name = clientId + STATE_UPDATER_ID_SUBSTRING + threadIdx;
         return new DefaultStateUpdater(
             name,
@@ -681,7 +684,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             restoreConsumer,
             changelogReader,
             topologyMetadata,
-            time
+            time,
+            streamThreadWakeup
         );
     }
 
@@ -1544,12 +1548,16 @@ public class StreamThread extends Thread implements ProcessingThread {
         ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
 
         lastPollMs = now;
+        taskManager.maybeThrowFatalStateUpdaterError();
 
         try {
             records = mainConsumer.poll(pollTime);
         } catch (final InvalidOffsetException e) {
             log.info("Found no valid offset for {} partitions, resetting.", e.partitions().size());
             resetOffsets(e.partitions(), e);
+        } catch (final WakeupException e) {
+            taskManager.maybeThrowFatalStateUpdaterError();
+            throw e;
         }
 
         return records;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -863,6 +863,10 @@ public class TaskManager {
             && !tasks.hasPendingTasksToInit();
     }
 
+    public void maybeThrowFatalStateUpdaterError() {
+        stateUpdater.maybeThrowFatalError();
+    }
+
     private void recycleTaskFromStateUpdater(final Task task,
                                              final Set<TopicPartition> inputPartitions,
                                              final Set<Task> tasksToCloseDirty,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -116,7 +116,7 @@ class DefaultStateUpdaterTest {
     private final ChangelogReader changelogReader = mock(ChangelogReader.class);
     private final TopologyMetadata topologyMetadata = unnamedTopology().build();
     private final DefaultStateUpdater stateUpdater =
-        new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time);
+        new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time, () -> { });
 
     @AfterEach
     public void tearDown() {
@@ -174,6 +174,7 @@ class DefaultStateUpdaterTest {
         stateUpdater.start();
         waitForCondition(() -> !stateUpdater.isRunning(), VERIFICATION_TIMEOUT, "State updater thread did not stop");
 
+        assertEquals(fatalError, assertThrows(AssertionError.class, stateUpdater::maybeThrowFatalError));
         assertThrows(StreamsException.class, () -> stateUpdater.add(task));
         final ExecutionException executionException = assertThrows(
             ExecutionException.class,
@@ -1592,7 +1593,7 @@ class DefaultStateUpdaterTest {
     public void shouldNotAutoCheckpointTasksIfIntervalNotElapsed() {
         // we need to use a non auto-ticking timer here to control how much time elapsed exactly
         final Time time = new MockTime();
-        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time);
+        final DefaultStateUpdater stateUpdater = new DefaultStateUpdater("test-state-updater", metrics, config, null, changelogReader, topologyMetadata, time, () -> { });
         try {
             final StreamTask task1 = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
             final StreamTask task2 = statefulTask(TASK_0_2, Set.of(TOPIC_PARTITION_B_0)).inState(State.RESTORING).build();
@@ -1837,7 +1838,7 @@ class DefaultStateUpdaterTest {
     @Test
     public void shouldRemoveMetricsWithoutInterference() {
         final DefaultStateUpdater stateUpdater2 =
-            new DefaultStateUpdater("test-state-updater2", metrics, config, null, changelogReader, topologyMetadata, time);
+            new DefaultStateUpdater("test-state-updater2", metrics, config, null, changelogReader, topologyMetadata, time, () -> { });
         final List<MetricName> threadMetrics = getMetricNames("test-state-updater");
         final List<MetricName> threadMetrics2 = getMetricNames("test-state-updater2");
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -50,7 +50,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -160,6 +162,49 @@ class DefaultStateUpdaterTest {
         verifyUpdatingTasks();
         verifyPausedTasks();
         verify(changelogReader).clear();
+    }
+
+    @Test
+    public void shouldFailRequestsAfterStateUpdaterThreadDies() throws Exception {
+        final StreamTask task = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final AssertionError fatalError = new AssertionError("fatal error");
+        doThrow(fatalError).when(changelogReader).restore(anyMap());
+
+        stateUpdater.add(task);
+        stateUpdater.start();
+        waitForCondition(() -> !stateUpdater.isRunning(), VERIFICATION_TIMEOUT, "State updater thread did not stop");
+
+        assertThrows(StreamsException.class, () -> stateUpdater.add(task));
+        final ExecutionException executionException = assertThrows(
+            ExecutionException.class,
+            () -> stateUpdater.remove(task.id(), StandbyUpdateListener.SuspendReason.MIGRATED).get()
+        );
+        assertInstanceOf(StreamsException.class, executionException.getCause());
+    }
+
+    @Test
+    public void shouldFailPendingRemovalWhenStateUpdaterThreadDies() throws Exception {
+        final StreamTask task = statefulTask(TASK_0_0, Set.of(TOPIC_PARTITION_A_0)).inState(State.RESTORING).build();
+        final CountDownLatch restoreStarted = new CountDownLatch(1);
+        final CountDownLatch throwFatalError = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            restoreStarted.countDown();
+            throwFatalError.await();
+            throw new AssertionError("fatal error");
+        }).when(changelogReader).restore(anyMap());
+
+        stateUpdater.add(task);
+        stateUpdater.start();
+        assertTrue(restoreStarted.await(CALL_TIMEOUT, TimeUnit.MILLISECONDS));
+        final CompletableFuture<StateUpdater.RemovedTaskResult> removal =
+            stateUpdater.remove(task.id(), StandbyUpdateListener.SuspendReason.MIGRATED);
+        throwFatalError.countDown();
+
+        final ExecutionException executionException = assertThrows(
+            ExecutionException.class,
+            () -> removal.get(CALL_TIMEOUT, TimeUnit.MILLISECONDS)
+        );
+        assertInstanceOf(StreamsException.class, executionException.getCause());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.InvalidPidMappingException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.StreamsGroupHeartbeatResponseData;
@@ -658,6 +659,42 @@ public class StreamThreadTest {
         thread.runOnceWithoutProcessingThreads();
 
         Mockito.verify(taskManager, never()).process(Mockito.anyInt(), Mockito.any());
+    }
+
+    @Test
+    public void shouldThrowStateUpdaterFatalErrorBeforePolling() {
+        final StreamsConfig config = new StreamsConfig(configProps(false, false));
+        final TaskManager taskManager = mock(TaskManager.class);
+        final AssertionError fatalError = new AssertionError("fatal error");
+        final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
+        when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
+        when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
+        doThrow(fatalError).when(taskManager).maybeThrowFatalStateUpdaterError();
+        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
+        topologyMetadata.buildAndRewriteTopology();
+        thread = buildStreamThread(mainConsumer, taskManager, config, topologyMetadata);
+        thread.setState(State.STARTING);
+
+        assertSame(fatalError, assertThrows(AssertionError.class, thread::runOnceWithoutProcessingThreads));
+        verify(mainConsumer, never()).poll(any());
+    }
+
+    @Test
+    public void shouldThrowStateUpdaterFatalErrorWhenItWakesUpPolling() {
+        final StreamsConfig config = new StreamsConfig(configProps(false, false));
+        final TaskManager taskManager = mock(TaskManager.class);
+        final AssertionError fatalError = new AssertionError("fatal error");
+        final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
+        when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
+        when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
+        doNothing().doThrow(fatalError).when(taskManager).maybeThrowFatalStateUpdaterError();
+        when(mainConsumer.poll(any())).thenThrow(new WakeupException());
+        final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
+        topologyMetadata.buildAndRewriteTopology();
+        thread = buildStreamThread(mainConsumer, taskManager, config, topologyMetadata);
+        thread.setState(State.STARTING);
+
+        assertSame(fatalError, assertThrows(AssertionError.class, thread::runOnceWithoutProcessingThreads));
     }
 
     @Test


### PR DESCRIPTION
## Description

KAFKA-20819 reports that a `StreamThread` can block while waiting for a task-removal future after its `StateUpdaterThread` has terminated. Requests submitted to the stopped updater were left unprocessed, and their futures could remain incomplete.

This change makes state-updater failure explicit and prevents callers from waiting on requests that cannot be processed:

- Marks the state updater as stopped on every thread exit path.
- Logs fatal `Error`s through the configured logger before rethrowing them.
- Completes pending task-removal futures exceptionally when the updater exits.
- Rejects task additions after an already-started updater has stopped.
- Returns an exceptionally completed future for task removals submitted after the updater has stopped.
- Preserves the existing ability to enqueue tasks before the updater starts and to restart it after a clean shutdown.

No public API, configuration, metrics, or compatibility behavior is changed.

## Testing

Added unit tests covering:

- Requests submitted after the state updater terminates with a fatal error.
- A removal request queued while the updater is running but still pending when the updater terminates.

Ran:

```
./gradlew :streams:spotlessJavaApply :streams:test \
  --tests org.apache.kafka.streams.processor.internals.DefaultStateUpdaterTest
```

This also ran the relevant Streams compilation, Checkstyle, and SpotBugs tasks. All tests passed.

Reviewers: Zheguang Zhao <zheguang.zhao@gmail.com>, Matthias J. Sax <matthias@confluent.io>
