### PR TITLE
KAFKA-20851 spotless gradle plugin version update: 8.4.0 -->> 8.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ plugins {
   id "com.github.spotbugs" version '6.5.9' apply false
   id 'org.scoverage' version '9.1' apply false
   id 'com.gradleup.shadow' version '9.6.1' apply false
-  id 'com.diffplug.spotless' version "8.4.0"
+  id 'com.diffplug.spotless' version "8.9.0"
 
   // Pre-register the KIP-1265 checker so `apply plugin:` resolves it inside subprojects { }.
   // The plugin itself ships from the `:api-checker` included build (see settings.gradle's


### PR DESCRIPTION
See KAFKA-20851 for more details (and testing procedure).

Note: verified locally:
 - `./gradlew build -x test` passes (spotlessCheck + checkstyle + spotbugs + compile all green)
 - `./gradlew clean spotlessApply --rerun-tasks --no-build-cache` ran 700 times with 0 failures

Testing ideas are borrowed from these PR's:
- #22012
- #22025

Release notes links:
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.9.0
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.8.0
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.7.0
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.6.0
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.1
 - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.0