### PR TITLE
KAFKA-19470: Cache Scala logger wrappers

### DIFF
--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -21,13 +21,31 @@ import com.typesafe.scalalogging.Logger
 import org.apache.kafka.server.logger.Log4jControllerRegistration
 import org.slf4j.{LoggerFactory, Marker, MarkerFactory}
 
+import java.util.concurrent.ConcurrentHashMap
+
 private object Logging {
   private val FatalMarker: Marker = MarkerFactory.getMarker("FATAL")
+  private val loggerCache = new ConcurrentHashMap[String, Logger]()
+
+  /**
+   * Logger wrappers are immutable, so instances with the same logger name can share one.
+   * The cache is keyed by name to preserve the behavior of loggerName overrides.
+   */
+  def loggerFor(name: String): Logger = {
+    val cached = loggerCache.get(name)
+    if (cached != null) {
+      cached
+    } else {
+      val created = Logger(LoggerFactory.getLogger(name))
+      val previous = loggerCache.putIfAbsent(name, created)
+      if (previous == null) created else previous
+    }
+  }
 }
 
 trait Logging {
 
-  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(loggerName))
+  protected lazy val logger: Logger = Logging.loggerFor(loggerName)
 
   protected var logIdent: String = _
 

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -21,7 +21,7 @@ import java.lang.management.ManagementFactory
 
 import javax.management.ObjectName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertSame, assertTrue}
 
 class LoggingTest extends Logging {
 
@@ -57,5 +57,17 @@ class LoggingTest extends Logging {
     val logging = new TestLogging
 
     assertEquals(logging.getClass.getName, logging.log.underlying.getName)
+  }
+
+  @Test
+  def testLoggerIsSharedByInstancesWithTheSameName(): Unit = {
+    class TestLogging extends Logging {
+      // Expose logger
+      def log = logger
+    }
+    val first = new TestLogging
+    val second = new TestLogging
+
+    assertSame(first.log, second.log)
   }
 }


### PR DESCRIPTION
Closes KAFKA-19470

### Summary

- Cache the immutable Scala logger wrapper by logger name in `kafka.utils.Logging`.
- Preserve custom `loggerName` overrides by using the resolved name as the cache key.
- Add a regression test proving that multiple instances with the same logger name share the wrapper.

`Logging.logger` was previously initialized independently for every object instance. The underlying SLF4J logger is name-based, so the wrapper can be reused safely. A `ConcurrentHashMap` keeps the lookup thread-safe while allowing concurrent construction to converge on one cached wrapper.

### Tests

- `./gradlew :core:test --tests kafka.utils.LoggingTest --no-build-cache --rerun-tasks --console=plain`
- `./gradlew :core:spotlessCheck --no-build-cache --console=plain`

The regression test was first verified to fail against the base branch, then passed after the cache implementation was added. Core Checkstyle and SpotBugs also passed as part of the test build.
