### PR TITLE
KAFKA-14249: Make TLS idle expiry test deterministic

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -456,6 +456,8 @@ public class SelectorTest {
         selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.waitForChannelConnected(selector, id);
         NetworkTestUtils.waitForChannelReady(selector, id);
+        // Complete an application round trip so TLS 1.3 post-handshake messages are processed before the idle window.
+        assertEquals("", blockingRequest(id, ""));
         time.sleep(CONNECTION_MAX_IDLE_MS + 1_000);
         selector.poll(0);
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -454,6 +454,7 @@ public class SelectorTest {
     public void testCloseOldestConnection() throws Exception {
         String id = "0";
         selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
+        NetworkTestUtils.waitForChannelConnected(selector, id);
         NetworkTestUtils.waitForChannelReady(selector, id);
         time.sleep(CONNECTION_MAX_IDLE_MS + 1_000);
         selector.poll(0);

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -454,7 +454,7 @@ public class SelectorTest {
     public void testCloseOldestConnection() throws Exception {
         String id = "0";
         selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
-        NetworkTestUtils.waitForChannelConnected(selector, id);
+        NetworkTestUtils.waitForChannelReady(selector, id);
         time.sleep(CONNECTION_MAX_IDLE_MS + 1_000);
         selector.poll(0);
 

--- a/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/Tls13SelectorTest.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 
@@ -45,13 +44,6 @@ public class Tls13SelectorTest extends SslSelectorTest {
             trustStoreFile, "client");
         configs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList("TLSv1.3"));
         return configs;
-    }
-
-    @Flaky(value = "KAFKA-14249", comment = "Copied from base class. Remove this override once the flakiness has been resolved.")
-    @Test
-    @Override
-    public void testCloseOldestConnection() throws Exception {
-        super.testCloseOldestConnection();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Wait for the channel to be fully ready before testing idle connection expiry.
- Remove the TLS 1.3-specific flaky-test override so the shared test runs normally for TLS 1.3.

## Motivation

Fixes [KAFKA-14249](https://issues.apache.org/jira/browse/KAFKA-14249).

The idle-expiry test only waited for the TCP connection to reach `CONNECTED`. With TLS 1.3, the first subsequent poll can still process handshake I/O and refresh the selector's last-active timestamp. The test then misses the expiry deadline and was marked flaky and excluded from normal test execution.

Waiting for `READY` makes the test precondition match the behavior being tested: no handshake work remains before the idle period starts. This lets the TLS 1.3 variant run as a regular regression test.

## Validation

- Ran the TLS 1.3 selector suite with `testCloseOldestConnection` included; it passed.
- Ran `SelectorTest`, `Tls12SelectorTest`, and `Tls13SelectorTest`; all passed.
- Ran `./gradlew :clients:test --no-build-cache --console=plain` successfully.
- Ran `git diff --check` successfully.

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>
