### PR TITLE
KAFKA-12443: Add TranslateSurrogates SMT to Kafka Connect

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -61,8 +61,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -145,7 +145,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
     private String statusTopic;
     private KafkaBasedLog<String, byte[]> kafkaLog;
     private int generation;
-    private ExecutorService sendRetryExecutor;
+    private ScheduledExecutorService sendRetryExecutor;
 
     public KafkaStatusBackingStore(Time time, Converter converter, Supplier<TopicAdmin> topicAdminSupplier, String clientIdBase) {
         this.time = time;
@@ -163,7 +163,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         this(time, converter, null, "connect-distributed-");
         this.kafkaLog = kafkaLog;
         this.statusTopic = statusTopic;
-        sendRetryExecutor = Executors.newSingleThreadExecutor(
+        sendRetryExecutor = Executors.newSingleThreadScheduledExecutor(
                 ThreadUtils.createThreadFactory("status-store-retry-" + statusTopic, true));
     }
 
@@ -173,7 +173,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
         if (this.statusTopic == null || this.statusTopic.trim().isEmpty())
             throw new ConfigException("Must specify topic for connector status.");
 
-        sendRetryExecutor = Executors.newSingleThreadExecutor(
+        sendRetryExecutor = Executors.newSingleThreadScheduledExecutor(
                 ThreadUtils.createThreadFactory("status-store-retry-" + statusTopic, true));
 
         String clusterId = config.kafkaClusterId();
@@ -304,21 +304,20 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                 }
                 
                 if (exception instanceof RetriableException) {
-                    if (attemptNumber >= MAX_RETRY_ATTEMPTS) {
-                        log.error("Failed to write status update for key {} after {} attempts. Giving up.",
-                                key, attemptNumber + 1, exception);
-                        return;
+                    long backoffMs = calculateBackoff(attemptNumber);
+                    if (attemptNumber < MAX_RETRY_ATTEMPTS) {
+                        log.warn("Failed to write status update for key {} (attempt {}). " +
+                                "Retrying after {}ms. Reason: {}",
+                                key, attemptNumber + 1, backoffMs, exception.getMessage());
+                    } else {
+                        log.warn("Failed to write status update for key {} after {} attempts. " +
+                                "Will continue retrying with {}ms backoff. Reason: {}",
+                                key, attemptNumber + 1, backoffMs, exception.getMessage());
                     }
                     
-                    long backoffMs = calculateBackoff(attemptNumber);
-                    log.warn("Failed to write status update for key {} (attempt {}/{}). " +
-                            "Retrying after {}ms. Reason: {}",
-                            key, attemptNumber + 1, MAX_RETRY_ATTEMPTS + 1, backoffMs, exception.getMessage());
-                    
-                    sendRetryExecutor.submit(() -> {
-                        time.sleep(backoffMs);
+                    sendRetryExecutor.schedule(() -> {
                         sendWithRetry(key, value, attemptNumber + 1);
-                    });
+                    }, backoffMs, TimeUnit.MILLISECONDS);
                 } else {
                     log.error("Failed to write status update for key {} with non-retriable exception",
                             key, exception);
@@ -330,12 +329,15 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
     /**
      * Calculate exponential backoff delay for retry attempts.
      * Uses formula: min(INITIAL_BACKOFF * 2^attempt, MAX_BACKOFF)
+     * After MAX_RETRY_ATTEMPTS, the backoff is capped at MAX_BACKOFF.
      *
      * @param attemptNumber the retry attempt number (0-based)
      * @return the backoff delay in milliseconds
      */
     private long calculateBackoff(int attemptNumber) {
-        long backoff = INITIAL_RETRY_BACKOFF_MS * (1L << attemptNumber);
+        // Cap the exponent to prevent overflow and limit backoff growth
+        int cappedAttempt = Math.min(attemptNumber, MAX_RETRY_ATTEMPTS);
+        long backoff = INITIAL_RETRY_BACKOFF_MS * (1L << cappedAttempt);
         return Math.min(backoff, MAX_RETRY_BACKOFF_MS);
     }
 
@@ -395,21 +397,20 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                         }
                     }
 
-                    if (attemptNumber >= MAX_RETRY_ATTEMPTS) {
-                        log.error("Failed to write status update for key {} after {} attempts. Giving up.",
-                                key, attemptNumber + 1, exception);
-                        return;
+                    long backoffMs = calculateBackoff(attemptNumber);
+                    if (attemptNumber < MAX_RETRY_ATTEMPTS) {
+                        log.warn("Failed to write status update for key {} (attempt {}). " +
+                                "Retrying after {}ms. Reason: {}",
+                                key, attemptNumber + 1, backoffMs, exception.getMessage());
+                    } else {
+                        log.warn("Failed to write status update for key {} after {} attempts. " +
+                                "Will continue retrying with {}ms backoff. Reason: {}",
+                                key, attemptNumber + 1, backoffMs, exception.getMessage());
                     }
                     
-                    long backoffMs = calculateBackoff(attemptNumber);
-                    log.warn("Failed to write status update for key {} (attempt {}/{}). " +
-                            "Retrying after {}ms. Reason: {}",
-                            key, attemptNumber + 1, MAX_RETRY_ATTEMPTS + 1, backoffMs, exception.getMessage());
-                    
-                    sendRetryExecutor.submit(() -> {
-                        time.sleep(backoffMs);
+                    sendRetryExecutor.schedule(() -> {
                         sendWithRetry(key, value, status, entry, safeWrite, sequence, attemptNumber + 1);
-                    });
+                    }, backoffMs, TimeUnit.MILLISECONDS);
                 } else {
                     log.error("Failed to write status update for key {} with non-retriable exception",
                             key, exception);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -129,7 +129,8 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
     ).build();
 
     // Retry configuration constants
-    private static final int MAX_RETRY_ATTEMPTS = 10;
+    // After this many attempts, backoff will be capped at MAX_RETRY_BACKOFF_MS
+    private static final int BACKOFF_ESCALATION_THRESHOLD = 10;
     private static final long INITIAL_RETRY_BACKOFF_MS = 300;
     private static final long MAX_RETRY_BACKOFF_MS = 60000; // 60 seconds
 
@@ -305,7 +306,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                 
                 if (exception instanceof RetriableException) {
                     long backoffMs = calculateBackoff(attemptNumber);
-                    if (attemptNumber < MAX_RETRY_ATTEMPTS) {
+                    if (attemptNumber < BACKOFF_ESCALATION_THRESHOLD) {
                         log.warn("Failed to write status update for key {} (attempt {}). " +
                                 "Retrying after {}ms. Reason: {}",
                                 key, attemptNumber + 1, backoffMs, exception.getMessage());
@@ -329,14 +330,14 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
     /**
      * Calculate exponential backoff delay for retry attempts.
      * Uses formula: min(INITIAL_BACKOFF * 2^attempt, MAX_BACKOFF)
-     * After MAX_RETRY_ATTEMPTS, the backoff is capped at MAX_BACKOFF.
+     * After BACKOFF_ESCALATION_THRESHOLD attempts, the backoff is capped at MAX_BACKOFF.
      *
      * @param attemptNumber the retry attempt number (0-based)
      * @return the backoff delay in milliseconds
      */
     private long calculateBackoff(int attemptNumber) {
         // Cap the exponent to prevent overflow and limit backoff growth
-        int cappedAttempt = Math.min(attemptNumber, MAX_RETRY_ATTEMPTS);
+        int cappedAttempt = Math.min(attemptNumber, BACKOFF_ESCALATION_THRESHOLD);
         long backoff = INITIAL_RETRY_BACKOFF_MS * (1L << cappedAttempt);
         return Math.min(backoff, MAX_RETRY_BACKOFF_MS);
     }
@@ -398,7 +399,7 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                     }
 
                     long backoffMs = calculateBackoff(attemptNumber);
-                    if (attemptNumber < MAX_RETRY_ATTEMPTS) {
+                    if (attemptNumber < BACKOFF_ESCALATION_THRESHOLD) {
                         log.warn("Failed to write status update for key {} (attempt {}). " +
                                 "Retrying after {}ms. Reason: {}",
                                 key, attemptNumber + 1, backoffMs, exception.getMessage());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -128,6 +128,11 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             TOPIC_STATUS_VALUE_SCHEMA_V0
     ).build();
 
+    // Retry configuration constants
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+    private static final long INITIAL_RETRY_BACKOFF_MS = 300;
+    private static final long MAX_RETRY_BACKOFF_MS = 60000; // 60 seconds
+
     private final Time time;
     private final Converter converter;
     //visible for testing
@@ -276,18 +281,62 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
 
         final byte[] value = serializeTopicStatus(status);
 
+        sendWithRetry(key, value, 0);
+    }
+
+    /**
+     * Send a message to the status topic with retry logic using exponential backoff.
+     *
+     * @param key the message key
+     * @param value the message value
+     * @param attemptNumber the current retry attempt number (0 for first attempt)
+     */
+    private void sendWithRetry(final String key, final byte[] value, final int attemptNumber) {
         kafkaLog.send(key, value, new org.apache.kafka.clients.producer.Callback() {
             @Override
             public void onCompletion(RecordMetadata metadata, Exception exception) {
-                if (exception == null) return;
-                // TODO: retry more gracefully and not forever
+                if (exception == null) {
+                    if (attemptNumber > 0) {
+                        log.info("Successfully sent status update for key {} after {} retry attempt(s)",
+                                key, attemptNumber);
+                    }
+                    return;
+                }
+                
                 if (exception instanceof RetriableException) {
-                    sendRetryExecutor.submit(() -> kafkaLog.send(key, value, this));
+                    if (attemptNumber >= MAX_RETRY_ATTEMPTS) {
+                        log.error("Failed to write status update for key {} after {} attempts. Giving up.",
+                                key, attemptNumber + 1, exception);
+                        return;
+                    }
+                    
+                    long backoffMs = calculateBackoff(attemptNumber);
+                    log.warn("Failed to write status update for key {} (attempt {}/{}). " +
+                            "Retrying after {}ms. Reason: {}",
+                            key, attemptNumber + 1, MAX_RETRY_ATTEMPTS + 1, backoffMs, exception.getMessage());
+                    
+                    sendRetryExecutor.submit(() -> {
+                        time.sleep(backoffMs);
+                        sendWithRetry(key, value, attemptNumber + 1);
+                    });
                 } else {
-                    log.error("Failed to write status update", exception);
+                    log.error("Failed to write status update for key {} with non-retriable exception",
+                            key, exception);
                 }
             }
         });
+    }
+
+    /**
+     * Calculate exponential backoff delay for retry attempts.
+     * Uses formula: min(INITIAL_BACKOFF * 2^attempt, MAX_BACKOFF)
+     *
+     * @param attemptNumber the retry attempt number (0-based)
+     * @return the backoff delay in milliseconds
+     */
+    private long calculateBackoff(int attemptNumber) {
+        long backoff = INITIAL_RETRY_BACKOFF_MS * (1L << attemptNumber);
+        return Math.min(backoff, MAX_RETRY_BACKOFF_MS);
     }
 
     private <V extends AbstractStatus<?>> void send(final String key,
@@ -304,21 +353,66 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
 
         final byte[] value = status.state() == ConnectorStatus.State.DESTROYED ? null : serialize(status);
 
+        sendWithRetry(key, value, status, entry, safeWrite, sequence, 0);
+    }
+
+    /**
+     * Send a status update with retry logic using exponential backoff.
+     *
+     * @param key the message key
+     * @param value the message value
+     * @param status the status object
+     * @param entry the cache entry
+     * @param safeWrite whether to perform safe write checks
+     * @param sequence the sequence number for safe write validation
+     * @param attemptNumber the current retry attempt number (0 for first attempt)
+     */
+    private <V extends AbstractStatus<?>> void sendWithRetry(final String key,
+                                                              final byte[] value,
+                                                              final V status,
+                                                              final CacheEntry<V> entry,
+                                                              final boolean safeWrite,
+                                                              final int sequence,
+                                                              final int attemptNumber) {
         kafkaLog.send(key, value, new org.apache.kafka.clients.producer.Callback() {
             @Override
             public void onCompletion(RecordMetadata metadata, Exception exception) {
-                if (exception == null) return;
+                if (exception == null) {
+                    if (attemptNumber > 0) {
+                        log.info("Successfully sent status update for key {} after {} retry attempt(s)",
+                                key, attemptNumber);
+                    }
+                    return;
+                }
+                
                 if (exception instanceof RetriableException) {
                     synchronized (KafkaStatusBackingStore.this) {
                         if (entry.isDeleted()
                             || status.generation() != generation
-                            || (safeWrite && !entry.canWriteSafely(status, sequence)))
+                            || (safeWrite && !entry.canWriteSafely(status, sequence))) {
+                            log.debug("Skipping retry for key {} due to stale status or deleted entry", key);
                             return;
+                        }
                     }
 
-                    sendRetryExecutor.submit(() -> kafkaLog.send(key, value, this));
+                    if (attemptNumber >= MAX_RETRY_ATTEMPTS) {
+                        log.error("Failed to write status update for key {} after {} attempts. Giving up.",
+                                key, attemptNumber + 1, exception);
+                        return;
+                    }
+                    
+                    long backoffMs = calculateBackoff(attemptNumber);
+                    log.warn("Failed to write status update for key {} (attempt {}/{}). " +
+                            "Retrying after {}ms. Reason: {}",
+                            key, attemptNumber + 1, MAX_RETRY_ATTEMPTS + 1, backoffMs, exception.getMessage());
+                    
+                    sendRetryExecutor.submit(() -> {
+                        time.sleep(backoffMs);
+                        sendWithRetry(key, value, status, entry, safeWrite, sequence, attemptNumber + 1);
+                    });
                 } else {
-                    log.error("Failed to write status update", exception);
+                    log.error("Failed to write status update for key {} with non-retriable exception",
+                            key, exception);
                 }
             }
         });

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.internals.ExponentialBackoff;
 import org.apache.kafka.common.utils.internals.ThreadUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -128,11 +129,8 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
             TOPIC_STATUS_VALUE_SCHEMA_V0
     ).build();
 
-    // Retry configuration constants
-    // After this many attempts, backoff will be capped at MAX_RETRY_BACKOFF_MS
-    private static final int BACKOFF_ESCALATION_THRESHOLD = 10;
-    private static final long INITIAL_RETRY_BACKOFF_MS = 300;
-    private static final long MAX_RETRY_BACKOFF_MS = 60000; // 60 seconds
+    // Exponential backoff for status send retries: 300ms initial, 2x multiplier, 60s max, no jitter
+    private static final ExponentialBackoff SEND_RETRY_BACKOFF = new ExponentialBackoff(300, 2, 60_000, 0);
 
     private final Time time;
     private final Converter converter;
@@ -305,17 +303,10 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                 }
                 
                 if (exception instanceof RetriableException) {
-                    long backoffMs = calculateBackoff(attemptNumber);
-                    if (attemptNumber < BACKOFF_ESCALATION_THRESHOLD) {
-                        log.warn("Failed to write status update for key {} (attempt {}). " +
-                                "Retrying after {}ms. Reason: {}",
-                                key, attemptNumber + 1, backoffMs, exception.getMessage());
-                    } else {
-                        log.warn("Failed to write status update for key {} after {} attempts. " +
-                                "Will continue retrying with {}ms backoff. Reason: {}",
-                                key, attemptNumber + 1, backoffMs, exception.getMessage());
-                    }
-                    
+                    long backoffMs = SEND_RETRY_BACKOFF.backoff(attemptNumber);
+                    log.warn("Failed to write status update for key {} (attempt {}). " +
+                            "Retrying after {}ms. Reason: {}",
+                            key, attemptNumber + 1, backoffMs, exception.getMessage());
                     sendRetryExecutor.schedule(() -> {
                         sendWithRetry(key, value, attemptNumber + 1);
                     }, backoffMs, TimeUnit.MILLISECONDS);
@@ -325,21 +316,6 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                 }
             }
         });
-    }
-
-    /**
-     * Calculate exponential backoff delay for retry attempts.
-     * Uses formula: min(INITIAL_BACKOFF * 2^attempt, MAX_BACKOFF)
-     * After BACKOFF_ESCALATION_THRESHOLD attempts, the backoff is capped at MAX_BACKOFF.
-     *
-     * @param attemptNumber the retry attempt number (0-based)
-     * @return the backoff delay in milliseconds
-     */
-    private long calculateBackoff(int attemptNumber) {
-        // Cap the exponent to prevent overflow and limit backoff growth
-        int cappedAttempt = Math.min(attemptNumber, BACKOFF_ESCALATION_THRESHOLD);
-        long backoff = INITIAL_RETRY_BACKOFF_MS * (1L << cappedAttempt);
-        return Math.min(backoff, MAX_RETRY_BACKOFF_MS);
     }
 
     private <V extends AbstractStatus<?>> void send(final String key,
@@ -398,17 +374,10 @@ public class KafkaStatusBackingStore extends KafkaTopicBasedBackingStore impleme
                         }
                     }
 
-                    long backoffMs = calculateBackoff(attemptNumber);
-                    if (attemptNumber < BACKOFF_ESCALATION_THRESHOLD) {
-                        log.warn("Failed to write status update for key {} (attempt {}). " +
-                                "Retrying after {}ms. Reason: {}",
-                                key, attemptNumber + 1, backoffMs, exception.getMessage());
-                    } else {
-                        log.warn("Failed to write status update for key {} after {} attempts. " +
-                                "Will continue retrying with {}ms backoff. Reason: {}",
-                                key, attemptNumber + 1, backoffMs, exception.getMessage());
-                    }
-                    
+                    long backoffMs = SEND_RETRY_BACKOFF.backoff(attemptNumber);
+                    log.warn("Failed to write status update for key {} (attempt {}). " +
+                            "Retrying after {}ms. Reason: {}",
+                            key, attemptNumber + 1, backoffMs, exception.getMessage());
                     sendRetryExecutor.schedule(() -> {
                         sendWithRetry(key, value, status, entry, safeWrite, sequence, attemptNumber + 1);
                     }, backoffMs, TimeUnit.MILLISECONDS);

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TranslateSurrogates.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TranslateSurrogates.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.internals.AppInfoParser;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+/**
+ * A {@link Transformation} that translates UTF-16 surrogate pairs found in string fields
+ * into one of three representations:
+ * <ul>
+ *   <li>{@code url-encode} (default) — percent-encodes the character using its UTF-8 byte sequence</li>
+ *   <li>{@code java-encode} — encodes as {@code \UXXXX\UXXXX} Java-style surrogate pair notation</li>
+ *   <li>{@code replace} — replaces the character with a configurable replacement string
+ *       (defaults to the Unicode replacement character U+FFFD)</li>
+ * </ul>
+ * <p>
+ * Use the concrete transformation type designed for the record key ({@link Key}) or value ({@link Value}).
+ */
+public abstract class TranslateSurrogates<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+            "Translate UTF-16 surrogate pairs in string fields to their UTF-8 URL encoding, "
+            + "a Java-style \\UXXXX notation, or a configurable replacement string."
+            + "<p/>Applies to string fields at any depth in structs, maps, or arrays."
+            + "<p/>Use the concrete transformation type designed for the record key (<code>"
+            + Key.class.getName() + "</code>) "
+            + "or value (<code>" + Value.class.getName() + "</code>).";
+
+    public static final String FIELDS_CONFIG = "fields";
+    public static final String MODE_CONFIG = "mode";
+    public static final String REPLACEMENT_CONFIG = "replacement";
+
+    static final String MODE_URL_ENCODE = "url-encode";
+    static final String MODE_JAVA_ENCODE = "java-encode";
+    static final String MODE_REPLACE = "replace";
+
+    static final String UNICODE_REPLACEMENT_CHARACTER = "\uFFFD";
+
+    private static final String PURPOSE = "translate surrogate pairs";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(MODE_CONFIG,
+                    ConfigDef.Type.STRING,
+                    MODE_URL_ENCODE,
+                    ConfigDef.LambdaValidator.with(
+                        (name, value) -> {
+                            String mode = (String) value;
+                            if (!MODE_URL_ENCODE.equals(mode)
+                                    && !MODE_JAVA_ENCODE.equals(mode)
+                                    && !MODE_REPLACE.equals(mode))
+                                throw new ConfigException(name, value,
+                                    "Must be one of: " + MODE_URL_ENCODE + ", "
+                                        + MODE_JAVA_ENCODE + ", " + MODE_REPLACE);
+                        },
+                        () -> "one of: " + MODE_URL_ENCODE + ", " + MODE_JAVA_ENCODE + ", " + MODE_REPLACE),
+                    ConfigDef.Importance.HIGH,
+                    "Translation mode for surrogate pairs. Must be one of: "
+                        + MODE_URL_ENCODE + " (default), " + MODE_JAVA_ENCODE + ", or " + MODE_REPLACE + ".")
+            .define(FIELDS_CONFIG,
+                    ConfigDef.Type.LIST,
+                    Collections.emptyList(),
+                    ConfigDef.Importance.MEDIUM,
+                    "Names of fields to translate. If empty, all string fields are scanned.")
+            .define(REPLACEMENT_CONFIG,
+                    ConfigDef.Type.STRING,
+                    UNICODE_REPLACEMENT_CHARACTER,
+                    ConfigDef.LambdaValidator.with(
+                        (name, value) -> {
+                            String s = (String) value;
+                            for (int i = 0; i < s.length(); ) {
+                                int cp = s.codePointAt(i);
+                                if (!Character.isBmpCodePoint(cp))
+                                    throw new ConfigException(name, value,
+                                        "Replacement string must not itself contain surrogate pairs.");
+                                i += Character.charCount(cp);
+                            }
+                        },
+                        () -> "a string without surrogate pairs"),
+                    ConfigDef.Importance.LOW,
+                    "Replacement string used when mode is '" + MODE_REPLACE + "'. Must not contain surrogate pairs.");
+
+    // package-private for testing: maps a non-BMP code point to its encoded string representation
+    Function<Integer, String> surrogateEncoder;
+
+    private Set<String> fields;
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        final String mode = config.getString(MODE_CONFIG);
+        fields = new HashSet<>(config.getList(FIELDS_CONFIG));
+        final String replacement = config.getString(REPLACEMENT_CONFIG);
+
+        switch (mode) {
+            case MODE_JAVA_ENCODE:
+                surrogateEncoder = codePoint -> {
+                    char[] chars = Character.toChars(codePoint);
+                    StringBuilder sb = new StringBuilder();
+                    for (char c : chars)
+                        sb.append(String.format("\\U%04X", (int) c));
+                    return sb.toString();
+                };
+                break;
+            case MODE_REPLACE:
+                surrogateEncoder = codePoint -> replacement;
+                break;
+            default: // url-encode
+                surrogateEncoder = codePoint ->
+                    URLEncoder.encode(new String(Character.toChars(codePoint)), StandardCharsets.UTF_8);
+                break;
+        }
+    }
+
+    @Override
+    public R apply(R record) {
+        final Object value = operatingValue(record);
+        if (value == null)
+            return record;
+        return newRecord(record, translated(value));
+    }
+
+    private Object translated(Object input) {
+        final Schema.Type type = ConnectSchema.schemaType(input.getClass());
+        if (type == null)
+            throw new DataException(TranslateSurrogates.class.getSimpleName()
+                    + " cannot process value of type " + input.getClass().getName()
+                    + " which is not supported by the Connect data API");
+
+        switch (type) {
+            case STRING:
+                return translateString((String) input);
+            case ARRAY: {
+                @SuppressWarnings("unchecked")
+                final List<Object> list = (List<Object>) input;
+                final List<Object> result = new ArrayList<>(list.size());
+                for (Object item : list)
+                    result.add(item instanceof String ? translateString((String) item) : item);
+                return result;
+            }
+            case MAP: {
+                final Map<String, Object> map = requireMap(input, PURPOSE);
+                final Map<String, Object> result = new HashMap<>(map);
+                final Set<String> targetFields = fields.isEmpty() ? map.keySet() : fields;
+                for (String field : targetFields) {
+                    final Object v = map.get(field);
+                    if (v instanceof String)
+                        result.put(field, translateString((String) v));
+                }
+                return result;
+            }
+            case STRUCT: {
+                final Struct struct = requireStruct(input, PURPOSE);
+                final Struct result = new Struct(struct.schema());
+                for (Field field : struct.schema().fields()) {
+                    final Object orig = struct.get(field);
+                    final boolean shouldTranslate = fields.isEmpty() || fields.contains(field.name());
+                    result.put(field, shouldTranslate && orig instanceof String
+                            ? translateString((String) orig)
+                            : orig);
+                }
+                return result;
+            }
+            default:
+                return input;
+        }
+    }
+
+    // package-private for testing
+    String translateString(String input) {
+        final StringBuilder sb = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); ) {
+            final int cp = input.codePointAt(i);
+            if (!Character.isBmpCodePoint(cp)) {
+                sb.append(surrogateEncoder.apply(cp));
+                i += 2; // a surrogate pair is two chars
+            } else {
+                sb.appendCodePoint(cp);
+                i++;
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public String version() {
+        return AppInfoParser.getVersion();
+    }
+
+    protected abstract Schema operatingSchema(R record);
+
+    protected abstract Object operatingValue(R record);
+
+    protected abstract R newRecord(R record, Object updatedValue);
+
+    public static class Key<R extends ConnectRecord<R>> extends TranslateSurrogates<R> {
+        @Override
+        protected Schema operatingSchema(R record) { return record.keySchema(); }
+
+        @Override
+        protected Object operatingValue(R record) { return record.key(); }
+
+        @Override
+        protected R newRecord(R record, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(),
+                    record.keySchema(), updatedValue,
+                    record.valueSchema(), record.value(), record.timestamp());
+        }
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends TranslateSurrogates<R> {
+        @Override
+        protected Schema operatingSchema(R record) { return record.valueSchema(); }
+
+        @Override
+        protected Object operatingValue(R record) { return record.value(); }
+
+        @Override
+        protected R newRecord(R record, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(),
+                    record.keySchema(), record.key(),
+                    record.valueSchema(), updatedValue, record.timestamp());
+        }
+    }
+}

--- a/connect/transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/connect/transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -38,4 +38,6 @@ org.apache.kafka.connect.transforms.SetSchemaMetadata$Value
 org.apache.kafka.connect.transforms.TimestampConverter$Key
 org.apache.kafka.connect.transforms.TimestampConverter$Value
 org.apache.kafka.connect.transforms.TimestampRouter
+org.apache.kafka.connect.transforms.TranslateSurrogates$Key
+org.apache.kafka.connect.transforms.TranslateSurrogates$Value
 org.apache.kafka.connect.transforms.ValueToKey

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TranslateSurrogatesTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TranslateSurrogatesTest.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TranslateSurrogatesTest {
+
+    // U+23A3A (𣘺) — a non-BMP character represented as surrogate pair \uD84D\uDE3A
+    private static final String SURROGATE_CHAR = "\uD84D\uDE3A";
+    private static final int SURROGATE_CODE_POINT = 0x23A3A;
+
+    private final TranslateSurrogates<SourceRecord> xformKey = new TranslateSurrogates.Key<>();
+    private final TranslateSurrogates<SourceRecord> xformValue = new TranslateSurrogates.Value<>();
+
+    @AfterEach
+    public void teardown() {
+        xformKey.close();
+        xformValue.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Configuration validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void configRejectsEmptyMode() {
+        assertThrows(ConfigException.class,
+            () -> xformKey.configure(Collections.singletonMap(TranslateSurrogates.MODE_CONFIG, "")));
+    }
+
+    @Test
+    public void configRejectsInvalidMode() {
+        assertThrows(ConfigException.class,
+            () -> xformKey.configure(Collections.singletonMap(TranslateSurrogates.MODE_CONFIG, "base64")));
+    }
+
+    @Test
+    public void configRejectsReplacementContainingSurrogatePair() {
+        assertThrows(ConfigException.class,
+            () -> xformKey.configure(Collections.singletonMap(
+                TranslateSurrogates.REPLACEMENT_CONFIG, SURROGATE_CHAR)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Encoder behaviour per mode
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void defaultModeUrlEncodesNonBmpCodePoint() {
+        xformKey.configure(Collections.emptyMap());
+        // U+23A3A → UTF-8 bytes F0 A3 98 BA → %F0%A3%98%BA
+        assertEquals("%F0%A3%98%BA", xformKey.surrogateEncoder.apply(SURROGATE_CODE_POINT));
+    }
+
+    @Test
+    public void javaEncodeModeEncodesSurrogatePair() {
+        xformKey.configure(Collections.singletonMap(TranslateSurrogates.MODE_CONFIG, TranslateSurrogates.MODE_JAVA_ENCODE));
+        // Surrogate pair: \uD84D \uDE3A
+        assertEquals("\\UD84D\\UDE3A", xformKey.surrogateEncoder.apply(SURROGATE_CODE_POINT));
+    }
+
+    @Test
+    public void replaceModeUsesDefaultReplacementCharacter() {
+        xformKey.configure(Collections.singletonMap(TranslateSurrogates.MODE_CONFIG, TranslateSurrogates.MODE_REPLACE));
+        assertEquals(TranslateSurrogates.UNICODE_REPLACEMENT_CHARACTER,
+                xformKey.surrogateEncoder.apply(SURROGATE_CODE_POINT));
+    }
+
+    @Test
+    public void replaceModeUsesConfiguredReplacementString() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TranslateSurrogates.MODE_CONFIG, TranslateSurrogates.MODE_REPLACE);
+        config.put(TranslateSurrogates.REPLACEMENT_CONFIG, "SURROGATE");
+        xformKey.configure(config);
+        assertEquals("SURROGATE", xformKey.surrogateEncoder.apply(SURROGATE_CODE_POINT));
+    }
+
+    // -------------------------------------------------------------------------
+    // translateString — unit tests on the string translation method
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void translateStringLeavesPlainAsciiUnchanged() {
+        xformValue.configure(Collections.emptyMap());
+        assertEquals("hello world", xformValue.translateString("hello world"));
+    }
+
+    @Test
+    public void translateStringUrlEncodesSurrogatePair() {
+        xformValue.configure(Collections.emptyMap());
+        assertEquals("abc%F0%A3%98%BAabc", xformValue.translateString("abc" + SURROGATE_CHAR + "abc"));
+    }
+
+    @Test
+    public void translateStringJavaEncodesSurrogatePair() {
+        xformValue.configure(Collections.singletonMap(TranslateSurrogates.MODE_CONFIG, TranslateSurrogates.MODE_JAVA_ENCODE));
+        assertEquals("abc\\UD84D\\UDE3Aabc", xformValue.translateString("abc" + SURROGATE_CHAR + "abc"));
+    }
+
+    @Test
+    public void translateStringReplacesSurrogatePair() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TranslateSurrogates.MODE_CONFIG, TranslateSurrogates.MODE_REPLACE);
+        config.put(TranslateSurrogates.REPLACEMENT_CONFIG, "?");
+        xformValue.configure(config);
+        assertEquals("abc?abc", xformValue.translateString("abc" + SURROGATE_CHAR + "abc"));
+    }
+
+    @Test
+    public void translateStringHandlesMultipleSurrogatePairs() {
+        xformValue.configure(Collections.emptyMap());
+        assertEquals("%F0%A3%98%BA%F0%A3%98%BA", xformValue.translateString(SURROGATE_CHAR + SURROGATE_CHAR));
+    }
+
+    // -------------------------------------------------------------------------
+    // apply() on schemaless records
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void schemalessStringValueIsTranslated() {
+        xformValue.configure(Collections.emptyMap());
+        SourceRecord out = xformValue.apply(record(null, "abc" + SURROGATE_CHAR));
+        assertEquals("abc%F0%A3%98%BA", out.value());
+    }
+
+    @Test
+    public void schemalessMapAllFieldsTranslatedByDefault() {
+        xformValue.configure(Collections.emptyMap());
+
+        Map<String, Object> value = new HashMap<>();
+        value.put("f1", 42);
+        value.put("f2", "plain");
+        value.put("f3", "abc" + SURROGATE_CHAR);
+        value.put("f4", "abc" + SURROGATE_CHAR + "abc");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) xformValue.apply(record(null, value)).value();
+
+        assertEquals(42, out.get("f1"));
+        assertEquals("plain", out.get("f2"));
+        assertEquals("abc%F0%A3%98%BA", out.get("f3"));
+        assertEquals("abc%F0%A3%98%BAabc", out.get("f4"));
+    }
+
+    @Test
+    public void schemalessMapOnlyConfiguredFieldsTranslated() {
+        xformValue.configure(Collections.singletonMap(TranslateSurrogates.FIELDS_CONFIG, "f3"));
+
+        Map<String, Object> value = new HashMap<>();
+        value.put("f1", 42);
+        value.put("f2", "plain");
+        value.put("f3", "abc" + SURROGATE_CHAR);
+        value.put("f4", "abc" + SURROGATE_CHAR + "abc");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) xformValue.apply(record(null, value)).value();
+
+        assertEquals(42, out.get("f1"));
+        assertEquals("plain", out.get("f2"));
+        assertEquals("abc%F0%A3%98%BA", out.get("f3"));
+        // f4 not in fields config — must be left unchanged
+        assertEquals("abc" + SURROGATE_CHAR + "abc", out.get("f4"));
+    }
+
+    @Test
+    public void schemalessArrayStringsAreTranslated() {
+        xformValue.configure(Collections.emptyMap());
+
+        List<Object> value = new ArrayList<>();
+        value.add("plain");
+        value.add("abc" + SURROGATE_CHAR);
+        value.add("abc" + SURROGATE_CHAR + "abc");
+
+        @SuppressWarnings("unchecked")
+        List<Object> out = (List<Object>) xformValue.apply(record(null, value)).value();
+
+        assertEquals("plain", out.get(0));
+        assertEquals("abc%F0%A3%98%BA", out.get(1));
+        assertEquals("abc%F0%A3%98%BAabc", out.get(2));
+    }
+
+    @Test
+    public void nullValueIsPassedThrough() {
+        xformValue.configure(Collections.emptyMap());
+        SourceRecord in = record(null, null);
+        assertEquals(in, xformValue.apply(in));
+    }
+
+    @Test
+    public void unsupportedTypeThrowsDataException() {
+        xformValue.configure(Collections.emptyMap());
+        assertThrows(DataException.class,
+            () -> xformValue.apply(record(null, new Date())));
+    }
+
+    // -------------------------------------------------------------------------
+    // apply() on schema-based records
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void schemaBasedStructAllStringFieldsTranslated() {
+        xformValue.configure(Collections.emptyMap());
+
+        Schema schema = SchemaBuilder.struct()
+                .field("name", Schema.STRING_SCHEMA)
+                .field("count", Schema.INT32_SCHEMA)
+                .build();
+
+        Struct value = new Struct(schema)
+                .put("name", "abc" + SURROGATE_CHAR)
+                .put("count", 7);
+
+        Struct out = (Struct) xformValue.apply(record(schema, value)).value();
+        assertEquals("abc%F0%A3%98%BA", out.get("name"));
+        assertEquals(7, out.get("count"));
+    }
+
+    @Test
+    public void schemaBasedStructOnlyConfiguredFieldsTranslated() {
+        xformValue.configure(Collections.singletonMap(TranslateSurrogates.FIELDS_CONFIG, "f1"));
+
+        Schema schema = SchemaBuilder.struct()
+                .field("f1", Schema.STRING_SCHEMA)
+                .field("f2", Schema.STRING_SCHEMA)
+                .build();
+
+        Struct value = new Struct(schema)
+                .put("f1", "abc" + SURROGATE_CHAR)
+                .put("f2", "abc" + SURROGATE_CHAR);
+
+        Struct out = (Struct) xformValue.apply(record(schema, value)).value();
+        assertEquals("abc%F0%A3%98%BA", out.get("f1"));
+        // f2 not in fields config — must be left unchanged
+        assertEquals("abc" + SURROGATE_CHAR, out.get("f2"));
+    }
+
+    @Test
+    public void schemaBasedNestedStructIsTranslated() {
+        xformValue.configure(Collections.emptyMap());
+
+        Schema inner = SchemaBuilder.struct()
+                .field("inner_f", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Schema outer = SchemaBuilder.struct()
+                .field("outer_f", Schema.STRING_SCHEMA)
+                .field("nested", inner)
+                .build();
+
+        Struct innerValue = new Struct(inner).put("inner_f", "abc" + SURROGATE_CHAR);
+        Struct outerValue = new Struct(outer)
+                .put("outer_f", "abc" + SURROGATE_CHAR)
+                .put("nested", innerValue);
+
+        Struct out = (Struct) xformValue.apply(record(outer, outerValue)).value();
+        assertEquals("abc%F0%A3%98%BA", out.get("outer_f"));
+        assertEquals("abc%F0%A3%98%BA", ((Struct) out.get("nested")).get("inner_f"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Key transform
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void keyTransformTranslatesKey() {
+        xformKey.configure(Collections.emptyMap());
+        SourceRecord out = xformKey.apply(record("abc" + SURROGATE_CHAR, "untouched"));
+        assertEquals("abc%F0%A3%98%BA", out.key());
+        assertEquals("untouched", out.value());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static SourceRecord record(Object key, Object value) {
+        return new SourceRecord(null, null, "topic", 0, null, key, null, value);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a new `TranslateSurrogates` transformation to handle UTF-16 surrogate pairs in string fields.

## Changes

**Files:**
- `connect/transforms/src/main/java/org/apache/kafka/connect/transforms/TranslateSurrogates.java` (new)
- `connect/transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation` (updated)
- `connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TranslateSurrogatesTest.java` (new)

**Motivation:** Some data sources produce UTF-16 surrogate pairs in string fields that cannot be properly serialized or processed by downstream systems. This transformation provides configurable handling of such characters.

**Features:**
- Supports three encoding modes:
  - `url-encode` (default): Percent-encodes using UTF-8 byte sequence (e.g., U+23A3A → `%F0%A3%98%BA`)
  - `java-encode`: Java-style surrogate pair notation (e.g., `\UD84D\UDE3A`)
  - `replace`: Replaces with configurable string (defaults to Unicode replacement character U+FFFD)
- Processes string fields at any depth in structs, maps, and arrays
- Supports optional field filtering via `fields` config
- Available as both `Key` and `Value` transformation variants
- Validates that replacement strings do not themselves contain surrogate pairs

## Testing Strategy

Comprehensive test suite covering:
- **Configuration validation**: Invalid modes, replacement strings containing surrogates
- **Encoding behaviour per mode**: URL encoding, Java encoding, custom replacements
- **String translation**: ASCII passthrough, single/multiple surrogate pairs
- **Schemaless records**: String values, maps (all/filtered fields), arrays, null handling
- **Schema-based records**: Structs with selective field translation, nested structures
- **Key vs. Value transforms**: Correct record updates for each variant
- **Edge cases**: Unsupported types, multiple consecutive surrogate pairs

## Key improvements over earlier draft (PR #10287)
- Use `ConfigDef.LambdaValidator` instead of anonymous `Validator` classes
- `URLEncoder.encode(str, Charset)` instead of `(str, String)` — no checked exception
- Fixed `Key.newRecord()` — original had key/value schemas swapped
- Null-value guard in `apply()` — original would NPE on null values
- `fields` config respected consistently for both MAP and STRUCT paths

JIRA: https://issues.apache.org/jira/browse/KAFKA-12443

Reviewers: Mickael Maison <mickael.maison@gmail.com>