### PR TITLE
KAFKA-20537: Return topic ID for existing topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -33,9 +33,18 @@ public class CreateTopicsResult {
     static final int UNKNOWN = -1;
 
     private final Map<String, KafkaFuture<TopicMetadataAndConfig>> futures;
+    private final Map<String, KafkaFuture<Uuid>> topicIdFutures;
 
     protected CreateTopicsResult(Map<String, KafkaFuture<TopicMetadataAndConfig>> futures) {
+        this(futures, futures.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            entry -> entry.getValue().thenApply(TopicMetadataAndConfig::topicId))));
+    }
+
+    CreateTopicsResult(Map<String, KafkaFuture<TopicMetadataAndConfig>> futures,
+                       Map<String, KafkaFuture<Uuid>> topicIdFutures) {
         this.futures = futures;
+        this.topicIdFutures = topicIdFutures;
     }
 
     /**
@@ -69,7 +78,9 @@ public class CreateTopicsResult {
     }
 
     /**
-     * Returns a future that provides topic ID for the topic when the request completes.
+     * Returns a future that provides the topic ID when the request completes.
+     * If the topic already exists, this future can succeed with the existing topic ID even though
+     * the future returned by {@link #values()} fails with {@link org.apache.kafka.common.errors.TopicExistsException}.
      * <p>
      * If broker version doesn't support replication factor in the response, throw
      * {@link org.apache.kafka.common.errors.UnsupportedVersionException}.
@@ -78,7 +89,7 @@ public class CreateTopicsResult {
      * have permission to describe topic configs.
      */
     public KafkaFuture<Uuid> topicId(String topic) {
-        return futures.get(topic).thenApply(TopicMetadataAndConfig::topicId);
+        return topicIdFutures.get(topic);
     }
     
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1956,24 +1956,27 @@ public class KafkaAdminClient extends AdminClient {
                                 topicIdFuture.completeExceptionally(exception);
                             }
                         } else {
-                            TopicMetadataAndConfig topicMetadataAndConfig;
                             if (result.topicConfigErrorCode() != Errors.NONE.code()) {
-                                topicMetadataAndConfig = new TopicMetadataAndConfig(
-                                    Errors.forCode(result.topicConfigErrorCode()).exception());
+                                ApiException exception = Errors.forCode(result.topicConfigErrorCode()).exception();
+                                topicIdFuture.completeExceptionally(exception);
+                                future.complete(new TopicMetadataAndConfig(exception));
                             } else if (result.numPartitions() == CreateTopicsResult.UNKNOWN) {
-                                topicMetadataAndConfig = new TopicMetadataAndConfig(new UnsupportedVersionException(
-                                    "Topic metadata and configs in CreateTopics response not supported"));
+                                UnsupportedVersionException exception = new UnsupportedVersionException(
+                                    "Topic metadata and configs in CreateTopics response not supported");
+                                topicIdFuture.completeExceptionally(exception);
+                                future.complete(new TopicMetadataAndConfig(exception));
                             } else {
                                 List<CreatableTopicConfigs> configs = result.configs();
                                 Config topicConfig = new Config(configs.stream()
                                     .map(this::configEntry)
                                     .collect(Collectors.toSet()));
-                                topicMetadataAndConfig = new TopicMetadataAndConfig(result.topicId(), result.numPartitions(),
+                                TopicMetadataAndConfig topicMetadataAndConfig = new TopicMetadataAndConfig(
+                                    result.topicId(), result.numPartitions(),
                                     result.replicationFactor(),
                                     topicConfig);
+                                topicIdFuture.complete(result.topicId());
+                                future.complete(topicMetadataAndConfig);
                             }
-                            topicIdFuture.complete(result.topicId());
-                            future.complete(topicMetadataAndConfig);
                         }
                     }
                 }
@@ -2008,10 +2011,14 @@ public class KafkaAdminClient extends AdminClient {
             void handleFailure(Throwable throwable) {
                 // If there were any topics retries due to a quota exceeded exception, we propagate
                 // the initial error back to the caller if the request timed out.
+                int throttleTimeDelta = (int) (time.milliseconds() - now);
                 maybeCompleteQuotaExceededException(options.shouldRetryOnQuotaViolation(),
-                    throwable, futures, quotaExceededExceptions, (int) (time.milliseconds() - now));
+                    throwable, futures, quotaExceededExceptions, throttleTimeDelta);
+                maybeCompleteQuotaExceededException(options.shouldRetryOnQuotaViolation(),
+                    throwable, topicIdFutures, quotaExceededExceptions, throttleTimeDelta);
                 // Fail all the other remaining futures
                 completeAllExceptionally(futures.values(), throwable);
+                completeAllExceptionally(topicIdFutures.values(), throwable);
             }
         };
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1876,30 +1876,37 @@ public class KafkaAdminClient extends AdminClient {
     public CreateTopicsResult createTopics(final Collection<NewTopic> newTopics,
                                            final CreateTopicsOptions options) {
         final Map<String, KafkaFutureImpl<TopicMetadataAndConfig>> topicFutures = new HashMap<>(newTopics.size());
+        final Map<String, KafkaFutureImpl<Uuid>> topicIdFutures = new HashMap<>(newTopics.size());
         final CreatableTopicCollection topics = new CreatableTopicCollection();
         for (NewTopic newTopic : newTopics) {
             if (topicNameIsUnrepresentable(newTopic.name())) {
                 KafkaFutureImpl<TopicMetadataAndConfig> future = new KafkaFutureImpl<>();
-                future.completeExceptionally(new InvalidTopicException("The given topic name '" +
-                    newTopic.name() + "' cannot be represented in a request."));
+                InvalidTopicException exception = new InvalidTopicException("The given topic name '" +
+                    newTopic.name() + "' cannot be represented in a request.");
+                future.completeExceptionally(exception);
                 topicFutures.put(newTopic.name(), future);
+                KafkaFutureImpl<Uuid> topicIdFuture = new KafkaFutureImpl<>();
+                topicIdFuture.completeExceptionally(exception);
+                topicIdFutures.put(newTopic.name(), topicIdFuture);
             } else if (!topicFutures.containsKey(newTopic.name())) {
                 topicFutures.put(newTopic.name(), new KafkaFutureImpl<>());
+                topicIdFutures.put(newTopic.name(), new KafkaFutureImpl<>());
                 topics.add(newTopic.convertToCreatableTopic());
             }
         }
         if (!topics.isEmpty()) {
             final long now = time.milliseconds();
             final long deadline = calcDeadlineMs(now, options.timeoutMs());
-            final Call call = getCreateTopicsCall(options, topicFutures, topics,
+            final Call call = getCreateTopicsCall(options, topicFutures, topicIdFutures, topics,
                 Collections.emptyMap(), now, deadline);
             runnable.call(call, now);
         }
-        return new CreateTopicsResult(new HashMap<>(topicFutures));
+        return new CreateTopicsResult(new HashMap<>(topicFutures), new HashMap<>(topicIdFutures));
     }
 
     private Call getCreateTopicsCall(final CreateTopicsOptions options,
                                      final Map<String, KafkaFutureImpl<TopicMetadataAndConfig>> futures,
+                                     final Map<String, KafkaFutureImpl<Uuid>> topicIdFutures,
                                      final CreatableTopicCollection topics,
                                      final Map<String, ThrottlingQuotaExceededException> quotaExceededExceptions,
                                      final long now,
@@ -1927,6 +1934,7 @@ public class KafkaAdminClient extends AdminClient {
                     if (future == null) {
                         log.warn("Server response mentioned unknown topic {}", result.name());
                     } else {
+                        KafkaFutureImpl<Uuid> topicIdFuture = topicIdFutures.get(result.name());
                         ApiError error = new ApiError(result.errorCode(), result.errorMessage());
                         if (error.isFailure()) {
                             if (error.is(Errors.THROTTLING_QUOTA_EXCEEDED)) {
@@ -1937,9 +1945,15 @@ public class KafkaAdminClient extends AdminClient {
                                     retryTopicQuotaExceededExceptions.put(result.name(), quotaExceededException);
                                 } else {
                                     future.completeExceptionally(quotaExceededException);
+                                    topicIdFuture.completeExceptionally(quotaExceededException);
                                 }
-                            } else {
+                            } else if (error.is(Errors.TOPIC_ALREADY_EXISTS)) {
+                                topicIdFuture.complete(result.topicId());
                                 future.completeExceptionally(error.exception());
+                            } else {
+                                ApiException exception = error.exception();
+                                future.completeExceptionally(exception);
+                                topicIdFuture.completeExceptionally(exception);
                             }
                         } else {
                             TopicMetadataAndConfig topicMetadataAndConfig;
@@ -1958,6 +1972,7 @@ public class KafkaAdminClient extends AdminClient {
                                     result.replicationFactor(),
                                     topicConfig);
                             }
+                            topicIdFuture.complete(result.topicId());
                             future.complete(topicMetadataAndConfig);
                         }
                     }
@@ -1967,9 +1982,11 @@ public class KafkaAdminClient extends AdminClient {
                     // The server should send back a response for every topic. But do a sanity check anyway.
                     completeUnrealizedFutures(futures.entrySet().stream(),
                         topic -> "The controller response did not contain a result for topic " + topic);
+                    completeUnrealizedFutures(topicIdFutures.entrySet().stream(),
+                        topic -> "The controller response did not contain a result for topic " + topic);
                 } else {
                     final long now = time.milliseconds();
-                    final Call call = getCreateTopicsCall(options, futures, retryTopics,
+                    final Call call = getCreateTopicsCall(options, futures, topicIdFutures, retryTopics,
                         retryTopicQuotaExceededExceptions, now, deadline);
                     runnable.call(call, now);
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -978,6 +978,27 @@ public class KafkaAdminClientTest {
     }
 
     @Test
+    public void testCreateTopicsReturnsTopicIdWhenTopicAlreadyExists() throws Exception {
+        Uuid topicId = Uuid.fromString("AAAAAAAAAAAAAAAAAAAAAA");
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareResponse(
+                expectCreateTopicsRequestWithTopics("myTopic"),
+                prepareCreateTopicsResponse(0,
+                    new CreatableTopicResult()
+                        .setName("myTopic")
+                        .setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code())
+                        .setTopicId(topicId)));
+
+            CreateTopicsResult result = env.adminClient().createTopics(
+                singleton(new NewTopic("myTopic", 1, (short) 1)));
+
+            assertEquals(topicId, result.topicId("myTopic").get());
+            TestUtils.assertFutureThrows(TopicExistsException.class, result.values().get("myTopic"));
+        }
+    }
+
+    @Test
     public void testCreateTopicsPartialResponse() throws Exception {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -999,6 +999,25 @@ public class KafkaAdminClientTest {
     }
 
     @Test
+    public void testCreateTopicsTopicIdFailsWhenTopicMetadataIsUnsupported() throws Exception {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareResponse(
+                expectCreateTopicsRequestWithTopics("myTopic"),
+                prepareCreateTopicsResponse(0,
+                    new CreatableTopicResult()
+                        .setName("myTopic")
+                        .setNumPartitions(CreateTopicsResult.UNKNOWN)));
+
+            CreateTopicsResult result = env.adminClient().createTopics(
+                singleton(new NewTopic("myTopic", 1, (short) 1)));
+
+            TestUtils.assertFutureThrows(UnsupportedVersionException.class, result.topicId("myTopic"));
+            assertNull(result.values().get("myTopic").get());
+        }
+    }
+
+    @Test
     public void testCreateTopicsPartialResponse() throws Exception {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
@@ -1160,6 +1179,8 @@ public class KafkaAdminClientTest {
 
             assertNull(result.values().get("topic1").get());
             ThrottlingQuotaExceededException e = TestUtils.assertFutureThrows(ThrottlingQuotaExceededException.class, result.values().get("topic2"));
+            assertEquals(0, e.throttleTimeMs());
+            e = TestUtils.assertFutureThrows(ThrottlingQuotaExceededException.class, result.topicId("topic2"));
             assertEquals(0, e.throttleTimeMs());
             TestUtils.assertFutureThrows(TopicExistsException.class, result.values().get("topic3"));
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -686,10 +686,14 @@ public class ReplicationControlManager {
         for (CreatableTopic topic : request.topics()) {
             ApiError error = topicErrors.get(topic.name());
             if (error != null) {
-                data.topics().add(new CreatableTopicResult().
+                CreatableTopicResult result = new CreatableTopicResult().
                     setName(topic.name()).
                     setErrorCode(error.error().code()).
-                    setErrorMessage(error.message()));
+                    setErrorMessage(error.message());
+                if (error.error() == Errors.TOPIC_ALREADY_EXISTS) {
+                    result.setTopicId(topicsByName.get(topic.name()));
+                }
+                data.topics().add(result);
                 resultsBuilder.append(resultsPrefix).append(topic).append(": ").
                     append(error.error()).append(" (").append(error.message()).append(")");
                 resultsPrefix = ", ";

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -702,7 +702,8 @@ public class ReplicationControlManagerTest {
         CreateTopicsResponseData expectedResponse4 = new CreateTopicsResponseData();
         expectedResponse4.topics().add(new CreatableTopicResult().setName("foo").
                 setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code()).
-                setErrorMessage("Topic 'foo' already exists."));
+                setErrorMessage("Topic 'foo' already exists.").
+                setTopicId(result3.response().topics().find("foo").topicId()));
         assertEquals(expectedResponse4, result4.response());
     }
 


### PR DESCRIPTION
## Summary

Return the existing topic ID in the `CreateTopicsResponse` when a
requested topic already exists, and expose that ID through
`CreateTopicsResult.topicId(topic)`.

## Motivation

The controller already has the topic ID in the controller metadata
image, so returning it avoids an additional metadata lookup for clients
that need the ID. The AdminClient now preserves that ID independently
from the topic-creation status.

## Compatibility

- `CreateTopicsResult.topicId(topic)` succeeds with the existing ID for
`TOPIC_ALREADY_EXISTS`.
- `CreateTopicsResult.values()` and `all()` continue to fail with
`TopicExistsException`, preserving their existing semantics.
- Older responses without topic metadata preserve the existing
`UnsupportedVersionException` behavior for metadata accessors.

## Validation

- `./gradlew :clients:test --tests
org.apache.kafka.clients.admin.KafkaAdminClientTest --no-build-cache
--console=plain` (291 tests passed)
- `./gradlew :metadata:test --tests
org.apache.kafka.controller.ReplicationControlManagerTest
--no-build-cache --console=plain` (75 tests passed)
- Checkstyle and SpotBugs completed successfully for the affected
modules.

Reviewers: Sushant Mahajan <smahajan@confluent.io>
