### PR TITLE
MINOR: KIP-909 follow-ups (port validation, dead code, doc, test mock)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/BootstrapConfiguration.java
+++ b/clients/src/main/java/org/apache/kafka/clients/BootstrapConfiguration.java
@@ -45,8 +45,12 @@ public final class BootstrapConfiguration {
                                                  final long bootstrapResolveTimeoutMs,
                                                  final long retryBackoffMs) {
         for (String url : bootstrapServers) {
-            if (Utils.getHost(url) == null || Utils.getPort(url) == null)
-                throw new ConfigException("Invalid url in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
+            try {
+                if (Utils.getHost(url) == null || Utils.getPort(url) == null)
+                    throw new ConfigException("Invalid url in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException("Invalid port in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
+            }
         }
         return new BootstrapConfiguration(bootstrapServers, clientDnsLookup, bootstrapResolveTimeoutMs, retryBackoffMs);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -114,12 +114,6 @@ public final class ClientUtils {
         return addresses;
     }
 
-    public static List<InetSocketAddress> parseAndValidateAddresses(AbstractConfig config) {
-        List<String> urls = config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
-        String clientDnsLookupConfig = config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG);
-        return parseAndValidateAddresses(urls, clientDnsLookupConfig);
-    }
-
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, String clientDnsLookupConfig) {
         return parseAndValidateAddresses(urls, ClientDnsLookup.forConfig(clientDnsLookupConfig));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -63,7 +63,7 @@ public class CommonClientConfigs {
     public static final String BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG = "bootstrap.resolve.timeout.ms";
     public static final long DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS = 2 * 60 * 1000L;
     public static final String BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC = "Maximum amount of time clients can spend trying to" +
-        " resolve for the bootstrap server address. If the resolution cannot be completed within this timeframe, a " +
+        " resolve DNS for the bootstrap server address. If the resolution cannot be completed within this timeframe, a " +
         "<code>BootstrapResolutionException</code> will be thrown. This failure is unrecoverable — the exception is" +
         " re-thrown on every subsequent API call, so the client must be closed and re-created after fixing the" +
         " underlying DNS or <code>bootstrap.servers</code> configuration issue.";

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -3450,7 +3450,8 @@ public class KafkaProducerTest {
             new TopicPartition("test-topic", 0),
             new OffsetAndMetadata(0L)
         );
-        ConsumerGroupMetadata groupMetadata = new ConsumerGroupMetadata("test-group");
+        ConsumerGroupMetadata groupMetadata = mock(ConsumerGroupMetadata.class);
+        when(groupMetadata.groupId()).thenReturn("test-group");
 
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(configs)) {
             assertThrows(BootstrapResolutionException.class,


### PR DESCRIPTION
Small review-follow-ups on top of the merged KIP-909 work (#21080,
#22897):

- **`BootstrapConfiguration.enabled(...)`**: wrap the host/port check
with `try/catch IllegalArgumentException` so a malformed port (e.g.
`host:99999999999999999999` that overflows `Integer.parseInt`) surfaces
as `ConfigException("Invalid port in ...")`, matching the pre-existing
behaviour in `ClientUtils.parseAndValidateAddresses`. Without this a
`NumberFormatException` would leak out of client construction.

- **`ClientUtils.parseAndValidateAddresses(AbstractConfig)`**: removed.
This overload had no callers after the KIP-909 changes. The remaining
two overloads (`(List<String>, String)` and `(List<String>,
ClientDnsLookup)`) are still used by `BrokerApiVersionsCommand` and
`ConnectionStressWorker`, which construct `NetworkClient` directly with
`BootstrapConfiguration.DISABLED` and pre-resolved addresses.

- **`CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC`**: reworded
from "resolve for the bootstrap server address" to "resolve DNS for the
bootstrap server address" for clarity.

- **`KafkaProducerTest`**: replaced `new
ConsumerGroupMetadata("test-group")` with
`mock(ConsumerGroupMetadata.class)` +
`when(...groupId()).thenReturn("test-group")` — the constructor is
`@Deprecated(forRemoval)`.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
