### PR TITLE
KAFKA-20325: Detect SSL listeners for dedicated controllers

### DIFF
--- a/docker/resources/common-scripts/configure
+++ b/docker/resources/common-scripts/configure
@@ -64,8 +64,14 @@ fi
 
 path /opt/kafka/config/ writable
 
-# Set if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints.
-if [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]]
+is_ssl_enabled() {
+  [[ ${KAFKA_ADVERTISED_LISTENERS-} == *"SSL://"* ]] ||
+    [[ ${KAFKA_LISTENERS-} == *"SSL://"* ]] ||
+    [[ ${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP-} =~ (^|,)[[:space:]]*[^,:]+:(SSL|SASL_SSL)(,|$) ]]
+}
+
+# Set if any configured listener uses SSL or SASL_SSL.
+if is_ssl_enabled
 then
   echo "SSL is enabled."
 

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -205,6 +205,38 @@ class DockerSanityTest(unittest.TestCase):
         
         self.assertEqual(total_errors, [])
 
+
+class DockerConfigureTest(unittest.TestCase):
+    IMAGE="apache/kafka"
+    FIXTURES_DIR="."
+
+    def test_ssl_controller_listener_configures_keystore(self):
+        command = [
+            "docker", "run", "--rm",
+            "--volume", f"{self.FIXTURES_DIR}/fixtures/secrets:/etc/kafka/secrets:ro",
+            "--env", "CLUSTER_ID=4L6g3nShT-eMCtK--X86sw",
+            "--env", "KAFKA_PROCESS_ROLES=controller",
+            "--env", "KAFKA_LISTENERS=CONTROLLER://:9093",
+            "--env", "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SSL",
+            "--env", "KAFKA_SSL_KEYSTORE_FILENAME=kafka01.keystore.jks",
+            "--env", "KAFKA_SSL_KEY_CREDENTIALS=kafka_ssl_key_creds",
+            "--env", "KAFKA_SSL_KEYSTORE_CREDENTIALS=kafka_keystore_creds",
+            "--env", "KAFKA_SSL_TRUSTSTORE_FILENAME=kafka.truststore.jks",
+            "--env", "KAFKA_SSL_TRUSTSTORE_CREDENTIALS=kafka_truststore_creds",
+            "--env", "KAFKA_SSL_CLIENT_AUTH=required",
+            self.IMAGE,
+            "bash", "-c",
+            "source /etc/kafka/docker/configure && "
+            "test \"$KAFKA_SSL_KEYSTORE_LOCATION\" = "
+            "/etc/kafka/secrets/kafka01.keystore.jks && "
+            "test \"$KAFKA_SSL_KEY_PASSWORD\" = abcdefgh && "
+            "test \"$KAFKA_SSL_TRUSTSTORE_LOCATION\" = "
+            "/etc/kafka/secrets/kafka.truststore.jks && "
+            "test \"$KAFKA_SSL_TRUSTSTORE_PASSWORD\" = abcdefgh",
+        ]
+        subprocess.run(command, check=True)
+
+
 class DockerSanityTestCombinedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.COMBINED_MODE_COMPOSE}")
@@ -225,10 +257,12 @@ def run_tests(image, mode, fixtures_dir):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
     DockerSanityTest.MODE = mode
+    DockerConfigureTest.IMAGE = image
+    DockerConfigureTest.FIXTURES_DIR = fixtures_dir
 
     test_classes_to_run = []
     if mode == "jvm" or mode == "native":
-        test_classes_to_run = [DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode]
+        test_classes_to_run = [DockerConfigureTest, DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode]
     
     loader = unittest.TestLoader()
     suites_list = []


### PR DESCRIPTION
## Summary

- Detect SSL and SASL_SSL listeners from `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP` and `KAFKA_LISTENERS` in addition to advertised listeners.
- Add a Docker regression test for a dedicated KRaft controller using `CONTROLLER:SSL` without advertised listeners.

## Motivation

Fixes [KAFKA-20325](https://issues.apache.org/jira/browse/KAFKA-20325).

Dedicated KRaft controllers must not set `KAFKA_ADVERTISED_LISTENERS`, but they can still use an SSL controller listener through `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP`. The Docker image previously detected SSL only from advertised listener names, so it skipped keystore and truststore initialization and the controller could not start with SSL.

The detection keeps the existing advertised-listener behavior and also respects the configured security protocol, including custom listener names such as `CONTROLLER:SSL` and `EXTERNAL:SASL_SSL`.

## Validation

- Added a regression test that fails against the previous script and passes after the change.
- Built an image containing the updated Docker script and ran the regression test successfully.
- Started a dedicated KRaft controller with `CONTROLLER:SSL`; the Kafka server reached the started state.
- `bash -n docker/resources/common-scripts/configure`
- `python3 -m py_compile docker/test/docker_sanity_test.py`
- `git diff --check`
