### PR TITLE
MINOR: deflake AdminMetadataTest

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -108,7 +108,6 @@ public class AdminMetadataTest {
     public void testDescribeCluster() throws Exception {
         try (Admin admin = clusterInstance.admin()) {
             DescribeClusterResult result = admin.describeCluster();
-            Collection<Node> nodes = result.nodes().get();
             assertEquals(clusterInstance.clusterId(), result.clusterId().get());
 
             // In KRaft, we return a random brokerId as the current controller.
@@ -116,8 +115,11 @@ public class AdminMetadataTest {
             assertTrue(clusterInstance.brokerIds().contains(controller.id()));
 
             Set<String> brokerEndpoints = Set.of(clusterInstance.bootstrapServers().split(","));
-            assertEquals(brokerEndpoints.size(), nodes.size());
-            for (Node node : nodes) {
+            TestUtils.waitForCondition(
+                    () -> admin.describeCluster().nodes().get().size() == brokerEndpoints.size(),
+                    "Timed out waiting for all brokers to be discovered");
+
+            for (Node node : admin.describeCluster().nodes().get()) {
                 String hostStr = node.host() + ":" + node.port();
                 assertTrue(brokerEndpoints.contains(hostStr),
                         "Unknown host:port pair " + hostStr + " in brokerVersionInfos");

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.BeforeEach;
+
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +59,11 @@ public class AdminMetadataTest {
 
     AdminMetadataTest(ClusterInstance clusterInstance) {
         this.clusterInstance = clusterInstance;
+    }
+
+    @BeforeEach
+    public void setup() throws InterruptedException {
+        clusterInstance.waitForReadyBrokers();
     }
 
     @ClusterTest
@@ -108,6 +115,7 @@ public class AdminMetadataTest {
     public void testDescribeCluster() throws Exception {
         try (Admin admin = clusterInstance.admin()) {
             DescribeClusterResult result = admin.describeCluster();
+            Collection<Node> nodes = result.nodes().get();
             assertEquals(clusterInstance.clusterId(), result.clusterId().get());
 
             // In KRaft, we return a random brokerId as the current controller.
@@ -115,11 +123,8 @@ public class AdminMetadataTest {
             assertTrue(clusterInstance.brokerIds().contains(controller.id()));
 
             Set<String> brokerEndpoints = Set.of(clusterInstance.bootstrapServers().split(","));
-            TestUtils.waitForCondition(
-                    () -> admin.describeCluster().nodes().get().size() == brokerEndpoints.size(),
-                    "Timed out waiting for all brokers to be discovered");
-
-            for (Node node : admin.describeCluster().nodes().get()) {
+            assertEquals(brokerEndpoints.size(), nodes.size());
+            for (Node node : nodes) {
                 String hostStr = node.host() + ":" + node.port();
                 assertTrue(brokerEndpoints.contains(hostStr),
                         "Unknown host:port pair " + hostStr + " in brokerVersionInfos");

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AdminMetadataTest.java
@@ -30,8 +30,6 @@ import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.test.TestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,11 +57,6 @@ public class AdminMetadataTest {
 
     AdminMetadataTest(ClusterInstance clusterInstance) {
         this.clusterInstance = clusterInstance;
-    }
-
-    @BeforeEach
-    public void setup() throws InterruptedException {
-        clusterInstance.waitForReadyBrokers();
     }
 
     @ClusterTest
@@ -113,6 +106,7 @@ public class AdminMetadataTest {
 
     @ClusterTest
     public void testDescribeCluster() throws Exception {
+        clusterInstance.waitForReadyBrokers();
         try (Admin admin = clusterInstance.admin()) {
             DescribeClusterResult result = admin.describeCluster();
             Collection<Node> nodes = result.nodes().get();


### PR DESCRIPTION
ClusterTest harness only waits for brokers to reach RUNNING, not for all
of them to be registered and propagated, so a single describeCluster()
can race with metadata propagation and see fewer brokers.   Adding a
wait until all of them have been discovered.

Reviewers: Lianet Magrans <lmagrans@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
