### PR TITLE
MINOR: ensure ps output is unlimited width

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -30,7 +30,7 @@ if [[ "$OSNAME" == "OS/390" ]]; then
 elif [[ "$OSNAME" == "OS400" ]]; then
     PIDS=$(ps -Af | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $2}')
 else
-    PIDS=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}'| xargs)
+    PIDS=$(ps axww | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}'| xargs)
 fi
 
 if [ -z "$PIDS" ]; then

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -31,7 +31,7 @@ COPY *kafka.tgz kafka.tgz
 RUN set -eux ; \
     apk update ; \
     apk upgrade ; \
-    apk add --no-cache bash; \
+    apk add --no-cache bash procps-ng; \
     mkdir opt/kafka; \
     if [ -n "$kafka_url" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -34,7 +34,7 @@ RUN set -eux ; \
     apk add --no-cache bash procps-ng; \
     mkdir opt/kafka; \
     if [ -n "$kafka_url" ]; then \
-        apk add --no-cache wget gcompat gpg gpg-agent procps; \
+        apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
         wget -nv -O KEYS https://downloads.apache.org/kafka/KEYS; \
@@ -72,9 +72,9 @@ RUN mkdir opt/kafka; \
     set -eux ; \
     apk update ; \
     apk upgrade ; \
-    apk add --no-cache bash; \
+    apk add --no-cache bash procps-ng; \
     if [ -n "$kafka_url" ]; then \
-        apk add --no-cache wget gcompat gpg gpg-agent procps; \
+        apk add --no-cache wget gcompat gpg gpg-agent; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
         tar xfz kafka.tgz -C /opt/kafka --strip-components 1; \


### PR DESCRIPTION
`kafka-server-stop.sh` uses `ps` to figure out Kafka's pid. This fails when the command is long which may happen due to classpath being passed as the args to the java command.

This change adds the `ww` flag which ensures no limits are put on `ps`' output. It also changes `jvm/Dockerfile` to use `ps` from `procps-ng` package as the `ps` implementation that ships in busybox limits the output to a max of `2048` characters [0].

[0]: https://github.com/mirror/busybox/blob/371fe9f71d445d18be28c82a2a6d82115c8af19d/procps/ps.c#L679

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
