### PR TITLE
KAFKA-20872: Integrate api-checker checks into CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,50 @@ jobs:
       - name: Verify license file
         run: python committer-tools/verify_license.py --skip-build
 
+  api-checker:
+    needs: [configure, validate]
+    if: ${{ ! needs.configure.outputs.is-draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [25, 17]
+    name: API Checker Java ${{ matrix.java }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.configure.outputs.sha }}
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: ${{ matrix.java }}
+          gradle-cache-read-only: ${{ !inputs.is-trunk }}
+          gradle-cache-write-only: ${{ inputs.is-trunk }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+      - name: Run API checker checks
+        run: |
+          ./gradlew --no-build-cache --continue --no-scan \
+            :api-checker:core:check \
+            :api-checker:gradle-plugins:check \
+            :api-checker:maven-plugin:check
+
+      - name: Archive API checker reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-checker-reports-java-${{ matrix.java }}
+          path: |
+            api-checker/**/build/reports/**
+            api-checker/**/build/test-results/**/*.xml
+          compression-level: 9
+          if-no-files-found: ignore
+
   test:
     needs: [configure, validate, load-catalog]
     if: ${{ ! needs.configure.outputs.is-draft }}
@@ -368,7 +412,7 @@ jobs:
 
   checks-complete:
     name: "CI checks completed"
-    needs: [configure, validate, test]
+    needs: [configure, validate, test, api-checker]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -383,7 +427,7 @@ jobs:
           exit 1
       - name: Check Dependency Outcomes
         run: |
-          if [[ "${{ needs.validate.result }}" == "success" && "${{ needs.test.result }}" == "success" ]]; then
+          if [[ "${{ needs.validate.result }}" == "success" && "${{ needs.test.result }}" == "success" && "${{ needs.api-checker.result }}" == "success" ]]; then
             echo "Required jobs completed successfully!"
             exit 0
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,11 +181,7 @@ jobs:
     if: ${{ ! needs.configure.outputs.is-draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [25, 17]
-    name: API Checker Java ${{ matrix.java }}
+    name: API Checker Java 25
 
     steps:
       - name: Checkout code
@@ -197,7 +193,7 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 25
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -213,7 +209,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: api-checker-reports-java-${{ matrix.java }}
+          name: api-checker-reports-java-25
           path: |
             api-checker/**/build/reports/**
             api-checker/**/build/test-results/**/*.xml


### PR DESCRIPTION
## Summary

The `api-checker` module is a composite-included Gradle build, so its
independent tests and verification tasks are not executed by Kafka's
existing root `test` task.

This change:

- adds a dedicated `api-checker` CI job;
- runs the `core`, `gradle-plugins`, and `maven-plugin` `check` tasks;
- tests the module on Java 17 and Java 25;
- archives its test and verification reports;
- makes `CI checks completed` depend on the new job.

The dedicated job does not participate in Kafka's normal/new/flaky test
catalog because the included build does not use that test-selection
infrastructure.

JIRA: https://issues.apache.org/jira/browse/KAFKA-20872

## Testing

The following checks passed locally on both Java 17 and Java 25:

```bash
./gradlew --no-build-cache --rerun-tasks --continue --no-scan \
  :api-checker:core:check \
  :api-checker:gradle-plugins:check \
  :api-checker:maven-plugin:check

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
