### PR TITLE
MINOR: Fix StreamPartitioner deprecation warning in ProcessorTopology

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1074,7 +1074,7 @@ public class ProcessorTopologyTest {
         assertEquals(headers, record.headers());
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     private StreamPartitioner<String, String> constantPartitioner(final Integer partition) {
         return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1074,26 +1074,9 @@ public class ProcessorTopologyTest {
         assertEquals(headers, record.headers());
     }
 
+    @SuppressWarnings("deprecation")
     private StreamPartitioner<String, String> constantPartitioner(final Integer partition) {
-        return new StreamPartitioner<String, String>() {
-            @Override
-            public Optional<Set<Integer>> partitions(final String topic,
-                                                    final String key,
-                                                    final String value,
-                                                    final Headers headers,
-                                                    final int numPartitions) {
-                return Optional.of(Collections.singleton(partition));
-            }
-
-            @Override
-            @Deprecated
-            public Optional<Set<Integer>> partitions(final String topic,
-                                                     final String key,
-                                                     final String value,
-                                                     final int numPartitions) {
-                return partitions(topic, key, value, null, numPartitions);
-            }
-        };
+        return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
     }
 
     private Topology createSimpleTopology(final int partition) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1075,7 +1075,25 @@ public class ProcessorTopologyTest {
     }
 
     private StreamPartitioner<String, String> constantPartitioner(final Integer partition) {
-        return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
+        return new StreamPartitioner<String, String>() {
+            @Override
+            public Optional<Set<Integer>> partitions(final String topic,
+                                                    final String key,
+                                                    final String value,
+                                                    final Headers headers,
+                                                    final int numPartitions) {
+                return Optional.of(Collections.singleton(partition));
+            }
+
+            @Override
+            @Deprecated
+            public Optional<Set<Integer>> partitions(final String topic,
+                                                     final String key,
+                                                     final String value,
+                                                     final int numPartitions) {
+                return partitions(topic, key, value, null, numPartitions);
+            }
+        };
     }
 
     private Topology createSimpleTopology(final int partition) {


### PR DESCRIPTION
`constantPartitioner` used a lambda, which implicitly overrides the
deprecated 4-arg `StreamPartitioner#partitions(String, K, V, int)`.
Since a lambda cannot be annotated with `@Deprecated`, the warning could
not be suppressed via the lambda itself.

Replaced the lambda with an anonymous class that implements the new
5-arg `partitions(String, K, V, Headers, int)` method, and kept the
deprecated 4-arg override (annotated `@Deprecated`) delegating to it for
source compatibility.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>
