### PR TITLE
MINOR: Rewrite testListTopicsWithOptionListInternal

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicCollection;
@@ -142,21 +141,15 @@ public class AdminMetadataTest {
     @ClusterTest
     public void testListTopicsWithOptionListInternal() throws Exception {
         try (Admin admin = clusterInstance.admin()) {
-            String topic = "test-topic";
-            admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).all().get();
-            clusterInstance.waitTopicCreation(topic, 1);
+            admin.createTopics(List.of(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, 1, (short) 1))).all().get();
+            clusterInstance.waitTopicCreation(Topic.GROUP_METADATA_TOPIC_NAME, 1);
 
-            try (Consumer<byte[], byte[]> consumer = clusterInstance.consumer()) {
-                consumer.subscribe(List.of(topic));
-                consumer.poll(Duration.ofMillis(100));
-            }
-
-            TestUtils.waitForCondition(() -> {
-                Set<String> topicNames = admin.listTopics(new ListTopicsOptions().listInternal(true)).names().get();
-                return topicNames.contains(Topic.GROUP_METADATA_TOPIC_NAME);
-            }, "Expected to see internal topic " + Topic.GROUP_METADATA_TOPIC_NAME);
+            Set<String> topicNames = admin.listTopics(new ListTopicsOptions().listInternal(true)).names().get();
+            assertTrue(topicNames.contains(Topic.GROUP_METADATA_TOPIC_NAME),
+                "Expected to see internal topic " + Topic.GROUP_METADATA_TOPIC_NAME);
         }
     }
+
 
     @ClusterTest
     public void testDescribeTopicsWithOptionPartitionSizeLimitPerResponse() throws Exception {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -140,10 +140,8 @@ public class AdminMetadataTest {
 
     @ClusterTest
     public void testListTopicsWithOptionListInternal() throws Exception {
+        clusterInstance.createTopic(Topic.GROUP_METADATA_TOPIC_NAME, 1, (short) 1);
         try (Admin admin = clusterInstance.admin()) {
-            admin.createTopics(List.of(new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, 1, (short) 1))).all().get();
-            clusterInstance.waitTopicCreation(Topic.GROUP_METADATA_TOPIC_NAME, 1);
-
             Set<String> topicNames = admin.listTopics(new ListTopicsOptions().listInternal(true)).names().get();
             assertTrue(topicNames.contains(Topic.GROUP_METADATA_TOPIC_NAME),
                 "Expected to see internal topic " + Topic.GROUP_METADATA_TOPIC_NAME);

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -150,7 +150,6 @@ public class AdminMetadataTest {
         }
     }
 
-
     @ClusterTest
     public void testDescribeTopicsWithOptionPartitionSizeLimitPerResponse() throws Exception {
         try (Admin admin = clusterInstance.admin()) {


### PR DESCRIPTION
Rewrite `testListTopicsWithOptionListInternal` to explicitly create the
`__consumer_offsets`  topic via Admin rather than relying on a
`consumer.poll(100ms)` to trigger group formation.

The Scala predecessor of this test relied on
`IntegrationTestHarness.setUp()`
pre-creating `__consumer_offsets` via `createOffsetsTopic()`. The Java
migration in
#22290 replaced that with a `consumer.subscribe` + `poll(100ms)`
sequence, which
races against internal group join timing.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
