### PR TITLE
MINOR: Fix blog post link in uses.md

### DIFF
--- a/docs/getting-started/uses.md
+++ b/docs/getting-started/uses.md
@@ -26,7 +26,7 @@ type: docs
 -->
 
 
-Here is a description of a few of the popular use cases for Apache Kafka®. For an overview of a number of these areas in action, see [this blog post](https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying/). 
+Here is a description of a few of the popular use cases for Apache Kafka®. For an overview of a number of these areas in action, see [this blog post](https://www.linkedin.com/blog/engineering/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying). 
 
 ## Messaging
 


### PR DESCRIPTION
Updated the link to the blog post about Apache Kafka use cases.

[Onboarding docu](https://kafka.apache.org/uses/) had a link pointing to
LinkedIn Engineering blog, which was non functional. The actual link was
pasted.

Reviewers: Ken Huang <s7133700@gmail.com>, Mickael Maison
 <mickael.maison@gmail.com>
