### PR TITLE
KAFKA-20869: Guard stream thread addition for global-only topologies

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1136,6 +1136,11 @@ public class KafkaStreams implements AutoCloseable {
      * @return name of the added stream thread or empty if a new stream thread could not be added
      */
     public Optional<String> addStreamThread() {
+        if (topologyMetadata.hasNoLocalTopology()) {
+            log.warn("Cannot add a stream thread to a topology with no local processing tasks");
+            return Optional.empty();
+        }
+
         if (isRunningOrRebalancing()) {
             final StreamThread streamThread;
             synchronized (changeThreadCount) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -722,6 +722,22 @@ public class KafkaStreamsTest {
     }
 
     @Test
+    public void shouldNotAddThreadToGlobalOnlyTopology() {
+        prepareStreams();
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.globalTable("global-topic");
+        props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+
+        try (final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time)) {
+            streams.start();
+
+            assertThat(streams.threads.size(), equalTo(0));
+            assertThat(streams.addStreamThread(), equalTo(Optional.empty()));
+            assertThat(streams.threads.size(), equalTo(0));
+        }
+    }
+
+    @Test
     public void shouldNotAddThreadWhenCreated() {
         prepareStreams();
         prepareStreamThread(streamThreadOne, 1);


### PR DESCRIPTION
### Summary
Prevent KafkaStreams#addStreamThread from creating a local StreamThread when the topology has no local processing tasks.

### Motivation
Global-only topologies intentionally start with zero local StreamThreads, even when num.stream.threads is configured with a positive value. Calling addStreamThread after startup must preserve that topology invariant; otherwise it creates a StreamThread that cannot build local tasks and can crash the client or repeatedly trigger thread replacement.

### Testing
- Added a regression test for a running global-only client that verifies no StreamThread is created and addStreamThread returns Optional.empty().
- Verified the test fails before the fix because addStreamThread creates a StreamThread and reaches an internal NullPointerException.
- ./gradlew :streams:check --no-build-cache --console=plain

Fixes KAFKA-20869