### PR TITLE
KAFKA-20838: Set initial rebalance delay to zero in IQv2StoreIntegrationTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -139,13 +140,9 @@ public class IQv2StoreIntegrationTest {
     private static final long WINDOW_START =
         (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
-    public static final EmbeddedKafkaCluster CLUSTER;
-    static {
-        final Properties brokerProps = new Properties();
-        // Each test application has one Streams group member, so waiting for more members only delays startup.
-        brokerProps.put(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0");
-        CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, brokerProps);
-    }
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS,
+            // Each test application has one Streams group member, so waiting for more members only delays startup.
+        Utils.mkProperties(Map.of(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0")));
     private static final Position POSITION_0 =
         Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 5L)))));
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -141,7 +141,7 @@ public class IQv2StoreIntegrationTest {
         (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS,
-            // Each test application has one Streams group member, so waiting for more members only delays startup.
+        // Each test application has one Streams group member, so waiting for more members only delays startup.
         Utils.mkProperties(Map.of(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0")));
     private static final Position POSITION_0 =
         Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 5L)))));

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -138,7 +139,13 @@ public class IQv2StoreIntegrationTest {
     private static final long WINDOW_START =
         (RECORD_TIME / WINDOW_SIZE.toMillis()) * WINDOW_SIZE.toMillis();
 
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    public static final EmbeddedKafkaCluster CLUSTER;
+    static {
+        final Properties brokerProps = new Properties();
+        // Each test application has one Streams group member, so waiting for more members only delays startup.
+        brokerProps.put(GroupCoordinatorConfig.STREAMS_GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0");
+        CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, brokerProps);
+    }
     private static final Position POSITION_0 =
         Position.fromMap(mkMap(mkEntry(INPUT_TOPIC_NAME, mkMap(mkEntry(0, 5L)))));
 


### PR DESCRIPTION
## Summary

- Set `group.streams.initial.rebalance.delay.ms=0` on this test's
embedded broker.
- Preserve the full 280-case IQv2 parameter matrix.

## Motivation

Each invocation starts exactly one `KafkaStreams` instance with
`num.stream.threads=1`. It does not add stream threads or start another
instance with the same `application.id`, and every invocation uses a
distinct application ID. Restore and global consumers are not
application-group members. Therefore, each affected Streams group has
one member.

The suite covers stores, DSL/PAPI, caching, logging, headers, and both
group protocols. It validates IQv2 store/query behavior, not initial
group formation, so the default delay only adds idle time.

Local JDK 21 results:

- Baseline: 953.808s; 280 passed; 216 delay warnings.
- Modified: 679.107s; 280 passed; no delay warnings; 28.8% faster.
- Modified rerun: 668.169s; 280 passed; no delay warnings; 30.0% faster.

The setting is scoped to this test's embedded broker. The classic group
protocol is unaffected.

## Testing

```text
./gradlew :streams:integration-tests:test \
  --tests '*IQv2StoreIntegrationTest' \
  --rerun -PmaxParallelForks=1
```

Final validation on the latest `upstream/trunk`: 280 tests passed, 0
failures,
0 errors, 678.436s, and no initial-delay warnings.

Reviewers: TengYao Chi <frankvicky@apache.org>, Chia-Ping Tsai
 <chia7712@gmail.com>, Uros (github:uros-b), Ken Huang
 <s7133700@gmail.com>
