### PR TITLE
KAFKA-20893: Avoid reporting incorrect task-offsets to Kafka Streams assignor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -369,7 +370,7 @@ public class ProcessorStateManager implements StateManager {
         }
 
         try {
-            stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+            stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
         } catch (final RuntimeException e) {
             throw new ProcessorStateException(format("%sError updating state directory offsets when creating the state manager",
                 logPrefix), e);
@@ -455,10 +456,18 @@ public class ProcessorStateManager implements StateManager {
 
     @Override
     public Map<TopicPartition, Long> changelogOffsets() {
+        return changelogOffsets(storeMetadata -> true);
+    }
+
+    private Map<TopicPartition, Long> persistentChangelogOffsets() {
+        return changelogOffsets(storeMetadata -> storeMetadata.stateStore.persistent());
+    }
+
+    private Map<TopicPartition, Long> changelogOffsets(final Predicate<StateStoreMetadata> storeFilter) {
         // return the current offsets for those logged stores
         final Map<TopicPartition, Long> changelogOffsets = new HashMap<>();
         for (final StateStoreMetadata storeMetadata : stores.values()) {
-            if (storeMetadata.changelogPartition != null) {
+            if (storeMetadata.changelogPartition != null && storeFilter.test(storeMetadata)) {
                 // for changelog whose offset is unknown, use 0L indicating earliest offset
                 // otherwise return the current offset + 1 as the next offset to fetch
                 changelogOffsets.put(
@@ -532,7 +541,7 @@ public class ProcessorStateManager implements StateManager {
                 storeMetadata.setEndOffset(optionalLag.getAsLong() + batchEndOffset);
             }
 
-            stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+            stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
         }
     }
 
@@ -756,7 +765,7 @@ public class ProcessorStateManager implements StateManager {
             }
         }
 
-        stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+        stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
     }
 
     // Commit a sentinel value when the changelog offset is not yet initialized/known

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -325,7 +325,7 @@ public class StateDirectory implements AutoCloseable {
         taskOffsetSums.remove(taskId);
     }
 
-    private long sumOfChangelogOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
+    static long sumOfChangelogOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
         long offsetSum = 0L;
         for (final Map.Entry<TopicPartition, Long> changelogEntry : changelogOffsets.entrySet()) {
             final long offset = changelogEntry.getValue();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1270,26 +1270,30 @@ public class TaskManager {
     }
 
     /**
-     * Recomputes the offset-sum snapshot reported to the streams-group coordinator from the offset sums maintained in
-     * the {@link StateDirectory}, which already cover all stateful tasks with state on disk (standby, warmup,
-     * restoring-active and dormant) using a conservative (per-partition lower-bound) sum. Running-active tasks are
-     * excluded: their assignment is not offset-driven and they are caught up by definition.
+     * Recomputes the offset-sum snapshot reported to the streams-group coordinator. The {@link StateDirectory} sums
+     * cover every task with state on disk, including tasks owned by a sibling stream thread and dormant ones.
+     * We include these, because we could take over such a task re-using the local state on disk.
+     * Running-active tasks are excluded: their assignment is not offset-driven and they are caught up by definition.
+     * For all other assigned tasks this thread owns, we overwrite the (potentially) state offset-sum from the
+     * state directory with the latest changelog offset information. This step also add offset-sums for in-memory
+     * state stores.
      */
     public void maybeUpdateTaskOffsetSumSnapshot() {
-        final Set<TaskId> runningActiveTasks = new HashSet<>();
+        final Map<TaskId, Long> offsetSums = new HashMap<>(stateDirectory.taskOffsetSums());
         for (final Task task : allTasks().values()) {
             if (task.isActive() && task.state() == State.RUNNING) {
-                runningActiveTasks.add(task.id());
+                offsetSums.remove(task.id());
+            } else if (task.state() != State.CREATED && task.state() != State.CLOSED) {
+                final Map<TopicPartition, Long> changelogOffsets = task.changelogOffsets();
+                if (!changelogOffsets.isEmpty()) {
+                    offsetSums.put(task.id(), StateDirectory.sumOfChangelogOffsets(task.id(), changelogOffsets));
+                }
             }
         }
 
-        final Map<TaskId, Long> offsetSums = stateDirectory.taskOffsetSums();
         final Map<StreamsRebalanceData.TaskId, Long> snapshot = new HashMap<>(offsetSums.size());
         for (final Map.Entry<TaskId, Long> entry : offsetSums.entrySet()) {
             final TaskId taskId = entry.getKey();
-            if (runningActiveTasks.contains(taskId)) {
-                continue;
-            }
             snapshot.put(
                 new StreamsRebalanceData.TaskId(String.valueOf(taskId.subtopology()), taskId.partition()),
                 entry.getValue()
@@ -1323,11 +1327,20 @@ public class TaskManager {
 
         final Map<TaskId, Long> taskOffsetSums = stateDirectory.taskOffsetSums(lockedTaskDirectoriesOfNonOwnedTasksAndClosedAndCreatedTasks);
 
-        // overlay latest offsets from assigned tasks
+        // Overlay latest offsets from assigned tasks.
+        // `stateDirectory.taskOffsetSums` above only cover what is recoverable from disk (potentially stale),
+        // including offsets from persistent stores which tasks are owned by sibling thread, as well as dormant tasks;
+        // We update this (potentially state) information with latest changelog offset inforamtion for all other
+        // tasks assigned to this thread; this step also adds offset-sum information for in-memory state stores
         for (final Task task : tasks.values()) {
             // exclude stateless and non-logged tasks
             if (task.isActive() && task.state() == State.RUNNING && !task.changelogPartitions().isEmpty()) {
                 taskOffsetSums.put(task.id(), Task.LATEST_OFFSET);
+            } else if (task.state() != State.CREATED && task.state() != State.CLOSED) {
+                final Map<TopicPartition, Long> changelogOffsets = task.changelogOffsets();
+                if (!changelogOffsets.isEmpty()) {
+                    taskOffsetSums.put(task.id(), StateDirectory.sumOfChangelogOffsets(task.id(), changelogOffsets));
+                }
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -547,6 +547,69 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
+    public void shouldNotTrackInMemoryStoreOffsetsInStateDirectory() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Arrays.asList(persistentStore, nonPersistentStore), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(mkMap(
+                mkEntry(persistentStorePartition, 100L),
+                mkEntry(nonPersistentStorePartition, 200L)));
+
+            // the shared sums outlive this task, so they must only count state that outlives it too (KAFKA-20893);
+            // the in-memory store's 201 is reported from the live task by TaskManager instead
+            assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 101L))));
+            assertThat(stateMgr.changelogOffsets(), is(mkMap(
+                mkEntry(persistentStorePartition, 101L),
+                mkEntry(nonPersistentStorePartition, 201L))));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 101L))));
+    }
+
+    @Test
+    public void shouldNotTrackOffsetsInStateDirectoryWhenNoStoreIsPersistent() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Collections.singletonList(nonPersistentStore), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(Collections.singletonMap(nonPersistentStorePartition, 200L));
+
+            assertThat(stateDirectory.taskOffsetSums(), is(Collections.emptyMap()));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldTrackPersistentStoreOffsetsInStateDirectory() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Arrays.asList(persistentStore, persistentStoreTwo), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(mkMap(
+                mkEntry(persistentStorePartition, 100L),
+                mkEntry(persistentStoreTwoPartition, 200L)));
+
+            assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 302L))));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 302L))));
+    }
+
+    @Test
     public void shouldGetRegisteredStore() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2033,6 +2033,45 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void shouldPublishLiveOffsetsForOwnTasksInTaskOffsetSumSnapshot() {
+        final StandbyTask ownStandbyTask = standbyTask(taskId02, taskId02ChangelogPartitions).inState(State.RUNNING).build();
+        when(ownStandbyTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p2changelog, 90L)));
+
+        final TasksRegistry tasks = mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+        when(tasks.allInitializedTasksPerId()).thenReturn(Collections.emptyMap());
+        when(stateUpdater.tasks()).thenReturn(Set.of(ownStandbyTask));
+        // the shared sums only cover what is recoverable from disk, so they can trail an open task's in-memory stores
+        when(stateDirectory.taskOffsetSums()).thenReturn(mkMap(
+            mkEntry(taskId02, 30L),
+            mkEntry(taskId03, 40L)
+        ));
+
+        taskManager.maybeUpdateTaskOffsetSumSnapshot();
+
+        // our own task reports its live sum, while a task held elsewhere on the instance keeps the on-disk sum
+        assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
+            mkEntry(new StreamsRebalanceData.TaskId("0", 2), 90L),
+            mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
+        )));
+    }
+
+    @Test
+    public void shouldComputeOffsetSumFromLiveOffsetsForOwnTasks() {
+        final StandbyTask ownStandbyTask = standbyTask(taskId02, taskId02ChangelogPartitions).inState(State.RUNNING).build();
+        when(ownStandbyTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p2changelog, 90L)));
+
+        final TasksRegistry tasks = mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+        when(tasks.allInitializedTasksPerId()).thenReturn(Collections.emptyMap());
+        when(stateUpdater.tasks()).thenReturn(Set.of(ownStandbyTask));
+        when(stateDirectory.taskOffsetSums(Collections.singleton(taskId02)))
+            .thenReturn(mkMap(mkEntry(taskId02, 30L)));
+
+        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId02, 90L))));
+    }
+
+    @Test
     public void shouldSkipUnknownOffsetsWhenComputingOffsetSum() {
         final StreamTask restoringStatefulTask = statefulTask(taskId01, taskId01ChangelogPartitions)
             .inState(State.RESTORING).build();


### PR DESCRIPTION
The `StateDirectory` offset cache should only contain data for
persistent state store. This PR avoids the offset from in-memory state
stores are added to the cache, and ensure that the read path fills in
missing information for other state stores (in particular in-memory
ones) on the fly.

Reviewers: Nick Telford <nick.telford@gmail.com>, Bill Bejeck
 <bbejeck@apache.org>
