### PR TITLE
KAFKA-20886: Preserve partitions without application.server

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -975,14 +975,20 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                               final Map<HostInfo, Set<TopicPartition>> standbyPartitionsByHost,
                                               final Map<TaskId, Set<TopicPartition>> partitionsForTask,
                                               final Map<ProcessId, ClientMetadata> clientMetadataMap) {
+        final boolean hasConfiguredHost = clientMetadataMap.values().stream()
+            .anyMatch(clientMetadata -> clientMetadata.hostInfo != null);
+
         for (final Map.Entry<ProcessId, ClientMetadata> entry : clientMetadataMap.entrySet()) {
             final HostInfo hostInfo = entry.getValue().hostInfo;
+            final ClientState state = entry.getValue().state;
 
-            // if application server is configured, also include host state map
-            if (hostInfo != null) {
+            // If application.server is configured on at least one client, preserve partitions from clients without
+            // an endpoint under the unavailable host. This keeps the partition count complete for IQ queries while
+            // still reporting that those partitions cannot be queried through an application server.
+            if (hostInfo != null || (hasConfiguredHost && (!state.activeTasks().isEmpty() || !state.standbyTasks().isEmpty()))) {
+                final HostInfo effectiveHostInfo = hostInfo == null ? HostInfo.unavailable() : hostInfo;
                 final Set<TopicPartition> topicPartitions = new HashSet<>();
                 final Set<TopicPartition> standbyPartitions = new HashSet<>();
-                final ClientState state = entry.getValue().state;
 
                 for (final TaskId id : state.activeTasks()) {
                     topicPartitions.addAll(partitionsForTask.get(id));
@@ -992,8 +998,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                     standbyPartitions.addAll(partitionsForTask.get(id));
                 }
 
-                partitionsByHost.put(hostInfo, topicPartitions);
-                standbyPartitionsByHost.put(hostInfo, standbyPartitions);
+                partitionsByHost.computeIfAbsent(effectiveHostInfo, ignored -> new HashSet<>()).addAll(topicPartitions);
+                standbyPartitionsByHost.computeIfAbsent(effectiveHostInfo, ignored -> new HashSet<>()).addAll(standbyPartitions);
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -128,6 +128,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_4;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.RACK_2;
@@ -1238,6 +1239,91 @@ public class StreamsPartitionAssignorTest {
         assertEquals(partitionsByHost, info20.partitionsByHost());
         assertEquals(standbyPartitionsByHost, info11.standbyPartitionByHost());
         assertEquals(standbyPartitionsByHost, info20.standbyPartitionByHost());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameter")
+    public void shouldPreservePartitionsForMultipleClientsWithoutApplicationServer(final Map<String, Object> parameterizedConfig) {
+        setUp(parameterizedConfig, false);
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor(parameterizedConfig);
+
+        subscriptions.put(CONSUMER_1,
+            new Subscription(
+                singletonList("topic1"),
+                getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS, USER_END_POINT).encode(),
+                emptyList(),
+                DEFAULT_GENERATION,
+                Optional.of(RACK_0)
+            ));
+        subscriptions.put(CONSUMER_2,
+            new Subscription(
+                singletonList("topic1"),
+                getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                emptyList(),
+                DEFAULT_GENERATION,
+                Optional.of(RACK_1)
+            ));
+        subscriptions.put(CONSUMER_3,
+            new Subscription(
+                singletonList("topic1"),
+                getInfo(PID_3, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                emptyList(),
+                DEFAULT_GENERATION,
+                Optional.of(RACK_2)
+            ));
+
+        final AssignmentInfo assignmentInfo = AssignmentInfo.decode(
+            partitionAssignor.assign(metadata, new GroupSubscription(subscriptions))
+                .groupAssignment()
+                .get(CONSUMER_1)
+                .userData()
+        );
+
+        final Set<TopicPartition> assignedPartitions = assignmentInfo.partitionsByHost().values().stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+        assertEquals(Set.of(new HostInfo("localhost", 8080), StreamsMetadataState.UNKNOWN_HOST),
+            assignmentInfo.partitionsByHost().keySet());
+        assertEquals(2, assignmentInfo.partitionsByHost().get(StreamsMetadataState.UNKNOWN_HOST).size());
+        assertEquals(Set.of(t1p0, t1p1, t1p2), assignedPartitions);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameter")
+    public void shouldNotCreateHostMetadataWhenNoClientHasApplicationServer(final Map<String, Object> parameterizedConfig) {
+        setUp(parameterizedConfig, false);
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor(parameterizedConfig);
+
+        subscriptions.put(CONSUMER_1,
+            new Subscription(
+                singletonList("topic1"),
+                getInfo(PID_1, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                emptyList(),
+                DEFAULT_GENERATION,
+                Optional.of(RACK_0)
+            ));
+        subscriptions.put(CONSUMER_2,
+            new Subscription(
+                singletonList("topic1"),
+                getInfo(PID_2, EMPTY_TASKS, EMPTY_TASKS).encode(),
+                emptyList(),
+                DEFAULT_GENERATION,
+                Optional.of(RACK_1)
+            ));
+
+        final AssignmentInfo assignmentInfo = AssignmentInfo.decode(
+            partitionAssignor.assign(metadata, new GroupSubscription(subscriptions))
+                .groupAssignment()
+                .get(CONSUMER_1)
+                .userData()
+        );
+
+        assertTrue(assignmentInfo.partitionsByHost().isEmpty());
+        assertTrue(assignmentInfo.standbyPartitionByHost().isEmpty());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Summary

When a Streams group mixes members with and without `application.server`, the assignor currently omits partitions assigned to endpoint-less members from `partitionsByHost`. Streams IQ derives source-topic partition counts from this map, so the omission can make key partitioning use a smaller modulo and return incorrect hosts or results.

Preserve those partitions under the existing `HostInfo.unavailable()` sentinel when at least one group member has an application server endpoint. This keeps the partition count complete while clearly marking those partitions as not queryable through an application server. When no member has an endpoint, retain the existing empty host metadata behavior.

No public API, wire format, or configuration changes.

### Test Strategy

Added parameterized tests across all assignor configurations for mixed and all-unconfigured groups. The mixed case verifies the unavailable sentinel and complete partition union; the all-unconfigured case verifies existing behavior.

Verified with:

- `./gradlew :streams:test --tests org.apache.kafka.streams.processor.internals.StreamsPartitionAssignorTest`
- `./gradlew :streams:spotlessCheck :streams:checkstyleMain :streams:checkstyleTest :streams:spotbugsMain`

Reviewers: Matthias J. Sax <matthias@confluent.io>
