### PR TITLE
KAFKA-17932: Avoid shutdown deadlock after metadata faults

### DIFF
--- a/core/src/main/scala/kafka/server/SharedServer.scala
+++ b/core/src/main/scala/kafka/server/SharedServer.scala
@@ -200,10 +200,13 @@ class SharedServer(
   /**
    * The fault handler to use when metadata loading fails.
    */
-  private def metadataLoaderFaultHandler: FaultHandler = faultHandlerFactory.build(
+  private[kafka] def metadataLoaderFaultHandler: FaultHandler = faultHandlerFactory.build(
     name = "metadata loading",
     fatal = sharedServerConfig.processRoles.contains(ProcessRole.ControllerRole),
-    action = () => SharedServer.this.synchronized {
+    // This action can run on the metadata loader event-handler thread. Shutdown holds the
+    // SharedServer monitor while waiting for that thread to terminate, so acquiring the
+    // monitor here would deadlock shutdown after a metadata loading failure.
+    action = () => {
       Option(brokerMetrics).foreach(_.metadataLoadErrorCount.getAndIncrement())
       Option(controllerServerMetrics).foreach(_.incrementMetadataErrorCount())
       snapshotsDisabledReason.compareAndSet(null, "metadata loading fault")

--- a/core/src/test/scala/unit/kafka/server/SharedServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SharedServerTest.scala
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.io.File
+import java.net.InetSocketAddress
+import java.util
+import java.util.concurrent.{CompletableFuture, CountDownLatch, TimeUnit, TimeoutException}
+
+import kafka.utils.TestUtils
+import org.apache.kafka.common.DirectoryId
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.{Time, Utils => KafkaUtils}
+import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsemble, MetaPropertiesVersion, PropertiesUtils}
+import org.apache.kafka.network.SocketServerConfigs
+import org.apache.kafka.raft.{KRaftConfigs, QuorumConfig}
+import org.apache.kafka.server.ServerSocketFactory
+import org.apache.kafka.server.config.ServerLogConfigs
+import org.apache.kafka.server.fault.FaultHandler
+import org.junit.jupiter.api.Assertions.{assertFalse, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Test
+
+class SharedServerTest {
+  private val clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+
+  @Test
+  def testMetadataLoaderFaultHandlerDoesNotWaitForSharedServerLock(): Unit = {
+    val logDir = TestUtils.tempDir()
+    val faultHandlerFactory = new CapturingFaultHandlerFactory
+    val server = newSharedServer(logDir, faultHandlerFactory)
+    try {
+      val faultHandler = server.metadataLoaderFaultHandler
+      assertNotNull(faultHandler)
+      assertNotNull(faultHandlerFactory.action)
+
+      val lockAcquired = new CountDownLatch(1)
+      val releaseLock = new CountDownLatch(1)
+      val lockHolder = new Thread(() => server.synchronized {
+        lockAcquired.countDown()
+        releaseLock.await()
+      })
+      lockHolder.start()
+      assertTrue(lockAcquired.await(5, TimeUnit.SECONDS))
+
+      val actionComplete = CompletableFuture.runAsync(() => faultHandlerFactory.action.run())
+      var actionTimedOut = false
+      try {
+        actionComplete.get(5, TimeUnit.SECONDS)
+      } catch {
+        case _: TimeoutException => actionTimedOut = true
+      } finally {
+        releaseLock.countDown()
+        lockHolder.join(5000)
+        actionComplete.get(5, TimeUnit.SECONDS)
+      }
+
+      assertFalse(actionTimedOut, "The metadata fault action must not wait for the SharedServer monitor")
+    } finally {
+      KafkaUtils.delete(logDir)
+    }
+  }
+
+  private def newSharedServer(logDir: File, faultHandlerFactory: FaultHandlerFactory): SharedServer = {
+    val metaProperties = new MetaProperties.Builder().
+      setVersion(MetaPropertiesVersion.V1).
+      setClusterId(clusterId).
+      setNodeId(0).
+      setDirectoryId(DirectoryId.random()).
+      build()
+    PropertiesUtils.writePropertiesFile(
+      metaProperties.toProperties,
+      new File(logDir, MetaPropertiesEnsemble.META_PROPERTIES_NAME).getAbsolutePath,
+      false)
+
+    val metaPropertiesEnsemble = new MetaPropertiesEnsemble.Loader().
+      addLogDirs(util.List.of(logDir.getAbsolutePath)).
+      addMetadataLogDir(logDir.getAbsolutePath).
+      load()
+
+    val properties = TestUtils.createBrokerConfig(0)
+    properties.put(KRaftConfigs.PROCESS_ROLES_CONFIG, "controller")
+    properties.put(ServerLogConfigs.LOG_DIR_CONFIG, logDir.getAbsolutePath)
+    properties.put(SocketServerConfigs.LISTENERS_CONFIG, "CONTROLLER://localhost:0")
+    properties.put(SocketServerConfigs.ADVERTISED_LISTENERS_CONFIG, "CONTROLLER://localhost:0")
+    properties.put(SocketServerConfigs.LISTENER_SECURITY_PROTOCOL_MAP_CONFIG, "CONTROLLER:PLAINTEXT")
+    properties.put(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "CONTROLLER")
+    properties.put(QuorumConfig.QUORUM_VOTERS_CONFIG, "0@localhost:0")
+    val config = KafkaConfig.fromProps(properties, doLog = false)
+
+    new SharedServer(
+      config,
+      metaPropertiesEnsemble,
+      Time.SYSTEM,
+      new Metrics(),
+      new CompletableFuture[util.Map[Integer, InetSocketAddress]](),
+      util.Collections.emptyList[InetSocketAddress](),
+      faultHandlerFactory,
+      ServerSocketFactory.INSTANCE)
+  }
+
+  private class CapturingFaultHandlerFactory extends FaultHandlerFactory {
+    var action: Runnable = _
+
+    override def build(name: String, fatal: Boolean, action: Runnable): FaultHandler = {
+      if (name == "metadata loading") {
+        this.action = action
+      }
+      new FaultHandler {
+        override def handleFault(failureMessage: String, cause: Throwable): RuntimeException = null
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes KAFKA-17932

### Summary

- Avoid taking the `SharedServer` monitor from the metadata loader fault action.
- Prevent shutdown from deadlocking while `SharedServer` holds the monitor and waits for the metadata loader event thread.
- Add a regression test that reproduces the lock-ordering failure and verifies the action completes while the monitor is held.

The metadata loader event handler can invoke the fault action after a metadata loading failure. Shutdown synchronizes on `SharedServer` and then joins the metadata loader event thread. The previous synchronized fault action inverted that order and could block both threads indefinitely. The metrics fields are volatile and the snapshot disable reason uses an atomic reference, so the action does not need the `SharedServer` monitor.

### Tests

- `./gradlew :core:test --tests kafka.server.SharedServerTest --no-build-cache --console=plain`
- `./gradlew :core:spotlessCheck --no-build-cache --console=plain`
- `git diff --check`

The regression test was verified to fail on the base branch with a timeout, then pass after removing the unnecessary monitor acquisition.
