### PR TITLE
KAFKA-20766: Avoid reverse DNS during SASL authentication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -230,10 +230,13 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                         metadataRegistry);
             } else {
                 LoginManager loginManager = loginManagers.get(clientSaslMechanism);
+                String serverName = SaslConfigs.GSSAPI_MECHANISM.equals(clientSaslMechanism)
+                        ? socket.getInetAddress().getHostName()
+                        : socket.getInetAddress().getHostAddress();
                 authenticatorCreator = () -> buildClientAuthenticator(configs,
                         saslCallbackHandlers.get(clientSaslMechanism),
                         id,
-                        socket.getInetAddress().getHostName(),
+                        serverName,
                         loginManager.serviceName(),
                         finalTransportLayer,
                         subjects.get(clientSaslMechanism));

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -206,7 +206,7 @@ public class SaslServerAuthenticator implements Authenticator {
         } else {
             try {
                 saslServer = SecurityManagerCompatibility.get().callAs(subject, () ->
-                    Sasl.createSaslServer(saslMechanism, "kafka", serverAddress().getHostName(), configs, callbackHandler));
+                    Sasl.createSaslServer(saslMechanism, "kafka", serverAddress().getHostAddress(), configs, callbackHandler));
                 if (saslServer == null) {
                     throw new SaslException("Kafka Server failed to create a SaslServer to interact with a client during session authentication with server mechanism " + saslMechanism);
                 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
@@ -21,12 +21,14 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
@@ -45,9 +47,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import javax.security.auth.Subject;
@@ -60,6 +67,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class SaslChannelBuilderTest {
@@ -161,6 +177,52 @@ public class SaslChannelBuilderTest {
 
         SaslChannelBuilder saslSslBuilder = createChannelBuilder(SecurityProtocol.SASL_SSL, "PLAIN");
         saslSslBuilder.configure(configs);
+    }
+
+    @Test
+    public void testNonGssapiClientUsesServerAddressWithoutReverseDns() throws Exception {
+        assertClientServerName("PLAIN", "127.0.0.1");
+    }
+
+    @Test
+    public void testGssapiClientUsesServerHostname() throws Exception {
+        assertClientServerName(SaslConfigs.GSSAPI_MECHANISM, "server.example.test");
+    }
+
+    private void assertClientServerName(String saslMechanism, String expectedServerName) throws Exception {
+        SaslChannelBuilder builder = Mockito.spy(createChannelBuilder(SecurityProtocol.SASL_PLAINTEXT, saslMechanism));
+        Map<String, Object> configs = new HashMap<>();
+        if (SaslConfigs.GSSAPI_MECHANISM.equals(saslMechanism)) {
+            configs.put(SaslConfigs.SASL_KERBEROS_SERVICE_NAME, "kafka");
+            configs.putAll(new ConfigDef().withClientSaslSupport().parse(configs));
+        }
+        builder.configure(configs);
+
+        InetAddress serverAddress = InetAddress.getByAddress("server.example.test", new byte[]{127, 0, 0, 1});
+        Socket socket = mock(Socket.class);
+        SocketChannel socketChannel = mock(SocketChannel.class);
+        SelectionKey selectionKey = mock(SelectionKey.class);
+        TransportLayer transportLayer = mock(TransportLayer.class);
+        SaslClientAuthenticator authenticator = mock(SaslClientAuthenticator.class);
+        AtomicReference<String> actualServerName = new AtomicReference<>();
+
+        when(selectionKey.channel()).thenReturn(socketChannel);
+        when(socketChannel.socket()).thenReturn(socket);
+        when(socket.getInetAddress()).thenReturn(serverAddress);
+        doReturn(transportLayer).when(builder).buildTransportLayer(eq("test"), same(selectionKey), same(socketChannel),
+                any(ChannelMetadataRegistry.class));
+        doAnswer(invocation -> {
+            actualServerName.set(invocation.getArgument(3));
+            return authenticator;
+        }).when(builder).buildClientAuthenticator(anyMap(), any(), anyString(), anyString(), anyString(),
+                same(transportLayer), any());
+
+        KafkaChannel channel = builder.buildChannel("test", selectionKey, 1024, MemoryPool.NONE,
+                mock(ChannelMetadataRegistry.class));
+
+        assertEquals(expectedServerName, actualServerName.get());
+        channel.close();
+        builder.close();
     }
 
     private SaslChannelBuilder createGssapiChannelBuilder(Map<String, JaasContext> jaasContexts, GSSManager gssManager) {

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -82,6 +82,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -170,6 +171,30 @@ public class SaslServerAuthenticatorTest {
     public void testLatestApiVersionsRequest() throws IOException {
         testApiVersionsRequest(ApiKeys.API_VERSIONS.latestVersion(),
                 "apache-kafka-java", AppInfoParser.getVersion());
+    }
+
+    @Test
+    public void testNonKerberosSaslServerUsesServerAddressWithoutReverseDns() throws IOException {
+        String mechanism = SCRAM_SHA_256.mechanismName();
+        SaslServer saslServer = mock(SaslServer.class);
+        TransportLayer transportLayer = mockTransportLayer();
+        InetAddress serverAddress = InetAddress.getByAddress("server.example.test", new byte[]{127, 0, 0, 1});
+        when(transportLayer.socketChannel().socket().getLocalAddress()).thenReturn(serverAddress);
+        Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
+                Collections.singletonList(mechanism));
+
+        try (MockedStatic<Sasl> ignored = Mockito.mockStatic(Sasl.class)) {
+            ignored.when(() -> Sasl.createSaslServer(eq(mechanism), eq("kafka"), anyString(), anyMap(), any()))
+                    .thenReturn(saslServer);
+
+            SaslServerAuthenticator authenticator = setupAuthenticator(configs, transportLayer, mechanism,
+                    new DefaultChannelMetadataRegistry());
+            mockRequest(saslHandshakeRequest(mechanism), transportLayer);
+            authenticator.authenticate();
+
+            ignored.verify(() -> Sasl.createSaslServer(eq(mechanism), eq("kafka"),
+                    eq(serverAddress.getHostAddress()), anyMap(), any()));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Avoid reverse DNS lookups when Kafka creates non-GSSAPI SASL client and server authenticators.
- Preserve the existing hostname path for GSSAPI so Kerberos service-principal resolution is unchanged.
- Add regression coverage for both client and server server-name selection.

## Motivation

Fixes [KAFKA-20766](https://issues.apache.org/jira/browse/KAFKA-20766).

`SaslServerAuthenticator` used `InetAddress.getHostName()` while creating the SASL server, and `SaslChannelBuilder` did the same for client authenticators. A slow or unavailable PTR lookup can block SASL channel authentication and, on the broker side, delay connection acceptance.

Non-GSSAPI paths now use the numeric address, keeping client and server values symmetric for custom SASL mechanisms such as DIGEST-MD5. GSSAPI retains the hostname because Kerberos service-principal resolution depends on it.

## Validation

- Added unit tests that verify non-GSSAPI clients use the numeric address and GSSAPI clients retain the hostname.
- Added a regression test that verifies non-Kerberos servers pass the numeric address to `Sasl.createSaslServer`.
- Ran the affected SASL integration tests, including custom mechanism pluggability and multi-mechanism reauthentication.
- Ran `./gradlew :clients:test --no-build-cache --console=plain` successfully.
- Ran `git diff --check` successfully.
