### PR TITLE
KAFKA-19050: Exclude empty streams integration artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,6 +358,15 @@ subprojects {
     tasks.register('uploadArchives').configure { dependsOn(publish) }
   }
 
+  if (project.path == ':streams:integration-tests') {
+    // This module publishes test artifacts, but its main source set is empty.
+    // Gradle module metadata cannot represent a publication with the main
+    // component removed, so disable metadata generation for this publication.
+    tasks.withType(GenerateModuleMetadata) {
+      enabled = false
+    }
+  }
+
   tasks.withType(AbstractArchiveTask).configureEach {
     reproducibleFileOrder = false
     preserveFileTimestamps = true
@@ -432,6 +441,10 @@ subprojects {
               def task = tasks.findByName(taskName)
               if (task != null)
                 artifact task
+            }
+
+            if (project.path == ':streams:integration-tests') {
+              artifacts.removeIf { it.classifier == null }
             }
 
             artifactId = base.archivesName.get()


### PR DESCRIPTION
## Summary

The `kafka-streams-integration-tests` module has no main source files, but the release publication currently includes its empty main JAR. The module's test JAR is already useful and should remain available to downstream integration tests.

This change removes only the classifier-less main artifact from that publication while preserving the test, test-sources, sources, javadoc, and POM artifacts. Gradle Module Metadata generation is disabled for this test-only publication because Gradle rejects metadata when the main artifact from the Java component is removed.

## Jira

https://issues.apache.org/jira/browse/KAFKA-19050

## Testing

* `./gradlew :streams:integration-tests:testJar :streams:integration-tests:testSrcJar :streams:integration-tests:generatePomFileForMavenJavaPublication`
* Published to an isolated temporary Maven local repository and verified that the main JAR is absent while `-test.jar`, `-test-sources.jar`, and the POM are present.
* `./gradlew :streams:integration-tests:check -x :streams:integration-tests:test`
* `./gradlew spotlessCheck`
* `git diff --check`

The full integration-test suite is unchanged and was not required for this build-publication-only change.
