### PR TITLE
KAFKA-12744: Upgrade argparse4j to 0.9.0

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -292,7 +292,7 @@ see: licenses/CDDL+GPL-1.1
 ---------------------------------------
 MIT License
 
-- argparse4j-0.7.0, see: licenses/argparse-MIT
+- argparse4j-0.9.0, see: licenses/argparse-MIT
 - classgraph-4.8.179, see: licenses/classgraph-MIT
 - jopt-simple-5.0.4, see: licenses/jopt-simple-MIT
 - slf4j-api-1.7.36, see: licenses/slf4j-MIT

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -327,7 +327,7 @@ public class MirrorMaker {
     }
 
     public static void main(String[] args) {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("connect-mirror-maker");
+        ArgumentParser parser = ArgumentParsers.newFor("connect-mirror-maker").build();
         parser.description("MirrorMaker 2.0 driver");
         parser.addArgument("config").type(Arguments.fileType().verifyCanRead())
             .metavar("mm2.properties").required(true)

--- a/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
+++ b/core/src/main/scala/kafka/docker/KafkaDockerWrapper.scala
@@ -77,7 +77,11 @@ object KafkaDockerWrapper extends Logging {
 
   private def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers.
-      newArgumentParser("kafka-docker-wrapper", true, "-", "@").
+      newFor("kafka-docker-wrapper").
+      addHelp(true).
+      prefixChars("-").
+      fromFilePrefix("@").
+      build().
       description("The Kafka docker wrapper.")
 
     val subparsers = parser.addSubparsers().dest("command")

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -24,7 +24,7 @@ import kafka.utils.Logging
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments.{append, store, storeTrue}
 import net.sourceforge.argparse4j.inf.{ArgumentParserException, Namespace, Subparser, Subparsers}
-import net.sourceforge.argparse4j.internal.HelpScreenException
+import net.sourceforge.argparse4j.helper.HelpScreenException
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.utils.internals.Exit
@@ -291,7 +291,11 @@ object StorageTool extends Logging {
 
   def parseArguments(args: Array[String]): Namespace = {
     val parser = ArgumentParsers
-      .newArgumentParser("kafka-storage", /* defaultHelp */true, /* prefixChars */"-", /* fromFilePrefix */ "@")
+      .newFor("kafka-storage")
+      .addHelp(true)
+      .prefixChars("-")
+      .fromFilePrefix("@")
+      .build()
       .description("The Kafka storage tool.")
 
     val subparsers = parser.addSubparsers().dest("command")

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -369,7 +369,8 @@ public final class MessageGenerator {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("message-generator")
+            .newFor("message-generator")
+            .build()
             .defaultHelp(true)
             .description("The Kafka message generator");
         parser.addArgument("--package", "-p")

--- a/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
+++ b/generator/src/main/java/org/apache/kafka/message/checker/MetadataSchemaCheckerTool.java
@@ -18,11 +18,11 @@
 package org.apache.kafka.message.checker;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.io.PrintStream;
 
@@ -41,7 +41,8 @@ public class MetadataSchemaCheckerTool {
         PrintStream writer
     ) throws Exception {
         ArgumentParser argumentParser = ArgumentParsers.
-            newArgumentParser("metadata-schema-checker").
+            newFor("metadata-schema-checker").
+            build().
             defaultHelp(true).
             description("The Kafka metadata schema checker tool.");
         Subparsers subparsers = argumentParser.addSubparsers().dest("command");

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   activation: "1.1.1",
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
-  argparse4j: "0.7.0",
+  argparse4j: "0.9.0",
   bcpkix: "1.85",
   caffeine: "3.2.0",
   checkstyle: project.hasProperty('checkstyleVersion') ? checkstyleVersion : "12.3.1",

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -201,7 +201,8 @@ public final class MetadataShell {
 
     public static void main(String[] args) {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("kafka-metadata-shell")
+            .newFor("kafka-metadata-shell")
+            .build()
             .defaultHelp(true)
             .description("The Apache Kafka metadata shell");
         parser.addArgument("--snapshot", "-s")

--- a/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/Commands.java
@@ -21,12 +21,12 @@ import org.apache.kafka.shell.InteractiveShell;
 import org.apache.kafka.shell.state.MetadataShellState;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import org.jline.reader.Candidate;
 
@@ -104,7 +104,7 @@ public final class Commands {
      * @param addShellCommands  True if we should include the shell-only commands.
      */
     public Commands(boolean addShellCommands) {
-        this.parser = ArgumentParsers.newArgumentParser("", false);
+        this.parser = ArgumentParsers.newFor("").addHelp(false).build();
         Subparsers subparsers = this.parser.addSubparsers().dest("command");
         for (Type type : TYPES.values()) {
             if (addShellCommands || !type.shellOnly()) {

--- a/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/command/ManCommandHandler.java
@@ -96,7 +96,7 @@ public final class ManCommandHandler implements Commands.Handler {
             writer.println("man: unknown command " + cmd +
                 ". Type help to get a list of commands.");
         } else {
-            ArgumentParser parser = ArgumentParsers.newArgumentParser(type.name(), false);
+            ArgumentParser parser = ArgumentParsers.newFor(type.name()).addHelp(false).build();
             type.addArguments(parser);
             writer.printf("%s: %s%n%n", cmd, type.description());
             parser.printHelp(writer);

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -108,7 +108,8 @@ public class ClientCompatibilityTest {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("client-compatibility-test")
+            .newFor("client-compatibility-test")
+            .build()
             .defaultHelp(true)
             .description("This tool is used to verify client compatibility guarantees.");
         parser.addArgument("--topic")

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterTool.java
@@ -70,7 +70,8 @@ public class ClusterTool {
 
     static void execute(String... args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("kafka-cluster")
+                .newFor("kafka-cluster")
+                .build()
                 .defaultHelp(true)
                 .description("The Kafka cluster tool.");
         Subparsers subparsers = parser.addSubparsers().dest("command");

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectInternalTopics.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectInternalTopics.java
@@ -154,7 +154,7 @@ public class ConnectInternalTopics {
     }
 
     private static ArgumentParser parser() {
-        var parser = ArgumentParsers.newArgumentParser("connect-internal-topics")
+        var parser = ArgumentParsers.newFor("connect-internal-topics").build()
                 .defaultHelp(true)
                 .description("Manage internal topics required by Kafka Connect clusters (config, status, and offset topics).");
 

--- a/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConnectPluginPath.java
@@ -97,7 +97,7 @@ public class ConnectPluginPath {
     }
 
     private static ArgumentParser parser() {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("connect-plugin-path")
+        ArgumentParser parser = ArgumentParsers.newFor("connect-plugin-path").build()
             .defaultHelp(true)
             .description("Manage plugins on the Connect plugin.path");
 

--- a/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/FeatureCommand.java
@@ -31,6 +31,7 @@ import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.server.util.CommandLineUtils;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
@@ -38,7 +39,6 @@ import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +74,8 @@ public class FeatureCommand {
 
     static void execute(String... args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("kafka-features")
+                .newFor("kafka-features")
+                .build()
                 .defaultHelp(true)
                 .description("This tool manages feature flags in Kafka.");
         MutuallyExclusiveGroup bootstrapGroup = parser.addMutuallyExclusiveGroup();

--- a/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/MetadataQuorumCommand.java
@@ -36,6 +36,7 @@ import org.apache.kafka.server.util.CommandLineUtils;
 import org.apache.kafka.server.util.Csv;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentGroup;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -44,7 +45,6 @@ import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,7 +97,8 @@ public class MetadataQuorumCommand {
 
     static void execute(String... args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("kafka-metadata-quorum")
+            .newFor("kafka-metadata-quorum")
+            .build()
             .defaultHelp(true)
             .description("This tool describes kraft metadata quorum status.");
         MutuallyExclusiveGroup connectionOptions = parser.addMutuallyExclusiveGroup().required(true);

--- a/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/OAuthCompatibilityTool.java
@@ -216,7 +216,8 @@ public class OAuthCompatibilityTool {
 
         private ArgsHandler() {
             this.parser = ArgumentParsers
-                .newArgumentParser("oauth-compatibility-tool")
+                .newFor("oauth-compatibility-tool")
+                .build()
                 .defaultHelp(true)
                 .description(DESCRIPTION);
         }

--- a/tools/src/main/java/org/apache/kafka/tools/PrintVersionAndExitAction.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PrintVersionAndExitAction.java
@@ -28,6 +28,7 @@ import java.util.Map;
 class PrintVersionAndExitAction implements ArgumentAction {
 
     @Override
+    @SuppressWarnings("deprecation") // Required by argparse4j until its legacy callback is removed.
     public void run(
         ArgumentParser parser,
         Argument arg,

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -253,7 +253,8 @@ public class ProducerPerformance {
     /** Get the command-line argument parser. */
     static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("kafka-producer-perf-test")
+                .newFor("kafka-producer-perf-test")
+                .build()
                 .defaultHelp(true)
                 .description("This tool is used to verify the producer performance. To enable transactions, " +
                         "you can specify a transactional id or set a transaction duration using --transaction-duration-ms. " +

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -71,7 +71,8 @@ public class TransactionalMessageCopier {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("transactional-message-copier")
+                .newFor("transactional-message-copier")
+                .build()
                 .defaultHelp(true)
                 .description("This tool copies messages transactionally from an input partition to an output topic, " +
                         "committing the consumed offsets along with the output messages");

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionsCommand.java
@@ -980,7 +980,7 @@ public abstract class TransactionsCommand {
 
     static ArgumentParser buildBaseParser() {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("kafka-transactions.sh");
+            .newFor("kafka-transactions.sh").build();
 
         parser.description("This tool is used to analyze the transactional state of producers in the cluster. " +
             "It can be used to detect and recover from hanging transactions.");

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -520,7 +520,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("verifiable-consumer")
+            .newFor("verifiable-consumer")
+            .build()
             .defaultHelp(true)
             .description("This tool consumes messages from a specific topic and emits consumer events (e.g. group rebalances, received messages, and offsets committed) as JSON objects to STDOUT.");
         MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -110,7 +110,8 @@ public class VerifiableProducer implements AutoCloseable {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("verifiable-producer")
+            .newFor("verifiable-producer")
+            .build()
             .defaultHelp(true)
             .description("This tool produces increasing integers to the specified topic and prints JSON metadata to stdout on each \"send\" request, making externally visible which messages have been acked and which have not.");
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableShareConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableShareConsumer.java
@@ -583,7 +583,8 @@ public class VerifiableShareConsumer implements Closeable, AcknowledgementCommit
 
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("verifiable-share-consumer")
+            .newFor("verifiable-share-consumer")
+            .build()
             .defaultHelp(true)
             .description("This tool creates a share group and consumes messages from a specific topic and emits share consumer events (e.g. share consumer startup, received messages, and offsets acknowledged) as JSON objects to STDOUT.");
         MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -200,7 +200,8 @@ public final class Agent {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("trogdor-agent")
+            .newFor("trogdor-agent")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor fault injection agent");
         parser.addArgument("--agent.config", "-c")

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/AgentClient.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/AgentClient.java
@@ -199,7 +199,8 @@ public class AgentClient {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser rootParser = ArgumentParsers
-            .newArgumentParser("trogdor-agent-client")
+            .newFor("trogdor-agent-client")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor agent client.");
         Subparsers subParsers = rootParser.addSubparsers().

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -129,7 +129,8 @@ public final class Coordinator {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("trogdor-coordinator")
+            .newFor("trogdor-coordinator")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor fault injection coordinator");
         parser.addArgument("--coordinator.config", "-c")

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -224,7 +224,8 @@ public class CoordinatorClient {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser rootParser = ArgumentParsers
-            .newArgumentParser("trogdor-coordinator-client")
+            .newFor("trogdor-coordinator-client")
+            .build()
             .description("The Trogdor coordinator client.");
         Subparsers subParsers = rootParser.addSubparsers().
             dest("command");


### PR DESCRIPTION
Corresponding JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-12744

### What is the purpose of this change?

Upgrade argparse4j from 0.7.0 to 0.9.0 and migrate Kafka's production parser construction to the supported builder API. The migration preserves the existing parser behavior, including help handling, prefix characters, and from-file prefixes, while updating the moved `HelpScreenException` package and `LICENSE-binary`.

### Brief change log

- Replace every production `ArgumentParsers.newArgumentParser` call with `newFor(...).build()`.
- Preserve the existing parser options for shell, storage, Docker, and command-line tools.
- Update `HelpScreenException` imports to the argparse4j 0.9.0 package.
- Keep the unavoidable legacy `ArgumentAction` callback suppression local to its required override.
- Update the binary dependency license record.

### Testing

- TDD red phase: compiling after only the dependency upgrade exposed the moved exception package and deprecated parser construction API.
- TDD green phase: migrated all production call sites and verified the relevant modules compile.
- `./gradlew :shell:compileJava :generator:compileJava :tools:compileJava :connect:mirror:compileJava :trogdor:compileJava :core:compileScala --no-build-cache --console=plain`
- `./gradlew :core:test --tests kafka.tools.StorageToolTest --tests kafka.docker.KafkaDockerWrapperTest :tools:test --tests org.apache.kafka.tools.MetadataQuorumCommandUnitTest --tests org.apache.kafka.tools.FeatureCommandTest --tests org.apache.kafka.tools.TransactionsCommandTest --no-build-cache --console=plain`
- `./gradlew :shell:test --tests org.apache.kafka.shell.command.CommandTest --no-build-cache --console=plain`
- `./gradlew :trogdor:test --tests org.apache.kafka.trogdor.agent.AgentTest --tests org.apache.kafka.trogdor.coordinator.CoordinatorTest --tests org.apache.kafka.trogdor.coordinator.CoordinatorClientTest --no-build-cache --console=plain`
- `./gradlew :generator:test --no-build-cache --console=plain` passed all 104 tests in a normal clone.
- `./gradlew spotlessCheck --no-build-cache --console=plain`
- `git diff --check`

The broad root check was started with the known worktree-only generator Git test excluded; the visible suites passed, and the run was stopped because it expanded into the full long-running integration suite. The targeted module tests and the complete generator suite passed independently.
