### PR TITLE
KAFKA-20828: Return should client throttle true for throttle based responses

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddRaftVoterResponse.java
@@ -48,6 +48,11 @@ public class AddRaftVoterResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
             return Map.of(Errors.forCode(data.errorCode()), 1);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AllocateProducerIdsResponse.java
@@ -59,6 +59,11 @@ public class AllocateProducerIdsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public Errors error() {
         return Errors.forCode(data.errorCode());
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterClientQuotasResponse.java
@@ -73,6 +73,11 @@ public class AlterClientQuotasResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new EnumMap<>(Errors.class);
         data.entries().forEach(entry ->

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionResponse.java
@@ -59,6 +59,11 @@ public class AlterPartitionResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static AlterPartitionResponse parse(Readable readable, short version) {
         return new AlterPartitionResponse(new AlterPartitionResponseData(readable, version));
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterShareGroupOffsetsResponse.java
@@ -58,6 +58,11 @@ public class AlterShareGroupOffsetsResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public AlterShareGroupOffsetsResponseData data() {
         return data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AssignReplicasToDirsResponse.java
@@ -52,6 +52,11 @@ public class AssignReplicasToDirsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static AssignReplicasToDirsResponse parse(Readable readable, short version) {
         return new AssignReplicasToDirsResponse(new AssignReplicasToDirsResponseData(
                 readable, version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupDescribeResponse.java
@@ -69,6 +69,11 @@ public class ConsumerGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static ConsumerGroupDescribeResponse parse(Readable readable, short version) {
         return new ConsumerGroupDescribeResponse(
             new ConsumerGroupDescribeResponseData(readable, version)

--- a/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ConsumerGroupHeartbeatResponse.java
@@ -71,6 +71,11 @@ public class ConsumerGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static ConsumerGroupHeartbeatResponse parse(Readable readable, short version) {
         return new ConsumerGroupHeartbeatResponse(new ConsumerGroupHeartbeatResponseData(
             readable, version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControllerRegistrationResponse.java
@@ -48,6 +48,11 @@ public class ControllerRegistrationResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public Map<Errors, Integer> errorCounts() {
         return Map.of(Errors.forCode(data.errorCode()), 1);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteShareGroupOffsetsResponse.java
@@ -58,6 +58,11 @@ public class DeleteShareGroupOffsetsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static DeleteShareGroupOffsetsResponse parse(Readable readable, short version) {
         return new DeleteShareGroupOffsetsResponse(
             new DeleteShareGroupOffsetsResponseData(readable, version)

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasResponse.java
@@ -75,6 +75,11 @@ public class DescribeClientQuotasResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public DescribeClientQuotasResponseData data() {
         return data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClusterResponse.java
@@ -58,6 +58,11 @@ public class DescribeClusterResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public DescribeClusterResponseData data() {
         return data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeProducersResponse.java
@@ -70,4 +70,9 @@ public class DescribeProducersResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeShareGroupOffsetsResponse.java
@@ -97,6 +97,11 @@ public class DescribeShareGroupOffsetsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static DescribeShareGroupOffsetsResponse parse(Readable readable, short version) {
         return new DescribeShareGroupOffsetsResponse(new DescribeShareGroupOffsetsResponseData(readable, version));
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeTransactionsResponse.java
@@ -68,4 +68,9 @@ public class DescribeTransactionsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
@@ -64,6 +64,11 @@ public final class FetchSnapshotResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public FetchSnapshotResponseData data() {
         return data;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/GetTelemetrySubscriptionsResponse.java
@@ -56,6 +56,11 @@ public class GetTelemetrySubscriptionsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public boolean hasError() {
         return error() != Errors.NONE;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListConfigResourcesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListConfigResourcesResponse.java
@@ -67,6 +67,11 @@ public class ListConfigResourcesResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public Collection<ConfigResource> configResources() {
         return data.configResources()
             .stream()

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListTransactionsResponse.java
@@ -63,4 +63,9 @@ public class ListTransactionsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -72,6 +72,12 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        // Version 2 added the throttle time, along with client-side throttling.
+        return version >= 2;
+    }
+
     public static OffsetsForLeaderEpochResponse parse(Readable readable, short version) {
         return new OffsetsForLeaderEpochResponse(new OffsetForLeaderEpochResponseData(readable, version));
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/PushTelemetryResponse.java
@@ -56,6 +56,11 @@ public class PushTelemetryResponse  extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public boolean hasError() {
         return error() != Errors.NONE;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RemoveRaftVoterResponse.java
@@ -48,6 +48,11 @@ public class RemoveRaftVoterResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
             return Map.of(Errors.forCode(data.errorCode()), 1);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareAcknowledgeResponse.java
@@ -82,6 +82,11 @@ public class ShareAcknowledgeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static ShareAcknowledgeResponse parse(Readable readable, short version) {
         return new ShareAcknowledgeResponse(
                 new ShareAcknowledgeResponseData(readable, version)

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareFetchResponse.java
@@ -101,6 +101,11 @@ public class ShareFetchResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     /**
      * Creates a {@link org.apache.kafka.common.requests.ShareFetchResponse} from the given byte buffer.
      * Unlike {@link org.apache.kafka.common.requests.ShareFetchResponse#of(Errors, int, LinkedHashMap, List, int)},

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupDescribeResponse.java
@@ -69,6 +69,11 @@ public class ShareGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static ShareGroupDescribeResponse parse(Readable readable, short version) {
         return new ShareGroupDescribeResponse(
                 new ShareGroupDescribeResponseData(readable, version)

--- a/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ShareGroupHeartbeatResponse.java
@@ -68,6 +68,11 @@ public class ShareGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static ShareGroupHeartbeatResponse parse(Readable readable, short version) {
         return new ShareGroupHeartbeatResponse(new ShareGroupHeartbeatResponseData(
                 readable, version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupDescribeResponse.java
@@ -75,6 +75,11 @@ public class StreamsGroupDescribeResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static StreamsGroupDescribeResponse parse(Readable readable, short version) {
         return new StreamsGroupDescribeResponse(
             new StreamsGroupDescribeResponseData(readable, version)

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -72,6 +72,11 @@ public class StreamsGroupHeartbeatResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static StreamsGroupHeartbeatResponse parse(Readable readable, short version) {
         return new StreamsGroupHeartbeatResponse(new StreamsGroupHeartbeatResponseData(
             readable, version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupTopologyDescriptionUpdateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupTopologyDescriptionUpdateResponse.java
@@ -65,6 +65,11 @@ public class StreamsGroupTopologyDescriptionUpdateResponse extends AbstractRespo
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
+    @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
     public static StreamsGroupTopologyDescriptionUpdateResponse parse(Readable readable, short version) {
         return new StreamsGroupTopologyDescriptionUpdateResponse(
             new StreamsGroupTopologyDescriptionUpdateResponseData(readable, version));

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateFeaturesResponse.java
@@ -69,6 +69,11 @@ public class UpdateFeaturesResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return data.toString();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateRaftVoterResponse.java
@@ -48,6 +48,11 @@ public class UpdateRaftVoterResponse extends AbstractResponse {
     }
 
     @Override
+    public boolean shouldClientThrottle(short version) {
+        return true;
+    }
+
+    @Override
     public Map<Errors, Integer> errorCounts() {
         if (data.errorCode() != Errors.NONE.code()) {
             return Map.of(Errors.forCode(data.errorCode()), 1);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -256,6 +256,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
@@ -4147,5 +4148,25 @@ public class RequestResponseTest {
                 .setTopologyDescriptionStatus(StreamsGroupDescribeResponse.TOPOLOGY_DESCRIPTION_STATUS_AVAILABLE)));
         StreamsGroupDescribeResponse response = new StreamsGroupDescribeResponse(data);
         assertThrows(UnsupportedVersionException.class, () -> response.serialize((short) 0));
+    }
+
+    // Any response that carries a throttle_time_ms field must indicate client-side throttling so that
+    // the client honours the broker's throttle time on quota violations. This guards against
+    // forgetting the override on new APIs.
+    @Test
+    public void testResponsesWithThrottleTimeFieldClientThrottle() {
+        for (ApiKeys apiKey : ApiKeys.values()) {
+            short version = apiKey.latestVersion();
+            Schema[] responseSchemas = apiKey.messageType.responseSchemas();
+            if (version >= responseSchemas.length || responseSchemas[version] == null)
+                continue;
+            boolean hasThrottleTimeField = responseSchemas[version].get("throttle_time_ms") != null;
+            if (!hasThrottleTimeField)
+                continue;
+            AbstractResponse response = getResponse(apiKey, version);
+            assertTrue(response.shouldClientThrottle(version),
+                apiKey + " response declares a throttle_time_ms field, so shouldClientThrottle(" + version
+                    + ") must return true.");
+        }
     }
 }


### PR DESCRIPTION
AbstractResponse.shouldClientThrottle() defaults to false, so responses
that carry a throttle_time_ms field but don't override it never trigger
client-side throttling — the client ignores the broker's throttle time
on quota violations.

This adds the missing override to every response that declares a
throttle_time_ms field, including the group heartbeat responses called
out in the JIRA (ConsumerGroupHeartbeatResponse,
ShareGroupHeartbeatResponse, StreamsGroupHeartbeatResponse).
OffsetsForLeaderEpochResponse returns version >= 2 (the version that
added the throttle field).

A regression test in RequestResponseTest asserts that every API whose
response schema has a throttle_time_ms field returns true from
shouldClientThrottle() at its latest version, so new APIs can't
reintroduce the bug.

Reviewers: Jun Rao <junrao@gmail.com>
