### PR TITLE
KAFKA-20822: Harden Trogdor polymorphic JSON deserialization

### DIFF
--- a/trogdor/src/main/java/org/apache/kafka/trogdor/common/JsonUtil.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/common/JsonUtil.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.io.File;
@@ -31,10 +33,19 @@ import java.io.File;
  * Utilities for working with JSON.
  */
 public class JsonUtil {
+    private static final BasicPolymorphicTypeValidator POLYMORPHIC_TYPE_VALIDATOR =
+        BasicPolymorphicTypeValidator.builder().
+            allowIfSubType("org.apache.kafka.trogdor.task.").
+            allowIfSubType("org.apache.kafka.trogdor.fault.").
+            allowIfSubType("org.apache.kafka.trogdor.workload.").
+            build();
+
     public static final ObjectMapper JSON_SERDE;
 
     static {
-        JSON_SERDE = new ObjectMapper();
+        JSON_SERDE = JsonMapper.builder().
+            polymorphicTypeValidator(POLYMORPHIC_TYPE_VALIDATOR).
+            build();
         JSON_SERDE.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         JSON_SERDE.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         JSON_SERDE.configure(JsonParser.Feature.ALLOW_COMMENTS, true);

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/task/TaskSpecTest.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/task/TaskSpecTest.java
@@ -18,11 +18,16 @@
 package org.apache.kafka.trogdor.task;
 
 import org.apache.kafka.trogdor.common.JsonUtil;
+import org.apache.kafka.trogdor.fault.ProcessStopFaultSpec;
+import org.apache.kafka.trogdor.workload.ExternalCommandSpec;
 
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,5 +50,27 @@ public class TaskSpecTest {
         assertEquals("foo", spec.error());
         String outputJson = JsonUtil.toJsonString(spec);
         assertEquals(inputJson, outputJson);
+    }
+
+    @Test
+    public void testTaskSpecAcceptsBuiltInTypesFromEachSupportedPackage() throws Exception {
+        List<TaskSpec> specs = List.of(
+            new NoOpTaskSpec(0, 1),
+            new ProcessStopFaultSpec(0, 1, List.of("node"), "java"),
+            new ExternalCommandSpec(0, 1, "node", List.of("true"), null, Optional.empty())
+        );
+
+        for (TaskSpec spec : specs) {
+            TaskSpec deserialized = JsonUtil.JSON_SERDE.readValue(JsonUtil.toJsonString(spec), TaskSpec.class);
+            assertEquals(spec.getClass(), deserialized.getClass());
+        }
+    }
+
+    @Test
+    public void testTaskSpecRejectsTypesOutsideSupportedPackages() {
+        assertThrows(InvalidTypeIdException.class, () ->
+            JsonUtil.JSON_SERDE.readValue(
+                "{\"class\":\"org.apache.kafka.trogdor.test.ExternalTaskSpec\",\"startMs\":0,\"durationMs\":1}",
+                TaskSpec.class));
     }
 }

--- a/trogdor/src/test/java/org/apache/kafka/trogdor/test/ExternalTaskSpec.java
+++ b/trogdor/src/test/java/org/apache/kafka/trogdor/test/ExternalTaskSpec.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.test;
+
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.trogdor.common.Platform;
+import org.apache.kafka.trogdor.task.TaskController;
+import org.apache.kafka.trogdor.task.TaskSpec;
+import org.apache.kafka.trogdor.task.TaskWorker;
+import org.apache.kafka.trogdor.task.WorkerStatusTracker;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Set;
+
+/**
+ * Test-only subtype used to verify that JsonUtil rejects classes outside the supported packages.
+ */
+public final class ExternalTaskSpec extends TaskSpec {
+    @JsonCreator
+    public ExternalTaskSpec(@JsonProperty("startMs") long startMs,
+                            @JsonProperty("durationMs") long durationMs) {
+        super(startMs, durationMs);
+    }
+
+    @Override
+    public TaskController newController(String id) {
+        return topology -> Set.of();
+    }
+
+    @Override
+    public TaskWorker newTaskWorker(String id) {
+        return new TaskWorker() {
+            @Override
+            public void start(Platform platform, WorkerStatusTracker status,
+                              KafkaFutureImpl<String> haltFuture) {
+            }
+
+            @Override
+            public void stop(Platform platform) {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes KAFKA-20822.

### Summary
- Configure Trogdor's shared Jackson mapper with a `BasicPolymorphicTypeValidator`.
- Allow only built-in `TaskSpec` implementations from the `task`, `fault`, and `workload` packages.
- Add regression coverage proving unsupported `TaskSpec` subtypes are rejected while built-in types from each supported package remain readable.

### Why
`TaskSpec` uses Jackson `JsonTypeInfo.Id.CLASS`, which previously allowed any class on the classpath that extended `TaskSpec` to be selected by the incoming `class` type id. The allowlist preserves the existing wire format and built-in task types while preventing external subtypes from being instantiated.

### Verification
- TDD RED: the unsupported-subtype regression test instantiated the external test subtype before the validator was added.
- TDD GREEN: `./gradlew :trogdor:test --tests org.apache.kafka.trogdor.task.TaskSpecTest --no-build-cache`
- Full module tests: `./gradlew :trogdor:test --no-build-cache`
- Static checks: `./gradlew :trogdor:spotlessCheck :trogdor:checkstyleMain :trogdor:checkstyleTest :trogdor:spotbugsMain --no-build-cache`
- `git diff --check`

No public JSON shape or built-in Trogdor task behavior is changed.