### PR TITLE
KAFKA-20875: Preserve wrapped-store chains in window adapters

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/PlainToHeadersWindowStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/PlainToHeadersWindowStoreAdapter.java
@@ -55,101 +55,102 @@ import static org.apache.kafka.streams.state.internals.Utils.rawPlainValue;
  *   <li>Read: {@code [value]} → {@code [headers][timestamp][value]} (add empty headers and timestamp=-1)</li>
  * </ul>
  */
-public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte[]> {
-    private final WindowStore<Bytes, byte[]> store;
+public class PlainToHeadersWindowStoreAdapter
+    extends WrappedStateStore<WindowStore<Bytes, byte[]>, Bytes, byte[]>
+    implements WindowStore<Bytes, byte[]> {
 
     public PlainToHeadersWindowStoreAdapter(final WindowStore<Bytes, byte[]> store) {
+        super(store);
         if (!store.persistent()) {
             throw new IllegalArgumentException("Provided store must be a persistent store, but it is not.");
         }
         if (store instanceof TimestampedBytesStore) {
             throw new IllegalArgumentException("Provided store must be a plain (non-timestamped) window store, but it is timestamped.");
         }
-        this.store = store;
     }
 
     @Override
     public void put(final Bytes key, final byte[] valueWithTimestampAndHeaders, final long windowStartTimestamp) {
-        store.put(key, rawPlainValue(valueWithTimestampAndHeaders), windowStartTimestamp);
+        wrapped().put(key, rawPlainValue(valueWithTimestampAndHeaders), windowStartTimestamp);
     }
 
     @Override
     public byte[] fetch(final Bytes key, final long timestamp) {
-        return convertFromPlainToHeaderFormat(store.fetch(key, timestamp));
+        return convertFromPlainToHeaderFormat(wrapped().fetch(key, timestamp));
     }
 
     @Override
     public WindowStoreIterator<byte[]> fetch(final Bytes key, final long timeFrom, final long timeTo) {
-        return new PlainToHeadersWindowStoreIteratorAdapter(store.fetch(key, timeFrom, timeTo));
+        return new PlainToHeadersWindowStoreIteratorAdapter(wrapped().fetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> fetch(final Bytes key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersWindowStoreIteratorAdapter(store.fetch(key, timeFrom, timeTo));
+        return new PlainToHeadersWindowStoreIteratorAdapter(wrapped().fetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> backwardFetch(final Bytes key, final long timeFrom, final long timeTo) {
-        return new PlainToHeadersWindowStoreIteratorAdapter(store.backwardFetch(key, timeFrom, timeTo));
+        return new PlainToHeadersWindowStoreIteratorAdapter(wrapped().backwardFetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> backwardFetch(final Bytes key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersWindowStoreIteratorAdapter(store.backwardFetch(key, timeFrom, timeTo));
+        return new PlainToHeadersWindowStoreIteratorAdapter(wrapped().backwardFetch(key, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo,
                                                            final long timeFrom, final long timeTo) {
-        return new PlainToHeadersIteratorAdapter<>(store.fetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().fetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo,
                                                            final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersIteratorAdapter<>(store.fetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().fetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo,
                                                                    final long timeFrom, final long timeTo) {
-        return new PlainToHeadersIteratorAdapter<>(store.backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo,
                                                                    final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersIteratorAdapter<>(store.backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(final long timeFrom, final long timeTo) {
-        return new PlainToHeadersIteratorAdapter<>(store.fetchAll(timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().fetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersIteratorAdapter<>(store.fetchAll(timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().fetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(final long timeFrom, final long timeTo) {
-        return new PlainToHeadersIteratorAdapter<>(store.backwardFetchAll(timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().backwardFetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new PlainToHeadersIteratorAdapter<>(store.backwardFetchAll(timeFrom, timeTo));
+        return new PlainToHeadersIteratorAdapter<>(wrapped().backwardFetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> all() {
-        return new PlainToHeadersIteratorAdapter<>(store.all());
+        return new PlainToHeadersIteratorAdapter<>(wrapped().all());
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardAll() {
-        return new PlainToHeadersIteratorAdapter<>(store.backwardAll());
+        return new PlainToHeadersIteratorAdapter<>(wrapped().backwardAll());
     }
 
 
@@ -164,7 +165,7 @@ public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte
         // Handle WindowKeyQuery: wrap iterator to convert from plain to headers format
         if (query instanceof WindowKeyQuery) {
             final WindowKeyQuery<Bytes, byte[]> windowKeyQuery = (WindowKeyQuery<Bytes, byte[]>) query;
-            final QueryResult<WindowStoreIterator<byte[]>> rawResult = store.query(windowKeyQuery, positionBound, config);
+            final QueryResult<WindowStoreIterator<byte[]>> rawResult = wrapped().query(windowKeyQuery, positionBound, config);
 
             if (rawResult.isSuccess()) {
                 final WindowStoreIterator<byte[]> wrappedIterator =
@@ -177,7 +178,7 @@ public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte
             // Handle WindowRangeQuery: wrap iterator to convert values
             final WindowRangeQuery<Bytes, byte[]> windowRangeQuery = (WindowRangeQuery<Bytes, byte[]>) query;
             final QueryResult<KeyValueIterator<Windowed<Bytes>, byte[]>> rawResult =
-                store.query(windowRangeQuery, positionBound, config);
+                wrapped().query(windowRangeQuery, positionBound, config);
 
             if (rawResult.isSuccess()) {
                 final KeyValueIterator<Windowed<Bytes>, byte[]> wrappedIterator =
@@ -188,7 +189,7 @@ public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte
             }
         } else {
             // For other query types, delegate to the underlying store
-            result = store.query(query, positionBound, config);
+            result = wrapped().query(query, positionBound, config);
         }
 
         if (config.isCollectExecutionInfo()) {
@@ -202,44 +203,44 @@ public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte
 
     @Override
     public Position getPosition() {
-        return store.getPosition();
+        return wrapped().getPosition();
     }
 
     @Override
     public String name() {
-        return store.name();
+        return wrapped().name();
     }
 
     @Override
     public void init(final StateStoreContext context,
                      final StateStore root) {
-        store.init(context, root);
+        wrapped().init(context, root);
     }
 
     @Override
     public void commit(final Map<TopicPartition, Long> changelogOffsets) {
-        store.commit(changelogOffsets);
+        wrapped().commit(changelogOffsets);
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public boolean managesOffsets() {
-        return store.managesOffsets();
+        return wrapped().managesOffsets();
     }
 
     @Override
     public Long committedOffset(final TopicPartition partition) {
-        return store.committedOffset(partition);
+        return wrapped().committedOffset(partition);
     }
 
     @Override
     public long approximateNumUncommittedBytes() {
-        return store.approximateNumUncommittedBytes();
+        return wrapped().approximateNumUncommittedBytes();
     }
 
     @Override
     public void close() {
-        store.close();
+        wrapped().close();
     }
 
     @Override
@@ -249,6 +250,6 @@ public class PlainToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte
 
     @Override
     public boolean isOpen() {
-        return store.isOpen();
+        return wrapped().isOpen();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingWindowStore.java
@@ -110,7 +110,7 @@ public class TimeOrderedCachingWindowStore
             return (RocksDBTimeOrderedWindowStore<?>) wrapped;
         }
         if (wrapped instanceof TimestampedToHeadersWindowStoreAdapter) {
-            return getWrappedStore(((TimestampedToHeadersWindowStoreAdapter) wrapped).store);
+            return getWrappedStore(((TimestampedToHeadersWindowStoreAdapter) wrapped).wrapped());
         }
         if (wrapped instanceof WrappedStateStore) {
             return getWrappedStore(((WrappedStateStore<?, Bytes, byte[]>) wrapped).wrapped());

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapter.java
@@ -56,137 +56,138 @@ import static org.apache.kafka.streams.state.internals.Utils.rawTimestampedValue
  *   <li>Read: {@code [timestamp][value]} → {@code [headers][timestamp][value]} (add empty headers)</li>
  * </ul>
  */
-public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes, byte[]> {
-    final WindowStore<Bytes, byte[]> store;
+public class TimestampedToHeadersWindowStoreAdapter
+    extends WrappedStateStore<WindowStore<Bytes, byte[]>, Bytes, byte[]>
+    implements WindowStore<Bytes, byte[]> {
 
     public TimestampedToHeadersWindowStoreAdapter(final WindowStore<Bytes, byte[]> store) {
+        super(store);
         if (!store.persistent()) {
             throw new IllegalArgumentException("Provided store must be a persistent store, but it is not.");
         }
         if (!(store instanceof TimestampedBytesStore)) {
             throw new IllegalArgumentException("Provided store must be a timestamped store, but it is not.");
         }
-        this.store = store;
     }
 
     @Override
     public void put(final Bytes key, final byte[] valueWithTimestampAndHeaders, final long windowStartTimestamp) {
-        store.put(key, rawTimestampedValue(valueWithTimestampAndHeaders), windowStartTimestamp);
+        wrapped().put(key, rawTimestampedValue(valueWithTimestampAndHeaders), windowStartTimestamp);
     }
 
     @Override
     public byte[] fetch(final Bytes key, final long timestamp) {
-        return convertToHeaderFormat(store.fetch(key, timestamp));
+        return convertToHeaderFormat(wrapped().fetch(key, timestamp));
     }
 
     @Override
     public WindowStoreIterator<byte[]> fetch(final Bytes key, final long timeFrom, final long timeTo) {
-        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(store.fetch(key, timeFrom, timeTo));
+        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(wrapped().fetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> fetch(final Bytes key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(store.fetch(key, timeFrom, timeTo));
+        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(wrapped().fetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> backwardFetch(final Bytes key, final long timeFrom, final long timeTo) {
-        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(store.backwardFetch(key, timeFrom, timeTo));
+        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(wrapped().backwardFetch(key, timeFrom, timeTo));
     }
 
     @Override
     public WindowStoreIterator<byte[]> backwardFetch(final Bytes key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(store.backwardFetch(key, timeFrom, timeTo));
+        return new TimestampedWindowToHeadersWindowStoreIteratorAdapter(wrapped().backwardFetch(key, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo,
                                                            final long timeFrom, final long timeTo) {
-        return new TimestampedToHeadersIteratorAdapter<>(store.fetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().fetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo,
                                                            final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedToHeadersIteratorAdapter<>(store.fetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().fetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo,
                                                                    final long timeFrom, final long timeTo) {
-        return new TimestampedToHeadersIteratorAdapter<>(store.backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(final Bytes keyFrom, final Bytes keyTo,
                                                                    final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedToHeadersIteratorAdapter<>(store.backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(final long timeFrom, final long timeTo) {
-        return new TimestampedToHeadersIteratorAdapter<>(store.fetchAll(timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().fetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedToHeadersIteratorAdapter<>(store.fetchAll(timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().fetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(final long timeFrom, final long timeTo) {
-        return new TimestampedToHeadersIteratorAdapter<>(store.backwardFetchAll(timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().backwardFetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return new TimestampedToHeadersIteratorAdapter<>(store.backwardFetchAll(timeFrom, timeTo));
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().backwardFetchAll(timeFrom, timeTo));
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> all() {
-        return new TimestampedToHeadersIteratorAdapter<>(store.all());
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().all());
     }
 
     @Override
     public KeyValueIterator<Windowed<Bytes>, byte[]> backwardAll() {
-        return new TimestampedToHeadersIteratorAdapter<>(store.backwardAll());
+        return new TimestampedToHeadersIteratorAdapter<>(wrapped().backwardAll());
     }
 
     @Override
     public String name() {
-        return store.name();
+        return wrapped().name();
     }
 
     @Override
     public void init(final StateStoreContext context, final StateStore root) {
-        store.init(context, root);
+        wrapped().init(context, root);
     }
 
     @Override
     public void commit(final Map<TopicPartition, Long> changelogOffsets) {
-        store.commit(changelogOffsets);
+        wrapped().commit(changelogOffsets);
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public boolean managesOffsets() {
-        return store.managesOffsets();
+        return wrapped().managesOffsets();
     }
 
     @Override
     public Long committedOffset(final TopicPartition partition) {
-        return store.committedOffset(partition);
+        return wrapped().committedOffset(partition);
     }
 
     @Override
     public long approximateNumUncommittedBytes() {
-        return store.approximateNumUncommittedBytes();
+        return wrapped().approximateNumUncommittedBytes();
     }
 
     @Override
     public void close() {
-        store.close();
+        wrapped().close();
     }
 
     @Override
@@ -196,7 +197,7 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
 
     @Override
     public boolean isOpen() {
-        return store.isOpen();
+        return wrapped().isOpen();
     }
 
     @SuppressWarnings("unchecked")
@@ -210,7 +211,7 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
         // Handle WindowKeyQuery: wrap iterator to convert from timestamped to headers format
         if (query instanceof WindowKeyQuery) {
             final WindowKeyQuery<Bytes, byte[]> windowKeyQuery = (WindowKeyQuery<Bytes, byte[]>) query;
-            final QueryResult<WindowStoreIterator<byte[]>> rawResult = store.query(windowKeyQuery, positionBound, config);
+            final QueryResult<WindowStoreIterator<byte[]>> rawResult = wrapped().query(windowKeyQuery, positionBound, config);
 
             if (rawResult.isSuccess()) {
                 final WindowStoreIterator<byte[]> wrappedIterator =
@@ -223,7 +224,7 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
             // Handle WindowRangeQuery: wrap iterator to convert values
             final WindowRangeQuery<Bytes, byte[]> windowRangeQuery = (WindowRangeQuery<Bytes, byte[]>) query;
             final QueryResult<KeyValueIterator<Windowed<Bytes>, byte[]>> rawResult =
-                store.query(windowRangeQuery, positionBound, config);
+                wrapped().query(windowRangeQuery, positionBound, config);
 
             if (rawResult.isSuccess()) {
                 final KeyValueIterator<Windowed<Bytes>, byte[]> wrappedIterator =
@@ -234,7 +235,7 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
             }
         } else {
             // For other query types, delegate to the underlying store
-            result = store.query(query, positionBound, config);
+            result = wrapped().query(query, positionBound, config);
         }
 
         if (config.isCollectExecutionInfo()) {
@@ -248,7 +249,7 @@ public class TimestampedToHeadersWindowStoreAdapter implements WindowStore<Bytes
 
     @Override
     public Position getPosition() {
-        return store.getPosition();
+        return wrapped().getPosition();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreWithHeadersBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreWithHeadersBuilder.java
@@ -118,7 +118,7 @@ public class TimestampedWindowStoreWithHeadersBuilder<K, V>
             return true;
         }
         if (stateStore instanceof TimestampedToHeadersWindowStoreAdapter) {
-            return isTimeOrderedStore(((TimestampedToHeadersWindowStoreAdapter) stateStore).store);
+            return isTimeOrderedStore(((TimestampedToHeadersWindowStoreAdapter) stateStore).wrapped());
         }
         if (stateStore instanceof WrappedStateStore) {
             return isTimeOrderedStore(((WrappedStateStore<?, ?, ?>) stateStore).wrapped());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/PlainToHeadersWindowStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/PlainToHeadersWindowStoreAdapterTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PlainToHeadersWindowStoreAdapterTest {
@@ -98,6 +99,12 @@ public class PlainToHeadersWindowStoreAdapterTest {
         if (adapter != null) {
             adapter.close();
         }
+    }
+
+    @Test
+    public void shouldPreserveWrappedStoreChain() {
+        assertSame(underlyingStore, adapter.wrapped());
+        assertSame(underlyingStore, adapter.findInner(RocksDBWindowStore.class));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedToHeadersWindowStoreAdapterTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TimestampedToHeadersWindowStoreAdapterTest {
@@ -99,6 +100,13 @@ public class TimestampedToHeadersWindowStoreAdapterTest {
         if (adapter != null) {
             adapter.close();
         }
+    }
+
+    @Test
+    public void shouldPreserveWrappedStoreChain() {
+        assertSame(underlyingStore, adapter.wrapped());
+        assertSame(underlyingStore, adapter.findInner(RocksDBTimestampedWindowStore.class));
+        assertTrue(WrappedStateStore.isTimestamped(adapter));
     }
 
     @Test


### PR DESCRIPTION
### Problem

The plain and timestamped window-store adapters used for header-aware compatibility directly implemented `WindowStore` and kept their delegates in private fields. As a result, the adapters terminated the standard `WrappedStateStore` chain: `wrapped()`, `findInner()`, and recursive store-type inspection could not see the underlying store.

### Solution

- Make both window-store adapters extend `WrappedStateStore`.
- Route existing delegation through the inherited `wrapped()` contract without changing value-format conversions.
- Update time-ordered-store detection to use `wrapped()` instead of adapter-specific delegate state.
- Add regression tests for direct wrapping, inner-store discovery, and timestamped-store detection.

### Testing

- RED: the new chain tests failed against the baseline at test compilation because neither adapter exposed `wrapped()` or `findInner()`.
- GREEN: both adapter test classes pass, including all existing query and execution-info tests.
- `./gradlew :streams:test --tests org.apache.kafka.streams.state.internals.PlainToHeadersWindowStoreAdapterTest --tests org.apache.kafka.streams.state.internals.TimestampedToHeadersWindowStoreAdapterTest --no-build-cache --console=plain`
- `./gradlew :streams:test --tests org.apache.kafka.streams.state.internals.TimestampedWindowStoreWithHeadersBuilderTest --tests org.apache.kafka.streams.state.internals.TimeOrderedCachingPersistentWindowStoreTest --no-build-cache --console=plain`
- `:streams:check` completed 9,298 tests with one timeout in `CustomStickyTaskAssignorTest.largeAssignmentShouldTerminateWithinAcceptableTime` under the `balance_subtopology` strategy; the parameterized test passed for all three strategies when rerun in isolation. Checkstyle, Spotless, SpotBugs, Javadoc, and the public API checker passed.

Fixes KAFKA-20875

Reviewers: Sean Quah <squah@confluent.io>
