### PR TITLE
MINOR: Fix StreamPartitioner removal warnings in integration tests

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
@@ -338,26 +337,7 @@ public class KStreamRepartitionIntegrationTest {
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
             @SuppressWarnings("removal")
             @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final int numPartitions
-            ) {
-                throw new AssertionError(
-                    "Deprecated 4-argument partitions method was called instead of "
-                        + "5-argument method containing headers."
-                );
-            }
-
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final Headers headers,
-                final int numPartitions
-            ) {
+            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
                 partitionerInvocation.incrementAndGet();
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
@@ -402,39 +382,12 @@ public class KStreamRepartitionIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("protocolAndOptimizationParameters")
+    @SuppressWarnings("removal")
     public void shouldUseStreamPartitionerForRepartitionOperation(final String topologyOptimization, final boolean useNewProtocol) throws Exception {
         final int partition = 1;
         final String repartitionName = "partitioner-test";
         final long timestamp = System.currentTimeMillis();
         final AtomicInteger partitionerInvocation = new AtomicInteger(0);
-
-        class FixedPartitioner implements StreamPartitioner<Integer, String> {
-            @SuppressWarnings("removal")
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final int numPartitions
-            ) {
-                throw new AssertionError(
-                    "Deprecated 4-argument partitions method was called instead of "
-                        + "5-argument method containing headers."
-                );
-            }
-
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final Headers headers,
-                final int numPartitions
-            ) {
-                partitionerInvocation.incrementAndGet();
-                return Optional.of(Collections.singleton(partition));
-            }
-        }
 
         final List<KeyValue<Integer, String>> expectedRecords = Arrays.asList(
             new KeyValue<>(1, "A"),
@@ -447,7 +400,10 @@ public class KStreamRepartitionIntegrationTest {
 
         final Repartitioned<Integer, String> repartitioned = Repartitioned
             .<Integer, String>as(repartitionName)
-            .withStreamPartitioner(new FixedPartitioner());
+            .withStreamPartitioner((topic, key, value, numPartitions) -> {
+                partitionerInvocation.incrementAndGet();
+                return Optional.of(Collections.singleton(partition));
+            });
 
         builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))
                .repartition(repartitioned)

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
@@ -335,8 +336,28 @@ public class KStreamRepartitionIntegrationTest {
         final List<KeyValue<Integer, String>> expectedRecords = expectedRecordsOnRepartition.subList(3, 5);
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
+            @SuppressWarnings("removal")
             @Override
-            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final int numPartitions
+            ) {
+                throw new AssertionError(
+                    "Deprecated 4-argument partitions method was called instead of "
+                        + "5-argument method containing headers."
+                );
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final Headers headers,
+                final int numPartitions
+            ) {
                 partitionerInvocation.incrementAndGet();
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
@@ -387,6 +408,34 @@ public class KStreamRepartitionIntegrationTest {
         final long timestamp = System.currentTimeMillis();
         final AtomicInteger partitionerInvocation = new AtomicInteger(0);
 
+        class FixedPartitioner implements StreamPartitioner<Integer, String> {
+            @SuppressWarnings("removal")
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final int numPartitions
+            ) {
+                throw new AssertionError(
+                    "Deprecated 4-argument partitions method was called instead of "
+                        + "5-argument method containing headers."
+                );
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final Headers headers,
+                final int numPartitions
+            ) {
+                partitionerInvocation.incrementAndGet();
+                return Optional.of(Collections.singleton(partition));
+            }
+        }
+
         final List<KeyValue<Integer, String>> expectedRecords = Arrays.asList(
             new KeyValue<>(1, "A"),
             new KeyValue<>(2, "B")
@@ -398,10 +447,7 @@ public class KStreamRepartitionIntegrationTest {
 
         final Repartitioned<Integer, String> repartitioned = Repartitioned
             .<Integer, String>as(repartitionName)
-            .withStreamPartitioner((topic, key, value, numPartitions) -> {
-                partitionerInvocation.incrementAndGet();
-                return Optional.of(Collections.singleton(partition));
-            });
+            .withStreamPartitioner(new FixedPartitioner());
 
         builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))
                .repartition(repartitioned)

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -382,7 +382,6 @@ public class KStreamRepartitionIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("protocolAndOptimizationParameters")
-    @SuppressWarnings("removal")
     public void shouldUseStreamPartitionerForRepartitionOperation(final String topologyOptimization, final boolean useNewProtocol) throws Exception {
         final int partition = 1;
         final String repartitionName = "partitioner-test";
@@ -398,6 +397,7 @@ public class KStreamRepartitionIntegrationTest {
 
         final StreamsBuilder builder = new StreamsBuilder();
 
+        @SuppressWarnings("removal")
         final Repartitioned<Integer, String> repartitioned = Repartitioned
             .<Integer, String>as(repartitionName)
             .withStreamPartitioner((topic, key, value, numPartitions) -> {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -99,83 +98,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         @SuppressWarnings("removal")
         @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final Void value,
-            final int numPartitions
-        ) {
-            throw new AssertionError(
-                "Deprecated 4-argument partitions method was called instead of "
-                    + "5-argument method containing headers."
-            );
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final Void value,
-            final Headers headers,
-            final int numPartitions
-        ) {
+        public Optional<Set<Integer>> partitions(final String topic, final String key, final Void value, final int numPartitions) {
             return Optional.of(Set.of(0, 1, 2));
-        }
-    }
-
-    private static class TableAPartitioner<V> implements StreamPartitioner<String, V> {
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final V value,
-            final int numPartitions
-        ) {
-            throw new AssertionError(
-                "Deprecated 4-argument partitions method was called instead of "
-                    + "5-argument method containing headers."
-            );
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final V value,
-            final Headers headers,
-            final int numPartitions
-        ) {
-            return Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions));
-        }
-    }
-
-    private static class TableBPartitioner<V> implements StreamPartitioner<String, V> {
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final V value,
-            final int numPartitions
-        ) {
-            throw new AssertionError(
-                "Deprecated 4-argument partitions method was called instead of "
-                    + "5-argument method containing headers."
-            );
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(
-            final String topic,
-            final String key,
-            final V value,
-            final Headers headers,
-            final int numPartitions
-        ) {
-            return Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions));
         }
     }
 
@@ -329,6 +253,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         return streamsConfig;
     }
 
+    @SuppressWarnings("removal")
     private static KafkaStreams prepareTopology(final String queryableName, final Properties streamsConfig) {
 
         final UniqueTopicSerdeScope serdeScope = new UniqueTopicSerdeScope();
@@ -358,8 +283,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
-            new TableAPartitioner<>(),
-            new TableBPartitioner<>()
+            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)),
+            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -371,6 +296,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         return new KafkaStreams(builder.build(streamsConfig), streamsConfig);
     }
 
+    @SuppressWarnings("removal")
     private static KafkaStreams prepareTopologyWithNonSingletonPartitions(final String queryableName, final Properties streamsConfig) {
 
         final UniqueTopicSerdeScope serdeScope = new UniqueTopicSerdeScope();
@@ -401,7 +327,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
                 new MultiPartitioner(),
-                new TableBPartitioner<>()
+                (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -413,17 +339,19 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         return new KafkaStreams(builder.build(streamsConfig), streamsConfig);
     }
 
+    @SuppressWarnings("removal")
     private static Repartitioned<String, String> repartitionA() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("a");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner(new TableAPartitioner<>())
+            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)))
             .withNumberOfPartitions(4);
     }
 
+    @SuppressWarnings("removal")
     private static Repartitioned<String, String> repartitionB() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("b");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner(new TableBPartitioner<>())
+            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions)))
             .withNumberOfPartitions(4);
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -96,9 +97,85 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
     static class MultiPartitioner implements StreamPartitioner<String, Void> {
 
+        @SuppressWarnings("removal")
         @Override
-        public Optional<Set<Integer>> partitions(final String topic, final String key, final Void value, final int numPartitions) {
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final Void value,
+            final int numPartitions
+        ) {
+            throw new AssertionError(
+                "Deprecated 4-argument partitions method was called instead of "
+                    + "5-argument method containing headers."
+            );
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final Void value,
+            final Headers headers,
+            final int numPartitions
+        ) {
             return Optional.of(Set.of(0, 1, 2));
+        }
+    }
+
+    private static class TableAPartitioner<V> implements StreamPartitioner<String, V> {
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final V value,
+            final int numPartitions
+        ) {
+            throw new AssertionError(
+                "Deprecated 4-argument partitions method was called instead of "
+                    + "5-argument method containing headers."
+            );
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final V value,
+            final Headers headers,
+            final int numPartitions
+        ) {
+            return Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions));
+        }
+    }
+
+    private static class TableBPartitioner<V> implements StreamPartitioner<String, V> {
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final V value,
+            final int numPartitions
+        ) {
+            throw new AssertionError(
+                "Deprecated 4-argument partitions method was called instead of "
+                    + "5-argument method containing headers."
+            );
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(
+            final String topic,
+            final String key,
+            final V value,
+            final Headers headers,
+            final int numPartitions
+        ) {
+            return Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions));
         }
     }
 
@@ -281,8 +358,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
-            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)),
-            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
+            new TableAPartitioner<>(),
+            new TableBPartitioner<>()
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -324,7 +401,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
                 new MultiPartitioner(),
-                (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
+                new TableBPartitioner<>()
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -339,14 +416,14 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
     private static Repartitioned<String, String> repartitionA() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("a");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)))
+            .withStreamPartitioner(new TableAPartitioner<>())
             .withNumberOfPartitions(4);
     }
 
     private static Repartitioned<String, String> repartitionB() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("b");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions)))
+            .withStreamPartitioner(new TableBPartitioner<>())
             .withNumberOfPartitions(4);
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -106,7 +106,6 @@ public class OptimizedKTableIntegrationTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     public void shouldApplyUpdatesToStandbyStore(final TestInfo testInfo) throws Exception {
         final int batch1NumMessages = 100;
         final int batch2NumMessages = 100;
@@ -139,6 +138,7 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
+                @SuppressWarnings("removal")
                 final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
                         .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -32,6 +33,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -57,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -77,6 +80,34 @@ public class OptimizedKTableIntegrationTest {
     private static int port = 0;
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
+
+    private static final StreamPartitioner<Integer, Object> PARTITION_ZERO_PARTITIONER =
+        new StreamPartitioner<>() {
+            @SuppressWarnings("removal")
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final Object value,
+                final int numPartitions
+            ) {
+                throw new AssertionError(
+                    "Deprecated 4-argument partitions method was called instead of "
+                        + "5-argument method containing headers."
+                );
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final Object value,
+                final Headers headers,
+                final int numPartitions
+            ) {
+                return Optional.of(Collections.singleton(0));
+            }
+        };
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
@@ -139,7 +170,7 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
                 final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                        .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                        .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
 
                 try {
                     // Assert that the current value in store reflects all messages being processed

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -33,7 +32,6 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -59,7 +57,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,34 +77,6 @@ public class OptimizedKTableIntegrationTest {
     private static int port = 0;
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
-
-    private static final StreamPartitioner<Integer, Object> PARTITION_ZERO_PARTITIONER =
-        new StreamPartitioner<>() {
-            @SuppressWarnings("removal")
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final Object value,
-                final int numPartitions
-            ) {
-                throw new AssertionError(
-                    "Deprecated 4-argument partitions method was called instead of "
-                        + "5-argument method containing headers."
-                );
-            }
-
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final Object value,
-                final Headers headers,
-                final int numPartitions
-            ) {
-                return Optional.of(Collections.singleton(0));
-            }
-        };
 
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
@@ -137,6 +106,7 @@ public class OptimizedKTableIntegrationTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void shouldApplyUpdatesToStandbyStore(final TestInfo testInfo) throws Exception {
         final int batch1NumMessages = 100;
         final int batch2NumMessages = 100;
@@ -170,7 +140,7 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
                 final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                        .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
+                        .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
                 try {
                     // Assert that the current value in store reflects all messages being processed

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -101,34 +100,6 @@ public class StoreQueryIntegrationTest {
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
 
-    private static final StreamPartitioner<Integer, Object> PARTITION_ZERO_PARTITIONER =
-        new StreamPartitioner<>() {
-            @SuppressWarnings("removal")
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final Object value,
-                final int numPartitions
-            ) {
-                throw new AssertionError(
-                    "Deprecated 4-argument partitions method was called instead of "
-                        + "5-argument method containing headers."
-                );
-            }
-
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final Object value,
-                final Headers headers,
-                final int numPartitions
-            ) {
-                return Optional.of(Collections.singleton(0));
-            }
-        };
-
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
     private String appId;
@@ -160,6 +131,7 @@ public class StoreQueryIntegrationTest {
         CLUSTER.stop();
     }
 
+    @SuppressWarnings("removal")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldQueryOnlyActivePartitionStoresByDefault(final boolean withHeaders) throws Exception {
@@ -184,7 +156,7 @@ public class StoreQueryIntegrationTest {
         until(() -> {
 
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
+                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
             final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
@@ -209,6 +181,7 @@ public class StoreQueryIntegrationTest {
         });
     }
 
+    @SuppressWarnings("removal")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldQuerySpecificActivePartitionStores(final boolean withHeaders) throws Exception {
@@ -232,7 +205,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
+                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
             //key belongs to this partition
             final int keyPartition = keyQueryMetadata.partition();
@@ -330,6 +303,7 @@ public class StoreQueryIntegrationTest {
         }, "store2 cannot find results for key");
     }
 
+    @SuppressWarnings("removal")
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void shouldQuerySpecificStalePartitionStores(final boolean withHeaders) throws Exception {
@@ -351,7 +325,7 @@ public class StoreQueryIntegrationTest {
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
+                .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
 
         //key belongs to this partition
         final int keyPartition = keyQueryMetadata.partition();
@@ -597,29 +571,10 @@ public class StoreQueryIntegrationTest {
     @ValueSource(booleans = {false, true})
     public void shouldFailWithIllegalArgumentExceptionWhenIQPartitionerReturnsMultiplePartitions(final boolean withHeaders) throws Exception {
 
+        @SuppressWarnings("removal")
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
-            @SuppressWarnings("removal")
             @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final int numPartitions
-            ) {
-                throw new AssertionError(
-                    "Deprecated 4-argument partitions method was called instead of "
-                        + "5-argument method containing headers."
-                );
-            }
-
-            @Override
-            public Optional<Set<Integer>> partitions(
-                final String topic,
-                final Integer key,
-                final String value,
-                final Headers headers,
-                final int numPartitions
-            ) {
+            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -100,6 +101,34 @@ public class StoreQueryIntegrationTest {
     private static final String INPUT_TOPIC_NAME = "input-topic";
     private static final String TABLE_NAME = "source-table";
 
+    private static final StreamPartitioner<Integer, Object> PARTITION_ZERO_PARTITIONER =
+        new StreamPartitioner<>() {
+            @SuppressWarnings("removal")
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final Object value,
+                final int numPartitions
+            ) {
+                throw new AssertionError(
+                    "Deprecated 4-argument partitions method was called instead of "
+                        + "5-argument method containing headers."
+                );
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final Object value,
+                final Headers headers,
+                final int numPartitions
+            ) {
+                return Optional.of(Collections.singleton(0));
+            }
+        };
+
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
 
     private String appId;
@@ -155,7 +184,7 @@ public class StoreQueryIntegrationTest {
         until(() -> {
 
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                    .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
 
             final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
@@ -203,7 +232,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                    .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
 
             //key belongs to this partition
             final int keyPartition = keyQueryMetadata.partition();
@@ -322,7 +351,7 @@ public class StoreQueryIntegrationTest {
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                .queryMetadataForKey(TABLE_NAME, key, PARTITION_ZERO_PARTITIONER);
 
         //key belongs to this partition
         final int keyPartition = keyQueryMetadata.partition();
@@ -569,8 +598,28 @@ public class StoreQueryIntegrationTest {
     public void shouldFailWithIllegalArgumentExceptionWhenIQPartitionerReturnsMultiplePartitions(final boolean withHeaders) throws Exception {
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
+            @SuppressWarnings("removal")
             @Override
-            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final int numPartitions
+            ) {
+                throw new AssertionError(
+                    "Deprecated 4-argument partitions method was called instead of "
+                        + "5-argument method containing headers."
+                );
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(
+                final String topic,
+                final Integer key,
+                final String value,
+                final Headers headers,
+                final int numPartitions
+            ) {
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
         }


### PR DESCRIPTION
This PR suppresses removal warnings caused by the deprecated 4-argument
`StreamPartitioner#partitions` method in Streams integration tests.

Validation:

- `./gradlew :streams:integration-tests:test`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>
