### PR TITLE
KAFKA-20295: Use current quorum voters for feature validation

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterFeatureSupportDescriber.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterFeatureSupportDescriber.java
@@ -22,9 +22,23 @@ import org.apache.kafka.metadata.VersionRange;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 
 public interface ClusterFeatureSupportDescriber {
     Iterator<Entry<Integer, Map<String, VersionRange>>> brokerSupported();
     Iterator<Entry<Integer, Map<String, VersionRange>>> controllerSupported();
+
+    /**
+     * The IDs of the controllers which are currently members of the quorum.
+     *
+     * <p>This is separate from {@link #controllerSupported()} because a controller
+     * registration can outlive the controller's membership in a dynamic quorum.
+     *
+     * @return the current quorum controller IDs, or an empty set when the caller
+     *         should use its static quorum configuration
+     */
+    default Set<Integer> controllerIds() {
+        return Set.of();
+    }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/FeatureControlManager.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.apache.kafka.common.metadata.MetadataRecordType.FEATURE_LEVEL_RECORD;
@@ -341,10 +342,17 @@ public class FeatureControlManager {
         HashSet<Integer> foundControllers = new HashSet<>();
         foundControllers.add(quorumFeatures.nodeId());
         if (metadataVersionOrThrow().isControllerRegistrationSupported()) {
+            Set<Integer> controllerIds = clusterSupportDescriber.controllerIds();
+            if (controllerIds.isEmpty()) {
+                controllerIds = Set.copyOf(quorumFeatures.quorumNodeIds());
+            }
             for (Iterator<Entry<Integer, Map<String, VersionRange>>> iter =
                  clusterSupportDescriber.controllerSupported();
                  iter.hasNext(); ) {
                 Entry<Integer, Map<String, VersionRange>> entry = iter.next();
+                if (!controllerIds.contains(entry.getKey())) {
+                    continue;
+                }
                 if (entry.getKey() == quorumFeatures.nodeId()) {
                     // No need to re-check the features supported by this controller, since we
                     // already checked that above.
@@ -357,7 +365,7 @@ public class FeatureControlManager {
                 foundControllers.add(entry.getKey());
                 numControllersChecked++;
             }
-            for (int id : quorumFeatures.quorumNodeIds()) {
+            for (int id : controllerIds) {
                 if (!foundControllers.contains(id)) {
                     return Optional.of("controller " + id + " has not registered, and may not " +
                         "support this feature");

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -527,6 +527,11 @@ public final class QuorumController implements Controller {
         public Iterator<Entry<Integer, Map<String, VersionRange>>> controllerSupported() {
             return clusterControl.controllerSupportedFeatures();
         }
+
+        @Override
+        public Set<Integer> controllerIds() {
+            return raftClient.voterIds();
+        }
     }
 
     class PeriodicTaskControlManagerQueueAccessor implements PeriodicTaskControlManager.QueueAccessor {

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -177,6 +177,14 @@ public class FeatureControlManagerTest {
         List<Map.Entry<Integer, Map<String, VersionRange>>> brokerRanges,
         List<Map.Entry<Integer, Map<String, VersionRange>>> controllerRanges
     ) {
+        return createFakeClusterFeatureSupportDescriber(brokerRanges, controllerRanges, Set.of());
+    }
+
+    static ClusterFeatureSupportDescriber createFakeClusterFeatureSupportDescriber(
+        List<Map.Entry<Integer, Map<String, VersionRange>>> brokerRanges,
+        List<Map.Entry<Integer, Map<String, VersionRange>>> controllerRanges,
+        Set<Integer> controllerIds
+    ) {
         return new ClusterFeatureSupportDescriber() {
             @Override
             public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> brokerSupported() {
@@ -187,7 +195,74 @@ public class FeatureControlManagerTest {
             public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> controllerSupported() {
                 return controllerRanges.iterator();
             }
+
+            @Override
+            public Set<Integer> controllerIds() {
+                return controllerIds;
+            }
         };
+    }
+
+    @Test
+    public void testFeatureUpgradeIgnoresRemovedControllerRegistration() {
+        FeatureControlManager manager = new FeatureControlManager.Builder().
+            setQuorumFeatures(new QuorumFeatures(
+                0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(0, 1, 2))).
+            setClusterFeatureSupportDescriber(createFakeClusterFeatureSupportDescriber(
+                List.of(),
+                List.of(
+                    new SimpleImmutableEntry<>(1, Map.of(
+                        MetadataVersion.FEATURE_NAME,
+                        VersionRange.of(MetadataVersion.IBP_3_7_IV0.featureLevel(),
+                            MetadataVersion.IBP_4_3_IV0.featureLevel()))),
+                    new SimpleImmutableEntry<>(2, Map.of(
+                        MetadataVersion.FEATURE_NAME,
+                        VersionRange.of(MetadataVersion.IBP_3_7_IV0.featureLevel(),
+                            MetadataVersion.IBP_4_2_IV1.featureLevel())))
+                ),
+                Set.of(0, 1))).
+            build();
+        manager.replay(new FeatureLevelRecord().setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_3_7_IV0.featureLevel()));
+
+        ControllerResult<ApiError> result = manager.updateFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_3_IV0.featureLevel()),
+            Map.of(),
+            false,
+            0);
+
+        assertEquals(ApiError.NONE, result.response());
+    }
+
+    @Test
+    public void testFeatureUpgradeRequiresCurrentControllerRegistration() {
+        FeatureControlManager manager = new FeatureControlManager.Builder().
+            setQuorumFeatures(new QuorumFeatures(
+                0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(0, 1))).
+            setClusterFeatureSupportDescriber(createFakeClusterFeatureSupportDescriber(
+                List.of(),
+                List.of(new SimpleImmutableEntry<>(1, Map.of(
+                    MetadataVersion.FEATURE_NAME,
+                    VersionRange.of(MetadataVersion.IBP_3_7_IV0.featureLevel(),
+                        MetadataVersion.IBP_4_3_IV0.featureLevel())))),
+                Set.of(0, 1, 2))).
+            build();
+        manager.replay(new FeatureLevelRecord().setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_3_7_IV0.featureLevel()));
+
+        ControllerResult<ApiError> result = manager.updateFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_3_IV0.featureLevel()),
+            Map.of(),
+            false,
+            0);
+
+        assertEquals(new ApiError(Errors.INVALID_UPDATE_VERSION,
+            "Invalid update version 30 for feature metadata.version. controller 2 has not " +
+                "registered, and may not support this feature"), result.response());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/MockRaftClient.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/MockRaftClient.java
@@ -61,6 +61,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -763,6 +764,11 @@ public final class MockRaftClient implements RaftClient<ApiMessageAndVersion>, A
     @Override
     public Optional<Node> voterNode(int id, ListenerName listenerName) {
         return Optional.empty();
+    }
+
+    @Override
+    public Set<Integer> voterIds() {
+        return Set.copyOf(shared.raftClients.keySet());
     }
 
     public List<RaftClient.Listener<ApiMessageAndVersion>> listeners() {

--- a/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/publisher/SnapshotEmitterTest.java
@@ -37,6 +37,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 
@@ -78,6 +79,11 @@ public class SnapshotEmitterTest {
         @Override
         public Optional<Node> voterNode(int id, ListenerName listenerName) {
             return Optional.empty();
+        }
+
+        @Override
+        public Set<Integer> voterIds() {
+            return Set.of();
         }
 
         @Override

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -3900,6 +3900,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         return partitionState.lastVoterSet().voterNode(id, listenerName);
     }
 
+    @Override
+    public Set<Integer> voterIds() {
+        return partitionState.lastVoterSet().voterIds();
+    }
+
     // Visible only for test
     QuorumState quorum() {
         // It's okay to return null since this method is only called by tests

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 public interface RaftClient<T> extends AutoCloseable {
@@ -151,6 +152,13 @@ public interface RaftClient<T> extends AutoCloseable {
      * @return the node information if it exists, otherwise {@code Optional.empty()}
      */
     Optional<Node> voterNode(int id, ListenerName listenerName);
+
+    /**
+     * Return the IDs of the voters in the current quorum.
+     *
+     * @return the current voter IDs
+     */
+    Set<Integer> voterIds();
 
     /**
      * Prepare a list of records to be appended to the log.

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientReconfigTest.java
@@ -1124,6 +1124,7 @@ public class KafkaRaftClientReconfigTest {
         int epoch = context.currentEpoch();
 
         assertTrue(context.client.quorum().isVoter(follower2));
+        assertEquals(voters.voterIds(), context.client.voterIds());
 
         checkLeaderMetricValues(3, 0, 0, context);
 
@@ -1144,6 +1145,7 @@ public class KafkaRaftClientReconfigTest {
 
         // follower2 should not be a voter in the latest voter set
         assertFalse(context.client.quorum().isVoter(follower2));
+        assertEquals(Set.of(local.id(), follower1.id()), context.client.voterIds());
         checkLeaderMetricValues(2, 1, 1, context);
 
         // Send a FETCH to increase the HWM and commit the new voter set


### PR DESCRIPTION
KAFKA-20295: Use current quorum voters for controller feature validation

The controller feature validation path currently iterates every controller registration in the metadata image. With a dynamic quorum, a controller can be removed from the Raft voter set while its historical registration remains in the image. If that registration advertises an older metadata.version range, it can incorrectly prevent a valid metadata.version upgrade.

This change exposes the current voter IDs from Raft and passes them through the cluster feature support describer. Feature validation now checks registered controller capabilities only for current quorum voters and requires each current voter to have a registration. Existing describers that do not provide dynamic voter IDs retain the static QuorumFeatures fallback.

Testing:

- `./gradlew :metadata:test --tests org.apache.kafka.controller.FeatureControlManagerTest --no-build-cache`
- `./gradlew :raft:test --tests org.apache.kafka.raft.KafkaRaftClientReconfigTest --no-build-cache`
- `./gradlew :metadata:test --no-build-cache`
- `./gradlew :metadata:spotlessCheck :raft:spotlessCheck --no-build-cache`
- `./gradlew :raft:kafkaPublicApiChecker :metadata:kafkaPublicApiChecker --no-build-cache`
- `git diff --check`

The regression tests cover both stale registrations from removed voters and missing registrations for current voters. Jira: https://issues.apache.org/jira/browse/KAFKA-20295

Reviewers: Davide Armand <davide.armand@aiven.io>
