### PR TITLE
KAFKA-20448: Fix JVM Docker archive builds

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux ; \
     apk upgrade ; \
     apk add --no-cache bash; \
     mkdir opt/kafka; \
-    if [ -n "$kafka_url" ]; then \
+    if [ -n "${kafka_url:-}" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \
@@ -73,7 +73,7 @@ RUN mkdir opt/kafka; \
     apk update ; \
     apk upgrade ; \
     apk add --no-cache bash; \
-    if [ -n "$kafka_url" ]; then \
+    if [ -n "${kafka_url:-}" ]; then \
         apk add --no-cache wget gcompat gpg gpg-agent procps; \
         wget -nv -O kafka.tgz "$kafka_url"; \
         wget -nv -O kafka.tgz.asc "$kafka_url.asc"; \

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -19,7 +19,9 @@ TOPIC="test-topic"
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c opt/kafka/config/server.properties
 
+# Keep the server PID because Alpine's BusyBox ps can truncate long Java command lines.
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=kafka.jsa" opt/kafka/bin/kafka-server-start.sh opt/kafka/config/server.properties &
+KAFKA_SERVER_PID=$!
 
 check_timeout() {
     if [ $TIMEOUT -eq 0 ]; then
@@ -39,7 +41,8 @@ echo "test" | opt/kafka/bin/kafka-console-producer.sh --topic $TOPIC --bootstrap
 opt/kafka/bin/kafka-console-consumer.sh --topic $TOPIC --from-beginning --bootstrap-server localhost:9092 --max-messages 1 --timeout-ms 20000
 [ $? -eq 0 ] || exit 1
 
-opt/kafka/bin/kafka-server-stop.sh
+kill -TERM "$KAFKA_SERVER_PID"
+wait "$KAFKA_SERVER_PID" || true
 
 # Wait until jsa file is generated
 TIMEOUT=20


### PR DESCRIPTION
## Summary
* Allow both JVM Docker stages to use a local Kafka archive when kafka_url is omitted.
* Capture the broker PID during CDS archive generation so shutdown does not depend on truncated Alpine BusyBox ps output.
* Preserve the existing URL download and signature verification path.

## Tests
* RED: docker/docker_build_test.py with --image-type=jvm, --kafka-archive, and --build failed before this change with kafka_url: parameter not set.
* GREEN: the same local-archive JVM Docker build passed after this change, including the JSA generation stage.
* bash -n docker/jvm/jsa_launch
* git diff --check

Reviewers: Sean Quah <squah@confluent.io>
