### PR TITLE
KAFKA-18584: Fix controller restart in combined mode

### DIFF
--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -370,11 +370,14 @@ class SharedServer(
 
   def ensureNotRaftLeader(): Unit = synchronized {
     // Ideally, this would just resign our leadership, if we had it. But we don't have an API in
-    // RaftManager for that yet, so shut down the RaftManager.
-    Option(raftManager).foreach(_raftManager => {
-      Utils.swallow(this.logger.underlying, () => _raftManager.shutdown())
-      raftManager = null
-    })
+    // RaftManager for that yet, so shut down the RaftManager. In combined mode, the broker still
+    // owns the shared RaftManager while the controller is restarted, so it must remain available.
+    if (!usedByBroker) {
+      Option(raftManager).foreach(_raftManager => {
+        Utils.swallow(this.logger.underlying, () => _raftManager.shutdown())
+        raftManager = null
+      })
+    }
   }
 
   private def stop(): Unit = synchronized {

--- a/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
+++ b/test-common/test-common-runtime/src/test/java/org/apache/kafka/common/test/junit/ClusterTestExtensionsTest.java
@@ -401,7 +401,7 @@ public class ClusterTestExtensionsTest {
         }
     }
 
-    @ClusterTest(types = {Type.KRAFT})
+    @ClusterTest(types = {Type.KRAFT, Type.CO_KRAFT})
     public void testControllerRestart(ClusterInstance cluster) throws ExecutionException, InterruptedException {
         try (Admin admin = cluster.admin()) {
 


### PR DESCRIPTION
Closes KAFKA-18584

### Summary

- Exercise `testControllerRestart` under both isolated and combined KRaft modes.
- Keep the shared Raft manager alive while the broker still owns it during a combined-mode controller restart.

In combined mode, `ControllerServer.shutdown()` previously shut down the shared Raft manager even though the broker continued using it. Restarting the controller could then observe a null manager and fail with the NPE reported in KAFKA-18584. The lifecycle guard preserves the manager until the broker releases it.

### Tests

- `./gradlew :test-common:test-common-runtime:test --tests org.apache.kafka.common.test.junit.ClusterTestExtensionsTest --no-build-cache --console=plain`
- `./gradlew :core:spotlessCheck :test-common:test-common-runtime:spotlessCheck --no-build-cache --console=plain`
- `./gradlew :core:checkstyleMain :test-common:test-common-runtime:checkstyleTest --no-build-cache --console=plain`

The targeted regression test passed three fresh reruns for both KRaft modes, and the full `ClusterTestExtensionsTest` passed.
