### PR TITLE
KAFKA-20855: Extract bootstrap resolution from NetworkClient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/BootstrapServerResolver.java
+++ b/clients/src/main/java/org/apache/kafka/clients/BootstrapServerResolver.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.errors.BootstrapResolutionException;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.common.utils.internals.ThreadUtils;
+
+import org.slf4j.Logger;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolves the configured bootstrap servers without blocking the network client event loop.
+ *
+ * <p>The resolver owns the asynchronous DNS operation and its timeout/retry state. The caller remains responsible
+ * for deciding whether metadata still needs to be bootstrapped and for applying the resolved addresses.</p>
+ *
+ * <p>This class is not thread-safe. {@link #ensureBootstrapped(long, MetadataUpdater)} must be called from the
+ * client's event loop.</p>
+ */
+final class BootstrapServerResolver implements AutoCloseable {
+    @FunctionalInterface
+    interface AddressResolver {
+        List<InetSocketAddress> resolve();
+    }
+
+    private final BootstrapConfiguration configuration;
+    private final Time time;
+    private final Logger log;
+    private final AddressResolver addressResolver;
+    private final ExecutorService executor;
+
+    private Timer timer;
+    private CompletableFuture<List<InetSocketAddress>> pendingResolution;
+    private long retryAtMs = -1L;
+    private BootstrapResolutionException exception;
+
+    BootstrapServerResolver(BootstrapConfiguration configuration, Time time, LogContext logContext) {
+        this(configuration, time, logContext, () -> ClientUtils.parseAddresses(
+            configuration.bootstrapServers,
+            configuration.clientDnsLookup));
+    }
+
+    BootstrapServerResolver(BootstrapConfiguration configuration,
+                            Time time,
+                            LogContext logContext,
+                            AddressResolver addressResolver) {
+        this.configuration = configuration;
+        this.time = time;
+        this.log = logContext.logger(BootstrapServerResolver.class);
+        this.addressResolver = Objects.requireNonNull(addressResolver, "addressResolver must not be null");
+
+        if (configuration == BootstrapConfiguration.DISABLED) {
+            this.executor = null;
+        } else {
+            this.executor = Executors.newSingleThreadExecutor(
+                ThreadUtils.createThreadFactory("kafka-bootstrap-dns-resolver", true));
+            startResolution();
+        }
+    }
+
+    void ensureBootstrapped(final long currentTimeMs, final MetadataUpdater metadataUpdater) {
+        if (configuration == BootstrapConfiguration.DISABLED || metadataUpdater.isBootstrapped() || exception != null)
+            return;
+
+        if (Thread.interrupted()) {
+            cancelResolution();
+            throw new InterruptException(new InterruptedException());
+        }
+
+        // Start the timer on the first poll so time spent constructing an idle client does not consume the timeout.
+        if (timer == null)
+            timer = time.timer(configuration.bootstrapResolveTimeoutMs);
+
+        // Process a result before checking the timeout so a result completed at the deadline is accepted.
+        if (maybeProcessResolutionResult(currentTimeMs, metadataUpdater))
+            return;
+
+        timer.update(currentTimeMs);
+        checkTimeout(metadataUpdater);
+        maybeStartResolution(currentTimeMs);
+    }
+
+    private void startResolution() {
+        pendingResolution = CompletableFuture.supplyAsync(addressResolver::resolve, executor);
+    }
+
+    private void cancelResolution() {
+        if (pendingResolution != null) {
+            pendingResolution.cancel(true);
+            pendingResolution = null;
+        }
+        retryAtMs = -1L;
+    }
+
+    private void checkTimeout(MetadataUpdater metadataUpdater) {
+        if (timer.isExpired() && exception == null) {
+            cancelResolution();
+            exception = new BootstrapResolutionException("Failed to resolve bootstrap servers after "
+                + configuration.bootstrapResolveTimeoutMs + "ms. Please check your bootstrap.servers configuration "
+                + "and DNS settings.");
+            metadataUpdater.bootstrapFailed(exception);
+        }
+    }
+
+    private void maybeStartResolution(final long currentTimeMs) {
+        if (exception != null || pendingResolution != null)
+            return;
+
+        if (retryAtMs >= 0 && currentTimeMs < retryAtMs)
+            return;
+
+        retryAtMs = -1L;
+        startResolution();
+    }
+
+    private boolean maybeProcessResolutionResult(final long currentTimeMs, MetadataUpdater metadataUpdater) {
+        if (pendingResolution == null || !pendingResolution.isDone())
+            return false;
+
+        List<InetSocketAddress> servers = List.of();
+        try {
+            servers = pendingResolution.getNow(List.of());
+        } catch (CompletionException e) {
+            log.debug("DNS resolution failed", e);
+        }
+        pendingResolution = null;
+
+        if (!servers.isEmpty()) {
+            log.debug("Bootstrap DNS resolution succeeded, {} servers resolved", servers.size());
+            metadataUpdater.bootstrap(servers);
+            return true;
+        }
+
+        log.debug("Failed to resolve bootstrap servers, will retry after {}ms. Remaining time: {}ms",
+            configuration.retryBackoffMs, timer.remainingMs());
+        retryAtMs = currentTimeMs + configuration.retryBackoffMs;
+        return false;
+    }
+
+    @Override
+    public void close() {
+        cancelResolution();
+        ThreadUtils.shutdownExecutorServiceQuietly(executor, 1, TimeUnit.SECONDS);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.BootstrapResolutionException;
 import org.apache.kafka.common.errors.DisconnectException;
-import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.metrics.Sensor;
@@ -49,10 +48,8 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.telemetry.internals.ClientTelemetrySender;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.LogContext;
-import org.apache.kafka.common.utils.internals.ThreadUtils;
 
 import org.slf4j.Logger;
 
@@ -70,11 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -152,15 +144,7 @@ public class NetworkClient implements KafkaClient {
 
     private final BootstrapConfiguration bootstrapConfiguration;
 
-    private Timer bootstrapTimer;
-
-    private CompletableFuture<List<InetSocketAddress>> pendingBootstrapResolution;
-
-    private volatile long bootstrapResolutionRetryMs = -1L;
-
-    private BootstrapResolutionException bootstrapException = null;
-
-    private final ExecutorService bootstrapExecutor;
+    private final BootstrapServerResolver bootstrapServerResolver;
 
     private final TelemetrySender telemetrySender;
 
@@ -390,27 +374,7 @@ public class NetworkClient implements KafkaClient {
         this.metadataRecoveryStrategy = metadataRecoveryStrategy;
         this.metadataClusterCheckEnable = metadataClusterCheckEnable;
         this.bootstrapConfiguration = bootstrapConfiguration;
-        // Bootstrap timer is lazily initialized on the first poll so its budget represents
-        // "time we spend on bootstrap once polling begins" — an idle gap between construction
-        // and the first poll should not eat into that budget.
-        this.bootstrapTimer = null;
-        // Create executor for async DNS resolution if bootstrap is enabled
-        if (bootstrapConfiguration != BootstrapConfiguration.DISABLED) {
-            this.bootstrapExecutor = Executors.newSingleThreadExecutor(ThreadUtils.createThreadFactory("kafka-bootstrap-dns-resolver", true));
-            // Kick off the first DNS resolution eagerly so it overlaps with the caller finishing
-            // construction. We deliberately don't start the timer here (see field comment);
-            // poll() remains the driver — it starts the timer, observes the result, propagates
-            // errors, and drives retries.
-            this.pendingBootstrapResolution = CompletableFuture.supplyAsync(
-                () -> ClientUtils.parseAddresses(
-                    bootstrapConfiguration.bootstrapServers,
-                    bootstrapConfiguration.clientDnsLookup
-                ),
-                bootstrapExecutor
-            );
-        } else {
-            this.bootstrapExecutor = null;
-        }
+        this.bootstrapServerResolver = new BootstrapServerResolver(bootstrapConfiguration, time, logContext);
     }
 
     /**
@@ -802,8 +766,7 @@ public class NetworkClient implements KafkaClient {
     public void close() {
         state.compareAndSet(State.ACTIVE, State.CLOSING);
         if (state.compareAndSet(State.CLOSING, State.CLOSED)) {
-            cancelBootstrapResolution();
-            ThreadUtils.shutdownExecutorServiceQuietly(bootstrapExecutor, 1, TimeUnit.SECONDS);
+            bootstrapServerResolver.close();
             this.selector.close();
             this.metadataUpdater.close();
             if (telemetrySender != null)
@@ -811,14 +774,6 @@ public class NetworkClient implements KafkaClient {
         } else {
             log.warn("Attempting to close NetworkClient that has already been closed.");
         }
-    }
-
-    private void cancelBootstrapResolution() {
-        if (pendingBootstrapResolution != null) {
-            pendingBootstrapResolution.cancel(true);
-            pendingBootstrapResolution = null;
-        }
-        bootstrapResolutionRetryMs = -1L;
     }
 
     /**
@@ -1288,117 +1243,14 @@ public class NetworkClient implements KafkaClient {
 
     /**
      * Attempts to resolve bootstrap server addresses via DNS and create an initial bootstrap cluster.
-     * This method is called from {@link #poll(long, long)} and uses a truly asynchronous approach
-     * to avoid blocking on DNS resolution.
-     *
-     * <p>DNS resolution is performed on a separate thread via {@link CompletableFuture}. This ensures
-     * the event loop remains responsive even if DNS lookups block or take a long time. The bootstrap
-     * timeout can interrupt a pending DNS resolution, unlike synchronous approaches.
+     * This method is called from {@link #poll(long, long)}. The resolver keeps DNS work and retry state
+     * outside of the network client's event-loop logic.
      *
      * @param currentTimeMs The current time in milliseconds
      * @throws BootstrapResolutionException if the bootstrap timeout expires before DNS resolution succeeds
      */
     void ensureBootstrapped(final long currentTimeMs) {
-        if (bootstrapConfiguration == BootstrapConfiguration.DISABLED || metadataUpdater.isBootstrapped())
-            return;
-
-        if (bootstrapException != null)
-            return;
-
-        if (Thread.interrupted()) {
-            cancelBootstrapResolution();
-            throw new InterruptException(new InterruptedException());
-        }
-
-        // Start the timer on the first poll so its budget represents "time we spend on
-        // bootstrap since polling began" — the caller may have created the client well before
-        // its first API call, and we don't want that idle gap to eat into the budget.
-        if (bootstrapTimer == null)
-            bootstrapTimer = time.timer(bootstrapConfiguration.bootstrapResolveTimeoutMs);
-
-        // Check if a pending resolution completed before checking the timeout, so that a
-        // result arriving at the same time as the deadline is not incorrectly rejected.
-        if (maybeProcessBootstrapResolutionResult(currentTimeMs))
-            return;
-
-        // Record a timeout failure before possibly triggering a new resolution.
-        // maybeStartBootstrapResolution skips if bootstrapException is set, so we
-        // don't kick off a fresh resolution after the failure has been recorded.
-        bootstrapTimer.update(currentTimeMs);
-        checkBootstrapTimeout();
-        maybeStartBootstrapResolution(currentTimeMs);
-    }
-
-    /**
-     * Record a permanent bootstrap failure on the metadata if the timeout has expired.
-     * The error is not thrown here; callers observe it through their metadata layer
-     * (e.g. {@link Metadata#maybeThrowFatalException()} for Producer/Consumer, or
-     * {@code AdminMetadataManager#bootstrapFatalException()} for AdminClient).
-     */
-    private void checkBootstrapTimeout() {
-        if (bootstrapTimer.isExpired() && bootstrapException == null) {
-            cancelBootstrapResolution();
-            bootstrapException = new BootstrapResolutionException("Failed to resolve bootstrap servers after " +
-                bootstrapConfiguration.bootstrapResolveTimeoutMs + "ms. " +
-                "Please check your bootstrap.servers configuration and DNS settings.");
-            metadataUpdater.bootstrapFailed(bootstrapException);
-        }
-    }
-
-    /**
-     * Trigger a new async DNS resolution if none is in progress and the retry backoff has elapsed.
-     */
-    private void maybeStartBootstrapResolution(final long currentTimeMs) {
-        if (bootstrapException != null)
-            return;
-
-        if (pendingBootstrapResolution != null)
-            return;
-
-        if (bootstrapResolutionRetryMs >= 0 && currentTimeMs < bootstrapResolutionRetryMs)
-            return;
-
-        bootstrapResolutionRetryMs = -1L;
-        if (bootstrapTimer == null)
-            bootstrapTimer = time.timer(bootstrapConfiguration.bootstrapResolveTimeoutMs);
-
-        pendingBootstrapResolution = CompletableFuture.supplyAsync(
-            () -> ClientUtils.parseAddresses(
-                bootstrapConfiguration.bootstrapServers,
-                bootstrapConfiguration.clientDnsLookup
-            ),
-            bootstrapExecutor
-        );
-    }
-
-    /**
-     * Check if a pending bootstrap DNS resolution has completed and process its result.
-     *
-     * @return true if the client is now bootstrapped and the caller should early return.
-     */
-    private boolean maybeProcessBootstrapResolutionResult(final long currentTimeMs) {
-        if (pendingBootstrapResolution == null || !pendingBootstrapResolution.isDone())
-            return false;
-
-        List<InetSocketAddress> servers = List.of();
-        try {
-            servers = pendingBootstrapResolution.getNow(List.of());
-        } catch (CompletionException e) {
-            log.debug("DNS resolution failed", e);
-        }
-
-        pendingBootstrapResolution = null;
-
-        if (!servers.isEmpty()) {
-            log.debug("Bootstrap DNS resolution succeeded, {} servers resolved", servers.size());
-            metadataUpdater.bootstrap(servers);
-            return true;
-        }
-
-        log.debug("Failed to resolve bootstrap servers, will retry after {}ms. Remaining time: {}ms",
-            bootstrapConfiguration.retryBackoffMs, bootstrapTimer.remainingMs());
-        bootstrapResolutionRetryMs = currentTimeMs + bootstrapConfiguration.retryBackoffMs;
-        return false;
+        bootstrapServerResolver.ensureBootstrapped(currentTimeMs, metadataUpdater);
     }
 
     class DefaultMetadataUpdater implements MetadataUpdater {

--- a/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.BootstrapResolutionException;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.test.TestUtils;
@@ -26,10 +27,12 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -161,6 +164,42 @@ public class BootstrapServerResolverTest {
         }
 
         verify(metadataUpdater).bootstrapFailed(any(BootstrapResolutionException.class));
+        verify(metadataUpdater, never()).bootstrap(any());
+    }
+
+    @Test
+    public void testInterruptedResolutionIsCancelled() throws Exception {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        CountDownLatch resolutionStarted = new CountDownLatch(1);
+        CountDownLatch resolutionMayFinish = new CountDownLatch(1);
+
+        try (BootstrapServerResolver resolver = new BootstrapServerResolver(
+            configuration(1000, 10),
+            time,
+            new LogContext(),
+            () -> {
+                resolutionStarted.countDown();
+                try {
+                    resolutionMayFinish.await();
+                } catch (InterruptedException e) {
+                    throw new AssertionError("Resolution was interrupted before the test released it", e);
+                }
+                return RESOLVED_ADDRESSES;
+            })) {
+            TestUtils.waitForCondition(() -> resolutionStarted.getCount() == 0,
+                "Bootstrap resolution did not start");
+
+            Thread.currentThread().interrupt();
+            try {
+                assertThrows(InterruptException.class,
+                    () -> resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater));
+            } finally {
+                Thread.interrupted();
+                resolutionMayFinish.countDown();
+            }
+        }
+
         verify(metadataUpdater, never()).bootstrap(any());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
@@ -183,7 +183,8 @@ public class BootstrapServerResolverTest {
                 try {
                     resolutionMayFinish.await();
                 } catch (InterruptedException e) {
-                    throw new AssertionError("Resolution was interrupted before the test released it", e);
+                    // Cancellation may interrupt the resolver while the test is releasing the blocked lookup.
+                    Thread.currentThread().interrupt();
                 }
                 return RESOLVED_ADDRESSES;
             })) {

--- a/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -65,6 +66,28 @@ public class BootstrapServerResolverTest {
         }
 
         verify(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+    }
+
+    @Test
+    public void testDisabledConfigurationDoesNotResolveOrBootstrap() {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        AtomicBoolean resolved = new AtomicBoolean();
+
+        try (BootstrapServerResolver resolver = new BootstrapServerResolver(
+            BootstrapConfiguration.DISABLED,
+            time,
+            new LogContext(),
+            () -> {
+                resolved.set(true);
+                return RESOLVED_ADDRESSES;
+            })) {
+            resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+        }
+
+        assertFalse(resolved.get());
+        verify(metadataUpdater, never()).bootstrap(any());
+        verify(metadataUpdater, never()).bootstrapFailed(any());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/BootstrapServerResolverTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.BootstrapResolutionException;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BootstrapServerResolverTest {
+    private static final List<String> BOOTSTRAP_SERVERS = List.of("bootstrap.example.com:9092");
+    private static final List<InetSocketAddress> RESOLVED_ADDRESSES = List.of(
+        new InetSocketAddress("127.0.0.1", 9092),
+        new InetSocketAddress("127.0.0.2", 9092));
+
+    @Test
+    public void testSuccessfulResolutionBootstrapsMetadata() throws Exception {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        AtomicBoolean bootstrapped = new AtomicBoolean();
+        when(metadataUpdater.isBootstrapped()).thenAnswer(__ -> bootstrapped.get());
+        doAnswer(invocation -> {
+            bootstrapped.set(true);
+            return null;
+        }).when(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+
+        try (BootstrapServerResolver resolver = newResolver(time, () -> RESOLVED_ADDRESSES)) {
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return bootstrapped.get();
+            }, "Bootstrap resolution did not complete");
+        }
+
+        verify(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+    }
+
+    @Test
+    public void testResolutionRetriesAfterAnEmptyResult() throws Exception {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        AtomicBoolean bootstrapped = new AtomicBoolean();
+        AtomicInteger attempts = new AtomicInteger();
+        when(metadataUpdater.isBootstrapped()).thenAnswer(__ -> bootstrapped.get());
+        doAnswer(invocation -> {
+            bootstrapped.set(true);
+            return null;
+        }).when(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+
+        BootstrapConfiguration configuration = configuration(1000, 10);
+        try (BootstrapServerResolver resolver = new BootstrapServerResolver(
+            configuration,
+            time,
+            new LogContext(),
+            () -> attempts.incrementAndGet() == 1 ? List.of() : RESOLVED_ADDRESSES)) {
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return attempts.get() == 1;
+            }, "Initial bootstrap resolution did not complete");
+
+            time.sleep(configuration.retryBackoffMs);
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return bootstrapped.get();
+            }, "Bootstrap resolution did not retry successfully");
+        }
+
+        assertEquals(2, attempts.get());
+        verify(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+    }
+
+    @Test
+    public void testResolutionRetriesAfterAnException() throws Exception {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        AtomicBoolean bootstrapped = new AtomicBoolean();
+        AtomicInteger attempts = new AtomicInteger();
+        when(metadataUpdater.isBootstrapped()).thenAnswer(__ -> bootstrapped.get());
+        doAnswer(invocation -> {
+            bootstrapped.set(true);
+            return null;
+        }).when(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+
+        BootstrapConfiguration configuration = configuration(1000, 10);
+        try (BootstrapServerResolver resolver = new BootstrapServerResolver(
+            configuration,
+            time,
+            new LogContext(),
+            () -> {
+                if (attempts.incrementAndGet() == 1)
+                    throw new IllegalStateException("DNS lookup failed");
+                return RESOLVED_ADDRESSES;
+            })) {
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return attempts.get() == 1;
+            }, "Initial bootstrap resolution did not complete");
+
+            time.sleep(configuration.retryBackoffMs);
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return bootstrapped.get();
+            }, "Bootstrap resolution did not retry successfully");
+        }
+
+        assertEquals(2, attempts.get());
+        verify(metadataUpdater).bootstrap(RESOLVED_ADDRESSES);
+    }
+
+    @Test
+    public void testResolutionFailureIsReportedAfterTimeout() throws Exception {
+        MockTime time = new MockTime();
+        MetadataUpdater metadataUpdater = metadataUpdater();
+        BootstrapConfiguration configuration = configuration(100, 10);
+        AtomicInteger attempts = new AtomicInteger();
+
+        try (BootstrapServerResolver resolver = new BootstrapServerResolver(
+            configuration,
+            time,
+            new LogContext(),
+            () -> {
+                attempts.incrementAndGet();
+                return List.of();
+            })) {
+            TestUtils.waitForCondition(() -> {
+                resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+                return attempts.get() == 1;
+            }, "Initial bootstrap resolution did not complete");
+
+            time.sleep(configuration.bootstrapResolveTimeoutMs);
+            resolver.ensureBootstrapped(time.milliseconds(), metadataUpdater);
+        }
+
+        verify(metadataUpdater).bootstrapFailed(any(BootstrapResolutionException.class));
+        verify(metadataUpdater, never()).bootstrap(any());
+    }
+
+    private static BootstrapServerResolver newResolver(MockTime time,
+                                                       BootstrapServerResolver.AddressResolver addressResolver) {
+        return new BootstrapServerResolver(configuration(1000, CommonClientConfigs.DEFAULT_RETRY_BACKOFF_MS),
+            time,
+            new LogContext(),
+            addressResolver);
+    }
+
+    private static BootstrapConfiguration configuration(long timeoutMs, long retryBackoffMs) {
+        return BootstrapConfiguration.enabled(
+            BOOTSTRAP_SERVERS,
+            ClientDnsLookup.USE_ALL_DNS_IPS,
+            timeoutMs,
+            retryBackoffMs);
+    }
+
+    private static MetadataUpdater metadataUpdater() {
+        MetadataUpdater metadataUpdater = mock(MetadataUpdater.class);
+        when(metadataUpdater.fetchNodes()).thenReturn(List.of(new Node(0, "broker", 9092)));
+        when(metadataUpdater.isBootstrapped()).thenReturn(false);
+        return metadataUpdater;
+    }
+}


### PR DESCRIPTION
### Summary

KIP-909 added asynchronous bootstrap DNS resolution state to `NetworkClient`. This change extracts that state machine into the package-private `BootstrapServerResolver` so `NetworkClient` remains focused on network I/O and metadata coordination.

The behavior is unchanged: resolution starts eagerly, the timeout starts on the first poll, completed results are processed before the deadline check, failed or empty resolutions retry with the configured backoff, and close/interrupt paths cancel outstanding work. There are no public API, configuration, protocol, or wire-format changes.

### Test Strategy

The resolver tests define the lifecycle contract for successful resolution, empty-result retry, exceptional-result retry, and timeout failure before the implementation is integrated. Existing `NetworkClientTest` bootstrap and networking coverage remains green.

Verified with:

- `./gradlew :clients:test --tests org.apache.kafka.clients.BootstrapServerResolverTest --tests org.apache.kafka.clients.NetworkClientTest`
- `./gradlew :clients:spotlessCheck :clients:checkstyleMain :clients:checkstyleTest :clients:spotbugsMain`
