### PR TITLE
KAFKA-20692: Add unit tests for ToolsUtils

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/ToolsUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ToolsUtilsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ToolsUtilsTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldNotPrintMetricsWhenMetricsAreNullOrEmpty(final Map<MetricName, Metric> metrics) {
+        assertEquals("", ToolsTestUtils.captureStandardOut(() -> ToolsUtils.printMetrics(metrics)));
+    }
+
+    @Test
+    public void shouldPrintMetricsInSortedOrderWithTypeSpecificFormatting() {
+        final MetricName firstMetricName = new MetricName("first", "group", "first metric", Map.of());
+        final MetricName secondMetricName = new MetricName("second", "group", "second metric", Map.of());
+        final Map<MetricName, Metric> metrics = new LinkedHashMap<>();
+        metrics.put(secondMetricName, metric(secondMetricName, "not-a-number"));
+        metrics.put(firstMetricName, metric(firstMetricName, 1.23456d));
+
+        final String output = ToolsTestUtils.captureStandardOut(() -> ToolsUtils.printMetrics(metrics));
+
+        assertTrue(output.startsWith("Metric Name"));
+        assertTrue(output.contains("group:first:{}  : 1.235"));
+        assertTrue(output.contains("group:second:{} : not-a-number"));
+        assertTrue(output.indexOf("group:first:{}") < output.indexOf("group:second:{}"));
+    }
+
+    @Test
+    public void shouldPrintTableWithAlignedColumns() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (PrintStream out = new PrintStream(output, true, StandardCharsets.UTF_8)) {
+            ToolsUtils.prettyPrintTable(
+                List.of("Name", "Value"),
+                List.of(List.of("short", "1"), List.of("longer", "22")),
+                out
+            );
+        }
+
+        assertEquals("Name  \tValue\t\nshort \t1    \t\nlonger\t22   \t\n", output.toString(StandardCharsets.UTF_8));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"localhost:9092", "host1:9091,host2:9092", "[::1]:9092"})
+    public void shouldAcceptValidBootstrapServer(final String hostPort) {
+        ToolsUtils.validateBootstrapServer(hostPort);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"localhost", "localhost:not-a-port", "localhost:9092,invalid"})
+    public void shouldRejectInvalidBootstrapServer(final String hostPort) {
+        assertThrows(IllegalArgumentException.class, () -> ToolsUtils.validateBootstrapServer(hostPort));
+    }
+
+    @Test
+    public void shouldReturnEachDuplicateOnlyOnce() {
+        assertEquals(Set.of("alpha", "beta"), ToolsUtils.duplicates(List.of("alpha", "beta", "alpha", "beta", "beta")));
+        assertEquals(Set.of(), ToolsUtils.duplicates(List.of("alpha", "beta")));
+    }
+
+    @Test
+    public void shouldReturnCopyWithoutSpecifiedElements() {
+        final Set<String> source = Set.of("alpha", "beta", "gamma");
+
+        final Set<String> result = ToolsUtils.minus(source, "beta", "missing", "beta");
+
+        assertEquals(Set.of("alpha", "gamma"), result);
+        assertEquals(Set.of("alpha", "beta", "gamma"), source);
+        assertFalse(result == source);
+    }
+
+    private static Metric metric(final MetricName metricName, final Object value) {
+        return new Metric() {
+            @Override
+            public MetricName metricName() {
+                return metricName;
+            }
+
+            @Override
+            public Object metricValue() {
+                return value;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Add focused unit coverage for all public methods in `ToolsUtils`:

* deterministic metric ordering and type-specific formatting
* tabular output alignment
* valid and invalid bootstrap server addresses
* duplicate detection without repeated results
* non-mutating set subtraction

The tests document the existing behavior without changing production code.

## Tests

* `./gradlew :tools:test --tests org.apache.kafka.tools.ToolsUtilsTest --no-build-cache --console=plain`
* `./gradlew :tools:spotlessCheck :tools:checkstyleMain :tools:checkstyleTest :tools:spotbugsMain --no-build-cache --console=plain`
* `git diff --check`

The full `:tools:test` suite was also started. The new `ToolsUtilsTest` cases passed, while unrelated integration tests encountered environment/timing failures in SASL consumer-group discovery and Connect Raft server startup; the long-running suite was stopped after those failures were observed.