### PR TITLE
KAFKA-19677: Close errored smoke test clients

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverCleanupTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverCleanupTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.streams.tests.SmokeTestClient;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SmokeTestDriverCleanupTest {
+
+    @Test
+    public void shouldCloseClientsThatEnteredErrorState() {
+        final SmokeTestClient client = mock(SmokeTestClient.class);
+        when(client.closed()).thenReturn(false);
+        when(client.error()).thenReturn(true);
+        final List<SmokeTestClient> clients = new ArrayList<>();
+        clients.add(client);
+
+        SmokeTestDriverIntegrationTest.closeClients(clients);
+
+        verify(client).close();
+        assertTrue(clients.isEmpty());
+    }
+}

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SmokeTestDriverIntegrationTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -55,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SmokeTestDriverIntegrationTest {
     private EmbeddedKafkaCluster cluster;
     public TestInfo testInfo;
-    private ArrayList<SmokeTestClient> clients = new ArrayList<>();
+    private final List<SmokeTestClient> clients = new ArrayList<>();
 
     protected Properties brokerConfig() {
         return new Properties();
@@ -81,13 +82,18 @@ public class SmokeTestDriverIntegrationTest {
     @AfterEach
     public void shutDown(final TestInfo testInfo) {
         // Clean up clients in case the test failed or timed out
+        closeClients(clients);
+        cluster.stop();
+        cluster = null;
+    }
+
+    static void closeClients(final List<SmokeTestClient> clients) {
         for (final SmokeTestClient client : clients) {
-            if (!client.closed() && !client.error()) {
+            if (!client.closed()) {
                 client.close();
             }
         }
-        cluster.stop();
-        cluster = null;
+        clients.clear();
     }
 
     private static class Driver extends Thread {


### PR DESCRIPTION
Closes KAFKA-19677

### Summary

- Close every `SmokeTestClient` that has not reached the closed state during `@AfterEach` cleanup, including clients in the `ERROR` state.
- Clear the client list after cleanup so a failed parameterized invocation cannot retain stale client references.
- Add a focused regression test for the error-state cleanup invariant.

`SmokeTestDriverIntegrationTest` runs multiple parameterized scenarios and rotates clients while the driver is active. Previously, cleanup skipped clients that reported `error()`, leaving their `KafkaStreams` resources open until the process exited. The next scenario could then start with resources from the failed scenario still alive. Cleanup now uses the lifecycle state that determines whether a close is still needed: any client that is not closed is closed before the cluster is stopped.

### Tests

- `./gradlew :streams:integration-tests:test --tests org.apache.kafka.streams.integration.SmokeTestDriverCleanupTest --no-build-cache --console=plain`
- `./gradlew :streams:integration-tests:test --tests org.apache.kafka.streams.integration.SmokeTestDriverIntegrationTest --no-build-cache --rerun-tasks --console=plain`
- `./gradlew :streams:integration-tests:spotlessCheck --no-build-cache --console=plain`

The cleanup regression test was verified to fail before the fix because `close()` was not called for an errored client, then pass after the fix. Both `SmokeTestDriverIntegrationTest` parameterizations pass after the change.
