### PR TITLE
KAFKA-20862 update gradle-versions-plugin to improve `dependencyUpdates` task result output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id 'io.github.ben-manes.versions' version '0.56.0'
+  id 'io.github.ben-manes.versions' version '0.61.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -64,7 +64,7 @@ versions += [
   httpclient: "4.5.14",
   jackson: "2.21.5",
   jacksonAnnotations: "2.21",
-  jacoco: "0.8.14",
+  jacoco: "0.8.15",
   javassist: "3.30.2-GA",
   // When upgrading Jetty, verify that it does not use the SLF4J 2.x fluent API
   // (e.g. Logger.atDebug()) in production code, as Kafka uses SLF4J 1.7.x.


### PR DESCRIPTION
_Prologue (how it started): an awkward situation with dependencies versions update report was spotted while testing  JaCoCo version update (i.e. after executing `./gradlew dependencyUpdates` task) so it makes sense to update JaCoCo version (0.8.14 -->> 0.8.15) all along._
___

Jira ticket: KAFKA-20862

**Action points (_i.e. tldr_):** 
- update `gradle-versions-plugin` 0.56.0 -->> 0.61.0:
  - `dependencyUpdates` task output looks **much** better now
  - `gradle-versions-plugin` developers used Kafka codebase for 0.57.0 and 0.58.0 versions :slightly_smiling_face: 
- (optional) update `jacoco`: 0.8.14 -->> 0.8.15

**Release notes:**
- gradle-versions-plugin:
   - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.57.0
   - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.58.0
   - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.59.0
   - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.60.0
   - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.61.0
   - https://github.com/ben-manes/gradle-versions-plugin/tree/v0.61.0#migrating-from-prior-versions
- jacoco:
   - https://github.com/jacoco/jacoco/releases/tag/v0.8.15

**Rationale (with much more details):** 
- I tried to update jacoco version (0.8.14 -->> 0.8.15) but stumbled upon on (turns out not to be an) issue: https://github.com/ben-manes/gradle-versions-plugin/issues/1028; however `gradle-versions-plugin` team covered this case in docs (they added a new section in their `README.md`):
  - https://github.com/ben-manes/gradle-versions-plugin/pull/1030 
  - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.57.0
- upon testing plugin version 0.57.0, I filed another ticket: https://github.com/ben-manes/gradle-versions-plugin/issues/1032 and while this was a non-issue (yet again) `gradle-versions-plugin` developers used my report and Kafka codebase to improve output for their `dependencyUpdates` task: 
  - https://github.com/ben-manes/gradle-versions-plugin/pull/1035
  - https://github.com/ben-manes/gradle-versions-plugin/pull/1036
  - https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.58.0

Addendum: Jacoco latest version release notes >> https://github.com/jacoco/jacoco/releases/tag/v0.8.15