### PR TITLE
KAFKA-20853: Support file-based Maven publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ These take the same arguments as the built-in variants.
 The following options should be set with a `-P` switch, for example `./gradlew -PmaxParallelForks=1 test`.
 
 * `commitId`: sets the build commit ID as .git/HEAD might not be correct if there are local commits added for build purposes.
-* `mavenUrl`: sets the URL of the maven deployment repository (`file://path/to/repo` can be used to point to a local repository).
+* `mavenUrl`: sets the URL of the Maven deployment repository (`file:///absolute/path/to/repo` can be used to point to a local repository).
 * `maxParallelForks`: maximum number of test processes to start in parallel. Defaults to the number of processors available to the JVM.
 * `maxScalacThreads`: maximum number of worker threads for the scalac backend. Defaults to the lowest of `8` and the number of processors
 available to the JVM. The value must be between 1 and 16 (inclusive). 

--- a/api-checker/build.gradle
+++ b/api-checker/build.gradle
@@ -103,10 +103,13 @@ subprojects {
             // come from ~/.gradle/gradle.properties via the same -PmavenUrl / -PmavenUsername /
             // -PmavenPassword properties release.py uses.
             maven {
-                url = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
-                credentials {
-                    username = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
-                    password = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+                def repositoryUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
+                url = repositoryUrl
+                if (!repositoryUrl || !'file'.equalsIgnoreCase(uri(repositoryUrl).scheme)) {
+                    credentials {
+                        username = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
+                        password = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -389,12 +389,13 @@ subprojects {
 
     publishing {
       repositories {
-        // To test locally, invoke gradlew with `-PmavenUrl=file:///some/local/path`
         maven {
           url = mavenUrl
-          credentials {
-            username = mavenUsername
-            password = mavenPassword
+          if (!mavenUrl || !'file'.equalsIgnoreCase(uri(mavenUrl).scheme)) {
+            credentials {
+              username = mavenUsername
+              password = mavenPassword
+            }
           }
         }
       }


### PR DESCRIPTION
This PR skip Maven credentials for `file:` repositories because Gradle's file
transport does not support authentication.

Apply the same fix to the api-checker build and correct the file URI example
in the README.

Tests:
- File publishing for `clients` and `api-checker:core`
- `./gradlew spotlessCheck`
- `git diff --check`