### PR TITLE
MINOR: Complete nodeApiVersions future when describeFeatures fails

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4606,7 +4606,8 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             void handleFailure(Throwable throwable) {
-                completeAllExceptionally(Collections.singletonList(future), throwable);
+                future.completeExceptionally(throwable);
+                nodeApiVersionsFuture.completeExceptionally(throwable);
             }
         };
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
+import org.apache.kafka.clients.admin.internals.InternalDescribeFeaturesResult;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
@@ -9027,10 +9028,10 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(
                 body -> body instanceof ApiVersionsRequest,
                 prepareApiVersionsResponseForDescribeFeatures(Errors.NONE));
-            final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(
-                new DescribeFeaturesOptions().timeoutMs(10000)).featureMetadata();
-            final FeatureMetadata metadata = future.get();
-            assertEquals(defaultFeatureMetadata(), metadata);
+            final var result = (InternalDescribeFeaturesResult) env.adminClient().describeFeatures(
+                new DescribeFeaturesOptions().timeoutMs(10000));
+            assertEquals(defaultFeatureMetadata(), result.featureMetadata().get());
+            assertNotNull(result.nodeApiVersions().get().apiVersion(ApiKeys.API_VERSIONS));
         }
     }
 
@@ -9042,9 +9043,9 @@ public class KafkaAdminClientTest {
                 prepareApiVersionsResponseForDescribeFeatures(Errors.INVALID_REQUEST));
             final DescribeFeaturesOptions options = new DescribeFeaturesOptions();
             options.timeoutMs(10000);
-            final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(options).featureMetadata();
-            final ExecutionException e = assertThrows(ExecutionException.class, future::get);
-            assertEquals(Errors.INVALID_REQUEST.exception().getClass(), e.getCause().getClass());
+            final var result = (InternalDescribeFeaturesResult) env.adminClient().describeFeatures(options);
+            TestUtils.assertFutureThrows(InvalidRequestException.class, result.featureMetadata());
+            TestUtils.assertFutureThrows(InvalidRequestException.class, result.nodeApiVersions());
         }
     }
 
@@ -9069,9 +9070,10 @@ public class KafkaAdminClientTest {
                 body -> body instanceof ApiVersionsRequest,
                 prepareApiVersionsResponseForDescribeFeatures(Errors.NONE),
                 env.cluster().nodeById(1));
-            final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(
-                new DescribeFeaturesOptions().timeoutMs(1000).nodeId(0)).featureMetadata();
-            assertThrows(ExecutionException.class, future::get);
+            final var result = (InternalDescribeFeaturesResult) env.adminClient().describeFeatures(
+                new DescribeFeaturesOptions().timeoutMs(1000).nodeId(0));
+            TestUtils.assertFutureThrows(TimeoutException.class, result.featureMetadata());
+            TestUtils.assertFutureThrows(TimeoutException.class, result.nodeApiVersions());
         }
     }
 


### PR DESCRIPTION
Follow-up to
https://github.com/apache/kafka/pull/20598#discussion_r3667202261

`describeFeatures()` now returns an `InternalDescribeFeaturesResult`
carrying a `nodeApiVersions` future, but `handleFailure` only completes
the `FeatureMetadata` future. When the ApiVersions request fails (for
example on timeout), `nodeApiVersions()` is never completed and callers
waiting on it hang indefinitely. The error-code branch in
`handleResponse` already completes both.

Extended the existing `testDescribeFeatures*` tests to assert both
futures. `testDescribeFeaturesWithNodeFailure` is the one that covers
`handleFailure`; it hangs until the class-level timeout without this
fix.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>
