### PR TITLE
MINOR: Fix duplicated closing brace in `{@link}` Javadoc tags in admin Result classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * The result of the {@link Admin#describeClassicGroups(Collection, DescribeClassicGroupsOptions)}} call.
+ * The result of the {@link Admin#describeClassicGroups(Collection, DescribeClassicGroupsOptions)} call.
  */
 @InterfaceAudience.Public
 public class DescribeClassicGroupsResult {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * The result of the {@link KafkaAdminClient#describeConsumerGroups(Collection, DescribeConsumerGroupsOptions)}} call.
+ * The result of the {@link KafkaAdminClient#describeConsumerGroups(Collection, DescribeConsumerGroupsOptions)} call.
  */
 @InterfaceAudience.Public
 public class DescribeConsumerGroupsResult {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * The result of the {@link KafkaAdminClient#describeShareGroups(Collection, DescribeShareGroupsOptions)}} call.
+ * The result of the {@link KafkaAdminClient#describeShareGroups(Collection, DescribeShareGroupsOptions)} call.
  */
 @InterfaceAudience.Public
 public class DescribeShareGroupsResult {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeStreamsGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeStreamsGroupsResult.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * The result of the {@link KafkaAdminClient#describeStreamsGroups(Collection, DescribeStreamsGroupsOptions)}} call.
+ * The result of the {@link KafkaAdminClient#describeStreamsGroups(Collection, DescribeStreamsGroupsOptions)} call.
  * <p>
  * The API of this class is evolving, see {@link Admin} for details.
  */


### PR DESCRIPTION
Fixes a typo in the class-level Javadoc of four admin result classes
where the `{@link ...}` tag had an extra closing brace (`}}` instead of
`}`). This caused a stray `}` to render right after the linked method in
the generated
[JavaDoc](https://javadoc.io/doc/org.apache.kafka/kafka-clients/latest/org/apache/kafka/clients/admin/package-summary.html)
output.

Changes
- DescribeClassicGroupsResult
- DescribeConsumerGroupsResult
- DescribeShareGroupsResult
- DescribeStreamsGroupsResult

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>, Mickael Maison
 <mickael.maison@gmail.com>
