### PR TITLE
MINOR: Fix malformed Javadoc link tags in clients and streams

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -179,7 +179,7 @@ public interface Consumer<K, V> extends Closeable {
     Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions, final Duration timeout);
 
     /**
-     * See {@link KafkaConsumer#clientInstanceId(Duration)}}
+     * See {@link KafkaConsumer#clientInstanceId(Duration)}
      */
     Uuid clientInstanceId(Duration timeout);
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -120,7 +120,7 @@ public interface Producer<K, V> extends Closeable {
     Map<MetricName, ? extends Metric> metrics();
 
     /**
-     * See {@link KafkaProducer#clientInstanceId(Duration)}}
+     * See {@link KafkaProducer#clientInstanceId(Duration)}
      */
     Uuid clientInstanceId(Duration timeout);
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
@@ -66,7 +66,7 @@ public final class RecordMetadata {
 
     /**
      * The offset of the record in the topic/partition.
-     * @return the offset of the record, or -1 if {{@link #hasOffset()}} returns false.
+     * @return the offset of the record, or -1 if {@link #hasOffset()} returns false.
      */
     public long offset() {
         return this.offset;
@@ -83,7 +83,7 @@ public final class RecordMetadata {
     /**
      * The timestamp of the record in the topic/partition.
      *
-     * @return the timestamp of the record, or -1 if the {{@link #hasTimestamp()}} returns false.
+     * @return the timestamp of the record, or -1 if the {@link #hasTimestamp()} returns false.
      */
     public long timestamp() {
         return this.timestamp;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -275,7 +275,7 @@ public class TransactionManager {
      * <ul>
      *     <li>{@link Producer#initTransactions()} calls {@link #initializeTransactions(boolean)}</li>
      *     <li>{@link Producer#beginTransaction()} calls {@link #beginTransaction()}</li>
-     *     <li>{@link Producer#commitTransaction()}} calls {@link #beginCommit()}</li>
+     *     <li>{@link Producer#commitTransaction()} calls {@link #beginCommit()}</li>
      *     <li>{@link Producer#abortTransaction()} calls {@link #beginAbort()}
      *     </li>
      *     <li>{@link Producer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)} calls

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -71,7 +71,7 @@ import static org.apache.kafka.streams.state.internals.RocksDBStore.DB_FILE_DIR;
  * timestamps:
  * <ul>
  *     <li>a {@code validFrom} timestamp. This timestamp is explicitly associated with the record
- *     as part of the {@link VersionedKeyValueStore#put(Object, Object, long)}} call to the store;
+ *     as part of the {@link VersionedKeyValueStore#put(Object, Object, long)} call to the store;
  *     i.e., this is the record's timestamp.</li>
  *     <li>a {@code validTo} timestamp. This is the timestamp of the next record (or deletion)
  *     associated with the same key, and is implicitly associated with the record. This timestamp


### PR DESCRIPTION
Fix six malformed Javadoc link tags across the clients and streams
modules. The changes remove extra closing braces and replace malformed
`{{@link ...}}` tags with valid `{@link ...}` tags so the generated API
documentation renders the references correctly.

This is a documentation-only change with no runtime or compatibility
impact.

Validation:

- `./gradlew :clients:javadoc :streams:javadoc spotlessCheck`

Generated-by: OpenAI Codex Reviewers: Ken Huang <s7133700@gmail.com>
Reviewers: Parker Chang <parkerhiphop027@gmail.com>, Andrew Schofield
<aschofield@confluent.io>
