### PR TITLE
KAFKA-20894: Make StreamsGroupDescription.toString null-safe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/StreamsGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/StreamsGroupDescription.java
@@ -247,7 +247,9 @@ public class StreamsGroupDescription {
             ", members=" + members.stream().map(StreamsGroupMemberDescription::toString).collect(Collectors.joining(",")) +
             ", groupState=" + groupState +
             ", coordinator=" + coordinator +
-            ", authorizedOperations=" + authorizedOperations.stream().map(AclOperation::toString).collect(Collectors.joining(",")) +
+            ", authorizedOperations=" + (authorizedOperations == null ?
+                "null" :
+                authorizedOperations.stream().map(AclOperation::toString).collect(Collectors.joining(","))) +
             ", topologyDescription=" + topologyDescription.map(Object::toString).orElse("") +
             ", topologyDescriptionStatus=" + topologyDescriptionStatus +
             ", assignorName=" + assignorName.orElse("") +

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientStreamsGroupTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientStreamsGroupTest.java
@@ -83,6 +83,7 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -897,6 +898,8 @@ public class KafkaAdminClientStreamsGroupTest extends KafkaAdminClientTestBase {
             final StreamsGroupDescription groupDescription = result.describedGroups().get(GROUP_ID).get();
 
             assertNull(groupDescription.authorizedOperations());
+            String descriptionText = assertDoesNotThrow(groupDescription::toString);
+            assertTrue(descriptionText.contains(", authorizedOperations=null,"));
         }
     }
 


### PR DESCRIPTION
`DescribeStreamsGroupsOptions` field `authorizedOperations` may be
`null`. This PR add a guard to `toString()` for this case, to handle
`null` correctly and to avoid a NPE.

Reviewers: Matthias J. Sax <matthias@confluent.io>
