### PR TITLE
KAFKA-20881: Ignore javadoc jars in Connect classpath

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -316,7 +316,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         lib_dir = self.path.home() + relative_path
         for pwd, dirs, files in os.walk(local_dir):
             for file in files:
-                if file.endswith(".jar"):
+                if file.endswith(".jar") and not file.endswith("-javadoc.jar"):
                     # Use the expected directory on the node instead of the path in the driver node
                     file_path = lib_dir + file
                     self.logger.info("Appending %s to Connect worker's CLASSPATH" % file_path)

--- a/tests/unit/services/check_connect.py
+++ b/tests/unit/services/check_connect.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import Mock, patch
+
+from kafkatest.services.connect import ConnectServiceBase
+
+
+class CheckConnectServiceBase(object):
+    def check_append_module_to_classpath_ignores_javadoc_jar(self):
+        service = Mock()
+        service.path.home.return_value = "/opt/kafka-dev"
+
+        jar_files = [
+            "connect-file-4.0.0-SNAPSHOT-javadoc.jar",
+            "connect-file-4.0.0-SNAPSHOT.jar",
+        ]
+        with patch("kafkatest.services.connect.os.getcwd", return_value="/workspace"), \
+                patch("kafkatest.services.connect.os.walk", return_value=[("", [], jar_files)]):
+            classpath = ConnectServiceBase.append_module_to_classpath(service, "file")
+
+        assert classpath == "export CLASSPATH=${CLASSPATH}:/opt/kafka-dev/connect/file/build/libs/connect-file-4.0.0-SNAPSHOT.jar; "

--- a/tests/unit/services/check_connect.py
+++ b/tests/unit/services/check_connect.py
@@ -20,15 +20,25 @@ from kafkatest.services.connect import ConnectServiceBase
 
 class CheckConnectServiceBase(object):
     def check_append_module_to_classpath_ignores_javadoc_jar(self):
+        classpath = self._append_module_to_classpath([
+            "connect-file-4.0.0-SNAPSHOT-javadoc.jar",
+            "connect-file-4.0.0-SNAPSHOT.jar",
+        ])
+
+        assert classpath == "export CLASSPATH=${CLASSPATH}:/opt/kafka-dev/connect/file/build/libs/connect-file-4.0.0-SNAPSHOT.jar; "
+
+    def check_append_module_to_classpath_returns_empty_for_javadoc_only(self):
+        classpath = self._append_module_to_classpath([
+            "connect-file-4.0.0-SNAPSHOT-javadoc.jar",
+        ])
+
+        assert classpath == ""
+
+    @staticmethod
+    def _append_module_to_classpath(jar_files):
         service = Mock()
         service.path.home.return_value = "/opt/kafka-dev"
 
-        jar_files = [
-            "connect-file-4.0.0-SNAPSHOT-javadoc.jar",
-            "connect-file-4.0.0-SNAPSHOT.jar",
-        ]
         with patch("kafkatest.services.connect.os.getcwd", return_value="/workspace"), \
                 patch("kafkatest.services.connect.os.walk", return_value=[("", [], jar_files)]):
-            classpath = ConnectServiceBase.append_module_to_classpath(service, "file")
-
-        assert classpath == "export CLASSPATH=${CLASSPATH}:/opt/kafka-dev/connect/file/build/libs/connect-file-4.0.0-SNAPSHOT.jar; "
+            return ConnectServiceBase.append_module_to_classpath(service, "file")


### PR DESCRIPTION
## Summary

KAFKA-20881 reports that Connect system tests can select the generated javadoc JAR as the file connector plugin after KAFKA-20032 began generating javadocs consistently. This change skips javadoc JARs when selecting a plugin artifact, so the runtime connector JAR is appended to the worker classpath.

## Testing

- TDD RED: the focused unit test selected connect-file-4.0.0-SNAPSHOT-javadoc.jar with the pre-change implementation.
- TDD GREEN: the focused unit test passes after excluding -javadoc.jar.
- Full system-test unit suite: 7 passed.
- Python compileall passed.
- git diff --check passed.

No public API, protocol, or configuration changes.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
