### PR TITLE
KAFKA-20839: Fix metadata.version stuck at MINIMUM_KRAFT_VERSION when…

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -20,6 +20,7 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.metadata.AbortTransactionRecord;
 import org.apache.kafka.common.metadata.BeginTransactionRecord;
 import org.apache.kafka.common.metadata.EndTransactionRecord;
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
 import org.apache.kafka.metadata.migration.ZkMigrationState;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -121,7 +122,8 @@ public class ActivationRecordsGenerator {
         long transactionStartOffset,
         boolean zkMigrationEnabled,
         FeatureControlManager featureControl,
-        MetadataVersion metadataVersion
+        MetadataVersion metadataVersion,
+        BootstrapMetadata bootstrapMetadata
     ) {
         StringBuilder logMessageBuilder = new StringBuilder("Performing controller activation. ");
 
@@ -145,10 +147,16 @@ public class ActivationRecordsGenerator {
         }
 
         if (metadataVersion.equals(MetadataVersion.MINIMUM_KRAFT_VERSION)) {
+            MetadataVersion bootstrapVersion = bootstrapMetadata.metadataVersion();
             logMessageBuilder.append("No metadata.version feature level record was found in the log. ")
-                .append("Treating the log as version ")
-                .append(MetadataVersion.MINIMUM_KRAFT_VERSION)
-                .append(". ");
+                .append("Writing metadata.version ")
+                .append(bootstrapVersion)
+                .append(" from bootstrap source '")
+                .append(bootstrapMetadata.source())
+                .append("'. ");
+            records.add(new ApiMessageAndVersion(new FeatureLevelRecord()
+                .setName(MetadataVersion.FEATURE_NAME)
+                .setFeatureLevel(bootstrapVersion.featureLevel()), (short) 0));
         }
 
         // In 3.9, we moved the minimum MV for migrations to 3.6. For non-empty logs, we allow the older 3.4 MV
@@ -232,7 +240,7 @@ public class ActivationRecordsGenerator {
                 bootstrapMetadata, bootstrapMetadata.metadataVersion());
         } else {
             return recordsForNonEmptyLog(activationMessageConsumer, transactionStartOffset, zkMigrationEnabled,
-                featureControl, featureControl.metadataVersion());
+                featureControl, featureControl.metadataVersion(), bootstrapMetadata);
         }
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -38,6 +38,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ActivationRecordsGeneratorTest {
 
+    private static final BootstrapMetadata TEST_BOOTSTRAP =
+        BootstrapMetadata.fromVersion(MetadataVersion.latestProduction(), "test");
+
     @Test
     public void testActivationMessageForEmptyLog() {
         ControllerResult<Void> result;
@@ -170,21 +173,22 @@ public class ActivationRecordsGeneratorTest {
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. No metadata.version feature level " +
-                "record was found in the log. Treating the log as version 3.0-IV1.", logMsg),
+                "record was found in the log. Writing metadata.version " + MetadataVersion.latestProduction() +
+                " from bootstrap source 'test'.", logMsg),
             -1L,
             false,
             buildFeatureControl(MetadataVersion.MINIMUM_KRAFT_VERSION, Optional.empty()),
-            MetadataVersion.MINIMUM_KRAFT_VERSION
+            MetadataVersion.MINIMUM_KRAFT_VERSION, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
-        assertEquals(0, result.records().size());
+        assertEquals(1, result.records().size());
 
         result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation.", logMsg),
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_3_IV0, Optional.empty()),
-            MetadataVersion.IBP_3_3_IV0
+            MetadataVersion.IBP_3_3_IV0, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -195,7 +199,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
-            MetadataVersion.IBP_3_4_IV0
+            MetadataVersion.IBP_3_4_IV0, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -207,7 +211,7 @@ public class ActivationRecordsGeneratorTest {
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(1, result.records().size());
@@ -221,7 +225,7 @@ public class ActivationRecordsGeneratorTest {
                     42L,
                     false,
                     buildFeatureControl(MetadataVersion.IBP_3_6_IV0, Optional.empty()),
-                    MetadataVersion.IBP_3_6_IV0
+                    MetadataVersion.IBP_3_6_IV0, TEST_BOOTSTRAP
                 )).getMessage()
         );
     }
@@ -238,7 +242,7 @@ public class ActivationRecordsGeneratorTest {
                     -1L,
                     true,
                     buildFeatureControl(MetadataVersion.IBP_3_3_IV0, Optional.empty()),
-                    MetadataVersion.IBP_3_3_IV0
+                    MetadataVersion.IBP_3_3_IV0, TEST_BOOTSTRAP
                 )).getMessage()
         );
 
@@ -250,7 +254,7 @@ public class ActivationRecordsGeneratorTest {
                     -1L,
                     true,
                     buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
-                    MetadataVersion.IBP_3_4_IV0
+                    MetadataVersion.IBP_3_4_IV0, TEST_BOOTSTRAP
                 )).getMessage()
         );
 
@@ -262,7 +266,7 @@ public class ActivationRecordsGeneratorTest {
                     -1L,
                     true,
                     buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),
-                    MetadataVersion.IBP_3_6_IV1
+                    MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
                 )
             ).getMessage()
         );
@@ -273,7 +277,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             true,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.PRE_MIGRATION)),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -284,7 +288,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             true,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.MIGRATION)),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -296,7 +300,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.MIGRATION)),
-            MetadataVersion.IBP_3_4_IV0
+            MetadataVersion.IBP_3_4_IV0, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(1, result.records().size());
@@ -308,7 +312,7 @@ public class ActivationRecordsGeneratorTest {
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.MIGRATION)),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(2, result.records().size());
@@ -319,7 +323,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.POST_MIGRATION)),
-            MetadataVersion.IBP_3_4_IV0
+            MetadataVersion.IBP_3_4_IV0, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -330,7 +334,7 @@ public class ActivationRecordsGeneratorTest {
             42L,
             false,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.POST_MIGRATION)),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(1, result.records().size());
@@ -342,7 +346,7 @@ public class ActivationRecordsGeneratorTest {
             -1L,
             true,
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.POST_MIGRATION)),
-            MetadataVersion.IBP_3_4_IV0
+            MetadataVersion.IBP_3_4_IV0, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(0, result.records().size());
@@ -354,7 +358,7 @@ public class ActivationRecordsGeneratorTest {
             42L,
             true,
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.POST_MIGRATION)),
-            MetadataVersion.IBP_3_6_IV1
+            MetadataVersion.IBP_3_6_IV1, TEST_BOOTSTRAP
         );
         assertTrue(result.isAtomic());
         assertEquals(1, result.records().size());


### PR DESCRIPTION
Description                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                 
  When a KRaft controller is activated on a non-empty metadata log that lacks a FeatureLevelRecord for metadata.version, the ActivationRecordsGenerator.recordsForNonEmptyLog() method only logs a warning but does not write the missing record. This causes                    
  FeatureControlManager to fall back to MINIMUM_KRAFT_VERSION (3.0-IV1), and the cluster's metadata.version remains permanently stuck at this value.                                                                                                                             
                                                                                                                                                                                                                                                                                 
  Root Cause                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                 
  This happens when the controller loses a leadership race during initial bootstrap activation:                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                 
  1. Controller formats metadata log with metadata.version = 3.9-IV0 (from BootstrapMetadata)                                                                                                                                                                                    
  2. On first activation, recordsForEmptyLog() is called and writes bootstrap records (including the FeatureLevelRecord for metadata.version)                                                                                                                                    
  3. If the controller loses leadership mid-write, some records are committed but the FeatureLevelRecord may be lost                                                                                                                                                             
  4. When the controller regains leadership, the log is non-empty but lacks the FeatureLevelRecord — recordsForNonEmptyLog() takes effect but previously only logged a warning without fixing the problem                                                                        
                                                                                                                                                                                                                                                                                 
  Impact                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                 
  - metadata.version permanently stuck at 3.0-IV1                                                                                                                                                                                                                                
  - KIP-919 features broken: --bootstrap-controller returns UnsupportedVersionException: Direct-to-controller communication is not supported with the current MetadataVersion                                                                                                    
  - Dynamic controller registration unavailable                                                                                                                                                                                                                                  
  - All features gated behind metadata.version >= 3.7-IV0 are blocked                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                 
  Reproduction                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                 
  1. Deploy a fresh KRaft 3.9.x cluster                                                                                                                                                                                                                                          
  2. During initial controller activation, trigger a leadership re-election (e.g., network partition)                                                                                                                                                                            
  3. Once the controller stabilizes, check metadata.version:                                                                                                                                                                                                                     
  kafka-features.sh --bootstrap-server <broker:9092> describe                                                                                                                                                                                                                    
  4. metadata.version shows 3.0-IV1 instead of 3.9-IV0                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                 
  Fix                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                 
  In ActivationRecordsGenerator.recordsForNonEmptyLog(), when the current metadataVersion equals MINIMUM_KRAFT_VERSION and the log lacks a FeatureLevelRecord, write one using the version from BootstrapMetadata (which was correctly set during kafka-storage format).         
                                                                                                                                                                                                                                                                                 
  Workaround                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                 
  Users affected by this bug can manually upgrade metadata.version after the controller stabilizes:                                                                                                                                                                              
  kafka-features.sh --bootstrap-server <broker:9092> upgrade --feature metadata.version=3.9

Reviewers: José Armando García Sancio <jsancio@apache.org>
