### PR TITLE
MINOR: Make StreamsGroupDescription.toString null-safe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/StreamsGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/StreamsGroupDescription.java
@@ -247,7 +247,9 @@ public class StreamsGroupDescription {
             ", members=" + members.stream().map(StreamsGroupMemberDescription::toString).collect(Collectors.joining(",")) +
             ", groupState=" + groupState +
             ", coordinator=" + coordinator +
-            ", authorizedOperations=" + authorizedOperations.stream().map(AclOperation::toString).collect(Collectors.joining(",")) +
+            ", authorizedOperations=" + (authorizedOperations == null ?
+                "null" :
+                authorizedOperations.stream().map(AclOperation::toString).collect(Collectors.joining(","))) +
             ", topologyDescription=" + topologyDescription.map(Object::toString).orElse("") +
             ", topologyDescriptionStatus=" + topologyDescriptionStatus +
             ", assignorName=" + assignorName.orElse("") +

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -6461,6 +6461,8 @@ public class KafkaAdminClientTest {
             final StreamsGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
 
             assertNull(groupDescription.authorizedOperations());
+            String descriptionText = assertDoesNotThrow(groupDescription::toString);
+            assertTrue(descriptionText.contains(", authorizedOperations=null,"));
         }
     }
 


### PR DESCRIPTION
`DescribeStreamsGroupsOptions` omits authorized operations by default. The omitted response value is converted to `null`, which is a documented valid state for `StreamsGroupDescription.authorizedOperations()`. However, `StreamsGroupDescription.toString()` unconditionally called `stream()` on that nullable set, so logging or otherwise rendering a successfully described group could throw `NullPointerException`.

This change renders omitted authorized operations as `null` while preserving the existing output format for populated sets. It also extends the existing AdminClient test for an omitted authorized-operations response to verify that the resulting description can be converted to a string and includes `authorizedOperations=null`.

Testing:
- `DOCKER_API_VERSION=1.40 ./gradlew clients:test`
- `./gradlew clients:test --tests org.apache.kafka.clients.admin.KafkaAdminClientTest.testDescribeStreamsGroupsWithAuthorizedOperationsOmitted --tests org.apache.kafka.clients.admin.internals.DescribeStreamsGroupsHandlerTest`
- `./gradlew spotlessCheck`
- `./gradlew clients:spotbugsMain clients:spotbugsTest -x test`

The full clients test suite, targeted regression tests, Checkstyle, SpotBugs main analysis, and Spotless checks passed. `clients:spotbugsTest` was skipped by the build configuration.

Generated-by: OpenAI Codex