### PR TITLE
KAFKA-20656: Normalize ByteBuffer values in Struct

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.data;
 
 import org.apache.kafka.common.annotation.InterfaceAudience;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.DataException;
 
 import java.nio.ByteBuffer;
@@ -162,11 +163,12 @@ public class Struct {
 
     /**
      * Equivalent to calling {@link #get(String)} and casting the result to a byte[].
+     * For {@link ByteBuffer} values, only the bytes between the current position and limit are returned.
      */
     public byte[] getBytes(String fieldName) {
         Object bytes = getCheckType(fieldName, Schema.Type.BYTES);
-        if (bytes instanceof ByteBuffer)
-            return ((ByteBuffer) bytes).array();
+        if (bytes instanceof ByteBuffer byteBuffer)
+            return Utils.toArray(byteBuffer);
         return (byte[]) bytes;
     }
 
@@ -242,12 +244,26 @@ public class Struct {
         if (o == null || getClass() != o.getClass()) return false;
         Struct struct = (Struct) o;
         return Objects.equals(schema, struct.schema) &&
-                Arrays.deepEquals(values, struct.values);
+                Arrays.deepEquals(normalizedValues(), struct.normalizedValues());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, Arrays.deepHashCode(values));
+        return Objects.hash(schema, Arrays.deepHashCode(normalizedValues()));
+    }
+
+    /**
+     * Normalize BYTES values to byte arrays so byte[] and ByteBuffer representations compare by content.
+     */
+    private Object[] normalizedValues() {
+        Object[] normalizedValues = values.clone();
+        for (Field field : schema.fields()) {
+            Object value = normalizedValues[field.index()];
+            if (field.schema().type() == Schema.Type.BYTES && value instanceof ByteBuffer byteBuffer) {
+                normalizedValues[field.index()] = Utils.toArray(byteBuffer);
+            }
+        }
+        return normalizedValues;
     }
 
     private Field lookupField(String fieldName) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,6 +88,27 @@ public class StructTest {
         assertEquals(ByteBuffer.wrap("foobar".getBytes()), ByteBuffer.wrap(struct.getBytes("bytes")));
 
         struct.validate();
+    }
+
+    @Test
+    public void testGetBytesPreservesByteBufferRemainingBytes() {
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[]{1, 2, 3, 4});
+        bytes.position(1);
+        bytes.limit(3);
+        Struct struct = new Struct(FLAT_STRUCT_SCHEMA).put("bytes", bytes);
+
+        assertArrayEquals(new byte[]{2, 3}, struct.getBytes("bytes"));
+        assertEquals(1, bytes.position());
+        assertEquals(3, bytes.limit());
+    }
+
+    @Test
+    public void testGetBytesSupportsDirectByteBuffer() {
+        ByteBuffer bytes = ByteBuffer.allocateDirect(2);
+        bytes.put((byte) 1).put((byte) 2).flip();
+        Struct struct = new Struct(FLAT_STRUCT_SCHEMA).put("bytes", bytes);
+
+        assertArrayEquals(new byte[]{1, 2}, struct.getBytes("bytes"));
     }
 
     @Test
@@ -286,6 +308,21 @@ public class StructTest {
         assertEquals(struct1.hashCode(), struct2.hashCode());
         assertNotEquals(struct1.hashCode(), struct3.hashCode());
         assertNotEquals(struct2.hashCode(), struct3.hashCode());
+    }
+
+    @Test
+    public void testEqualsAndHashCodeWithEquivalentByteBufferValue() {
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[]{1, 2, 3, 4});
+        bytes.position(1);
+        bytes.limit(3);
+        Struct byteBufferStruct = new Struct(FLAT_STRUCT_SCHEMA).put("bytes", bytes);
+        Struct byteArrayStruct = new Struct(FLAT_STRUCT_SCHEMA).put("bytes", new byte[]{2, 3});
+
+        assertEquals(byteArrayStruct, byteBufferStruct);
+        assertEquals(byteBufferStruct, byteArrayStruct);
+        assertEquals(byteArrayStruct.hashCode(), byteBufferStruct.hashCode());
+        assertEquals(1, bytes.position());
+        assertEquals(3, bytes.limit());
     }
 
     @Test


### PR DESCRIPTION
### What

Fix `Struct` handling of `Schema.Type.BYTES` values represented by
`ByteBuffer`.

- `getBytes` now returns the logical bytes from the current position
through the limit, including for direct buffers.
- `Struct.equals` and `Struct.hashCode` normalize direct BYTES fields so
equivalent `byte[]` and `ByteBuffer` values compare consistently.
- The source `ByteBuffer` position and limit are preserved.

No public API signature or wire format is changed.

### Tests

- TDD RED: added sliced-buffer, direct-buffer, and equality/hash-code
regression tests; all three failed on the pre-fix implementation.
- TDD GREEN: all new regression tests passed after the fix.
- `./gradlew :connect:api:test --tests
org.apache.kafka.connect.data.StructTest --no-build-cache
--console=plain`
- `./gradlew :connect:api:test --no-build-cache --console=plain`
- `./gradlew :connect:api:spotlessCheck :connect:api:checkstyleMain
:connect:api:checkstyleTest :connect:api:spotbugsMain --no-build-cache
--console=plain`
- `git diff --check`

Closes KAFKA-20656

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Sean Quah
 <squah@confluent.io>
