### PR TITLE
MINOR: improve "streams" default rebalance listener

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -100,7 +100,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
                 runningAssignment.warmupTasks().stream()
             ));
 
-        log.info("Processing new assignment {} from Streams Rebalance Protocol", assignment);
+        log.info("Processing new assignment {} from Streams Rebalance Protocol", runningAssignment);
 
         try {
             streamThread.setStreamsGroupReady(assignment.isGroupReady());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -90,6 +90,8 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
 
     @Override
     public void onTasksAssigned(final StreamsRebalanceData.Assignment assignment) {
+        log.debug("Received broker assignment {}", assignment);
+
         final long start = time.milliseconds();
         final StreamsRebalanceData.Assignment runningAssignment = deduplicateTasks(assignment);
         final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions =

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -91,10 +91,14 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
     @Override
     public void onTasksAssigned(final StreamsRebalanceData.Assignment assignment) {
         final long start = time.milliseconds();
+        final StreamsRebalanceData.Assignment runningAssignment = deduplicateTasks(assignment);
         final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions =
-            pairWithTopicPartitions(assignment.activeTasks().stream());
+            pairWithTopicPartitions(runningAssignment.activeTasks().stream());
         final Map<TaskId, Set<TopicPartition>> standbyTasksWithPartitions =
-            pairWithTopicPartitions(deduplicateTasks(assignment).stream());
+            pairWithTopicPartitions(Stream.concat(
+                runningAssignment.standbyTasks().stream(),
+                runningAssignment.warmupTasks().stream()
+            ));
 
         log.info("Processing new assignment {} from Streams Rebalance Protocol", assignment);
 
@@ -103,7 +107,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
             taskManager.handleAssignment(activeTasksWithPartitions, standbyTasksWithPartitions);
             streamThread.setState(StreamThread.State.PARTITIONS_ASSIGNED);
             taskManager.handleRebalanceComplete();
-            streamsRebalanceData.setReconciledAssignment(assignment);
+            streamsRebalanceData.setReconciledAssignment(runningAssignment);
         } finally {
             tasksAssignedSensor.record(time.milliseconds() - start);
         }
@@ -120,7 +124,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
         }
     }
 
-    private Set<StreamsRebalanceData.TaskId> deduplicateTasks(final StreamsRebalanceData.Assignment assignment) {
+    private StreamsRebalanceData.Assignment deduplicateTasks(final StreamsRebalanceData.Assignment assignment) {
         // The overlaps below are only used to warn about them, so they are kept sorted to give the log a
         // deterministic and readable task order.
         final SortedSet<StreamsRebalanceData.TaskId> standbyAndWarmup = new TreeSet<>(assignment.standbyTasks());
@@ -131,18 +135,29 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
                 standbyAndWarmup);
         }
 
-        final Set<StreamsRebalanceData.TaskId> replicas = new HashSet<>(assignment.standbyTasks());
-        replicas.addAll(assignment.warmupTasks());
-
-        final SortedSet<StreamsRebalanceData.TaskId> activeAndReplica = new TreeSet<>(replicas);
+        final SortedSet<StreamsRebalanceData.TaskId> activeAndReplica = new TreeSet<>(assignment.standbyTasks());
+        activeAndReplica.addAll(assignment.warmupTasks());
         activeAndReplica.retainAll(assignment.activeTasks());
         if (!activeAndReplica.isEmpty()) {
             log.warn("Tasks {} were assigned as active tasks and also as standby or warm-up tasks. The standby and " +
                 "warm-up assignment is ignored, and the tasks are run as active tasks.", activeAndReplica);
         }
 
-        replicas.removeAll(assignment.activeTasks());
-        return replicas;
+        // The client runs one task per task id, so it reports one role for it. A task assigned as both standby and
+        // warm-up is reported as a standby: the standby is a permanent part of the assignment, while the warm-up is
+        // only injected on top of it and goes away again.
+        final Set<StreamsRebalanceData.TaskId> standbyTasks = new HashSet<>(assignment.standbyTasks());
+        standbyTasks.removeAll(assignment.activeTasks());
+        final Set<StreamsRebalanceData.TaskId> warmupTasks = new HashSet<>(assignment.warmupTasks());
+        warmupTasks.removeAll(assignment.activeTasks());
+        warmupTasks.removeAll(standbyTasks);
+
+        return new StreamsRebalanceData.Assignment(
+            assignment.activeTasks(),
+            standbyTasks,
+            warmupTasks,
+            assignment.isGroupReady()
+        );
     }
 
     private Map<TaskId, Set<TopicPartition>> pairWithTopicPartitions(final Stream<StreamsRebalanceData.TaskId> taskIdStream) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListener.java
@@ -28,8 +28,11 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.slf4j.Logger;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -91,7 +94,7 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
         final Map<TaskId, Set<TopicPartition>> activeTasksWithPartitions =
             pairWithTopicPartitions(assignment.activeTasks().stream());
         final Map<TaskId, Set<TopicPartition>> standbyTasksWithPartitions =
-            pairWithTopicPartitions(Stream.concat(assignment.standbyTasks().stream(), assignment.warmupTasks().stream()));
+            pairWithTopicPartitions(deduplicateTasks(assignment).stream());
 
         log.info("Processing new assignment {} from Streams Rebalance Protocol", assignment);
 
@@ -115,6 +118,31 @@ public class DefaultStreamsRebalanceListener implements StreamsRebalanceListener
         } finally {
             tasksLostSensor.record(time.milliseconds() - start);
         }
+    }
+
+    private Set<StreamsRebalanceData.TaskId> deduplicateTasks(final StreamsRebalanceData.Assignment assignment) {
+        // The overlaps below are only used to warn about them, so they are kept sorted to give the log a
+        // deterministic and readable task order.
+        final SortedSet<StreamsRebalanceData.TaskId> standbyAndWarmup = new TreeSet<>(assignment.standbyTasks());
+        standbyAndWarmup.retainAll(assignment.warmupTasks());
+        if (!standbyAndWarmup.isEmpty()) {
+            log.warn("Tasks {} were assigned as standby tasks and as warm-up tasks. A standby task and a warm-up " +
+                "task are the same thing on the client, so the two assignments are merged into a single task each.",
+                standbyAndWarmup);
+        }
+
+        final Set<StreamsRebalanceData.TaskId> replicas = new HashSet<>(assignment.standbyTasks());
+        replicas.addAll(assignment.warmupTasks());
+
+        final SortedSet<StreamsRebalanceData.TaskId> activeAndReplica = new TreeSet<>(replicas);
+        activeAndReplica.retainAll(assignment.activeTasks());
+        if (!activeAndReplica.isEmpty()) {
+            log.warn("Tasks {} were assigned as active tasks and also as standby or warm-up tasks. The standby and " +
+                "warm-up assignment is ignored, and the tasks are run as active tasks.", activeAndReplica);
+        }
+
+        replicas.removeAll(assignment.activeTasks());
+        return replicas;
     }
 
     private Map<TaskId, Set<TopicPartition>> pairWithTopicPartitions(final Stream<StreamsRebalanceData.TaskId> taskIdStream) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.internals.StreamsRebalanceData;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.RebalanceListenerMetrics;
@@ -32,6 +33,7 @@ import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,6 +42,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -54,6 +57,9 @@ import static org.mockito.Mockito.when;
 
 public class DefaultStreamsRebalanceListenerTest {
     private static final String THREAD_ID = "test-thread-id";
+    private static final String MERGED_WARNING = "merged into a single task";
+    private static final String IGNORED_WARNING = "is ignored";
+
     private final TaskManager taskManager = mock(TaskManager.class);
     private final StreamThread streamThread = mock(StreamThread.class);
     private final StreamsMetricsImpl streamsMetrics = mock(StreamsMetricsImpl.class);
@@ -87,6 +93,25 @@ public class DefaultStreamsRebalanceListenerTest {
                 THREAD_ID
             );
         }
+    }
+
+    private StreamsRebalanceData rebalanceDataWithSubtopologies(final String... subtopologyIds) {
+        final StreamsRebalanceData streamsRebalanceData = mock(StreamsRebalanceData.class);
+        final Map<String, StreamsRebalanceData.Subtopology> subtopologies = new HashMap<>();
+        for (final String subtopologyId : subtopologyIds) {
+            subtopologies.put(subtopologyId, new StreamsRebalanceData.Subtopology(
+                Set.of("source" + subtopologyId), Set.of(), Map.of(), Map.of(), Set.of()));
+        }
+        when(streamsRebalanceData.subtopologies()).thenReturn(subtopologies);
+        return streamsRebalanceData;
+    }
+
+    private String warningContaining(final LogCaptureAppender appender, final String fragment) {
+        return appender.getMessages("WARN").stream()
+            .filter(message -> message.contains(fragment))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(
+                "No WARN containing \"" + fragment + "\". Messages: " + appender.getMessages("WARN")));
     }
 
     @ParameterizedTest
@@ -180,7 +205,12 @@ public class DefaultStreamsRebalanceListenerTest {
             false
         );
 
-        assertDoesNotThrow(() -> defaultStreamsRebalanceListener.onTasksAssigned(assignment));
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(DefaultStreamsRebalanceListener.class)) {
+            assertDoesNotThrow(() -> defaultStreamsRebalanceListener.onTasksAssigned(assignment));
+
+            assertTrue(appender.getMessages("WARN").isEmpty(),
+                "No warning should be logged for an assignment without overlapping roles: " + appender.getMessages("WARN"));
+        }
 
         final InOrder inOrder = inOrder(taskManager, streamThread, streamsRebalanceData);
         inOrder.verify(streamThread).setStreamsGroupReady(false);
@@ -194,6 +224,35 @@ public class DefaultStreamsRebalanceListenerTest {
         inOrder.verify(streamThread).setState(StreamThread.State.PARTITIONS_ASSIGNED);
         inOrder.verify(taskManager).handleRebalanceComplete();
         inOrder.verify(streamsRebalanceData).setReconciledAssignment(assignment);
+    }
+
+    @Test
+    void shouldDropStandbyAndWarmupForTaskThatIsAlsoAssignedAsActive() {
+        createRebalanceListenerWithRebalanceData(rebalanceDataWithSubtopologies("1", "2", "3", "4"));
+
+        final StreamsRebalanceData.Assignment assignment = new StreamsRebalanceData.Assignment(
+            Set.of(new StreamsRebalanceData.TaskId("1", 0)),
+            Set.of(new StreamsRebalanceData.TaskId("1", 0), new StreamsRebalanceData.TaskId("2", 0), new StreamsRebalanceData.TaskId("3", 0)),
+            Set.of(new StreamsRebalanceData.TaskId("1", 0), new StreamsRebalanceData.TaskId("3", 0), new StreamsRebalanceData.TaskId("4", 0)),
+            true
+        );
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(DefaultStreamsRebalanceListener.class)) {
+            assertDoesNotThrow(() -> defaultStreamsRebalanceListener.onTasksAssigned(assignment));
+
+            final String mergedWarning = warningContaining(appender, MERGED_WARNING);
+            assertTrue(mergedWarning.contains("[1_0, 3_0]"), "Only the merged task should be named: " + mergedWarning);
+            final String ignoredWarning = warningContaining(appender, IGNORED_WARNING);
+            assertTrue(ignoredWarning.contains("[1_0]"), "Only the ignored task should be named: " + ignoredWarning);
+        }
+
+        verify(taskManager).handleAssignment(
+            Map.of(new TaskId(1, 0), Set.of(new TopicPartition("source1", 0))),
+            Map.of(
+                new TaskId(2, 0), Set.of(new TopicPartition("source2", 0)),
+                new TaskId(3, 0), Set.of(new TopicPartition("source3", 0)),
+                new TaskId(4, 0), Set.of(new TopicPartition("source4", 0)))
+        );
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStreamsRebalanceListenerTest.java
@@ -228,7 +228,8 @@ public class DefaultStreamsRebalanceListenerTest {
 
     @Test
     void shouldDropStandbyAndWarmupForTaskThatIsAlsoAssignedAsActive() {
-        createRebalanceListenerWithRebalanceData(rebalanceDataWithSubtopologies("1", "2", "3", "4"));
+        final StreamsRebalanceData streamsRebalanceData = rebalanceDataWithSubtopologies("1", "2", "3", "4");
+        createRebalanceListenerWithRebalanceData(streamsRebalanceData);
 
         final StreamsRebalanceData.Assignment assignment = new StreamsRebalanceData.Assignment(
             Set.of(new StreamsRebalanceData.TaskId("1", 0)),
@@ -253,6 +254,15 @@ public class DefaultStreamsRebalanceListenerTest {
                 new TaskId(3, 0), Set.of(new TopicPartition("source3", 0)),
                 new TaskId(4, 0), Set.of(new TopicPartition("source4", 0)))
         );
+
+        // The next heartbeat reports the reconciled assignment as the owned tasks, and the client runs one task per
+        // task id: 1_0 is reported as active only, and 3_0 as a standby only, since the standby outlives the warm-up.
+        verify(streamsRebalanceData).setReconciledAssignment(new StreamsRebalanceData.Assignment(
+            Set.of(new StreamsRebalanceData.TaskId("1", 0)),
+            Set.of(new StreamsRebalanceData.TaskId("2", 0), new StreamsRebalanceData.TaskId("3", 0)),
+            Set.of(new StreamsRebalanceData.TaskId("4", 0)),
+            true
+        ));
     }
 
     @Test


### PR DESCRIPTION
If the broker side assignor makes an error on task assignment, it could
crash the client with a "duplicate taskId" error.

This PR adds a proper task-id deduplication guard plus new WARN logs to
let the user know that it received some bad assignment.

Reviewers: Bill Bejeck <bbejeck@apache.org>
