### PR TITLE
KAFKA-20657: Serialize ByteBuffer values by remaining bytes

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -631,7 +631,7 @@ public class JsonConverter implements Converter, HeaderConverter {
                     if (value instanceof byte[])
                         return JSON_NODE_FACTORY.binaryNode((byte[]) value);
                     else if (value instanceof ByteBuffer)
-                        return JSON_NODE_FACTORY.binaryNode(((ByteBuffer) value).array());
+                        return JSON_NODE_FACTORY.binaryNode(Utils.toArray((ByteBuffer) value));
                     else
                         throw new DataException("Invalid type for bytes type: " + value.getClass());
                 case ARRAY: {

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -578,6 +578,29 @@ public class JsonConverterTest {
     }
 
     @Test
+    public void slicedByteBufferToJsonUsesRemainingBytes() throws IOException {
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+        bytes.position(1);
+        bytes.limit(3);
+
+        JsonNode converted = parse(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, bytes));
+        validateEnvelope(converted);
+        assertArrayEquals(new byte[] {2, 3}, converted.get(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME).binaryValue());
+    }
+
+    @Test
+    public void directByteBufferToJson() throws IOException {
+        ByteBuffer bytes = ByteBuffer.allocateDirect(2);
+        bytes.put((byte) 1);
+        bytes.put((byte) 2);
+        bytes.flip();
+
+        JsonNode converted = parse(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, bytes));
+        validateEnvelope(converted);
+        assertArrayEquals(new byte[] {1, 2}, converted.get(JsonSchema.ENVELOPE_PAYLOAD_FIELD_NAME).binaryValue());
+    }
+
+    @Test
     public void stringToJson() {
         JsonNode converted = parse(converter.fromConnectData(TOPIC, Schema.STRING_SCHEMA, "test-string"));
         validateEnvelope(converted);


### PR DESCRIPTION
## Summary

Use the ByteBuffer's remaining bytes when serializing Connect BYTES values to JSON.

The previous implementation used ByteBuffer.array(), which serialized an entire backing array for sliced buffers and threw UnsupportedOperationException for direct buffers. Utils.toArray(ByteBuffer) preserves the logical position-to-limit range and supports both buffer types without changing the public API or wire format.

Fixes KAFKA-20657

## Tests

- TDD RED: the new sliced and direct ByteBuffer tests failed against the previous implementation.
- TDD GREEN: both tests pass after the implementation change.
- ./gradlew :connect:json:test --no-build-cache --console=plain
- ./gradlew :connect:json:spotlessCheck :connect:json:checkstyleMain :connect:json:checkstyleTest :connect:json:spotbugsMain --no-build-cache --console=plain
- git diff --check