### PR TITLE
MINOR: Remove unused SubscriptionState.hasPartitionsNeedingValidation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -902,16 +902,6 @@ public class SubscriptionState {
         return result;
     }
 
-    public synchronized boolean hasPartitionsNeedingValidation(long nowMs) {
-        for (TopicPartitionState tps  : assignment.partitionStateValues()) {
-            if (tps.awaitingValidation() && !tps.awaitingRetryBackoff(nowMs) && tps.position != null) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     public synchronized boolean isAssigned(TopicPartition tp) {
         return assignment.contains(tp);
     }


### PR DESCRIPTION
`SubscriptionState.hasPartitionsNeedingValidation` has no callers.

It was added in #20324 alongside `PositionsValidator`, but that class
ended up using the broader `SubscriptionState.hasAllFetchPositions()`
for its skip check, so this method was never wired up.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
