### PR TITLE
KAFKA-20861: Kafka Streams should handle corrupted assignments pro-actively

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManager.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
+import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackCompletedEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackNeededEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnTasksAssignedCallbackCompletedEvent;
@@ -775,6 +776,12 @@ public class StreamsMembershipManager implements RequestManager {
                 return;
             }
 
+            final Set<String> unknownSubtopologies = unknownSubtopologies(activeTasks, standbyTasks, warmupTasks);
+            if (!unknownSubtopologies.isEmpty()) {
+                failOnUnknownSubtopologies(unknownSubtopologies);
+                return;
+            }
+
             processAssignmentReceived(
                 toTasksAssignment(activeTasks),
                 toTasksAssignment(standbyTasks),
@@ -945,6 +952,38 @@ public class StreamsMembershipManager implements RequestManager {
     private static Map<String, SortedSet<Integer>> toTasksAssignment(final List<StreamsGroupHeartbeatResponseData.TaskIds> taskIds) {
         return taskIds.stream()
             .collect(Collectors.toMap(StreamsGroupHeartbeatResponseData.TaskIds::subtopologyId, taskId -> new TreeSet<>(taskId.partitions())));
+    }
+
+    private Set<String> unknownSubtopologies(final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks,
+                                             final List<StreamsGroupHeartbeatResponseData.TaskIds> standbyTasks,
+                                             final List<StreamsGroupHeartbeatResponseData.TaskIds> warmupTasks) {
+        final Set<String> knownSubtopologies = streamsRebalanceData.subtopologies().keySet();
+        final Set<String> unknownSubtopologies = new TreeSet<>(); // use an ordered set for "proper" error logging
+        for (final List<StreamsGroupHeartbeatResponseData.TaskIds> tasks : List.of(activeTasks, standbyTasks, warmupTasks)) {
+            for (final StreamsGroupHeartbeatResponseData.TaskIds taskIds : tasks) {
+                if (!knownSubtopologies.contains(taskIds.subtopologyId())) {
+                    unknownSubtopologies.add(taskIds.subtopologyId());
+                }
+            }
+        }
+        return unknownSubtopologies;
+    }
+
+    private void failOnUnknownSubtopologies(final Set<String> unknownSubtopologies) {
+        final String errorMessage = String.format(
+            "Member %s of Streams group %s was assigned tasks of subtopologies %s, which are not part of the topology "
+                + "of this client (which has subtopologies %s). The assignment cannot be applied, because the "
+                + "partitions of a task are resolved through this client's own topology. This points at a problem on "
+                + "the group coordinator, for example in a custom broker-side task assignor, or at a topology that "
+                + "differs from the one the group was initialized with.",
+            memberId,
+            groupId,
+            unknownSubtopologies,
+            new TreeSet<>(streamsRebalanceData.subtopologies().keySet())
+        );
+        log.error(errorMessage);
+        backgroundEventHandler.add(new ErrorEvent(new KafkaException(errorMessage)));
+        transitionToFatal();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsMembershipManagerTest.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.CloseOptions;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
+import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackCompletedEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnAllTasksLostCallbackNeededEvent;
 import org.apache.kafka.clients.consumer.internals.events.StreamsOnTasksAssignedCallbackCompletedEvent;
@@ -67,6 +69,7 @@ import java.util.stream.Stream;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.CONSUMER_METRIC_GROUP_PREFIX;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.COORDINATOR_METRICS_SUFFIX;
 import static org.apache.kafka.common.requests.ShareGroupHeartbeatRequest.LEAVE_GROUP_MEMBER_EPOCH;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -76,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -92,6 +96,7 @@ public class StreamsMembershipManagerTest {
 
     private static final String SUBTOPOLOGY_ID_0 = "subtopology-0";
     private static final String SUBTOPOLOGY_ID_1 = "subtopology-1";
+    private static final String UNKNOWN_SUBTOPOLOGY_ID = "subtopology-not-in-this-topology";
 
     private static final String TOPIC_0 = "topic-0";
     private static final String TOPIC_1 = "topic-1";
@@ -200,6 +205,83 @@ public class StreamsMembershipManagerTest {
             "Invalid response data, task collections must be all null or all non-null: " + response.data(),
             exception.getMessage()
         );
+    }
+
+    @Test
+    public void testActiveTaskOfUnknownSubtopologyInHeartbeatResponseFailsMember() {
+        testTasksOfUnknownSubtopologyInHeartbeatResponseFailMember(
+            List.of(taskIds(UNKNOWN_SUBTOPOLOGY_ID, List.of(PARTITION_0))),
+            List.of(),
+            List.of()
+        );
+    }
+
+    @Test
+    public void testStandbyTaskOfUnknownSubtopologyInHeartbeatResponseFailsMember() {
+        testTasksOfUnknownSubtopologyInHeartbeatResponseFailMember(
+            List.of(),
+            List.of(taskIds(UNKNOWN_SUBTOPOLOGY_ID, List.of(PARTITION_0))),
+            List.of()
+        );
+    }
+
+    @Test
+    public void testWarmupTaskOfUnknownSubtopologyInHeartbeatResponseFailsMember() {
+        testTasksOfUnknownSubtopologyInHeartbeatResponseFailMember(
+            List.of(),
+            List.of(),
+            List.of(taskIds(UNKNOWN_SUBTOPOLOGY_ID, List.of(PARTITION_0)))
+        );
+    }
+
+    @Test
+    public void testKnownTasksAlongsideUnknownSubtopologyInHeartbeatResponseFailMember() {
+        // The known part of the assignment is not applied either: a task of an unknown subtopology cannot be resolved
+        // to topic partitions, so there is no correct subset of the assignment to run.
+        testTasksOfUnknownSubtopologyInHeartbeatResponseFailMember(
+            List.of(
+                taskIds(SUBTOPOLOGY_ID_0, List.of(PARTITION_0)),
+                taskIds(UNKNOWN_SUBTOPOLOGY_ID, List.of(PARTITION_0))
+            ),
+            List.of(),
+            List.of()
+        );
+    }
+
+    private void testTasksOfUnknownSubtopologyInHeartbeatResponseFailMember(
+        final List<StreamsGroupHeartbeatResponseData.TaskIds> activeTasks,
+        final List<StreamsGroupHeartbeatResponseData.TaskIds> standbyTasks,
+        final List<StreamsGroupHeartbeatResponseData.TaskIds> warmupTasks
+    ) {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
+        joining();
+
+        // Must not throw: the exception would be swallowed by the heartbeat response callback, leaving the member
+        // unable to ever reconcile again.
+        assertDoesNotThrow(() -> membershipManager.onHeartbeatSuccess(
+            makeHeartbeatResponse(activeTasks, standbyTasks, warmupTasks)));
+
+        verifyInStateFatal(membershipManager);
+        final ArgumentCaptor<BackgroundEvent> eventCaptor = ArgumentCaptor.forClass(BackgroundEvent.class);
+        verify(backgroundEventHandler, atLeastOnce()).add(eventCaptor.capture());
+        final ErrorEvent errorEvent = eventCaptor.getAllValues().stream()
+            .filter(event -> event instanceof ErrorEvent)
+            .map(event -> (ErrorEvent) event)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No ErrorEvent was passed to the background event handler"));
+        assertInstanceOf(KafkaException.class, errorEvent.error());
+        final String message = errorEvent.error().getMessage();
+        assertTrue(message.contains(UNKNOWN_SUBTOPOLOGY_ID), "The unknown subtopology should be named: " + message);
+        assertTrue(message.contains(SUBTOPOLOGY_ID_0), "The client's own subtopologies should be named: " + message);
+        assertTrue(message.contains(GROUP_ID), "The group should be named: " + message);
+
+        // No part of the assignment is applied: the member must not start the tasks it does understand, because the
+        // assignment as a whole cannot be reconciled.
+        assertTrue(
+            eventCaptor.getAllValues().stream().noneMatch(event -> event instanceof StreamsTasksAssignedEvent),
+            "No tasks should have been handed to the application: " + eventCaptor.getAllValues()
+        );
+        verify(subscriptionState, never()).assignFromSubscribedAwaitingCallback(any(), any());
     }
 
     @Test
@@ -469,6 +551,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingEmptyToSingleStandbyTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> standbyTasks =
             Set.of(new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0));
         joining();
@@ -491,6 +574,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingStandbyTaskToDifferentStandbyTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> standbyTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -527,6 +611,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingSingleStandbyTaskToAdditionalStandbyTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> standbyTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -564,6 +649,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingMultipleStandbyTaskToSingleStandbyTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> standbyTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0),
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_1)
@@ -636,6 +722,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingStandbyTaskToWarmupTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> standbyTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -672,6 +759,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingEmptyToSingleWarmupTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> warmupTasks =
             Set.of(new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0));
         joining();
@@ -694,6 +782,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingWarmupTaskToDifferentWarmupTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> warmupTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -730,6 +819,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingSingleWarmupTaskToAdditionalWarmupTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> warmupTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -767,6 +857,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingMultipleWarmupTaskToSingleWarmupTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> warmupTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0),
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_1)
@@ -843,6 +934,7 @@ public class StreamsMembershipManagerTest {
 
     @Test
     public void testReconcilingWarmupTaskToStandbyTask() {
+        setupStreamsRebalanceDataWithOneSubtopologyOneSourceTopic(SUBTOPOLOGY_ID_0, TOPIC_0);
         final Set<StreamsRebalanceData.TaskId> warmupTasksSetup = Set.of(
             new StreamsRebalanceData.TaskId(SUBTOPOLOGY_ID_0, PARTITION_0)
         );
@@ -2587,6 +2679,15 @@ public class StreamsMembershipManagerTest {
                 )
             )
         );
+    }
+
+    private static StreamsGroupHeartbeatResponseData.TaskIds taskIds(
+        final String subtopologyId,
+        final List<Integer> partitions
+    ) {
+        return new StreamsGroupHeartbeatResponseData.TaskIds()
+            .setSubtopologyId(subtopologyId)
+            .setPartitions(partitions);
     }
 
     private StreamsGroupHeartbeatResponse makeHeartbeatResponseWithActiveTasks(final String subtopologyId,


### PR DESCRIPTION
This PR ensures that KafkaStreams fails with a clear error message if a
bad task assignment is received from the broker.

This fix prevents Kafka Streams from hitting KAFKA-20860

Reviewers: Zheguang Zhao <zheguang.zhao@gmail.com>, Lianet Magrans
 <lmagrans@confluent.io>
