### PR TITLE
KAFKA-18970: Enable client module metadata publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2018,10 +2018,6 @@ project(':clients') {
     generator project(':generator')
   }
 
-  tasks.withType(GenerateModuleMetadata) {
-    enabled = false
-  }
-
   task createVersionFile() {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId


### PR DESCRIPTION
## Summary

- Enable Gradle module metadata generation for the kafka-clients publication.

## Motivation

[KAFKA-18970](https://issues.apache.org/jira/browse/KAFKA-18970) tracks the disabled Gradle Module Metadata publication for the clients submodule. The clients publication should provide its .module metadata so Gradle consumers can resolve its published variants and capabilities.

## Validation

- `./gradlew :clients:generateMetadataFileForMavenJavaPublication --no-build-cache --console=plain`
- Verified `clients/build/publications/mavenJava/module.json` contains the `org.apache.kafka:kafka-clients` component and published variants.
- `./gradlew --no-daemon :clients:generateMetadataFileForMavenJavaPublication :clients:check --exclude-task test --no-build-cache --console=plain`
- `git diff --check`

The full `:clients:check` test task was also started. It reached the existing `KafkaProducerTest.testTopicExpiryInMetadata` test, which remained in `KafkaProducer.waitOnMetadata` for over an hour without completing; the run was interrupted after confirming the wait was unrelated to this one-line build configuration change.

Reviewers: Uros (github:uros-b)
