### PR TITLE
KAFKA-20876: Retry windowed restore after control record

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -1088,9 +1088,10 @@ public class StoreChangelogReader implements ChangelogReader {
                 }
                 windowedPartitionsRetention.keySet().removeAll(seekToBeginningPartitions);
 
-                final ConsumerRecords<byte[], byte[]> polledRecords = restoreConsumer.poll(pollTime);
+                final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> polledRecordsByPartition =
+                    pollWindowedPartitions(windowedPartitionsRetention.keySet(), endOffsets);
 
-                seekByRetentionFromPolledRecords(polledRecords, windowedPartitionsRetention, seekToBeginningPartitions);
+                seekByRetentionFromPolledRecords(polledRecordsByPartition, windowedPartitionsRetention, seekToBeginningPartitions);
             } catch (final TimeoutException e) {
                 log.debug("Could not seek by timestamp for changelog partitions {}, falling back to seek-to-beginning",
                     windowedPartitionsRetention.keySet(), e);
@@ -1116,14 +1117,48 @@ public class StoreChangelogReader implements ChangelogReader {
         }
     }
 
-    private void seekByRetentionFromPolledRecords(final ConsumerRecords<byte[], byte[]> polledRecords,
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> pollWindowedPartitions(
+        final Set<TopicPartition> windowedPartitions,
+        final Map<TopicPartition, Long> endOffsets) {
+        final ConsumerRecords<byte[], byte[]> polledRecords = restoreConsumer.poll(pollTime);
+        final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> polledRecordsByPartition = new HashMap<>();
+        final Set<TopicPartition> partitionsToRetry = new HashSet<>();
+
+        for (final TopicPartition partition : windowedPartitions) {
+            final List<ConsumerRecord<byte[], byte[]>> records = polledRecords.records(partition);
+            if (!records.isEmpty()) {
+                polledRecordsByPartition.put(partition, records);
+            } else {
+                final Long endOffset = endOffsets.get(partition);
+                if (endOffset != null && endOffset > 1) {
+                    // The record at endOffset - 1 may be a transaction control record, which is not
+                    // returned by the consumer. Retry at the preceding offset before giving up.
+                    restoreConsumer.seek(partition, endOffset - 2);
+                    partitionsToRetry.add(partition);
+                } else {
+                    polledRecordsByPartition.put(partition, Collections.emptyList());
+                }
+            }
+        }
+
+        if (!partitionsToRetry.isEmpty()) {
+            final ConsumerRecords<byte[], byte[]> retriedRecords = restoreConsumer.poll(pollTime);
+            for (final TopicPartition partition : partitionsToRetry) {
+                polledRecordsByPartition.put(partition, retriedRecords.records(partition));
+            }
+        }
+
+        return polledRecordsByPartition;
+    }
+
+    private void seekByRetentionFromPolledRecords(final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> polledRecords,
                                                    final Map<TopicPartition, Long> windowedPartitionsRetention,
                                                    final Set<TopicPartition> seekToBeginningPartitions) {
         final Map<TopicPartition, Long> seekTimestamps = new HashMap<>();
         for (final Map.Entry<TopicPartition, Long> entry : windowedPartitionsRetention.entrySet()) {
             final TopicPartition partition = entry.getKey();
             final long retentionPeriod = entry.getValue();
-            final List<ConsumerRecord<byte[], byte[]>> records = polledRecords.records(partition);
+            final List<ConsumerRecord<byte[], byte[]>> records = polledRecords.getOrDefault(partition, Collections.emptyList());
             if (!records.isEmpty()) {
                 final long latestTimestamp = records.get(0).timestamp();
                 final long seekTimestamp = latestTimestamp - retentionPeriod;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1462,8 +1463,9 @@ public class StoreChangelogReaderTest {
         }
     }
 
-    @Test
-    public void shouldSeekByTimestampForWindowedStoreWithoutCheckpoint() {
+    @ParameterizedTest(name = "latest visible record offset {0}")
+    @ValueSource(longs = {98L, 99L})
+    public void shouldSeekByTimestampForWindowedStoreWithoutCheckpoint(final long latestRecordOffset) {
         final long retentionMs = Duration.ofHours(2).toMillis();
         final long offsetForTimestamp = 42L;
         final long latestRecordTimestamp = 10_000_000L;
@@ -1496,9 +1498,12 @@ public class StoreChangelogReaderTest {
         timestampConsumer.updateEndOffsets(Collections.singletonMap(tp, endOffset));
         adminClient.updateEndOffsets(Collections.singletonMap(tp, endOffset));
 
-        // schedule adding the record during poll, after the partition is assigned
+        // Offset 98 models the latest visible record when endOffset - 1 is a transaction control record,
+        // which the consumer filters out. Offset 99 covers the normal case where the latest record is
+        // visible at endOffset - 1.
+        // Schedule adding the record during poll, after the partition is assigned.
         timestampConsumer.schedulePollTask(() -> timestampConsumer.addRecord(new ConsumerRecord<>(
-            tp.topic(), tp.partition(), endOffset - 1,
+            tp.topic(), tp.partition(), latestRecordOffset,
             latestRecordTimestamp, TimestampType.CREATE_TIME,
             0, 0, new byte[0], new byte[0],
             new RecordHeaders(), Optional.empty())));


### PR DESCRIPTION
## Summary

When a windowed changelog ends with a transaction control record, the
restore consumer filters that record from poll results. Probing only
`endOffset - 1` therefore returns no record and incorrectly abandons the
retention-based restore optimization.

This change retries the probe from the preceding offset before falling
back to the beginning. The regression test covers both a visible latest
record and the filtered control-record case.

## Testing

- TDD RED: the new filtered-record case failed on the baseline branch
because restoration fell back to the beginning.
- TDD GREEN: `./gradlew :streams:test --tests
org.apache.kafka.streams.processor.internals.StoreChangelogReaderTest.shouldSeekByTimestampForWindowedStoreWithoutCheckpoint
--no-build-cache --console=plain`
- Full module: `./gradlew :streams:test --no-build-cache
--console=plain` (BUILD SUCCESSFUL, 6m 54s)
- The targeted Gradle run completed the affected streams checkstyle and
SpotBugs tasks successfully.
- `git diff --check`

Jira: https://issues.apache.org/jira/browse/KAFKA-20876 Reviewers: Mingi
Cho (github:ChoMinGi)
