### PR TITLE
KAFKA-20679: Remove deprecated Yammer group coordinator metrics

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -713,7 +713,7 @@ class BrokerServer(
       .withLoader(loader)
       .withWriter(writer)
       .withCoordinatorRuntimeMetrics(new GroupCoordinatorRuntimeMetrics(metrics))
-      .withGroupCoordinatorMetrics(new GroupCoordinatorMetrics(KafkaYammerMetrics.defaultRegistry, metrics))
+      .withGroupCoordinatorMetrics(new GroupCoordinatorMetrics(metrics))
       .withGroupConfigManager(groupConfigManager)
       .withPersister(persister)
       .withAuthorizerPlugin(authorizerPlugin.toJava)

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1560,7 +1560,7 @@ Classic Group Count
 </td>  
 <td>
 
-kafka.server:type=GroupMetadataManager,name=NumGroups
+kafka.server:type=group-coordinator-metrics,name=group-count,protocol=classic
 </td>  
 <td>
 
@@ -1573,7 +1573,7 @@ Classic Group Count, per State
 </td>  
 <td>
 
-kafka.server:type=GroupMetadataManager,name=NumGroups[PreparingRebalance,CompletingRebalance,Empty,Stable,Dead]
+kafka.server:type=group-coordinator-metrics,name=classic-group-count,state={PreparingRebalance,CompletingRebalance,Empty,Stable,Dead}
 </td>  
 <td>
 
@@ -1612,7 +1612,7 @@ Group Offset Count
 </td>  
 <td>
 
-kafka.server:type=GroupMetadataManager,name=NumOffsets
+kafka.server:type=group-coordinator-metrics,name=offset-count
 </td>  
 <td>
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetrics.java
@@ -30,10 +30,7 @@ import org.apache.kafka.coordinator.group.classic.ClassicGroupState;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup.ConsumerGroupState;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
-import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 import org.apache.kafka.timeline.SnapshotRegistry;
-
-import com.yammer.metrics.core.MetricsRegistry;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,58 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoCloseable {
 
     public static final String METRICS_GROUP = "group-coordinator-metrics";
-
-    /**
-     * @deprecated Since 4.4. Use kafka.server:type=group-coordinator-metrics,name=group-count,protocol=classic
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS = getMetricName(
-        "GroupMetadataManager", "NumGroups");
-    /**
-     * @deprecated Since 4.4. Use kafka.server:type=group-coordinator-metrics,name=offset-count instead.
-     *             This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_OFFSETS = getMetricName(
-        "GroupMetadataManager", "NumOffsets");
-    /**
-     * @deprecated Since 4.4. Use
-     *             kafka.server:type=group-coordinator-metrics,name=classic-group-count,state=PreparingRebalance
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS_PREPARING_REBALANCE = getMetricName(
-        "GroupMetadataManager", "NumGroupsPreparingRebalance");
-    /**
-     * @deprecated Since 4.4. Use
-     *             kafka.server:type=group-coordinator-metrics,name=classic-group-count,state=CompletingRebalance
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS_COMPLETING_REBALANCE = getMetricName(
-        "GroupMetadataManager", "NumGroupsCompletingRebalance");
-    /**
-     * @deprecated Since 4.4. Use kafka.server:type=group-coordinator-metrics,name=classic-group-count,state=Stable
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS_STABLE = getMetricName(
-        "GroupMetadataManager", "NumGroupsStable");
-    /**
-     * @deprecated Since 4.4. Use kafka.server:type=group-coordinator-metrics,name=classic-group-count,state=Dead
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS_DEAD = getMetricName(
-        "GroupMetadataManager", "NumGroupsDead");
-    /**
-     * @deprecated Since 4.4. Use kafka.server:type=group-coordinator-metrics,name=classic-group-count,state=Empty
-     *             instead. This metric will be removed in Kafka 5.0.
-     */
-    @Deprecated(since = "4.4", forRemoval = true)
-    public static final com.yammer.metrics.core.MetricName NUM_CLASSIC_GROUPS_EMPTY = getMetricName(
-        "GroupMetadataManager", "NumGroupsEmpty");
 
     public static final String GROUP_COUNT_METRIC_NAME = "group-count";
     public static final String GROUP_COUNT_PROTOCOL_TAG = "protocol";
@@ -156,7 +101,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     private final MetricName streamsGroupCountDeadMetricName;
     private final MetricName streamsGroupCountNotReadyMetricName;
 
-    private final MetricsRegistry registry;
     private final Metrics metrics;
     private final Map<TopicPartition, GroupCoordinatorMetricsShard> shards = new ConcurrentHashMap<>();
 
@@ -166,12 +110,11 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     public final Map<String, Sensor> globalSensors;
 
     public GroupCoordinatorMetrics() {
-        this(KafkaYammerMetrics.defaultRegistry(), new Metrics());
+        this(new Metrics());
     }
 
     @SuppressWarnings("MethodLength")
-    public GroupCoordinatorMetrics(MetricsRegistry registry, Metrics metrics) {
-        this.registry = Objects.requireNonNull(registry);
+    public GroupCoordinatorMetrics(Metrics metrics) {
         this.metrics = Objects.requireNonNull(metrics);
 
         offsetCountMetricName = metrics.metricName(
@@ -341,7 +284,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
             Map.of(STREAMS_GROUP_COUNT_STATE_TAG, StreamsGroupState.NOT_READY.toString())
         );
 
-        registerGauges();
+        registerMetrics();
 
         Sensor offsetCommitsSensor = metrics.sensor(OFFSET_COMMITS_SENSOR_NAME);
         offsetCommitsSensor.add(new Meter(
@@ -571,16 +514,6 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
     @Override
     public void close() {
         Arrays.asList(
-            NUM_OFFSETS,
-            NUM_CLASSIC_GROUPS,
-            NUM_CLASSIC_GROUPS_PREPARING_REBALANCE,
-            NUM_CLASSIC_GROUPS_COMPLETING_REBALANCE,
-            NUM_CLASSIC_GROUPS_STABLE,
-            NUM_CLASSIC_GROUPS_DEAD,
-            NUM_CLASSIC_GROUPS_EMPTY
-        ).forEach(registry::removeMetric);
-
-        Arrays.asList(
             offsetCountMetricName,
             classicGroupCountMetricName,
             classicGroupCountPreparingRebalanceMetricName,
@@ -652,60 +585,7 @@ public class GroupCoordinatorMetrics extends CoordinatorMetrics implements AutoC
         }
     }
 
-    public static com.yammer.metrics.core.MetricName getMetricName(String type, String name) {
-        return getMetricName("kafka.coordinator.group", type, name);
-    }
-
-    private void registerGauges() {
-        registry.newGauge(NUM_OFFSETS, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numOffsets();
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups();
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS_PREPARING_REBALANCE, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups(ClassicGroupState.PREPARING_REBALANCE);
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS_COMPLETING_REBALANCE, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups(ClassicGroupState.COMPLETING_REBALANCE);
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS_STABLE, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups(ClassicGroupState.STABLE);
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS_DEAD, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups(ClassicGroupState.DEAD);
-            }
-        });
-
-        registry.newGauge(NUM_CLASSIC_GROUPS_EMPTY, new com.yammer.metrics.core.Gauge<Long>() {
-            @Override
-            public Long value() {
-                return numClassicGroups(ClassicGroupState.EMPTY);
-            }
-        });
-
+    private void registerMetrics() {
         metrics.addMetric(
             offsetCountMetricName,
             (Gauge<Long>) (config, now) -> numOffsets()

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsShardTest.java
@@ -22,8 +22,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
-import com.yammer.metrics.core.MetricsRegistry;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,11 +30,10 @@ public class GroupCoordinatorMetricsShardTest {
 
     @Test
     public void testTimelineGaugeCounters() {
-        MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         TopicPartition tp = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
+        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metrics);
         GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(snapshotRegistry, tp);
 
         shard.incrementNumOffsets();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/GroupCoordinatorMetricsTest.java
@@ -32,8 +32,6 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup.ShareGroupStat
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
-import com.yammer.metrics.core.MetricsRegistry;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -48,8 +46,6 @@ import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.SHARE_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.STREAMS_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.assertGaugeValue;
-import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.assertMetricsForTypeEqual;
-import static org.apache.kafka.coordinator.group.metrics.MetricsTestUtils.metricName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,7 +54,6 @@ public class GroupCoordinatorMetricsTest {
 
     @Test
     public void testMetricNames() {
-        MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
 
         Set<org.apache.kafka.common.MetricName> expectedMetrics = Set.of(
@@ -192,33 +187,16 @@ public class GroupCoordinatorMetricsTest {
                 Map.of("state", StreamsGroupState.NOT_READY.toString()))
         );
 
-        try {
-            try (GroupCoordinatorMetrics ignored = new GroupCoordinatorMetrics(registry, metrics)) {
-                Set<String> expectedRegistry = Set.of(
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumOffsets",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroups",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroupsPreparingRebalance",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroupsCompletingRebalance",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroupsStable",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroupsDead",
-                    "kafka.coordinator.group:type=GroupMetadataManager,name=NumGroupsEmpty"
-                );
-
-                assertMetricsForTypeEqual(registry, "kafka.coordinator.group", expectedRegistry);
-                expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName), metricName + " is missing"));
-            }
-            assertMetricsForTypeEqual(registry, "kafka.coordinator.group", Set.of());
-            expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
-        } finally {
-            registry.shutdown();
+        try (GroupCoordinatorMetrics ignored = new GroupCoordinatorMetrics(metrics)) {
+            expectedMetrics.forEach(metricName -> assertTrue(metrics.metrics().containsKey(metricName), metricName + " is missing"));
         }
+        expectedMetrics.forEach(metricName -> assertFalse(metrics.metrics().containsKey(metricName)));
     }
 
     @Test
     public void aggregateShards() {
-        MetricsRegistry registry = new MetricsRegistry();
         Metrics metrics = new Metrics();
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
+        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metrics);
         SnapshotRegistry snapshotRegistry0 = new SnapshotRegistry(new LogContext());
         SnapshotRegistry snapshotRegistry1 = new SnapshotRegistry(new LogContext());
         TopicPartition tp0 = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
@@ -268,7 +246,6 @@ public class GroupCoordinatorMetricsTest {
 
         assertEquals(4, shard0.numClassicGroups());
         assertEquals(5, shard1.numClassicGroups());
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroups"), 9);
         assertGaugeValue(
             metrics,
             metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "classic")),
@@ -290,14 +267,12 @@ public class GroupCoordinatorMetricsTest {
             metrics.metricName("group-count", METRICS_GROUP, Map.of("protocol", "consumer")),
             7
         );
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumOffsets"), 7);
         assertGaugeValue(
             metrics,
             metrics.metricName(GroupCoordinatorMetrics.OFFSET_COUNT_METRIC_NAME, METRICS_GROUP),
             7
         );
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsPreparingRebalance"), 2);
         assertGaugeValue(
             metrics,
             metrics.metricName(
@@ -307,7 +282,6 @@ public class GroupCoordinatorMetricsTest {
             2
         );
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsCompletingRebalance"), 2);
         assertGaugeValue(
             metrics,
             metrics.metricName(
@@ -317,7 +291,6 @@ public class GroupCoordinatorMetricsTest {
             2
         );
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsStable"), 2);
         assertGaugeValue(
             metrics,
             metrics.metricName(
@@ -327,7 +300,6 @@ public class GroupCoordinatorMetricsTest {
             2
         );
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsDead"), 1);
         assertGaugeValue(
             metrics,
             metrics.metricName(
@@ -337,7 +309,6 @@ public class GroupCoordinatorMetricsTest {
             1
         );
 
-        assertGaugeValue(registry, metricName("GroupMetadataManager", "NumGroupsEmpty"), 2);
         assertGaugeValue(
             metrics,
             metrics.metricName(
@@ -366,10 +337,9 @@ public class GroupCoordinatorMetricsTest {
 
     @Test
     public void testGlobalSensors() {
-        MetricsRegistry registry = new MetricsRegistry();
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
+        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metrics);
         GroupCoordinatorMetricsShard shard = coordinatorMetrics.newMetricsShard(
             new SnapshotRegistry(new LogContext()), new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0)
         );
@@ -417,10 +387,9 @@ public class GroupCoordinatorMetricsTest {
 
     @Test
     public void testStreamsGroupTopologyDescriptionSetAndGetSensors() {
-        MetricsRegistry registry = new MetricsRegistry();
         Time time = new MockTime();
         Metrics metrics = new Metrics(time);
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(registry, metrics);
+        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metrics);
 
         coordinatorMetrics.recordSensor(GroupCoordinatorMetrics.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_SET_SUCCESS_SENSOR_NAME);
         coordinatorMetrics.recordSensor(GroupCoordinatorMetrics.STREAMS_GROUP_TOPOLOGY_DESCRIPTION_SET_ERROR_SENSOR_NAME);

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/MetricsTestUtils.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/metrics/MetricsTestUtils.java
@@ -19,46 +19,11 @@ package org.apache.kafka.coordinator.group.metrics;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 
-import com.yammer.metrics.core.Gauge;
-import com.yammer.metrics.core.MetricsRegistry;
-
-import java.util.Set;
-import java.util.TreeSet;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MetricsTestUtils {
-    static void assertMetricsForTypeEqual(
-        MetricsRegistry registry,
-        String expectedPrefix,
-        Set<String> expected
-    ) {
-        Set<String> actual = new TreeSet<>();
-        registry.allMetrics().forEach((name, __) -> {
-            StringBuilder bld = new StringBuilder();
-            bld.append(name.getGroup());
-            bld.append(":type=").append(name.getType());
-            bld.append(",name=").append(name.getName());
-            if (bld.toString().startsWith(expectedPrefix)) {
-                actual.add(bld.toString());
-            }
-        });
-        assertEquals(new TreeSet<>(expected), actual);
-    }
-
-    static void assertGaugeValue(MetricsRegistry registry, com.yammer.metrics.core.MetricName metricName, long count) {
-        Gauge gauge = (Gauge) registry.allMetrics().get(metricName);
-
-        assertEquals(count, (long) gauge.value());
-    }
-
     static void assertGaugeValue(Metrics metrics, MetricName metricName, long count) {
         Long metricVal = (Long) metrics.metrics().get(metricName).metricValue();
         assertEquals(count, metricVal);
-    }
-
-    static com.yammer.metrics.core.MetricName metricName(String type, String name) {
-        String mBeanName = String.format("kafka.coordinator.group:type=%s,name=%s", type, name);
-        return new com.yammer.metrics.core.MetricName("kafka.coordinator.group", type, name, null, mBeanName);
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/coordinator/GroupCoordinatorShardLoadingBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/coordinator/GroupCoordinatorShardLoadingBenchmark.java
@@ -47,8 +47,6 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata;
 import org.apache.kafka.storage.internals.log.UnifiedLog;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
-import com.yammer.metrics.core.MetricsRegistry;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -294,9 +292,8 @@ public class GroupCoordinatorShardLoadingBenchmark {
         LogContext logContext = new LogContext();
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(logContext);
 
-        MetricsRegistry metricsRegistry = new MetricsRegistry();
         Metrics metrics = new Metrics();
-        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metricsRegistry, metrics);
+        GroupCoordinatorMetrics coordinatorMetrics = new GroupCoordinatorMetrics(metrics);
 
         coordinatorShard = new GroupCoordinatorShard.Builder(config, configManager)
             .withAuthorizerPlugin(Optional.empty())


### PR DESCRIPTION
## Summary

- Remove the deprecated Yammer-based group coordinator metrics scheduled for removal in Kafka 5.0.
- Simplify `GroupCoordinatorMetrics` to use Kafka Metrics only, including its constructor, registration, and cleanup paths.
- Update the broker, benchmark, coordinator tests, test utilities, and monitoring documentation for the Kafka Metrics replacements.
- Jira: https://issues.apache.org/jira/browse/KAFKA-20679

## TDD verification

- RED: on the baseline, a test asserting that deprecated Yammer metrics are not registered failed because the old gauges were present (`expected: <true> but was: <false>`).
- GREEN: after the production removal, the coordinator metrics tests pass and the deprecated Yammer APIs are no longer referenced in the affected paths.

## Testing

- `./gradlew :group-coordinator:test --tests org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsTest --tests org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetricsShardTest --no-build-cache --console=plain`
- `./gradlew :group-coordinator:test --no-build-cache --console=plain`
- `./gradlew :core:compileScala :jmh-benchmarks:compileJava --no-build-cache --console=plain --quiet`
- Checkstyle and SpotBugs completed successfully as part of the coordinator test task.
- `git diff --check`

The deprecated metrics were explicitly marked for Kafka 5.0 removal in KIP-1301, and the replacement metrics remain covered by the existing Kafka Metrics assertions.

Reviewers: Sean Quah <squah@confluent.io>
