### PR TITLE
KAFKA-20828: Centralize client throttling version logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -303,7 +303,11 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
      * throttle time. Client-side throttling is needed when communicating with a newer version of broker which, on
      * quota violation, sends out responses before throttling.
      */
-    public boolean shouldClientThrottle(short version) {
+    public final boolean shouldClientThrottle(short version) {
+        Short firstPostKip219Version = Kip219ClientThrottleVersion.BOUNDARIES.get(apiKey);
+        if (firstPostKip219Version != null) {
+            return version >= firstPostKip219Version;
+        }
         return apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
@@ -74,8 +74,4 @@ public class AddOffsetsToTxnResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponse.java
@@ -158,8 +158,4 @@ public class AddPartitionsToTxnResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
@@ -68,8 +68,4 @@ public class AlterConfigsResponse extends AbstractResponse {
         return new AlterConfigsResponse(new AlterConfigsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponse.java
@@ -70,8 +70,4 @@ public class AlterReplicaLogDirsResponse extends AbstractResponse {
         return new AlterReplicaLogDirsResponse(new AlterReplicaLogDirsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -142,11 +142,6 @@ public class ApiVersionsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
-
     public boolean zkMigrationReady() {
         return data.zkMigrationReady();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateAclsResponse.java
@@ -60,8 +60,4 @@ public class CreateAclsResponse extends AbstractResponse {
         return new CreateAclsResponse(new CreateAclsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateDelegationTokenResponse.java
@@ -99,11 +99,6 @@ public class CreateDelegationTokenResponse extends AbstractResponse {
         return error() != Errors.NONE;
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
-
     // Do not print tokenId and Hmac, overwrite a temp copy of the data with empty content
     @Override
     public String toString() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -53,11 +53,6 @@ public class CreatePartitionsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsResponse.java
@@ -77,8 +77,4 @@ public class CreateTopicsResponse extends AbstractResponse {
         return new CreateTopicsResponse(new CreateTopicsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 3;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteAclsResponse.java
@@ -82,11 +82,6 @@ public class DeleteAclsResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
-
     private void validate(short version) {
         if (version == 0) {
             final boolean unsupported = filterResults().stream()

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteGroupsResponse.java
@@ -90,8 +90,4 @@ public class DeleteGroupsResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
@@ -75,8 +75,4 @@ public class DeleteRecordsResponse extends AbstractResponse {
         return new DeleteRecordsResponse(new DeleteRecordsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsResponse.java
@@ -72,8 +72,4 @@ public class DeleteTopicsResponse extends AbstractResponse {
         return new DeleteTopicsResponse(new DeleteTopicsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
@@ -92,11 +92,6 @@ public class DescribeAclsResponse extends AbstractResponse {
         return new DescribeAclsResponse(new DescribeAclsResponseData(readable, version), version);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
-
     private void validate(Optional<Short> version) {
         if (version.isPresent() && version.get() == 0) {
             final boolean unsupported = acls().stream()

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -251,8 +251,4 @@ public class DescribeConfigsResponse extends AbstractResponse {
         return new DescribeConfigsResponse(new DescribeConfigsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeDelegationTokenResponse.java
@@ -123,11 +123,6 @@ public class DescribeDelegationTokenResponse extends AbstractResponse {
         return error() != Errors.NONE;
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
-
     // Do not print tokenId and Hmac, overwrite a temp copy of the data with empty content
     @Override
     public String toString() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsResponse.java
@@ -147,8 +147,4 @@ public class DescribeGroupsResponse extends AbstractResponse {
         return new DescribeGroupsResponse(new DescribeGroupsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -67,8 +67,4 @@ public class DescribeLogDirsResponse extends AbstractResponse {
         return new DescribeLogDirsResponse(new DescribeLogDirsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/EndTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndTxnResponse.java
@@ -77,8 +77,4 @@ public class EndTxnResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ExpireDelegationTokenResponse.java
@@ -69,8 +69,4 @@ public class ExpireDelegationTokenResponse extends AbstractResponse {
         return error() != Errors.NONE;
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -170,11 +170,6 @@ public class FetchResponse extends AbstractResponse {
         return 4 + data.size(cache, version);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 8;
-    }
-
     public static Optional<FetchResponseData.EpochEndOffset> divergingEpoch(FetchResponseData.PartitionData partitionResponse) {
         return partitionResponse.divergingEpoch().epoch() < 0 ? Optional.empty()
                 : Optional.of(partitionResponse.divergingEpoch());

--- a/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FindCoordinatorResponse.java
@@ -115,11 +115,6 @@ public class FindCoordinatorResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
-
     public List<FindCoordinatorResponseData.Coordinator> coordinators() {
         if (!data.coordinators().isEmpty())
             return data.coordinators();

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatResponse.java
@@ -70,8 +70,4 @@ public class HeartbeatResponse extends AbstractResponse {
         return new HeartbeatResponse(new HeartbeatResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/IncrementalAlterConfigsResponse.java
@@ -81,11 +81,6 @@ public class IncrementalAlterConfigsResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 0;
-    }
-
-    @Override
     public int throttleTimeMs() {
         return data.throttleTimeMs();
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/InitProducerIdResponse.java
@@ -75,8 +75,4 @@ public class InitProducerIdResponse extends AbstractResponse {
         return Errors.forCode(data.errorCode());
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -81,8 +81,4 @@ public class JoinGroupResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 3;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/Kip219ClientThrottleVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/Kip219ClientThrottleVersion.java
@@ -22,8 +22,8 @@ import java.util.Map;
 
 final class Kip219ClientThrottleVersion {
 
-    // Each value is the first version of the corresponding API after KIP-219 was introduced. An entry should be
-    // removed once no supported version below the boundary contains throttle_time_ms.
+    // Each value is the first version of the corresponding API after KIP-219 was introduced. Remove an entry when
+    // there are no supported versions below the boundary.
     static final Map<ApiKeys, Short> BOUNDARIES = Map.ofEntries(
         Map.entry(ApiKeys.PRODUCE, (short) 6),
         Map.entry(ApiKeys.FETCH, (short) 8),

--- a/clients/src/main/java/org/apache/kafka/common/requests/Kip219ClientThrottleVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/Kip219ClientThrottleVersion.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import java.util.Map;
+
+final class Kip219ClientThrottleVersion {
+
+    // Each value is the first version of the corresponding API after KIP-219 was introduced. An entry should be
+    // removed once no supported version below the boundary contains throttle_time_ms.
+    static final Map<ApiKeys, Short> BOUNDARIES = Map.ofEntries(
+        Map.entry(ApiKeys.PRODUCE, (short) 6),
+        Map.entry(ApiKeys.FETCH, (short) 8),
+        Map.entry(ApiKeys.LIST_OFFSETS, (short) 3),
+        Map.entry(ApiKeys.METADATA, (short) 6),
+        Map.entry(ApiKeys.OFFSET_COMMIT, (short) 4),
+        Map.entry(ApiKeys.OFFSET_FETCH, (short) 4),
+        Map.entry(ApiKeys.FIND_COORDINATOR, (short) 2),
+        Map.entry(ApiKeys.JOIN_GROUP, (short) 3),
+        Map.entry(ApiKeys.HEARTBEAT, (short) 2),
+        Map.entry(ApiKeys.LEAVE_GROUP, (short) 2),
+        Map.entry(ApiKeys.SYNC_GROUP, (short) 2),
+        Map.entry(ApiKeys.DESCRIBE_GROUPS, (short) 2),
+        Map.entry(ApiKeys.LIST_GROUPS, (short) 2),
+        Map.entry(ApiKeys.API_VERSIONS, (short) 2),
+        Map.entry(ApiKeys.CREATE_TOPICS, (short) 3),
+        Map.entry(ApiKeys.DELETE_TOPICS, (short) 2),
+        Map.entry(ApiKeys.DELETE_RECORDS, (short) 1),
+        Map.entry(ApiKeys.INIT_PRODUCER_ID, (short) 1),
+        Map.entry(ApiKeys.ADD_PARTITIONS_TO_TXN, (short) 1),
+        Map.entry(ApiKeys.ADD_OFFSETS_TO_TXN, (short) 1),
+        Map.entry(ApiKeys.END_TXN, (short) 1),
+        Map.entry(ApiKeys.TXN_OFFSET_COMMIT, (short) 1),
+        Map.entry(ApiKeys.DESCRIBE_CONFIGS, (short) 2),
+        Map.entry(ApiKeys.ALTER_CONFIGS, (short) 1),
+        Map.entry(ApiKeys.CREATE_PARTITIONS, (short) 1),
+        Map.entry(ApiKeys.DELETE_GROUPS, (short) 1)
+    );
+
+    private Kip219ClientThrottleVersion() {}
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupResponse.java
@@ -153,11 +153,6 @@ public class LeaveGroupResponse extends AbstractResponse {
     }
 
     @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
-
-    @Override
     public boolean equals(Object other) {
         return other instanceof LeaveGroupResponse &&
                    ((LeaveGroupResponse) other).data.equals(this.data);

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsResponse.java
@@ -56,8 +56,4 @@ public class ListGroupsResponse extends AbstractResponse {
         return new ListGroupsResponse(new ListGroupsResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsResponse.java
@@ -96,11 +96,6 @@ public class ListOffsetsResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 3;
-    }
-
     public static ListOffsetsTopicResponse singletonListOffsetsTopicResponse(TopicPartition tp, Errors error, long timestamp, long offset, int epoch) {
         return new ListOffsetsTopicResponse()
                  .setName(tp.topic())

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -514,8 +514,4 @@ public class MetadataResponse extends AbstractResponse {
         return new MetadataResponse(responseData, hasReliableEpoch);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 6;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitResponse.java
@@ -119,11 +119,6 @@ public class OffsetCommitResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 4;
-    }
-
     public static boolean useTopicIds(short version) {
         return version >= 10;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetDeleteResponse.java
@@ -164,8 +164,4 @@ public class OffsetDeleteResponse extends AbstractResponse {
         data.setThrottleTimeMs(throttleTimeMs);
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 0;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -221,11 +221,6 @@ public class OffsetFetchResponse extends AbstractResponse {
         return data;
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 4;
-    }
-
     public static OffsetFetchResponseData.OffsetFetchResponseGroup groupError(
         OffsetFetchRequestData.OffsetFetchRequestGroup group,
         Errors error,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -289,8 +289,4 @@ public class ProduceResponse extends AbstractResponse {
         return new ProduceResponse(new ProduceResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 6;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RenewDelegationTokenResponse.java
@@ -69,8 +69,4 @@ public class RenewDelegationTokenResponse extends AbstractResponse {
         return error() != Errors.NONE;
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -65,8 +65,4 @@ public class SyncGroupResponse extends AbstractResponse {
         return new SyncGroupResponse(new SyncGroupResponseData(readable, version));
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 2;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/TxnOffsetCommitResponse.java
@@ -273,8 +273,4 @@ public class TxnOffsetCommitResponse extends AbstractResponse {
         return data.toString();
     }
 
-    @Override
-    public boolean shouldClientThrottle(short version) {
-        return version >= 1;
-    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -360,57 +360,47 @@ public class RequestResponseTest {
     }
 
     @Test
-    public void testClientThrottlesResponsesWithThrottleTime() {
-        Map<ApiKeys, Short> postKip219Version = Map.ofEntries(
-            Map.entry(ApiKeys.PRODUCE, (short) 6),
-            Map.entry(ApiKeys.FETCH, (short) 8),
-            Map.entry(ApiKeys.LIST_OFFSETS, (short) 3),
-            Map.entry(ApiKeys.METADATA, (short) 6),
-            Map.entry(ApiKeys.OFFSET_COMMIT, (short) 4),
-            Map.entry(ApiKeys.OFFSET_FETCH, (short) 4),
-            Map.entry(ApiKeys.FIND_COORDINATOR, (short) 2),
-            Map.entry(ApiKeys.JOIN_GROUP, (short) 3),
-            Map.entry(ApiKeys.HEARTBEAT, (short) 2),
-            Map.entry(ApiKeys.LEAVE_GROUP, (short) 2),
-            Map.entry(ApiKeys.SYNC_GROUP, (short) 2),
-            Map.entry(ApiKeys.DESCRIBE_GROUPS, (short) 2),
-            Map.entry(ApiKeys.LIST_GROUPS, (short) 2),
-            Map.entry(ApiKeys.API_VERSIONS, (short) 2),
-            Map.entry(ApiKeys.CREATE_TOPICS, (short) 3),
-            Map.entry(ApiKeys.DELETE_TOPICS, (short) 2),
-            Map.entry(ApiKeys.DELETE_RECORDS, (short) 1),
-            Map.entry(ApiKeys.INIT_PRODUCER_ID, (short) 1),
-            Map.entry(ApiKeys.ADD_PARTITIONS_TO_TXN, (short) 1),
-            Map.entry(ApiKeys.ADD_OFFSETS_TO_TXN, (short) 1),
-            Map.entry(ApiKeys.END_TXN, (short) 1),
-            Map.entry(ApiKeys.TXN_OFFSET_COMMIT, (short) 1),
-            Map.entry(ApiKeys.DESCRIBE_ACLS, (short) 1),
-            Map.entry(ApiKeys.CREATE_ACLS, (short) 1),
-            Map.entry(ApiKeys.DELETE_ACLS, (short) 1),
-            Map.entry(ApiKeys.DESCRIBE_CONFIGS, (short) 2),
-            Map.entry(ApiKeys.ALTER_CONFIGS, (short) 1),
-            Map.entry(ApiKeys.ALTER_REPLICA_LOG_DIRS, (short) 1),
-            Map.entry(ApiKeys.DESCRIBE_LOG_DIRS, (short) 1),
-            Map.entry(ApiKeys.CREATE_PARTITIONS, (short) 1),
-            Map.entry(ApiKeys.CREATE_DELEGATION_TOKEN, (short) 1),
-            Map.entry(ApiKeys.RENEW_DELEGATION_TOKEN, (short) 1),
-            Map.entry(ApiKeys.EXPIRE_DELEGATION_TOKEN, (short) 1),
-            Map.entry(ApiKeys.DESCRIBE_DELEGATION_TOKEN, (short) 1),
-            Map.entry(ApiKeys.DELETE_GROUPS, (short) 1)
-        );
+    public void testKip219BoundariesHaveThrottleTimeField() {
+        Kip219ClientThrottleVersion.BOUNDARIES.forEach((apiKey, boundaryVersion) -> {
+            assertTrue(getResponse(apiKey, boundaryVersion).shouldClientThrottle(boundaryVersion),
+                apiKey + " should client throttle at KIP-219 boundary " + boundaryVersion);
+            assertNotNull(apiKey.messageType.responseSchemas()[boundaryVersion].get("throttle_time_ms"),
+                apiKey + " KIP-219 boundary " + boundaryVersion +
+                    " precedes the version that added throttle_time_ms");
+        });
+    }
 
-        for (ApiKeys apiKey : ApiKeys.values()) {
+    @Test
+    public void testKip219BoundariesAreStillNeeded() {
+        List<ApiKeys> obsoleteApiKeys = new ArrayList<>();
+        Kip219ClientThrottleVersion.BOUNDARIES.forEach((apiKey, boundaryVersion) -> {
+            boolean stillNeeded = false;
             for (short version : apiKey.allVersions()) {
-                boolean responseHasThrottleTime =
-                    apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null;
-                short firstPostKip219Version = postKip219Version.getOrDefault(apiKey, apiKey.oldestVersion());
-                boolean shouldClientThrottle = responseHasThrottleTime &&
-                    version >= firstPostKip219Version;
-                assertEquals(shouldClientThrottle, getResponse(apiKey, version).shouldClientThrottle(version),
-                    "Unexpected shouldClientThrottle result for " + apiKey + " version " + version +
-                        ": responseHasThrottleTime=" + responseHasThrottleTime +
-                        ", firstPostKip219Version=" + firstPostKip219Version);
+                if (version < boundaryVersion &&
+                    apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null) {
+                    stillNeeded = true;
+                    break;
+                }
             }
+            if (!stillNeeded) {
+                obsoleteApiKeys.add(apiKey);
+            }
+        });
+        assertEquals(List.of(), obsoleteApiKeys,
+            "These BOUNDARIES entries are obsolete and should be removed");
+    }
+
+    @Test
+    public void testClientThrottleForCommonResponses() {
+        assertClientThrottle(PRODUCE, (short) 6);
+        assertClientThrottle(FETCH, (short) 8);
+        assertClientThrottle(METADATA, (short) 6);
+    }
+
+    private void assertClientThrottle(ApiKeys apiKey, short boundaryVersion) {
+        for (short version : apiKey.allVersions()) {
+            assertEquals(version >= boundaryVersion, getResponse(apiKey, version).shouldClientThrottle(version),
+                "Unexpected shouldClientThrottle result for " + apiKey + " version " + version);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -372,22 +372,9 @@ public class RequestResponseTest {
 
     @Test
     public void testKip219BoundariesAreStillNeeded() {
-        List<ApiKeys> obsoleteApiKeys = new ArrayList<>();
-        Kip219ClientThrottleVersion.BOUNDARIES.forEach((apiKey, boundaryVersion) -> {
-            boolean stillNeeded = false;
-            for (short version : apiKey.allVersions()) {
-                if (version < boundaryVersion &&
-                    apiKey.messageType.responseSchemas()[version].get("throttle_time_ms") != null) {
-                    stillNeeded = true;
-                    break;
-                }
-            }
-            if (!stillNeeded) {
-                obsoleteApiKeys.add(apiKey);
-            }
-        });
-        assertEquals(List.of(), obsoleteApiKeys,
-            "These BOUNDARIES entries are obsolete and should be removed");
+        Kip219ClientThrottleVersion.BOUNDARIES.forEach((apiKey, boundaryVersion) ->
+            assertTrue(apiKey.messageType.lowestSupportedVersion() < boundaryVersion,
+                apiKey + " KIP-219 boundary " + boundaryVersion + " is obsolete and should be removed"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Follow-up to KAFKA-20828 and PR #22908.

This change centralizes the response-version logic for KIP-219
client-side throttling.

The remaining historical KIP-219 boundaries are stored in a
dedicated`Kip219ClientThrottleVersion` class.
`AbstractResponse.shouldClientThrottle()` uses these boundaries for APIs
that still support versions from before KIP-219. For APIs without a
boundary entry, throttling is determined by the presence
of`throttle_time_ms` in the response schema.

Boundary entries that are no longer needed because no supported
pre-boundary versions remain have been removed. A regression test
ensures entries are also removed when future protocol-version
deprecations make them removals.

`shouldClientThrottle()` is now final, preventing response subclasses
from overriding the centralized behavior. The version-specific overrides
previously spread across individual response classes have been removed.

## Testing

The tests cover:

- Every configured boundary having a `throttle_time_ms` response field.
- Every configured boundary still having a supported version below it.
- The expected throttling boundaries for Produce, Fetch, and Metadata
responses.

The following checks passed:

- `./gradlew :clients:test --tests
org.apache.kafka.common.requests.RequestResponseTest`
- `./gradlew :clients:test --tests
org.apache.kafka.common.requests.RequestResponseTest.testKip219BoundariesAreStillNeeded`
- `./gradlew :clients:spotlessCheck`
- `./gradlew :clients:checkstyleMain`
- `./gradlew :clients:checkstyleTest`

Reviewers: Jun Rao <junrao@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
