### PR TITLE
KAFKA-20853: Remove invalid local Maven publishing guidance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,6 @@ subprojects {
 
     publishing {
       repositories {
-        // To test locally, invoke gradlew with `-PmavenUrl=file:///some/local/path`
         maven {
           url = mavenUrl
           credentials {


### PR DESCRIPTION
### What

Remove the Gradle comment that tells contributors to publish to a local `file:` Maven repository with `-PmavenUrl`. Gradle configures credentials for the repository, so that command fails with `Authentication scheme 'all' is not supported by protocol 'file'`. The supported local workflow is `publishToMavenLocal`.

### Testing

- RED: `./gradlew :clients:publishMavenJavaPublicationToMavenRepository -PmavenUrl=file:///tmp/... -PmavenUsername=unused -PmavenPassword=unused --no-daemon --no-build-cache --console=plain` reproduced the reported authentication failure.
- GREEN: `./gradlew :clients:publishToMavenLocal --no-daemon --no-build-cache --console=plain` passed.
- `./gradlew spotlessCheck --no-daemon --no-build-cache --console=plain` passed.
- `git diff --check` passed.

Documentation-only Gradle change; no API, protocol, or KIP impact.

Reviewers: Uros (github:uros-b)
