### PR TITLE
MINOR: Deflake KafkaProducerTest.testSendOffsetsToTransactionTriggersMetadataRefreshThenNegotiatesV6()

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -2079,7 +2079,7 @@ public class KafkaProducerTest {
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
-        var time = new MockTime(1);
+        var time = new MockTime();
         var metadata = newMetadata(0, 0, Long.MAX_VALUE);
         var client = new MockClient(time, metadata);
         // Seed the metadata cache with a known topic id so the producer can
@@ -2154,7 +2154,7 @@ public class KafkaProducerTest {
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
-        var time = new MockTime(1);
+        var time = new MockTime();
         var metadata = newMetadata(0, 0, Long.MAX_VALUE);
         var client = new MockClient(time, metadata);
         // The initial metadata snapshot contains the topic so the producer can


### PR DESCRIPTION
Removes `autoTickMs` from `MockTime` since the background thread can
burn through the timeout budget.

https://develocity.apache.org/scans/tests?search.rootProjectNames=kafka&search.timeZoneId=America%2FChicago&tests.container=org.apache.kafka.clients.producer.KafkaProducerTest&tests.test=testSendOffsetsToTransactionTriggersMetadataRefreshThenNegotiatesV6()

Reviewers: Bill Bejeck <bbejeck@apache.org>
