### PR TITLE
KAFKA-15513: Test SCRAM authentication for KRaft controllers

### DIFF
--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -151,3 +151,31 @@ class TestVerifiableProducer(Test):
         num_produced = self.producer.num_acked
         assert num_produced == self.num_messages, "num_produced: %d, num_messages: %d" % (num_produced, self.num_messages)
 
+    @cluster(num_nodes=4)
+    @matrix(controller_sasl_mechanism=['SCRAM-SHA-256', 'SCRAM-SHA-512'], metadata_quorum=[quorum.isolated_kraft])
+    def test_isolated_kraft_controller_scram(self, controller_sasl_mechanism, metadata_quorum):
+        """Verify that an isolated KRaft quorum can bootstrap with SCRAM controller listeners."""
+        self.kafka.security_protocol = self.kafka.interbroker_security_protocol = 'PLAINTEXT'
+        self.kafka.client_sasl_mechanism = controller_sasl_mechanism
+
+        controller_quorum = self.kafka.controller_quorum
+        controller_quorum.security_protocol = 'SASL_PLAINTEXT'
+        controller_quorum.client_sasl_mechanism = controller_sasl_mechanism
+        controller_quorum.interbroker_security_protocol = 'SASL_PLAINTEXT'
+        controller_quorum.interbroker_sasl_mechanism = controller_sasl_mechanism
+        controller_quorum.controller_security_protocol = 'SASL_PLAINTEXT'
+        controller_quorum.controller_sasl_mechanism = controller_sasl_mechanism
+        controller_quorum.intercontroller_security_protocol = 'SASL_PLAINTEXT'
+        controller_quorum.intercontroller_sasl_mechanism = controller_sasl_mechanism
+
+        self.kafka.start()
+
+        node = self.producer.nodes[0]
+        node.version = KafkaVersion(str(DEV_BRANCH))
+        self.producer.start()
+        wait_until(lambda: self.producer.num_acked > 5, timeout_sec=15,
+                   err_msg="Producer failed to start in a reasonable amount of time.")
+
+        assert is_version(node, [node.version.vstring], proc_grep_string=VerifiableProducer.__qualname__, logger=self.logger)
+        self.producer.wait()
+        assert self.producer.num_acked == self.num_messages

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -863,7 +863,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     self.close_port(controller_listener)
 
         self.security_config.setup_node(node)
-        if self.quorum_info.using_zk or self.quorum_info.has_brokers: # TODO: SCRAM currently unsupported for controller quorum
+        if self.quorum_info.using_zk or self.quorum_info.has_brokers:
             self.maybe_setup_broker_scram_credentials(node)
 
         if self.quorum_info.using_kraft:
@@ -917,6 +917,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 # build (max supported is 4.3-IV0), and Feature.validateVersion() does not enforce
                 # the dependency, so the feature can be bootstrapped on its own.
                 cmd += " --feature share.version=%s" % self.share_version
+            if self.node_quorum_info.has_controller_role:
+                for mechanism in sorted(self.security_config.serves_kraft_sasl):
+                    if self.security_config.is_sasl_scram(mechanism):
+                        cmd += " --add-scram %s=[name=%s,password=%s]" % (
+                            mechanism,
+                            SecurityConfig.SCRAM_BROKER_USER,
+                            SecurityConfig.SCRAM_BROKER_PASSWORD,
+                        )
             self.logger.info("Running log directory format command...\n%s" % cmd)
             node.account.ssh(cmd)
 

--- a/tests/kafkatest/services/security/templates/jaas.conf
+++ b/tests/kafkatest/services/security/templates/jaas.conf
@@ -66,7 +66,7 @@ KafkaServer {
 	user_client="client-secret"
 	user_kafka="kafka-secret";
 {% endif %}
-{% if "SCRAM-SHA-256" in client_sasl_mechanism or "SCRAM-SHA-512" in client_sasl_mechanism %}
+{% if "SCRAM-SHA-256" in enabled_sasl_mechanisms or "SCRAM-SHA-512" in enabled_sasl_mechanisms %}
 	org.apache.kafka.common.security.scram.ScramLoginModule required
 	username="{{ SecurityConfig.SCRAM_BROKER_USER }}"
 	password="{{ SecurityConfig.SCRAM_BROKER_PASSWORD }}";


### PR DESCRIPTION
## Summary

Add a focused system-test path for SCRAM authentication on isolated KRaft controller quorums. The test covers both SCRAM-SHA-256 and SCRAM-SHA-512.

The Kafka test service now bootstraps the controller quorum with the broker SCRAM credentials using `kafka-storage.sh --add-scram`, and the KafkaServer JAAS entry is selected from all enabled SASL mechanisms, including mechanisms used only by KRaft controller channels.

## Motivation

KAFKA-15513 is not covered by the system-test harness: controller-quorum SCRAM was explicitly skipped, and formatted controller metadata did not contain the initial credentials needed for authentication.

## Testing

- `./gradlew :core:test --tests kafka.tools.StorageToolTest.testBootstrapScramRecords --no-daemon --console=plain`
- `./gradlew checkstyleMain checkstyleTest spotlessCheck --no-daemon --console=plain`
- Python compilation and targeted SCRAM bootstrap assertions
- `git diff --check`
- The full ducktape test is not run locally because the ducktape/worker environment is unavailable; CI should execute `TestVerifiableProducer.test_isolated_kraft_controller_scram` for both mechanisms.

## Jira

https://issues.apache.org/jira/browse/KAFKA-15513