### PR TITLE
KAFKA-20877: Fix incorrect restore-rate and update-rate metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -2235,7 +2235,7 @@ public class StreamThread extends Thread implements ProcessingThread {
         if (runOnceLatencyWindow > 0.0) {
             final double latencyWindow =
                 windowedSum.measure(metricsConfig, now);
-            ratioSensor.record(latencyWindow / runOnceLatencyWindow);
+            ratioSensor.record(latencyWindow / runOnceLatencyWindow, now);
         } else {
             ratioSensor.record(0.0, now);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -28,7 +28,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
@@ -189,7 +189,7 @@ public class TaskMetrics {
                                        final String taskId,
                                        final StreamsMetricsImpl streamsMetrics,
                                        final Sensor... parentSensor) {
-        return invocationRateAndTotalSensor(
+        return rateAndTotalSensor(
             threadId,
             taskId,
             RESTORE,
@@ -205,7 +205,7 @@ public class TaskMetrics {
                                       final String taskId,
                                       final StreamsMetricsImpl streamsMetrics,
                                       final Sensor... parentSensor) {
-        return invocationRateAndTotalSensor(
+        return rateAndTotalSensor(
             threadId,
             taskId,
             UPDATE,
@@ -250,7 +250,7 @@ public class TaskMetrics {
     public static Sensor droppedRecordsSensor(final String threadId,
                                               final String taskId,
                                               final StreamsMetricsImpl streamsMetrics) {
-        return invocationRateAndTotalSensor(
+        return rateAndTotalSensor(
             threadId,
             taskId,
             DROPPED_RECORDS,
@@ -281,19 +281,20 @@ public class TaskMetrics {
         return sensor;
     }
 
-    private static Sensor invocationRateAndTotalSensor(final String threadId,
-                                                       final String taskId,
-                                                       final String operation,
-                                                       final String descriptionOfRate,
-                                                       final String descriptionOfTotal,
-                                                       final RecordingLevel recordingLevel,
-                                                       final StreamsMetricsImpl streamsMetrics,
-                                                       final Sensor... parentSensors) {
+    private static Sensor rateAndTotalSensor(
+        final String threadId,
+        final String taskId,
+        final String operation,
+        final String descriptionOfRate,
+        final String descriptionOfTotal,
+        final RecordingLevel recordingLevel,
+        final StreamsMetricsImpl streamsMetrics,
+        final Sensor... parentSensors
+    ) {
         final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, operation, recordingLevel, parentSensors);
         final Map<String, String> tags = streamsMetrics.taskLevelTagMap(threadId, taskId);
 
-        addInvocationRateToSensor(sensor, TASK_LEVEL_GROUP, tags, operation, descriptionOfRate);
-        addSumMetricToSensor(sensor, TASK_LEVEL_GROUP, tags, operation, true, descriptionOfTotal);
+        addRateOfSumAndSumMetricsToSensor(sensor, TASK_LEVEL_GROUP, tags, operation, descriptionOfRate, descriptionOfTotal);
         return sensor;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStore.java
@@ -189,7 +189,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStore<S extends Seg
         final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
 
         if (segment == null) {
-            expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+            expiredRecordSensor.record();
             LOG.warn("Skipping record for expired segment.");
         } else {
             synchronized (position) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -255,6 +255,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
         if (segment == null) {
             expiredRecordSensor.record();
+            LOG.warn("Skipping record for expired segment.");
         } else {
             synchronized (position) {
                 // Transactional puts stage their position too, so READ_COMMITTED never sees a position ahead of the data.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -254,7 +254,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         final long segmentId = segments.segmentId(timestamp);
         final S segment = segments.getOrCreateSegmentIfLive(segmentId, internalProcessorContext, observedStreamTime);
         if (segment == null) {
-            expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+            expiredRecordSensor.record();
         } else {
             synchronized (position) {
                 // Transactional puts stage their position too, so READ_COMMITTED never sees a position ahead of the data.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -159,8 +159,8 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
                         }
                         removeExpiredSegments();
                         if (expiredRecords > 0) {
-                            if (expiredRecordSensor != null && context != null) {
-                                expiredRecordSensor.record(expiredRecords, context.currentSystemTimeMs());
+                            if (expiredRecordSensor != null) {
+                                expiredRecordSensor.record(expiredRecords);
                             }
                             LOG.warn("Skipping {} records for expired segments.", expiredRecords);
                         }
@@ -205,8 +205,8 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]>, WithRe
             if (windowEndTimestamp <= observedStreamTime - retentionPeriod) {
                 // The provided context is not required to implement InternalProcessorContext,
                 // If it doesn't, we can't record this metric (in fact, we wouldn't have even initialized it).
-                if (expiredRecordSensor != null && context != null) {
-                    expiredRecordSensor.record(1.0d, context.currentSystemTimeMs());
+                if (expiredRecordSensor != null) {
+                    expiredRecordSensor.record();
                 }
                 LOG.warn("Skipping record for expired segment.");
             } else if (transactionBuffer != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -155,7 +155,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
                         }
                         removeExpiredSegments();
                         if (expiredRecords > 0) {
-                            expiredRecordSensor.record(expiredRecords, internalProcessorContext.currentSystemTimeMs());
+                            expiredRecordSensor.record(expiredRecords);
                             LOG.warn("Skipping {} records for expired segments.", expiredRecords);
                         }
                     }
@@ -195,7 +195,7 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]>, WithRete
 
         synchronized (position) {
             if (windowStartTimestamp <= observedStreamTime - retentionPeriod) {
-                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+                expiredRecordSensor.record();
                 LOG.warn("Skipping record for expired segment.");
             } else if (transactionBuffer != null) {
                 if (value != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -132,7 +132,7 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
 
         synchronized (position) {
             if (timestamp < observedStreamTime - gracePeriod) {
-                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+                expiredRecordSensor.record();
                 LOG.warn("Skipping record for expired put.");
                 StoreQueryUtils.updatePosition(position, internalProcessorContext);
                 return PUT_RETURN_CODE_NOT_PUT;
@@ -160,7 +160,7 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
 
         synchronized (position) {
             if (timestamp < observedStreamTime - gracePeriod) {
-                expiredRecordSensor.record(1.0d, internalProcessorContext.currentSystemTimeMs());
+                expiredRecordSensor.record();
                 LOG.warn("Skipping record for expired delete.");
                 return null;
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -75,9 +75,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -488,12 +488,26 @@ public class StandbyTaskTest {
         task.recordRestoration(time, 25L, 30L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(25.0));
-        assertThat(rateMetric.metricValue(), not(0.0));
+        // the rate measures updated records per second, not update batches per second; with no time
+        // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
+        assertTrue(
+            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.03333
+            // using 0.5 as good intermediate to the expected value of 0.83333
+            // -> avoid equalTo(...) on floating point numbers
+            0.5d < ((Number) rateMetric.metricValue()).doubleValue(),
+            "Expected a value larger 0.5 [precisely 0.83333...], but got " + rateMetric.metricValue()
+        );
 
         task.recordRestoration(time, 50L, 55L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
-        assertThat(rateMetric.metricValue(), not(0.0));
+        assertTrue(
+            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.06666
+            // using 2.0 as good intermediate to the expected value of 2.5
+            // -> avoid equalTo(...) on floating point numbers
+            2.0d < ((Number) rateMetric.metricValue()).doubleValue(),
+            "Expected a value larger 2.0 [precisely 2.5], but got " + rateMetric.metricValue()
+        );
     }
 
     private KafkaMetric getMetric(final String operation,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -490,23 +489,23 @@ public class StandbyTaskTest {
         assertThat(totalMetric.metricValue(), equalTo(25.0));
         // the rate measures updated records per second, not update batches per second; with no time
         // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
-        assertTrue(
-            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.03333
-            // using 0.5 as good intermediate to the expected value of 0.83333
-            // -> avoid equalTo(...) on floating point numbers
-            0.5d < ((Number) rateMetric.metricValue()).doubleValue(),
-            "Expected a value larger 0.5 [precisely 0.83333...], but got " + rateMetric.metricValue()
+        assertEquals(
+            25.0 / 30.0,
+            ((Number) rateMetric.metricValue()).doubleValue(),
+            0.0001d,
+            "update-rate must measure updated records per second, not update batches per second; "
+                + "counting batches would give 1/30 == 0.03333 (KAFKA-20877)"
         );
 
         task.recordRestoration(time, 50L, 55L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
-        assertTrue(
-            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.06666
-            // using 2.0 as good intermediate to the expected value of 2.5
-            // -> avoid equalTo(...) on floating point numbers
-            2.0d < ((Number) rateMetric.metricValue()).doubleValue(),
-            "Expected a value larger 2.0 [precisely 2.5], but got " + rateMetric.metricValue()
+        assertEquals(
+            75.0 / 30.0,
+            ((Number) rateMetric.metricValue()).doubleValue(),
+            0.0001d,
+            "update-rate must measure updated records per second, not update batches per second; "
+                + "counting batches would give 2/30 == 0.06666 (KAFKA-20877)"
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1153,24 +1153,24 @@ public class StreamTaskTest {
         assertThat(totalMetric.metricValue(), equalTo(25.0));
         // the rate measures restored records per second, not restore batches per second; with no time
         // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
-        assertTrue(
-            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.03333
-            // using 0.5 as good intermediate to the expected value of 0.83333
-            // -> avoid equalTo(...) on floating point numbers
-            0.5d < ((Number) rateMetric.metricValue()).doubleValue(),
-            "Expected a value larger 0.5 [precisely 0.83333...], but got " + rateMetric.metricValue()
+        assertEquals(
+            25.0 / 30.0,
+            ((Number) rateMetric.metricValue()).doubleValue(),
+            0.0001d,
+            "restore-rate must measure restored records per second, not restore batches per second; "
+                + "counting batches would give 1/30 == 0.03333 (KAFKA-20877)"
         );
         assertThat(remainMetric.metricValue(), equalTo(70.0));
 
         task.recordRestoration(time, 50L, 55L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
-        assertTrue(
-            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.06666
-            // using 2.0 as good intermediate to the expected value of 2.5
-            // -> avoid equalTo(...) on floating point numbers
-            2.0d < ((Number) rateMetric.metricValue()).doubleValue(),
-            "Expected a value larger 2.0 [precisely 2.5], but got " + rateMetric.metricValue()
+        assertEquals(
+            75.0 / 30.0,
+            ((Number) rateMetric.metricValue()).doubleValue(),
+            0.0001d,
+            "restore-rate must measure restored records per second, not restore batches per second; "
+                + "counting batches would give 2/30 == 0.06666 (KAFKA-20877)"
         );
         assertThat(remainMetric.metricValue(), equalTo(15.0));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1151,13 +1151,27 @@ public class StreamTaskTest {
         task.recordRestoration(time, 25L, 30L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(25.0));
-        assertThat(rateMetric.metricValue(), not(0.0));
+        // the rate measures restored records per second, not restore batches per second; with no time
+        // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
+        assertTrue(
+            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.03333
+            // using 0.5 as good intermediate to the expected value of 0.83333
+            // -> avoid equalTo(...) on floating point numbers
+            0.5d < ((Number) rateMetric.metricValue()).doubleValue(),
+            "Expected a value larger 0.5 [precisely 0.83333...], but got " + rateMetric.metricValue()
+        );
         assertThat(remainMetric.metricValue(), equalTo(70.0));
 
         task.recordRestoration(time, 50L, 55L, false);
 
         assertThat(totalMetric.metricValue(), equalTo(75.0));
-        assertThat(rateMetric.metricValue(), not(0.0));
+        assertTrue(
+            // regression test for KAFKA-20877: previously we did incorrectly count batches which would result in 0.06666
+            // using 2.0 as good intermediate to the expected value of 2.5
+            // -> avoid equalTo(...) on floating point numbers
+            2.0d < ((Number) rateMetric.metricValue()).doubleValue(),
+            "Expected a value larger 2.0 [precisely 2.5], but got " + rateMetric.metricValue()
+        );
         assertThat(remainMetric.metricValue(), equalTo(15.0));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetricsTest.java
@@ -240,21 +240,12 @@ public class TaskMetricsTest {
         try (final MockedStatic<StreamsMetricsImpl> streamsMetricsStaticMock = mockStatic(StreamsMetricsImpl.class)) {
             final Sensor sensor = TaskMetrics.droppedRecordsSensor(THREAD_ID, TASK_ID, streamsMetrics);
             streamsMetricsStaticMock.verify(
-                () -> StreamsMetricsImpl.addInvocationRateToSensor(
+                () -> StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor(
                     expectedSensor,
                     TASK_LEVEL_GROUP,
                     tagMap,
                     operation,
-                    rateDescription
-                )
-            );
-            streamsMetricsStaticMock.verify(
-                () -> StreamsMetricsImpl.addSumMetricToSensor(
-                    expectedSensor,
-                    TASK_LEVEL_GROUP,
-                    tagMap,
-                    operation,
-                    true,
+                    rateDescription,
                     totalDescription
                 )
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -1585,8 +1585,6 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             TestUtils.tempDirectory(),
             new StreamsConfig(streamsConfig)
         );
-        final Time time = Time.SYSTEM;
-        context.setSystemTimeMs(time.milliseconds());
         bytesStore.init(context, bytesStore);
 
         // write a record to advance stream time, with a high enough timestamp

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -88,7 +88,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1622,7 +1621,16 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());
-        assertNotEquals(0.0, dropRate.metricValue());
+        // exactly one record was dropped, over the rate's default un-elapsed sampling window of
+        // (metrics.num.samples - 1) * metrics.sample.window.ms == 30s. The delta is generous because the
+        // window also grows by however long the store work takes between recording and reading the
+        // metric; it still separates one dropped record from none (0.0) and from two (0.06666).
+        assertEquals(
+            1.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate should reflect the single dropped record over the ~30s sampling window"
+        );
 
         bytesStore.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -961,8 +961,6 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             TestUtils.tempDirectory(),
             new StreamsConfig(streamsConfig)
         );
-        final Time time = Time.SYSTEM;
-        context.setSystemTimeMs(time.milliseconds());
         bytesStore.init(context, bytesStore);
 
         // write a record to advance stream time, with a high enough timestamp

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -95,7 +95,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -998,7 +997,16 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());
-        assertNotEquals(0.0, dropRate.metricValue());
+        // exactly one record was dropped, over the rate's default un-elapsed sampling window of
+        // (metrics.num.samples - 1) * metrics.sample.window.ms == 30s. The delta is generous because the
+        // window also grows by however long the store work takes between recording and reading the
+        // metric; it still separates one dropped record from none (0.0) and from two (0.06666).
+        assertEquals(
+            1.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate should reflect the single dropped record over the ~30s sampling window"
+        );
 
         bytesStore.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -893,9 +893,7 @@ public abstract class AbstractSessionBytesStoreTest {
             new StreamsConfig(streamsConfig),
             recordCollector
         );
-        final Time time = Time.SYSTEM;
         context.setTime(1L);
-        context.setSystemTimeMs(time.milliseconds());
         sessionStore.init(context, sessionStore);
 
         // Advance stream time by inserting record with large enough timestamp that records with timestamp 0 are expired

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -71,7 +71,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -931,7 +930,16 @@ public abstract class AbstractSessionBytesStoreTest {
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());
-        assertNotEquals(0.0, dropRate.metricValue());
+        // exactly one record was dropped, over the rate's default un-elapsed sampling window of
+        // (metrics.num.samples - 1) * metrics.sample.window.ms == 30s. The delta is generous because the
+        // window also grows by however long the store work takes between recording and reading the
+        // metric; it still separates one dropped record from none (0.0) and from two (0.06666).
+        assertEquals(
+            1.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate should reflect the single dropped record over the ~30s sampling window"
+        );
 
         sessionStore.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -67,7 +67,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1044,7 +1043,16 @@ public abstract class AbstractWindowBytesStoreTest {
             )
         ));
         assertEquals(1.0, dropTotal.metricValue());
-        assertNotEquals(0.0, dropRate.metricValue());
+        // exactly one record was dropped, over the rate's default un-elapsed sampling window of
+        // (metrics.num.samples - 1) * metrics.sample.window.ms == 30s. The delta is generous because the
+        // window also grows by however long the store work takes between recording and reading the
+        // metric; it still separates one dropped record from none (0.0) and from two (0.06666).
+        assertEquals(
+            1.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate should reflect the single dropped record over the ~30s sampling window"
+        );
 
         windowStore.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogCaptureAppender;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -1006,8 +1005,6 @@ public abstract class AbstractWindowBytesStoreTest {
             new StreamsConfig(streamsConfig),
             recordCollector
         );
-        final Time time = Time.SYSTEM;
-        context.setSystemTimeMs(time.milliseconds());
         context.setTime(1L);
         windowStore.init(context, windowStore);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -17,9 +17,13 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
@@ -37,6 +41,8 @@ import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -316,6 +322,50 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
             "txn-in-memory-session-store", RETENTION_PERIOD, "scope");
         store.init(ctx, store);
         return store;
+    }
+
+
+    @Test
+    public void shouldMeasureExpiredRecordsDroppedDuringRestoreAsRecords() {
+        // The restore path reports every record skipped for an expired segment in a single sensor
+        // recording, so the rate has to reflect the number of records dropped rather than the number of
+        // recordings. Mirrors the same coverage for InMemoryWindowStore.
+        //
+        // Align the context's cached system time with the metrics clock, so the rate's sampling window is
+        // the un-elapsed default of (metrics.num.samples - 1) * metrics.sample.window.ms == 30s.
+        context.setSystemTimeMs(Time.SYSTEM.milliseconds());
+
+        final List<KeyValue<byte[], byte[]>> batch = new LinkedList<>();
+        // advances observed stream time far enough that every record after it falls outside retention
+        batch.add(new KeyValue<>(
+            SessionKeySchema.toBinary(Bytes.wrap("on-time".getBytes()), 0L, 4 * RETENTION_PERIOD).get(),
+            Serdes.Long().serializer().serialize("", 0L)));
+        for (int key = 1; key <= 3; key++) {
+            batch.add(new KeyValue<>(
+                SessionKeySchema.toBinary(Bytes.wrap(("expired-" + key).getBytes()), 0L, 0L).get(),
+                Serdes.Long().serializer().serialize("", (long) key)));
+        }
+
+        context.restore(sessionStore.name(), batch);
+
+        final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
+        final Map<String, String> tags = mkMap(
+            mkEntry("thread-id", Thread.currentThread().getName()),
+            mkEntry("task-id", "0_0")
+        );
+        final Metric dropTotal = metrics.get(
+            new MetricName("dropped-records-total", "stream-task-metrics", "", tags));
+        final Metric dropRate = metrics.get(
+            new MetricName("dropped-records-rate", "stream-task-metrics", "", tags));
+
+        assertEquals(3.0, dropTotal.metricValue());
+        assertEquals(
+            3.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate must reflect the 3 records dropped, not the single sensor recording; "
+                + "counting recordings would give 1/30 == 0.03333 (KAFKA-20877)"
+        );
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -330,10 +329,6 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
         // The restore path reports every record skipped for an expired segment in a single sensor
         // recording, so the rate has to reflect the number of records dropped rather than the number of
         // recordings. Mirrors the same coverage for InMemoryWindowStore.
-        //
-        // Align the context's cached system time with the metrics clock, so the rate's sampling window is
-        // the un-elapsed default of (metrics.num.samples - 1) * metrics.sample.window.ms == 30s.
-        context.setSystemTimeMs(Time.SYSTEM.milliseconds());
 
         final List<KeyValue<byte[], byte[]>> batch = new LinkedList<>();
         // advances observed stream time far enough that every record after it falls outside retention

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -323,7 +323,6 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
         return store;
     }
 
-
     @Test
     public void shouldMeasureExpiredRecordsDroppedDuringRestoreAsRecords() {
         // The restore path reports every record skipped for an expired segment in a single sensor

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -173,8 +172,6 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
 
     @Test
     public void shouldMeasureExpiredRecordsDroppedDuringRestoreAsRecords() {
-        context.setSystemTimeMs(Time.SYSTEM.milliseconds());
-
         final StateSerdes<Integer, String> serdes = new StateSerdes<>("", Serdes.Integer(), Serdes.String());
 
         final List<KeyValue<byte[], byte[]>> batch = new LinkedList<>();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -17,10 +17,13 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -53,6 +56,7 @@ import java.io.File;
 import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -165,6 +169,44 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
             assertEquals(windowedPair(3, "three", 2 * WINDOW_SIZE), iterator.next());
             assertFalse(iterator.hasNext());
         }
+    }
+
+    @Test
+    public void shouldMeasureExpiredRecordsDroppedDuringRestoreAsRecords() {
+        context.setSystemTimeMs(Time.SYSTEM.milliseconds());
+
+        final StateSerdes<Integer, String> serdes = new StateSerdes<>("", Serdes.Integer(), Serdes.String());
+
+        final List<KeyValue<byte[], byte[]>> batch = new LinkedList<>();
+        // advances observed stream time far enough that every record after it falls outside retention
+        batch.add(new KeyValue<>(
+            toStoreKeyBinary(0, 4 * RETENTION_PERIOD, 0, new RecordHeaders(), serdes).get(),
+            serdes.rawValue("on-time")));
+        for (int key = 1; key <= 3; key++) {
+            batch.add(new KeyValue<>(
+                toStoreKeyBinary(key, 0L, 0, new RecordHeaders(), serdes).get(),
+                serdes.rawValue("expired")));
+        }
+
+        context.restore(STORE_NAME, batch);
+
+        final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
+        final String threadId = Thread.currentThread().getName();
+        final Map<String, String> tags = mkMap(mkEntry("thread-id", threadId), mkEntry("task-id", "0_0"));
+
+        final Metric dropTotal = metrics.get(
+            new MetricName("dropped-records-total", "stream-task-metrics", "", tags));
+        final Metric dropRate = metrics.get(
+            new MetricName("dropped-records-rate", "stream-task-metrics", "", tags));
+
+        assertEquals(3.0, dropTotal.metricValue());
+        assertEquals(
+            3.0 / 30.0,
+            ((Number) dropRate.metricValue()).doubleValue(),
+            0.005d,
+            "dropped-records-rate must reflect the 3 records dropped, not the single sensor recording; "
+                + "counting recordings would give 1/30 == 0.03333 (KAFKA-20877)"
+        );
     }
 
     @Test


### PR DESCRIPTION
Both metrics incorrectly report "batches restored per second" instead of
"records restored per seconds".

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, Bill Bejeck
 <bbejeck@apache.org>
