### PR TITLE
KAFKA-19558: Batch consumer group descriptions

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommand.java
@@ -80,6 +80,8 @@ import joptsimple.OptionSpec;
 public class ConsumerGroupCommand {
 
     static final String MISSING_COLUMN_VALUE = "-";
+    // Keep each describe request bounded so --all-groups remains usable on large clusters.
+    static final int DESCRIBE_GROUPS_BATCH_SIZE = 50;
 
     public static void main(String[] args) {
         ConsumerGroupCommandOptions opts = ConsumerGroupCommandOptions.fromArgs(args);
@@ -806,13 +808,17 @@ public class ConsumerGroupCommand {
 
         Map<String, ConsumerGroupDescription> describeConsumerGroups(Collection<String> groupIds) throws Exception {
             Map<String, ConsumerGroupDescription> res = new HashMap<>();
-            Map<String, KafkaFuture<ConsumerGroupDescription>> stringKafkaFutureMap = adminClient.describeConsumerGroups(
-                groupIds,
-                withTimeoutMs(new DescribeConsumerGroupsOptions())
-            ).describedGroups();
+            List<String> groupIdList = new ArrayList<>(groupIds);
+            for (int batchStart = 0; batchStart < groupIdList.size(); batchStart += DESCRIBE_GROUPS_BATCH_SIZE) {
+                int batchEnd = Math.min(batchStart + DESCRIBE_GROUPS_BATCH_SIZE, groupIdList.size());
+                Map<String, KafkaFuture<ConsumerGroupDescription>> descriptions = adminClient.describeConsumerGroups(
+                    groupIdList.subList(batchStart, batchEnd),
+                    withTimeoutMs(new DescribeConsumerGroupsOptions())
+                ).describedGroups();
 
-            for (Entry<String, KafkaFuture<ConsumerGroupDescription>> e : stringKafkaFutureMap.entrySet()) {
-                res.put(e.getKey(), e.getValue().get());
+                for (Entry<String, KafkaFuture<ConsumerGroupDescription>> description : descriptions.entrySet()) {
+                    res.put(description.getKey(), description.getValue().get());
+                }
             }
             return res;
         }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupServiceTest.java
@@ -104,6 +104,27 @@ public class ConsumerGroupServiceTest {
     }
 
     @Test
+    public void testDescribeConsumerGroupsIsBatched() throws Exception {
+        List<String> groups = IntStream.range(0, 101).mapToObj(i -> "group-" + i).toList();
+        ConsumerGroupCommand.ConsumerGroupService groupService = consumerGroupService(
+            new String[]{"--bootstrap-server", "localhost:9092", "--group", GROUP, "--describe", "--state"});
+
+        when(admin.describeConsumerGroups(any(), any())).thenAnswer(invocation -> {
+            Collection<String> requestedGroups = invocation.getArgument(0);
+            assertTrue(requestedGroups.size() <= ConsumerGroupCommand.DESCRIBE_GROUPS_BATCH_SIZE);
+            Map<String, KafkaFuture<ConsumerGroupDescription>> descriptions = requestedGroups.stream().collect(Collectors.toMap(
+                Function.identity(), group -> KafkaFuture.completedFuture(describeGroup(group))));
+            return new DescribeConsumerGroupsResult(descriptions);
+        });
+
+        Map<String, ConsumerGroupDescription> descriptions = groupService.describeConsumerGroups(groups);
+
+        assertEquals(groups.size(), descriptions.size());
+        assertEquals(Set.copyOf(groups), descriptions.keySet());
+        verify(admin, times(3)).describeConsumerGroups(any(), any());
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     public void testAdminRequestsForDescribeNegativeOffsets() throws Exception {
         String[] args = new String[]{"--bootstrap-server", "localhost:9092", "--group", GROUP, "--describe", "--offsets"};
@@ -274,6 +295,30 @@ public class ConsumerGroupServiceTest {
         KafkaFutureImpl<ConsumerGroupDescription> future = new KafkaFutureImpl<>();
         future.complete(description);
         return new DescribeConsumerGroupsResult(Map.of(GROUP, future));
+    }
+
+    @SuppressWarnings("deprecation")
+    private ConsumerGroupDescription describeGroup(String groupId) {
+        return new ConsumerGroupDescription(groupId,
+            true,
+            Set.of(new MemberDescription(
+                "member-" + groupId,
+                Optional.empty(),
+                Optional.empty(),
+                "client",
+                "host",
+                new MemberAssignment(Set.of()),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()
+            )),
+            RangeAssignor.class.getName(),
+            GroupType.CLASSIC,
+            GroupState.STABLE,
+            new Node(1, "localhost", 9092),
+            Set.of(),
+            Optional.empty(),
+            Optional.empty());
     }
 
     private ListConsumerGroupOffsetsResult listGroupOffsetsResult(String groupId) {


### PR DESCRIPTION
## Summary
* Split consumer group describe requests into batches of at most 50 groups.
* Preserve the existing result aggregation and output behavior for individual and all-group descriptions.
* Keep the change scoped to describe operations, which avoids changing the existing offset reset behavior.

## Tests
* RED: ConsumerGroupServiceTest.testDescribeConsumerGroupsIsBatched failed before the change because 101 group IDs were sent in one request.
* GREEN: ConsumerGroupServiceTest.testDescribeConsumerGroupsIsBatched
* ConsumerGroupServiceTest
* DescribeConsumerGroupTest.testDescribeAllExistingGroups
* Checkstyle, SpotBugs, and Spotless