### PR TITLE
KAFKA-18838: Ensure arbitrary memory records are invalid

### DIFF
--- a/raft/src/test/java/org/apache/kafka/common/record/internal/ArbitraryMemoryRecordsTest.java
+++ b/raft/src/test/java/org/apache/kafka/common/record/internal/ArbitraryMemoryRecordsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record.internal;
+
+import org.apache.kafka.common.errors.CorruptRecordException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ArbitraryMemoryRecordsTest {
+
+    @Test
+    public void testGeneratedRecordsAreAlwaysInvalid() {
+        for (int seed = 0; seed < 100; seed++) {
+            MemoryRecords records = ArbitraryMemoryRecords.buildRandomRecords(new Random(seed));
+            int currentSeed = seed;
+            assertThrows(CorruptRecordException.class, () -> records.batches().iterator().hasNext(),
+                    () -> "Expected records generated with seed " + currentSeed + " to be invalid");
+        }
+    }
+}

--- a/raft/src/testFixtures/java/org/apache/kafka/common/record/internal/ArbitraryMemoryRecords.java
+++ b/raft/src/testFixtures/java/org/apache/kafka/common/record/internal/ArbitraryMemoryRecords.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.record.internal;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -32,13 +31,21 @@ public final class ArbitraryMemoryRecords {
         for (int i = 0; i < tries; i++) {
             long seed = System.nanoTime() + i;
             Random random = new Random(seed);
-            int size = random.nextInt(128) + 1;
-            byte[] bytes = new byte[size];
-            random.nextBytes(bytes);
-            MemoryRecords records = MemoryRecords.readableRecords(ByteBuffer.wrap(bytes));
+            MemoryRecords records = buildRandomRecords(random);
             assertDoesNotThrow(
                     () -> test.accept(records),
-                    () -> "Failed with seed=" + seed + ", size=" + size + ", bytes=" + Arrays.toString(bytes));
+                    () -> "Failed with seed=" + seed + ", size=" + records.sizeInBytes());
         }
+    }
+
+    static MemoryRecords buildRandomRecords(Random random) {
+        int size = random.nextInt(128) + DefaultRecordBatch.RECORD_BATCH_OVERHEAD;
+        byte[] bytes = new byte[size];
+        random.nextBytes(bytes);
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.putInt(Records.SIZE_OFFSET, size - Records.LOG_OVERHEAD);
+        buffer.put(Records.MAGIC_OFFSET, (byte) (RecordBatch.CURRENT_MAGIC_VALUE + 1));
+        return MemoryRecords.readableRecords(buffer);
     }
 }


### PR DESCRIPTION
## Summary\n\n- Generate random-sized memory records with a record length matching the buffer.\n- Force an unsupported magic value so every generated record set is invalid.\n- Add a deterministic regression test for the generator contract.\n\n## Motivation\n\n[KAFKA-18838](https://issues.apache.org/jira/browse/KAFKA-18838) notes that random bytes can accidentally form a valid memory record set. The Raft tests using this fixture expect malformed input, so relying on random chance makes their coverage nondeterministic. The generator now preserves random payload variation while making invalidity explicit.\n\n## Validation\n\n- Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details
> Task :api-checker:core:compileJava UP-TO-DATE
> Task :api-checker:gradle-plugins:pluginDescriptors UP-TO-DATE
> Task :api-checker:core:processResources NO-SOURCE
> Task :api-checker:core:classes UP-TO-DATE
> Task :api-checker:core:jar UP-TO-DATE
> Task :api-checker:gradle-plugins:compileJava UP-TO-DATE
> Task :api-checker:gradle-plugins:processResources UP-TO-DATE
> Task :api-checker:gradle-plugins:classes UP-TO-DATE
> Task :api-checker:gradle-plugins:jar UP-TO-DATE

> Configure project :
Starting build with version 4.4.0-SNAPSHOT (commit id unknown) using Gradle 9.4.1, Java 25 and Scala 2.13.18
Build properties: ignoreFailures=false, maxParallelForks=8, maxScalacThreads=8, maxTestRetries=0

> Task :server-common:processResources NO-SOURCE
> Task :server-common:createVersionFile UP-TO-DATE
> Task :storage:processResources UP-TO-DATE
> Task :storage:storage-api:processResources NO-SOURCE
> Task :raft:processResources UP-TO-DATE
> Task :storage:createVersionFile UP-TO-DATE
> Task :storage:storage-api:createVersionFile UP-TO-DATE
> Task :raft:createVersionFile UP-TO-DATE
> Task :server-common:processTestFixturesResources NO-SOURCE
> Task :raft:processTestFixturesResources NO-SOURCE
> Task :test-common:test-common-util:compileJava UP-TO-DATE
> Task :raft:processTestResources UP-TO-DATE
> Task :test-common:test-common-util:processResources UP-TO-DATE
> Task :test-common:test-common-util:classes UP-TO-DATE
> Task :test-common:test-common-util:jar UP-TO-DATE
> Task :clients:processResources UP-TO-DATE
> Task :clients:createVersionFile UP-TO-DATE
> Task :clients:processTestFixturesResources NO-SOURCE
> Task :generator:compileJava UP-TO-DATE
> Task :generator:processResources NO-SOURCE
> Task :generator:classes UP-TO-DATE
> Task :generator:jar UP-TO-DATE
> Task :raft:processMessages UP-TO-DATE
> Task :storage:processMessages UP-TO-DATE
> Task :clients:processMessages UP-TO-DATE
> Task :clients:compileJava UP-TO-DATE
> Task :clients:compileTestFixturesJava UP-TO-DATE
> Task :clients:classes UP-TO-DATE
> Task :server-common:compileJava UP-TO-DATE
> Task :storage:storage-api:compileJava UP-TO-DATE
> Task :storage:storage-api:classes UP-TO-DATE
> Task :storage:storage-api:jar UP-TO-DATE
> Task :server-common:compileTestFixturesJava UP-TO-DATE
> Task :server-common:classes UP-TO-DATE
> Task :server-common:jar UP-TO-DATE
> Task :server-common:testFixturesClasses UP-TO-DATE
> Task :server-common:testFixturesJar UP-TO-DATE
> Task :clients:shadowJar UP-TO-DATE
> Task :clients:jar SKIPPED
> Task :clients:testFixturesClasses UP-TO-DATE
> Task :clients:testFixturesJar UP-TO-DATE
> Task :storage:compileJava UP-TO-DATE
> Task :storage:classes UP-TO-DATE
> Task :storage:jar UP-TO-DATE
> Task :raft:compileJava UP-TO-DATE
> Task :raft:classes UP-TO-DATE
> Task :raft:jar UP-TO-DATE
> Task :raft:compileTestFixturesJava UP-TO-DATE
> Task :raft:testFixturesClasses UP-TO-DATE
> Task :raft:testFixturesJar UP-TO-DATE
> Task :raft:checkstyleMain UP-TO-DATE
> Task :raft:compileTestJava UP-TO-DATE
> Task :raft:testClasses UP-TO-DATE
> Task :raft:checkstyleTest UP-TO-DATE
> Task :raft:spotbugsMain UP-TO-DATE

> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 4 > ArbitraryMemoryRecordsTest > testGeneratedRecordsAreAlwaysInvalid() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 1 > MockLogTest > testRandomRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 3 > KafkaRaftClientFetchTest > testRandomRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 2 > KafkaRaftLogTest > testRandomRecords() PASSED

> Task :raft:copyTestXml SKIPPED

[Incubating] Problems report is available at: file:///Users/developseop/Desktop/kafka-18838/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.4.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 14s
44 actionable tasks: 1 executed, 43 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html\n- > Task :api-checker:gradle-plugins:pluginDescriptors UP-TO-DATE
> Task :api-checker:gradle-plugins:processResources UP-TO-DATE
> Task :api-checker:core:compileJava UP-TO-DATE
> Task :api-checker:core:processResources NO-SOURCE
> Task :api-checker:core:classes UP-TO-DATE
> Task :api-checker:core:jar UP-TO-DATE
> Task :api-checker:gradle-plugins:compileJava UP-TO-DATE
> Task :api-checker:gradle-plugins:classes UP-TO-DATE
> Task :api-checker:gradle-plugins:jar UP-TO-DATE

> Configure project :
Starting build with version 4.4.0-SNAPSHOT (commit id unknown) using Gradle 9.4.1, Java 25 and Scala 2.13.18
Build properties: ignoreFailures=false, maxParallelForks=8, maxScalacThreads=8, maxTestRetries=0

> Task :server-common:processResources NO-SOURCE
> Task :storage:storage-api:processResources NO-SOURCE
> Task :storage:processResources UP-TO-DATE
> Task :storage:storage-api:createVersionFile UP-TO-DATE
> Task :server-common:createVersionFile UP-TO-DATE
> Task :raft:processResources UP-TO-DATE
> Task :storage:createVersionFile UP-TO-DATE
> Task :raft:createVersionFile UP-TO-DATE
> Task :clients:processResources UP-TO-DATE
> Task :raft:processTestFixturesResources NO-SOURCE
> Task :server-common:processTestFixturesResources NO-SOURCE
> Task :clients:createVersionFile UP-TO-DATE
> Task :raft:processTestResources UP-TO-DATE
> Task :clients:processTestFixturesResources NO-SOURCE
> Task :test-common:test-common-util:compileJava UP-TO-DATE
> Task :test-common:test-common-util:processResources UP-TO-DATE
> Task :test-common:test-common-util:classes UP-TO-DATE
> Task :test-common:test-common-util:jar UP-TO-DATE
> Task :generator:compileJava UP-TO-DATE
> Task :generator:processResources NO-SOURCE
> Task :generator:classes UP-TO-DATE
> Task :generator:jar UP-TO-DATE
> Task :raft:processMessages UP-TO-DATE
> Task :clients:processMessages UP-TO-DATE
> Task :storage:processMessages UP-TO-DATE
> Task :clients:compileJava UP-TO-DATE
> Task :server-common:compileJava UP-TO-DATE
> Task :server-common:classes UP-TO-DATE
> Task :server-common:jar UP-TO-DATE
> Task :storage:storage-api:compileJava UP-TO-DATE
> Task :storage:storage-api:classes UP-TO-DATE
> Task :storage:storage-api:jar UP-TO-DATE
> Task :clients:compileTestFixturesJava UP-TO-DATE
> Task :clients:classes UP-TO-DATE
> Task :storage:compileJava UP-TO-DATE
> Task :server-common:compileTestFixturesJava UP-TO-DATE
> Task :server-common:testFixturesClasses UP-TO-DATE
> Task :server-common:testFixturesJar UP-TO-DATE
> Task :storage:classes UP-TO-DATE
> Task :storage:jar UP-TO-DATE
> Task :raft:compileJava UP-TO-DATE
> Task :raft:classes UP-TO-DATE
> Task :clients:shadowJar UP-TO-DATE
> Task :clients:jar SKIPPED
> Task :clients:testFixturesClasses UP-TO-DATE
> Task :raft:jar UP-TO-DATE
> Task :clients:testFixturesJar UP-TO-DATE
> Task :raft:compileTestFixturesJava UP-TO-DATE
> Task :raft:testFixturesClasses UP-TO-DATE
> Task :raft:testFixturesJar UP-TO-DATE
> Task :raft:checkstyleMain UP-TO-DATE
> Task :raft:compileTestJava UP-TO-DATE
> Task :raft:testClasses UP-TO-DATE
> Task :raft:checkstyleTest UP-TO-DATE
> Task :raft:spotbugsMain UP-TO-DATE

> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 5 > ElectionStateTest > testVotedCandidateWithoutVotedDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > EpochElectionTest > testRecordRejectedVote() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > EpochElectionTest > testRecordGrantedVote() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > EpochElectionTest > testStateOnInitialization() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > EpochElectionTest > testOverWritingVote() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > ElectionStateTest > testVotedCandidateWithoutVotedId() PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 5 > ElectionStateTest > testQuorumStateDataRoundTrip(short) > "testQuorumStateDataRoundTrip(short).version=0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > ElectionStateTest > testQuorumStateDataRoundTrip(short) > "testQuorumStateDataRoundTrip(short).version=1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > ElectionStateTest > testVotedCandidateWithVotedDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > ArbitraryMemoryRecordsTest > testGeneratedRecordsAreAlwaysInvalid() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromEndQuorumEpochResponseWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testEqualsAndHashCodeWithSameEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testSize() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromVotersRecordEndpointsWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromEndQuorumEpochRequestWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromBeginQuorumEpochRequestWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithInvalidNegativeId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testFailedToParseNodeId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromBeginQuorumEpochRequestWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromFetchResponseWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromFetchSnapshotResponseWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testVotersRecordEndpointsWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromInetSocketAddressesWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testToVoterNode() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testFailedToParseDirectoryId2() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testAddressWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testInvalidPositivePort() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testInvalidNegativePort() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testPortSectionMustStartWithAColon() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testNoColonFollowingHostname() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromFetchResponseWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromVoteResponseWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromBeginQuorumEpochResponseWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromEndQuorumEpochRequestWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromEndQuorumEpochResponseWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromBeginQuorumEpochResponseWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromVoteResponseWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testVotersRecordEndpointsWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testEqualsAndHashCodeWithDifferentEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testToBeginQuorumEpochRequestWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromVotersRecordEndpointsWithEmptyEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testToBeginQuorumEpochRequestWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testAddressWithValidEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testFromFetchSnapshotResponseWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > EndpointsTest > testIsEmptyWithEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testFailedToParsePort() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithoutHostname() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithUnbalancedBrackets() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithoutId2() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithBrackets() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithNoColonFollowingPort() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoterWithoutId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testParseDynamicVoter2() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > DynamicVoterTest > testFailedToParseDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadUnknownLeader(KRaftVersion) > "testWriteReadUnknownLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateOffsetLessThanOldestSnapshotOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTruncateBelowHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testAppendAsFollower() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTopicId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateValidEpochAndOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateOffsetLessThanLEO() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testEndOffsetForEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateEpochGreaterThanLastKnownEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadUnknownLeader(KRaftVersion) > "testWriteReadUnknownLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testMockLogReadExtremelyLargeMultiBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTruncateWillRemoveOlderSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotRejectVoteFromLocalId(boolean) > "testCannotRejectVoteFromLocalId(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotRejectVoteFromLocalId(boolean) > "testCannotRejectVoteFromLocalId(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testSingleNodeQuorum(boolean) > "testSingleNodeQuorum(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testSingleNodeQuorum(boolean) > "testSingleNodeQuorum(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testThreeNodeQuorumVoteGranted(boolean) > "testThreeNodeQuorumVoteGranted(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testThreeNodeQuorumVoteGranted(boolean) > "testThreeNodeQuorumVoteGranted(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testEmptyAppendNotAllowed() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateEpochLessThanFirstEpochInLog() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateEpochLessThanOldestSnapshotEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testFailToIncreaseLogStartPastHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadOutOfRangeOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateExistingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testLogLimitsReturnsAtLeastOne() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testLogLimitsReturnsLessThanMaxBytes() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotMuchEarlierEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateOffsetGreatThanEndOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadVotedCandidate(KRaftVersion) > "testWriteReadVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadVotedCandidate(KRaftVersion) > "testWriteReadVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testCantReadVersionQuorumState() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testCreateAndClear() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadElectedLeader(KRaftVersion) > "testWriteReadElectedLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUpdateLogStartOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testWriteReadElectedLeader(KRaftVersion) > "testWriteReadElectedLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testSupportedVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=true, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateUnknownEpochLessThanLastKnownGreaterThanOldestSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=true, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=false, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > FileQuorumStateStoreTest > testReload() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=false, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testLeaderEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testTwoNodeQuorumVoteRejected(boolean) > "testTwoNodeQuorumVoteRejected(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testTwoNodeQuorumVoteRejected(boolean) > "testTwoNodeQuorumVoteRejected(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testTwoNodeQuorumVoteGranted(boolean) > "testTwoNodeQuorumVoteGranted(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testTwoNodeQuorumVoteGranted(boolean) > "testTwoNodeQuorumVoteGranted(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotChangeVoteRejectedToGranted(boolean) > "testCannotChangeVoteRejectedToGranted(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotChangeVoteRejectedToGranted(boolean) > "testCannotChangeVoteRejectedToGranted(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testIdempotentGrant(boolean) > "testIdempotentGrant(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testIdempotentGrant(boolean) > "testIdempotentGrant(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotGrantOrRejectNonVoters(boolean) > "testCannotGrantOrRejectNonVoters(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotGrantOrRejectNonVoters(boolean) > "testCannotGrantOrRejectNonVoters(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadUpToLogEnd() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotMuchLaterEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidLeaderEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testAppendControlRecord() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUnexpectedAppendOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testAssignEpochStartOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testParsingThreeDynamicVoters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testRoundTripSingleVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testParsingEmptyStringFails() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testRoundTripThreeVoters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testParsingInvalidStringWithDuplicateNodeIds() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testToVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testInvalidVoterSet(boolean) > "testInvalidVoterSet(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testInvalidVoterSet(boolean) > "testInvalidVoterSet(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testRandomRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testValidateOffsetEqualToOldestSnapshotOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > DynamicVotersTest > testParsingSingleDynamicVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testIdempotentReject(boolean) > "testIdempotentReject(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testIdempotentReject(boolean) > "testIdempotentReject(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testThreeNodeQuorumVoteRejected(boolean) > "testThreeNodeQuorumVoteRejected(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testThreeNodeQuorumVoteRejected(boolean) > "testThreeNodeQuorumVoteRejected(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testElectionState(boolean) > "testElectionState(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testElectionState(boolean) > "testElectionState(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotChangeVoteGrantedToRejected(boolean) > "testCannotChangeVoteGrantedToRejected(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > CandidateStateTest > testCannotChangeVoteGrantedToRejected(boolean) > "testCannotChangeVoteGrantedToRejected(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotBeforeLogStartOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotValidation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUpdateHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testMonotonicEpochStartOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testHasUpdatedLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testLeaderIdAndEndpoint() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUnflushedRecordsLostAfterReopen() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testPreVoteAfterSuccessfulFetchFromLeader(boolean) > "testPreVoteAfterSuccessfulFetchFromLeader(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testPreVoteAfterSuccessfulFetchFromLeader(boolean) > "testPreVoteAfterSuccessfulFetchFromLeader(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testFetchTimeoutExpiration() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testGrantStandardVote(boolean) > "testGrantStandardVote(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testGrantStandardVote(boolean) > "testGrantStandardVote(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testPreVoteIfHasNotFetchedFromLeaderYet(boolean) > "testPreVoteIfHasNotFetchedFromLeaderYet(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testPreVoteIfHasNotFetchedFromLeaderYet(boolean) > "testPreVoteIfHasNotFetchedFromLeaderYet(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > FollowerStateTest > testMonotonicHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadRespectsMaxSizeInBytes(int) > "testReadRespectsMaxSizeInBytes(int).expectedBatches=1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadRespectsMaxSizeInBytes(int) > "testReadRespectsMaxSizeInBytes(int).expectedBatches=2" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotInMiddleOfBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotWithMissingEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testMockLogReadExtremelyLargeSingleBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=11, buffer=java.nio.HeapByteBuffer[pos=0 lim=11 cap=11]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testWakeupClientOnSend() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=16, buffer=java.nio.HeapByteBuffer[pos=0 lim=16 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ControlRecordTest > testCtr() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ControlRecordTest > testControlRecordTypeValues() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=243, buffer=java.nio.HeapByteBuffer[pos=0 lim=243 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTruncateFullyToLatestSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testAppendAsLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testDecrementHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testMetadataValidation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testDoesntTruncateFully() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUpdateLogStartOffsetWillRemoveOlderSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTopicPartition() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadUpToHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testTruncateTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testUpdateLogStartOffsetWithMissingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testCreateSnapshotLaterThanHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > MockLogTest > testReadMissingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendToBlackedOutDestination(boolean) > "testSendToBlackedOutDestination(boolean).withDestinationId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendToBlackedOutDestination(boolean) > "testSendToBlackedOutDestination(boolean).withDestinationId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testUnsupportedVersionError() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendAndFailAuthentication() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendAndReceiveOutboundRequest(boolean) > "testSendAndReceiveOutboundRequest(boolean).withDestinationId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendAndReceiveOutboundRequest(boolean) > "testSendAndReceiveOutboundRequest(boolean).withDestinationId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testSendAndDisconnect() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=4" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=5" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=6" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=7" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=8" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=9" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=10" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=11" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=12" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=13" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=14" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=15" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=16" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=17" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaNetworkChannelTest > testFetchRequestDowngrade(short) > "testFetchRequestDowngrade(short).version=18" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > KafkaRaftClientDriverTest > testUncaughtException() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > KafkaRaftClientDriverTest > testShutdown() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithPendingRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ResignedStateTest > testNegativeScenarioAcknowledgeResignation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ResignedStateTest > testResignedState() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testSingleBatchAccumulation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterCompletesEarlyWithAckWhenCommittedFalse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testLingerBeginsOnFirstWrite() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithPendingAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ResignedStateTest > testGrantVote(boolean) > "testGrantVote(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ResignedStateTest > testGrantVote(boolean) > "testGrantVote(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ResignedStateTest > testLeaderEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testIsOperationPendingWithRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testMaybeExpirePendingAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testCanReplaceAddVoterWithAnotherAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testRemoveVoterLifecycle() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testIsOperationPendingWithAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testMaybeExpirePendingRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testCannotSetAddVoterWhenRemoveVoterPresent() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testAddVoterLifecycle() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testCannotSetRemoveVoterWhenAddVoterPresent() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testMaybeResetPendingVoterHandlerState() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > ChangeVoterHandlerStateTest > testCanReplaceRemoveVoterWithAnotherRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > NotifyingRawSnapshotWriterTest > testFailingFreeze() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > NotifyingRawSnapshotWriterTest > testCloseWithoutFreeze() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 12 > NotifyingRawSnapshotWriterTest > testFreezeClose() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testMaxNumberOfBatches() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testInvalidControlRecordOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testForceDrain() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testAutoRemoveOldVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testObserversDoNotAutoJoin() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testDelayedDrain() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testDrainDoesNotBlockWithConcurrentAppend() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testForceDrainBeforeAppendLeaderChangeMessage() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testDelayedDrainAreReleased() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testLingerIgnoredIfAccumulatorEmpty() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testPartialFetchSnapshotRequestAsLeader(boolean) > "testPartialFetchSnapshotRequestAsLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testUnflushedBuffersReleasedByClose() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testInvalidControlRecordEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testMultipleControlRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterFailsWhenLosingLeadership() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testCompletedBatchReleaseBuffer() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testAutoAddNewVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testObserverDoesNotAddItselfWhenAutoJoinDisabled() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testEmptyControlBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testMultipleBatchAccumulation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testLeaderChangeMessageWritten() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > BatchAccumulatorTest > testCloseWhenEmpty() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInBeginQuorumEpoch(boolean) > "testClusterAuthorizationFailedInBeginQuorumEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testFetchMaxBytesAlwaysReturnsAtLeastOneBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterIsLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_0, hasFetchedFromLeader=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_0, hasFetchedFromLeader=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testPartialFetchSnapshotRequestAsLeader(boolean) > "testPartialFetchSnapshotRequestAsLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLatestSnapshotId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testObserverRemovesOldVoterAndAutoJoins() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInBeginQuorumEpoch(boolean) > "testClusterAuthorizationFailedInBeginQuorumEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientAutoJoinTest > testObserverDoesNotAutoJoinWithKRaftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testFetchMaxBytesAlwaysReturnsAllBatchesForLargeMax() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsCandidateFromStateStore(boolean) > "testInitializeAsCandidateFromStateStore(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsCandidateFromStateStore(boolean) > "testInitializeAsCandidateFromStateStore(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_1, hasFetchedFromLeader=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumStartsNewElectionImmediatelyIfFollowerUnattached(boolean) > "testEndQuorumStartsNewElectionImmediatelyIfFollowerUnattached(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInVote(boolean) > "testClusterAuthorizationFailedInVote(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumStartsNewElectionImmediatelyIfFollowerUnattached(boolean) > "testEndQuorumStartsNewElectionImmediatelyIfFollowerUnattached(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollowerObserver(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_1, hasFetchedFromLeader=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterAfterElectionWithKraftVersion0(Errors) > "testFollowerSendsUpdateVoterAfterElectionWithKraftVersion0(Errors).updateVoterError=NONE" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponsePartialData(boolean) > "testFetchSnapshotResponsePartialData(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInVote(boolean) > "testClusterAuthorizationFailedInVote(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestTimeout(KRaftVersion, RaftProtocol) > "testPreVoteRequestTimeout(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidFetchRequest(boolean) > "testInvalidFetchRequest(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testUnchangedHighWatermarkDeferred() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testReplicationOfHigherPartitionLeaderEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterAfterElectionWithKraftVersion0(Errors) > "testFollowerSendsUpdateVoterAfterElectionWithKraftVersion0(Errors).updateVoterError=UNSUPPORTED_VERSION" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerReadsKRaftBootstrapRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidFetchRequest(boolean) > "testInvalidFetchRequest(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInEndQuorumEpoch(boolean) > "testClusterAuthorizationFailedInEndQuorumEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testFetchMaxBytesBatchesInvariants() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponsePartialData(boolean) > "testFetchSnapshotResponsePartialData(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsUnattachedAndBecomeLeader(boolean) > "testInitializeAsUnattachedAndBecomeLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestOffsetLessThanLogStart(boolean) > "testFetchRequestOffsetLessThanLogStart(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInEndQuorumEpoch(boolean) > "testClusterAuthorizationFailedInEndQuorumEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInFetch(boolean) > "testClusterAuthorizationFailedInFetch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > KafkaRaftClientClusterAuthTest > testClusterAuthorizationFailedInFetch(boolean) > "testClusterAuthorizationFailedInFetch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > LeaderAndEpochTest > testConstructorWithEmptyLeaderId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateOffsetLessThanOldestSnapshotOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > LeaderAndEpochTest > testConstructorThrowsExceptionWhenLeaderIdIsNull() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > LeaderAndEpochTest > testConstructorWithValidLeaderId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testOutdatedHwmCompletedWhenLeaderKnowsHwm() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsUnattachedAndBecomeLeader(boolean) > "testInitializeAsUnattachedAndBecomeLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testBootstrapCheckpointIsNotReturnedOnFetch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestOffsetLessThanLogStart(boolean) > "testFetchRequestOffsetLessThanLogStart(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testFetchMaxBytesWithTwoBatches() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteResponseIgnoredAfterBecomingFollower(boolean) > "testVoteResponseIgnoredAfterBecomingFollower(boolean).withKip853Rpc=true" PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithoutFencedPreviousLeaders() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteResponseIgnoredAfterBecomingFollower(boolean) > "testVoteResponseIgnoredAfterBecomingFollower(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderShouldResignLeadershipIfNotGetFetchSnapshotRequestFromMajorityVoters(boolean) > "testLeaderShouldResignLeadershipIfNotGetFetchSnapshotRequestFromMajorityVoters(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testUnknownHwmDeferredWhenLeaderDoesNotKnowHwm() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testHighWatermarkSentInFetchRequest() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testSentFetchUsesQuorumMaxBytesConfiguration() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testRejectVotesFromSameEpochAfterResigningLeadership(boolean) > "testRejectVotesFromSameEpochAfterResigningLeadership(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testRejectVotesFromSameEpochAfterResigningLeadership(boolean) > "testRejectVotesFromSameEpochAfterResigningLeadership(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderShouldResignLeadershipIfNotGetFetchSnapshotRequestFromMajorityVoters(boolean) > "testLeaderShouldResignLeadershipIfNotGetFetchSnapshotRequestFromMajorityVoters(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithKraftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithOnlyStaticVoters(boolean) > "testDescribeQuorumWithOnlyStaticVoters(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testListenerRenotified(boolean) > "testListenerRenotified(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterWithKraftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithOnlyStaticVoters(boolean) > "testDescribeQuorumWithOnlyStaticVoters(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterResignRegistration(boolean) > "testHandleLeaderChangeFiresAfterResignRegistration(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterResignRegistration(boolean) > "testHandleLeaderChangeFiresAfterResignRegistration(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testListenerRenotified(boolean) > "testListenerRenotified(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol) > "testProspectiveReceivesBeginQuorumRequest(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsCandidate(KRaftVersion) > "testHandlePreVoteRequestAsCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsCandidate(KRaftVersion) > "testHandlePreVoteRequestAsCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithNewerEpoch(boolean) > "testFetchSnapshotRequestWithNewerEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testLeaderRejectPreVoteRequestOnSameEpoch(KRaftVersion) > "testLeaderRejectPreVoteRequestOnSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithNewerEpoch(boolean) > "testFetchSnapshotRequestWithNewerEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithObserver(boolean, boolean) > "testDescribeQuorumWithObserver(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterWithPendingAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToUnattachedHigherEpoch(KRaftVersion) > "testCandidateToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToUnattachedHigherEpoch(KRaftVersion) > "testCandidateToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testLeaderRejectPreVoteRequestOnSameEpoch(KRaftVersion) > "testLeaderRejectPreVoteRequestOnSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testRejectPreVoteIfRemoteLogIsNotUpToDate(KRaftVersion) > "testRejectPreVoteIfRemoteLogIsNotUpToDate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testRejectPreVoteIfRemoteLogIsNotUpToDate(KRaftVersion) > "testRejectPreVoteIfRemoteLogIsNotUpToDate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestTruncateToLogStart(boolean) > "testFetchRequestTruncateToLogStart(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithObserver(boolean, boolean) > "testDescribeQuorumWithObserver(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testSoftRetentionLimit() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testTruncateBelowHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithKraftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerWithVotedCandidate(KRaftVersion) > "testHandlePreVoteRequestAsFollowerWithVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testTopicId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollowerWithVotedCandidate(KRaftVersion) > "testHandlePreVoteRequestAsFollowerWithVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestTruncateToLogStart(boolean) > "testFetchRequestTruncateToLogStart(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateValidEpochAndOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToFollowerSameEpoch(KRaftVersion) > "testCandidateToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToFollowerSameEpoch(KRaftVersion) > "testCandidateToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithObserver(boolean, boolean) > "testDescribeQuorumWithObserver(boolean, boolean).withKip853Rpc=false, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsUnattached(KRaftVersion) > "testInitializeAsUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsUnattached(KRaftVersion) > "testInitializeAsUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterOldEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattached(KRaftVersion) > "testUnattachedToUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattached(KRaftVersion) > "testUnattachedToUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testFollowerGrantsPreVoteIfHasNotFetchedYet(KRaftVersion) > "testFollowerGrantsPreVoteIfHasNotFetchedYet(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateOffsetLessThanLEO() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToFollowerHigherEpoch(KRaftVersion) > "testCandidateToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToFollowerHigherEpoch(KRaftVersion) > "testCandidateToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToFollowerSameEpoch(KRaftVersion) > "testFollowerVotedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToFollowerSameEpoch(KRaftVersion) > "testFollowerVotedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToLeaderOrResigned(KRaftVersion) > "testProspectiveToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testFollowerGrantsPreVoteIfHasNotFetchedYet(KRaftVersion) > "testFollowerGrantsPreVoteIfHasNotFetchedYet(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToLeaderOrResigned(KRaftVersion) > "testProspectiveToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedWithLeader(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedWithLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseToNotFollower(boolean) > "testFetchSnapshotResponseToNotFollower(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testInvalidKRaftUpgradeVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterToEmptyVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedWithLeader(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedWithLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchSatisfiedByWrite(boolean) > "testPurgatoryFetchSatisfiedByWrite(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testMaxBatchSize() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterFailsWhenLosingLeadership() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateEpochGreaterThanLastKnownEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToAndFromFollowerSameEpoch(KRaftVersion) > "testProspectiveVotedToAndFromFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchSatisfiedByWrite(boolean) > "testPurgatoryFetchSatisfiedByWrite(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseToNotFollower(boolean) > "testFetchSnapshotResponseToNotFollower(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsCandidateAndOnlyVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerReplication(boolean) > "testFollowerReplication(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerReplication(boolean) > "testFollowerReplication(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testInvalidVoterReplicaPreVoteRequest(KRaftVersion) > "testInvalidVoterReplicaPreVoteRequest(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoterBecomeProspectiveAfterFetchTimeout(boolean) > "testVoterBecomeProspectiveAfterFetchTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoterBecomeProspectiveAfterFetchTimeout(boolean) > "testVoterBecomeProspectiveAfterFetchTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testLeaderDoesNotBootstrapRecordsWithKraftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToAndFromFollowerSameEpoch(KRaftVersion) > "testProspectiveVotedToAndFromFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testRandomRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterWithNoneVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testInvalidVoterReplicaPreVoteRequest(KRaftVersion) > "testInvalidVoterReplicaPreVoteRequest(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToCandidate(KRaftVersion) > "testLeaderToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToCandidate(KRaftVersion) > "testLeaderToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestOffsetAtZero(boolean) > "testFetchRequestOffsetAtZero(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresInVotedState(boolean) > "testHandleCommitCallbackFiresInVotedState(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterWithKraftVersion0(Errors) > "testFollowerSendsUpdateVoterWithKraftVersion0(Errors).updateVoterError=NONE" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToLeaderOrResigned(KRaftVersion) > "testUnattachedToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToLeaderOrResigned(KRaftVersion) > "testUnattachedToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedHigherEpoch(KRaftVersion) > "testFollowerToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterWithKraftVersion0(Errors) > "testFollowerSendsUpdateVoterWithKraftVersion0(Errors).updateVoterError=UNSUPPORTED_VERSION" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedHigherEpoch(KRaftVersion) > "testFollowerToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToLeaderOrResigned(KRaftVersion) > "testFollowerToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToLeaderOrResigned(KRaftVersion) > "testFollowerToLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToFollowerHigherEpoch(KRaftVersion) > "testUnattachedVotedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testDefaultHwmDeferred() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToFollowerHigherEpoch(KRaftVersion) > "testUnattachedVotedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testResignedToUnattachedInHigherEpoch(KRaftVersion) > "testResignedToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testResignedToUnattachedInHigherEpoch(KRaftVersion) > "testResignedToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToFollowerSameEpoch(KRaftVersion) > "testLeaderToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestClusterIdValidation(KRaftVersion) > "testPreVoteRequestClusterIdValidation(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresInVotedState(boolean) > "testHandleCommitCallbackFiresInVotedState(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterIfPendingFetchDuringTimeout() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestOffsetAtZero(boolean) > "testFetchRequestOffsetAtZero(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverQuorumDiscoveryFailure(boolean) > "testObserverQuorumDiscoveryFailure(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverQuorumDiscoveryFailure(boolean) > "testObserverQuorumDiscoveryFailure(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleEndQuorumRequest(boolean) > "testHandleEndQuorumRequest(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToFollowerSameEpoch(KRaftVersion) > "testLeaderToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleEndQuorumRequest(boolean) > "testHandleEndQuorumRequest(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerAsObserverDoesNotBecomeProspectiveAfterFetchTimeout(boolean) > "testFollowerAsObserverDoesNotBecomeProspectiveAfterFetchTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerAsObserverDoesNotBecomeProspectiveAfterFetchTimeout(boolean) > "testFollowerAsObserverDoesNotBecomeProspectiveAfterFetchTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testUpdatedHighWatermarkCompleted() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=11, buffer=java.nio.HeapByteBuffer[pos=0 lim=11 cap=11]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCleanupOlderSnapshots() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=16, buffer=java.nio.HeapByteBuffer[pos=0 lim=16 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedVoted(KRaftVersion) > "testProspectiveToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedVoted(KRaftVersion) > "testProspectiveToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeVotedAndLeaderAreDifferent(KRaftVersion) > "testInitializeVotedAndLeaderAreDifferent(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeVotedAndLeaderAreDifferent(KRaftVersion) > "testInitializeVotedAndLeaderAreDifferent(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteRequestClusterIdValidation(KRaftVersion) > "testPreVoteRequestClusterIdValidation(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverFollowerToUnattached(KRaftVersion) > "testObserverFollowerToUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterWithNoneVoterId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KafkaRaftClientFetchTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=243, buffer=java.nio.HeapByteBuffer[pos=0 lim=243 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchCompletedByFollowerTransition(boolean) > "testPurgatoryFetchCompletedByFollowerTransition(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverFollowerToUnattached(KRaftVersion) > "testObserverFollowerToUnattached(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromOlderEpoch(boolean) > "testFetchSnapshotResponseFromOlderEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testTruncateWillRemoveOlderSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testLeaderAcceptPreVoteFromObserver(KRaftVersion) > "testLeaderAcceptPreVoteFromObserver(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithNoneVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchCompletedByFollowerTransition(boolean) > "testPurgatoryFetchCompletedByFollowerTransition(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedWithLeaderNoEndpointToAndFromProspective(KRaftVersion) > "testUnattachedWithLeaderNoEndpointToAndFromProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedWithLeaderNoEndpointToAndFromProspective(KRaftVersion) > "testUnattachedWithLeaderNoEndpointToAndFromProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeVotedAndLeaderAreSame(KRaftVersion) > "testInitializeVotedAndLeaderAreSame(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeVotedAndLeaderAreSame(KRaftVersion) > "testInitializeVotedAndLeaderAreSame(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerSameEpoch(KRaftVersion) > "testFollowerToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerSameEpoch(KRaftVersion) > "testFollowerToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToProspective(KRaftVersion) > "testFollowerToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToProspective(KRaftVersion) > "testFollowerToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testLeaderAcceptPreVoteFromObserver(KRaftVersion) > "testLeaderAcceptPreVoteFromObserver(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithExistingVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testEmptyAppendNotAllowed() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterToNotLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromOlderEpoch(boolean) > "testFetchSnapshotResponseFromOlderEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderImmediatelySendsDivergingEpoch(boolean) > "testLeaderImmediatelySendsDivergingEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteNotSupportedByRemote(KRaftVersion) > "testPreVoteNotSupportedByRemote(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateEpochLessThanFirstEpochInLog() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestUnknownPartition(boolean) > "testFetchSnapshotRequestUnknownPartition(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithMissingDefaultListener() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderImmediatelySendsDivergingEpoch(boolean) > "testLeaderImmediatelySendsDivergingEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLeaderRediscoveryAfterRequestTimeout(boolean) > "testFollowerLeaderRediscoveryAfterRequestTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLeaderRediscoveryAfterRequestTimeout(boolean) > "testFollowerLeaderRediscoveryAfterRequestTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteNotSupportedByRemote(KRaftVersion) > "testPreVoteNotSupportedByRemote(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateEpochLessThanOldestSnapshotEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestUnknownPartition(boolean) > "testFetchSnapshotRequestUnknownPartition(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLatestSnapshotIdMissing() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterAfterKRaftVersionUpgrade() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToAnyStateLowerEpoch(KRaftVersion) > "testCandidateToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToAnyStateLowerEpoch(KRaftVersion) > "testCandidateToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToUnattachedSameEpoch(KRaftVersion) > "testFollowerVotedToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToUnattachedSameEpoch(KRaftVersion) > "testFollowerVotedToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsResigned(KRaftVersion) > "testHandlePreVoteRequestAsResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffsetOnEmptyLog(boolean) > "testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffsetOnEmptyLog(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotDivergingEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateExistingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsResigned(KRaftVersion) > "testHandlePreVoteRequestAsResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterWithoutFencedPreviousLeaders() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testInvalidPreVoteRequest(KRaftVersion) > "testInvalidPreVoteRequest(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testInvalidPreVoteRequest(KRaftVersion) > "testInvalidPreVoteRequest(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveLosesElectionHasLeaderButMissingEndpoint(KRaftVersion) > "testProspectiveLosesElectionHasLeaderButMissingEndpoint(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveLosesElectionHasLeaderButMissingEndpoint(KRaftVersion) > "testProspectiveLosesElectionHasLeaderButMissingEndpoint(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromNewerEpochNotLeader(boolean) > "testFetchSnapshotResponseFromNewerEpochNotLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerSameEpochAndMoreEndpoints(KRaftVersion) > "testFollowerToFollowerSameEpochAndMoreEndpoints(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffsetOnEmptyLog(boolean) > "testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffsetOnEmptyLog(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerSameEpochAndMoreEndpoints(KRaftVersion) > "testFollowerToFollowerSameEpochAndMoreEndpoints(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToProspective(KRaftVersion) > "testCandidateToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGracefulShutdownSingleMemberQuorum(boolean) > "testGracefulShutdownSingleMemberQuorum(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToProspective(KRaftVersion) > "testCandidateToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGracefulShutdownSingleMemberQuorum(boolean) > "testGracefulShutdownSingleMemberQuorum(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testLogLimitsReturnsAtLeastOne() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testSegmentMsConfigIsSetInMetadataLog() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkMetadata() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testNonFollowerAcknowledgement() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteResponseIgnoredAfterBecomingFollower(KRaftVersion) > "testPreVoteResponseIgnoredAfterBecomingFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToCandidate(KRaftVersion) > "testCandidateToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToCandidate(KRaftVersion) > "testCandidateToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToAnyStateLowerEpoch(KRaftVersion) > "testLeaderToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotOlderEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToAnyStateLowerEpoch(KRaftVersion) > "testLeaderToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToCandidate(KRaftVersion) > "testFollowerToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToCandidate(KRaftVersion) > "testFollowerToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedWithLeaderInHigherEpoch(KRaftVersion) > "testProspectiveToUnattachedWithLeaderInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedWithLeaderInHigherEpoch(KRaftVersion) > "testProspectiveToUnattachedWithLeaderInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToUnattachedSameEpoch(KRaftVersion) > "testCandidateToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToUnattachedSameEpoch(KRaftVersion) > "testCandidateToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromNewerEpochNotLeader(boolean) > "testFetchSnapshotResponseFromNewerEpochNotLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testLogLimitsReturnsLessThanMaxBytes() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithPendingRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumSizeOne() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testPreVoteResponseIgnoredAfterBecomingFollower(KRaftVersion) > "testPreVoteResponseIgnoredAfterBecomingFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandleInvalidPreVoteRequestWithOlderEpoch(KRaftVersion) > "testHandleInvalidPreVoteRequestWithOlderEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandleInvalidPreVoteRequestWithOlderEpoch(KRaftVersion) > "testHandleInvalidPreVoteRequestWithOlderEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumSizeTwo(boolean) > "testUpdateHighWatermarkQuorumSizeTwo(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumSizeTwo(boolean) > "testUpdateHighWatermarkQuorumSizeTwo(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testCheckQuorumWithOneVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testHighWatermarkDoesNotDecreaseFromNewVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumSizeThree(boolean) > "testUpdateHighWatermarkQuorumSizeThree(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumSizeThree(boolean) > "testUpdateHighWatermarkQuorumSizeThree(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToResigned(KRaftVersion) > "testLeaderToResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestWithLastFetchedEpochLessThanOldestSnapshot(boolean) > "testFetchRequestWithLastFetchedEpochLessThanOldestSnapshot(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithApiVersionsFromIncorrectNode() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testInvalidMaybeAppendUpgradedKRaftVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollower(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollower(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_0, hasFetchedFromLeader=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollower(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollower(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_0, hasFetchedFromLeader=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestWithLastFetchedEpochLessThanOldestSnapshot(boolean) > "testFetchRequestWithLastFetchedEpochLessThanOldestSnapshot(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToResigned(KRaftVersion) > "testLeaderToResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testBeginQuorumEpochTimer(boolean) > "testBeginQuorumEpochTimer(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testBeginQuorumEpochTimer(boolean) > "testBeginQuorumEpochTimer(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testVolatileVoters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializePrimordialEpoch(KRaftVersion) > "testInitializePrimordialEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testGrantVote(boolean) > "testGrantVote(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializePrimordialEpoch(KRaftVersion) > "testInitializePrimordialEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollower(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollower(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_1, hasFetchedFromLeader=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsFollower(KRaftVersion, boolean) > "testHandlePreVoteRequestAsFollower(KRaftVersion, boolean).kraftVersion=KRAFT_VERSION_1, hasFetchedFromLeader=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedObserver(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedObserver(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedObserver(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedObserver(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testGrantVote(boolean) > "testGrantVote(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithPendingAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToFollowerHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToFollowerHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToAnyStateLowerEpoch(KRaftVersion) > "testFollowerToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToAnyStateLowerEpoch(KRaftVersion) > "testFollowerToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchResponseWithSnapshotId(boolean) > "testFetchResponseWithSnapshotId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeWithCorruptedStore(KRaftVersion) > "testInitializeWithCorruptedStore(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithRecordBatchTooLargeException(boolean) > "testAppendFailedWithRecordBatchTooLargeException(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeWithCorruptedStore(KRaftVersion) > "testInitializeWithCorruptedStore(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToUnattachedHigherEpoch(KRaftVersion) > "testFollowerVotedToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToUnattachedHigherEpoch(KRaftVersion) > "testFollowerVotedToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToFollower(KRaftVersion) > "testObserverUnattachedToFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToFollower(KRaftVersion) > "testObserverUnattachedToFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testLeaderEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testNonMonotonicHighWatermarkUpdate(boolean) > "testNonMonotonicHighWatermarkUpdate(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testNonMonotonicHighWatermarkUpdate(boolean) > "testNonMonotonicHighWatermarkUpdate(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testFollowerAcknowledgement(boolean) > "testFollowerAcknowledgement(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testFollowerAcknowledgement(boolean) > "testFollowerAcknowledgement(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testCheckQuorum(boolean) > "testCheckQuorum(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterInvalidClusterId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testCheckQuorum(boolean) > "testCheckQuorum(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateVotersFromNoDirectoryIdToDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkRemovingFollowerFromVoterStates() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testUpdateHighWatermarkQuorumRemovingLeaderFromVoterStates() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testIdempotentEndOffsetUpdate() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testCheckQuorumAfterVoterSetChanges() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedWithLeaderToProspective(KRaftVersion) > "testUnattachedWithLeaderToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedWithLeaderToProspective(KRaftVersion) > "testUnattachedWithLeaderToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToAnyStateLowerEpoch(KRaftVersion) > "testUnattachedToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToAnyStateLowerEpoch(KRaftVersion) > "testUnattachedToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToProspective(KRaftVersion) > "testUnattachedVotedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToProspective(KRaftVersion) > "testUnattachedVotedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testMaybeAppendUpgradedKRaftVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testNonMonotonicLocalEndOffsetUpdate() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchResponseWithSnapshotId(boolean) > "testFetchResponseWithSnapshotId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterNewEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToFollowerHigherEpoch(KRaftVersion) > "testProspectiveToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToFollowerHigherEpoch(KRaftVersion) > "testProspectiveToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToLeader(KRaftVersion) > "testCandidateToLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testHighWatermarkDoesIncreaseFromNewVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterTimeout() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestClusterIdValidation(boolean) > "testFetchSnapshotRequestClusterIdValidation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testGetNonLeaderFollowersByFetchOffsetDescending(boolean) > "testGetNonLeaderFollowersByFetchOffsetDescending(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testGetNonLeaderFollowersByFetchOffsetDescending(boolean) > "testGetNonLeaderFollowersByFetchOffsetDescending(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > LeaderStateTest > testRequireNonNullAccumulator() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testGrantVoteWithLeader(boolean) > "testGrantVoteWithLeader(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testGrantVoteWithLeader(boolean) > "testGrantVoteWithLeader(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testLeaderEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testGrantVoteWithoutVotedKey(boolean) > "testGrantVoteWithoutVotedKey(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testGrantVoteWithoutVotedKey(boolean) > "testGrantVoteWithoutVotedKey(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithRecordBatchTooLargeException(boolean) > "testAppendFailedWithRecordBatchTooLargeException(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsProspectiveWithVotedCandidate(boolean) > "testHandleVoteRequestAsProspectiveWithVotedCandidate(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsProspectiveWithVotedCandidate(boolean) > "testHandleVoteRequestAsProspectiveWithVotedCandidate(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testCanGrantVoteWithVotedKey(boolean) > "testCanGrantVoteWithVotedKey(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testCanGrantVoteWithVotedKey(boolean) > "testCanGrantVoteWithVotedKey(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToLeader(KRaftVersion) > "testCandidateToLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedSameEpoch(KRaftVersion) > "testUnattachedVotedToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testElectionStateAndElectionTimeout(boolean, boolean) > "testElectionStateAndElectionTimeout(boolean, boolean).hasVotedKey=true, hasLeaderId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testElectionStateAndElectionTimeout(boolean, boolean) > "testElectionStateAndElectionTimeout(boolean, boolean).hasVotedKey=false, hasLeaderId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > UnattachedStateTest > testElectionStateAndElectionTimeout(boolean, boolean) > "testElectionStateAndElectionTimeout(boolean, boolean).hasVotedKey=false, hasLeaderId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestClusterIdValidation(boolean) > "testFetchSnapshotRequestClusterIdValidation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testCreateSnapshotAsFollowerWithInvalidSnapshotId(boolean) > "testCreateSnapshotAsFollowerWithInvalidSnapshotId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testCreateSnapshotAsFollowerWithInvalidSnapshotId(boolean) > "testCreateSnapshotAsFollowerWithInvalidSnapshotId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterInvalidFeatureVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedSameEpoch(KRaftVersion) > "testUnattachedVotedToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattachedVotedSameEpoch(KRaftVersion) > "testUnattachedToUnattachedVotedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattachedVotedSameEpoch(KRaftVersion) > "testUnattachedToUnattachedVotedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverFollowerToProspectiveOrCandidateOrLeaderOrResigned(KRaftVersion) > "testObserverFollowerToProspectiveOrCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverFollowerToProspectiveOrCandidateOrLeaderOrResigned(KRaftVersion) > "testObserverFollowerToProspectiveOrCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedCannotAddVotedStateForSelf(KRaftVersion) > "testUnattachedCannotAddVotedStateForSelf(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedCannotAddVotedStateForSelf(KRaftVersion) > "testUnattachedCannotAddVotedStateForSelf(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsFollower(KRaftVersion) > "testInitializeAsFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsFollower(KRaftVersion) > "testInitializeAsFollower(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsResignedCandidate(KRaftVersion) > "testInitializeAsResignedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsResignedCandidate(KRaftVersion) > "testInitializeAsResignedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToLeaderWithoutGrantedVote(KRaftVersion) > "testCandidateToLeaderWithoutGrantedVote(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToLeaderWithoutGrantedVote(KRaftVersion) > "testCandidateToLeaderWithoutGrantedVote(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToFollowerSameEpoch(KRaftVersion) > "testUnattachedVotedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToFollowerSameEpoch(KRaftVersion) > "testUnattachedVotedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsOnlyVoter(KRaftVersion) > "testInitializeAsOnlyVoter(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsOnlyVoter(KRaftVersion) > "testInitializeAsOnlyVoter(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToCandidate(KRaftVersion) > "testProspectiveToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToCandidate(KRaftVersion) > "testProspectiveToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToProspective(KRaftVersion) > "testProspectiveToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToProspective(KRaftVersion) > "testProspectiveToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerHigherEpoch(KRaftVersion) > "testFollowerToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToFollowerHigherEpoch(KRaftVersion) > "testFollowerToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedWithLeaderInHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedWithLeaderInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedWithLeaderInHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedWithLeaderInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToProspective(KRaftVersion) > "testObserverUnattachedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderIgnoreVoteRequestOnSameEpoch(boolean) > "testLeaderIgnoreVoteRequestOnSameEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testListenerReceivesBootstrapSnapshotViaFollowerFetch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testBufferSupplierCreatedAndClosedOnLogRead() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testEmptyPartition() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderIgnoreVoteRequestOnSameEpoch(boolean) > "testLeaderIgnoreVoteRequestOnSameEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testNodeDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testUnattachedAsVoterCanBecomeFollowerAfterFindingLeader(boolean) > "testUnattachedAsVoterCanBecomeFollowerAfterFindingLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testUnattachedAsVoterCanBecomeFollowerAfterFindingLeader(boolean) > "testUnattachedAsVoterCanBecomeFollowerAfterFindingLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testLeaderMetricsAreReset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testBufferSupplierCreatedOnSnapshotRead() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testObserverDiscoversLeaderWithUnknownVoters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestAtLogStartOffsetWithValidEpoch(boolean) > "testFetchRequestAtLogStartOffsetWithValidEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testChannelWokenUpIfLingerTimeoutReachedWithoutAppend(boolean) > "testChannelWokenUpIfLingerTimeoutReachedWithoutAppend(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToProspective(KRaftVersion) > "testObserverUnattachedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedInHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToUnattachedInHigherEpoch(KRaftVersion) > "testProspectiveWithLeaderToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsVotedNoLeader(KRaftVersion) > "testInitializeAsVotedNoLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsVotedNoLeader(KRaftVersion) > "testInitializeAsVotedNoLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testHighWatermarkRetained(KRaftVersion) > "testHighWatermarkRetained(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testHighWatermarkRetained(KRaftVersion) > "testHighWatermarkRetained(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterInvalidClusterId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToCandidate(KRaftVersion) > "testProspectiveWithLeaderToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToCandidate(KRaftVersion) > "testProspectiveWithLeaderToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToFollowerSameEpoch(KRaftVersion) > "testProspectiveToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToFollowerSameEpoch(KRaftVersion) > "testProspectiveToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToLeader(KRaftVersion) > "testLeaderToLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testUpdateWithSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToLeader(KRaftVersion) > "testLeaderToLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testChannelWokenUpIfLingerTimeoutReachedWithoutAppend(boolean) > "testChannelWokenUpIfLingerTimeoutReachedWithoutAppend(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToUnattachedHigherEpoch(KRaftVersion) > "testLeaderToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToUnattachedHigherEpoch(KRaftVersion) > "testLeaderToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsUnattachedWhenMissingEndpoints(KRaftVersion) > "testInitializeAsUnattachedWhenMissingEndpoints(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsUnattachedWhenMissingEndpoints(KRaftVersion) > "testInitializeAsUnattachedWhenMissingEndpoints(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToAnyStateLowerEpoch(KRaftVersion) > "testUnattachedVotedToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToAnyStateLowerEpoch(KRaftVersion) > "testUnattachedVotedToAnyStateLowerEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToFollowerHigherEpoch(KRaftVersion) > "testLeaderToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithNoneVoterId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testUpdateWithSnapshotAndLogOverride() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToFollowerHigherEpoch(KRaftVersion) > "testLeaderToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCanBecomeFollowerOfNonVoter(KRaftVersion) > "testCanBecomeFollowerOfNonVoter(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithoutLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestAtLogStartOffsetWithValidEpoch(boolean) > "testFetchRequestAtLogStartOffsetWithValidEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedVoted(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testTrimPrefixTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testUpdateWithEmptySnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testHandlePreVoteRequestAsUnattachedVoted(KRaftVersion) > "testHandlePreVoteRequestAsUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean) > "testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testUpdateWithoutSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testEmptyPartitionWithNoStaticVoters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > KRaftControlRecordStateMachineTest > testTruncateTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > RecordsSnapshotWriterTest > testBuilderKRaftVersion0WithVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > RecordsSnapshotWriterTest > testBuilderKRaftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterResponseCausesEpochChange() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > RecordsSnapshotWriterTest > testKBuilderRaftVersion1WithVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterToNotLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 6 > RecordsSnapshotWriterTest > testBuilderKRaftVersion1WithoutVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testHandleBeginQuorumRequestMoreEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithOlderEpoch(boolean) > "testFetchSnapshotRequestWithOlderEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean) > "testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCanBecomeFollowerOfNonVoter(KRaftVersion) > "testCanBecomeFollowerOfNonVoter(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithOlderEpoch(boolean) > "testFetchSnapshotRequestWithOlderEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testLeaderUpdatesVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testNoLocalIdInitializationFailsIfElectionStateHasVotedCandidate(KRaftVersion) > "testNoLocalIdInitializationFailsIfElectionStateHasVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testNoLocalIdInitializationFailsIfElectionStateHasVotedCandidate(KRaftVersion) > "testNoLocalIdInitializationFailsIfElectionStateHasVotedCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean) > "testDescribeQuorumNonMonotonicFollowerFetch(boolean, boolean).withKip853Rpc=false, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsFollowerNonEmptyLog(boolean) > "testInitializeAsFollowerNonEmptyLog(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsFollowerNonEmptyLog(boolean) > "testInitializeAsFollowerNonEmptyLog(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsObserver(boolean) > "testHandleVoteRequestAsObserver(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsObserver(boolean) > "testHandleVoteRequestAsObserver(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedVotedHigherEpoch(KRaftVersion) > "testFollowerToUnattachedVotedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testInvalidUpdateVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestBootstrapSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testListenerReceivesBootstrapSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedVotedHigherEpoch(KRaftVersion) > "testFollowerToUnattachedVotedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testHasRemoteLeader(KRaftVersion) > "testHasRemoteLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testHasRemoteLeader(KRaftVersion) > "testHasRemoteLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedHigherEpoch(KRaftVersion) > "testUnattachedVotedToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedHigherEpoch(KRaftVersion) > "testUnattachedVotedToUnattachedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedInHigherEpoch(KRaftVersion) > "testProspectiveToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveToUnattachedInHigherEpoch(KRaftVersion) > "testProspectiveToUnattachedInHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToFollowerHigherEpoch(KRaftVersion) > "testUnattachedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToFollowerHigherEpoch(KRaftVersion) > "testUnattachedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedVoted(KRaftVersion) > "testUnattachedVotedToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToUnattachedVoted(KRaftVersion) > "testUnattachedVotedToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testResignedToFollowerInSameEpoch(KRaftVersion) > "testResignedToFollowerInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testResignedToFollowerInSameEpoch(KRaftVersion) > "testResignedToFollowerInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToUnattachedVoted(KRaftVersion) > "testObserverUnattachedToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToUnattachedVoted(KRaftVersion) > "testObserverUnattachedToUnattachedVoted(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveVotedToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveVotedToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithLaggingNewVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestAtLogStartOffsetWithInvalidEpoch(boolean) > "testFetchRequestAtLogStartOffsetWithInvalidEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testResignWillCompleteFetchPurgatory(boolean) > "testResignWillCompleteFetchPurgatory(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToCandidate(KRaftVersion) > "testUnattachedToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToCandidate(KRaftVersion) > "testUnattachedToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToFollowerSameEpoch(KRaftVersion) > "testUnattachedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToFollowerSameEpoch(KRaftVersion) > "testUnattachedToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedSameEpoch(KRaftVersion) > "testFollowerToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerToUnattachedSameEpoch(KRaftVersion) > "testFollowerToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToProspective(KRaftVersion) > "testUnattachedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToProspective(KRaftVersion) > "testUnattachedToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToProspective(KRaftVersion) > "testLeaderToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToProspective(KRaftVersion) > "testLeaderToProspective(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToFollowerSameEpoch(KRaftVersion) > "testProspectiveWithLeaderToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveWithLeaderToFollowerSameEpoch(KRaftVersion) > "testProspectiveWithLeaderToFollowerSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestAtLogStartOffsetWithInvalidEpoch(boolean) > "testFetchRequestAtLogStartOffsetWithInvalidEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestAsFollower(boolean) > "testFetchSnapshotRequestAsFollower(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestAsFollower(boolean) > "testFetchSnapshotRequestAsFollower(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterTimedOut() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testResignWillCompleteFetchPurgatory(boolean) > "testResignWillCompleteFetchPurgatory(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedWithLeaderToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveVotedWithLeaderToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedWithLeaderToUnattachedInSameEpoch(KRaftVersion) > "testProspectiveVotedWithLeaderToUnattachedInSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCannotFollowSelf(KRaftVersion) > "testCannotFollowSelf(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCannotFollowSelf(KRaftVersion) > "testCannotFollowSelf(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsResignedLeader(KRaftVersion) > "testInitializeAsResignedLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeAsResignedLeader(KRaftVersion) > "testInitializeAsResignedLeader(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToCandidate(KRaftVersion) > "testProspectiveVotedToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testProspectiveVotedToCandidate(KRaftVersion) > "testProspectiveVotedToCandidate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToUnattachedSameEpoch(KRaftVersion) > "testLeaderToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testLeaderToUnattachedSameEpoch(KRaftVersion) > "testLeaderToUnattachedSameEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeWithEmptyLocalId(KRaftVersion) > "testInitializeWithEmptyLocalId(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testInitializeWithEmptyLocalId(KRaftVersion) > "testInitializeWithEmptyLocalId(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToResigned(KRaftVersion) > "testCandidateToResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCandidateToResigned(KRaftVersion) > "testCandidateToResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToCandidateOrLeaderOrResigned(KRaftVersion) > "testObserverUnattachedToCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestWithLargerLastFetchedEpoch(boolean) > "testFetchRequestWithLargerLastFetchedEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterWithoutFencedPreviousLeaders() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testObserverUnattachedToCandidateOrLeaderOrResigned(KRaftVersion) > "testObserverUnattachedToCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattachedVotedHigherEpoch(KRaftVersion) > "testUnattachedToUnattachedVotedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedToUnattachedVotedHigherEpoch(KRaftVersion) > "testUnattachedToUnattachedVotedHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCannotTransitionToFollowerWithNoLeaderEndpoint(KRaftVersion) > "testCannotTransitionToFollowerWithNoLeaderEndpoint(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testCannotTransitionToFollowerWithNoLeaderEndpoint(KRaftVersion) > "testCannotTransitionToFollowerWithNoLeaderEndpoint(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToCandidateOrLeaderOrResigned(KRaftVersion) > "testUnattachedVotedToCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testUnattachedVotedToCandidateOrLeaderOrResigned(KRaftVersion) > "testUnattachedVotedToCandidateOrLeaderOrResigned(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToFollowerHigherEpoch(KRaftVersion) > "testFollowerVotedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > QuorumStateTest > testFollowerVotedToFollowerHigherEpoch(KRaftVersion) > "testFollowerVotedToFollowerHigherEpoch(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testRequestToBootstrapList() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochSentBasedOnFetchOffset(boolean) > "testEndQuorumEpochSentBasedOnFetchOffset(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testResetAllConnections() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testFindReadyWithRequestTimedOut() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testSuccessfulResponse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testRequestTimeout() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testFindReadyWithInflightRequest() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testBackoffAfterFailure() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testAnyInflightRequestWithAnyRequest() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testHasRequestTimedOut() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RequestManagerTest > testIgnoreUnexpectedResponse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testLeaderWritesBootstrapRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchRequestWithLargerLastFetchedEpoch(boolean) > "testFetchRequestWithLargerLastFetchedEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testAddVoterWithMissingDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > BlockingMessageQueueTest > testWakeupsAreTransparentToIsEmptyAndDrainedOnPoll() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > BlockingMessageQueueTest > testAddRejectsNullMessage() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > BlockingMessageQueueTest > testOfferAndPoll() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > BlockingMessageQueueTest > testWakeupFromPoll() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochSentBasedOnFetchOffset(boolean) > "testEndQuorumEpochSentBasedOnFetchOffset(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestAsLeader(boolean) > "testFetchSnapshotRequestAsLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testKRaftUpgradeVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestAsLeader(boolean) > "testFetchSnapshotRequestAsLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithFollowers(boolean, boolean) > "testDescribeQuorumWithFollowers(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerDoesNotRequestLeaderBootstrapSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testUpdateVoterToNotLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithFollowers(boolean, boolean) > "testDescribeQuorumWithFollowers(boolean, boolean).withKip853Rpc=true, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testCreateSnapshotAsLeaderWithInvalidSnapshotId(boolean) > "testCreateSnapshotAsLeaderWithInvalidSnapshotId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testRemoveVoterInvalidClusterId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > KafkaRaftClientReconfigTest > testFollowerSendsUpdateVoterWhenDifferent() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumWithFollowers(boolean, boolean) > "testDescribeQuorumWithFollowers(boolean, boolean).withKip853Rpc=false, withBootstrapSnapshot=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidVoteRequest(boolean) > "testInvalidVoteRequest(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidVoteRequest(boolean) > "testInvalidVoteRequest(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testCreateSnapshotAsLeaderWithInvalidSnapshotId(boolean) > "testCreateSnapshotAsLeaderWithInvalidSnapshotId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumIgnoredAsLeaderIfOlderEpoch(boolean) > "testEndQuorumIgnoredAsLeaderIfOlderEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromNewerEpochLeader(boolean) > "testFetchSnapshotResponseFromNewerEpochLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumIgnoredAsLeaderIfOlderEpoch(boolean) > "testEndQuorumIgnoredAsLeaderIfOlderEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithFencedEpoch(boolean) > "testAppendFailedWithFencedEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromMemoryRecords(CompressionType) > "testReadFromMemoryRecords(CompressionType).compressionType=none" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseFromNewerEpochLeader(boolean) > "testFetchSnapshotResponseFromNewerEpochLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithFencedEpoch(boolean) > "testAppendFailedWithFencedEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsFollowerEmptyLog(boolean) > "testInitializeAsFollowerEmptyLog(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsFollowerEmptyLog(boolean) > "testInitializeAsFollowerEmptyLog(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesFromHigherEpochAfterResigningCandidacy(boolean) > "testGrantVotesFromHigherEpochAfterResigningCandidacy(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesFromHigherEpochAfterResigningCandidacy(boolean) > "testGrantVotesFromHigherEpochAfterResigningCandidacy(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeObserverNoPreviousState(boolean) > "testInitializeObserverNoPreviousState(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeObserverNoPreviousState(boolean) > "testInitializeObserverNoPreviousState(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFollowerListenerNotified(boolean) > "testFollowerListenerNotified(boolean).entireLog=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFollowerListenerNotified(boolean) > "testFollowerListenerNotified(boolean).entireLog=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testStaticVotersIgnoredWithBootstrapSnapshot(boolean) > "testStaticVotersIgnoredWithBootstrapSnapshot(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testAdvanceLogStartOffsetAfterCleaning() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateOffsetGreatThanEndOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromMemoryRecords(CompressionType) > "testReadFromMemoryRecords(CompressionType).compressionType=gzip" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testStaticVotersIgnoredWithBootstrapSnapshot(boolean) > "testStaticVotersIgnoredWithBootstrapSnapshot(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsResignedLeaderFromStateStore(boolean) > "testInitializeAsResignedLeaderFromStateStore(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsResignedLeaderFromStateStore(boolean) > "testInitializeAsResignedLeaderFromStateStore(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsResignedAndUnableToContactQuorum(boolean) > "testInitializeAsResignedAndUnableToContactQuorum(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsResignedAndUnableToContactQuorum(boolean) > "testInitializeAsResignedAndUnableToContactQuorum(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseMissingSnapshot(boolean) > "testFetchSnapshotResponseMissingSnapshot(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_996_PROTOCOL" PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteRequestTimeout(boolean) > "testVoteRequestTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseMissingSnapshot(boolean) > "testFetchSnapshotResponseMissingSnapshot(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteRequestTimeout(boolean) > "testVoteRequestTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testSecondListenerNotified(boolean) > "testSecondListenerNotified(boolean).entireLog=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateElectionTimeout(boolean) > "testCandidateElectionTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateUnknownEpochLessThanLastKnownGreaterThanOldestSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotMuchLaterEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testSecondListenerNotified(boolean) > "testSecondListenerNotified(boolean).entireLog=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateElectionTimeout(boolean) > "testCandidateElectionTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidLeaderEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchResponseWithInvalidSnapshotId(boolean) > "testFetchResponseWithInvalidSnapshotId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverLeaderRediscoveryAfterBrokerNotAvailableError(boolean) > "testObserverLeaderRediscoveryAfterBrokerNotAvailableError(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol) > "testProspectiveTransitionsToUnattachedOnElectionFailure(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCleanupPartialSnapshots() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchResponseWithInvalidSnapshotId(boolean) > "testFetchResponseWithInvalidSnapshotId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverLeaderRediscoveryAfterBrokerNotAvailableError(boolean) > "testObserverLeaderRediscoveryAfterBrokerNotAvailableError(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverHandleRetryFetchToBootstrapServer(boolean) > "testObserverHandleRetryFetchToBootstrapServer(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverHandleRetryFetchToBootstrapServer(boolean) > "testObserverHandleRetryFetchToBootstrapServer(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateIgnoreVoteRequestOnSameEpoch(boolean) > "testCandidateIgnoreVoteRequestOnSameEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateIgnoreVoteRequestOnSameEpoch(boolean) > "testCandidateIgnoreVoteRequestOnSameEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithPartialData() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumEpochAfterUserInitiatedResign(boolean) > "testHandleBeginQuorumEpochAfterUserInitiatedResign(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderImmediatelySendsSnapshotId(boolean) > "testLeaderImmediatelySendsSnapshotId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumEpochAfterUserInitiatedResign(boolean) > "testHandleBeginQuorumEpochAfterUserInitiatedResign(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testStartupWithInvalidSnapshotState() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderImmediatelySendsSnapshotId(boolean) > "testLeaderImmediatelySendsSnapshotId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testDeleteNonExistentSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderAcceptVoteFromObserver(boolean) > "testLeaderAcceptVoteFromObserver(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromMemoryRecords(CompressionType) > "testReadFromMemoryRecords(CompressionType).compressionType=snappy" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testUnexpectedAppendOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testReadMissingSnapshotFile() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderAcceptVoteFromObserver(boolean) > "testLeaderAcceptVoteFromObserver(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestMissingSnapshot(boolean) > "testFetchSnapshotRequestMissingSnapshot(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverHandleRetryFetchToLeader(boolean) > "testObserverHandleRetryFetchToLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverHandleRetryFetchToLeader(boolean) > "testObserverHandleRetryFetchToLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testSnapshotDeletionWithInvalidSnapshotState() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestMissingSnapshot(boolean) > "testFetchSnapshotRequestMissingSnapshot(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumEpochHeartbeat(boolean) > "testBeginQuorumEpochHeartbeat(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumEpochHeartbeat(boolean) > "testBeginQuorumEpochHeartbeat(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderListenerNotified(boolean, boolean) > "testLeaderListenerNotified(boolean, boolean).entireLog=false, withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidVoterReplicaVoteRequest() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsOnlyVoterWithEmptyElectionState(boolean) > "testInitializeAsOnlyVoterWithEmptyElectionState(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsOnlyVoterWithEmptyElectionState(boolean) > "testInitializeAsOnlyVoterWithEmptyElectionState(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderListenerNotified(boolean, boolean) > "testLeaderListenerNotified(boolean, boolean).entireLog=false, withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderListenerNotified(boolean, boolean) > "testLeaderListenerNotified(boolean, boolean).entireLog=true, withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderGracefulShutdownTimeout(boolean) > "testLeaderGracefulShutdownTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testLeaderListenerNotified(boolean, boolean) > "testLeaderListenerNotified(boolean, boolean).entireLog=true, withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromMemoryRecords(CompressionType) > "testReadFromMemoryRecords(CompressionType).compressionType=lz4" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderGracefulShutdownTimeout(boolean) > "testLeaderGracefulShutdownTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochRequestClusterIdValidation(boolean) > "testEndQuorumEpochRequestClusterIdValidation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseWithInvalidId(boolean) > "testFetchSnapshotResponseWithInvalidId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochRequestClusterIdValidation(boolean) > "testEndQuorumEpochRequestClusterIdValidation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateWaitsRestOfElectionTimeoutAfterElectionLoss(boolean) > "testCandidateWaitsRestOfElectionTimeoutAfterElectionLoss(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCandidateWaitsRestOfElectionTimeoutAfterElectionLoss(boolean) > "testCandidateWaitsRestOfElectionTimeoutAfterElectionLoss(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_0, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromMemoryRecords(CompressionType) > "testReadFromMemoryRecords(CompressionType).compressionType=zstd" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotResponseWithInvalidId(boolean) > "testFetchSnapshotResponseWithInvalidId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testElectionTimeoutAfterUserInitiatedResign(boolean) > "testElectionTimeoutAfterUserInitiatedResign(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testLeaderChangeControlBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testElectionTimeoutAfterUserInitiatedResign(boolean) > "testElectionTimeoutAfterUserInitiatedResign(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverFetchWithNoLocalId(boolean) > "testObserverFetchWithNoLocalId(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverFetchWithNoLocalId(boolean) > "testObserverFetchWithNoLocalId(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithInvalidPosition(boolean) > "testFetchSnapshotRequestWithInvalidPosition(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithNotLeaderException(boolean) > "testAppendFailedWithNotLeaderException(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithNotLeaderException(boolean) > "testAppendFailedWithNotLeaderException(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testUnattachedAsObserverDoesNotBecomeProspectiveAfterElectionTimeout(boolean) > "testUnattachedAsObserverDoesNotBecomeProspectiveAfterElectionTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testUnattachedAsObserverDoesNotBecomeProspectiveAfterElectionTimeout(boolean) > "testUnattachedAsObserverDoesNotBecomeProspectiveAfterElectionTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromFileRecords(CompressionType) > "testReadFromFileRecords(CompressionType).compressionType=none" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftClientSnapshotTest > testFetchSnapshotRequestWithInvalidPosition(boolean) > "testFetchSnapshotRequestWithInvalidPosition(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_595_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithLeader(boolean, boolean) > "testGrantVoteWithLeader(boolean, boolean).isLogUpToDate=true, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithLeader(boolean, boolean) > "testGrantVoteWithLeader(boolean, boolean).isLogUpToDate=true, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithLeader(boolean, boolean) > "testGrantVoteWithLeader(boolean, boolean).isLogUpToDate=false, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithLeader(boolean, boolean) > "testGrantVoteWithLeader(boolean, boolean).isLogUpToDate=false, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithVotedKey(boolean, boolean) > "testGrantVoteWithVotedKey(boolean, boolean).isLogUpToDate=true, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithVotedKey(boolean, boolean) > "testGrantVoteWithVotedKey(boolean, boolean).isLogUpToDate=true, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithVotedKey(boolean, boolean) > "testGrantVoteWithVotedKey(boolean, boolean).isLogUpToDate=false, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVoteWithVotedKey(boolean, boolean) > "testGrantVoteWithVotedKey(boolean, boolean).isLogUpToDate=false, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testSingleNodeQuorum(boolean) > "testSingleNodeQuorum(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromFileRecords(CompressionType) > "testReadFromFileRecords(CompressionType).compressionType=gzip" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testSingleNodeQuorum(boolean) > "testSingleNodeQuorum(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testThreeNodeQuorumVoteGranted(boolean) > "testThreeNodeQuorumVoteGranted(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testThreeNodeQuorumVoteGranted(boolean) > "testThreeNodeQuorumVoteGranted(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanGrantVoteWithoutDirectoryId(boolean) > "testCanGrantVoteWithoutDirectoryId(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanGrantVoteWithoutDirectoryId(boolean) > "testCanGrantVoteWithoutDirectoryId(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=true, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=true, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=false, withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testGrantVote(boolean, boolean) > "testGrantVote(boolean, boolean).isLogUpToDate=false, withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testLeaderEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testTwoNodeQuorumVoteRejected(boolean) > "testTwoNodeQuorumVoteRejected(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testTwoNodeQuorumVoteRejected(boolean) > "testTwoNodeQuorumVoteRejected(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanChangePreVote(boolean) > "testCanChangePreVote(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanChangePreVote(boolean) > "testCanChangePreVote(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testTwoNodeQuorumVoteGranted(boolean) > "testTwoNodeQuorumVoteGranted(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testTwoNodeQuorumVoteGranted(boolean) > "testTwoNodeQuorumVoteGranted(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCannotGrantOrRejectNonVoters(boolean) > "testCannotGrantOrRejectNonVoters(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCannotGrantOrRejectNonVoters(boolean) > "testCannotGrantOrRejectNonVoters(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testConsecutiveGrant(boolean) > "testConsecutiveGrant(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testConsecutiveGrant(boolean) > "testConsecutiveGrant(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testElectionTimeout() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanGrantVoteWithDirectoryId(boolean) > "testCanGrantVoteWithDirectoryId(boolean).isLogUpToDate=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testCanGrantVoteWithDirectoryId(boolean) > "testCanGrantVoteWithDirectoryId(boolean).isLogUpToDate=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testThreeNodeQuorumVoteRejected(boolean) > "testThreeNodeQuorumVoteRejected(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testThreeNodeQuorumVoteRejected(boolean) > "testThreeNodeQuorumVoteRejected(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testElectionState(boolean) > "testElectionState(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testElectionState(boolean) > "testElectionState(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testConsecutiveReject(boolean) > "testConsecutiveReject(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > ProspectiveStateTest > testConsecutiveReject(boolean) > "testConsecutiveReject(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=13" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testBuildBatch(CompressionType) > "testBuildBatch(CompressionType).compressionType=none" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testBuildBatch(CompressionType) > "testBuildBatch(CompressionType).compressionType=gzip" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=14" PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=15" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromFileRecords(CompressionType) > "testReadFromFileRecords(CompressionType).compressionType=snappy" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_853_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=16" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromFileRecords(CompressionType) > "testReadFromFileRecords(CompressionType).compressionType=lz4" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testBuildBatch(CompressionType) > "testBuildBatch(CompressionType).compressionType=snappy" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=17" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 9 > RecordsBatchReaderTest > testReadFromFileRecords(CompressionType) > "testReadFromFileRecords(CompressionType).compressionType=zstd" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderStateUpdateWithDifferentFetchRequestVersions(short) > "testLeaderStateUpdateWithDifferentFetchRequestVersions(short).version=18" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderShouldNotResignLeadershipIfOnlyOneVoters(boolean) > "testLeaderShouldNotResignLeadershipIfOnlyOneVoters(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderShouldNotResignLeadershipIfOnlyOneVoters(boolean) > "testLeaderShouldNotResignLeadershipIfOnlyOneVoters(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumIgnoredAsCandidateIfOlderEpoch(boolean) > "testEndQuorumIgnoredAsCandidateIfOlderEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_996_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testBuildBatch(CompressionType) > "testBuildBatch(CompressionType).compressionType=lz4" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumIgnoredAsCandidateIfOlderEpoch(boolean) > "testEndQuorumIgnoredAsCandidateIfOlderEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverFollowerSendFetchToBestNode(boolean) > "testObserverFollowerSendFetchToBestNode(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverFollowerSendFetchToBestNode(boolean) > "testObserverFollowerSendFetchToBestNode(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInvalidVoterReplicaBeginQuorumEpochRequest() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesFromHigherEpochAfterResigningLeadership(boolean) > "testGrantVotesFromHigherEpochAfterResigningLeadership(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesFromHigherEpochAfterResigningLeadership(boolean) > "testGrantVotesFromHigherEpochAfterResigningLeadership(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleInvalidVoteRequestWithOlderEpoch(boolean) > "testHandleInvalidVoteRequestWithOlderEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleInvalidVoteRequestWithOlderEpoch(boolean) > "testHandleInvalidVoteRequestWithOlderEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterUnattachedRegistration(boolean) > "testHandleLeaderChangeFiresAfterUnattachedRegistration(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterUnattachedRegistration(boolean) > "testHandleLeaderChangeFiresAfterUnattachedRegistration(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerGracefulShutdown(boolean) > "testFollowerGracefulShutdown(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerGracefulShutdown(boolean) > "testFollowerGracefulShutdown(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testBuildBatch(CompressionType) > "testBuildBatch(CompressionType).compressionType=zstd" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=128" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=157" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=256" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=433" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=512" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=777" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > BatchBuilderTest > testHasRoomForUncompressed(int) > "testHasRoomForUncompressed(int).batchSize=1024" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1166_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLateRegisteredListenerCatchesUp(boolean) > "testLateRegisteredListenerCatchesUp(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testRandomRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testValidateOffsetEqualToOldestSnapshotOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotBeforeLogStartOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testHighWatermarkOffsetMetadata() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLateRegisteredListenerCatchesUp(boolean) > "testLateRegisteredListenerCatchesUp(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverReplication(boolean, boolean) > "testObserverReplication(boolean, boolean).withKip853Rpc=true, canBecomeVoter=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverReplication(boolean, boolean) > "testObserverReplication(boolean, boolean).withKip853Rpc=true, canBecomeVoter=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverReplication(boolean, boolean) > "testObserverReplication(boolean, boolean).withKip853Rpc=false, canBecomeVoter=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverReplication(boolean, boolean) > "testObserverReplication(boolean, boolean).withKip853Rpc=false, canBecomeVoter=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > KafkaRaftClientPreVoteTest > testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol) > "testProspectiveWithLeaderTransitionsToFollower(KRaftVersion, RaftProtocol).kraftVersion=KRAFT_VERSION_1, raftProtocol=KIP_1186_PROTOCOL" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > MockExpirationServiceTest > testFailAfter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > ValidOffsetAndEpochTest > diverging() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > ValidOffsetAndEpochTest > testValidWithoutSpecifyingOffsetAndEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > ValidOffsetAndEpochTest > valid() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > ValidOffsetAndEpochTest > snapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsCandidateAndBecomeLeaderQuorumOfThree(boolean) > "testInitializeAsCandidateAndBecomeLeaderQuorumOfThree(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsCandidateAndBecomeLeaderQuorumOfThree(boolean) > "testInitializeAsCandidateAndBecomeLeaderQuorumOfThree(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordVoterQuorumState(KRaftVersion) > "shouldRecordVoterQuorumState(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordVoterQuorumState(KRaftVersion) > "shouldRecordVoterQuorumState(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordNonVoterQuorumState(KRaftVersion) > "shouldRecordNonVoterQuorumState(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordNonVoterQuorumState(KRaftVersion) > "shouldRecordNonVoterQuorumState(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingUnattached(boolean) > "testAccumulatorClearedAfterBecomingUnattached(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordRate(KRaftVersion) > "shouldRecordRate(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordRate(KRaftVersion) > "shouldRecordRate(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordLogEnd(KRaftVersion) > "shouldRecordLogEnd(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordLogEnd(KRaftVersion) > "shouldRecordLogEnd(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordNumUnknownVoterConnections(KRaftVersion) > "shouldRecordNumUnknownVoterConnections(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordNumUnknownVoterConnections(KRaftVersion) > "shouldRecordNumUnknownVoterConnections(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > testNumberOfVoters(KRaftVersion) > "testNumberOfVoters(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > testNumberOfVoters(KRaftVersion) > "testNumberOfVoters(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > testLeaderMetrics(KRaftVersion) > "testLeaderMetrics(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > testLeaderMetrics(KRaftVersion) > "testLeaderMetrics(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingUnattached(boolean) > "testAccumulatorClearedAfterBecomingUnattached(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testRejectVotesFromSameEpochAfterResigningCandidacy(boolean) > "testRejectVotesFromSameEpochAfterResigningCandidacy(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testRejectVotesFromSameEpochAfterResigningCandidacy(boolean) > "testRejectVotesFromSameEpochAfterResigningCandidacy(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordLatency(KRaftVersion) > "shouldRecordLatency(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordLatency(KRaftVersion) > "shouldRecordLatency(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordPollIdleRatio(KRaftVersion) > "shouldRecordPollIdleRatio(KRaftVersion).kraftVersion=KRAFT_VERSION_0" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > KafkaRaftMetricsTest > shouldRecordPollIdleRatio(KRaftVersion) > "shouldRecordPollIdleRatio(KRaftVersion).kraftVersion=KRAFT_VERSION_1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testNonoverlappingFromStaticVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > TestNoStaticVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testAddAtNonOverlapping() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testAddAt() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testClear() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testStaticVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testTrimPrefixTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testBootstrapAddAt() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 10 > VoterSetHistoryTest > testTruncateTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingFollower(boolean) > "testAccumulatorClearedAfterBecomingFollower(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingFollower(boolean) > "testAccumulatorClearedAfterBecomingFollower(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeSingleMemberQuorum(boolean) > "testInitializeSingleMemberQuorum(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeSingleMemberQuorum(boolean) > "testInitializeSingleMemberQuorum(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsFollowerWithVotedCandidate(boolean) > "testHandleVoteRequestAsFollowerWithVotedCandidate(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsFollowerWithVotedCandidate(boolean) > "testHandleVoteRequestAsFollowerWithVotedCandidate(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderAppendSingleMemberQuorum(boolean) > "testLeaderAppendSingleMemberQuorum(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderAppendSingleMemberQuorum(boolean) > "testLeaderAppendSingleMemberQuorum(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverUnattachedSendFetchToBootstrapServers(boolean) > "testObserverUnattachedSendFetchToBootstrapServers(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverUnattachedSendFetchToBootstrapServers(boolean) > "testObserverUnattachedSendFetchToBootstrapServers(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumResponse(boolean) > "testHandleBeginQuorumResponse(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumResponse(boolean) > "testHandleBeginQuorumResponse(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingVoted(boolean) > "testAccumulatorClearedAfterBecomingVoted(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAccumulatorClearedAfterBecomingVoted(boolean) > "testAccumulatorClearedAfterBecomingVoted(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testMetrics(boolean) > "testMetrics(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testMetrics(boolean) > "testMetrics(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithBufferAllocationException(boolean) > "testAppendFailedWithBufferAllocationException(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testAppendFailedWithBufferAllocationException(boolean) > "testAppendFailedWithBufferAllocationException(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testListenerCommitCallbackAfterLeaderWrite(boolean) > "testListenerCommitCallbackAfterLeaderWrite(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testListenerCommitCallbackAfterLeaderWrite(boolean) > "testListenerCommitCallbackAfterLeaderWrite(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderShouldResignLeadershipIfNotGetFetchRequestFromMajorityVoters(boolean) > "testLeaderShouldResignLeadershipIfNotGetFetchRequestFromMajorityVoters(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testDeleteSnapshots() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderShouldResignLeadershipIfNotGetFetchRequestFromMajorityVoters(boolean) > "testLeaderShouldResignLeadershipIfNotGetFetchRequestFromMajorityVoters(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresInCandidateState(boolean) > "testHandleCommitCallbackFiresInCandidateState(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresInCandidateState(boolean) > "testHandleCommitCallbackFiresInCandidateState(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffset(boolean) > "testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffset(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testSegmentsLessThanLatestSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testReadRespectsMaxSizeInBytes(int) > "testReadRespectsMaxSizeInBytes(int).expectedBatches=1" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffset(boolean) > "testHandleLeaderChangeFiresAfterListenerReachesEpochStartOffset(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testReadRespectsMaxSizeInBytes(int) > "testReadRespectsMaxSizeInBytes(int).expectedBatches=2" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumRequest(boolean) > "testHandleBeginQuorumRequest(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumRequest(boolean) > "testHandleBeginQuorumRequest(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochRetriesWhileResigned(boolean) > "testEndQuorumEpochRetriesWhileResigned(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEndQuorumEpochRetriesWhileResigned(boolean) > "testEndQuorumEpochRetriesWhileResigned(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsProspective(boolean) > "testHandleVoteRequestAsProspective(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsProspective(boolean) > "testHandleVoteRequestAsProspective(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testReadRespectsMaxSizeInBytes(int) > "testReadRespectsMaxSizeInBytes(int).expectedBatches=3" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotInMiddleOfBatch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesWhenShuttingDown(boolean) > "testGrantVotesWhenShuttingDown(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotWithMissingEpoch() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testConfig() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=11, buffer=java.nio.HeapByteBuffer[pos=0 lim=11 cap=11]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=16, buffer=java.nio.HeapByteBuffer[pos=0 lim=16 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testGrantVotesWhenShuttingDown(boolean) > "testGrantVotesWhenShuttingDown(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=256, buffer=java.nio.HeapByteBuffer[pos=0 lim=256 cap=256]), expectedException=Optional[class org.apache.kafka.common.errors.CorruptRecordException]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testInvalidMemoryRecords(MemoryRecords, Optional) > "testInvalidMemoryRecords(MemoryRecords, Optional).records=MemoryRecords(size=243, buffer=java.nio.HeapByteBuffer[pos=0 lim=243 cap=256]), expectedException=Optional.empty" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testChannelWokenUpIfLingerTimeoutReachedDuringAppend(boolean) > "testChannelWokenUpIfLingerTimeoutReachedDuringAppend(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testTruncateFullyToLatestSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotFromEndOffset() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testChannelWokenUpIfLingerTimeoutReachedDuringAppend(boolean) > "testChannelWokenUpIfLingerTimeoutReachedDuringAppend(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testDoesntTruncateFully() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateSnapshotLaterThanHighWatermark() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testReadMissingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > KafkaRaftLogTest > testCreateRaftLogTruncatesFully() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > TreeMapLogHistoryTest > testAddAt() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > TreeMapLogHistoryTest > testClear() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > TreeMapLogHistoryTest > testEmpty() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > TreeMapLogHistoryTest > testTrimPrefixTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 8 > TreeMapLogHistoryTest > testTruncateTo() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderGracefulShutdown(boolean) > "testLeaderGracefulShutdown(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testLeaderGracefulShutdown(boolean) > "testLeaderGracefulShutdown(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLeaderRediscoveryAfterBrokerNotAvailableError(boolean) > "testFollowerLeaderRediscoveryAfterBrokerNotAvailableError(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLeaderRediscoveryAfterBrokerNotAvailableError(boolean) > "testFollowerLeaderRediscoveryAfterBrokerNotAvailableError(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testResignInOlderEpochIgnored(boolean) > "testResignInOlderEpochIgnored(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testResignInOlderEpochIgnored(boolean) > "testResignInOlderEpochIgnored(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleBeginQuorumRequestMoreEndpoints() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsLeaderFromStateStoreSingleMemberQuorum(boolean) > "testInitializeAsLeaderFromStateStoreSingleMemberQuorum(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsLeaderFromStateStoreSingleMemberQuorum(boolean) > "testInitializeAsLeaderFromStateStoreSingleMemberQuorum(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteRequestClusterIdValidation(boolean) > "testVoteRequestClusterIdValidation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testVoteRequestClusterIdValidation(boolean) > "testVoteRequestClusterIdValidation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsFollowerWithElectedLeader(boolean) > "testHandleVoteRequestAsFollowerWithElectedLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleVoteRequestAsFollowerWithElectedLeader(boolean) > "testHandleVoteRequestAsFollowerWithElectedLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEmptyRecordSetInFetchResponse(boolean) > "testEmptyRecordSetInFetchResponse(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testEmptyRecordSetInFetchResponse(boolean) > "testEmptyRecordSetInFetchResponse(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchTimeout(boolean) > "testPurgatoryFetchTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testPurgatoryFetchTimeout(boolean) > "testPurgatoryFetchTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumShouldNotSendAfterFetchRequest(boolean) > "testBeginQuorumShouldNotSendAfterFetchRequest(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumShouldNotSendAfterFetchRequest(boolean) > "testBeginQuorumShouldNotSendAfterFetchRequest(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterFollowerRegistration(boolean) > "testHandleLeaderChangeFiresAfterFollowerRegistration(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleLeaderChangeFiresAfterFollowerRegistration(boolean) > "testHandleLeaderChangeFiresAfterFollowerRegistration(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchResponseIgnoredAfterBecomingFollowerOfDifferentLeader(boolean) > "testFetchResponseIgnoredAfterBecomingFollowerOfDifferentLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchResponseIgnoredAfterBecomingFollowerOfDifferentLeader(boolean) > "testFetchResponseIgnoredAfterBecomingFollowerOfDifferentLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testReregistrationChangesListenerContext(boolean) > "testReregistrationChangesListenerContext(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testReregistrationChangesListenerContext(boolean) > "testReregistrationChangesListenerContext(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignIfObserver(boolean) > "testCannotResignIfObserver(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignIfObserver(boolean) > "testCannotResignIfObserver(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverGracefulShutdown(boolean) > "testObserverGracefulShutdown(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverGracefulShutdown(boolean) > "testObserverGracefulShutdown(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumNonLeader(boolean) > "testDescribeQuorumNonLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testDescribeQuorumNonLeader(boolean) > "testDescribeQuorumNonLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresAfterFollowerHighWatermarkAdvances(boolean) > "testHandleCommitCallbackFiresAfterFollowerHighWatermarkAdvances(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleCommitCallbackFiresAfterFollowerHighWatermarkAdvances(boolean) > "testHandleCommitCallbackFiresAfterFollowerHighWatermarkAdvances(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignWithLargerEpochThanCurrentEpoch(boolean) > "testCannotResignWithLargerEpochThanCurrentEpoch(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignWithLargerEpochThanCurrentEpoch(boolean) > "testCannotResignWithLargerEpochThanCurrentEpoch(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLogReconciliation(boolean) > "testFollowerLogReconciliation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFollowerLogReconciliation(boolean) > "testFollowerLogReconciliation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchResponseIgnoredAfterBecomingProspective(boolean) > "testFetchResponseIgnoredAfterBecomingProspective(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchResponseIgnoredAfterBecomingProspective(boolean) > "testFetchResponseIgnoredAfterBecomingProspective(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchShouldBeTreatedAsLeaderAcknowledgement(boolean) > "testFetchShouldBeTreatedAsLeaderAcknowledgement(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchShouldBeTreatedAsLeaderAcknowledgement(boolean) > "testFetchShouldBeTreatedAsLeaderAcknowledgement(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchRequestClusterIdValidation(boolean) > "testFetchRequestClusterIdValidation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testFetchRequestClusterIdValidation(boolean) > "testFetchRequestClusterIdValidation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignIfNotLeader(boolean) > "testCannotResignIfNotLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testCannotResignIfNotLeader(boolean) > "testCannotResignIfNotLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleValidVoteRequestAsFollower(boolean) > "testHandleValidVoteRequestAsFollower(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleValidVoteRequestAsFollower(boolean) > "testHandleValidVoteRequestAsFollower(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsFollowerAndOnlyVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testInitializeAsResignedAndOnlyVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverLeaderRediscoveryAfterRequestTimeout(boolean) > "testObserverLeaderRediscoveryAfterRequestTimeout(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testObserverLeaderRediscoveryAfterRequestTimeout(boolean) > "testObserverLeaderRediscoveryAfterRequestTimeout(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumEpochRequestClusterIdValidation(boolean) > "testBeginQuorumEpochRequestClusterIdValidation(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testBeginQuorumEpochRequestClusterIdValidation(boolean) > "testBeginQuorumEpochRequestClusterIdValidation(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleEndQuorumRequestWithLowerPriorityToBecomeLeader(boolean) > "testHandleEndQuorumRequestWithLowerPriorityToBecomeLeader(boolean).withKip853Rpc=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > KafkaRaftClientTest > testHandleEndQuorumRequestWithLowerPriorityToBecomeLeader(boolean) > "testHandleEndQuorumRequestWithLowerPriorityToBecomeLeader(boolean).withKip853Rpc=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > QuorumConfigTest > testIllegalConfig() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testAddRaftVoterRequestAckWhenCommittedNotIgnorable() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteResponseForAllVersion(short, String) > "testSingletonVoteResponseForAllVersion(short, String).version=0, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1,"voteGranted":true}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteResponseForAllVersion(short, String) > "testSingletonVoteResponseForAllVersion(short, String).version=1, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1,"voteGranted":true}]}],"nodeEndpoints":[{"nodeId":1,"host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteResponseForAllVersion(short, String) > "testSingletonVoteResponseForAllVersion(short, String).version=2, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1,"voteGranted":true}]}],"nodeEndpoints":[{"nodeId":1,"host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testRemoveVoterResponse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteRequestForAllVersion(short, String) > "testSingletonVoteRequestForAllVersion(short, String).version=0, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"replicaEpoch":1,"replicaId":1,"lastOffsetEpoch":1000,"lastOffset":1000}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteRequestForAllVersion(short, String) > "testSingletonVoteRequestForAllVersion(short, String).version=1, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","voterId":2,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"replicaEpoch":1,"replicaId":1,"replicaDirectoryId":"RX0U9QN9Qq2JhRN4yqQyxw","voterDirectoryId":"Qsz3dBrgSouJwXoJY14HmQ","lastOffsetEpoch":1000,"lastOffset":1000}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteRequestForAllVersion(short, String) > "testSingletonVoteRequestForAllVersion(short, String).version=2, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","voterId":2,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"replicaEpoch":1,"replicaId":1,"replicaDirectoryId":"RX0U9QN9Qq2JhRN4yqQyxw","voterDirectoryId":"Qsz3dBrgSouJwXoJY14HmQ","lastOffsetEpoch":1000,"lastOffset":1000,"preVote":true}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonVoteRequestForAllVersion(short, String) > "testSingletonVoteRequestForAllVersion(short, String).version=2, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","voterId":2,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"replicaEpoch":1,"replicaId":1,"replicaDirectoryId":"RX0U9QN9Qq2JhRN4yqQyxw","voterDirectoryId":"Qsz3dBrgSouJwXoJY14HmQ","lastOffsetEpoch":1000,"lastOffset":1000,"preVote":true}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testAddVoterResponse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotRequestForAllVersion(short, Uuid, String) > "testSingletonFetchSnapshotRequestForAllVersion(short, Uuid, String).version=0, directoryId=AAAAAAAAAAAAAAAAAAAAAA, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","replicaId":1,"maxBytes":1000,"topics":[{"name":"topic","partitions":[{"partition":1,"currentLeaderEpoch":1,"snapshotId":{"endOffset":10,"epoch":1},"position":10}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotRequestForAllVersion(short, Uuid, String) > "testSingletonFetchSnapshotRequestForAllVersion(short, Uuid, String).version=1, directoryId=AAAAAAAAAAAAAAAAAAAAAQ, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","replicaId":1,"maxBytes":1000,"topics":[{"name":"topic","partitions":[{"partition":1,"currentLeaderEpoch":1,"snapshotId":{"endOffset":10,"epoch":1},"position":10,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ"}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotRequestV1Compatibility(short, Uuid, String) > "testSingletonFetchSnapshotRequestV1Compatibility(short, Uuid, String).version=0, directoryId=AAAAAAAAAAAAAAAAAAAAAA, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","replicaId":1,"maxBytes":1000,"topics":[{"name":"topic","partitions":[{"partition":1,"currentLeaderEpoch":1,"snapshotId":{"endOffset":10,"epoch":1},"position":10}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotRequestV1Compatibility(short, Uuid, String) > "testSingletonFetchSnapshotRequestV1Compatibility(short, Uuid, String).version=1, directoryId=AAAAAAAAAAAAAAAAAAAAAQ, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","replicaId":1,"maxBytes":1000,"topics":[{"name":"topic","partitions":[{"partition":1,"currentLeaderEpoch":1,"snapshotId":{"endOffset":10,"epoch":1},"position":10,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ"}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=4, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"partitionMaxBytes":10}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=5, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=7, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=11, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=12, lastFetchedEpoch=10, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=15, lastFetchedEpoch=10, expectedJson={"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchRequestForAllVersion(FetchRequestTestCase) > "testSingletonFetchRequestForAllVersion(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAQ, version=17, lastFetchedEpoch=10, expectedJson={"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ"}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonEndQuorumEpochRequestForAllVersion(short, String) > "testSingletonEndQuorumEpochRequestForAllVersion(short, String).version=0, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"leaderId":1,"leaderEpoch":1,"preferredSuccessors":[1]}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonEndQuorumEpochRequestForAllVersion(short, String) > "testSingletonEndQuorumEpochRequestForAllVersion(short, String).version=1, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"leaderId":1,"leaderEpoch":1,"preferredCandidates":[{"candidateId":1,"candidateDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ"}]}]}],"leaderEndpoints":[]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testErrorResponse() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumResponseForAllVersion(short, String) > "testSingletonDescribeQuorumResponseForAllVersion(short, String).version=0, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"leaderId":1,"leaderEpoch":1,"highWatermark":1000,"currentVoters":[{"replicaId":1,"logEndOffset":-1}],"observers":[{"replicaId":1,"logEndOffset":-1}]}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumResponseForAllVersion(short, String) > "testSingletonDescribeQuorumResponseForAllVersion(short, String).version=1, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"leaderId":1,"leaderEpoch":1,"highWatermark":1000,"currentVoters":[{"replicaId":1,"logEndOffset":-1,"lastFetchTimestamp":0,"lastCaughtUpTimestamp":0}],"observers":[{"replicaId":1,"logEndOffset":-1,"lastFetchTimestamp":0,"lastCaughtUpTimestamp":0}]}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumResponseForAllVersion(short, String) > "testSingletonDescribeQuorumResponseForAllVersion(short, String).version=2, expectedJson={"errorCode":0,"errorMessage":"","topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"errorMessage":"","leaderId":1,"leaderEpoch":1,"highWatermark":1000,"currentVoters":[{"replicaId":1,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ","logEndOffset":-1,"lastFetchTimestamp":0,"lastCaughtUpTimestamp":0}],"observers":[{"replicaId":1,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ","logEndOffset":-1,"lastFetchTimestamp":0,"lastCaughtUpTimestamp":0}]}]}],"nodes":[{"nodeId":1,"listeners":[]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=4, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"partitionMaxBytes":10}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=5, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=7, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=11, lastFetchedEpoch=-1, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=12, lastFetchedEpoch=10, expectedJson={"replicaId":-1,"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topic":"topic","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAA, version=15, lastFetchedEpoch=10, expectedJson={"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testFetchRequestV17Compatibility(FetchRequestTestCase) > "testFetchRequestV17Compatibility(FetchRequestTestCase).testCase=FetchRequestTestCase[replicaDirectoryId=AAAAAAAAAAAAAAAAAAAAAQ, version=17, lastFetchedEpoch=10, expectedJson={"maxWaitMs":0,"minBytes":0,"maxBytes":2147483647,"isolationLevel":0,"sessionId":0,"sessionEpoch":-1,"topics":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partition":2,"currentLeaderEpoch":5,"fetchOffset":333,"lastFetchedEpoch":10,"logStartOffset":0,"partitionMaxBytes":10,"replicaDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ"}]}],"forgottenTopicsData":[],"rackId":""}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=4, preferredReadReplicaId=-1, expectedJson={"throttleTimeMs":0,"responses":[{"topic":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=5, preferredReadReplicaId=-1, expectedJson={"throttleTimeMs":0,"responses":[{"topic":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=7, preferredReadReplicaId=-1, expectedJson={"throttleTimeMs":0,"errorCode":0,"sessionId":0,"responses":[{"topic":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=11, preferredReadReplicaId=21, expectedJson={"throttleTimeMs":0,"errorCode":0,"sessionId":0,"responses":[{"topic":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"preferredReadReplica":21,"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=12, preferredReadReplicaId=21, expectedJson={"throttleTimeMs":0,"errorCode":0,"sessionId":0,"responses":[{"topic":"topic","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"preferredReadReplica":21,"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=13, preferredReadReplicaId=21, expectedJson={"throttleTimeMs":0,"errorCode":0,"sessionId":0,"responses":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"preferredReadReplica":21,"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchResponseForAllVersion(FetchResponseTestCase) > "testSingletonFetchResponseForAllVersion(FetchResponseTestCase).testCase=FetchResponseTestCase[version=16, preferredReadReplicaId=21, expectedJson={"throttleTimeMs":0,"errorCode":0,"sessionId":0,"responses":[{"topicId":"AAAAAAAAAAAAAAAAAAAAAQ","partitions":[{"partitionIndex":1,"errorCode":0,"highWatermark":1000,"lastStableOffset":900,"logStartOffset":10,"abortedTransactions":[{"producerId":1,"firstOffset":10}],"preferredReadReplica":21,"records":""}]}]}]" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonBeginQuorumEpochResponseForAllVersion(short, String) > "testSingletonBeginQuorumEpochResponseForAllVersion(short, String).version=0, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonBeginQuorumEpochResponseForAllVersion(short, String) > "testSingletonBeginQuorumEpochResponseForAllVersion(short, String).version=1, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1}]}],"nodeEndpoints":[{"nodeId":1,"host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonBeginQuorumEpochRequestForAllVersion(short, String) > "testSingletonBeginQuorumEpochRequestForAllVersion(short, String).version=0, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"leaderId":1,"leaderEpoch":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonBeginQuorumEpochRequestForAllVersion(short, String) > "testSingletonBeginQuorumEpochRequestForAllVersion(short, String).version=1, expectedJson={"clusterId":"I4ZmrWqfT2e-upky_4fdPA","voterId":1,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1,"voterDirectoryId":"AAAAAAAAAAAAAAAAAAAAAQ","leaderId":1,"leaderEpoch":1}]}],"leaderEndpoints":[{"name":"PLAINTEXT","host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonEndQuorumEpochResponseForAllVersion(short, String) > "testSingletonEndQuorumEpochResponseForAllVersion(short, String).version=0, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonEndQuorumEpochResponseForAllVersion(short, String) > "testSingletonEndQuorumEpochResponseForAllVersion(short, String).version=1, expectedJson={"errorCode":0,"topics":[{"topicName":"topic","partitions":[{"partitionIndex":0,"errorCode":0,"leaderId":1,"leaderEpoch":1}]}],"nodeEndpoints":[{"nodeId":1,"host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotResponseForAllVersion(short, String) > "testSingletonFetchSnapshotResponseForAllVersion(short, String).version=0, expectedJson={"throttleTimeMs":0,"errorCode":0,"topics":[{"name":"topic","partitions":[{"index":1,"errorCode":0,"snapshotId":{"endOffset":0,"epoch":0},"size":0,"position":0,"unalignedRecords":""}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonFetchSnapshotResponseForAllVersion(short, String) > "testSingletonFetchSnapshotResponseForAllVersion(short, String).version=1, expectedJson={"throttleTimeMs":0,"errorCode":0,"topics":[{"name":"topic","partitions":[{"index":1,"errorCode":0,"snapshotId":{"endOffset":0,"epoch":0},"size":0,"position":0,"unalignedRecords":""}]}],"nodeEndpoints":[{"nodeId":1,"host":"localhost","port":9990}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumRequestForAllVersion(short, String) > "testSingletonDescribeQuorumRequestForAllVersion(short, String).version=0, expectedJson={"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumRequestForAllVersion(short, String) > "testSingletonDescribeQuorumRequestForAllVersion(short, String).version=1, expectedJson={"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > RaftUtilTest > testSingletonDescribeQuorumRequestForAllVersion(short, String) > "testSingletonDescribeQuorumRequestForAllVersion(short, String).version=2, expectedJson={"topics":[{"topicName":"topic","partitions":[{"partitionIndex":1}]}]}" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > BatchMemoryPoolTest > testOversizeAllocation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > BatchMemoryPoolTest > testReleaseBufferNotMatchingBatchSize() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > BatchMemoryPoolTest > testAllocateAndRelease() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > BatchMemoryPoolTest > testMultipleAllocations() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > MemoryBatchReaderTest > testIteration() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testBatchWriteReadSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testCreateSnapshotWithSameId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testPartialWriteReadSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testBufferWriteReadSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testAbortedSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testAppendToFrozenSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testWritingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 5 > FileRawSnapshotTest > testWriteReadSnapshot() PASSED


> Task :raft:test

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testFileRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testWithAllSupportedControlRecords(ControlRecordType) > "testWithAllSupportedControlRecords(ControlRecordType).type=LEADER_CHANGE" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testWithAllSupportedControlRecords(ControlRecordType) > "testWithAllSupportedControlRecords(ControlRecordType).type=SNAPSHOT_HEADER" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testWithAllSupportedControlRecords(ControlRecordType) > "testWithAllSupportedControlRecords(ControlRecordType).type=SNAPSHOT_FOOTER" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testWithAllSupportedControlRecords(ControlRecordType) > "testWithAllSupportedControlRecords(ControlRecordType).type=KRAFT_VERSION" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testWithAllSupportedControlRecords(ControlRecordType) > "testWithAllSupportedControlRecords(ControlRecordType).type=KRAFT_VOTERS" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testControlRecordIterationWithKraftVersion0() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testControlRecordIterationWithKraftVersion1() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testMemoryRecords() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testCrcValidation() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testControlRecordTypeValues() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testEmptyRecords(Records) > "testEmptyRecords(Records).records=FileRecords(size=0, file=/var/folders/p5/76qsvrnn75x7myc5lp4b27j00000gn/T/kafka11589505586004911100.tmp, start=0, end=2147483647)" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > RecordsIteratorTest > testEmptyRecords(Records) > "testEmptyRecords(Records).records=MemoryRecords(size=0, buffer=java.nio.HeapByteBuffer[pos=0 lim=0 cap=0])" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > SnapshotWriterReaderTest > testAbortedSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > SnapshotWriterReaderTest > testSnapshotDelimiters() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > SnapshotWriterReaderTest > testAppendToFrozenSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 11 > SnapshotWriterReaderTest > testWritingSnapshot() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canMakeProgressIfMajorityIsReachable() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canElectNewLeaderAfterOldLeaderFailure() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > leadershipWillNotChangeDuringNetworkPartitionIfMajorityStillReachable() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canElectNewLeaderAfterOldLeaderPartitionedAway() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canMakeProgressAfterBackToBackLeaderFailures() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canRecoverFromSingleNodeCommittedDataLoss() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canRecoverAfterAllNodesKilled() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > leadershipAssignedOnlyOnceWithNetworkPartitionIfThereExistsMajority() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > RaftEventSimulationTest > canElectInitialLeader() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testIsVoterWithDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testOverlappingMajority() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testIsOnlyVoterInNotStandalone() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testUpdateVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testEndpoints(boolean) > "testEndpoints(boolean).withDirectoryId=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testEndpoints(boolean) > "testEndpoints(boolean).withDirectoryId=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testRemoveVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testVoterIds() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testRecordRoundTrip() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testVoterNodeIsVoterWithDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testAddVoter() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testSupportsVersion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testVoterNodeIsVoterWithoutDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testNonOverlappingMajority() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testIsVoterWithoutDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testVoterNode() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testIsOnlyVoterInStandalone() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testCannotRemoveToEmptyVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testEmptyVoterSet() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testUpdateVoterIgnoringDirectoryId() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > VoterSetTest > testVoterNodes() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testNumWaitingWithMixedCompletions() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testMultipleAwaitersWithSameThreshold() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testExpiration() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testCompleteAllExceptionally() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testThresholdCompletion() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testExpirationReducesWaitingCount() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testCompleteAll() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > ThresholdPurgatoryTest > testMaybeCompleteWithHigherValue() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testValidSnapshotFilename() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testValidPartialSnapshotFilename() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testDeleteSnapshot(boolean) > "testDeleteSnapshot(boolean).renameBeforeDeleting=true" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testDeleteSnapshot(boolean) > "testDeleteSnapshot(boolean).renameBeforeDeleting=false" PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testValidDeletedSnapshotFilename() PASSED

Gradle Test Run :raft:test > Gradle Test Executor 7 > SnapshotsTest > testInvalidSnapshotFilenames() PASSED

> Task :raft:copyTestXml SKIPPED

[Incubating] Problems report is available at: file:///Users/developseop/Desktop/kafka-18838/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.4.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 31m 58s
44 actionable tasks: 1 executed, 43 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html\n- 