### PR TITLE
KAFKA-20850: Test suppress changelog upgrade and downgrade

### DIFF
--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -324,7 +324,17 @@ class StreamsTestBaseService(KafkaPathResolverMixin, JmxMixin, Service):
 class StreamsSmokeTestBaseService(StreamsTestBaseService):
     """Base class for Streams Smoke Test services providing some common settings and functionality"""
 
-    def __init__(self, test_context, kafka, command, processing_guarantee = 'at_least_once', group_protocol = 'classic', num_threads = 3, replication_factor = 3, transactional = False):
+    def __init__(
+            self,
+            test_context,
+            kafka,
+            command,
+            processing_guarantee='at_least_once',
+            group_protocol='classic',
+            num_threads=3,
+            replication_factor=3,
+            transactional=False,
+            extra_configs=None):
         super(StreamsSmokeTestBaseService, self).__init__(test_context,
                                                           kafka,
                                                           "org.apache.kafka.streams.tests.StreamsSmokeTest",
@@ -336,6 +346,7 @@ class StreamsSmokeTestBaseService(StreamsTestBaseService):
         self.UPGRADE_FROM = None
         self.REPLICATION_FACTOR = replication_factor
         self.TRANSACTIONAL = transactional
+        self.EXTRA_CONFIGS = extra_configs or {}
 
     def set_version(self, kafka_streams_version):
         self.KAFKA_STREAMS_VERSION = kafka_streams_version
@@ -364,6 +375,8 @@ class StreamsSmokeTestBaseService(StreamsTestBaseService):
 
         if self.TRANSACTIONAL:
             properties['enable.transactional.statestores'] = "true"
+
+        properties.update(self.EXTRA_CONFIGS)
 
         cfg = KafkaConfig(**properties)
         return cfg.render()
@@ -419,8 +432,27 @@ class StreamsSmokeTestDriverService(StreamsSmokeTestBaseService):
         return cmd
 
 class StreamsSmokeTestJobRunnerService(StreamsSmokeTestBaseService):
-    def __init__(self, test_context, kafka, processing_guarantee, group_protocol = 'classic', num_threads = 3, replication_factor = 3, transactional = False):
-        super(StreamsSmokeTestJobRunnerService, self).__init__(test_context, kafka, "process", processing_guarantee, group_protocol, num_threads, replication_factor, transactional)
+    def __init__(
+            self,
+            test_context,
+            kafka,
+            processing_guarantee,
+            group_protocol='classic',
+            num_threads=3,
+            replication_factor=3,
+            transactional=False,
+            extra_configs=None):
+        super(StreamsSmokeTestJobRunnerService, self).__init__(
+            test_context,
+            kafka,
+            "process",
+            processing_guarantee,
+            group_protocol,
+            num_threads,
+            replication_factor,
+            transactional,
+            extra_configs
+        )
 
 class StreamsSmokeTestShutdownDeadlockService(StreamsSmokeTestBaseService):
     def __init__(self, test_context, kafka):

--- a/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
@@ -32,6 +32,8 @@ smoke_test_versions = [str(LATEST_2_4), str(LATEST_2_5), str(LATEST_2_6),
                        str(LATEST_3_7), str(LATEST_3_8), str(LATEST_3_9),
                        str(LATEST_4_0), str(LATEST_4_1), str(LATEST_4_2),
                        str(LATEST_4_3)]
+DSL_STORE_FORMAT_CONFIG = "dsl.store.format"
+DSL_STORE_FORMAT_HEADERS = "HEADERS"
 
 class StreamsUpgradeTest(Test):
     """
@@ -63,9 +65,32 @@ class StreamsUpgradeTest(Test):
         """
         Starts 3 KafkaStreams instances with <old_version>, and upgrades one-by-one to <new_version>
         """
+        self._run_app_transition(from_version, str(DEV_VERSION), bounce_type)
 
-        to_version = str(DEV_VERSION)
+    @cluster(num_nodes=9)
+    @matrix(direction=["upgrade", "downgrade"], metadata_quorum=[quorum.combined_kraft])
+    def test_app_upgrade_downgrade_with_headers(self, direction, metadata_quorum):
+        """
+        Verifies that suppress() changelogs remain readable when the DSL store format is HEADERS.
 
+        The test covers both directions across the 4.3/4.4 boundary because 4.3 is the first
+        release that supports the headers-aware DSL store format.
+        """
+        transition_versions = {
+            "upgrade": (str(LATEST_4_3), str(DEV_VERSION)),
+            "downgrade": (str(DEV_VERSION), str(LATEST_4_3)),
+        }
+        from_version, to_version = transition_versions[direction]
+
+        self._run_app_transition(
+            from_version=from_version,
+            to_version=to_version,
+            bounce_type="full",
+            extra_configs={DSL_STORE_FORMAT_CONFIG: DSL_STORE_FORMAT_HEADERS}
+        )
+
+    def _run_app_transition(self, from_version, to_version, bounce_type, extra_configs=None):
+        """Run a Streams application transition while preserving the existing smoke workload."""
         if from_version == to_version:
             return
 
@@ -89,9 +114,27 @@ class StreamsUpgradeTest(Test):
 
         self.driver = StreamsSmokeTestDriverService(self.test_context, self.kafka)
         self.driver.disable_auto_terminate()
-        self.processor1 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee = "at_least_once", replication_factor = 1)
-        self.processor2 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee = "at_least_once", replication_factor = 1)
-        self.processor3 = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, processing_guarantee = "at_least_once", replication_factor = 1)
+        self.processor1 = StreamsSmokeTestJobRunnerService(
+            self.test_context,
+            self.kafka,
+            processing_guarantee="at_least_once",
+            replication_factor=1,
+            extra_configs=extra_configs
+        )
+        self.processor2 = StreamsSmokeTestJobRunnerService(
+            self.test_context,
+            self.kafka,
+            processing_guarantee="at_least_once",
+            replication_factor=1,
+            extra_configs=extra_configs
+        )
+        self.processor3 = StreamsSmokeTestJobRunnerService(
+            self.test_context,
+            self.kafka,
+            processing_guarantee="at_least_once",
+            replication_factor=1,
+            extra_configs=extra_configs
+        )
 
         self.purge_state_dir(self.processor1)
         self.purge_state_dir(self.processor2)


### PR DESCRIPTION
### What

Add system-test coverage for the headers-aware `suppress()` changelog across the 4.3/4.4 boundary.

- Allow Streams smoke job runners to receive additional Streams properties.
- Configure `dsl.store.format=HEADERS` for the new coverage.
- Exercise both `LATEST_4_3 -> DEV_VERSION` and `DEV_VERSION -> LATEST_4_3` full restarts.
- Extract the shared application transition setup so the existing upgrade matrix keeps the same behavior.

The test keeps the existing suppress() topology and continuously generates the smoke workload while all three processors are restarted. Each processor must rejoin, process records after the restart, and close cleanly; a changelog restore failure surfaces as a startup, processing, or shutdown failure. This test intentionally does not claim a separate final output-topic comparison because the driver runs in `disableAutoTerminate` mode during the transition.

### Testing

- RED: a pre-change contract check failed because the HEADERS property and bidirectional test were absent.
- GREEN: `python3 -m py_compile tests/kafkatest/services/streams.py tests/kafkatest/tests/streams/streams_application_upgrade_test.py`.
- GREEN: service property rendering confirmed `dsl.store.format=HEADERS`.
- `./gradlew :streams:test --tests org.apache.kafka.streams.DslStoreFormatTest :streams:compileTestFixturesJava :streams:spotlessCheck` passed.
- `git diff --check` passed.

The Ducktape system test itself was not executed locally because this environment has no Kafka system-test cluster. No API, protocol, or KIP changes.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>
