### PR TITLE
KAFKA-19107: Prune stale MirrorMaker checkpoints

### DIFF
--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/Checkpoint.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/Checkpoint.java
@@ -136,13 +136,18 @@ public class Checkpoint {
         long upstreamOffset = valueStruct.getLong(UPSTREAM_OFFSET_KEY);
         long downstreamOffset = valueStruct.getLong(DOWNSTREAM_OFFSET_KEY);
         String metadata = valueStruct.getString(METADATA_KEY);
-        Struct keyStruct = KEY_SCHEMA.read(ByteBuffer.wrap(record.key()));
-        String group = keyStruct.getString(CONSUMER_GROUP_ID_KEY);
-        String topic = keyStruct.getString(TOPIC_KEY);
-        int partition = keyStruct.getInt(PARTITION_KEY);
-        return new Checkpoint(group, new TopicPartition(topic, partition), upstreamOffset,
+        Key key = deserializeKey(record.key());
+        return new Checkpoint(key.consumerGroupId(), key.topicPartition(), upstreamOffset,
             downstreamOffset, metadata);
     }
+
+    static Key deserializeKey(byte[] key) {
+        Struct keyStruct = KEY_SCHEMA.read(ByteBuffer.wrap(key));
+        return new Key(keyStruct.getString(CONSUMER_GROUP_ID_KEY),
+            new TopicPartition(keyStruct.getString(TOPIC_KEY), keyStruct.getInt(PARTITION_KEY)));
+    }
+
+    record Key(String consumerGroupId, TopicPartition topicPartition) { }
 
     private static Schema valueSchema(short version) {
         if (version != VERSION) {

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/CheckpointStore.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/CheckpointStore.java
@@ -74,7 +74,7 @@ public class CheckpointStore implements AutoCloseable {
     }
 
     // potentially long running
-    public boolean start()  {
+    public synchronized boolean start()  {
         checkpointsPerConsumerGroup = readCheckpoints();
         isInitialized = true;
         if (log.isTraceEnabled()) {
@@ -89,17 +89,17 @@ public class CheckpointStore implements AutoCloseable {
         return isInitialized;
     }
 
-    public void update(String group, Map<TopicPartition, Checkpoint> newCheckpoints) {
+    public synchronized void update(String group, Map<TopicPartition, Checkpoint> newCheckpoints) {
         Map<TopicPartition, Checkpoint> oldCheckpoints = checkpointsPerConsumerGroup.computeIfAbsent(group, ignored -> new HashMap<>());
         oldCheckpoints.putAll(newCheckpoints);
     }
 
-    public Map<TopicPartition, Checkpoint> get(String group) {
+    public synchronized Map<TopicPartition, Checkpoint> get(String group) {
         Map<TopicPartition, Checkpoint> result = checkpointsPerConsumerGroup.get(group);
         return result == null ? null : Map.copyOf(result);
     }
 
-    public Map<String, Map<TopicPartition, OffsetAndMetadata>> computeConvertedUpstreamOffset() {
+    public synchronized Map<String, Map<TopicPartition, OffsetAndMetadata>> computeConvertedUpstreamOffset() {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> result = new HashMap<>();
 
         for (Map.Entry<String, Map<TopicPartition, Checkpoint>> entry : checkpointsPerConsumerGroup.entrySet()) {
@@ -143,10 +143,22 @@ public class CheckpointStore implements AutoCloseable {
                 }
             } else {
                 try {
-                    Checkpoint cp = Checkpoint.deserializeRecord(cpRecord);
-                    if (consumerGroups.contains(cp.consumerGroupId())) {
-                        Map<TopicPartition, Checkpoint> cps = checkpoints.computeIfAbsent(cp.consumerGroupId(), ignored1 -> new HashMap<>());
-                        cps.put(cp.topicPartition(), cp);
+                    Checkpoint.Key key = Checkpoint.deserializeKey(cpRecord.key());
+                    if (consumerGroups.contains(key.consumerGroupId())) {
+                        if (cpRecord.value() == null) {
+                            Map<TopicPartition, Checkpoint> cps = checkpoints.get(key.consumerGroupId());
+                            if (cps != null) {
+                                cps.remove(key.topicPartition());
+                                if (cps.isEmpty()) {
+                                    checkpoints.remove(key.consumerGroupId());
+                                }
+                            }
+                        } else {
+                            Checkpoint cp = Checkpoint.deserializeRecord(cpRecord);
+                            Map<TopicPartition, Checkpoint> cps = checkpoints.computeIfAbsent(key.consumerGroupId(),
+                                    ignored1 -> new HashMap<>());
+                            cps.put(key.topicPartition(), cp);
+                        }
                     }
                 } catch (SchemaException ex) {
                     log.warn("Ignored invalid checkpoint record at offset {}", cpRecord.offset(), ex);
@@ -174,6 +186,17 @@ public class CheckpointStore implements AutoCloseable {
             }
         }
         return checkpoints;
+    }
+
+    synchronized void remove(String group, TopicPartition topicPartition) {
+        Map<TopicPartition, Checkpoint> checkpoints = checkpointsPerConsumerGroup.get(group);
+        if (checkpoints == null) {
+            return;
+        }
+        checkpoints.remove(topicPartition);
+        if (checkpoints.isEmpty()) {
+            checkpointsPerConsumerGroup.remove(group);
+        }
     }
 
     // accessible for testing

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -25,6 +26,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -41,7 +43,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -72,6 +78,8 @@ public class MirrorCheckpointTask extends SourceTask {
     private Scheduler scheduler;
     private Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset;
     private CheckpointStore checkpointStore;
+    private final Map<Checkpoint.Key, Checkpoint> staleCheckpoints = new ConcurrentHashMap<>();
+    private final Queue<SourceRecord> pendingCheckpointRecords = new ConcurrentLinkedQueue<>();
 
     public MirrorCheckpointTask() {}
 
@@ -80,6 +88,15 @@ public class MirrorCheckpointTask extends SourceTask {
             ReplicationPolicy replicationPolicy, OffsetSyncStore offsetSyncStore, Set<String> consumerGroups,
             Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset,
             CheckpointStore checkpointStore) {
+        this(sourceClusterAlias, targetClusterAlias, replicationPolicy, offsetSyncStore, consumerGroups,
+                idleConsumerGroupsOffset, checkpointStore, null);
+    }
+
+    // for testing
+    MirrorCheckpointTask(String sourceClusterAlias, String targetClusterAlias,
+            ReplicationPolicy replicationPolicy, OffsetSyncStore offsetSyncStore, Set<String> consumerGroups,
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> idleConsumerGroupsOffset,
+            CheckpointStore checkpointStore, Admin targetAdminClient) {
         this.sourceClusterAlias = sourceClusterAlias;
         this.targetClusterAlias = targetClusterAlias;
         this.replicationPolicy = replicationPolicy;
@@ -87,6 +104,8 @@ public class MirrorCheckpointTask extends SourceTask {
         this.consumerGroups = consumerGroups;
         this.idleConsumerGroupsOffset = idleConsumerGroupsOffset;
         this.checkpointStore = checkpointStore;
+        this.targetAdminClient = targetAdminClient;
+        this.checkpointsTopic = "checkpoints.internal";
         this.topicFilter = topic -> true;
         this.interval = Duration.ofNanos(1);
         this.pollTimeout = Duration.ofNanos(1);
@@ -96,6 +115,8 @@ public class MirrorCheckpointTask extends SourceTask {
     public void start(Map<String, String> props) {
         MirrorCheckpointTaskConfig config = new MirrorCheckpointTaskConfig(props);
         stopping = false;
+        staleCheckpoints.clear();
+        pendingCheckpointRecords.clear();
         sourceClusterAlias = config.sourceClusterAlias();
         targetClusterAlias = config.targetClusterAlias();
         consumerGroups = config.taskConsumerGroups();
@@ -163,6 +184,10 @@ public class MirrorCheckpointTask extends SourceTask {
                 return null;
             }
             List<SourceRecord> records = new ArrayList<>();
+            SourceRecord pendingRecord;
+            while ((pendingRecord = pendingCheckpointRecords.poll()) != null) {
+                records.add(pendingRecord);
+            }
             for (String group : consumerGroups) {
                 records.addAll(sourceRecordsForGroup(group));
             }
@@ -201,6 +226,7 @@ public class MirrorCheckpointTask extends SourceTask {
             .map(x -> checkpoint(group, x.getKey(), x.getValue()))
             .flatMap(Optional::stream) // do not emit checkpoints for partitions that don't have offset-syncs
             .filter(x -> x.downstreamOffset() >= 0)  // ignore offsets we cannot translate accurately
+            .filter(this::isNotStaleCheckpoint)
             .filter(this::checkpointIsMoreRecent) // do not emit checkpoints for partitions that have a later checkpoint
             .collect(Collectors.toMap(Checkpoint::topicPartition, Function.identity()));
     }
@@ -261,11 +287,19 @@ public class MirrorCheckpointTask extends SourceTask {
     }
 
     SourceRecord checkpointRecord(Checkpoint checkpoint, long timestamp) {
+        return checkpointRecord(checkpoint, checkpoint.recordValue(), timestamp);
+    }
+
+    private SourceRecord checkpointTombstoneRecord(Checkpoint checkpoint, long timestamp) {
+        return checkpointRecord(checkpoint, null, timestamp);
+    }
+
+    private SourceRecord checkpointRecord(Checkpoint checkpoint, byte[] value, long timestamp) {
         return new SourceRecord(
             checkpoint.connectPartition(), MirrorUtils.wrapOffset(0),
             checkpointsTopic, 0,
             Schema.BYTES_SCHEMA, checkpoint.recordKey(),
-            Schema.BYTES_SCHEMA, checkpoint.recordValue(),
+            Schema.BYTES_SCHEMA, value,
             timestamp);
     }
 
@@ -342,7 +376,12 @@ public class MirrorCheckpointTask extends SourceTask {
             String consumerGroupId = group.getKey();
             // for each idle consumer at target, read the checkpoints (converted upstream offset)
             // from the pre-populated map
-            Map<TopicPartition, OffsetAndMetadata> convertedUpstreamOffset = group.getValue();
+            Map<TopicPartition, OffsetAndMetadata> convertedUpstreamOffset = group.getValue().entrySet().stream()
+                    .filter(entry -> !staleCheckpoints.containsKey(new Checkpoint.Key(consumerGroupId, entry.getKey())))
+                    .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            if (convertedUpstreamOffset.isEmpty()) {
+                continue;
+            }
 
             Map<TopicPartition, OffsetAndMetadata> offsetToSync = new HashMap<>();
             Map<TopicPartition, OffsetAndMetadata> targetConsumerOffset = idleConsumerGroupsOffset.get(consumerGroupId);
@@ -397,22 +436,71 @@ public class MirrorCheckpointTask extends SourceTask {
 
     void syncGroupOffset(String consumerGroupId, Map<TopicPartition, OffsetAndMetadata> offsetToSync) throws ExecutionException, InterruptedException {
         if (targetAdminClient != null) {
-            adminCall(
-                    () -> targetAdminClient.alterConsumerGroupOffsets(consumerGroupId, offsetToSync).all()
-                            .whenComplete((v, throwable) -> {
-                                if (throwable != null) {
-                                    if (throwable.getCause() instanceof UnknownMemberIdException) {
-                                        log.warn("Unable to sync offsets for consumer group {}. This is likely caused " +
-                                                "by consumers currently using this group in the target cluster.", consumerGroupId);
-                                    } else {
-                                        log.error("Unable to sync offsets for consumer group {}.", consumerGroupId, throwable);
-                                    }
-                                } else {
-                                    log.trace("Sync-ed {} offsets for consumer group {}.", offsetToSync.size(), consumerGroupId);
-                                }
-                            }),
+            AlterConsumerGroupOffsetsResult result = adminCall(
+                    () -> targetAdminClient.alterConsumerGroupOffsets(consumerGroupId, offsetToSync),
                     () -> String.format("alter offsets for consumer group %s on %s cluster", consumerGroupId, targetClusterAlias)
             );
+            offsetToSync.keySet().forEach(topicPartition -> result.partitionResult(topicPartition)
+                    .whenComplete((v, throwable) -> handleOffsetSyncResult(consumerGroupId, topicPartition, throwable)));
         }
+    }
+
+    private void handleOffsetSyncResult(String consumerGroupId, TopicPartition topicPartition, Throwable throwable) {
+        if (throwable == null) {
+            log.trace("Sync-ed offset for {} partition {}.", consumerGroupId, topicPartition);
+            return;
+        }
+
+        Throwable cause = unwrap(throwable);
+        if (cause instanceof UnknownMemberIdException) {
+            log.warn("Unable to sync offsets for consumer group {}. This is likely caused " +
+                    "by consumers currently using this group in the target cluster.", consumerGroupId);
+        } else if (cause instanceof UnknownTopicOrPartitionException) {
+            removeStaleCheckpoint(consumerGroupId, topicPartition);
+        } else {
+            log.error("Unable to sync offset for consumer group {} and partition {}.",
+                    consumerGroupId, topicPartition, throwable);
+        }
+    }
+
+    private void removeStaleCheckpoint(String consumerGroupId, TopicPartition topicPartition) {
+        Checkpoint.Key key = new Checkpoint.Key(consumerGroupId, topicPartition);
+        Map<TopicPartition, Checkpoint> checkpoints = checkpointStore.get(consumerGroupId);
+        Checkpoint checkpoint = checkpoints == null ? null : checkpoints.get(topicPartition);
+        if (checkpoint == null) {
+            return;
+        }
+        if (staleCheckpoints.putIfAbsent(key, checkpoint) != null) {
+            return;
+        }
+
+        pendingCheckpointRecords.add(checkpointTombstoneRecord(checkpoint, System.currentTimeMillis()));
+        checkpointStore.remove(consumerGroupId, topicPartition);
+        log.info("Skipping offset for deleted topic partition {} in consumer group {} and emitting a checkpoint tombstone.",
+                topicPartition, consumerGroupId);
+    }
+
+    private boolean isNotStaleCheckpoint(Checkpoint checkpoint) {
+        Checkpoint.Key key = checkpointKey(checkpoint);
+        Checkpoint staleCheckpoint = staleCheckpoints.get(key);
+        if (staleCheckpoint == null) {
+            return true;
+        }
+        if (staleCheckpoint.equals(checkpoint)) {
+            return false;
+        }
+        return staleCheckpoints.remove(key, staleCheckpoint);
+    }
+
+    private static Checkpoint.Key checkpointKey(Checkpoint checkpoint) {
+        return new Checkpoint.Key(checkpoint.consumerGroupId(), checkpoint.topicPartition());
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        Throwable cause = throwable;
+        while ((cause instanceof CompletionException || cause instanceof ExecutionException) && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/CheckpointStoreTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/CheckpointStoreTest.java
@@ -67,6 +67,28 @@ public class CheckpointStoreTest {
     }
 
     @Test
+    public void testReadCheckpointTombstone() {
+        Set<String> consumerGroups = Set.of("group1");
+
+        MirrorCheckpointTaskConfig config = mock(MirrorCheckpointTaskConfig.class);
+        when(config.checkpointsTopic()).thenReturn("checkpoint.topic");
+
+        try (CheckpointStore store = new CheckpointStore(config, consumerGroups) {
+            @Override
+            void readCheckpointsImpl(MirrorCheckpointTaskConfig config, Callback<ConsumerRecord<byte[], byte[]>> consumedCallback) {
+                Checkpoint checkpoint = new Checkpoint("group1", new TopicPartition("topic", 0), 1, 0, "");
+                consumedCallback.onCompletion(null,
+                        new ConsumerRecord<>("checkpoint.topic", 0, 0L, checkpoint.recordKey(), checkpoint.recordValue()));
+                consumedCallback.onCompletion(null,
+                        new ConsumerRecord<>("checkpoint.topic", 0, 1L, checkpoint.recordKey(), null));
+            }
+        }) {
+            assertTrue(store.start(), "expected start to return success");
+            assertTrue(store.checkpointsPerConsumerGroup.isEmpty());
+        }
+    }
+
+    @Test
     public void testReadCheckpointsTopicError() {
         Set<String> consumerGroups = Set.of("group1");
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorCheckpointTaskTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MirrorCheckpointTaskTest {
@@ -203,6 +210,119 @@ public class MirrorCheckpointTaskTest {
         Map<String, Map<TopicPartition, OffsetAndMetadata>> output = mirrorCheckpointTask.syncGroupOffset();
 
         assertEquals(101, output.get(consumer).get(tp).offset(), "Consumer " + topic + " failed");
+    }
+
+    @Test
+    public void testDeletedTopicPartitionIsRemovedFromCheckpointSync() throws Exception {
+        String consumerGroup = "consumer";
+        TopicPartition topicPartition = new TopicPartition("source.topic", 0);
+        Checkpoint checkpoint = new Checkpoint(consumerGroup, topicPartition, 200, 101, "metadata");
+        Map<TopicPartition, Checkpoint> checkpoints = new HashMap<>();
+        checkpoints.put(topicPartition, checkpoint);
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        checkpointsPerConsumerGroup.put(consumerGroup, checkpoints);
+        CheckpointStore checkpointStore = new CheckpointStore(checkpointsPerConsumerGroup);
+
+        Admin targetAdmin = mock(Admin.class);
+        AlterConsumerGroupOffsetsResult alterResult = mock(AlterConsumerGroupOffsetsResult.class);
+        KafkaFutureImpl<Void> allFuture = new KafkaFutureImpl<>();
+        allFuture.completeExceptionally(new UnknownTopicOrPartitionException());
+        KafkaFutureImpl<Void> partitionFuture = new KafkaFutureImpl<>();
+        partitionFuture.completeExceptionally(new UnknownTopicOrPartitionException());
+        when(alterResult.all()).thenReturn(allFuture);
+        when(alterResult.partitionResult(topicPartition)).thenReturn(partitionFuture);
+        when(targetAdmin.alterConsumerGroupOffsets(eq(consumerGroup),
+                eq(Map.of(topicPartition, checkpoint.offsetAndMetadata())))).thenReturn(alterResult);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), new HashMap<>(), checkpointStore, targetAdmin);
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> firstSync = mirrorCheckpointTask.syncGroupOffset();
+        List<SourceRecord> tombstones = mirrorCheckpointTask.poll();
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> secondSync = mirrorCheckpointTask.syncGroupOffset();
+
+        assertEquals(checkpoint.offsetAndMetadata(), firstSync.get(consumerGroup).get(topicPartition));
+        assertEquals(1, tombstones.size());
+        assertEquals("checkpoints.internal", tombstones.get(0).topic());
+        assertEquals(checkpoint.connectPartition(), tombstones.get(0).sourcePartition());
+        assertNull(tombstones.get(0).value());
+        assertTrue(secondSync.isEmpty());
+        verify(targetAdmin, times(1)).alterConsumerGroupOffsets(eq(consumerGroup),
+                eq(Map.of(topicPartition, checkpoint.offsetAndMetadata())));
+    }
+
+    @Test
+    public void testDeletedTopicPartitionDoesNotPreventOtherPartitionsFromSyncing() throws Exception {
+        String consumerGroup = "consumer";
+        TopicPartition deletedTopicPartition = new TopicPartition("source.deleted", 0);
+        TopicPartition existingTopicPartition = new TopicPartition("source.existing", 0);
+        Checkpoint deletedCheckpoint = new Checkpoint(consumerGroup, deletedTopicPartition, 200, 101, "metadata");
+        Checkpoint existingCheckpoint = new Checkpoint(consumerGroup, existingTopicPartition, 300, 201, "metadata");
+        Map<TopicPartition, Checkpoint> checkpoints = new HashMap<>();
+        checkpoints.put(deletedTopicPartition, deletedCheckpoint);
+        checkpoints.put(existingTopicPartition, existingCheckpoint);
+        Map<String, Map<TopicPartition, Checkpoint>> checkpointsPerConsumerGroup = new HashMap<>();
+        checkpointsPerConsumerGroup.put(consumerGroup, checkpoints);
+
+        Admin targetAdmin = mock(Admin.class);
+        AlterConsumerGroupOffsetsResult alterResult = mock(AlterConsumerGroupOffsetsResult.class);
+        KafkaFutureImpl<Void> deletedPartitionFuture = new KafkaFutureImpl<>();
+        deletedPartitionFuture.completeExceptionally(new UnknownTopicOrPartitionException());
+        KafkaFutureImpl<Void> existingPartitionFuture = new KafkaFutureImpl<>();
+        existingPartitionFuture.complete(null);
+        when(alterResult.partitionResult(deletedTopicPartition)).thenReturn(deletedPartitionFuture);
+        when(alterResult.partitionResult(existingTopicPartition)).thenReturn(existingPartitionFuture);
+        Map<TopicPartition, OffsetAndMetadata> offsets = Map.of(
+                deletedTopicPartition, deletedCheckpoint.offsetAndMetadata(),
+                existingTopicPartition, existingCheckpoint.offsetAndMetadata());
+        when(targetAdmin.alterConsumerGroupOffsets(eq(consumerGroup), eq(offsets))).thenReturn(alterResult);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), null, Set.of(), new HashMap<>(),
+                new CheckpointStore(checkpointsPerConsumerGroup), targetAdmin);
+
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> synced = mirrorCheckpointTask.syncGroupOffset();
+        List<SourceRecord> tombstones = mirrorCheckpointTask.poll();
+
+        assertEquals(offsets, synced.get(consumerGroup));
+        assertEquals(1, tombstones.size());
+        assertEquals(deletedCheckpoint.connectPartition(), tombstones.get(0).sourcePartition());
+        verify(targetAdmin, times(1)).alterConsumerGroupOffsets(eq(consumerGroup), eq(offsets));
+    }
+
+    @Test
+    public void testDeletedTopicPartitionDoesNotEmitAnotherCheckpointAfterTombstone() throws Exception {
+        String consumerGroup = "consumer";
+        TopicPartition topicPartition = new TopicPartition("source.topic", 0);
+        Checkpoint checkpoint = new Checkpoint(consumerGroup, topicPartition, 200, 100, "metadata");
+        Map<TopicPartition, Checkpoint> checkpoints = new HashMap<>();
+        checkpoints.put(topicPartition, checkpoint);
+        CheckpointStore checkpointStore = new CheckpointStore(new HashMap<>(Map.of(consumerGroup, checkpoints)));
+
+        OffsetSyncStoreTest.FakeOffsetSyncStore offsetSyncStore = new OffsetSyncStoreTest.FakeOffsetSyncStore();
+        offsetSyncStore.start(true);
+        offsetSyncStore.sync(new TopicPartition("topic", 0), 200, 100);
+
+        Admin targetAdmin = mock(Admin.class);
+        AlterConsumerGroupOffsetsResult alterResult = mock(AlterConsumerGroupOffsetsResult.class);
+        KafkaFutureImpl<Void> partitionFuture = new KafkaFutureImpl<>();
+        partitionFuture.completeExceptionally(new UnknownTopicOrPartitionException());
+        when(alterResult.partitionResult(topicPartition)).thenReturn(partitionFuture);
+        when(targetAdmin.alterConsumerGroupOffsets(eq(consumerGroup),
+                eq(Map.of(topicPartition, checkpoint.offsetAndMetadata())))).thenReturn(alterResult);
+
+        MirrorCheckpointTask mirrorCheckpointTask = new MirrorCheckpointTask("source", "target",
+                new DefaultReplicationPolicy(), offsetSyncStore, Set.of(), new HashMap<>(), checkpointStore, targetAdmin);
+        mirrorCheckpointTask.syncGroupOffset();
+
+        Map<TopicPartition, Checkpoint> emittedCheckpoints = mirrorCheckpointTask.checkpointsForGroup(
+                Map.of(new TopicPartition("topic", 0), new OffsetAndMetadata(200, "metadata")), consumerGroup);
+        assertTrue(emittedCheckpoints.isEmpty(), emittedCheckpoints.toString());
+
+        offsetSyncStore.sync(new TopicPartition("topic", 0), 201, 101);
+        Map<TopicPartition, Checkpoint> recoveredCheckpoints = mirrorCheckpointTask.checkpointsForGroup(
+                Map.of(new TopicPartition("topic", 0), new OffsetAndMetadata(201, "metadata")), consumerGroup);
+        assertEquals(201, recoveredCheckpoints.get(topicPartition).upstreamOffset());
     }
 
     @Test


### PR DESCRIPTION
## Motivation
MirrorCheckpointTask retries the same checkpoint forever when a target topic-partition has been deleted. The aggregate alter-offsets future turns a single missing partition into a recurring error, and the compacted checkpoints topic retains the stale record.

## Changes
- Process `alterConsumerGroupOffsets` results per partition.
- Stop retrying a partition after `UnknownTopicOrPartitionException`.
- Emit a checkpoint tombstone so the stale record is removed from the compacted topic.
- Apply checkpoint tombstones when loading `CheckpointStore`.
- Synchronize checkpoint-store access used by poll and offset-sync scheduler.

## Tests
- `./gradlew :connect:mirror-client:test :connect:mirror:test`
- `./gradlew :connect:mirror-client:spotlessCheck :connect:mirror:spotlessCheck :connect:mirror-client:checkstyleMain :connect:mirror-client:checkstyleTest :connect:mirror:checkstyleMain :connect:mirror:checkstyleTest :connect:mirror-client:spotbugsMain :connect:mirror:spotbugsMain`
- `git diff --check`

Jira: https://issues.apache.org/jira/browse/KAFKA-19107
Reviewers: Ming-Yen Chung <mingyen066@gmail.com>
