### PR TITLE
KAFKA-15367: Test non-JBOD to JBOD transition

### DIFF
--- a/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
+++ b/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
@@ -1150,6 +1150,43 @@ public class KRaftClusterTest {
         }
     }
 
+    @Test
+    public void testNonJbodToJbodTransition() throws Exception {
+        try (KafkaClusterTestKit cluster = new KafkaClusterTestKit.Builder(
+            new TestKitNodes.Builder()
+                .setBootstrapMetadataVersion(MetadataVersion.IBP_3_7_IV1)
+                .setNumBrokerNodes(1)
+                .setNumControllerNodes(1)
+                .build()).build()) {
+            cluster.format();
+            cluster.startup();
+            cluster.waitForReadyBrokers();
+
+            var expectedDirectoryId = cluster.brokers().get(0).logManager().directoryIds().values().stream()
+                .findFirst().orElseThrow();
+            var actualDirectories = new AtomicReference<>("");
+
+            TestUtils.waitForCondition(() -> {
+                var registration = clusterImage(cluster, 0).brokers().get(0);
+                return registration != null && registration.directories().isEmpty();
+            }, "Broker registration should not contain directories before JBOD support is enabled");
+
+            try (Admin admin = cluster.admin()) {
+                admin.updateFeatures(
+                    Map.of(MetadataVersion.FEATURE_NAME,
+                        new FeatureUpdate(MetadataVersion.IBP_3_7_IV2.featureLevel(), FeatureUpdate.UpgradeType.UPGRADE))
+                ).all().get();
+            }
+
+            TestUtils.waitForCondition(() -> {
+                var registration = clusterImage(cluster, 0).brokers().get(0);
+                actualDirectories.set(registration == null ? "<missing>" : registration.directories().toString());
+                return registration != null && registration.directories().equals(List.of(expectedDirectoryId));
+            }, () -> "Broker did not re-register with its directory after JBOD support was enabled; expected directory: " +
+                expectedDirectoryId + ", actual directories: " + actualDirectories.get());
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testDescribeKRaftVersion(boolean usingBootstrapControllers) throws Exception {


### PR DESCRIPTION
Corresponding JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-15367

### What is the purpose of this change?

Add an integration regression test for a broker transitioning from non-JBOD metadata to JBOD-supported metadata. Before `IBP_3_7_IV2`, the controller's broker registration must not contain log directories. After upgrading to `IBP_3_7_IV2`, the broker must re-register and publish the directory ID that it actually loaded.

This verifies the externally observable behavior handled by `BrokerRegistrationTracker`, rather than only asserting that the metadata-version update request succeeded.

### Brief change log

- Start a one-broker, one-controller KRaft cluster with `IBP_3_7_IV1`.
- Assert that the broker registration initially has no directories.
- Upgrade `metadata.version` to `IBP_3_7_IV2`.
- Assert that the broker re-registers with the loaded directory UUID.

### Testing

- TDD: added the state-transition assertions first; the test fixture's formatting behavior was then accounted for by deriving the expected UUID from the broker's loaded `LogManager` state.
- `./gradlew :server:test --tests org.apache.kafka.server.KRaftClusterTest.testNonJbodToJbodTransition --no-build-cache --console=plain`
- `./gradlew :server:test --tests org.apache.kafka.server.KRaftClusterTest --no-build-cache --console=plain`
- `./gradlew spotlessCheck --no-build-cache --console=plain`
- `git diff --check`
