### PR TITLE
KAFKA-16987: Release connector resources after failure

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -81,6 +81,8 @@ public class WorkerConnector implements Runnable {
     private final String version;
 
     private State state;
+    private volatile boolean connectorStopRequired;
+    private volatile boolean failureCleanupPerformed;
     private final CloseableOffsetStorageReader offsetStorageReader;
     private final ConnectorOffsetBackingStore offsetStore;
 
@@ -110,6 +112,8 @@ public class WorkerConnector implements Runnable {
         this.externalFailure = null;
         this.stopping = false;
         this.cancelled = false;
+        this.connectorStopRequired = false;
+        this.failureCleanupPerformed = false;
     }
 
     public ClassLoader loader() {
@@ -153,10 +157,16 @@ public class WorkerConnector implements Runnable {
 
     void doRun() {
         initialize();
+        if (state == State.FAILED) {
+            // Initialization failures must release connector-owned resources while preserving FAILED status.
+            cleanupAfterFailure();
+        }
         while (!stopping) {
             Throwable failure = externalFailure;
-            if (failure != null)
+            if (failure != null) {
                 onFailure(failure);
+                cleanupAfterFailure();
+            }
 
             TargetState newTargetState;
             Callback<TargetState> stateChangeCallback;
@@ -166,6 +176,10 @@ public class WorkerConnector implements Runnable {
             }
             if (newTargetState != null && !stopping) {
                 doTransitionTo(newTargetState, stateChangeCallback);
+                if (state == State.FAILED) {
+                    // A failed transition must release connector-owned resources before the run loop waits again.
+                    cleanupAfterFailure();
+                }
             }
             synchronized (this) {
                 if (pendingTargetStateChange.get() != null
@@ -194,11 +208,13 @@ public class WorkerConnector implements Runnable {
             log.debug("{} Initializing connector {}", this, connName);
             if (isSinkConnector()) {
                 SinkConnectorConfig.validate(config);
+                connectorStopRequired = true;
                 connector.initialize(new WorkerSinkConnectorContext());
             } else {
                 Objects.requireNonNull(offsetStore, "Offset store cannot be null for source connectors");
                 Objects.requireNonNull(offsetStorageReader, "Offset reader cannot be null for source connectors");
                 offsetStore.start();
+                connectorStopRequired = true;
                 connector.initialize(new WorkerSourceConnectorContext(offsetStorageReader));
             }
         } catch (Throwable t) {
@@ -216,6 +232,7 @@ public class WorkerConnector implements Runnable {
                 case INIT:
                 case PAUSED:
                 case STOPPED:
+                    connectorStopRequired = true;
                     connector.start(config);
                     this.state = State.STARTED;
                     return true;
@@ -262,7 +279,7 @@ public class WorkerConnector implements Runnable {
             }
 
             if (state == State.STARTED) {
-                connector.stop();
+                stopConnector();
             }
 
             if (state == State.FAILED && newState != State.STOPPED) {
@@ -301,6 +318,17 @@ public class WorkerConnector implements Runnable {
     }
 
     void doShutdown() {
+        doShutdown(false);
+    }
+
+    private void cleanupAfterFailure() {
+        if (!failureCleanupPerformed) {
+            failureCleanupPerformed = true;
+            doShutdown(true);
+        }
+    }
+
+    private void doShutdown(boolean preserveFailureState) {
         try {
             TargetState preEmptedState = pendingTargetStateChange.getAndSet(null);
             Callback<TargetState> stateChangeCallback = pendingStateChangeCallback.getAndSet(null);
@@ -311,15 +339,17 @@ public class WorkerConnector implements Runnable {
                                     + " as the connector has been scheduled for shutdown"),
                         null);
             }
-            if (state == State.STARTED)
-                connector.stop();
+            if (connectorStopRequired && (state == State.STARTED || (preserveFailureState && state == State.FAILED)))
+                stopConnector();
+            if (preserveFailureState)
+                return;
             this.state = State.STOPPED;
             statusListener.onShutdown(connName);
             log.info("Completed shutdown for {}", this);
         } catch (Throwable t) {
             log.error("{} Error while shutting down connector", this, t);
-            state = State.FAILED;
-            statusListener.onFailure(connName, t);
+            if (!preserveFailureState)
+                onFailure(t);
         } finally {
             Utils.closeQuietly(ctx, "connector context for " + connName);
             Utils.closeQuietly(metrics, "connector metrics for " + connName);
@@ -328,6 +358,11 @@ public class WorkerConnector implements Runnable {
                 Utils.closeQuietly(offsetStore::stop, "offset backing store for " + connName);
             }
         }
+    }
+
+    private void stopConnector() {
+        connectorStopRequired = false;
+        connector.stop();
     }
 
     public synchronized void cancel() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.storage.ConnectorOffsetBackingStore;
 import org.apache.kafka.connect.util.Callback;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -54,6 +55,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -135,6 +137,45 @@ public class WorkerConnectorTest {
         verifyInitialize();
         verify(listener).onFailure(CONNECTOR, exception);
         verifyCleanShutdown(false);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConnectorType.class, names = {"SOURCE", "SINK"})
+    @Timeout(5)
+    public void testInitializeFailureReleasesResourcesImmediately(ConnectorType connectorType) throws InterruptedException {
+        setup(connectorType);
+        RuntimeException exception = new RuntimeException();
+
+        when(connector.version()).thenReturn(VERSION);
+        doThrow(exception).when(connector).initialize(any());
+
+        WorkerConnector workerConnector = new WorkerConnector(
+                CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+
+        runAndVerifyFailureCleanup(workerConnector, () -> {
+            verify(listener).onFailure(CONNECTOR, exception);
+            assertFailedMetric(workerConnector);
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConnectorType.class, names = {"SOURCE", "SINK"})
+    @Timeout(5)
+    public void testExternalFailureReleasesResourcesImmediately(ConnectorType connectorType) throws InterruptedException {
+        setup(connectorType);
+        RuntimeException exception = new RuntimeException();
+
+        when(connector.version()).thenReturn(VERSION);
+
+        WorkerConnector workerConnector = new WorkerConnector(
+                CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        workerConnector.fail(exception);
+
+        runAndVerifyFailureCleanup(workerConnector, () -> {
+            verifyInitialize();
+            verify(listener).onFailure(CONNECTOR, exception);
+            assertFailedMetric(workerConnector);
+        });
     }
 
     @ParameterizedTest
@@ -366,6 +407,51 @@ public class WorkerConnectorTest {
 
         verify(onStateChange).onCompletion(any(Exception.class), isNull());
         verifyNoMoreInteractions(onStateChange);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConnectorType.class, names = {"SOURCE", "SINK"})
+    @Timeout(5)
+    public void testStartupFailureReleasesResourcesImmediately(ConnectorType connectorType) throws InterruptedException {
+        setup(connectorType);
+        RuntimeException exception = new RuntimeException();
+
+        when(connector.version()).thenReturn(VERSION);
+        doThrow(exception).when(connector).start(CONFIG);
+
+        Callback<TargetState> onStateChange = mockCallback();
+        WorkerConnector workerConnector = new WorkerConnector(
+                CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+        workerConnector.transitionTo(TargetState.STARTED, onStateChange);
+
+        runAndVerifyFailureCleanup(workerConnector, () -> {
+            verify(connector).start(CONFIG);
+            verify(listener).onFailure(CONNECTOR, exception);
+            verify(onStateChange).onCompletion(any(Exception.class), isNull());
+            assertFailedMetric(workerConnector);
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConnectorType.class, names = {"SOURCE", "SINK"})
+    @Timeout(5)
+    public void testFailureCleanupContinuesWhenStopFails(ConnectorType connectorType) throws InterruptedException {
+        setup(connectorType);
+        RuntimeException initializationException = new RuntimeException();
+        RuntimeException stopException = new RuntimeException();
+
+        when(connector.version()).thenReturn(VERSION);
+        doThrow(initializationException).when(connector).initialize(any());
+        doThrow(stopException).when(connector).stop();
+
+        WorkerConnector workerConnector = new WorkerConnector(
+                CONNECTOR, connector, connectorConfig, ctx, metrics, listener, offsetStorageReader, offsetStore, classLoader);
+
+        runAndVerifyFailureCleanup(workerConnector, () -> {
+            verify(listener).onFailure(CONNECTOR, initializationException);
+            verifyNoMoreInteractions(listener);
+            assertFailedMetric(workerConnector);
+        });
     }
 
     @ParameterizedTest
@@ -633,6 +719,19 @@ public class WorkerConnectorTest {
             verify(connector).initialize(any(SourceConnectorContext.class));
         } else if (connectorType == ConnectorType.SINK) {
             verify(connector).initialize(any(SinkConnectorContext.class));
+        }
+    }
+
+    private void runAndVerifyFailureCleanup(WorkerConnector workerConnector, Runnable assertions) throws InterruptedException {
+        Thread connectorThread = new Thread(workerConnector);
+        connectorThread.start();
+        try {
+            verify(connector, timeout(1000)).stop();
+            verify(ctx, timeout(1000)).close();
+            assertions.run();
+        } finally {
+            workerConnector.shutdown();
+            assertTrue(workerConnector.awaitShutdown(1000));
         }
     }
 


### PR DESCRIPTION
## Summary

When a connector enters FAILED during initialization, startup, or an external failure notification, connector-owned resources can remain allocated until a later shutdown request. This change performs the failure cleanup immediately while preserving FAILED status so a later STOPPED target-state request can still be processed.

The cleanup calls connector.stop() at most once for each start lifecycle, preserves the original failure if stop() also throws, and continues closing the connector context, metrics, and offset resources.

## Testing

- Added parameterized source/sink lifecycle tests for initialization failure, startup failure, external failure, and stop failure during cleanup.
- `./gradlew :connect:runtime:test --tests org.apache.kafka.connect.runtime.WorkerConnectorTest`
- `./gradlew :connect:runtime:test --tests org.apache.kafka.connect.integration.ConnectWorkerIntegrationTest.testStoppedState`
- `./gradlew :connect:runtime:spotlessCheck :connect:runtime:checkstyleMain :connect:runtime:checkstyleTest :connect:runtime:spotbugsMain`
- `./gradlew :connect:runtime:test` completed 1,529 tests with one unrelated timing-sensitive OffsetStorageReader test failure; that test passed when rerun independently.

This contribution is my original work, and I license it to the Apache Software Foundation under the Apache License, Version 2.0.