### PR TITLE
KAFKA-13185: Clear pending records after pre-commit rewind

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -451,6 +451,9 @@ class WorkerSinkTask extends WorkerTask<ConsumerRecord<byte[], byte[]>, SinkReco
                     log.debug("{} Rewinding topic partition {} to offset {}", this, entry.getKey(), entry.getValue().offset());
                     consumer.seek(entry.getKey(), entry.getValue().offset());
                 }
+                // Discard the pending batch and its offsets so the next poll re-reads from the last committed position.
+                messageBatch.clear();
+                origOffsets.clear();
                 currentOffsets.putAll(lastCommittedOffsetsForPartitions);
             }
             onCommitCompleted(t, commitSeqno, null);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -471,6 +471,43 @@ public class WorkerSinkTaskTest {
     }
 
     @Test
+    public void testPreCommitFailureClearsPendingMessageBatch() {
+        createTask(initialState);
+        expectTaskGetTopic();
+
+        workerTask.initialize(TASK_CONFIG);
+        workerTask.initializeAndStart();
+        verifyInitializeTask();
+
+        expectPollInitialAssignment()
+                .thenAnswer(expectConsumerPoll(1))
+                .thenAnswer(expectConsumerPoll(0));
+        expectConversionAndTransformation(null, new RecordHeaders());
+
+        doNothing()
+                .doThrow(new RetriableException("put failed"))
+                .doNothing()
+                .when(sinkTask).put(anyList());
+
+        workerTask.iteration(); // Initial assignment
+        workerTask.iteration(); // The first delivery is retriable and remains in messageBatch
+
+        when(sinkTask.preCommit(anyMap())).thenThrow(new RetriableException("flush failed"));
+        sinkTaskContext.getValue().requestCommit();
+        workerTask.iteration(); // Rewind before polling the same record again
+
+        final ArgumentCaptor<Collection<SinkRecord>> records = ArgumentCaptor.forClass(Collection.class);
+        verify(sinkTask, times(3)).put(records.capture());
+        assertEquals(0, records.getAllValues().get(2).size(),
+                "A failed pre-commit must discard the stale batch before the next poll");
+        assertEquals(Map.of(
+                        TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET),
+                        TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET)),
+                workerTask.currentOffsets(),
+                "A failed pre-commit must retain the last committed offsets");
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testPollRedeliveryWithConsumerRebalance() {
         createTask(initialState);


### PR DESCRIPTION
Closes KAFKA-13185

### Summary

- Clear the pending `messageBatch` when a sink task pre-commit fails and the consumer is rewound to the last committed position.
- Clear the matching `origOffsets` as well, so the discarded batch cannot advance `currentOffsets` during the recovery poll.
- Add a regression test covering a retriable `put`, a failed `preCommit`, and the subsequent empty delivery.

When `SinkTask.put` raises a `RetriableException`, `WorkerSinkTask` keeps the batch for redelivery. If the following `preCommit` also fails, the worker seeks to the last committed offset but previously retained that batch. The next poll could therefore deliver stale records, and retaining `origOffsets` could reintroduce offsets that had just been rewound. The recovery path now discards both pieces of pending state before polling again.

### Tests

- `./gradlew :connect:runtime:test --tests org.apache.kafka.connect.runtime.WorkerSinkTaskTest.testPreCommitFailureClearsPendingMessageBatch --no-build-cache --console=plain`
- `./gradlew :connect:runtime:spotlessCheck :connect:runtime:test --tests org.apache.kafka.connect.runtime.WorkerSinkTaskTest --no-build-cache --console=plain`
- `./gradlew :connect:runtime:test --no-build-cache --console=plain`

The regression test was verified RED before the fix because the stale batch was delivered with one record, then GREEN after the fix with an empty delivery and last-committed offsets preserved.