### PR TITLE
KAFKA-16870: Avoid schemaless containers from Values.parseString

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -403,7 +403,8 @@ public class Values {
      * Parse the specified string representation of a value into its schema and value.
      *
      * @param value the string form of the value
-     * @return the schema and value; never null, but whose schema and value may be null
+     * @return the schema and value; never null, but whose schema and value may be null. If a container cannot be represented by a
+     *         single Connect schema, the original input is returned as a string value.
      * @see #convertToString
      */
     public static SchemaAndValue parseString(String value) {
@@ -905,14 +906,12 @@ public class Values {
             SchemaMerger elementSchema = new SchemaMerger();
             while (parser.hasNext()) {
                 if (parser.canConsume(ARRAY_END_DELIMITER)) {
-                    Schema listSchema;
-                    if (elementSchema.hasCommonSchema()) {
-                        listSchema = SchemaBuilder.array(elementSchema.schema()).schema();
-                        result = alignListEntriesWithSchema(listSchema, result);
-                    } else {
-                        // Every value is null
-                        listSchema = SchemaBuilder.arrayOfNull().build();
+                    if (!elementSchema.hasCommonSchema()) {
+                        throw new DataException("Unable to infer a common schema for array elements");
                     }
+
+                    Schema listSchema = SchemaBuilder.array(elementSchema.schema()).schema();
+                    result = alignListEntriesWithSchema(listSchema, result);
                     return new SchemaAndValue(listSchema, result);
                 }
 
@@ -944,16 +943,12 @@ public class Values {
             SchemaMerger valueSchema = new SchemaMerger();
             while (parser.hasNext()) {
                 if (parser.canConsume(MAP_END_DELIMITER)) {
-                    Schema mapSchema;
-                    if (keySchema.hasCommonSchema() && valueSchema.hasCommonSchema()) {
-                        mapSchema = SchemaBuilder.map(keySchema.schema(), valueSchema.schema()).build();
-                        result = alignMapKeysAndValuesWithSchema(mapSchema, result);
-                    } else if (keySchema.hasCommonSchema()) {
-                        mapSchema = SchemaBuilder.mapWithNullValues(keySchema.schema());
-                        result = alignMapKeysWithSchema(mapSchema, result);
-                    } else {
-                        mapSchema = SchemaBuilder.mapOfNull().build();
+                    if (!keySchema.hasCommonSchema() || !valueSchema.hasCommonSchema()) {
+                        throw new DataException("Unable to infer a common schema for map keys and values");
                     }
+
+                    Schema mapSchema = SchemaBuilder.map(keySchema.schema(), valueSchema.schema()).build();
+                    result = alignMapKeysAndValuesWithSchema(mapSchema, result);
                     return new SchemaAndValue(mapSchema, result);
                 }
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -37,12 +37,12 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -212,17 +212,15 @@ public class ValuesTest {
     }
 
     @Test
-    public void shouldParseEmptyMap() {
+    public void shouldReturnOriginalStringForEmptyMap() {
         SchemaAndValue schemaAndValue = Values.parseString("{}");
-        assertEquals(Type.MAP, schemaAndValue.schema().type());
-        assertEquals(Map.of(), schemaAndValue.value());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{}"), schemaAndValue);
     }
 
     @Test
-    public void shouldParseEmptyArray() {
+    public void shouldReturnOriginalStringForEmptyArray() {
         SchemaAndValue schemaAndValue = Values.parseString("[]");
-        assertEquals(Type.ARRAY, schemaAndValue.schema().type());
-        assertEquals(List.of(), schemaAndValue.value());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[]"), schemaAndValue);
     }
 
     @Test
@@ -244,18 +242,15 @@ public class ValuesTest {
     }
 
     @Test
-    public void shouldParseNullMapValues() {
+    public void shouldReturnOriginalStringForNullMapValues() {
         SchemaAndValue schemaAndValue = Values.parseString("{3: null}");
-        assertEquals(Type.MAP, schemaAndValue.schema().type());
-        assertEquals(Type.INT8, schemaAndValue.schema().keySchema().type());
-        assertEquals(Collections.singletonMap((byte) 3, null), schemaAndValue.value());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{3: null}"), schemaAndValue);
     }
 
     @Test
-    public void shouldParseNullArrayElements() {
+    public void shouldReturnOriginalStringForNullArrayElements() {
         SchemaAndValue schemaAndValue = Values.parseString("[null]");
-        assertEquals(Type.ARRAY, schemaAndValue.schema().type());
-        assertEquals(Collections.singletonList(null), schemaAndValue.value());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[null]"), schemaAndValue);
     }
 
     @Test
@@ -460,101 +455,103 @@ public class ValuesTest {
     }
 
     /**
-     * We parse into different element types, but cannot infer a common element schema.
-     * This behavior should be independent of the order that the elements appear in the string
+     * A Connect array schema must describe all elements with one element schema. If the elements do not
+     * have a common schema, preserve the original literal regardless of element order.
      */
     @Test
-    public void shouldParseStringListWithMultipleElementTypes() {
-        assertParseStringArrayWithNoSchema(
-                List.of((byte) 1, (byte) 2, (short) 300, "four"),
-                "[1, 2, 300, \"four\"]");
-        assertParseStringArrayWithNoSchema(
-                List.of((byte) 2, (short) 300, "four", (byte) 1),
-                "[2, 300, \"four\", 1]");
-        assertParseStringArrayWithNoSchema(
-                List.of((short) 300, "four", (byte) 1, (byte) 2),
-                "[300, \"four\", 1, 2]");
-        assertParseStringArrayWithNoSchema(
-                List.of("four", (byte) 1, (byte) 2, (short) 300),
-                "[\"four\", 1, 2, 300]");
+    public void shouldReturnOriginalStringForStringListWithMultipleElementTypes() {
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[1, 2, 300, \"four\"]"),
+                Values.parseString("[1, 2, 300, \"four\"]"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[2, 300, \"four\", 1]"),
+                Values.parseString("[2, 300, \"four\", 1]"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[300, \"four\", 1, 2]"),
+                Values.parseString("[300, \"four\", 1, 2]"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[\"four\", 1, 2, 300]"),
+                Values.parseString("[\"four\", 1, 2, 300]"));
     }
 
-    private void assertParseStringArrayWithNoSchema(List<Object> expected, String str) {
-        SchemaAndValue result = Values.parseString(str);
-        assertEquals(Type.ARRAY, result.schema().type());
-        assertNull(result.schema().valueSchema());
-        List<?> list = (List<?>) result.value();
-        assertEquals(expected, list);
+    @Test
+    public void shouldReturnOriginalStringWhenArrayElementSchemasAreNotCompatible() {
+        String input = "[1, \"four\"]";
+
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, input), Values.parseString(input));
+    }
+
+    @Test
+    public void shouldReturnSchemaAndValueAcceptedByConnectSchemaForIncompatibleArray() {
+        SchemaAndValue schemaAndValue = Values.parseString("[1, \"four\"]");
+
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value()));
+    }
+
+    @Test
+    public void shouldReturnOriginalStringWhenNestedArrayHasNoCommonElementSchema() {
+        String input = "[[1, \"four\"]]";
+
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, input), Values.parseString(input));
     }
 
     /**
-     * Maps with an inconsistent key type don't find a common type for the keys or the values
-     * This behavior should be independent of the order that the pairs appear in the string
+     * A Connect map schema must describe all keys with one key schema. If the keys do not have a common
+     * schema, preserve the original literal regardless of entry order.
      */
     @Test
-    public void shouldParseStringMapWithMultipleKeyTypes() {
-        Map<Object, Object> expected = new HashMap<>();
-        expected.put((byte) 1, (byte) 1);
-        expected.put((byte) 2, (byte) 1);
-        expected.put((short) 300, (short) 300);
-        expected.put("four", (byte) 1);
-        assertParseStringMapWithNoSchema(expected, "{1:1, 2:1, 300:300, \"four\":1}");
-        assertParseStringMapWithNoSchema(expected, "{2:1, 300:300, \"four\":1, 1:1}");
-        assertParseStringMapWithNoSchema(expected, "{300:300, \"four\":1, 1:1, 2:1}");
-        assertParseStringMapWithNoSchema(expected, "{\"four\":1, 1:1, 2:1, 300:300}");
+    public void shouldReturnOriginalStringForStringMapWithMultipleKeyTypes() {
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{1:1, 2:1, 300:300, \"four\":1}"),
+                Values.parseString("{1:1, 2:1, 300:300, \"four\":1}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{2:1, 300:300, \"four\":1, 1:1}"),
+                Values.parseString("{2:1, 300:300, \"four\":1, 1:1}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{300:300, \"four\":1, 1:1, 2:1}"),
+                Values.parseString("{300:300, \"four\":1, 1:1, 2:1}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{\"four\":1, 1:1, 2:1, 300:300}"),
+                Values.parseString("{\"four\":1, 1:1, 2:1, 300:300}"));
     }
 
     /**
-     * Maps with a consistent key type may still not have a common type for the values
-     * This behavior should be independent of the order that the pairs appear in the string
+     * A Connect map schema must describe all values with one value schema. If the values do not have a
+     * common schema, preserve the original literal regardless of entry order.
      */
     @Test
-    public void shouldParseStringMapWithMultipleValueTypes() {
-        Map<Object, Object> expected = new HashMap<>();
-        expected.put((short) 1, (byte) 1);
-        expected.put((short) 2, (byte) 1);
-        expected.put((short) 300, (short) 300);
-        expected.put((short) 4, "four");
-        assertParseStringMapWithNoSchema(expected, "{1:1, 2:1, 300:300, 4:\"four\"}");
-        assertParseStringMapWithNoSchema(expected, "{2:1, 300:300, 4:\"four\", 1:1}");
-        assertParseStringMapWithNoSchema(expected, "{300:300, 4:\"four\", 1:1, 2:1}");
-        assertParseStringMapWithNoSchema(expected, "{4:\"four\", 1:1, 2:1, 300:300}");
-    }
-
-    private void assertParseStringMapWithNoSchema(Map<Object, Object> expected, String str) {
-        SchemaAndValue result = Values.parseString(str);
-        assertEquals(Type.MAP, result.schema().type());
-        assertNull(result.schema().valueSchema());
-        Map<?, ?> list = (Map<?, ?>) result.value();
-        assertEquals(expected, list);
+    public void shouldReturnOriginalStringForStringMapWithMultipleValueTypes() {
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{1:1, 2:1, 300:300, 4:\"four\"}"),
+                Values.parseString("{1:1, 2:1, 300:300, 4:\"four\"}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{2:1, 300:300, 4:\"four\", 1:1}"),
+                Values.parseString("{2:1, 300:300, 4:\"four\", 1:1}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{300:300, 4:\"four\", 1:1, 2:1}"),
+                Values.parseString("{300:300, 4:\"four\", 1:1, 2:1}"));
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{4:\"four\", 1:1, 2:1, 300:300}"),
+                Values.parseString("{4:\"four\", 1:1, 2:1, 300:300}"));
     }
 
     @Test
-    public void shouldParseNestedArray() {
+    public void shouldReturnOriginalStringWhenMapValueSchemasAreNotCompatible() {
+        String input = "{1:1, 2:\"two\"}";
+
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, input), Values.parseString(input));
+    }
+
+    @Test
+    public void shouldReturnOriginalStringForNestedArrayWithoutElementSchema() {
         SchemaAndValue schemaAndValue = Values.parseString("[[]]");
-        assertEquals(Type.ARRAY, schemaAndValue.schema().type());
-        assertEquals(Type.ARRAY, schemaAndValue.schema().valueSchema().type());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[[]]"), schemaAndValue);
     }
 
     @Test
-    public void shouldParseArrayContainingMap() {
+    public void shouldReturnOriginalStringForArrayContainingMapWithoutInnerSchema() {
         SchemaAndValue schemaAndValue = Values.parseString("[{}]");
-        assertEquals(Type.ARRAY, schemaAndValue.schema().type());
-        assertEquals(Type.MAP, schemaAndValue.schema().valueSchema().type());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "[{}]"), schemaAndValue);
     }
 
     @Test
-    public void shouldParseNestedMap() {
+    public void shouldReturnOriginalStringForNestedMapWithoutInnerSchema() {
         SchemaAndValue schemaAndValue = Values.parseString("{\"a\":{}}");
-        assertEquals(Type.MAP, schemaAndValue.schema().type());
-        assertEquals(Type.MAP, schemaAndValue.schema().valueSchema().type());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{\"a\":{}}"), schemaAndValue);
     }
 
     @Test
-    public void shouldParseMapContainingArray() {
+    public void shouldReturnOriginalStringForMapContainingArrayWithoutInnerSchema() {
         SchemaAndValue schemaAndValue = Values.parseString("{\"a\":[]}");
-        assertEquals(Type.MAP, schemaAndValue.schema().type());
-        assertEquals(Type.ARRAY, schemaAndValue.schema().valueSchema().type());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "{\"a\":[]}"), schemaAndValue);
     }
 
     /**
@@ -1016,16 +1013,11 @@ public class ValuesTest {
      * The parser does not convert Numbers to Decimals, or Strings containing numbers to Numbers automatically.
      */
     @Test
-    public void shouldNotConvertArrayValuesToDecimal() {
+    public void shouldReturnOriginalStringForArrayValuesWithoutACommonSchema() {
         List<Object> decimals = List.of("\"1.0\"", BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE),
                 BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE), (byte) 1, (byte) 1);
-        List<Object> expected = new ArrayList<>(decimals); // most values are directly reproduced with the same type
-        expected.set(0, "1.0"); // The quotes are parsed away, but the value remains a string
         SchemaAndValue schemaAndValue = Values.parseString(decimals.toString());
-        Schema schema = schemaAndValue.schema();
-        assertEquals(Type.ARRAY, schema.type());
-        assertNull(schema.valueSchema());
-        assertEquals(expected, schemaAndValue.value());
+        assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, decimals.toString()), schemaAndValue);
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -485,6 +485,13 @@ public class ValuesTest {
     }
 
     @Test
+    public void shouldReturnSchemaAndValueAcceptedByConnectSchemaForIncompatibleMap() {
+        SchemaAndValue schemaAndValue = Values.parseString("{1:1, 2:\"two\"}");
+
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value()));
+    }
+
+    @Test
     public void shouldReturnOriginalStringWhenNestedArrayHasNoCommonElementSchema() {
         String input = "[[1, \"four\"]]";
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/SimpleHeaderConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/SimpleHeaderConverterTest.java
@@ -20,10 +20,12 @@ import org.apache.kafka.common.utils.internals.AppInfoParser;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Values;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -166,45 +168,49 @@ public class SimpleHeaderConverterTest {
     }
 
     @Test
-    public void shouldConvertMapWithStringKeysAndMixedValuesToMap() {
+    public void shouldConvertMapWithStringKeysAndMixedValuesToString() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("foo", "bar");
         map.put("baz", (short) 3456);
         SchemaAndValue result = roundTrip(null, map);
-        assertEquals(Schema.Type.MAP, result.schema().type());
-        assertEquals(Schema.Type.STRING, result.schema().keySchema().type());
-        assertNull(result.schema().valueSchema());
-        assertEquals(map, result.value());
+        assertEquals(Schema.STRING_SCHEMA, result.schema());
+        assertEquals(Values.convertToString(null, map), result.value());
     }
 
     @Test
-    public void shouldConvertListWithMixedValuesToListWithoutSchema() {
+    public void shouldConvertListWithMixedValuesToString() {
         List<Object> list = new ArrayList<>();
         list.add("foo");
         list.add((short) 13344);
         SchemaAndValue result = roundTrip(null, list);
-        assertEquals(Schema.Type.ARRAY, result.schema().type());
-        assertNull(result.schema().valueSchema());
-        assertEquals(list, result.value());
+        assertEquals(Schema.STRING_SCHEMA, result.schema());
+        assertEquals(Values.convertToString(null, list), result.value());
     }
 
     @Test
-    public void shouldConvertEmptyMapToMap() {
+    public void shouldReturnOriginalStringForHeaderWithIncompatibleContainerValues() {
+        String serialized = "[1, \"two\"]";
+
+        SchemaAndValue result = converter.toConnectHeader(TOPIC, HEADER, serialized.getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(Schema.STRING_SCHEMA, result.schema());
+        assertEquals(serialized, result.value());
+    }
+
+    @Test
+    public void shouldConvertEmptyMapToString() {
         Map<Object, Object> map = new LinkedHashMap<>();
         SchemaAndValue result = roundTrip(null, map);
-        assertEquals(Schema.Type.MAP, result.schema().type());
-        assertNull(result.schema().keySchema());
-        assertNull(result.schema().valueSchema());
-        assertEquals(map, result.value());
+        assertEquals(Schema.STRING_SCHEMA, result.schema());
+        assertEquals(Values.convertToString(null, map), result.value());
     }
 
     @Test
-    public void shouldConvertEmptyListToList() {
+    public void shouldConvertEmptyListToString() {
         List<Object> list = new ArrayList<>();
         SchemaAndValue result = roundTrip(null, list);
-        assertEquals(Schema.Type.ARRAY, result.schema().type());
-        assertNull(result.schema().valueSchema());
-        assertEquals(list, result.value());
+        assertEquals(Schema.STRING_SCHEMA, result.schema());
+        assertEquals(Values.convertToString(null, list), result.value());
     }
 
     @Test


### PR DESCRIPTION
## What

`Values.parseString` no longer returns arrays or maps with missing inner schemas when it cannot infer a common schema. Instead, it falls back to the original literal as a `STRING` value. This also makes `SimpleHeaderConverter` safe for empty and heterogeneous containers because it relies on `Values.parseString`.

## Why

Connect arrays and maps require inner schemas for validation. Returning a container with a null inner schema creates a `SchemaAndValue` that fails later in `ConnectSchema.validateValue`, for example when used as a struct field value. Falling back to the original string preserves the input without manufacturing an invalid Connect value.

## Testing

- Added RED tests for heterogeneous arrays, nested containers, heterogeneous map values, and header conversion.
- Added a regression test that validates the returned `SchemaAndValue` with `ConnectSchema.validateValue`.
- `./gradlew :connect:api:test :connect:api:spotlessCheck :connect:api:checkstyleMain :connect:api:checkstyleTest :connect:api:spotbugsMain --no-build-cache --console=plain`
- `./gradlew :connect:transforms:test :connect:api:spotlessCheck :connect:api:checkstyleMain :connect:api:checkstyleTest :connect:api:spotbugsMain --no-build-cache --console=plain`

I confirm that this contribution is my original work and that I license it to Apache Kafka under the Apache License, Version 2.0.

JIRA: https://issues.apache.org/jira/browse/KAFKA-16870