### PR TITLE
KAFKA-20667: Index ACLs by principal during authorization

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclCache.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/AclCache.java
@@ -40,17 +40,30 @@ public class AclCache {
      */
     private final ImmutableMap<Uuid, StandardAcl> aclsById;
 
+    /**
+     * Contains the current ACLs indexed by principal.
+     */
+    private final ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal;
+
     AclCache() {
-        this(ImmutableNavigableSet.empty(), ImmutableMap.empty());
+        this(ImmutableNavigableSet.empty(), ImmutableMap.empty(), ImmutableMap.empty());
     }
 
-    private AclCache(final ImmutableNavigableSet<StandardAcl> aclsByResource, final ImmutableMap<Uuid, StandardAcl> aclsById) {
+    private AclCache(final ImmutableNavigableSet<StandardAcl> aclsByResource,
+                     final ImmutableMap<Uuid, StandardAcl> aclsById,
+                     final ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal) {
         this.aclsByResource = aclsByResource;
         this.aclsById = aclsById;
+        this.aclsByPrincipal = aclsByPrincipal;
     }
 
     public ImmutableNavigableSet<StandardAcl> aclsByResource() {
         return aclsByResource;
+    }
+
+    ImmutableNavigableSet<StandardAcl> aclsByPrincipal(String principal) {
+        ImmutableNavigableSet<StandardAcl> result = aclsByPrincipal.get(principal);
+        return result == null ? ImmutableNavigableSet.empty() : result;
     }
 
     Iterable<AclBinding> acls(AclBindingFilter filter) {
@@ -80,13 +93,18 @@ public class AclCache {
 
         ImmutableMap<Uuid, StandardAcl> aclsById = this.aclsById.updated(id, acl);
 
+        ImmutableNavigableSet<StandardAcl> principalAcls = this.aclsByPrincipal(acl.principal())
+            .added(acl);
+        ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal = this.aclsByPrincipal
+            .updated(acl.principal(), principalAcls);
+
         if (this.aclsByResource.contains(acl)) {
             throw new RuntimeException("Unable to add the ACL with ID " + id +
                     " to aclsByResource");
         }
 
         ImmutableNavigableSet<StandardAcl> aclsByResource = this.aclsByResource.added(acl);
-        return new AclCache(aclsByResource, aclsById);
+        return new AclCache(aclsByResource, aclsById, aclsByPrincipal);
     }
 
     AclCache removeAcl(Uuid id) {
@@ -102,6 +120,11 @@ public class AclCache {
         }
 
         ImmutableNavigableSet<StandardAcl> aclsByResource = this.aclsByResource.removed(acl);
-        return new AclCache(aclsByResource, aclsById);
+        ImmutableNavigableSet<StandardAcl> principalAcls = this.aclsByPrincipal(acl.principal())
+            .removed(acl);
+        ImmutableMap<String, ImmutableNavigableSet<StandardAcl>> aclsByPrincipal = principalAcls.isEmpty()
+            ? this.aclsByPrincipal.removed(acl.principal())
+            : this.aclsByPrincipal.updated(acl.principal(), principalAcls);
+        return new AclCache(aclsByResource, aclsById, aclsByPrincipal);
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -343,7 +343,13 @@ public class StandardAuthorizerData {
             AclOperation.UNKNOWN,
             AclPermissionType.UNKNOWN);
         AclCache aclCacheSnapshot = aclCache;
-        checkSection(aclCacheSnapshot, action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
+        if (hasResourceAcls(aclCacheSnapshot.aclsByResource(), action, exemplar)) {
+            matchingRuleBuilder.hasResourceAcls = true;
+        }
+        for (KafkaPrincipal principal : matchingPrincipals) {
+            checkSection(aclCacheSnapshot.aclsByPrincipal(principal.toString()),
+                action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
+        }
         if (matchingRuleBuilder.foundDeny()) {
             return matchingRuleBuilder.build();
         }
@@ -359,7 +365,13 @@ public class StandardAuthorizerData {
             "",
             AclOperation.UNKNOWN,
             AclPermissionType.UNKNOWN);
-        checkSection(aclCacheSnapshot, action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
+        if (hasResourceAcls(aclCacheSnapshot.aclsByResource(), action, exemplar)) {
+            matchingRuleBuilder.hasResourceAcls = true;
+        }
+        for (KafkaPrincipal principal : matchingPrincipals) {
+            checkSection(aclCacheSnapshot.aclsByPrincipal(principal.toString()),
+                action, exemplar, matchingPrincipals, host, matchingRuleBuilder);
+        }
         return matchingRuleBuilder.build();
     }
 
@@ -377,15 +389,50 @@ public class StandardAuthorizerData {
         return i;
     }
 
+    private boolean hasResourceAcls(
+            NavigableSet<StandardAcl> aclsByResource, Action action,
+            StandardAcl exemplar
+    ) {
+        String resourceName = action.resourcePattern().name();
+        NavigableSet<StandardAcl> tailSet = aclsByResource.tailSet(exemplar, true);
+        Iterator<StandardAcl> iterator = tailSet.iterator();
+        while (iterator.hasNext()) {
+            StandardAcl acl = iterator.next();
+            if (!acl.resourceType().equals(action.resourcePattern().resourceType())) {
+                return false;
+            }
+            int matchesUpTo = matchesUpTo(resourceName, acl.resourceName());
+            if (matchesUpTo == acl.resourceName().length()) {
+                if (acl.patternType() == LITERAL && matchesUpTo != resourceName.length()) {
+                    continue;
+                }
+                return true;
+            } else if (!(acl.resourceName().equals(WILDCARD) && acl.patternType() == LITERAL)) {
+                exemplar = new StandardAcl(exemplar.resourceType(),
+                    exemplar.resourceName().substring(0, matchesUpTo),
+                    exemplar.patternType(),
+                    exemplar.principal(),
+                    exemplar.host(),
+                    exemplar.operation(),
+                    exemplar.permissionType());
+                tailSet = aclsByResource.tailSet(exemplar, true);
+                iterator = tailSet.iterator();
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void checkSection(
-            AclCache aclCacheSnapshot, Action action,
+            NavigableSet<StandardAcl> aclsByPrincipal, Action action,
             StandardAcl exemplar,
             Set<KafkaPrincipal> matchingPrincipals,
             String host,
             MatchingRuleBuilder matchingRuleBuilder
     ) {
         String resourceName = action.resourcePattern().name();
-        NavigableSet<StandardAcl> tailSet = aclCacheSnapshot.aclsByResource().tailSet(exemplar, true);
+        NavigableSet<StandardAcl> tailSet = aclsByPrincipal.tailSet(exemplar, true);
         Iterator<StandardAcl> iterator = tailSet.iterator();
         while (iterator.hasNext()) {
             StandardAcl acl = iterator.next();
@@ -415,7 +462,7 @@ public class StandardAuthorizerData {
                     exemplar.host(),
                     exemplar.operation(),
                     exemplar.permissionType());
-                tailSet = aclCacheSnapshot.aclsByResource().tailSet(exemplar, true);
+                tailSet = aclsByPrincipal.tailSet(exemplar, true);
                 iterator = tailSet.iterator();
                 continue;
             }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclCacheTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/AclCacheTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata.authorizer;
+
+import org.apache.kafka.common.Uuid;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.apache.kafka.common.acl.AclOperation.READ;
+import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
+import static org.apache.kafka.common.resource.PatternType.LITERAL;
+import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AclCacheTest {
+    @Test
+    public void testAclsByPrincipalIsUpdatedWhenAclsAreAddedAndRemoved() {
+        StandardAcl userAcl = new StandardAcl(TOPIC, "topic", LITERAL, "User:alice", "*", READ, ALLOW);
+        StandardAcl wildcardAcl = new StandardAcl(TOPIC, "other-topic", LITERAL, "User:*", "*", READ, ALLOW);
+        Uuid userAclId = new Uuid(1, 1);
+        Uuid wildcardAclId = new Uuid(2, 2);
+
+        AclCache cache = new AclCache()
+            .addAcl(userAclId, userAcl)
+            .addAcl(wildcardAclId, wildcardAcl);
+
+        assertEquals(Set.of(userAcl), cache.aclsByPrincipal("User:alice"));
+        assertEquals(Set.of(wildcardAcl), cache.aclsByPrincipal("User:*"));
+        assertTrue(cache.aclsByPrincipal("User:bob").isEmpty());
+
+        cache = cache.removeAcl(userAclId);
+
+        assertTrue(cache.aclsByPrincipal("User:alice").isEmpty());
+        assertEquals(Set.of(wildcardAcl), cache.aclsByPrincipal("User:*"));
+    }
+}


### PR DESCRIPTION
## Summary

`StandardAuthorizerData.checkSection` currently scans every ACL in the relevant resource section before filtering by principal. With many ACLs and a metadata request covering many topics, this repeats the same unrelated principal checks for every topic.

This change adds a persistent, immutable ACL index keyed by principal. Authorization now searches the request principal's ACLs and the wildcard-principal ACLs while retaining the resource index for the existing default-allow semantics. ACL add and remove operations update both indexes atomically through the existing copy-on-write cache snapshots.

## Jira

https://issues.apache.org/jira/browse/KAFKA-20667

## Testing

* `./gradlew :metadata:test --tests org.apache.kafka.metadata.authorizer.AclCacheTest --tests org.apache.kafka.metadata.authorizer.StandardAuthorizerTest`
* `./gradlew :metadata:test`
* `./gradlew :metadata:spotlessCheck`
* `git diff --check`

The tests cover principal-index add/remove behavior and the existing authorization semantics, including prefix ACLs, wildcard ACLs, deny precedence, and the default-allow behavior when a resource has ACLs for another principal.
