### PR TITLE
MINOR:  make "rack.aware.assignment.tags" and "num.standby.replicas" constant

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -155,6 +155,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup.ShareGroupStat
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupAssignmentBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupDescribeResult;
@@ -2397,7 +2398,7 @@ public class GroupMetadataManager {
                 )
         ));
 
-        String rackAwareTagsValue = currentAssignmentConfigs.getOrDefault("rack.aware.assignment.tags", "").trim();
+        String rackAwareTagsValue = currentAssignmentConfigs.getOrDefault(StreamsAssignmentConfigs.RACK_AWARE_ASSIGNMENT_TAGS, "").trim();
         // The MISSING_CLIENT_TAGS status (code 6) requires version 1 of the RPC: version 0 clients
         // throw on unknown status codes, so it must not be sent to them.
         if (requestApiVersion >= 1 && !rackAwareTagsValue.isEmpty()) {
@@ -9914,9 +9915,9 @@ public class GroupMetadataManager {
         final List<String> rackAwareAssignmentTags = groupConfig.flatMap(GroupConfig::streamsRackAwareAssignmentTags)
             .orElse(config.streamsGroupRackAwareAssignmentTags());
         Map<String, String> configs = new TreeMap<>();
-        configs.put("num.standby.replicas", numStandbyReplicas.toString());
+        configs.put(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, numStandbyReplicas.toString());
         if (!rackAwareAssignmentTags.isEmpty()) {
-            configs.put("rack.aware.assignment.tags", String.join(",", rackAwareAssignmentTags));
+            configs.put(StreamsAssignmentConfigs.RACK_AWARE_ASSIGNMENT_TAGS, String.join(",", rackAwareAssignmentTags));
         }
         return configs;
     }

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsAssignmentConfigs.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/StreamsAssignmentConfigs.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupSpec;
+
+/**
+ * Keys of the assignment configurations that the group coordinator passes to the task assignor
+ * through {@link GroupSpec#configs()}.
+ */
+public class StreamsAssignmentConfigs {
+
+    public static final String NUM_STANDBY_REPLICAS = "num.standby.replicas";
+
+    public static final String RACK_AWARE_ASSIGNMENT_TAGS = "rack.aware.assignment.tags";
+
+    private StreamsAssignmentConfigs() {
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignor.java
@@ -24,6 +24,7 @@ import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignmentS
 import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignorException;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class StickyTaskAssignor implements TaskAssignor {
         final LocalState localState = new LocalState();
         localState.numStandbyReplicas =
             groupSpec.configs().isEmpty() ? 0
-                : Integer.parseInt(groupSpec.configs().get("num.standby.replicas"));
+                : Integer.parseInt(groupSpec.configs().get(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS));
 
         // Helpers for computing active tasks per member, and tasks per member
         localState.totalActiveTasks = 0;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -142,6 +142,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
 import org.apache.kafka.coordinator.group.streams.MockTaskAssignor;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
@@ -19143,7 +19144,7 @@ public class GroupMetadataManagerTest {
                 .withTargetAssignmentTimestamp(12345L)
                 .withMetadataHash(groupMetadataHash)
                 .withValidatedTopologyEpoch(0)
-                .withLastAssignmentConfigs(Map.of("num.standby.replicas", "0"))
+                .withLastAssignmentConfigs(Map.of(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, "0"))
             )
             .build();
 
@@ -19213,7 +19214,7 @@ public class GroupMetadataManagerTest {
                 .withTargetAssignmentEpoch(10)
                 .withMetadataHash(groupMetadataHash)
                 .withValidatedTopologyEpoch(0)
-                .withLastAssignmentConfigs(Map.of("num.standby.replicas", "0"))
+                .withLastAssignmentConfigs(Map.of(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, "0"))
             )
             .build();
 
@@ -19275,7 +19276,7 @@ public class GroupMetadataManagerTest {
                 .withTargetAssignmentEpoch(10)
                 .withMetadataHash(groupMetadataHash)
                 .withValidatedTopologyEpoch(0)
-                .withLastAssignmentConfigs(Map.of("num.standby.replicas", "0"))
+                .withLastAssignmentConfigs(Map.of(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, "0"))
             )
             .build();
 
@@ -23016,7 +23017,7 @@ public class GroupMetadataManagerTest {
         assertFalse(assignmentConfigs.isEmpty(), "Expected assignment configs to be present");
 
         StreamsGroupMetadataValue.LastAssignmentConfig standbyReplicasConfig = assignmentConfigs.stream()
-            .filter(config -> "num.standby.replicas".equals(config.key()))
+            .filter(config -> StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS.equals(config.key()))
             .findFirst()
             .orElse(null);
 
@@ -23027,7 +23028,7 @@ public class GroupMetadataManagerTest {
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
         int newGroupEpoch = group.groupEpoch();
         assertEquals(11, newGroupEpoch);
-        assertEquals("2", group.lastAssignmentConfigs().get("num.standby.replicas"));
+        assertEquals("2", group.lastAssignmentConfigs().get(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS));
     }
 
     @Test
@@ -23693,7 +23694,7 @@ public class GroupMetadataManagerTest {
 
         // Verify that the new number of standby replicas is used
         assertEquals(
-            Map.of("num.standby.replicas", "2"),
+            Map.of(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, "2"),
             assignor.lastPassedAssignmentConfigs()
         );
 
@@ -24081,7 +24082,7 @@ public class GroupMetadataManagerTest {
         // Verify that the number of standby replicas is evaluated to max,
         // and task offset interval is evaluated to min
         assertEquals(
-            Map.of("num.standby.replicas", String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_MAX_STANDBY_REPLICAS_DEFAULT)),
+            Map.of(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_MAX_STANDBY_REPLICAS_DEFAULT)),
             assignor.lastPassedAssignmentConfigs());
         assertEquals(GroupCoordinatorConfig.STREAMS_GROUP_MIN_TASK_OFFSET_INTERVAL_MS_DEFAULT,
             result.response().data().taskOffsetIntervalMs());
@@ -30358,7 +30359,7 @@ public class GroupMetadataManagerTest {
     private Map<String, String> getDefaultAssignmentConfigs() {
         // Use the same default value as GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT
         return new TreeMap<>(Map.of(
-            "num.standby.replicas", String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT)
+            StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT)
         ));
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupTestUtil.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.requests.StreamsGroupHeartbeatRequest;
 import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
 import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.streams.MemberState;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
@@ -73,7 +74,7 @@ class StreamsGroupTestUtil {
     static Map<String, String> getDefaultAssignmentConfigs() {
         // Use the same default value as GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT
         return new TreeMap<>(Map.of(
-            "num.standby.replicas", String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT)
+            StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, String.valueOf(GroupCoordinatorConfig.STREAMS_GROUP_NUM_STANDBY_REPLICAS_DEFAULT)
         ));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -262,7 +262,7 @@ class StreamsCoordinatorRecordHelpersTest {
     public void testNewStreamsGroupMetadataRecord() {
         List<StreamsGroupMetadataValue.LastAssignmentConfig> expectedAssignmentConfigs = List.of(
             new StreamsGroupMetadataValue.LastAssignmentConfig()
-                .setKey("num.standby.replicas")
+                .setKey(StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS)
                 .setValue("2")
         );
         CoordinatorRecord expectedRecord = CoordinatorRecord.record(
@@ -279,7 +279,7 @@ class StreamsCoordinatorRecordHelpersTest {
         );
 
         assertEquals(expectedRecord, StreamsCoordinatorRecordHelpers.newStreamsGroupMetadataRecord(GROUP_ID, 42, 43, 44, Map.of(
-            "num.standby.replicas", "2"
+            StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS, "2"
         ), -1, -1));
     }
 

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/StickyTaskAssignorTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.coordinator.group.streams.assignor;
 import org.apache.kafka.coordinator.group.api.streams.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.collections.Sets;
@@ -46,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StickyTaskAssignorTest {
 
-    public static final String NUM_STANDBY_REPLICAS_CONFIG = "num.standby.replicas";
+    public static final String NUM_STANDBY_REPLICAS_CONFIG = StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS;
     private final StickyTaskAssignor assignor = new StickyTaskAssignor();
 
     @Test

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsStickyAssignorBenchmark.java
@@ -22,6 +22,7 @@ import org.apache.kafka.coordinator.group.api.streams.assignor.GroupSpec;
 import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+import org.apache.kafka.coordinator.group.streams.StreamsAssignmentConfigs;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TopologyMetadata;
 import org.apache.kafka.coordinator.group.streams.assignor.GroupSpecImpl;
@@ -107,7 +108,7 @@ public class StreamsStickyAssignorBenchmark {
 
         Map<String, StreamsGroupMember> members = createMembers();
         this.assignmentConfigs = Map.of(
-            "num.standby.replicas",
+            StreamsAssignmentConfigs.NUM_STANDBY_REPLICAS,
             Integer.toString(standbyReplicas)
         );
         this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs);


### PR DESCRIPTION
change: make "rack.aware.assignment.tags" and "num.standby.replicas" constance

Reviewers: Matthias J. Sax <matthias@confluent.io>, Andrew Schofield <aschofield@confluent.io>
