### PR TITLE
KAFKA-20874: Close SslFactory in JaasOptionsUtils.createSSLSocketFactory()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/JaasOptionsUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/secured/JaasOptionsUtils.java
@@ -85,10 +85,14 @@ public class JaasOptionsUtils {
     public SSLSocketFactory createSSLSocketFactory() {
         Map<String, ?> sslClientConfig = getSslClientConfig();
         SslFactory sslFactory = new SslFactory(ConnectionMode.CLIENT);
-        sslFactory.configure(sslClientConfig);
-        SSLSocketFactory socketFactory = ((DefaultSslEngineFactory) sslFactory.sslEngineFactory()).sslContext().getSocketFactory();
-        log.debug("Created SSLSocketFactory: {}", sslClientConfig);
-        return socketFactory;
+        try {
+            sslFactory.configure(sslClientConfig);
+            SSLSocketFactory socketFactory = ((DefaultSslEngineFactory) sslFactory.sslEngineFactory()).sslContext().getSocketFactory();
+            log.debug("Created SSLSocketFactory: {}", sslClientConfig);
+            return socketFactory;
+        } finally {
+            sslFactory.close();
+        }
     }
 
     public String validatePassword(String name) {

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -176,6 +176,8 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
 
     @Override
     public void close() {
+        // JaasOptionsUtils.createSSLSocketFactory() closes the SslFactory after obtaining an SSLSocketFactory,
+        // relying on close() not invalidating already returned SSLContext/SSLSocketFactory objects.
         this.sslContext = null;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/JaasOptionsUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/JaasOptionsUtilsTest.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.net.ssl.SSLSocketFactory;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,6 +51,14 @@ public class JaasOptionsUtilsTest extends OAuthBearerTest {
         assertEquals(sslKeystore, sslClientConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
         assertEquals(sslTruststore, sslClientConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
         assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslClientConfig.get(SslConfigs.SSL_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    public void testCreateSSLSocketFactory() {
+        JaasOptionsUtils jou = new JaasOptionsUtils(Collections.emptyMap());
+        SSLSocketFactory socketFactory = jou.createSSLSocketFactory();
+        assertNotNull(socketFactory);
+        assertTrue(socketFactory.getDefaultCipherSuites().length > 0);
     }
 
     @Test


### PR DESCRIPTION
The SslFactory created in createSSLSocketFactory() was never closed,
leaking the underlying DefaultSslEngineFactory. Wrap in try/finally to
close it after extracting the SSLSocketFactory. This is safe because
DefaultSslEngineFactory.close() only nulls its sslContext field without
invalidating the SSLContext held by the returned SSLSocketFactory.

Added a test to exercise createSSLSocketFactory() directly.

Reviewers: Luke Chen <showuon@gmail.com>, Ken Huang <s7133700@gmail.com>
