### PR TITLE
KAFKA-20882 Reduce build time: use `tasks.register` for Gradle tasks lazy creation (instead of `task` / `tasks.create`)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1369,7 +1369,7 @@ project(':core') {
   }
 
   tasks.register('siteDocsTar', Tar) {
-    dependsOn(['genProtocolErrorDocs', 'genProtocolTypesDocs', 'genProtocolApiKeyDocs', 'genProtocolMessageDocs',
+    dependsOn = ['genProtocolErrorDocs', 'genProtocolTypesDocs', 'genProtocolApiKeyDocs', 'genProtocolMessageDocs',
                 'genAdminClientConfigDocs', 'genProducerConfigDocs', 'genConsumerConfigDocs',
                 'genKafkaConfigDocs', 'genTopicConfigDocs', 'genGroupConfigDocs',
                 ':connect:runtime:genConnectConfigDocs', ':connect:runtime:genConnectTransformationDocs',
@@ -1379,7 +1379,7 @@ project(':core') {
                 ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs',
                 ':connect:mirror:genMirrorSourceConfigDocs', ':connect:mirror:genMirrorCheckpointConfigDocs',
                 ':connect:mirror:genMirrorHeartbeatConfigDocs', ':connect:mirror:genMirrorConnectorConfigDocs',
-                ':storage:genRemoteLogManagerConfigDoc', ':storage:genRemoteLogMetadataManagerConfigDoc'])
+                ':storage:genRemoteLogManagerConfigDoc', ':storage:genRemoteLogMetadataManagerConfigDoc']
     archiveClassifier = 'site-docs'
     compression = Compression.GZIP
     from project.file("$rootDir/docs")

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ allprojects {
       }
     }
   }
-  task printAllDependencies(type: DependencyReportTask) {}
+  tasks.register('printAllDependencies', DependencyReportTask) {}
 
   tasks.withType(Javadoc) {
     options.charSet = 'UTF-8'
@@ -314,10 +314,10 @@ subprojects {
 
   // enable running :dependencies task recursively on all subprojects
   // eg: ./gradlew allDeps
-  task allDeps(type: DependencyReportTask) {}
+  tasks.register('allDeps', DependencyReportTask) {}
   // enable running :dependencyInsight task recursively on all subprojects
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
-  task allDepInsight(type: DependencyInsightReportTask) {showingAllVariants = false} doLast {}
+  tasks.register('allDepInsight', DependencyInsightReportTask) {showingAllVariants = false}
 
   apply plugin: 'java-library'
 
@@ -633,7 +633,8 @@ subprojects {
     finalizedBy("copyTestXml")
   }
 
-  task integrationTest(type: Test, dependsOn: compileJava) {
+  tasks.register('integrationTest', Test) {
+    dependsOn compileJava
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
@@ -668,7 +669,8 @@ subprojects {
     }
   }
 
-  task unitTest(type: Test, dependsOn: compileJava) {
+  tasks.register('unitTest', Test) {
+    dependsOn compileJava
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
@@ -714,21 +716,22 @@ subprojects {
     from "$rootDir/NOTICE"
   }
 
-  task srcJar(type: Jar) {
+  tasks.register('srcJar', Jar) {
     archiveClassifier = 'sources'
     from "$rootDir/LICENSE"
     from "$rootDir/NOTICE"
     from sourceSets.main.allSource
   }
 
-  task javadocJar(type: Jar, dependsOn: javadoc) {
+  tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
     archiveClassifier = 'javadoc'
     from "$rootDir/LICENSE"
     from "$rootDir/NOTICE"
     from javadoc.destinationDir
   }
 
-  task docsJar(dependsOn: javadocJar)
+  tasks.register('docsJar') { dependsOn javadocJar }
 
   // Consumed by root aggregatedJavadoc; mirrors compileClasspath.
   configurations {
@@ -769,7 +772,7 @@ kafkaPublicApiChecker {
   task systemTestLibs(dependsOn: jar)
 
   if (!sourceSets.test.allSource.isEmpty()) {
-    task testJar(type: Jar) {
+    tasks.register('testJar', Jar) {
       archiveClassifier = 'test'
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
@@ -780,7 +783,8 @@ kafkaPublicApiChecker {
       exclude 'junit-platform.properties'
     }
 
-    task testSrcJar(type: Jar, dependsOn: testJar) {
+    tasks.register('testSrcJar', Jar) {
+      dependsOn testJar
       archiveClassifier = 'test-sources'
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
@@ -795,7 +799,8 @@ kafkaPublicApiChecker {
       zincVersion = versions.zinc
     }
 
-    task scaladocJar(type:Jar, dependsOn: scaladoc) {
+    tasks.register('scaladocJar', Jar) {
+      dependsOn scaladoc
       archiveClassifier = 'scaladoc'
       from "$rootDir/LICENSE"
       from "$rootDir/NOTICE"
@@ -1100,7 +1105,7 @@ project(':server') {
     testRuntimeOnly runtimeTestLibs
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -1271,7 +1276,7 @@ project(':core') {
     }
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
     }
@@ -1279,101 +1284,102 @@ project(':core') {
     duplicatesStrategy = 'exclude'
   }
 
-  task genProtocolErrorDocs(type: JavaExec) {
+  tasks.register('genProtocolErrorDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.common.protocol.Errors'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "protocol_errors.html").newOutputStream()
   }
 
-  task genProtocolTypesDocs(type: JavaExec) {
+  tasks.register('genProtocolTypesDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.common.protocol.types.Type'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "protocol_types.html").newOutputStream()
   }
 
-  task genProtocolApiKeyDocs(type: JavaExec) {
+  tasks.register('genProtocolApiKeyDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.common.protocol.ApiKeys'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "protocol_api_keys.html").newOutputStream()
   }
 
-  task genProtocolMessageDocs(type: JavaExec) {
+  tasks.register('genProtocolMessageDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.common.protocol.Protocol'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "protocol_messages.html").newOutputStream()
   }
 
-  task genAdminClientConfigDocs(type: JavaExec) {
+  tasks.register('genAdminClientConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.clients.admin.AdminClientConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "admin_client_config.html").newOutputStream()
   }
 
-  task genProducerConfigDocs(type: JavaExec) {
+  tasks.register('genProducerConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.clients.producer.ProducerConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "producer_config.html").newOutputStream()
   }
 
-  task genConsumerConfigDocs(type: JavaExec) {
+  tasks.register('genConsumerConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.clients.consumer.ConsumerConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "consumer_config.html").newOutputStream()
   }
 
-  task genKafkaConfigDocs(type: JavaExec) {
+  tasks.register('genKafkaConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'kafka.server.KafkaConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "kafka_config.html").newOutputStream()
   }
 
-  task genTopicConfigDocs(type: JavaExec) {
+  tasks.register('genTopicConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.storage.internals.log.LogConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "topic_config.html").newOutputStream()
   }
 
-  task genGroupConfigDocs(type: JavaExec) {
+  tasks.register('genGroupConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.coordinator.group.GroupConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "group_config.html").newOutputStream()
   }
 
-  task genConsumerMetricsDocs(type: JavaExec) {
+  tasks.register('genConsumerMetricsDocs', JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     mainClass = 'org.apache.kafka.clients.consumer.internals.FetchMetricsRegistry'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "consumer_metrics.html").newOutputStream()
   }
 
-  task genProducerMetricsDocs(type: JavaExec) {
+  tasks.register('genProducerMetricsDocs', JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
     mainClass = 'org.apache.kafka.clients.producer.internals.ProducerMetrics'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "producer_metrics.html").newOutputStream()
   }
 
-  task siteDocsTar(dependsOn: ['genProtocolErrorDocs', 'genProtocolTypesDocs', 'genProtocolApiKeyDocs', 'genProtocolMessageDocs',
-                               'genAdminClientConfigDocs', 'genProducerConfigDocs', 'genConsumerConfigDocs',
-                               'genKafkaConfigDocs', 'genTopicConfigDocs', 'genGroupConfigDocs',
-                               ':connect:runtime:genConnectConfigDocs', ':connect:runtime:genConnectTransformationDocs',
-                               ':connect:runtime:genConnectPredicateDocs',
-                               ':connect:runtime:genSinkConnectorConfigDocs', ':connect:runtime:genSourceConnectorConfigDocs',
-                               ':streams:genStreamsConfigDocs', 'genConsumerMetricsDocs', 'genProducerMetricsDocs',
-                               ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs',
-                               ':connect:mirror:genMirrorSourceConfigDocs', ':connect:mirror:genMirrorCheckpointConfigDocs',
-                               ':connect:mirror:genMirrorHeartbeatConfigDocs', ':connect:mirror:genMirrorConnectorConfigDocs',
-                               ':storage:genRemoteLogManagerConfigDoc', ':storage:genRemoteLogMetadataManagerConfigDoc'], type: Tar) {
+  tasks.register('siteDocsTar', Tar) {
+    dependsOn(['genProtocolErrorDocs', 'genProtocolTypesDocs', 'genProtocolApiKeyDocs', 'genProtocolMessageDocs',
+                'genAdminClientConfigDocs', 'genProducerConfigDocs', 'genConsumerConfigDocs',
+                'genKafkaConfigDocs', 'genTopicConfigDocs', 'genGroupConfigDocs',
+                ':connect:runtime:genConnectConfigDocs', ':connect:runtime:genConnectTransformationDocs',
+                ':connect:runtime:genConnectPredicateDocs',
+                ':connect:runtime:genSinkConnectorConfigDocs', ':connect:runtime:genSourceConnectorConfigDocs',
+                ':streams:genStreamsConfigDocs', 'genConsumerMetricsDocs', 'genProducerMetricsDocs',
+                ':connect:runtime:genConnectMetricsDocs', ':connect:runtime:genConnectOpenAPIDocs',
+                ':connect:mirror:genMirrorSourceConfigDocs', ':connect:mirror:genMirrorCheckpointConfigDocs',
+                ':connect:mirror:genMirrorHeartbeatConfigDocs', ':connect:mirror:genMirrorConnectorConfigDocs',
+                ':storage:genRemoteLogManagerConfigDoc', ':storage:genRemoteLogMetadataManagerConfigDoc'])
     archiveClassifier = 'site-docs'
     compression = Compression.GZIP
     from project.file("$rootDir/docs")
@@ -1383,7 +1389,8 @@ project(':core') {
     duplicatesStrategy = 'exclude'
   }
 
-  tasks.create(name: "releaseTarGz", dependsOn: configurations.archives.artifacts, type: Tar) {
+  tasks.register('releaseTarGz', Tar) {
+    dependsOn = configurations.archives.artifacts
     into "kafka_${versions.baseScala}-${archiveVersion.get()}"
     compression = Compression.GZIP
     from(project.file("$rootDir/bin")) { into "bin/" }
@@ -1444,7 +1451,7 @@ project(':core') {
     }
   }
 
-  tasks.create(name: "copyDependantTestLibs", type: Copy) {
+  tasks.register('copyDependantTestLibs', Copy) {
     from (configurations.testRuntimeClasspath) {
       include('*.jar')
     }
@@ -1519,7 +1526,7 @@ project(':metadata') {
     generator project(':generator')
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages',JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.common.metadata",
@@ -1569,7 +1576,7 @@ project(':group-coordinator:group-coordinator-api') {
     implementation project(':clients')
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -1670,7 +1677,7 @@ project(':group-coordinator') {
     configProperties = checkstyleConfigProperties("import-control-group-coordinator.xml")
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.coordinator.group.generated",
@@ -1827,7 +1834,7 @@ project(':transaction-coordinator') {
     configProperties = checkstyleConfigProperties("import-control-transaction-coordinator.xml")
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.coordinator.transaction.generated",
@@ -1940,7 +1947,7 @@ project(':share-coordinator') {
     configProperties = checkstyleConfigProperties("import-control-share-coordinator.xml")
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.coordinator.share.generated",
@@ -2060,7 +2067,7 @@ project(':clients') {
     enabled = false
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2119,7 +2126,7 @@ project(':clients') {
     delete "${layout.buildDirectory.get().asFile.path}/kafka/"
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.common.message",
@@ -2135,7 +2142,7 @@ project(':clients') {
     outputs.dir("${projectDir}/build/generated/main/java/org/apache/kafka/common/message")
   }
 
-  task processTestMessages(type:JavaExec) {
+  tasks.register('processTestMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.common.message",
@@ -2271,7 +2278,7 @@ project(':raft') {
     generator project(':generator')
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2290,7 +2297,7 @@ project(':raft') {
     }
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.raft.generated",
@@ -2372,7 +2379,7 @@ project(':server-common') {
     testRuntimeOnly runtimeTestLibs
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2435,7 +2442,7 @@ project(':storage:storage-api') {
     testRuntimeOnly runtimeTestLibs
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2526,7 +2533,7 @@ project(':storage') {
     generator project(':generator')
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2545,7 +2552,7 @@ project(':storage') {
     }
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.server.log.remote.metadata.storage.generated",
@@ -2560,14 +2567,14 @@ project(':storage') {
     outputs.dir("${projectDir}/build/generated/main/java/org/apache/kafka/server/log/remote/metadata/storage/generated")
   }
 
-  task genRemoteLogManagerConfigDoc(type: JavaExec) {
+  tasks.register('genRemoteLogManagerConfigDoc', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "remote_log_manager_config.html").newOutputStream()
   }
 
-  task genRemoteLogMetadataManagerConfigDoc(type: JavaExec) {
+  tasks.register('genRemoteLogMetadataManagerConfigDoc', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
@@ -2622,7 +2629,7 @@ project(':tools:tools-api') {
     testRuntimeOnly runtimeTestLibs
   }
 
-  task createVersionFile() {
+  tasks.register('createVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2723,7 +2730,7 @@ project(':tools') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
     }
@@ -2781,7 +2788,7 @@ project(':trogdor') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
     }
@@ -2825,7 +2832,7 @@ project(':shell') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       include('jline-*jar')
     }
@@ -2883,7 +2890,7 @@ project(':streams') {
     generator project(':generator')
   }
 
-  task processMessages(type:JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.streams.internals.generated",
@@ -2919,7 +2926,7 @@ project(':streams') {
     exclude "**/org/apache/kafka/streams/internals/**", "**/org/apache/kafka/streams/**/internals/**"
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
     }
@@ -2927,7 +2934,7 @@ project(':streams') {
     duplicatesStrategy = 'exclude'
   }
 
-  task createStreamsVersionFile() {
+  tasks.register('createStreamsVersionFile') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildStreamsVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
@@ -2958,15 +2965,15 @@ project(':streams') {
     dependsOn testFixturesJar
   }
 
-  task genStreamsConfigDocs(type: JavaExec) {
+  tasks.register('genStreamsConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.streams.StreamsConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "streams_config.html").newOutputStream()
   }
 
-  task testAll(
-    dependsOn: [
+  tasks.register('testAll') {
+    dependsOn = [
             ':streams:test',
             ':streams:integration-tests:test',
             ':streams:test-utils:test',
@@ -2999,7 +3006,7 @@ project(':streams') {
             ':streams:upgrade-system-tests-43:test',
             ':streams:examples:test'
     ]
-  )
+  }
 }
 
 project(':streams:streams-scala') {
@@ -3031,7 +3038,7 @@ project(':streams:streams-scala') {
     scalaDocOptions.additionalParameters = ["-no-link-warnings"]
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-streams*')
     }
@@ -3103,7 +3110,7 @@ project(':streams:test-utils') {
     testRuntimeOnly runtimeTestLibs
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-streams*')
     }
@@ -3141,7 +3148,7 @@ project(':streams:examples') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-streams*')
     }
@@ -3628,7 +3635,8 @@ project(':jmh-benchmarks') {
     configProperties = checkstyleConfigProperties("import-control-jmh-benchmarks.xml")
   }
 
-  task jmh(type: JavaExec, dependsOn: [':jmh-benchmarks:clean', ':jmh-benchmarks:shadowJar']) {
+  tasks.register('jmh', JavaExec) {
+    dependsOn = [':jmh-benchmarks:clean', ':jmh-benchmarks:shadowJar']
 
     mainClass = "-jar"
 
@@ -3666,7 +3674,7 @@ project(':connect:api') {
     include "**/org/apache/kafka/connect/**" // needed for the `aggregatedJavadoc` task
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -3701,7 +3709,7 @@ project(':connect:transforms') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -3739,7 +3747,7 @@ project(':connect:json') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -3847,7 +3855,7 @@ project(':connect:runtime') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -3860,56 +3868,57 @@ project(':connect:runtime') {
     dependsOn copyDependantLibs
   }
 
-  task genConnectConfigDocs(type: JavaExec) {
+  tasks.register('genConnectConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.runtime.distributed.DistributedConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "connect_config.html").newOutputStream()
   }
 
-  task genSinkConnectorConfigDocs(type: JavaExec) {
+  tasks.register('genSinkConnectorConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.runtime.SinkConnectorConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "sink_connector_config.html").newOutputStream()
   }
 
-  task genSourceConnectorConfigDocs(type: JavaExec) {
+  tasks.register('genSourceConnectorConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.runtime.SourceConnectorConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "source_connector_config.html").newOutputStream()
   }
 
-  task genConnectTransformationDocs(type: JavaExec) {
+  tasks.register('genConnectTransformationDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.tools.TransformationDoc'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "connect_transforms.html").newOutputStream()
   }
 
-  task genConnectPredicateDocs(type: JavaExec) {
+  tasks.register('genConnectPredicateDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.tools.PredicateDoc'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "connect_predicates.html").newOutputStream()
   }
 
-  task genConnectMetricsDocs(type: JavaExec) {
+  tasks.register('genConnectMetricsDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.runtime.ConnectMetrics'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "connect_metrics.html").newOutputStream()
   }
 
-  task setVersionInOpenAPISpec(type: Copy) {
+  tasks.register('setVersionInOpenAPISpec', Copy) {
     from "$rootDir/gradle/openapi.template"
     into "${layout.buildDirectory.get().asFile.path}/resources/docs"
     rename ('openapi.template', 'openapi.yaml')
     expand(kafkaVersion: "$rootProject.version")
   }
 
-  task genConnectOpenAPIDocs(type: io.swagger.v3.plugins.gradle.tasks.ResolveTask, dependsOn: setVersionInOpenAPISpec) {
+  tasks.register('genConnectOpenAPIDocs', io.swagger.v3.plugins.gradle.tasks.ResolveTask) {
+    dependsOn setVersionInOpenAPISpec
     classpath = sourceSets.main.runtimeClasspath
 
     buildClasspath = classpath + configurations.swagger
@@ -3956,7 +3965,7 @@ project(':connect:file') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -3995,7 +4004,7 @@ project(':connect:basic-auth-extension') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -4061,7 +4070,7 @@ project(':connect:mirror') {
     enabled = false
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')
@@ -4070,28 +4079,28 @@ project(':connect:mirror') {
     duplicatesStrategy = 'exclude'
   }
 
-  task genMirrorConnectorConfigDocs(type: JavaExec) {
+  tasks.register('genMirrorConnectorConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.mirror.MirrorConnectorConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "mirror_connector_config.html").newOutputStream()
   }
 
-  task genMirrorSourceConfigDocs(type: JavaExec) {
+  tasks.register('genMirrorSourceConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.mirror.MirrorSourceConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "mirror_source_config.html").newOutputStream()
   }
 
-  task genMirrorCheckpointConfigDocs(type: JavaExec) {
+  tasks.register('genMirrorCheckpointConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.mirror.MirrorCheckpointConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
     standardOutput = new File(generatedDocsDir, "mirror_checkpoint_config.html").newOutputStream()
   }
 
-  task genMirrorHeartbeatConfigDocs(type: JavaExec) {
+  tasks.register('genMirrorHeartbeatConfigDocs', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.apache.kafka.connect.mirror.MirrorHeartbeatConfig'
     if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
@@ -4123,7 +4132,7 @@ project(':connect:mirror-client') {
     enabled = true
   }
 
-  tasks.create(name: "copyDependantLibs", type: Copy) {
+  tasks.register('copyDependantLibs', Copy) {
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
       exclude('connect-*')

--- a/build.gradle
+++ b/build.gradle
@@ -769,7 +769,7 @@ kafkaPublicApiChecker {
     enabled = true
     failOnViolation = true
 }
-  task systemTestLibs(dependsOn: jar)
+  tasks.register('systemTestLibs') { dependsOn jar }
 
   if (!sourceSets.test.allSource.isEmpty()) {
     tasks.register('testJar', Jar) {
@@ -1526,7 +1526,7 @@ project(':metadata') {
     generator project(':generator')
   }
 
-  tasks.register('processMessages',JavaExec) {
+  tasks.register('processMessages', JavaExec) {
     mainClass = "org.apache.kafka.message.MessageGenerator"
     classpath = configurations.generator
     args = [ "-p", "org.apache.kafka.common.metadata",
@@ -4171,7 +4171,7 @@ configurations {
   }
 }
 
-task aggregatedJavadoc(type: Javadoc) {
+tasks.register('aggregatedJavadoc', Javadoc) {
   destinationDir = file("${layout.buildDirectory.get().asFile.path}/docs/javadoc")
 }
 


### PR DESCRIPTION
JIRA ticket: KAFKA-20882

:bulb:  How to test: execute `./gradlew clean releaseTarGz
--rerun-tasks --no-build-cache --no-configuration-cache --no-daemon`;
results (on my box, that is):
- **trunk:** BUILD SUCCESSFUL in **4m 4s**
- **this PR:** BUILD SUCCESSFUL in **3m 54s**

:warning:  Note: `allDepInsight` task is producing equivalent (not
identical) results; I made some tests comparing output files for both
trunk and this PR:
```
./gradlew allDepInsight --configuration runtimeClasspath --dependency
com.fasterxml.jackson.core:jackson-databind >
someTxtFileForTrunkOrThisPR.txt
```

:information_source: Some related links:
- https://docs.gradle.org/9.6.1/userguide/organizing_tasks.html
-
https://docs.gradle.org/9.6.1/userguide/writing_tasks_intermediate.html
-
https://docs.gradle.org/9.6.1/userguide/task_configuration_avoidance.html#task_configuration_avoidance
- https://docs.gradle.org/9.6.1/userguide/lazy_configuration.html
- https://docs.gradle.org/9.6.1/userguide/more_about_tasks.html
- https://docs.gradle.org/9.6.1/userguide/best_practices_tasks.html
-
https://stackoverflow.com/questions/53654190/what-is-the-difference-between-registering-and-creating-in-gradle-kotlin-dsl

Reviewers: Mickael Maison <mickael.maison@gmail.com>
