### PR TITLE
KAFKA-20845: Don't flush empty batch when appending large records in group coordinator

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -700,25 +700,9 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         log.warn("Tried to flush an empty batch for {}.", tp);
                         // There should not be any deferred events attached to the batch. We fail
                         // the batch just in case. As a side effect, coordinator state is also
-                        // reverted. There are (at least) two cases to consider which can result in
-                        // revertible coordinator state changes:
-                        //  1. The previous failed write operation was non-replaying and updated
-                        //     coordinator state directly. We can't persist its records because they
-                        //     weren't added to the batch successfully, so we must revert the
-                        //     coordinator state changes to keep the coordinator state in sync with
-                        //     the log.
-                        //  2. The current write operation is non-replaying and has updated
-                        //     coordinator state directly. After this flush, it will append its
-                        //     records to the log. We must revert state changes due to case 1, which
-                        //     means we must also throw to avoid appending records to the log. We
-                        //     pick a retriable exception, so that a previous failed write operation
-                        //     doesn't cause a fatal error.
-                        //
-                        //  NB: The handling of empty batches is still not fully correct. If there
-                        //      is no attempt to flush the empty batch before appending new records,
-                        //      we end up keeping coordinator state changes from case 1 without
-                        //      corresponding records written to the log.
-                        throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
+                        // reverted, but there should be no changes since the batch was empty.
+                        failCurrentBatch(new IllegalStateException("Record batch was empty"));
+                        return;
                     }
 
                     long flushStartMs = time.milliseconds();

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -960,8 +960,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         recordsToAppend
                     );
 
-                    if (!currentBatch.builder.hasRoomFor(estimatedSizeUpperBound) &&
-                        currentBatch.builder.numRecords() > 0) {
+                    if (currentBatch.builder.numRecords() > 0 &&
+                        !currentBatch.builder.hasRoomFor(estimatedSizeUpperBound)) {
                         // Start a new batch when the total uncompressed data size would exceed
                         // the max batch size. We still allow atomic writes with an uncompressed size
                         // larger than the max batch size as long as they compress down to under the max

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -960,7 +960,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         recordsToAppend
                     );
 
-                    if (!currentBatch.builder.hasRoomFor(estimatedSizeUpperBound)) {
+                    if (!currentBatch.builder.hasRoomFor(estimatedSizeUpperBound) &&
+                        currentBatch.builder.numRecords() > 0) {
                         // Start a new batch when the total uncompressed data size would exceed
                         // the max batch size. We still allow atomic writes with an uncompressed size
                         // larger than the max batch size as long as they compress down to under the max

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -697,7 +697,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     if (currentBatch.builder.numRecords() == 0) {
                         // The only way we can get here is if append() has failed in an unexpected
                         // way and left an empty batch. Try to clean it up.
-                        log.debug("Tried to flush an empty batch for {}.", tp);
+                        log.warn("Tried to flush an empty batch for {}.", tp);
                         // There should not be any deferred events attached to the batch. We fail
                         // the batch just in case. As a side effect, coordinator state is also
                         // reverted, but there should be no changes since the batch was empty.

--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -700,9 +700,25 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         log.warn("Tried to flush an empty batch for {}.", tp);
                         // There should not be any deferred events attached to the batch. We fail
                         // the batch just in case. As a side effect, coordinator state is also
-                        // reverted, but there should be no changes since the batch was empty.
-                        failCurrentBatch(new IllegalStateException("Record batch was empty"));
-                        return;
+                        // reverted. There are (at least) two cases to consider which can result in
+                        // revertible coordinator state changes:
+                        //  1. The previous failed write operation was non-replaying and updated
+                        //     coordinator state directly. We can't persist its records because they
+                        //     weren't added to the batch successfully, so we must revert the
+                        //     coordinator state changes to keep the coordinator state in sync with
+                        //     the log.
+                        //  2. The current write operation is non-replaying and has updated
+                        //     coordinator state directly. After this flush, it will append its
+                        //     records to the log. We must revert state changes due to case 1, which
+                        //     means we must also throw to avoid appending records to the log. We
+                        //     pick a retriable exception, so that a previous failed write operation
+                        //     doesn't cause a fatal error.
+                        //
+                        //  NB: The handling of empty batches is still not fully correct. If there
+                        //      is no attempt to flush the empty batch before appending new records,
+                        //      we end up keeping coordinator state changes from case 1 without
+                        //      corresponding records written to the log.
+                        throw Errors.COORDINATOR_NOT_AVAILABLE.exception();
                     }
 
                     long flushStartMs = time.milliseconds();

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.coordinator.common.runtime;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
@@ -5003,8 +5004,6 @@ public class CoordinatorRuntimeTest {
         assertEquals("response2", write2.get(5, TimeUnit.SECONDS));
 
         // Complete transaction #1. It will flush the current empty batch.
-        // The coordinator must not try to write an empty batch, otherwise the mock partition writer
-        // will throw an exception.
         // Use TV_1 since this test doesn't check epoch validation
         CompletableFuture<Void> complete1 = runtime.scheduleTransactionCompletion(
             "complete#1",
@@ -5016,12 +5015,12 @@ public class CoordinatorRuntimeTest {
             TransactionVersion.TV_1.featureLevel()
         );
 
-        // Verify that the completion is not committed yet.
-        assertFalse(complete1.isDone());
-
-        // Commit and verify that writes are completed.
-        writer.commit(TP);
-        assertNull(complete1.get(5, TimeUnit.SECONDS));
+        // Complete transaction #1 should fail.
+        // The coordinator must fail the empty batch *and* throw (see explanation in
+        // flushCurrentBatch), so the completion fails with a retriable error.
+        assertFutureThrows(CoordinatorNotAvailableException.class, complete1);
+        assertNull(ctx.currentBatch);
+        assertEquals(List.of(), writer.entries(TP));
     }
 
     @Test

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -5339,7 +5339,7 @@ public class CoordinatorRuntimeTest {
     }
 
     @Test
-    public void testLargeCompressibleRecordSucceeds() throws Exception {
+    public void testLargeCompressibleRecordDoesNotFlushEmptyBatch() throws Exception {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();
         Compression compression = Compression.gzip().build();

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.coordinator.common.runtime;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.compress.Compression;
-import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
@@ -5004,6 +5003,8 @@ public class CoordinatorRuntimeTest {
         assertEquals("response2", write2.get(5, TimeUnit.SECONDS));
 
         // Complete transaction #1. It will flush the current empty batch.
+        // The coordinator must not try to write an empty batch, otherwise the mock partition writer
+        // will throw an exception.
         // Use TV_1 since this test doesn't check epoch validation
         CompletableFuture<Void> complete1 = runtime.scheduleTransactionCompletion(
             "complete#1",
@@ -5015,12 +5016,12 @@ public class CoordinatorRuntimeTest {
             TransactionVersion.TV_1.featureLevel()
         );
 
-        // Complete transaction #1 should fail.
-        // The coordinator must fail the empty batch *and* throw (see explanation in
-        // flushCurrentBatch), so the completion fails with a retriable error.
-        assertFutureThrows(CoordinatorNotAvailableException.class, complete1);
-        assertNull(ctx.currentBatch);
-        assertEquals(List.of(), writer.entries(TP));
+        // Verify that the completion is not committed yet.
+        assertFalse(complete1.isDone());
+
+        // Commit and verify that writes are completed.
+        writer.commit(TP);
+        assertNull(complete1.get(5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -5339,6 +5339,72 @@ public class CoordinatorRuntimeTest {
     }
 
     @Test
+    public void testLargeCompressibleRecordSucceeds() throws Exception {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = new MockPartitionWriter();
+        Compression compression = Compression.gzip().build();
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withWriteTimeout(Duration.ofMillis(30))
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
+                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withCompression(compression)
+                .withSerializer(new StringSerializer())
+                .withAppendLingerMs(OptionalInt.of(10))
+                .withExecutorService(mock(ExecutorService.class))
+                .withCachedBufferMaxBytesSupplier(() -> CACHED_BUFFER_MAX_BYTES)
+                .build();
+
+        // Schedule the loading.
+        runtime.scheduleLoadOperation(TP, 10);
+
+        // Verify the initial state.
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        assertNull(ctx.currentBatch);
+        assertEquals(0, ctx.batchEpoch);
+
+        // Get the max batch size.
+        int maxBatchSize = writer.config(TP).maxMessageSize();
+
+        // Create a large record of highly compressible data.
+        List<String> largeRecord = List.of("a".repeat(3 * maxBatchSize));
+
+        // Write the large record. The record does not fit in an empty batch uncompressed,
+        // but it fits once compressed, so it goes into a batch on its own. The batch is
+        // flushed immediately because it has no room left.
+        long batchTimestamp = timer.time().milliseconds();
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP,
+            state -> new CoordinatorResult<>(largeRecord, "response1")
+        );
+
+        // Verify the state.
+        assertEquals(1L, ctx.coordinator.lastWrittenOffset());
+        assertEquals(0L, ctx.coordinator.lastCommittedOffset());
+        assertEquals(List.of(
+            new MockCoordinatorShard.RecordAndMetadata(0, largeRecord.get(0))
+        ), ctx.coordinator.coordinator().fullRecords());
+        assertEquals(List.of(
+            records(batchTimestamp, compression, largeRecord)
+        ), writer.entries(TP));
+
+        // KAFKA-20845: Only a single batch must have been created and flushed.
+        assertEquals(1, ctx.batchEpoch);
+
+        // Commit and verify that the write is completed.
+        writer.commit(TP);
+        assertTrue(write.isDone());
+        assertEquals(1L, ctx.coordinator.lastCommittedOffset());
+        assertEquals("response1", write.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void testLargeCompressibleRecordTriggersFlushAndSucceeds() throws Exception {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -5393,7 +5393,9 @@ public class CoordinatorRuntimeTest {
             records(batchTimestamp, compression, largeRecord)
         ), writer.entries(TP));
 
-        // KAFKA-20845: Only a single batch must have been created and flushed.
+        // KAFKA-20845: Only a single batch must have been created and flushed. When the write is
+        //              non-replaying and has made in-memory changes, both the in-memory changes and
+        //              the records must be attached to the same batch.
         assertEquals(1, ctx.batchEpoch);
 
         // Commit and verify that the write is completed.


### PR DESCRIPTION
When appending records, we create a new batch if no batch exists.
KAFKA-19760 introduced a flush of any existing batch when appending
large records, to maximize our chances of compressing the records under
the max.message.bytes. When these two things happen in the same append
operation, we flush an empty batch.

Flushing an empty batch is written to fail and revert the coordinator
state. This would be harmless, except some group coordinator operations
update the coordinator state directly without replay. Upon appending
their records and triggering the empty batch flush, their state changes
are then reverted while their records are written. The group
coordinator's in-memory state diverges from the on-disk state and
subsequent writes for the group can be invalid for the on-disk state.
eg. we may have a consumer group downgraded to a classic group, followed
by consumer group records which is invalid.

Do not flush empty batches when appending large records.

Reviewers: nileshkumar3 <nileshkumar3@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>, Dongnuo Lyu <dlyu@confluent.io>, David Jacot
 <david.jacot@gmail.com>
