### PR TITLE
KAFKA-20148: Wait for remote log task completion before cleanup

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -818,6 +818,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         protected final TopicIdPartition topicIdPartition;
         private final Logger logger;
+        private final ReentrantLock executionLock = new ReentrantLock();
 
         public RLMTask(TopicIdPartition topicIdPartition) {
             this.topicIdPartition = topicIdPartition;
@@ -829,33 +830,48 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
 
         public void run() {
-            if (isCancelled()) {
-                logger.debug("Skipping the current run for partition {} as it is cancelled", topicIdPartition);
-                return;
-            }
-            if (!remoteLogMetadataManagerPlugin.get().isReady(topicIdPartition)) {
-                logger.debug("Skipping the current run for partition {} as the remote-log metadata is not ready", topicIdPartition);
-                return;
-            }
-
+            executionLock.lock();
             try {
-                Optional<UnifiedLog> unifiedLogOptional = fetchLog.apply(topicIdPartition.topicPartition());
-
-                if (unifiedLogOptional.isEmpty()) {
+                if (isCancelled()) {
+                    logger.debug("Skipping the current run for partition {} as it is cancelled", topicIdPartition);
+                    return;
+                }
+                if (!remoteLogMetadataManagerPlugin.get().isReady(topicIdPartition)) {
+                    logger.debug("Skipping the current run for partition {} as the remote-log metadata is not ready", topicIdPartition);
                     return;
                 }
 
-                execute(unifiedLogOptional.get());
-            } catch (InterruptedException ex) {
-                if (!isCancelled()) {
-                    logger.warn("Current thread for partition {} is interrupted", topicIdPartition, ex);
+                try {
+                    Optional<UnifiedLog> unifiedLogOptional = fetchLog.apply(topicIdPartition.topicPartition());
+
+                    if (unifiedLogOptional.isEmpty()) {
+                        return;
+                    }
+
+                    execute(unifiedLogOptional.get());
+                } catch (InterruptedException ex) {
+                    if (!isCancelled()) {
+                        logger.warn("Current thread for partition {} is interrupted", topicIdPartition, ex);
+                    }
+                } catch (RetriableException | RetriableRemoteStorageException ex) {
+                    logger.debug("Encountered a retryable error while executing current task for partition {}", topicIdPartition, ex);
+                } catch (Exception ex) {
+                    if (!isCancelled()) {
+                        logger.warn("Current task for partition {} received error but it will be scheduled", topicIdPartition, ex);
+                    }
                 }
-            } catch (RetriableException | RetriableRemoteStorageException ex) {
-                logger.debug("Encountered a retryable error while executing current task for partition {}", topicIdPartition, ex);
-            } catch (Exception ex) {
-                if (!isCancelled()) {
-                    logger.warn("Current task for partition {} received error but it will be scheduled", topicIdPartition, ex);
-                }
+            } finally {
+                executionLock.unlock();
+            }
+        }
+
+        void awaitExecutionCompletion() {
+            executionLock.lock();
+            try {
+                // Wait for an in-flight execution to finish before its owner proceeds with cleanup.
+                logger.debug("Remote log task for partition {} completed", topicIdPartition);
+            } finally {
+                executionLock.unlock();
             }
         }
 
@@ -1528,8 +1544,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 }
             }
 
-            // Update log start offset with the computed value after retention cleanup is done
-            remoteLogRetentionHandler.logStartOffset.ifPresent(offset -> handleLogStartOffsetUpdate(topicIdPartition.topicPartition(), offset));
+            // Cancellation must win over log-start-offset updates.
+            if (!isCancelled()) remoteLogRetentionHandler.logStartOffset.ifPresent(offset -> handleLogStartOffsetUpdate(topicIdPartition.topicPartition(), offset));
 
             // At this point in time we have updated the log start offsets, but not initiated a deletion.
             // Either a follower has picked up the changes to the log start offset, or they have not.
@@ -2233,6 +2249,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 future.cancel(true);
             } catch (Exception ex) {
                 LOGGER.error("Error occurred while canceling the task: {}", rlmTask, ex);
+            } finally {
+                rlmTask.awaitExecutionCompletion();
             }
         }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -110,9 +110,11 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -2802,6 +2804,96 @@ public class RemoteLogManagerTest {
             assertEquals(0L, currentLogStartOffset.get());
             verify(remoteStorageManager, never()).deleteLogSegmentData(any());
         }
+    }
+
+    @Test
+    public void testExpirationDoesNotAdvanceLogStartOffsetAfterCancellation()
+            throws RemoteStorageException, ExecutionException, InterruptedException {
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", 0L);
+        logProps.put("retention.ms", -1L);
+        when(mockLog.config()).thenReturn(new LogConfig(logProps));
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(100L);
+
+        checkpoint.write(List.of(epochEntry0));
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+
+        List<RemoteLogSegmentMetadata> metadata = listRemoteLogSegmentMetadata(
+                leaderTopicIdPartition, 1, 100, 1024, List.of(epochEntry0), RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(invocation -> metadata.iterator());
+
+        CountDownLatch scanPaused = new CountDownLatch(1);
+        CountDownLatch resumeScan = new CountDownLatch(1);
+        Iterator<RemoteLogSegmentMetadata> blockingIterator = new Iterator<>() {
+            private boolean hasReturnedMetadata = false;
+
+            @Override
+            public boolean hasNext() {
+                if (hasReturnedMetadata) {
+                    scanPaused.countDown();
+                    try {
+                        assertTrue(resumeScan.await(5, TimeUnit.SECONDS));
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return !hasReturnedMetadata;
+            }
+
+            @Override
+            public RemoteLogSegmentMetadata next() {
+                hasReturnedMetadata = true;
+                return metadata.get(0);
+            }
+        };
+        AtomicInteger epochSegmentListCalls = new AtomicInteger();
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(invocation -> epochSegmentListCalls.getAndIncrement() == 0
+                        ? metadata.iterator()
+                        : blockingIterator);
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        RemoteLogManager.RLMExpirationTask expirationTask = remoteLogManager.new RLMExpirationTask(leaderTopicIdPartition);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread cleanupThread = new Thread(() -> {
+            try {
+                expirationTask.run();
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        cleanupThread.start();
+
+        Future<?> scheduledFuture = mock(Future.class);
+        RemoteLogManager.RLMTaskWithFuture taskWithFuture =
+                new RemoteLogManager.RLMTaskWithFuture(expirationTask, scheduledFuture);
+        Thread cancellationThread = null;
+        try {
+            assertTrue(scanPaused.await(5, TimeUnit.SECONDS));
+            cancellationThread = new Thread(taskWithFuture::cancel);
+            cancellationThread.start();
+            assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                while (!expirationTask.isCancelled()) {
+                    Thread.yield();
+                }
+            });
+            assertTrue(cancellationThread.isAlive());
+        } finally {
+            resumeScan.countDown();
+        }
+        cancellationThread.join(5_000);
+        cleanupThread.join(5_000);
+
+        assertFalse(cancellationThread.isAlive());
+        assertFalse(cleanupThread.isAlive());
+        assertNull(failure.get());
+        verify(scheduledFuture).cancel(true);
+        assertEquals(0L, currentLogStartOffset.get());
+        verify(remoteStorageManager, never()).deleteLogSegmentData(any());
     }
 
     @Test


### PR DESCRIPTION
### Problem

When remote storage is disabled, partition tasks are cancelled while an expiration run may still be scanning remote metadata. The scan can then publish a stale log-start-offset update after cancellation, racing with partition cleanup.

### Solution

- Serialize each remote-log task execution with its cancellation completion path.
- Interrupt the scheduled future and wait for any in-flight execution before `stopPartitions` continues cleanup.
- Make cancellation take precedence over a pending expiration log-start-offset update.

### Testing

- RED: `testExpirationDoesNotAdvanceLogStartOffsetAfterCancellation` failed against the baseline because the cancelled task advanced the offset to `100`.
- GREEN: the regression test passes after the fix.
- `./gradlew :storage:test --tests org.apache.kafka.server.log.remote.storage.RemoteLogManagerTest.testExpirationDoesNotAdvanceLogStartOffsetAfterCancellation --no-build-cache --console=plain`
- `./gradlew :storage:test --tests org.apache.kafka.server.log.remote.storage.RemoteLogManagerTest --no-build-cache --console=plain`
- `./gradlew :storage:checkstyleTest :storage:spotlessCheck :storage:spotbugsMain --no-build-cache --console=plain`
- Full `:storage:check` completed 1,252 tests with one timeout in `TransactionsWithTieredStoreTest.testFailureToFenceEpochWithTV1`; the same test passed when rerun in isolation, so the result is recorded as local parallel-test variability rather than a changed-path failure.

Fixes KAFKA-20148