### PR TITLE
KAFKA-20857: Use Java 25 in Docker images

### DIFF
--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM docker.io/library/eclipse-temurin:21-jre-alpine AS build-jsa
+FROM docker.io/library/eclipse-temurin:25-jre-alpine AS build-jsa
 
 USER root
 
@@ -49,7 +49,7 @@ RUN set -eux ; \
 RUN /etc/kafka/docker/jsa_launch
 
 
-FROM docker.io/library/eclipse-temurin:21-jre-alpine
+FROM docker.io/library/eclipse-temurin:25-jre-alpine
 
 # exposed ports
 EXPOSE 9092

--- a/docker/jvm/jsa_launch
+++ b/docker/jvm/jsa_launch
@@ -20,6 +20,7 @@ TOPIC="test-topic"
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=storage.jsa" opt/kafka/bin/kafka-storage.sh format --standalone -t $KAFKA_CLUSTER_ID -c opt/kafka/config/server.properties
 
 KAFKA_JVM_PERFORMANCE_OPTS="-XX:ArchiveClassesAtExit=kafka.jsa" opt/kafka/bin/kafka-server-start.sh opt/kafka/config/server.properties &
+KAFKA_PID=$!
 
 check_timeout() {
     if [ $TIMEOUT -eq 0 ]; then
@@ -39,7 +40,11 @@ echo "test" | opt/kafka/bin/kafka-console-producer.sh --topic $TOPIC --bootstrap
 opt/kafka/bin/kafka-console-consumer.sh --topic $TOPIC --from-beginning --bootstrap-server localhost:9092 --max-messages 1 --timeout-ms 20000
 [ $? -eq 0 ] || exit 1
 
-opt/kafka/bin/kafka-server-stop.sh
+# Keep the server PID instead of rediscovering it from `ps`. The JVM command
+# line contains a long classpath, which can be truncated before kafka.Kafka is
+# visible to process-name matching.
+kill -TERM "$KAFKA_PID"
+wait "$KAFKA_PID" || true
 
 # Wait until jsa file is generated
 TIMEOUT=20

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:21 AS build-native-image
+FROM ghcr.io/graalvm/graalvm-community:25 AS build-native-image
 
 ARG kafka_url
 

--- a/docker/native/Dockerfile
+++ b/docker/native/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:25 AS build-native-image
+FROM ghcr.io/graalvm/graalvm-community:25i2 AS build-native-image
 
 ARG kafka_url
 

--- a/docker/native/README.md
+++ b/docker/native/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 - The Native Apache Kafka Docker Image can launch brokers with sub-second startup time and minimal memory footprint by leveraging native Kafka executable.
-- The native Kafka executable is built by compiling Apache Kafka code ahead-of-time using the [GraalVM native-image tool](https://www.graalvm.org/jdk21/reference-manual/native-image/).
+- The native Kafka executable is built by compiling Apache Kafka code ahead-of-time using the [GraalVM native-image tool](https://www.graalvm.org/latest/reference-manual/native-image/).
 - This image is experimental and intended for local development and testing purposes only; it is not recommended for production use.
 - This is introduced with [KIP-974](https://cwiki.apache.org/confluence/x/KZizDw).
 
@@ -33,4 +33,3 @@ Check out [this](../README.md) guide.
 
 ## How to run system tests on native Apache Kafka
 Check out [this](../../tests/README.md#running-tests-using-docker) guide.
-


### PR DESCRIPTION
### What

Update the JVM and native Docker build images to Java 25, the latest LTS supported by Kafka.

- Use Eclipse Temurin 25 JRE Alpine for JVM image build and runtime stages.
- Use GraalVM Community 25 for native-image compilation.
- Stop the JVM used for dynamic CDS generation by its captured PID so the JSA archive is generated reliably despite long classpaths being truncated by process discovery.

### Testing

- `./gradlew releaseTarGz --no-build-cache --console=plain`
- JVM Docker build stage and final image build with Java 25 passed.
- JVM JSA generation exercised Kafka startup, topic creation, produce, consume, and graceful shutdown; both `kafka.jsa` and `storage.jsa` were produced.
- JVM image smoke test: `kafka-topics.sh --version` -> `4.4.0-SNAPSHOT`.
- GraalVM Community 25 native-image build and final image build passed.
- Native image smoke test: `kafka.Kafka --help`.
- `bash -n docker/jvm/jsa_launch docker/native/native_command.sh`
- `git diff --check`

This change does not modify Kafka APIs, protocols, or configuration semantics, so no KIP is required.

Reviewers: Arthur S (github:arixmkii), Gaurav Narula <gaurav_narula2@apple.com>
