### PR TITLE
KAFKA-19622: Document KRaft migration operating modes

### DIFF
--- a/docs/operations/kraft.md
+++ b/docs/operations/kraft.md
@@ -306,3 +306,10 @@ Note: `00000000000000000000-0000000000.checkpoint` does not contain cluster meta
 ## ZooKeeper to KRaft Migration
 
 In order to migrate from ZooKeeper to KRaft you need to use a bridge release. The last bridge release is Kafka 3.9. See the [ZooKeeper to KRaft Migration steps](/39/operations/kraft/#zookeeper-to-kraft-migration) in the 3.9 documentation.
+
+The migration includes two intermediate operating modes:
+
+* **Hybrid mode:** KRaft controllers manage a cluster whose brokers still run in ZooKeeper mode. This is the higher-risk mode, so keep it only as long as needed to restart the brokers in KRaft mode.
+* **Dual-write mode:** KRaft brokers write metadata to both ZooKeeper and the KRaft metadata log. This mode is closer to a pure KRaft deployment and can be used to validate client traffic and broker health before completing the migration. It should still be treated as a temporary migration mode rather than a permanent operating state.
+
+Before finalizing the migration, verify that client traffic is unaffected and that broker health is stable. Finalizing the migration is irreversible: after finalization, the cluster cannot be rolled back to ZooKeeper mode.


### PR DESCRIPTION
## Summary

- Document the two intermediate operating modes in a ZooKeeper-to-KRaft migration.
- Explain why hybrid mode should be kept only for the broker restart window.
- Describe dual-write mode as a temporary validation phase for client traffic and broker health.
- Make the irreversible nature of migration finalization explicit.

## Why

[KAFKA-19622](https://issues.apache.org/jira/browse/KAFKA-19622) asks for the operational limitations and risks of KRaft dual-write mode. The migration documentation currently links to the 3.9 procedure without explaining the risk distinction between hybrid and dual-write mode or what operators should verify before finalization.

This change is documentation-only and does not alter the migration protocol or runtime behavior.

## Validation

- `./gradlew :core:siteDocsTar --no-build-cache`
- `git diff --check`

The generated site-docs archive was inspected to verify that `operations/kraft.md` contains the new migration guidance.

Fixes KAFKA-19622

Reviewers: Uros (github:uros-b)
