### PR TITLE
HOTFIX: Remove Time.SYSTEM from ProducerMetadata

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/producer/ProducerMetadataAddBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/producer/ProducerMetadataAddBenchmark.java
@@ -72,7 +72,7 @@ public class ProducerMetadataAddBenchmark {
         }
 
         metadata = new ProducerMetadata(100L, 1000L, TimeUnit.MINUTES.toMillis(5), METADATA_IDLE_MS,
-            new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
+            new LogContext(), new ClusterResourceListeners());
 
         long nowMs = Time.SYSTEM.milliseconds();
         for (String topic : topics) {


### PR DESCRIPTION
Followup from
https://github.com/apache/kafka/pull/22083#issuecomment-5087539668

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
