### PR TITLE
MINOR: Avoid reflective class loading for share state persister

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -751,16 +751,16 @@ class BrokerServer(
   }
 
   private def createShareStatePersister(): Persister = {
-    if (config.shareGroupConfig.shareGroupPersisterClassName.nonEmpty) {
-      val klass = Utils.loadClass(config.shareGroupConfig.shareGroupPersisterClassName, classOf[Object]).asInstanceOf[Class[Persister]]
-      if (klass.getName.equals(classOf[DefaultStatePersister].getName)) {
+    val className = config.shareGroupConfig.shareGroupPersisterClassName
+    if (className.nonEmpty) {
+      if (className.equals(classOf[DefaultStatePersister].getName)) {
         DefaultStatePersister.instance(
           NetworkUtils.buildNetworkClient("Persister", config, metrics, Time.SYSTEM, new LogContext(s"[Persister broker=${config.brokerId}]")),
           new ShareCoordinatorMetadataCacheHelperImpl(metadataCache, key => shareCoordinator.partitionFor(key), config.interBrokerListenerName, groupConfigManager, () => config.messageMaxBytes),
           Time.SYSTEM,
           shareGroupTimer
         )
-      } else if (klass.getName.equals(classOf[NoOpStatePersister].getName)) {
+      } else if (className.equals(classOf[NoOpStatePersister].getName)) {
         info("Using no-op persister")
         new NoOpStatePersister()
       } else {

--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1093,10 +1093,6 @@
   "queryAllPublicMethods":true
 },
 {
-  "name":"org.apache.kafka.server.share.persister.DefaultStatePersister",
-  "methods":[{"name":"<init>","parameterTypes":["org.apache.kafka.server.share.persister.PersisterStateManager"] }]
-},
-{
   "name":"org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler$Content",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,


### PR DESCRIPTION
Remove unnecessary reflective class loading from
`createShareStatePersister` by comparing the configured class name
directly.

Also remove the corresponding `DefaultStatePersister` entry from
`reflect-config.json`.

Follow-up to #22900.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>, Sushant Mahajan <smahajan@confluent.io>
