### PR TITLE
MINOR: version updates for build and project dependencies (multiple CVEs are addressed)

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -243,7 +243,7 @@ License Version 2.0:
 - log4j-slf4j-impl-2.25.5
 - log4j-1.2-api-2.25.5
 - lz4-java-1.11.1
-- maven-artifact-3.9.15
+- maven-artifact-3.9.16
 - metrics-core-2.2.0
 - opentelemetry-proto-1.3.2-alpha
 - plexus-utils-3.6.1
@@ -253,7 +253,7 @@ License Version 2.0:
 - scala-reflect-2.13.18
 - snappy-java-1.1.10.7
 - snakeyaml-2.5
-- swagger-annotations-2.2.48
+- swagger-annotations-2.2.52
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ These take the same arguments as the built-in variants.
 
 ### Determining if any dependencies could be updated
 ```bash
-./gradlew dependencyUpdates --no-parallel
+./gradlew dependencyUpdates
 ```
 
 ### Common build options ###

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,17 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.54.0'
+  id 'io.github.ben-manes.versions' version '0.56.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '12.2.1'
+  id 'org.owasp.dependencycheck' version '12.2.2'
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.5.1' apply false
-  id 'org.scoverage' version '8.1' apply false
-  id 'com.gradleup.shadow' version '9.4.1' apply false
+  id "com.github.spotbugs" version '6.5.9' apply false
+  id 'org.scoverage' version '9.1' apply false
+  id 'com.gradleup.shadow' version '9.6.1' apply false
   id 'com.diffplug.spotless' version "8.4.0"
 
   // Pre-register the KIP-1265 checker so `apply plugin:` resolves it inside subprojects { }.

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ group=org.apache.kafka
 version=4.4.0-SNAPSHOT
 scalaVersion=2.13.18
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-swaggerVersion=2.2.48
+swaggerVersion=2.2.52
 task=build
 org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.84",
+  bcpkix: "1.85",
   caffeine: "3.2.0",
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.3.1",
   commonsValidator: "1.10.1",
@@ -70,7 +70,7 @@ versions += [
   // (e.g. Logger.atDebug()) in production code, as Kafka uses SLF4J 1.7.x.
   jetty: "12.0.37",
   jersey: "3.1.10",
-  jgit: "7.6.0.202603022253-r",
+  jgit: "7.7.1.202607240634-r",
   jline: "3.30.16",
   jmh: "1.37",
   hamcrest: "3.0",
@@ -82,7 +82,7 @@ versions += [
   jfreechart: "1.5.6",
   jopt: "5.0.4",
   jose4j: "0.9.6",
-  junit: "5.14.3",
+  junit: "5.14.4",
   kafka_0110: "0.11.0.3",
   kafka_10: "1.0.2",
   kafka_11: "1.1.1",
@@ -114,7 +114,7 @@ versions += [
   // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/internal/CompressionType.java#L73-L74
   // https://github.com/yawkat/lz4-java/blob/main/src/java/net/jpountz/lz4/LZ4Constants.java#L23-L24
   lz4: "1.11.1",
-  mavenArtifact: "3.9.15",
+  mavenArtifact: "3.9.16",
   metrics: "2.2.0",
   mockito: "5.23.0",
   opentelemetryProto: "1.3.2-alpha",
@@ -137,7 +137,7 @@ versions += [
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-10",
-  junitPlatform: "1.14.3",
+  junitPlatform: "1.14.4",
   hdrHistogram: "2.2.2",
   hash4j: "0.22.0"
 ]


### PR DESCRIPTION
details:   - bcpkix: 1.84 -->> 1.85   - jgit: 7.6.0 -->> 7.7.1   -
junit: 5.14.3 -->> 5.14.4   - junitPlatform: 1.14.3 -->> 1.14.4   -
mavenArtifact: 3.9.15 -->> 3.9.16   - swagger: 2.2.48 -->> 2.2.52   -
Gradle plugins:    - gradle-versions-plugin: version update (0.54.0 -->>
0.56.0) and name change (from `com.github.ben-manes.versions plugin` to
`io.github.ben-manes.versions`)       - note: plugin now supports
parallel build (and hence `--no-parallel` switch is not required
anymore)    - dependencycheck: 12.2.1 -->> 12.2.2    - spotbugs: 6.5.1
-->> 6.5.9    - scoverage: 8.1 -->> 9.1    - shadow: 9.4.1 -->> 9.6.1

CVEs addressed via bcpkix and jgit version updates:   - bcpkix: several
vulnerabilities are addressed:
https://github.com/bcgit/bc-java/blob/r1rv85/docs/releasenotes.html#L330
- JGit: these two vulnerabilities are addressed:     - CVE-2026-44432
- https://www.cve.org/CVERecord?id=CVE-2026-44432       -
https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j
- CVE-2026-56624       - https://www.cve.org/CVERecord?id=CVE-2026-56624
- https://lists.apache.org/thread/o4c2jml522j3z80gbryqzc2f1253ltp6

Some notable release notes links:   - bcpkix:
https://github.com/bcgit/bc-java/blob/r1rv85/docs/releasenotes.html#L22
- JGit:     -
https://projects.eclipse.org/projects/technology.jgit/releases/7.7.0
- https://projects.eclipse.org/projects/technology.jgit/releases/7.7.1
- gradle-versions-plugin:     -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.55.0
-
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.56.0
- scoverage gradle plugin:     -
https://github.com/scoverage/gradle-scoverage/releases/tag/9.0     -
https://github.com/scoverage/gradle-scoverage/releases/tag/9.1   -
shadow gradle plugin:
https://gradleup.com/shadow/changes/#961-2026-07-22

Reviewers: Mickael Maison <mickael.maison@gmail.com>
