### PR TITLE
KAFKA-20881: Select the correct Connect module JAR in system tests

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -26,6 +26,7 @@ from ducktape.utils.util import wait_until
 
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka.util import fix_opts_for_new_jvm, get_log4j_config_param, get_log4j_config_for_connect
+from kafkatest.version import DEV_VERSION
 
 
 class ConnectServiceBase(KafkaPathResolverMixin, Service):
@@ -314,13 +315,12 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         relative_path = "/connect/" + module + "/build/libs/"
         local_dir = cwd + relative_path
         lib_dir = self.path.home() + relative_path
-        for pwd, dirs, files in os.walk(local_dir):
-            for file in files:
-                if file.endswith(".jar"):
-                    # Use the expected directory on the node instead of the path in the driver node
-                    file_path = lib_dir + file
-                    self.logger.info("Appending %s to Connect worker's CLASSPATH" % file_path)
-                    return "export CLASSPATH=${CLASSPATH}:%s; " % file_path
+        jar_name = "connect-%s-%s.jar" % (module, DEV_VERSION)
+        if os.path.isfile(local_dir + jar_name):
+            # Use the expected directory on the node instead of the path in the driver node
+            file_path = lib_dir + jar_name
+            self.logger.info("Appending %s to Connect worker's CLASSPATH" % file_path)
+            return "export CLASSPATH=${CLASSPATH}:%s; " % file_path
 
         self.logger.info("Jar not found within %s" % local_dir)
         return ""


### PR DESCRIPTION
Connect system tests currently add the first JAR returned by `os.walk`
to the worker classpath, which may select a javadoc JAR instead of the
executable module JAR.

This change uses `DEV_VERSION` to construct and select the exact
expected JAR for each Connect module, removing the dependency on
filesystem traversal order.

Reviewers: PoAn Yang <payang@apache.org>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
