### PR TITLE
KAFKA-19812: Handle missing Docker environment variables

### DIFF
--- a/docker/resources/common-scripts/configure
+++ b/docker/resources/common-scripts/configure
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ensure() {
-  if [[ -z "${!1}" ]]; then
+  if [[ -z "${!1-}" ]]; then
     echo "$1 environment variable not set"
     exit 1
   fi

--- a/docker/test/common_scripts_test.py
+++ b/docker/test/common_scripts_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+
+CONFIGURE_SCRIPT = Path(__file__).parents[1] / "resources" / "common-scripts" / "configure"
+
+
+class CommonScriptsTest(unittest.TestCase):
+    @staticmethod
+    def run_configure(**environment):
+        env = {"PATH": os.environ["PATH"]}
+        env.update(environment)
+        return subprocess.run(
+            ["bash", "-u", str(CONFIGURE_SCRIPT)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_missing_required_variable_is_reported_with_nounset(self):
+        result = self.run_configure(KAFKA_PROCESS_ROLES="controller")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stdout,
+            "Running in KRaft mode...\nCLUSTER_ID environment variable not set\n",
+        )
+        self.assertEqual(result.stderr, "")
+
+    def test_empty_required_variable_is_reported_with_nounset(self):
+        result = self.run_configure(KAFKA_PROCESS_ROLES="controller", CLUSTER_ID="")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stdout,
+            "Running in KRaft mode...\nCLUSTER_ID environment variable not set\n",
+        )
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -19,6 +19,7 @@ import unittest
 import subprocess
 from HTMLTestRunner import HTMLTestRunner
 import test.constants as constants
+from test.common_scripts_test import CommonScriptsTest
 import os
 
 class DockerSanityTest(unittest.TestCase):
@@ -226,9 +227,9 @@ def run_tests(image, mode, fixtures_dir):
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
     DockerSanityTest.MODE = mode
 
-    test_classes_to_run = []
+    test_classes_to_run = [CommonScriptsTest]
     if mode == "jvm" or mode == "native":
-        test_classes_to_run = [DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode]
+        test_classes_to_run.extend([DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode])
     
     loader = unittest.TestLoader()
     suites_list = []


### PR DESCRIPTION
Closes KAFKA-19812

### Summary

- Make the Docker `configure` script's indirect environment-variable lookup safe with `bash -u`.
- Preserve the existing validation for both unset and empty variables.
- Add regression tests for the user-facing error message and include them in the Docker sanity test runner.

When the Docker entrypoint runs with `set -u`, `${!1}` raises an unbound-variable error before `ensure` can report which required variable is missing. Using the nounset-safe form `${!1-}` keeps the validation behavior intact while making the diagnostic actionable.

### Tests

- `python3 -m unittest docker.test.common_scripts_test`
- `bash -n docker/resources/common-scripts/configure`
- `python3 -m py_compile docker/test/common_scripts_test.py docker/test/docker_sanity_test.py`
- `git diff --check`

The regression test was verified to fail on the base branch with the `!1: unbound variable` error, then pass after the fix.
