### PR TITLE
KAFKA-20837: Batch the produce in Connect integration tests

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -33,7 +33,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.MetricName;
@@ -1016,26 +1015,26 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     @Test
-    public void testConnectorMetricsNew() throws InterruptedException, ExecutionException {
+    public void testConnectorMetricsNew() throws InterruptedException {
         testConnectorMetrics(METRIC_NAMES_NEW, () -> assertMetrics(false));
     }
 
     @Test
-    public void testConnectorMetricsLegacy() throws InterruptedException, ExecutionException {
+    public void testConnectorMetricsLegacy() throws InterruptedException {
         testConnectorMetrics(METRIC_NAMES_LEGACY, () -> assertMetrics(true));
     }
 
     @Test
-    public void testConnectorMetricsDefault() throws InterruptedException, ExecutionException {
+    public void testConnectorMetricsDefault() throws InterruptedException {
         testConnectorMetrics(null, () -> assertMetrics(true));
     }
 
     @Test
-    public void testConnectorMetricsNewAndLegacy() throws InterruptedException, ExecutionException {
+    public void testConnectorMetricsNewAndLegacy() throws InterruptedException {
         testConnectorMetrics(METRIC_NAMES_NEW + "," + METRIC_NAMES_LEGACY, () -> assertMetrics(true) && assertMetrics(false));
     }
 
-    private void testConnectorMetrics(String format, Supplier<Boolean> assertions) throws InterruptedException, ExecutionException {
+    private void testConnectorMetrics(String format, Supplier<Boolean> assertions) throws InterruptedException {
         // one way replication from primary to backup
         mm2Props.put(BACKUP_CLUSTER_ALIAS + "->" + PRIMARY_CLUSTER_ALIAS + ".enabled", "false");
         if (format != null) {
@@ -1049,14 +1048,9 @@ public class MirrorConnectorsIntegrationBaseTest {
 
         String topic = "test-topic-metrics";
         primary.kafka().createTopic(topic);
-        try (KafkaProducer<byte[], byte[]> producer = primary.kafka().createProducer(Map.of())) {
-            var futures = IntStream.range(0, NUM_RECORDS_PRODUCED)
-                    .mapToObj(i -> producer.send(new ProducerRecord<byte[], byte[]>(topic, ("value" + i).getBytes())))
-                    .toList();
-            for (var future : futures) {
-                future.get();
-            }
-        }
+        primary.kafka().produce(IntStream.range(0, NUM_RECORDS_PRODUCED)
+                .mapToObj(i -> new ProducerRecord<byte[], byte[]>(topic, ("value" + i).getBytes()))
+                .toList());
 
         waitUntilMirrorMakerIsRunning(backup,
                 List.of(MirrorSourceConnector.class, MirrorCheckpointConnector.class),

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -1050,8 +1050,11 @@ public class MirrorConnectorsIntegrationBaseTest {
         String topic = "test-topic-metrics";
         primary.kafka().createTopic(topic);
         try (KafkaProducer<byte[], byte[]> producer = primary.kafka().createProducer(Map.of())) {
-            for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-                producer.send(new ProducerRecord<>(topic, ("value" + i).getBytes())).get();
+            var futures = IntStream.range(0, NUM_RECORDS_PRODUCED)
+                    .mapToObj(i -> producer.send(new ProducerRecord<byte[], byte[]>(topic, ("value" + i).getBytes())))
+                    .toList();
+            for (var future : futures) {
+                future.get();
             }
         }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -1326,8 +1326,9 @@ public class MirrorConnectorsIntegrationBaseTest {
         Timer timer = Time.SYSTEM.timer(RECORD_PRODUCE_DURATION_MS);
 
         try {
-            for (ProducerRecord<byte[], byte[]> record : records) {
-                producer.send(record).get(timer.remainingMs(), TimeUnit.MILLISECONDS);
+            var futures = records.stream().map(producer::send).toList();
+            for (var future : futures) {
+                future.get(timer.remainingMs(), TimeUnit.MILLISECONDS);
                 timer.update();
             }
         } catch (ExecutionException | InterruptedException | TimeoutException e) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.integration;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
@@ -144,9 +146,9 @@ public class ErrorHandlingIntegrationTest {
                 "Connector task was not assigned a partition.");
 
         // produce some strings into test topic
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            connect.kafka().produce("test-topic", "key-" + i, "value-" + i);
-        }
+        connect.kafka().produce(IntStream.range(0, NUM_RECORDS_PRODUCED)
+                .mapToObj(i -> new ProducerRecord<>("test-topic", ("key-" + i).getBytes(), ("value-" + i).getBytes()))
+                .toList());
 
         // consume all records from test topic
         log.info("Consuming records from test topic");
@@ -223,9 +225,9 @@ public class ErrorHandlingIntegrationTest {
             "Connector task was not assigned a partition.");
 
         // produce some strings into test topic
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            connect.kafka().produce("test-topic", "key-" + i, "value-" + i);
-        }
+        connect.kafka().produce(IntStream.range(0, NUM_RECORDS_PRODUCED)
+                .mapToObj(i -> new ProducerRecord<>("test-topic", ("key-" + i).getBytes(), ("value-" + i).getBytes()))
+                .toList());
 
         // consume all records from test topic
         log.info("Consuming records from test topic");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -146,9 +148,9 @@ public class ExampleConnectIntegrationTest {
                 "Connector tasks were not assigned a partition each.");
 
         // produce some messages into source topic partitions
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            connect.kafka().produce("test-topic", i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
-        }
+        connect.kafka().produce(IntStream.range(0, NUM_RECORDS_PRODUCED)
+                .mapToObj(i -> new ProducerRecord<>("test-topic", i % NUM_TOPIC_PARTITIONS, "key".getBytes(), ("simple-message-value-" + i).getBytes()))
+                .toList());
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals(NUM_RECORDS_PRODUCED,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -111,9 +113,9 @@ public class MonitorableSinkIntegrationTest {
         assertEquals(MonitorableSinkConnector.VALUE, kafkaMetric.metricValue());
 
         // produce some records
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            connect.kafka().produce("test-topic", "key-" + i, "value-" + i);
-        }
+        connect.kafka().produce(IntStream.range(0, NUM_RECORDS_PRODUCED)
+                .mapToObj(i -> new ProducerRecord<>("test-topic", ("key-" + i).getBytes(), ("value-" + i).getBytes()))
+                .toList());
 
         // wait for records to reach the task
         connectorHandle.taskHandle(TASK_ID).awaitRecords(CONSUME_MAX_DURATION_MS);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.transforms.Filter;
 import org.apache.kafka.connect.transforms.predicates.HasHeaderKey;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -146,12 +148,12 @@ public class TransformationIntegrationTest {
         assertConnectorRunning();
 
         // produce some messages into source topic partitions
-        for (int i = 0; i < numBarRecords; i++) {
-            connect.kafka().produce(barTopic, i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
-        }
-        for (int i = 0; i < numFooRecords; i++) {
-            connect.kafka().produce(fooTopic, i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
-        }
+        connect.kafka().produce(IntStream.range(0, numBarRecords)
+                .mapToObj(i -> new ProducerRecord<>(barTopic, i % NUM_TOPIC_PARTITIONS, "key".getBytes(), ("simple-message-value-" + i).getBytes()))
+                .toList());
+        connect.kafka().produce(IntStream.range(0, numFooRecords)
+                .mapToObj(i -> new ProducerRecord<>(fooTopic, i % NUM_TOPIC_PARTITIONS, "key".getBytes(), ("simple-message-value-" + i).getBytes()))
+                .toList());
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals(
@@ -235,9 +237,9 @@ public class TransformationIntegrationTest {
         assertConnectorRunning();
 
         // produce some messages into source topic partitions
-        for (int i = 0; i < numRecords; i++) {
-            connect.kafka().produce(topic, i % NUM_TOPIC_PARTITIONS, "key", i % 2 == 0 ? "simple-message-value-" + i : null);
-        }
+        connect.kafka().produce(IntStream.range(0, numRecords)
+                .mapToObj(i -> new ProducerRecord<>(topic, i % NUM_TOPIC_PARTITIONS, "key".getBytes(), i % 2 == 0 ? ("simple-message-value-" + i).getBytes() : null))
+                .toList());
 
         // consume all records from the source topic or fail, to ensure that they were correctly produced.
         assertEquals(

--- a/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -49,6 +49,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
@@ -419,9 +420,11 @@ public class EmbeddedKafkaCluster {
 
     public void produce(List<ProducerRecord<byte[], byte[]>> records) {
         var futures = records.stream().map(producer::send).toList();
+        var timer = Time.SYSTEM.timer(DEFAULT_PRODUCE_SEND_DURATION_MS);
         for (int i = 0; i < futures.size(); i++) {
             try {
-                futures.get(i).get(DEFAULT_PRODUCE_SEND_DURATION_MS, TimeUnit.MILLISECONDS);
+                futures.get(i).get(timer.remainingMs(), TimeUnit.MILLISECONDS);
+                timer.update();
             } catch (Exception e) {
                 throw new KafkaException("Could not produce message: " + records.get(i), e);
             }

--- a/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/testFixtures/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -414,11 +414,17 @@ public class EmbeddedKafkaCluster {
     }
 
     public void produce(String topic, Integer partition, String key, String value) {
-        ProducerRecord<byte[], byte[]> msg = new ProducerRecord<>(topic, partition, key == null ? null : key.getBytes(), value == null ? null : value.getBytes());
-        try {
-            producer.send(msg).get(DEFAULT_PRODUCE_SEND_DURATION_MS, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-            throw new KafkaException("Could not produce message: " + msg, e);
+        produce(List.of(new ProducerRecord<>(topic, partition, key == null ? null : key.getBytes(), value == null ? null : value.getBytes())));
+    }
+
+    public void produce(List<ProducerRecord<byte[], byte[]>> records) {
+        var futures = records.stream().map(producer::send).toList();
+        for (int i = 0; i < futures.size(); i++) {
+            try {
+                futures.get(i).get(DEFAULT_PRODUCE_SEND_DURATION_MS, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                throw new KafkaException("Could not produce message: " + records.get(i), e);
+            }
         }
     }
 


### PR DESCRIPTION
Connect integration tests produce records one at a time and block on
send().get() for each one. The accumulator never holds more than one
record, so the producer cannot batch and every record pays a round trip
plus a full linger.ms wait for a batch that can never fill.

EmbeddedKafkaCluster#produce only accepts a single record, so callers
that need many records have to loop. Add a
produce(List<ProducerRecord<byte[], byte[]>>) overload that sends the
whole list before awaiting any acknowledgement, and have the
single-record overloads delegate to it. Blocking behaviour is unchanged.
Six call sites across four integration test classes produce ~11,000
records this way.

MirrorConnectorsIntegrationBaseTest#produceMessages and
#testConnectorMetrics drive their own producers, so they get the same
send-all-then-await shape in place. produceMessages still bounds the
whole batch with the existing Timer, so its timeout behaviour is
unchanged.

Measured with -PmaxParallelForks=1, two runs per side:

```
before   after
MirrorConnectorsIntegrationBaseTest#testOffsetTranslationBehindReplicationFlow
95.8s   41.0s
TransformationIntegrationTest#testFilterOnTopicNameWithSinkConnector
34.9s   14.6s
ExampleConnectIntegrationTest#testSinkConnector
29.1s   14.8s
TransformationIntegrationTest#testFilterOnTombstonesWithSinkConnector
24.4s   14.4s
ErrorHandlingIntegrationTest#testErrantRecordReporter
13.5s    7.2s
ErrorHandlingIntegrationTest#testSkipRetryAndDLQWithHeaders
12.2s    7.4s
MonitorableSinkIntegrationTest#testMonitorableSinkConnectorAndTask
9.7s    3.7s
```

Total for the four connect:runtime classes: 149.2s -> 87.4s.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
