### PR TITLE
MINOR: Fix stale test command examples in README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Module-scoped build:
 ./gradlew clients:test --tests RequestResponseTest
 
 # Single test method
-./gradlew core:test --tests kafka.api.ProducerFailureHandlingTest.testCannotSendToInternalTopic
+./gradlew clients:clients-integration-tests:test --tests org.apache.kafka.clients.producer.ProducerFailureHandlingTest.testCannotSendToInternalTopic
 
 # Coverage (whole project or one module)
 ./gradlew reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ N=500; I=0; while [ $I -lt $N ] && ./gradlew clients:test --tests RequestRespons
 
 ### Running a particular test method within a unit/integration test
 ```bash
-./gradlew core:test --tests kafka.api.ProducerFailureHandlingTest.testCannotSendToInternalTopic
 ./gradlew clients:test --tests org.apache.kafka.clients.MetadataTest.testTimeToNextUpdate
+./gradlew clients:clients-integration-tests:test --tests org.apache.kafka.clients.producer.ProducerFailureHandlingTest.testCannotSendToInternalTopic
 ./gradlew streams:integration-tests:test --tests org.apache.kafka.streams.integration.RestoreIntegrationTest.shouldRestoreNullRecord
 ```
 


### PR DESCRIPTION
Updates the example `./gradlew` test commands in `README.md` and
`AGENTS.md`.

`ProducerFailureHandlingTest` now lives under
`clients:clients-integration-tests`  instead of `core:test`, so the old
command no longer works.

Verified locally
- `./gradlew clients:clients-integration-tests:test --tests
org.apache.kafka.clients.producer.ProducerFailureHandlingTest.testCannotSendToInternalTopic`

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
