### PR TITLE
KAFKA-20830: Speed up testFailToStartWhenInternalTopicsAreNotCompacted

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -212,6 +212,9 @@ public class InternalTopicsIntegrationTest {
 
         // Try to start one worker, with three bad topics
         WorkerHandle worker = connect.addWorker(); // should have failed to start before returning
+        // The worker is expected to fail startup, so shorten the request timeout to avoid
+        // blocking for the default 10 seconds on every health check.
+        connect.requestTimeout(1000);
         assertFalse(connect.isHealthy(worker));
         assertFalse(connect.allWorkersHealthy());
         assertFalse(connect.anyWorkersHealthy());
@@ -222,6 +225,7 @@ public class InternalTopicsIntegrationTest {
 
         // Try to start one worker, with two bad topics remaining
         worker = connect.addWorker(); // should have failed to start before returning
+        connect.requestTimeout(1000);
         assertFalse(connect.isHealthy(worker));
         assertFalse(connect.allWorkersHealthy());
         assertFalse(connect.anyWorkersHealthy());
@@ -232,6 +236,7 @@ public class InternalTopicsIntegrationTest {
 
         // Try to start one worker, with one bad topic remaining
         worker = connect.addWorker(); // should have failed to start before returning
+        connect.requestTimeout(1000);
         assertFalse(connect.isHealthy(worker));
         assertFalse(connect.allWorkersHealthy());
         assertFalse(connect.anyWorkersHealthy());


### PR DESCRIPTION
The test uses REST to verify the health of a dead worker, but the
default timeout is 10 seconds. That means it takes 30 seconds (3 * 10
seconds) to complete all verifications for a run. So we add
connect.requestTimeout(1000) to speed it up. The timeout has to be set
after every addWorker() call since a new worker starts with the default
timeout.

Locally this cuts the test time from 1m41.50s to 20.802s (times taken
from the JUnit report). The ~81s difference matches the expected saving:
9 health checks (3 rounds x 3 assertions) x 9s shorter timeout.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
