### PR TITLE
KAFKA-20328: [2/N] headers-aware decorator/forwarder test coverage

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecoratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecoratorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.KeyValueStoreReadOnlyDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.SessionStoreReadOnlyDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.TimestampedKeyValueStoreReadOnlyDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.TimestampedKeyValueStoreReadOnlyDecoratorWithHeaders;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.TimestampedWindowStoreReadOnlyDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.VersionedKeyValueStoreReadOnlyDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.WindowStoreReadOnlyDecorator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.WindowStore;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+
+import static org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.getReadOnlyStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class AbstractReadOnlyDecoratorTest {
+
+    // Dispatch tests pin getReadOnlyStore to the exact decorator per store type. Because the
+    // *WithHeaders interfaces extend their base store interface, a reordered/removed instanceof check
+    // would silently fall through to the base decorator; asserting the exact class catches that.
+
+    @Test
+    public void shouldWrapTimestampedKeyValueStoreWithHeaders() {
+        assertEquals(TimestampedKeyValueStoreReadOnlyDecoratorWithHeaders.class,
+            getReadOnlyStore(mock(TimestampedKeyValueStoreWithHeaders.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapTimestampedKeyValueStore() {
+        assertEquals(TimestampedKeyValueStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(TimestampedKeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapVersionedKeyValueStore() {
+        assertEquals(VersionedKeyValueStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(VersionedKeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapKeyValueStore() {
+        assertEquals(KeyValueStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(KeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapTimestampedWindowStore() {
+        assertEquals(TimestampedWindowStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(TimestampedWindowStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapWindowStore() {
+        assertEquals(WindowStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(WindowStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapSessionStore() {
+        assertEquals(SessionStoreReadOnlyDecorator.class,
+            getReadOnlyStore(mock(SessionStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldReturnUnknownStoreTypeUnwrapped() {
+        final StateStore store = mock(StateStore.class);
+        assertSame(store, getReadOnlyStore(store));
+    }
+
+    // flush/init/commit/close are defined on the abstract parent and shared by every decorator, so
+    // one representative subtype suffices to verify they are blocked on a read-only global store.
+    @Test
+    public void shouldThrowOnFlush() {
+        final StateStore store = getReadOnlyStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, store::flush);
+        assertEquals(AbstractReadOnlyDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnInit() {
+        final StateStore store = getReadOnlyStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,
+            () -> store.init((StateStoreContext) null, null));
+        assertEquals(AbstractReadOnlyDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnCommit() {
+        final StateStore store = getReadOnlyStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,
+            () -> store.commit(null));
+        assertEquals(AbstractReadOnlyDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnClose() {
+        final StateStore store = getReadOnlyStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, store::close);
+        assertEquals(AbstractReadOnlyDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    // Read-only decorators must reject every write; the base KeyValueStore mutators are representative.
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowOnKeyValueStoreWrites() {
+        final KeyValueStore<Object, Object> store =
+            (KeyValueStore<Object, Object>) getReadOnlyStore(mock(KeyValueStore.class));
+        assertThrows(UnsupportedOperationException.class, () -> store.put("k", "v"));
+        assertThrows(UnsupportedOperationException.class, () -> store.putIfAbsent("k", "v"));
+        assertThrows(UnsupportedOperationException.class, () -> store.putAll(Collections.emptyList()));
+        assertThrows(UnsupportedOperationException.class, () -> store.delete("k"));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecoratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecoratorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.KeyValueStoreReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.SessionStoreReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.SessionStoreWithHeadersReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.TimestampedKeyValueStoreReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.TimestampedKeyValueStoreReadWriteDecoratorWithHeaders;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.TimestampedWindowStoreReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.TimestampedWindowStoreWithHeadersReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.VersionedKeyValueStoreReadWriteDecorator;
+import org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.WindowStoreReadWriteDecorator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.SessionStoreWithHeaders;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.WindowStore;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.wrapWithReadWriteStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class AbstractReadWriteDecoratorTest {
+
+    // Dispatch tests pin wrapWithReadWriteStore to the exact decorator per store type. Because the
+    // *WithHeaders interfaces extend their base store interface, a reordered/removed instanceof check
+    // would silently fall through to the base decorator; asserting the exact class catches that.
+
+    @Test
+    public void shouldWrapTimestampedKeyValueStoreWithHeaders() {
+        assertEquals(TimestampedKeyValueStoreReadWriteDecoratorWithHeaders.class,
+            wrapWithReadWriteStore(mock(TimestampedKeyValueStoreWithHeaders.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapTimestampedKeyValueStore() {
+        assertEquals(TimestampedKeyValueStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(TimestampedKeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapVersionedKeyValueStore() {
+        assertEquals(VersionedKeyValueStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(VersionedKeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapKeyValueStore() {
+        assertEquals(KeyValueStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(KeyValueStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapTimestampedWindowStoreWithHeaders() {
+        assertEquals(TimestampedWindowStoreWithHeadersReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(TimestampedWindowStoreWithHeaders.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapTimestampedWindowStore() {
+        assertEquals(TimestampedWindowStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(TimestampedWindowStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapWindowStore() {
+        assertEquals(WindowStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(WindowStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapSessionStoreWithHeaders() {
+        assertEquals(SessionStoreWithHeadersReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(SessionStoreWithHeaders.class)).getClass());
+    }
+
+    @Test
+    public void shouldWrapSessionStore() {
+        assertEquals(SessionStoreReadWriteDecorator.class,
+            wrapWithReadWriteStore(mock(SessionStore.class)).getClass());
+    }
+
+    @Test
+    public void shouldReturnUnknownStoreTypeUnwrapped() {
+        final StateStore store = mock(StateStore.class);
+        assertSame(store, wrapWithReadWriteStore(store));
+    }
+
+    // init/commit/close are defined on the abstract parent and shared by every decorator, so one
+    // representative subtype suffices to verify they are blocked for user code.
+    @Test
+    public void shouldThrowOnInit() {
+        final StateStore store = wrapWithReadWriteStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,
+            () -> store.init((StateStoreContext) null, null));
+        assertEquals(AbstractReadWriteDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnCommit() {
+        final StateStore store = wrapWithReadWriteStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,
+            () -> store.commit(null));
+        assertEquals(AbstractReadWriteDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+
+    @Test
+    public void shouldThrowOnClose() {
+        final StateStore store = wrapWithReadWriteStore(mock(KeyValueStore.class));
+        final UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,
+            store::close);
+        assertEquals(AbstractReadWriteDecorator.ERROR_MESSAGE, e.getMessage());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterCompletenessTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterCompletenessTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.SessionStore;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Requires every {@link SessionStore} method to be classified into a contract group, so a header-aware
+ * override that is silently dropped (returning raw bytes) fails this test rather than escaping to
+ * manual testing (KAFKA-20328). Behavioral assertions live in
+ * {@link SessionToHeadersStoreAdapterTest}. The Instant overloads delegate to their long counterparts
+ * (SessionStore defaults), so they convert/wrap too.
+ * <p>
+ * Signatures use erased parameter types, so a key ({@code K}) or value ({@code V}) appears as {@code Object}.
+ */
+public class SessionToHeadersStoreAdapterCompletenessTest {
+
+    private static final Set<String> VALUE_CONVERTING = Set.of(
+        "fetchSession(Object,long,long)",
+        "fetchSession(Object,Instant,Instant)"
+    );
+
+    private static final Set<String> ITERATOR_WRAPPING = Set.of(
+        "findSessions(Object,long,long)",
+        "findSessions(Object,Instant,Instant)",
+        "findSessions(long,long)",
+        "findSessions(Object,Object,long,long)",
+        "findSessions(Object,Object,Instant,Instant)",
+        "backwardFindSessions(Object,long,long)",
+        "backwardFindSessions(Object,Instant,Instant)",
+        "backwardFindSessions(Object,Object,long,long)",
+        "backwardFindSessions(Object,Object,Instant,Instant)",
+        "fetch(Object)",
+        "fetch(Object,Object)",
+        "backwardFetch(Object)",
+        "backwardFetch(Object,Object)"
+    );
+
+    private static final Set<String> HEADER_STRIPPING = Set.of(
+        "put(Windowed,Object)"
+    );
+
+    private static final Set<String> DELEGATING = Set.of(
+        "remove(Windowed)",
+        "name()",
+        "init(StateStoreContext,StateStore)",
+        "commit(Map)",
+        "managesOffsets()",
+        "committedOffset(TopicPartition)",
+        "approximateNumUncommittedBytes()",
+        "close()",
+        "persistent()",
+        "isOpen()",
+        "getPosition()"
+    );
+
+    // query has bespoke iterator wrapping; flush is a deprecated no-op; readOnly returns `this`.
+    private static final Set<String> SPECIAL = Set.of(
+        "query(Query,PositionBound,QueryConfig)",
+        "flush()",
+        "readOnly(IsolationLevel)"
+    );
+
+    @Test
+    public void everySessionStoreMethodMustBeClassified() {
+        final Set<String> classified = Stream.of(
+                VALUE_CONVERTING, ITERATOR_WRAPPING, HEADER_STRIPPING, DELEGATING, SPECIAL)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+
+        final Set<String> unclassified = Arrays.stream(SessionStore.class.getMethods())
+            .filter(m -> !m.isSynthetic())
+            .filter(m -> !Modifier.isStatic(m.getModifiers()))
+            .map(SessionToHeadersStoreAdapterCompletenessTest::signature)
+            .filter(sig -> !classified.contains(sig))
+            .collect(Collectors.toCollection(TreeSet::new));
+
+        assertTrue(unclassified.isEmpty(),
+            "Unclassified SessionStore method(s): " + unclassified + ". Add each to a contract group in "
+                + "this test AND cover it with a behavioral test in SessionToHeadersStoreAdapterTest, so a "
+                + "forgotten header conversion cannot leak raw bytes silently.");
+    }
+
+    private static String signature(final Method m) {
+        return m.getName() + "(" + Arrays.stream(m.getParameterTypes())
+            .map(Class::getSimpleName)
+            .collect(Collectors.joining(",")) + ")";
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionToHeadersStoreAdapterTest.java
@@ -37,6 +37,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.time.Instant;
+
 import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -252,5 +254,32 @@ public class SessionToHeadersStoreAdapterTest {
     @Test
     public void shouldReturnNullFromRawAggregationValueForNull() {
         assertNull(Utils.rawAggregation(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFindSessionsByTimeRangeIterator() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.findSessions(10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result = adapter.findSessions(10L, 20L);
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
+    }
+
+    // Instant overloads delegate to the long-based overloads; verify conversion still happens.
+    @Test
+    public void shouldConvertFetchSessionViaInstantOverload() {
+        when(innerStore.fetchSession(KEY, 10L, 20L)).thenReturn(RAW_VALUE);
+        final byte[] result = adapter.fetchSession(KEY, Instant.ofEpochMilli(10L), Instant.ofEpochMilli(20L));
+        assertArrayEquals(VALUE_WITH_EMPTY_HEADERS, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldWrapFindSessionsViaInstantOverload() {
+        final KeyValueIterator<Windowed<Bytes>, byte[]> innerIter = mock(KeyValueIterator.class);
+        when(innerStore.findSessions(KEY, 10L, 20L)).thenReturn(innerIter);
+        final KeyValueIterator<Windowed<Bytes>, byte[]> result =
+            adapter.findSessions(KEY, Instant.ofEpochMilli(10L), Instant.ofEpochMilli(20L));
+        assertInstanceOf(SessionToHeadersIteratorAdapter.class, result);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersIteratorAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersIteratorAdapterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class TimestampedToHeadersIteratorAdapterTest {
+
+    private static final String KEY = "key";
+    private static final byte[] RAW_VALUE = "value".getBytes();
+    private static final byte[] VALUE_WITH_EMPTY_HEADERS = convertToHeaderFormat(RAW_VALUE);
+
+    @Mock
+    private KeyValueIterator<String, byte[]> innerIterator;
+
+    private TimestampedToHeadersIteratorAdapter<String> adapter;
+
+    @BeforeEach
+    public void setUp() {
+        adapter = new TimestampedToHeadersIteratorAdapter<>(innerIterator);
+    }
+
+    @Test
+    public void shouldConvertNextValueToHeaderFormat() {
+        when(innerIterator.next()).thenReturn(KeyValue.pair(KEY, RAW_VALUE));
+
+        final KeyValue<String, byte[]> result = adapter.next();
+
+        assertArrayEquals(VALUE_WITH_EMPTY_HEADERS, result.value);
+    }
+
+    @Test
+    public void shouldKeepKeyUnchangedOnNext() {
+        when(innerIterator.next()).thenReturn(KeyValue.pair(KEY, RAW_VALUE));
+
+        final KeyValue<String, byte[]> result = adapter.next();
+
+        assertEquals(KEY, result.key);
+    }
+
+    @Test
+    public void shouldReturnNullWhenInnerNextReturnsNull() {
+        when(innerIterator.next()).thenReturn(null);
+
+        assertNull(adapter.next());
+    }
+
+    @Test
+    public void shouldConvertNullValueWithinKeyValueToNull() {
+        when(innerIterator.next()).thenReturn(KeyValue.pair(KEY, null));
+
+        final KeyValue<String, byte[]> result = adapter.next();
+
+        assertEquals(KEY, result.key);
+        assertNull(result.value);
+    }
+
+    @Test
+    public void shouldDelegatePeekNextKey() {
+        when(innerIterator.peekNextKey()).thenReturn(KEY);
+
+        assertEquals(KEY, adapter.peekNextKey());
+    }
+
+    @Test
+    public void shouldDelegateHasNextWhenTrue() {
+        when(innerIterator.hasNext()).thenReturn(true);
+
+        assertTrue(adapter.hasNext());
+    }
+
+    @Test
+    public void shouldDelegateHasNextWhenFalse() {
+        when(innerIterator.hasNext()).thenReturn(false);
+
+        assertFalse(adapter.hasNext());
+    }
+
+    @Test
+    public void shouldDelegateClose() {
+        adapter.close();
+
+        verify(innerIterator).close();
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterCompletenessTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterCompletenessTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.WindowStore;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Requires every {@link WindowStore} method to be classified into a contract group, so a header-aware
+ * override that is silently dropped (returning raw bytes) fails this test rather than escaping to
+ * manual testing (KAFKA-20328). Behavioral assertions live in
+ * {@link TimestampedToHeadersWindowStoreAdapterTest}.
+ * <p>
+ * Signatures use erased parameter types, so a key ({@code K}) or value ({@code V}) appears as {@code Object}.
+ */
+public class TimestampedToHeadersWindowStoreAdapterCompletenessTest {
+
+    private static final Set<String> VALUE_CONVERTING = Set.of(
+        "fetch(Object,long)"
+    );
+
+    private static final Set<String> ITERATOR_WRAPPING = Set.of(
+        "fetch(Object,long,long)",
+        "fetch(Object,Instant,Instant)",
+        "backwardFetch(Object,long,long)",
+        "backwardFetch(Object,Instant,Instant)",
+        "fetch(Object,Object,long,long)",
+        "fetch(Object,Object,Instant,Instant)",
+        "backwardFetch(Object,Object,long,long)",
+        "backwardFetch(Object,Object,Instant,Instant)",
+        "fetchAll(long,long)",
+        "fetchAll(Instant,Instant)",
+        "backwardFetchAll(long,long)",
+        "backwardFetchAll(Instant,Instant)",
+        "all()",
+        "backwardAll()"
+    );
+
+    private static final Set<String> HEADER_STRIPPING = Set.of(
+        "put(Object,Object,long)"
+    );
+
+    private static final Set<String> DELEGATING = Set.of(
+        "name()",
+        "init(StateStoreContext,StateStore)",
+        "commit(Map)",
+        "managesOffsets()",
+        "committedOffset(TopicPartition)",
+        "approximateNumUncommittedBytes()",
+        "close()",
+        "persistent()",
+        "isOpen()",
+        "getPosition()"
+    );
+
+    // query has bespoke iterator wrapping; flush is a deprecated no-op; readOnly returns `this`.
+    private static final Set<String> SPECIAL = Set.of(
+        "query(Query,PositionBound,QueryConfig)",
+        "flush()",
+        "readOnly(IsolationLevel)"
+    );
+
+    @Test
+    public void everyWindowStoreMethodMustBeClassified() {
+        final Set<String> classified = Stream.of(
+                VALUE_CONVERTING, ITERATOR_WRAPPING, HEADER_STRIPPING, DELEGATING, SPECIAL)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+
+        final Set<String> unclassified = Arrays.stream(WindowStore.class.getMethods())
+            .filter(m -> !m.isSynthetic())
+            .filter(m -> !Modifier.isStatic(m.getModifiers()))
+            .map(TimestampedToHeadersWindowStoreAdapterCompletenessTest::signature)
+            .filter(sig -> !classified.contains(sig))
+            .collect(Collectors.toCollection(TreeSet::new));
+
+        assertTrue(unclassified.isEmpty(),
+            "Unclassified WindowStore method(s): " + unclassified + ". Add each to a contract group in "
+                + "this test AND cover it with a behavioral test in TimestampedToHeadersWindowStoreAdapterTest, "
+                + "so a forgotten header conversion cannot leak raw bytes silently.");
+    }
+
+    private static String signature(final Method m) {
+        return m.getName() + "(" + Arrays.stream(m.getParameterTypes())
+            .map(Class::getSimpleName)
+            .collect(Collectors.joining(",")) + ")";
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterTest.java
@@ -31,9 +31,11 @@ import org.apache.kafka.streams.query.WindowKeyQuery;
 import org.apache.kafka.streams.query.WindowRangeQuery;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedBytesStore;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -48,11 +50,18 @@ import java.time.Instant;
 import java.util.Properties;
 
 import static java.time.Duration.ofMillis;
+import static org.apache.kafka.streams.state.HeadersBytesStore.convertToHeaderFormat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class TimestampedToHeadersWindowStoreAdapterTest {
 
@@ -318,5 +327,175 @@ public class TimestampedToHeadersWindowStoreAdapterTest {
             }
         }
         assertFalse(foundAdapterInfo, "Expected no execution info from adapter when not requested");
+    }
+
+    // Method-level behavioral coverage over a mocked inner store: reads convert/wrap, put strips
+    // headers. See TimestampedToHeadersWindowStoreAdapterCompletenessTest for the completeness guard.
+    private static final Bytes KEY = new Bytes("key".getBytes());
+    private static final Bytes KEY_TO = new Bytes("key-to".getBytes());
+    private static final byte[] RAW_VALUE = new byte[] {0, 0, 0, 0, 0, 0, 0, 42, 'v', 'a', 'l'};
+    private static final Instant T_FROM = Instant.ofEpochMilli(0L);
+    private static final Instant T_TO = Instant.ofEpochMilli(10L);
+
+    private WindowStore<Bytes, byte[]> mockInner;
+    private TimestampedToHeadersWindowStoreAdapter mockAdapter;
+
+    private void setUpMockAdapter() {
+        mockInner = mock(WindowStore.class, withSettings().extraInterfaces(TimestampedBytesStore.class));
+        when(mockInner.persistent()).thenReturn(true);
+        mockAdapter = new TimestampedToHeadersWindowStoreAdapter(mockInner);
+    }
+
+    @Test
+    public void shouldStripHeadersOnPut() {
+        setUpMockAdapter();
+        mockAdapter.put(KEY, convertToHeaderFormat(RAW_VALUE), 5L);
+        verify(mockInner).put(KEY, RAW_VALUE, 5L);
+    }
+
+    @Test
+    public void shouldConvertFetchByKeyAndTimestampToHeaderFormat() {
+        setUpMockAdapter();
+        when(mockInner.fetch(KEY, 5L)).thenReturn(RAW_VALUE);
+        assertArrayEquals(convertToHeaderFormat(RAW_VALUE), mockAdapter.fetch(KEY, 5L));
+    }
+
+    @Test
+    public void shouldReturnNullWhenFetchByKeyAndTimestampReturnsNull() {
+        setUpMockAdapter();
+        when(mockInner.fetch(KEY, 5L)).thenReturn(null);
+        assertNull(mockAdapter.fetch(KEY, 5L));
+    }
+
+    @Test
+    public void shouldWrapFetchByKeyAndTimeRangeIterator() {
+        setUpMockAdapter();
+        final WindowStoreIterator<byte[]> inner = mock(WindowStoreIterator.class);
+        when(mockInner.fetch(KEY, 0L, 10L)).thenReturn(inner);
+        assertInstanceOf(WindowStoreIterator.class, mockAdapter.fetch(KEY, 0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapFetchByKeyAndInstantRangeIterator() {
+        setUpMockAdapter();
+        final WindowStoreIterator<byte[]> inner = mock(WindowStoreIterator.class);
+        when(mockInner.fetch(KEY, T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(WindowStoreIterator.class, mockAdapter.fetch(KEY, T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchByKeyAndTimeRangeIterator() {
+        setUpMockAdapter();
+        final WindowStoreIterator<byte[]> inner = mock(WindowStoreIterator.class);
+        when(mockInner.backwardFetch(KEY, 0L, 10L)).thenReturn(inner);
+        assertInstanceOf(WindowStoreIterator.class, mockAdapter.backwardFetch(KEY, 0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchByKeyAndInstantRangeIterator() {
+        setUpMockAdapter();
+        final WindowStoreIterator<byte[]> inner = mock(WindowStoreIterator.class);
+        when(mockInner.backwardFetch(KEY, T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(WindowStoreIterator.class, mockAdapter.backwardFetch(KEY, T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapFetchByKeyRangeAndTimeRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.fetch(KEY, KEY_TO, 0L, 10L)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.fetch(KEY, KEY_TO, 0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapFetchByKeyRangeAndInstantRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.fetch(KEY, KEY_TO, T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.fetch(KEY, KEY_TO, T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchByKeyRangeAndTimeRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.backwardFetch(KEY, KEY_TO, 0L, 10L)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.backwardFetch(KEY, KEY_TO, 0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchByKeyRangeAndInstantRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.backwardFetch(KEY, KEY_TO, T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.backwardFetch(KEY, KEY_TO, T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapFetchAllByTimeRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.fetchAll(0L, 10L)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.fetchAll(0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapFetchAllByInstantRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.fetchAll(T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.fetchAll(T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchAllByTimeRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.backwardFetchAll(0L, 10L)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.backwardFetchAll(0L, 10L));
+    }
+
+    @Test
+    public void shouldWrapBackwardFetchAllByInstantRangeIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.backwardFetchAll(T_FROM, T_TO)).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.backwardFetchAll(T_FROM, T_TO));
+    }
+
+    @Test
+    public void shouldWrapAllIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.all()).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.all());
+    }
+
+    @Test
+    public void shouldWrapBackwardAllIterator() {
+        setUpMockAdapter();
+        final KeyValueIterator<Windowed<Bytes>, byte[]> inner = mock(KeyValueIterator.class);
+        when(mockInner.backwardAll()).thenReturn(inner);
+        assertInstanceOf(TimestampedToHeadersIteratorAdapter.class, mockAdapter.backwardAll());
+    }
+
+    @Test
+    public void shouldDelegateName() {
+        setUpMockAdapter();
+        when(mockInner.name()).thenReturn("inner-store");
+        assertEquals("inner-store", mockAdapter.name());
+    }
+
+    @Test
+    public void shouldDelegateIsOpen() {
+        setUpMockAdapter();
+        when(mockInner.isOpen()).thenReturn(true);
+        assertTrue(mockAdapter.isOpen());
+    }
+
+    @Test
+    public void shouldReturnPersistentTrue() {
+        setUpMockAdapter();
+        assertTrue(mockAdapter.persistent());
     }
 }


### PR DESCRIPTION
Ref: https://issues.apache.org/jira/browse/KAFKA-20328

Second PR of the KAFKA-20328 audit.
Adds unit coverage for the header-aware forwarding/decorator layers so that missing method overrides (ex. backwardFetch, backwardFindSessions) are caught by tests rather than by manual testing.

Format-converting adapters:
- TimestampedToHeadersWindowStoreAdapter: was query-only; add behavioral coverage
- TimestampedToHeadersIteratorAdapter: new test
- SessionToHeadersStoreAdapter: add the missing findSessions(long,long) case

Decorators (previously untested):
  - AbstractReadWriteDecoratorTest / AbstractReadOnlyDecoratorTest