### PR TITLE
MINOR:Fix typo in build.gradle and dependencies.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ ext {
 
   runtimeTestLibs = [
     libs.slf4jLog4j2,
-    libs.junitPlatformLanucher,
+    libs.junitPlatformLauncher,
     libs.jacksonDataformatYaml,
     project(":test-common:test-common-util")
   ]
@@ -1691,7 +1691,7 @@ project(':test-common:test-common-util') {
   }
 
   dependencies {
-    implementation libs.junitPlatformLanucher
+    implementation libs.junitPlatformLauncher
     implementation libs.junitJupiterApi
     implementation libs.junitJupiter
     implementation libs.slf4jApi
@@ -1725,7 +1725,7 @@ project(':test-common:test-common-runtime') {
     implementation project(':raft')
     implementation project(':storage')
 
-    implementation libs.junitPlatformLanucher
+    implementation libs.junitPlatformLauncher
     implementation libs.junitJupiter
     implementation libs.jacksonDataformatYaml
     implementation libs.slf4jApi

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -192,7 +192,7 @@ libs += [
   junitJupiter: "org.junit.jupiter:junit-jupiter:$versions.junit",
   junitJupiterApi: "org.junit.jupiter:junit-jupiter-api:$versions.junit",
   junitPlatformSuiteEngine: "org.junit.platform:junit-platform-suite-engine:$versions.junitPlatform",
-  junitPlatformLanucher: "org.junit.platform:junit-platform-launcher:$versions.junitPlatform",
+  junitPlatformLauncher: "org.junit.platform:junit-platform-launcher:$versions.junitPlatform",
   hamcrest: "org.hamcrest:hamcrest:$versions.hamcrest",
   kafkaStreams_0110: "org.apache.kafka:kafka-streams:$versions.kafka_0110",
   kafkaStreams_10: "org.apache.kafka:kafka-streams:$versions.kafka_10",


### PR DESCRIPTION
Fix the `junitPlatformLanucher` typo in the Gradle dependency alias.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
