### PR TITLE
MINOR: De-duplicate the metering lifecycle across Metered*WithHeaders iterators

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
@@ -86,7 +86,10 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
         return iter.hasNext();
     }
 
-    public void close() {
+    // Final: this owns the metering lifecycle (sensor recording, numOpenIterators decrement,
+    // openIterators deregistration). A subclass that overrode it and forgot super.close() would
+    // silently drop the decrement and deregistration. Subclasses vary only in next()/hasNext().
+    public final void close() {
         try {
             iter.close();
         } finally {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
@@ -70,8 +70,11 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
         openIterators.add(this);
     }
 
+    // Final: the constructor's openIterators.add(this) sorts through this via the set's
+    // startTimestamp comparator, i.e. on a not-yet-fully-constructed object. Keeping it final stops a
+    // subclass from overriding it with something that reads its own not-yet-assigned state.
     @Override
-    public long startTimestamp() {
+    public final long startTimestamp() {
         return startTimestampMs;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
@@ -18,30 +18,30 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
 
 import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
- * Shared metering lifecycle for the {@code Metered*WithHeaders} iterators that back the
- * headers-aware IQv2 range/window/session query types and yield {@link ReadOnlyRecord}s.
+ * Shared metering lifecycle for the metered iterators of the {@code Metered*WithHeaders} stores,
+ * whatever result type they yield: the {@code KeyValueIterator}s returned by the store's own range/
+ * fetch/find methods and the {@code ReadOnlyRecordIterator}s that back the headers-aware IQv2
+ * range/window/session query types.
  *
  * <p>Every such iterator opens over a raw {@code KeyValueIterator<RawKey, byte[]>} and needs the
  * same bookkeeping: stamp the open time (for the {@code oldest-iterator-open-since-ms} metric),
  * register in {@code numOpenIterators}/{@code openIterators}, and on {@link #close()} record the
- * operation and iterator-duration sensors and deregister. Only {@link #next()} genuinely differs
- * per store -- raw key/value types, value deserialization, key derivation, timestamp source, and
- * whether a negative/absent timestamp is rejected -- so subclasses implement just that.
+ * operation and iterator-duration sensors and deregister. This base is deliberately result-type
+ * agnostic -- it implements only {@link MeteredIterator} and does not bind the yielded key/value
+ * types -- so each subclass declares its own result interface (a {@code KeyValueIterator} or a
+ * {@code ReadOnlyRecordIterator}) and implements just the parts that genuinely differ: the
+ * deserializing {@code next()} (and, for the {@code KeyValueIterator}s, a peeking {@code hasNext()}
+ * and {@code peekNextKey()}).
  *
  * @param <RawKey> the raw iterator's key type
- * @param <K>      the {@link ReadOnlyRecord} key type
- * @param <V>      the {@link ReadOnlyRecord} value type
  */
-abstract class AbstractMeteredReadOnlyRecordIterator<RawKey, K, V>
-    implements ReadOnlyRecordIterator<K, V>, MeteredIterator {
+abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
 
     final KeyValueIterator<RawKey, byte[]> iter;
     private final Sensor operationSensor;
@@ -52,12 +52,12 @@ abstract class AbstractMeteredReadOnlyRecordIterator<RawKey, K, V>
     private final long startNs;
     private final long startTimestampMs;
 
-    AbstractMeteredReadOnlyRecordIterator(final KeyValueIterator<RawKey, byte[]> iter,
-                                          final Sensor operationSensor,
-                                          final Sensor iteratorSensor,
-                                          final Time time,
-                                          final LongAdder numOpenIterators,
-                                          final Set<MeteredIterator> openIterators) {
+    AbstractMeteredIterator(final KeyValueIterator<RawKey, byte[]> iter,
+                            final Sensor operationSensor,
+                            final Sensor iteratorSensor,
+                            final Time time,
+                            final LongAdder numOpenIterators,
+                            final Set<MeteredIterator> openIterators) {
         this.iter = iter;
         this.operationSensor = operationSensor;
         this.iteratorSensor = iteratorSensor;
@@ -75,12 +75,14 @@ abstract class AbstractMeteredReadOnlyRecordIterator<RawKey, K, V>
         return startTimestampMs;
     }
 
-    @Override
+    /**
+     * Delegates to the raw iterator. Subclasses that buffer a peeked element (the
+     * {@code KeyValueIterator}s) override this to also account for the buffered element.
+     */
     public boolean hasNext() {
         return iter.hasNext();
     }
 
-    @Override
     public void close() {
         try {
             iter.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredReadOnlyRecordIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredReadOnlyRecordIterator.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+
+import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Shared metering lifecycle for the {@code Metered*WithHeaders} iterators that back the
+ * headers-aware IQv2 range/window/session query types and yield {@link ReadOnlyRecord}s.
+ *
+ * <p>Every such iterator opens over a raw {@code KeyValueIterator<RawKey, byte[]>} and needs the
+ * same bookkeeping: stamp the open time (for the {@code oldest-iterator-open-since-ms} metric),
+ * register in {@code numOpenIterators}/{@code openIterators}, and on {@link #close()} record the
+ * operation and iterator-duration sensors and deregister. Only {@link #next()} genuinely differs
+ * per store -- raw key/value types, value deserialization, key derivation, timestamp source, and
+ * whether a negative/absent timestamp is rejected -- so subclasses implement just that.
+ *
+ * @param <RawKey> the raw iterator's key type
+ * @param <K>      the {@link ReadOnlyRecord} key type
+ * @param <V>      the {@link ReadOnlyRecord} value type
+ */
+abstract class AbstractMeteredReadOnlyRecordIterator<RawKey, K, V>
+    implements ReadOnlyRecordIterator<K, V>, MeteredIterator {
+
+    final KeyValueIterator<RawKey, byte[]> iter;
+    private final Sensor operationSensor;
+    private final Sensor iteratorSensor;
+    private final Time time;
+    private final LongAdder numOpenIterators;
+    private final Set<MeteredIterator> openIterators;
+    private final long startNs;
+    private final long startTimestampMs;
+
+    AbstractMeteredReadOnlyRecordIterator(final KeyValueIterator<RawKey, byte[]> iter,
+                                          final Sensor operationSensor,
+                                          final Sensor iteratorSensor,
+                                          final Time time,
+                                          final LongAdder numOpenIterators,
+                                          final Set<MeteredIterator> openIterators) {
+        this.iter = iter;
+        this.operationSensor = operationSensor;
+        this.iteratorSensor = iteratorSensor;
+        this.time = time;
+        this.numOpenIterators = numOpenIterators;
+        this.openIterators = openIterators;
+        this.startNs = time.nanoseconds();
+        this.startTimestampMs = time.milliseconds();
+        numOpenIterators.increment();
+        openIterators.add(this);
+    }
+
+    @Override
+    public long startTimestamp() {
+        return startTimestampMs;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iter.hasNext();
+    }
+
+    @Override
+    public void close() {
+        try {
+            iter.close();
+        } finally {
+            final long duration = time.nanoseconds() - startNs;
+            operationSensor.record(duration);
+            iteratorSensor.record(duration);
+            numOpenIterators.decrement();
+            openIterators.remove(this);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeaders.java
@@ -585,30 +585,12 @@ public class MeteredSessionStoreWithHeaders<K, AGG>
      * non-negative when the window is constructed, so this iterator's {@code next()} can never throw.
      */
     private class MeteredSessionWithHeadersReadOnlyRecordIterator
-        implements ReadOnlyRecordIterator<Windowed<K>, AGG>, MeteredIterator {
-
-        private final KeyValueIterator<Windowed<Bytes>, byte[]> iter;
-        private final long startNs;
-        private final long startTimestampMs;
+        extends AbstractMeteredReadOnlyRecordIterator<Windowed<Bytes>, Windowed<K>, AGG> {
 
         private MeteredSessionWithHeadersReadOnlyRecordIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> iter
         ) {
-            this.iter = iter;
-            this.startNs = time.nanoseconds();
-            this.startTimestampMs = time.milliseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
-        }
-
-        @Override
-        public long startTimestamp() {
-            return startTimestampMs;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return iter.hasNext();
+            super(iter, fetchSensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
         }
 
         @Override
@@ -625,19 +607,6 @@ public class MeteredSessionStoreWithHeaders<K, AGG>
                 headers);
             ((RecordHeaders) record.headers()).setReadOnly();
             return record;
-        }
-
-        @Override
-        public void close() {
-            try {
-                iter.close();
-            } finally {
-                final long duration = time.nanoseconds() - startNs;
-                fetchSensor.record(duration);
-                iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
-            }
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeaders.java
@@ -510,24 +510,13 @@ public class MeteredSessionStoreWithHeaders<K, AGG>
     }
 
     private class MeteredSessionStoreWithHeadersIterator
-        implements KeyValueIterator<Windowed<K>, AggregationWithHeaders<AGG>>, MeteredIterator {
+        extends AbstractMeteredIterator<Windowed<Bytes>>
+        implements KeyValueIterator<Windowed<K>, AggregationWithHeaders<AGG>> {
 
-        private final KeyValueIterator<Windowed<Bytes>, byte[]> iter;
-        private final long startNs;
-        private final long startTimestampMs;
         private KeyValue<Windowed<K>, AggregationWithHeaders<AGG>> cachedNext;
 
         private MeteredSessionStoreWithHeadersIterator(final KeyValueIterator<Windowed<Bytes>, byte[]> iter) {
-            this.iter = iter;
-            this.startNs = time.nanoseconds();
-            this.startTimestampMs = time.milliseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
-        }
-
-        @Override
-        public long startTimestamp() {
-            return startTimestampMs;
+            super(iter, fetchSensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
         }
 
         @Override
@@ -553,19 +542,6 @@ public class MeteredSessionStoreWithHeaders<K, AGG>
         }
 
         @Override
-        public void close() {
-            try {
-                iter.close();
-            } finally {
-                final long duration = time.nanoseconds() - startNs;
-                fetchSensor.record(duration);
-                iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
-            }
-        }
-
-        @Override
         public Windowed<K> peekNextKey() {
             if (cachedNext == null) {
                 cachedNext = next();
@@ -585,7 +561,8 @@ public class MeteredSessionStoreWithHeaders<K, AGG>
      * non-negative when the window is constructed, so this iterator's {@code next()} can never throw.
      */
     private class MeteredSessionWithHeadersReadOnlyRecordIterator
-        extends AbstractMeteredReadOnlyRecordIterator<Windowed<Bytes>, Windowed<K>, AGG> {
+        extends AbstractMeteredIterator<Windowed<Bytes>>
+        implements ReadOnlyRecordIterator<Windowed<K>, AGG> {
 
         private MeteredSessionWithHeadersReadOnlyRecordIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> iter

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -657,48 +657,9 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
         return new MeteredTimestampedKeyValueStoreWithHeadersIterator(store.reverseAll(), allSensor);
     }
 
-    /**
-     * Shared scaffolding for the metered iterators below: tracks {@code num-open-iterators},
-     * {@code oldest-iterator-open-since-ms}, and per-operation iterator duration, and delegates
-     * closing the wrapped raw iterator. Subclasses only need to implement the deserializing
-     * {@code next()}/{@code hasNext()} (and, where applicable, {@code peekNextKey()}).
-     */
-    private abstract class AbstractMeteredIterator implements MeteredIterator {
-
-        final KeyValueIterator<Bytes, byte[]> iter;
-        private final Sensor sensor;
-        private final long startNs;
-        private final long startTimestampMs;
-
-        AbstractMeteredIterator(final KeyValueIterator<Bytes, byte[]> iter, final Sensor sensor) {
-            this.iter = iter;
-            this.sensor = sensor;
-            this.startNs = time.nanoseconds();
-            this.startTimestampMs = time.milliseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
-        }
-
-        @Override
-        public long startTimestamp() {
-            return startTimestampMs;
-        }
-
-        public void close() {
-            try {
-                iter.close();
-            } finally {
-                final long duration = time.nanoseconds() - startNs;
-                sensor.record(duration);
-                iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
-            }
-        }
-    }
-
     @SuppressWarnings("unchecked")
-    private class MeteredTimestampedKeyValueStoreWithHeadersQueryIterator extends AbstractMeteredIterator implements KeyValueIterator<K, V> {
+    private class MeteredTimestampedKeyValueStoreWithHeadersQueryIterator
+        extends AbstractMeteredIterator<Bytes> implements KeyValueIterator<K, V> {
 
         private final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer;
 
@@ -711,7 +672,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer,
             final boolean returnPlainValue
         ) {
-            super(iter, sensor);
+            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
             this.valueTimestampHeadersDeserializer = valueTimestampHeadersDeserializer;
             this.returnPlainValue = returnPlainValue;
         }
@@ -777,7 +738,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
      * {@code next()} throws.
      */
     private class MeteredTimestampedKeyValueStoreWithHeadersReadOnlyRecordIterator
-        extends AbstractMeteredReadOnlyRecordIterator<Bytes, K, V> {
+        extends AbstractMeteredIterator<Bytes> implements ReadOnlyRecordIterator<K, V> {
 
         private final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer;
 
@@ -812,7 +773,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
     }
 
     private class MeteredTimestampedKeyValueStoreWithHeadersIterator
-        extends AbstractMeteredIterator implements KeyValueIterator<K, ValueTimestampHeaders<V>> {
+        extends AbstractMeteredIterator<Bytes> implements KeyValueIterator<K, ValueTimestampHeaders<V>> {
 
         private KeyValue<K, ValueTimestampHeaders<V>> cachedNext;
 
@@ -820,7 +781,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final KeyValueIterator<Bytes, byte[]> iter,
             final Sensor sensor
         ) {
-            super(iter, sensor);
+            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -777,7 +777,7 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
      * {@code next()} throws.
      */
     private class MeteredTimestampedKeyValueStoreWithHeadersReadOnlyRecordIterator
-        extends AbstractMeteredIterator implements ReadOnlyRecordIterator<K, V> {
+        extends AbstractMeteredReadOnlyRecordIterator<Bytes, K, V> {
 
         private final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer;
 
@@ -786,13 +786,8 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
             final Sensor sensor,
             final Function<byte[], ValueTimestampHeaders<V>> valueTimestampHeadersDeserializer
         ) {
-            super(iter, sensor);
+            super(iter, sensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
             this.valueTimestampHeadersDeserializer = valueTimestampHeadersDeserializer;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return iter.hasNext();
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
@@ -563,25 +563,14 @@ public class MeteredTimestampedWindowStoreWithHeaders<K, V>
     }
 
     private class MeteredTimestampedWindowStoreWithHeadersKeyValueIterator
-        implements KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>>, MeteredIterator {
+        extends AbstractMeteredIterator<Windowed<Bytes>>
+        implements KeyValueIterator<Windowed<K>, ValueTimestampHeaders<V>> {
 
-        private final KeyValueIterator<Windowed<Bytes>, byte[]> iter;
-        private final long startNs;
-        private final long startTimestampMs;
         private KeyValue<Windowed<K>, ValueTimestampHeaders<V>> cachedNext;
 
         private MeteredTimestampedWindowStoreWithHeadersKeyValueIterator(
             final KeyValueIterator<Windowed<Bytes>, byte[]> iter) {
-            this.iter = iter;
-            this.startNs = time.nanoseconds();
-            this.startTimestampMs = time.milliseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
-        }
-
-        @Override
-        public long startTimestamp() {
-            return this.startTimestampMs;
+            super(iter, fetchSensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
         }
 
         @Override
@@ -603,19 +592,6 @@ public class MeteredTimestampedWindowStoreWithHeaders<K, V>
             final K key = deserializeKey(next.key.key().get(), headers);
             final Windowed<K> windowedKey = new Windowed<>(key, next.key.window());
             return KeyValue.pair(windowedKey, valueTimestampHeaders);
-        }
-
-        @Override
-        public void close() {
-            try {
-                iter.close();
-            } finally {
-                final long duration = time.nanoseconds() - startNs;
-                fetchSensor.record(duration);
-                iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
-            }
         }
 
         @Override
@@ -662,7 +638,8 @@ public class MeteredTimestampedWindowStoreWithHeaders<K, V>
      *                 result, or a {@code Windowed<Bytes>} for a range result
      */
     private class MeteredWindowStoreWithHeadersReadOnlyRecordIterator<RawKey>
-        extends AbstractMeteredReadOnlyRecordIterator<RawKey, Windowed<K>, V> {
+        extends AbstractMeteredIterator<RawKey>
+        implements ReadOnlyRecordIterator<Windowed<K>, V> {
 
         private final BiFunction<RawKey, Headers, Windowed<K>> toWindowedKey;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeaders.java
@@ -662,33 +662,16 @@ public class MeteredTimestampedWindowStoreWithHeaders<K, V>
      *                 result, or a {@code Windowed<Bytes>} for a range result
      */
     private class MeteredWindowStoreWithHeadersReadOnlyRecordIterator<RawKey>
-        implements ReadOnlyRecordIterator<Windowed<K>, V>, MeteredIterator {
+        extends AbstractMeteredReadOnlyRecordIterator<RawKey, Windowed<K>, V> {
 
-        private final KeyValueIterator<RawKey, byte[]> iter;
         private final BiFunction<RawKey, Headers, Windowed<K>> toWindowedKey;
-        private final long startNs;
-        private final long startTimestampMs;
 
         private MeteredWindowStoreWithHeadersReadOnlyRecordIterator(
             final KeyValueIterator<RawKey, byte[]> iter,
             final BiFunction<RawKey, Headers, Windowed<K>> toWindowedKey
         ) {
-            this.iter = iter;
+            super(iter, fetchSensor, iteratorDurationSensor, time, numOpenIterators, openIterators);
             this.toWindowedKey = toWindowedKey;
-            this.startNs = time.nanoseconds();
-            this.startTimestampMs = time.milliseconds();
-            numOpenIterators.increment();
-            openIterators.add(this);
-        }
-
-        @Override
-        public long startTimestamp() {
-            return startTimestampMs;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return iter.hasNext();
         }
 
         @Override
@@ -721,19 +704,6 @@ public class MeteredTimestampedWindowStoreWithHeaders<K, V>
                 headers);
             ((RecordHeaders) record.headers()).setReadOnly();
             return record;
-        }
-
-        @Override
-        public void close() {
-            try {
-                iter.close();
-            } finally {
-                final long duration = time.nanoseconds() - startNs;
-                fetchSensor.record(duration);
-                iteratorDurationSensor.record(duration);
-                numOpenIterators.decrement();
-                openIterators.remove(this);
-            }
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -678,24 +679,38 @@ public class MeteredSessionStoreWithHeadersTest {
         init();
 
         when(innerStore.query(any(), any(PositionBound.class), any(QueryConfig.class)))
-            .thenReturn((QueryResult) QueryResult.forResult(new KeyValueIteratorStub<>(
-                Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator())));
+            .thenReturn(
+                (QueryResult) QueryResult.forResult(new KeyValueIteratorStub<>(
+                    Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator())),
+                (QueryResult) QueryResult.forResult(new KeyValueIteratorStub<>(
+                    Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator())));
 
-        final KafkaMetric iteratorDurationMetric = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
         final KafkaMetric fetchLatencyMetric = metric("fetch-latency-avg");
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
-        final QueryResult<ReadOnlyRecordIterator<Windowed<String>, String>> result = store.query(
-            TimestampedWindowRangeWithHeadersQuery.<String, String>withKey(KEY),
-            PositionBound.unbounded(),
-            new QueryConfig(false));
-        assertTrue(result.isSuccess());
-        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = result.getResult()) {
-            // nothing to iterate; just hold it open, then close
-            mockTime.sleep(100L);
+        // Two samples (2ms then 3ms), deterministic under mockTime, so avg (2.5ms) and max (3ms) differ
+        // and are pinned exactly -- one sample would leave avg == max.
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = store.query(
+                TimestampedWindowRangeWithHeadersQuery.<String, String>withKey(KEY),
+                PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
+            mockTime.sleep(2);
         }
 
-        assertTrue((Double) iteratorDurationMetric.metricValue() > 0.0);
-        assertTrue((Double) fetchLatencyMetric.metricValue() > 0.0);
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
+
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = store.query(
+                TimestampedWindowRangeWithHeadersQuery.<String, String>withKey(KEY),
+                PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
+            mockTime.sleep(3);
+        }
+
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
+        assertTrue((double) fetchLatencyMetric.metricValue() > 0.0);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
@@ -716,7 +716,9 @@ public class MeteredSessionStoreWithHeadersTest {
 
         assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
         assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
-        assertTrue((double) fetchLatencyMetric.metricValue() > 0.0);
+        // fetchSensor is recorded only from the iterator's close() on this path, so the two samples
+        // (2ms, 3ms) average to exactly 2.5ms.
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) fetchLatencyMetric.metricValue());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
@@ -647,25 +647,31 @@ public class MeteredSessionStoreWithHeadersTest {
         setUp();
         init();
 
-        final Headers headers = new RecordHeaders();
-        headers.add("key1", "value1".getBytes());
-        final AggregationWithHeaders<String> valueAndHeaders = AggregationWithHeaders.make(VALUE, headers);
-
-        final AggregationWithHeadersSerializer<String> serializer = new AggregationWithHeadersSerializer<>(Serdes.String().serializer());
-        final byte[] serializedValue = serializer.serialize(CHANGELOG_TOPIC, valueAndHeaders);
-
         when(innerStore.fetch(KEY_BYTES))
-            .thenReturn(new KeyValueIteratorStub<>(
-                Collections.singleton(KeyValue.pair(WINDOWED_KEY_BYTES, serializedValue)).iterator()));
+            .thenReturn(
+                new KeyValueIteratorStub<>(Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator()),
+                new KeyValueIteratorStub<>(Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator()));
 
-        final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(KEY);
+        final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
-        mockTime.sleep(100L);
+        // Two samples (2ms then 3ms) so avg (2.5ms) and max (3ms) differ -- one sample would leave them
+        // identical and not actually pin avg. Mirrors the KV sibling shouldTimeIteratorDuration.
+        try (KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(KEY)) {
+            mockTime.sleep(2);
+        }
 
-        iterator.close();
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
-        final KafkaMetric iteratorDurationMetric = metric("iterator-duration-avg");
-        assertTrue((Double) iteratorDurationMetric.metricValue() > 0.0);
+        try (KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(KEY)) {
+            mockTime.sleep(3);
+        }
+
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     // The above shouldTimeIteratorDuration goes through store.fetch() -> the KeyValueIterator sibling.

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
@@ -667,6 +667,37 @@ public class MeteredSessionStoreWithHeadersTest {
         assertTrue((Double) iteratorDurationMetric.metricValue() > 0.0);
     }
 
+    // The above shouldTimeIteratorDuration goes through store.fetch() -> the KeyValueIterator sibling.
+    // This pins the same close()-path recording for the ReadOnlyRecordIterator that backs
+    // TimestampedWindowRangeWithHeadersQuery.withKey, whose close() records both the operation sensor
+    // (fetch) and the iterator-duration sensor via the shared AbstractMeteredIterator lifecycle.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void shouldTimeIteratorDurationForTimestampedWindowRangeWithHeadersQuery() {
+        setUp();
+        init();
+
+        when(innerStore.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn((QueryResult) QueryResult.forResult(new KeyValueIteratorStub<>(
+                Collections.<KeyValue<Windowed<Bytes>, byte[]>>emptyList().iterator())));
+
+        final KafkaMetric iteratorDurationMetric = metric("iterator-duration-avg");
+        final KafkaMetric fetchLatencyMetric = metric("fetch-latency-avg");
+
+        final QueryResult<ReadOnlyRecordIterator<Windowed<String>, String>> result = store.query(
+            TimestampedWindowRangeWithHeadersQuery.<String, String>withKey(KEY),
+            PositionBound.unbounded(),
+            new QueryConfig(false));
+        assertTrue(result.isSuccess());
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = result.getResult()) {
+            // nothing to iterate; just hold it open, then close
+            mockTime.sleep(100L);
+        }
+
+        assertTrue((Double) iteratorDurationMetric.metricValue() > 0.0);
+        assertTrue((Double) fetchLatencyMetric.metricValue() > 0.0);
+    }
+
     @Test
     public void shouldRemoveMetricsOnClose() {
         setUp();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
@@ -670,7 +670,9 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
 
         assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
         assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
-        assertTrue((double) getLatencyAvgMetric.metricValue() > 0.0);
+        // getSensor is recorded only from the iterator's close() on this path, so the two samples
+        // (2ms, 3ms) average to exactly 2.5ms.
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) getLatencyAvgMetric.metricValue());
     }
 
     @SuppressWarnings("unused")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
@@ -639,7 +639,9 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
     public void shouldTimeIteratorDurationForTimestampedRangeWithHeadersQuery() {
         setUp();
         when(inner.query(any(), any(PositionBound.class), any(QueryConfig.class)))
-                .thenReturn((QueryResult) QueryResult.forResult(KeyValueIterators.emptyIterator()));
+                .thenReturn(
+                    (QueryResult) QueryResult.forResult(KeyValueIterators.emptyIterator()),
+                    (QueryResult) QueryResult.forResult(KeyValueIterators.emptyIterator()));
         init();
 
         final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
@@ -651,15 +653,23 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
         assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
         assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
-        final QueryResult<ReadOnlyRecordIterator<String, String>> result = metered.query(
-                TimestampedRangeWithHeadersQuery.withNoBounds(), PositionBound.unbounded(), new QueryConfig(false));
-        try (ReadOnlyRecordIterator<String, String> iterator = result.getResult()) {
-            // nothing to iterate; just hold it open, then close
+        // Two samples (2ms then 3ms) so avg (2.5ms) and max (3ms) differ -- one sample would leave them
+        // identical and not actually pin avg. Mirrors the sibling shouldTimeIteratorDuration above.
+        try (ReadOnlyRecordIterator<String, String> iterator = metered.query(
+                TimestampedRangeWithHeadersQuery.<String, String>withNoBounds(), PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
             mockTime.sleep(2);
         }
 
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
+
+        try (ReadOnlyRecordIterator<String, String> iterator = metered.query(
+                TimestampedRangeWithHeadersQuery.<String, String>withNoBounds(), PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
+            mockTime.sleep(3);
+        }
+
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
         assertTrue((double) getLatencyAvgMetric.metricValue() > 0.0);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
@@ -629,6 +629,40 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
         assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
+    // The above shouldTimeIteratorDuration goes through metered.all() -> the KeyValueIterator sibling.
+    // This pins the same close()-path recording for the ReadOnlyRecordIterator that backs
+    // TimestampedRangeWithHeadersQuery, whose close() records both the operation sensor (get) and the
+    // iterator-duration sensor. All three Metered*WithHeaders ReadOnlyRecordIterators now share that
+    // close() via AbstractMeteredIterator, so this also guards the shared lifecycle.
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTimeIteratorDurationForTimestampedRangeWithHeadersQuery() {
+        setUp();
+        when(inner.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+                .thenReturn((QueryResult) QueryResult.forResult(KeyValueIterators.emptyIterator()));
+        init();
+
+        final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
+        final KafkaMetric getLatencyAvgMetric = metric("get-latency-avg");
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
+        assertNotNull(getLatencyAvgMetric);
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
+
+        final QueryResult<ReadOnlyRecordIterator<String, String>> result = metered.query(
+                TimestampedRangeWithHeadersQuery.withNoBounds(), PositionBound.unbounded(), new QueryConfig(false));
+        try (ReadOnlyRecordIterator<String, String> iterator = result.getResult()) {
+            // nothing to iterate; just hold it open, then close
+            mockTime.sleep(2);
+        }
+
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
+        assertTrue((double) getLatencyAvgMetric.metricValue() > 0.0);
+    }
+
     @SuppressWarnings("unused")
     @Test
     public void shouldTrackOldestOpenIteratorTimestamp() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -630,20 +630,28 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
     public void shouldTimeIteratorDuration() {
         setUp();
         store.init(context, store);
-        when(innerStoreMock.all()).thenReturn(windowRangeIterator(List.of()));
+        when(innerStoreMock.all()).thenReturn(windowRangeIterator(List.of()), windowRangeIterator(List.of()));
 
         final KafkaMetric iteratorDurationAvg = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMax = metric("iterator-duration-max");
         assertEquals(Double.NaN, (Double) iteratorDurationAvg.metricValue());
         assertEquals(Double.NaN, (Double) iteratorDurationMax.metricValue());
 
+        // Two samples (2ms then 3ms) so avg (2.5ms) and max (3ms) differ -- one sample would leave them
+        // identical and not actually pin avg.
         try (KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
-            // nothing to iterate; just hold it open, then close
             mockTime.sleep(2);
         }
 
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
+
+        try (KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
+            mockTime.sleep(3);
+        }
+
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
     }
 
     // The above shouldTimeIteratorDuration goes through store.all() -> the KeyValueIterator sibling.
@@ -656,7 +664,9 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
         setUp();
         store.init(context, store);
         when(innerStoreMock.query(any(), any(PositionBound.class), any(QueryConfig.class)))
-            .thenReturn((QueryResult) QueryResult.forResult(windowKeyIterator(List.of())));
+            .thenReturn(
+                (QueryResult) QueryResult.forResult(windowKeyIterator(List.of())),
+                (QueryResult) QueryResult.forResult(windowKeyIterator(List.of())));
 
         final KafkaMetric iteratorDurationAvg = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMax = metric("iterator-duration-max");
@@ -664,18 +674,27 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
         assertEquals(Double.NaN, (Double) iteratorDurationAvg.metricValue());
         assertEquals(Double.NaN, (Double) iteratorDurationMax.metricValue());
 
-        final QueryResult<ReadOnlyRecordIterator<Windowed<String>, String>> result = store.query(
-            TimestampedWindowKeyWithHeadersQuery.<String, String>withKeyAndWindowStartRange(
-                KEY, Instant.ofEpochMilli(5), Instant.ofEpochMilli(100)),
-            PositionBound.unbounded(),
-            new QueryConfig(false));
-        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = result.getResult()) {
-            // nothing to iterate; just hold it open, then close
+        // Two samples (2ms then 3ms) so avg (2.5ms) and max (3ms) differ -- one sample would leave them
+        // identical and not actually pin avg. Mirrors the sibling shouldTimeIteratorDuration above.
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = store.query(
+                TimestampedWindowKeyWithHeadersQuery.<String, String>withKeyAndWindowStartRange(
+                    KEY, Instant.ofEpochMilli(5), Instant.ofEpochMilli(100)),
+                PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
             mockTime.sleep(2);
         }
 
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
         assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
+
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = store.query(
+                TimestampedWindowKeyWithHeadersQuery.<String, String>withKeyAndWindowStartRange(
+                    KEY, Instant.ofEpochMilli(5), Instant.ofEpochMilli(100)),
+                PositionBound.unbounded(), new QueryConfig(false)).getResult()) {
+            mockTime.sleep(3);
+        }
+
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
         assertTrue((double) fetchLatencyAvg.metricValue() > 0.0);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -695,7 +695,9 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
 
         assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
         assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
-        assertTrue((double) fetchLatencyAvg.metricValue() > 0.0);
+        // fetchSensor is recorded only from the iterator's close() on this path, so the two samples
+        // (2ms, 3ms) average to exactly 2.5ms.
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) fetchLatencyAvg.metricValue());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedWindowStoreWithHeadersTest.java
@@ -74,6 +74,7 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -110,6 +111,7 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
     private WindowStore<Bytes, byte[]> innerStoreMock;
     private final Metrics metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.DEBUG));
     private MeteredTimestampedWindowStoreWithHeaders<String, String> store;
+    private MockTime mockTime;
     private Deserializer<String> keyDeserializer;
 
     public void setUp() {
@@ -130,11 +132,12 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
 
         when(innerStoreMock.name()).thenReturn(STORE_NAME);
 
+        mockTime = new MockTime();
         store = new MeteredTimestampedWindowStoreWithHeaders<>(
             innerStoreMock,
             WINDOW_SIZE_MS, // any size
             STORE_TYPE,
-            new MockTime(),
+            mockTime,
             Serdes.String(),
             new ValueTimestampHeadersSerde<>(new SerdeThatDoesntHandleNull())
         );
@@ -619,6 +622,63 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
         assertEquals(-1L, (Long) openIterators.metricValue());
     }
 
+    // The window store previously had no iterator-duration coverage at all. This mirrors the
+    // session/KV shouldTimeIteratorDuration: it goes through store.all() -> the KeyValueIterator
+    // sibling, whose close() records the operation (fetch) and iterator-duration sensors via the
+    // shared AbstractMeteredIterator lifecycle.
+    @Test
+    public void shouldTimeIteratorDuration() {
+        setUp();
+        store.init(context, store);
+        when(innerStoreMock.all()).thenReturn(windowRangeIterator(List.of()));
+
+        final KafkaMetric iteratorDurationAvg = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationMax = metric("iterator-duration-max");
+        assertEquals(Double.NaN, (Double) iteratorDurationAvg.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMax.metricValue());
+
+        try (KeyValueIterator<Windowed<String>, ValueTimestampHeaders<String>> iterator = store.all()) {
+            // nothing to iterate; just hold it open, then close
+            mockTime.sleep(2);
+        }
+
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
+    }
+
+    // The above shouldTimeIteratorDuration goes through store.all() -> the KeyValueIterator sibling.
+    // This pins the same close()-path recording for the ReadOnlyRecordIterator that backs
+    // TimestampedWindowKeyWithHeadersQuery, whose close() records both the operation sensor (fetch)
+    // and the iterator-duration sensor via the shared AbstractMeteredIterator lifecycle.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void shouldTimeIteratorDurationForTimestampedWindowKeyWithHeadersQuery() {
+        setUp();
+        store.init(context, store);
+        when(innerStoreMock.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn((QueryResult) QueryResult.forResult(windowKeyIterator(List.of())));
+
+        final KafkaMetric iteratorDurationAvg = metric("iterator-duration-avg");
+        final KafkaMetric iteratorDurationMax = metric("iterator-duration-max");
+        final KafkaMetric fetchLatencyAvg = metric("fetch-latency-avg");
+        assertEquals(Double.NaN, (Double) iteratorDurationAvg.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMax.metricValue());
+
+        final QueryResult<ReadOnlyRecordIterator<Windowed<String>, String>> result = store.query(
+            TimestampedWindowKeyWithHeadersQuery.<String, String>withKeyAndWindowStartRange(
+                KEY, Instant.ofEpochMilli(5), Instant.ofEpochMilli(100)),
+            PositionBound.unbounded(),
+            new QueryConfig(false));
+        try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = result.getResult()) {
+            // nothing to iterate; just hold it open, then close
+            mockTime.sleep(2);
+        }
+
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvg.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMax.metricValue());
+        assertTrue((double) fetchLatencyAvg.metricValue() > 0.0);
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void shouldLeaveIteratorOpenWhenNextThrowsAndNotClosed() {
@@ -889,10 +949,14 @@ public class MeteredTimestampedWindowStoreWithHeadersTest {
     }
 
     private KafkaMetric numOpenIteratorsMetric() {
+        return metric("num-open-iterators");
+    }
+
+    private KafkaMetric metric(final String name) {
         return metrics.metrics().entrySet().stream()
-                .filter(entry -> entry.getKey().name().equals("num-open-iterators"))
+                .filter(entry -> entry.getKey().name().equals(name))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("num-open-iterators metric not registered"))
+                .orElseThrow(() -> new AssertionError(name + " metric not registered"))
                 .getValue();
     }
 }


### PR DESCRIPTION
The metered iterators backing the headers-aware IQv2 query types and the
`Metered*WithHeaders` stores' own range/fetch/find methods each
hand-rolled the same  metering lifecycle: stamping the open time (for
`oldest-iterator-open-since-ms`),  registering in
`numOpenIterators`/`openIterators`, and recording the operation and
iterator-duration sensors on `close()`. Only `next()` (and, for the
`KeyValueIterator`  ones, `peekNextKey()`/`hasNext()`) genuinely differs
per store.

Extract that lifecycle into a shared, result-type-agnostic
`AbstractMeteredIterator<RawKey>`  (implements `MeteredIterator`). All
seven `Metered*WithHeaders` iterators now extend it and  declare their
own result interface:

- three `ReadOnlyRecordIterator` iterators (the session /
timestamped-window /
  timestamped-key-value headers query results), and
- four `KeyValueIterator` iterators (the session and timestamped-window
`KeyValueIterator`
  siblings, plus the timestamped-key-value query and plain iterators).

This also folds away the former per-file `AbstractMeteredIterator`
inside `MeteredTimestampedKeyValueStoreWithHeaders`, so there is a
single metering base.  `startTimestamp()` and `close()` are `final`: the
constructor registers `this` in a  `startTimestamp`-ordered set (so a
subclass must not override `startTimestamp()` with  not-yet-assigned
state), and `close()` owns the sensor recording, `numOpenIterators`
decrement and `openIterators` deregistration (so a subclass must not
silently drop them).

Adds iterator-duration close-path tests across the three stores (two
samples each, pinning avg vs max and the operation sensor exactly),
including the window store's first duration coverage.

Follow-ups (out of scope, tracked separately): migrating the non-headers
metered iterators  (`MeteredWindowedKeyValueIterator`,
`MeteredWindowStoreIterator`, `MeteredKeyValueStoreIterator`)  onto this
base; KAFKA-20902 (oldest-iterator metric same-millisecond collision);
KAFKA-20922 (TimestampedRangeWithHeadersQuery iterator can NPE on a
null-deserialized value).

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Suman Pal
 (github:sumanpal97), Bill Bejeck <bbejeck@apache.org>
