### PR TITLE
KAFKA-20835: Validate only changed group configurations

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -135,7 +135,7 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
       case GROUP =>
         validateGroupName(resource.name())
         val filteredConfigs = filterAndValidateNullConfigs(newConfigs, "group")
-        GroupConfig.validate(filteredConfigs, kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
+        GroupConfig.validate(filteredConfigs, oldConfigs, kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
       case _ => throwExceptionForUnknownResourceType(resource)
     }
   }

--- a/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
+++ b/core/src/main/scala/kafka/server/ControllerConfigurationValidator.scala
@@ -135,7 +135,8 @@ class ControllerConfigurationValidator(kafkaConfig: KafkaConfig) extends Configu
       case GROUP =>
         validateGroupName(resource.name())
         val filteredConfigs = filterAndValidateNullConfigs(newConfigs, "group")
-        GroupConfig.validate(filteredConfigs, oldConfigs, kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
+        GroupConfig.validate(filteredConfigs, oldConfigs, resource.name(),
+          kafkaConfig.groupCoordinatorConfig, kafkaConfig.shareGroupConfig)
       case _ => throwExceptionForUnknownResourceType(resource)
     }
   }

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
@@ -185,6 +185,41 @@ class ControllerConfigurationValidatorTest {
   }
 
   @Test
+  def testGroupConfigChangeIgnoresUnchangedOutOfRangeSessionTimeout(): Unit = {
+    val existingConfig = new util.TreeMap[String, String]()
+    existingConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "90000")
+
+    val newConfig = new util.TreeMap[String, String](existingConfig)
+    newConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "6000")
+
+    validator.validate(new ConfigResource(GROUP, "group"), newConfig, existingConfig)
+  }
+
+  @Test
+  def testGroupConfigChangeIgnoresUnchangedOutOfRangeHeartbeatInterval(): Unit = {
+    val existingConfig = new util.TreeMap[String, String]()
+    existingConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "16000")
+
+    val newConfig = new util.TreeMap[String, String](existingConfig)
+    newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000")
+
+    validator.validate(new ConfigResource(GROUP, "group"), newConfig, existingConfig)
+  }
+
+  @Test
+  def testInvalidChangedGroupConfigIsStillRejected(): Unit = {
+    val existingConfig = new util.TreeMap[String, String]()
+    existingConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000")
+
+    val newConfig = new util.TreeMap[String, String](existingConfig)
+    newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "90000")
+
+    assertEquals("consumer.session.timeout.ms must be in the range 45000 to 60000 inclusive.",
+      assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
+        new ConfigResource(GROUP, "group"), newConfig, existingConfig)).getMessage)
+  }
+
+  @Test
   def testInvalidGroupNameGroupConfig(): Unit = {
     val config = new util.TreeMap[String, String]()
     assertEquals("Default group resources are not allowed.",

--- a/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerConfigurationValidatorTest.scala
@@ -185,38 +185,41 @@ class ControllerConfigurationValidatorTest {
   }
 
   @Test
-  def testGroupConfigChangeIgnoresUnchangedOutOfRangeSessionTimeout(): Unit = {
-    val existingConfig = new util.TreeMap[String, String]()
-    existingConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "90000")
+  def testGroupConfigChangeUsesEvaluatedOldSessionTimeout(): Unit = {
+    val oldConfig = new util.TreeMap[String, String]()
+    // The current valid session timeout range is 45000 to 60000 ms.
+    oldConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "90000")
 
-    val newConfig = new util.TreeMap[String, String](existingConfig)
+    val newConfig = new util.TreeMap[String, String](oldConfig)
     newConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "6000")
 
-    validator.validate(new ConfigResource(GROUP, "group"), newConfig, existingConfig)
+    validator.validate(new ConfigResource(GROUP, "group"), newConfig, oldConfig)
   }
 
   @Test
-  def testGroupConfigChangeIgnoresUnchangedOutOfRangeHeartbeatInterval(): Unit = {
-    val existingConfig = new util.TreeMap[String, String]()
-    existingConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "16000")
+  def testGroupConfigChangeUsesEvaluatedOldHeartbeatInterval(): Unit = {
+    val oldConfig = new util.TreeMap[String, String]()
+    // The current valid heartbeat interval range is 5000 to 15000 ms.
+    oldConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "16000")
 
-    val newConfig = new util.TreeMap[String, String](existingConfig)
+    val newConfig = new util.TreeMap[String, String](oldConfig)
     newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000")
 
-    validator.validate(new ConfigResource(GROUP, "group"), newConfig, existingConfig)
+    validator.validate(new ConfigResource(GROUP, "group"), newConfig, oldConfig)
   }
 
   @Test
   def testInvalidChangedGroupConfigIsStillRejected(): Unit = {
-    val existingConfig = new util.TreeMap[String, String]()
-    existingConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000")
+    val oldConfig = new util.TreeMap[String, String]()
+    // The current valid session timeout range is 45000 to 60000 ms.
+    oldConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000")
 
-    val newConfig = new util.TreeMap[String, String](existingConfig)
+    val newConfig = new util.TreeMap[String, String](oldConfig)
     newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "90000")
 
     assertEquals("consumer.session.timeout.ms must be in the range 45000 to 60000 inclusive.",
       assertThrows(classOf[InvalidConfigurationException], () => validator.validate(
-        new ConfigResource(GROUP, "group"), newConfig, existingConfig)).getMessage)
+        new ConfigResource(GROUP, "group"), newConfig, oldConfig)).getMessage)
   }
 
   @Test

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -22,17 +22,15 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -495,81 +493,43 @@ public final class GroupConfig extends AbstractConfig {
     /**
      * Check a group configuration after an alter operation.
      *
-     * <p>Only values changed by the operation are validated against the current broker-level
-     * bounds. Values that were already stored may be outside those bounds after a broker
-     * configuration change, but they must not prevent an unrelated group configuration from
-     * being updated. Cross-field validation still considers the effective value of every
-     * involved setting.</p>
+     * <p>The old configuration is first evaluated against the current broker-level bounds.
+     * Values changed by the operation are then overlaid and the resulting configuration is
+     * validated normally. This prevents a previously stored value that became out of range
+     * after a broker configuration change from blocking an unrelated update.</p>
      *
      * @param newGroupConfig         The complete group config after the alter operation.
-     * @param existingGroupConfig    The complete group config before the alter operation.
+     * @param oldGroupConfig         The complete group config before the alter operation.
+     * @param groupId                The group id.
      * @param groupCoordinatorConfig The group coordinator config.
      * @param shareGroupConfig       The share group config.
      */
     public static void validate(
         Map<String, String> newGroupConfig,
-        Map<String, String> existingGroupConfig,
+        Map<String, String> oldGroupConfig,
+        String groupId,
         GroupCoordinatorConfig groupCoordinatorConfig,
         ShareGroupConfig shareGroupConfig
     ) {
-        Map<String, String> changedConfigs = new LinkedHashMap<>();
-        newGroupConfig.forEach((name, value) -> {
-            if (!Objects.equals(value, existingGroupConfig.get(name))) {
-                changedConfigs.put(name, value);
-            }
-        });
+        Properties evaluatedOldGroupConfig = evaluate(
+            Utils.mkProperties(oldGroupConfig),
+            groupId,
+            groupCoordinatorConfig,
+            shareGroupConfig
+        );
 
-        Set<String> changedConfigNames = new HashSet<>(changedConfigs.keySet());
-        existingGroupConfig.keySet().forEach(name -> {
+        oldGroupConfig.keySet().forEach(name -> {
             if (!newGroupConfig.containsKey(name)) {
-                changedConfigNames.add(name);
+                evaluatedOldGroupConfig.remove(name);
+            }
+        });
+        newGroupConfig.forEach((name, value) -> {
+            if (!value.equals(oldGroupConfig.get(name))) {
+                evaluatedOldGroupConfig.setProperty(name, value);
             }
         });
 
-        // All names in the resulting configuration must still be known, even though only
-        // changed values are subject to value validation.
-        validateNames(newGroupConfig);
-        validateNoDuplicateRackAwareAssignmentTags(changedConfigs);
-        var parsed = CONFIG_DEF.parse(changedConfigs);
-        parsed.keySet().retainAll(changedConfigs.keySet());
-        validateIndividualValues(parsed, groupCoordinatorConfig, shareGroupConfig);
-
-        validateSessionExceedsHeartbeat(
-            newGroupConfig,
-            changedConfigNames,
-            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
-            groupCoordinatorConfig.consumerGroupMinSessionTimeoutMs(),
-            groupCoordinatorConfig.consumerGroupMaxSessionTimeoutMs(),
-            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs(),
-            groupCoordinatorConfig.consumerGroupMinHeartbeatIntervalMs(),
-            groupCoordinatorConfig.consumerGroupMaxHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            newGroupConfig,
-            changedConfigNames,
-            SHARE_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
-            groupCoordinatorConfig.shareGroupMinSessionTimeoutMs(),
-            groupCoordinatorConfig.shareGroupMaxSessionTimeoutMs(),
-            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs(),
-            groupCoordinatorConfig.shareGroupMinHeartbeatIntervalMs(),
-            groupCoordinatorConfig.shareGroupMaxHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            newGroupConfig,
-            changedConfigNames,
-            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
-            groupCoordinatorConfig.streamsGroupMinSessionTimeoutMs(),
-            groupCoordinatorConfig.streamsGroupMaxSessionTimeoutMs(),
-            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs(),
-            groupCoordinatorConfig.streamsGroupMinHeartbeatIntervalMs(),
-            groupCoordinatorConfig.streamsGroupMaxHeartbeatIntervalMs()
-        );
+        validate(Utils.propsToStringMap(evaluatedOldGroupConfig), groupCoordinatorConfig, shareGroupConfig);
     }
 
     /**
@@ -600,41 +560,6 @@ public final class GroupConfig extends AbstractConfig {
      * @param shareGroupConfig       The share group config.
      */
     private static void validateValues(
-        Map<String, Object> parsed,
-        GroupCoordinatorConfig groupCoordinatorConfig,
-        ShareGroupConfig shareGroupConfig
-    ) {
-        validateIndividualValues(parsed, groupCoordinatorConfig, shareGroupConfig);
-
-        // Cross-field validations: session timeout must be greater than heartbeat interval.
-        validateSessionExceedsHeartbeat(
-            parsed,
-            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
-            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            parsed,
-            SHARE_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
-            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            parsed,
-            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
-            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs()
-        );
-    }
-
-    /**
-     * Validates individual group configuration values without checking relationships between
-     * settings. This lets alter validation handle unchanged, out-of-range values separately.
-     */
-    private static void validateIndividualValues(
         Map<String, Object> parsed,
         GroupCoordinatorConfig groupCoordinatorConfig,
         ShareGroupConfig shareGroupConfig
@@ -732,6 +657,29 @@ public final class GroupConfig extends AbstractConfig {
             groupCoordinatorConfig.streamsGroupMaxWarmupReplicas()
         );
 
+        // Cross-field validations: session timeout must be greater than heartbeat interval.
+        validateSessionExceedsHeartbeat(
+            parsed,
+            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
+            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            parsed,
+            SHARE_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
+            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            parsed,
+            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
+            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs()
+        );
+
         // DLQ validation (KIP-1191)
         // DLQ topic name must not start with "__" (reserved for internal topics)
         String dlqTopicName = (String) parsed.get(ERRORS_DEADLETTERQUEUE_TOPIC_NAME_CONFIG);
@@ -798,55 +746,6 @@ public final class GroupConfig extends AbstractConfig {
         int value = (Integer) parsed.get(key);
         if (value < min)
             throw new InvalidConfigurationException(key + " must be greater than or equal to " + min);
-    }
-
-    /**
-     * Validates a session/heartbeat relationship for an alter operation. Unchanged values are
-     * clamped to the current broker-level bounds before the relationship is checked because a
-     * broker configuration change may have made the stored value stale.
-     */
-    private static void validateSessionExceedsHeartbeat(
-        Map<String, String> newGroupConfig,
-        Set<String> changedConfigNames,
-        String sessionKey,
-        int defaultSession,
-        int minSession,
-        int maxSession,
-        String heartbeatKey,
-        int defaultHeartbeat,
-        int minHeartbeat,
-        int maxHeartbeat
-    ) {
-        if (!changedConfigNames.contains(sessionKey) && !changedConfigNames.contains(heartbeatKey)) {
-            return;
-        }
-
-        int effectiveSession = effectiveValue(newGroupConfig, sessionKey, defaultSession, minSession, maxSession);
-        int effectiveHeartbeat = effectiveValue(
-            newGroupConfig,
-            heartbeatKey,
-            defaultHeartbeat,
-            minHeartbeat,
-            maxHeartbeat
-        );
-        if (effectiveSession <= effectiveHeartbeat) {
-            throw new InvalidConfigurationException(sessionKey + " must be greater than " + heartbeatKey);
-        }
-    }
-
-    private static int effectiveValue(
-        Map<String, String> groupConfig,
-        String key,
-        int defaultValue,
-        int minValue,
-        int maxValue
-    ) {
-        String rawValue = groupConfig.get(key);
-        if (rawValue == null) {
-            return defaultValue;
-        }
-        int value = Integer.parseInt(rawValue.trim());
-        return Math.max(minValue, Math.min(maxValue, value));
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -27,9 +27,12 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -490,6 +493,86 @@ public final class GroupConfig extends AbstractConfig {
     }
 
     /**
+     * Check a group configuration after an alter operation.
+     *
+     * <p>Only values changed by the operation are validated against the current broker-level
+     * bounds. Values that were already stored may be outside those bounds after a broker
+     * configuration change, but they must not prevent an unrelated group configuration from
+     * being updated. Cross-field validation still considers the effective value of every
+     * involved setting.</p>
+     *
+     * @param newGroupConfig         The complete group config after the alter operation.
+     * @param existingGroupConfig    The complete group config before the alter operation.
+     * @param groupCoordinatorConfig The group coordinator config.
+     * @param shareGroupConfig       The share group config.
+     */
+    public static void validate(
+        Map<String, String> newGroupConfig,
+        Map<String, String> existingGroupConfig,
+        GroupCoordinatorConfig groupCoordinatorConfig,
+        ShareGroupConfig shareGroupConfig
+    ) {
+        Map<String, String> changedConfigs = new LinkedHashMap<>();
+        newGroupConfig.forEach((name, value) -> {
+            if (!Objects.equals(value, existingGroupConfig.get(name))) {
+                changedConfigs.put(name, value);
+            }
+        });
+
+        Set<String> changedConfigNames = new HashSet<>(changedConfigs.keySet());
+        existingGroupConfig.keySet().forEach(name -> {
+            if (!newGroupConfig.containsKey(name)) {
+                changedConfigNames.add(name);
+            }
+        });
+
+        // All names in the resulting configuration must still be known, even though only
+        // changed values are subject to value validation.
+        validateNames(newGroupConfig);
+        validateNoDuplicateRackAwareAssignmentTags(changedConfigs);
+        var parsed = CONFIG_DEF.parse(changedConfigs);
+        parsed.keySet().retainAll(changedConfigs.keySet());
+        validateIndividualValues(parsed, groupCoordinatorConfig, shareGroupConfig);
+
+        validateSessionExceedsHeartbeat(
+            newGroupConfig,
+            changedConfigNames,
+            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
+            groupCoordinatorConfig.consumerGroupMinSessionTimeoutMs(),
+            groupCoordinatorConfig.consumerGroupMaxSessionTimeoutMs(),
+            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs(),
+            groupCoordinatorConfig.consumerGroupMinHeartbeatIntervalMs(),
+            groupCoordinatorConfig.consumerGroupMaxHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            newGroupConfig,
+            changedConfigNames,
+            SHARE_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
+            groupCoordinatorConfig.shareGroupMinSessionTimeoutMs(),
+            groupCoordinatorConfig.shareGroupMaxSessionTimeoutMs(),
+            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs(),
+            groupCoordinatorConfig.shareGroupMinHeartbeatIntervalMs(),
+            groupCoordinatorConfig.shareGroupMaxHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            newGroupConfig,
+            changedConfigNames,
+            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
+            groupCoordinatorConfig.streamsGroupMinSessionTimeoutMs(),
+            groupCoordinatorConfig.streamsGroupMaxSessionTimeoutMs(),
+            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs(),
+            groupCoordinatorConfig.streamsGroupMinHeartbeatIntervalMs(),
+            groupCoordinatorConfig.streamsGroupMaxHeartbeatIntervalMs()
+        );
+    }
+
+    /**
      * Rejects an alterConfigs request whose rack-aware assignment tags contain duplicate keys, inspecting the
      * raw value because {@link ConfigDef} removes duplicates from LIST values before they can be validated.
      *
@@ -517,6 +600,41 @@ public final class GroupConfig extends AbstractConfig {
      * @param shareGroupConfig       The share group config.
      */
     private static void validateValues(
+        Map<String, Object> parsed,
+        GroupCoordinatorConfig groupCoordinatorConfig,
+        ShareGroupConfig shareGroupConfig
+    ) {
+        validateIndividualValues(parsed, groupCoordinatorConfig, shareGroupConfig);
+
+        // Cross-field validations: session timeout must be greater than heartbeat interval.
+        validateSessionExceedsHeartbeat(
+            parsed,
+            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
+            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            parsed,
+            SHARE_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
+            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs()
+        );
+        validateSessionExceedsHeartbeat(
+            parsed,
+            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
+            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
+            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs()
+        );
+    }
+
+    /**
+     * Validates individual group configuration values without checking relationships between
+     * settings. This lets alter validation handle unchanged, out-of-range values separately.
+     */
+    private static void validateIndividualValues(
         Map<String, Object> parsed,
         GroupCoordinatorConfig groupCoordinatorConfig,
         ShareGroupConfig shareGroupConfig
@@ -614,29 +732,6 @@ public final class GroupConfig extends AbstractConfig {
             groupCoordinatorConfig.streamsGroupMaxWarmupReplicas()
         );
 
-        // Cross-field validations: session timeout must be greater than heartbeat interval.
-        validateSessionExceedsHeartbeat(
-            parsed,
-            CONSUMER_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupSessionTimeoutMs(),
-            CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.consumerGroupHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            parsed,
-            SHARE_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupSessionTimeoutMs(),
-            SHARE_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.shareGroupHeartbeatIntervalMs()
-        );
-        validateSessionExceedsHeartbeat(
-            parsed,
-            STREAMS_SESSION_TIMEOUT_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupSessionTimeoutMs(),
-            STREAMS_HEARTBEAT_INTERVAL_MS_CONFIG,
-            groupCoordinatorConfig.streamsGroupHeartbeatIntervalMs()
-        );
-
         // DLQ validation (KIP-1191)
         // DLQ topic name must not start with "__" (reserved for internal topics)
         String dlqTopicName = (String) parsed.get(ERRORS_DEADLETTERQUEUE_TOPIC_NAME_CONFIG);
@@ -703,6 +798,55 @@ public final class GroupConfig extends AbstractConfig {
         int value = (Integer) parsed.get(key);
         if (value < min)
             throw new InvalidConfigurationException(key + " must be greater than or equal to " + min);
+    }
+
+    /**
+     * Validates a session/heartbeat relationship for an alter operation. Unchanged values are
+     * clamped to the current broker-level bounds before the relationship is checked because a
+     * broker configuration change may have made the stored value stale.
+     */
+    private static void validateSessionExceedsHeartbeat(
+        Map<String, String> newGroupConfig,
+        Set<String> changedConfigNames,
+        String sessionKey,
+        int defaultSession,
+        int minSession,
+        int maxSession,
+        String heartbeatKey,
+        int defaultHeartbeat,
+        int minHeartbeat,
+        int maxHeartbeat
+    ) {
+        if (!changedConfigNames.contains(sessionKey) && !changedConfigNames.contains(heartbeatKey)) {
+            return;
+        }
+
+        int effectiveSession = effectiveValue(newGroupConfig, sessionKey, defaultSession, minSession, maxSession);
+        int effectiveHeartbeat = effectiveValue(
+            newGroupConfig,
+            heartbeatKey,
+            defaultHeartbeat,
+            minHeartbeat,
+            maxHeartbeat
+        );
+        if (effectiveSession <= effectiveHeartbeat) {
+            throw new InvalidConfigurationException(sessionKey + " must be greater than " + heartbeatKey);
+        }
+    }
+
+    private static int effectiveValue(
+        Map<String, String> groupConfig,
+        String key,
+        int defaultValue,
+        int minValue,
+        int maxValue
+    ) {
+        String rawValue = groupConfig.get(key);
+        if (rawValue == null) {
+            return defaultValue;
+        }
+        int value = Integer.parseInt(rawValue.trim());
+        return Math.max(minValue, Math.min(maxValue, value));
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupConfigTest.java
@@ -629,6 +629,30 @@ public class GroupConfigTest {
     }
 
     @Test
+    public void testAlterValidationIgnoresUnchangedOutOfRangeValue() {
+        Map<String, String> existingConfig = Map.of(
+            GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "70000"
+        );
+        Map<String, String> newConfig = new HashMap<>(existingConfig);
+        newConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "6000");
+
+        assertDoesNotThrow(() -> GroupConfig.validate(
+            newConfig, existingConfig, createGroupCoordinatorConfig(), createShareGroupConfig()));
+    }
+
+    @Test
+    public void testAlterValidationRejectsChangedOutOfRangeValue() {
+        Map<String, String> existingConfig = Map.of(
+            GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000"
+        );
+        Map<String, String> newConfig = new HashMap<>(existingConfig);
+        newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "70000");
+
+        assertThrows(InvalidConfigurationException.class, () -> GroupConfig.validate(
+            newConfig, existingConfig, createGroupCoordinatorConfig(), createShareGroupConfig()));
+    }
+
+    @Test
     public void testInvalidConfigName() {
         Map<String, String> props = new HashMap<>();
         props.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "10");

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupConfigTest.java
@@ -630,26 +630,28 @@ public class GroupConfigTest {
 
     @Test
     public void testAlterValidationIgnoresUnchangedOutOfRangeValue() {
-        Map<String, String> existingConfig = Map.of(
+        // The current valid session timeout range is 45000 to 60000 ms.
+        Map<String, String> oldGroupConfig = Map.of(
             GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "70000"
         );
-        Map<String, String> newConfig = new HashMap<>(existingConfig);
+        Map<String, String> newConfig = new HashMap<>(oldGroupConfig);
         newConfig.put(GroupConfig.CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, "6000");
 
         assertDoesNotThrow(() -> GroupConfig.validate(
-            newConfig, existingConfig, createGroupCoordinatorConfig(), createShareGroupConfig()));
+            newConfig, oldGroupConfig, "group", createGroupCoordinatorConfig(), createShareGroupConfig()));
     }
 
     @Test
     public void testAlterValidationRejectsChangedOutOfRangeValue() {
-        Map<String, String> existingConfig = Map.of(
+        // The current valid session timeout range is 45000 to 60000 ms.
+        Map<String, String> oldGroupConfig = Map.of(
             GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "50000"
         );
-        Map<String, String> newConfig = new HashMap<>(existingConfig);
+        Map<String, String> newConfig = new HashMap<>(oldGroupConfig);
         newConfig.put(GroupConfig.CONSUMER_SESSION_TIMEOUT_MS_CONFIG, "70000");
 
         assertThrows(InvalidConfigurationException.class, () -> GroupConfig.validate(
-            newConfig, existingConfig, createGroupCoordinatorConfig(), createShareGroupConfig()));
+            newConfig, oldGroupConfig, "group", createGroupCoordinatorConfig(), createShareGroupConfig()));
     }
 
     @Test


### PR DESCRIPTION
The controller receives the complete group configuration after an alter
operation. A group override that was valid when stored can fall outside
the current broker bounds after a broker configuration change, which
previously prevented unrelated group configuration updates.

Evaluate the stored group configuration against the current broker
bounds, overlay the values changed by the alter operation, and run the
result through the existing validation path. This allows stale overrides
to remain unchanged while still validating changed values and
session/heartbeat relationships using their effective values.

Reviewers: Sean Quah <squah@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
