### PR TITLE
MINOR: bind only on loopback in SelectorTest/SslSelectorTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
@@ -688,7 +689,7 @@ public class SelectorTest {
             new HashMap<>(), true, false, channelBuilder, pool, new LogContext());
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
-            ss.bind(new InetSocketAddress(0));
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
             InetSocketAddress serverAddress = (InetSocketAddress) ss.getLocalAddress();
 
@@ -822,7 +823,7 @@ public class SelectorTest {
         int conns = 5;
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
-            ss.bind(new InetSocketAddress(0));
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             InetSocketAddress serverAddress = (InetSocketAddress) ss.getLocalAddress();
 
             for (int i = 0; i < conns; i++) {
@@ -849,7 +850,7 @@ public class SelectorTest {
         Map<String, String> knownNameAndVersion = softwareNameAndVersionTags("A", "B");
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
-            ss.bind(new InetSocketAddress(0));
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             InetSocketAddress serverAddress = (InetSocketAddress) ss.getLocalAddress();
 
             Thread sender = createSender(serverAddress, randomPayload(1));

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
@@ -260,7 +261,7 @@ public abstract class SslSelectorTest extends SelectorTest {
                 new HashMap<>(), true, false, channelBuilder, pool, new LogContext());
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
-            ss.bind(new InetSocketAddress(0));
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
             InetSocketAddress serverAddress = (InetSocketAddress) ss.getLocalAddress();
 


### PR DESCRIPTION
SslSelectorTest/SelectorTest have test methods which attempt to bind a socket on all interfaces. This is excessive and interferes on dev machines with full tunnel VPNs.

This change modifies the bind call to use the loopback interface instead.

Reviewers: Uros (github:uros-b), Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
