### PR TITLE
KAFKA-20716: Document unclean leader election transaction limitations

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -202,9 +202,12 @@ public class TopicConfig {
         "loss. Enabling this configuration for a topic that uses transactions is incompatible with exactly-once " +
         "semantics. An unclean election can remove a transaction's COMMIT or ABORT marker from the elected replica, " +
         "causing consumers with <code>isolation.level=read_committed</code> to stop at the last stable offset. " +
-        "If this occurs, use <code>kafka-transactions.sh find-hanging</code> to identify the affected transaction and " +
-        "<code>kafka-transactions.sh abort</code> to recover it. Verify the transaction and partition before aborting " +
-        "it, since an unclean election may already have caused data loss." +
+        "If this occurs, use <code>kafka-transactions.sh find-hanging</code> with <code>--topic</code> or " +
+        "<code>--broker-id</code> to look for an open transaction whose marker is missing. If it reports a transaction " +
+        "whose producer state is still available, use <code>kafka-transactions.sh abort</code> with its topic, partition, " +
+        "and start offset to abort it. These commands cannot restore records or markers lost by an unclean election. " +
+        "Verify the transaction and partition before aborting it, since an unclean election may already have caused " +
+        "data loss." +
         "<p>Note: In KRaft mode, when enabling this config dynamically, it needs to wait for the unclean leader election " +
         "thread to trigger election periodically (default is 5 minutes). Please run <code>kafka-leader-election.sh</code> with <code>unclean</code> option " +
          "to trigger the unclean leader election immediately if needed.</p>";

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -199,7 +199,13 @@ public class TopicConfig {
     public static final String UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG = "unclean.leader.election.enable";
     public static final String UNCLEAN_LEADER_ELECTION_ENABLE_DOC = "Indicates whether to enable replicas " +
         "not in the ISR set to be elected as leader as a last resort, even though doing so may result in data " +
-        "loss.<p>Note: In KRaft mode, when enabling this config dynamically, it needs to wait for the unclean leader election" +
+        "loss. Enabling this configuration for a topic that uses transactions is incompatible with exactly-once " +
+        "semantics. An unclean election can remove a transaction's COMMIT or ABORT marker from the elected replica, " +
+        "causing consumers with <code>isolation.level=read_committed</code> to stop at the last stable offset. " +
+        "If this occurs, use <code>kafka-transactions.sh find-hanging</code> to identify the affected transaction and " +
+        "<code>kafka-transactions.sh abort</code> to recover it. Verify the transaction and partition before aborting " +
+        "it, since an unclean election may already have caused data loss." +
+        "<p>Note: In KRaft mode, when enabling this config dynamically, it needs to wait for the unclean leader election " +
         "thread to trigger election periodically (default is 5 minutes). Please run <code>kafka-leader-election.sh</code> with <code>unclean</code> option " +
          "to trigger the unclean leader election immediately if needed.</p>";
 

--- a/server/src/test/java/org/apache/kafka/server/UncleanLeaderElectionTest.java
+++ b/server/src/test/java/org/apache/kafka/server/UncleanLeaderElectionTest.java
@@ -28,12 +28,21 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.GroupProtocol;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.ElectionNotNeededException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
@@ -41,6 +50,7 @@ import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.controller.ReplicationControlManager;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.coordinator.transaction.TransactionLogConfig;
 import org.apache.kafka.metadata.LeaderAndIsr;
 import org.apache.kafka.metadata.LeaderConstants;
 import org.apache.kafka.metadata.MetadataCache;
@@ -57,12 +67,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.kafka.server.TestUtils.awaitLeaderChange;
@@ -137,6 +149,126 @@ public class UncleanLeaderElectionTest {
     )
     public void testUncleanLeaderElectionEnabledConsumer() throws Exception {
         testUncleanLeaderElectionEnabled(GroupProtocol.CONSUMER);
+    }
+
+    @ClusterTest(
+        serverProperties = {
+            @ClusterConfigProperty(key = TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, value = "true"),
+            @ClusterConfigProperty(key = TransactionLogConfig.TRANSACTIONS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = TransactionLogConfig.TRANSACTIONS_TOPIC_MIN_ISR_CONFIG, value = "1")
+        }
+    )
+    public void testUncleanLeaderElectionCanLeaveReadCommittedConsumerAtLastStableOffset() throws Exception {
+        disableEligibleLeaderReplicas();
+
+        String transactionalId = "unclean-election-" + UUID.randomUUID();
+        Map<String, Object> producerConfig = Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers(),
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+                ProducerConfig.ACKS_CONFIG, "all",
+                ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId
+        );
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig)) {
+            producer.initTransactions();
+
+            var transactionStateTopic = admin.describeTopics(Set.of(Topic.TRANSACTION_STATE_TOPIC_NAME))
+                    .allTopicNames().get().get(Topic.TRANSACTION_STATE_TOPIC_NAME);
+            int transactionPartitionId = Utils.abs(transactionalId.hashCode()) % transactionStateTopic.partitions().size();
+            int transactionCoordinatorId = transactionStateTopic.partitions().stream()
+                    .filter(partition -> partition.partition() == transactionPartitionId)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Transaction state partition is missing"))
+                    .leader().id();
+            int followerId = transactionCoordinatorId == BROKER_ID_0 ? BROKER_ID_1 : BROKER_ID_0;
+
+            NewTopic newTopic = new NewTopic(TOPIC, Map.of(PARTITION_ID, List.of(transactionCoordinatorId, followerId)))
+                    .configs(Map.of(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "1"));
+            admin.createTopics(List.of(newTopic)).all().get();
+            try {
+                admin.electLeaders(ElectionType.PREFERRED, Set.of(TOPIC_PARTITION)).all().get();
+            } catch (ExecutionException e) {
+                assertInstanceOf(ElectionNotNeededException.class, e.getCause());
+            }
+
+            int leaderId = awaitLeaderChange(cluster, TOPIC_PARTITION, Optional.of(transactionCoordinatorId));
+            KafkaBroker leader = cluster.brokers().get(leaderId);
+            KafkaBroker follower = cluster.brokers().get(followerId);
+
+            produceMessage(cluster, TOPIC, "before");
+            waitForCondition(
+                    () -> {
+                        var log = follower.replicaManager().localLog(TOPIC_PARTITION);
+                        return log.isDefined() && log.get().logEndOffset() >= 1;
+                    },
+                    DEFAULT_MAX_WAIT_MS,
+                    "Timed out waiting for the follower to replicate the non-transactional record"
+            );
+
+            producer.beginTransaction();
+            producer.send(new ProducerRecord<>(TOPIC, "transactional")).get();
+
+            // The follower must contain the transaction data, but must be stopped before the marker is committed.
+            waitForCondition(
+                    () -> {
+                        var log = follower.replicaManager().localLog(TOPIC_PARTITION);
+                        return log.isDefined() && log.get().logEndOffset() >= 2;
+                    },
+                    DEFAULT_MAX_WAIT_MS,
+                    "Timed out waiting for the follower to replicate the transactional record"
+            );
+            follower.shutdown();
+            follower.awaitShutdown();
+            waitForCondition(
+                    () -> {
+                        var leaderAndIsr = leader.replicaManager().metadataCache().getLeaderAndIsr(TOPIC, PARTITION_ID);
+                        return leaderAndIsr.isPresent() && leaderAndIsr.get().isr().equals(Set.of(leaderId));
+                    },
+                    DEFAULT_MAX_WAIT_MS,
+                    "Timed out waiting for the follower to leave the ISR"
+            );
+
+            // The marker is now written only to the leader. The follower will retain the open transaction after failover.
+            producer.commitTransaction();
+
+            // Close the producer while its coordinator is still available; no client cleanup should depend on the old leader.
+            producer.close();
+            leader.shutdown();
+            leader.awaitShutdown();
+            follower.startup();
+            awaitLeaderChange(cluster, TOPIC_PARTITION, Optional.of(followerId));
+
+            Map<String, Object> consumerConfig = Map.of(
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers(),
+                    ConsumerConfig.GROUP_ID_CONFIG, "unclean-election-consumer-" + UUID.randomUUID(),
+                    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+                    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false,
+                    ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString()
+            );
+
+            try (Consumer<String, String> consumer = new KafkaConsumer<>(consumerConfig)) {
+                consumer.assign(List.of(TOPIC_PARTITION));
+                consumer.seekToBeginning(List.of(TOPIC_PARTITION));
+                List<String> values = new java.util.ArrayList<>();
+                waitForCondition(
+                        () -> {
+                            for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofMillis(100))) {
+                                values.add(record.value());
+                            }
+                            return !values.isEmpty();
+                        },
+                        DEFAULT_MAX_WAIT_MS,
+                        "Timed out waiting for the read_committed consumer to read the non-transactional record"
+                );
+
+                assertEquals(List.of("before"), values);
+                assertEquals(1, consumer.position(TOPIC_PARTITION));
+                assertTrue(consumer.poll(Duration.ofMillis(500)).isEmpty());
+            }
+        }
     }
 
     private void testUncleanLeaderElectionEnabled(GroupProtocol groupProtocol) throws Exception {

--- a/server/src/test/java/org/apache/kafka/server/UncleanLeaderElectionTest.java
+++ b/server/src/test/java/org/apache/kafka/server/UncleanLeaderElectionTest.java
@@ -68,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -252,7 +253,7 @@ public class UncleanLeaderElectionTest {
             try (Consumer<String, String> consumer = new KafkaConsumer<>(consumerConfig)) {
                 consumer.assign(List.of(TOPIC_PARTITION));
                 consumer.seekToBeginning(List.of(TOPIC_PARTITION));
-                List<String> values = new java.util.ArrayList<>();
+                List<String> values = new ArrayList<>();
                 waitForCondition(
                         () -> {
                             for (ConsumerRecord<String, String> record : consumer.poll(Duration.ofMillis(100))) {


### PR DESCRIPTION
## Summary

- Document that enabling unclean leader election on transactional topics
is incompatible with exactly-once semantics.
- Explain how a missing transaction marker can leave `read_committed`
consumers stuck at the last stable offset.
- Point operators to `kafka-transactions.sh find-hanging` and `abort`
for recovery, with an explicit warning to verify the transaction and
partition first.
- Preserve the existing KRaft operational note and fix its missing word
boundary.
- Add deterministic end-to-end coverage that reproduces the
stale-follower case and verifies the `read_committed` result after an
unclean election.

## Why

[KAFKA-20716](https://issues.apache.org/jira/browse/KAFKA-20716) reports
that an unclean election can leave a partition with transactional data
but without its COMMIT/ABORT marker. Maintainers confirmed that unclean
leader election cannot guarantee EOS, asked for this limitation to be
documented clearly, and requested an end-to-end test.

The regression test initializes the transaction coordinator first,
places the data partition leader on that broker, waits until the
follower has the transactional record, stops the follower before the
marker is committed, and then performs an unclean election. It verifies
that a `read_committed` consumer returns only the earlier
non-transactional record and remains at offset 1.

This change does not alter broker behavior or introduce automatic
transaction reconciliation.

## Validation

- `./gradlew :server:test --tests
org.apache.kafka.server.UncleanLeaderElectionTest --no-build-cache
--console=plain`
- `./gradlew :server:test --tests
org.apache.kafka.server.UncleanLeaderElectionTest.testUncleanLeaderElectionCanLeaveReadCommittedConsumerAtLastStableOffset
--no-build-cache --console=plain`
- `./gradlew :server:spotlessCheck :server:checkstyleMain
:server:checkstyleTest :server:spotbugsMain`
- `./gradlew :clients:test :clients:spotlessCheck
:clients:checkstyleMain :core:genTopicConfigDocs :core:siteDocsTar
--no-build-cache`
- `./gradlew :core:genTopicConfigDocs :clients:spotlessCheck
:clients:checkstyleMain :clients:spotbugsMain --no-build-cache`
- `git diff --check`

The new test passed in both Raft-Isolated and Raft-Combined cluster
variants. The generated `docs/generated/topic_config.html` was inspected
to verify the new text and HTML rendering.

Fixes KAFKA-20716

Reviewers: Luke Chen <showuon@gmail.com>
