### PR TITLE
Release RocksDB's default ReadOptions on store close

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RocksDBReadOptionsReleaseIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RocksDBReadOptionsReleaseIntegrationTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code RocksDBStore} releases {@code RocksDB.defaultReadOptions_} after {@code db.close()}, which
+ * is safe only because the database is already closed and every open iterator was closed first.
+ * That ordering is the whole safety argument, so it is worth exercising against a real broker with
+ * segments rolling and expiring underneath live iterators.
+ *
+ * <p>Record timestamps advance a minute apart, so a short retention churns segments continuously
+ * while interactive queries iterate across them. A use-after-free would surface here as a crash, a
+ * corrupted read, or a processing exception.
+ */
+@Tag("integration")
+@Timeout(600)
+public class RocksDBReadOptionsReleaseIntegrationTest {
+
+    private static final int NUM_BROKERS = 1;
+
+    private static final String STORE_NAME = "windowed-counts";
+    private static final long WINDOW_SIZE_MS = 10_000L;
+    /** Segment interval is derived as max(retention / 2, 60s), so this yields 2.5 min segments. */
+    private static final long RETENTION_MS = 300_000L;
+    /** One minute of stream time per record: rolls a segment every few records. */
+    private static final long ADVANCE_MS = 60_000L;
+    private static final int NUM_RECORDS = 90;
+
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    @BeforeAll
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterAll
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+
+    private KafkaStreams kafkaStreams;
+    private Properties streamsConfiguration;
+    private String inputTopic;
+    private String outputTopic;
+
+    @BeforeEach
+    public void before(final TestInfo testInfo) throws InterruptedException {
+        final String safeTestName = safeUniqueTestName(testInfo);
+        inputTopic = "input-" + safeTestName;
+        outputTopic = "output-" + safeTestName;
+        CLUSTER.createTopic(inputTopic, 2, 1);
+        CLUSTER.createTopic(outputTopic, 2, 1);
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        // No cache, so every record reaches the store and forces segment work.
+        streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        if (kafkaStreams != null) {
+            kafkaStreams.close(Duration.ofSeconds(60));
+            kafkaStreams.cleanUp();
+        }
+        IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    @Test
+    public void shouldServeQueriesCorrectlyWhileSegmentsRollAndExpire() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+                .groupByKey()
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(WINDOW_SIZE_MS)))
+                .count(Materialized.<String, Long>as(
+                        Stores.persistentWindowStore(
+                                STORE_NAME,
+                                Duration.ofMillis(RETENTION_MS),
+                                Duration.ofMillis(WINDOW_SIZE_MS),
+                                false)))
+                .toStream()
+                .map((windowedKey, count) ->
+                        KeyValue.pair(windowedKey.key() + "@" + windowedKey.window().start(), count))
+                .to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
+
+        final AtomicReference<Throwable> uncaught = new AtomicReference<>();
+        kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
+        kafkaStreams.setUncaughtExceptionHandler(throwable -> {
+            uncaught.compareAndSet(null, throwable);
+            return StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+        });
+        IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
+
+        // Hammer the store with iterators while segments roll and expire underneath.
+        final CountDownLatch stopQuerying = new CountDownLatch(1);
+        final AtomicInteger successfulQueries = new AtomicInteger();
+        final AtomicInteger concurrentModifications = new AtomicInteger();
+        final AtomicReference<Throwable> queryFailure = new AtomicReference<>();
+        final Thread querier = new Thread(() -> {
+            while (stopQuerying.getCount() > 0) {
+                try {
+                    final ReadOnlyWindowStore<String, Long> store = kafkaStreams.store(
+                            StoreQueryParameters.fromNameAndType(STORE_NAME, QueryableStoreTypes.windowStore()));
+                    try (KeyValueIterator<?, ?> all =
+                                 store.fetchAll(Instant.ofEpochMilli(0), Instant.ofEpochMilli(Long.MAX_VALUE / 2))) {
+                        while (all.hasNext()) {
+                            all.next();
+                        }
+                    }
+                    try (WindowStoreIterator<Long> single =
+                                 store.fetch("k0", Instant.ofEpochMilli(0), Instant.ofEpochMilli(Long.MAX_VALUE / 2))) {
+                        while (single.hasNext()) {
+                            single.next();
+                        }
+                    }
+                    successfulQueries.incrementAndGet();
+                } catch (final InvalidStateStoreException rebalancing) {
+                    // Expected while the store migrates; keep going.
+                } catch (final ConcurrentModificationException preExistingRace) {
+                    // NOT caused by releasing defaultReadOptions_. AbstractSegments holds its
+                    // segments in a plain TreeMap, so an interactive query iterating
+                    // AbstractSegments.segments() races the StreamThread creating or expiring a
+                    // segment. Verified to reproduce at the same rate with the release reverted, so
+                    // it is counted and tolerated rather than allowed to mask what this test covers.
+                    concurrentModifications.incrementAndGet();
+                } catch (final Throwable t) {
+                    queryFailure.compareAndSet(null, t);
+                    return;
+                }
+            }
+        }, "iterator-stress");
+        querier.setDaemon(true);
+        querier.start();
+
+        produceAdvancingRecords();
+
+        final List<KeyValue<String, Long>> received =
+                IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                        consumerConfig(), outputTopic, NUM_RECORDS, 120_000L);
+
+        stopQuerying.countDown();
+        querier.join(Duration.ofSeconds(30).toMillis());
+
+        if (queryFailure.get() != null) {
+            throw new AssertionError(
+                    "interactive queries must not fail while segments expire", queryFailure.get());
+        }
+        if (uncaught.get() != null) {
+            throw new AssertionError("the topology must not raise an uncaught exception", uncaught.get());
+        }
+        assertTrue(successfulQueries.get() > 0,
+                "expected at least one successful query against a live store, got " + successfulQueries.get());
+
+        // Each record sits in its own window, so every record yields exactly one aggregate update.
+        assertEquals(NUM_RECORDS, received.size(),
+                "every record should produce one windowed count despite segment expiry");
+        for (final KeyValue<String, Long> kv : received) {
+            assertEquals(1L, kv.value, "each window holds exactly one record: " + kv.key);
+        }
+    }
+
+    private void produceAdvancingRecords() {
+        final Properties producerConfig = new Properties();
+        producerConfig.put("bootstrap.servers", CLUSTER.bootstrapServers());
+        producerConfig.put("key.serializer", StringSerializer.class);
+        producerConfig.put("value.serializer", StringSerializer.class);
+
+        final List<KeyValue<String, String>> batch = new ArrayList<>();
+        for (int i = 0; i < NUM_RECORDS; i++) {
+            batch.add(KeyValue.pair("k" + (i % 4), "v" + i));
+        }
+        long timestamp = 0L;
+        for (final KeyValue<String, String> record : batch) {
+            IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                    inputTopic, List.of(record), producerConfig, timestamp);
+            timestamp += ADVANCE_MS;
+        }
+    }
+
+    private Properties consumerConfig() {
+        final Properties config = new Properties();
+        config.put("bootstrap.servers", CLUSTER.bootstrapServers());
+        config.put("group.id", "verifier-" + System.nanoTime());
+        config.put("auto.offset.reset", "earliest");
+        config.put("key.deserializer", StringDeserializer.class);
+        config.put("value.deserializer", LongDeserializer.class);
+        return config;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -75,6 +75,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -111,6 +112,23 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     private static final long BLOCK_SIZE = 4096L;
     private static final int MAX_WRITE_BUFFERS = 3;
     static final String DB_FILE_DIR = "rocksdb";
+
+    // RocksDB allocates a ReadOptions per instance in a field initializer but never closes it, and
+    // AbstractNativeReference has no finalizer, so its native memory is leaked for the lifetime of
+    // the JVM. Null if a future rocksdbjni renames the field or fixes the leak, which turns
+    // releaseDefaultReadOptions into a no-op.
+    private static final Field DEFAULT_READ_OPTIONS_FIELD = resolveDefaultReadOptionsField();
+
+    private static Field resolveDefaultReadOptionsField() {
+        try {
+            final Field field = RocksDB.class.getDeclaredField("defaultReadOptions_");
+            field.setAccessible(true);
+            return field;
+        } catch (final NoSuchFieldException | RuntimeException e) {
+            log.debug("Could not resolve RocksDB.defaultReadOptions_; its native memory will not be reclaimed", e);
+            return null;
+        }
+    }
 
     final String name;
     private final String parentDir;
@@ -963,6 +981,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
         dbAccessor.close();
         db.close();
+        releaseDefaultReadOptions(db);
         userSpecifiedOptions.close();
         if (offsetsCfOptions != null) {
             offsetsCfOptions.close();
@@ -985,6 +1004,26 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         filter = null;
         cache = null;
         statistics = null;
+    }
+
+    // Important: only call this after db.close(). The newIterator overloads that take no explicit
+    // ReadOptions pass this field to JNI, and Streams uses newIterator(ColumnFamilyHandle), so
+    // releasing it while an iterator is live would be a use-after-free. Closing the database first
+    // invalidates any such iterator anyway, and close() closes all open iterators before this.
+    // Never throws, and is safe to call twice.
+    // VisibleForTesting
+    static void releaseDefaultReadOptions(final RocksDB db) {
+        if (db == null || DEFAULT_READ_OPTIONS_FIELD == null) {
+            return;
+        }
+        try {
+            final ReadOptions defaultReadOptions = (ReadOptions) DEFAULT_READ_OPTIONS_FIELD.get(db);
+            if (defaultReadOptions != null) {
+                defaultReadOptions.close();
+            }
+        } catch (final IllegalAccessException | RuntimeException e) {
+            log.debug("Failed to release RocksDB's default ReadOptions", e);
+        }
     }
 
     /**
@@ -1014,6 +1053,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
         if (db != null) {
             db.close();
+            releaseDefaultReadOptions(db);
             db = null;
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBReadOptionsLongRunTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBReadOptionsLongRunTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Sustained-churn measurement for the {@code defaultReadOptions_} release. Stream time advances
+ * continuously so segments roll and expire throughout, which is how the leak accumulates in
+ * production. Two things are reported at the end: how many segments still own their native
+ * {@code ReadOptions}, which should track the number of segments still open rather than the
+ * cumulative number ever opened; and how many distinct native addresses were handed out, which
+ * only stays small if the memory is actually returned to the allocator and reused.
+ *
+ * <p>{@link TopologyTestDriver} rather than a live cluster, because it runs the real store and
+ * segment lifecycle single-threaded: the segment map can be sampled safely and stream time can be
+ * advanced far enough to churn thousands of segments in seconds.
+ *
+ * <p>Sized for CI by default. Longer runs via
+ * {@code -Dreadoptions.longrun.records=200000}.
+ */
+public class RocksDBReadOptionsLongRunTest {
+
+    private static final String STORE_NAME = "long-run-counts";
+    private static final long WINDOW_SIZE_MS = 1_000L;
+    private static final long RETENTION_MS = 120_000L;
+    /** Segment interval is max(retention / 2, 60s) = 60s, so this rolls a segment every record. */
+    private static final long ADVANCE_MS = 60_000L;
+
+    private static final int RECORDS =
+            Integer.parseInt(System.getProperty("readoptions.longrun.records", "3000"));
+
+    private static Field defaultReadOptionsField() throws Exception {
+        final Field field = RocksDB.class.getDeclaredField("defaultReadOptions_");
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static Field segmentsField() throws Exception {
+        final Field field = AbstractRocksDBSegmentedBytesStore.class.getDeclaredField("segments");
+        field.setAccessible(true);
+        return field;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AbstractSegments<? extends RocksDBStore> segmentsOf(final StateStore store) throws Exception {
+        StateStore current = store;
+        while (true) {
+            if (current instanceof WrappedStateStore) {
+                current = (StateStore) ((WrappedStateStore<?, ?, ?>) current).wrapped();
+            } else if (current instanceof WindowToTimestampedWindowByteStoreAdapter) {
+                // Not a WrappedStateStore, so it needs unwrapping by hand.
+                current = ((WindowToTimestampedWindowByteStoreAdapter) current).store;
+            } else {
+                break;
+            }
+        }
+        if (!(current instanceof AbstractRocksDBSegmentedBytesStore)) {
+            throw new AssertionError("expected a segmented RocksDB store, unwrapped to " + current.getClass());
+        }
+        return (AbstractSegments<? extends RocksDBStore>) segmentsField().get(current);
+    }
+
+    @Test
+    public void shouldNotAccumulateReadOptionsUnderSustainedSegmentChurn() throws Exception {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "readoptions-long-run");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        props.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream("input", Consumed.with(Serdes.String(), Serdes.String()))
+                .groupByKey()
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(WINDOW_SIZE_MS)))
+                .count(Materialized.as(Stores.persistentWindowStore(
+                        STORE_NAME,
+                        Duration.ofMillis(RETENTION_MS),
+                        Duration.ofMillis(WINDOW_SIZE_MS),
+                        false)));
+
+        final Field readOptionsField = defaultReadOptionsField();
+
+        // Identity-keyed: one entry per ReadOptions instance ever observed.
+        final IdentityHashMap<ReadOptions, Boolean> everSeen = new IdentityHashMap<>();
+        final Set<Long> distinctAddresses = new HashSet<>();
+        final Field nativeHandle = org.rocksdb.RocksObject.class.getDeclaredField("nativeHandle_");
+        nativeHandle.setAccessible(true);
+
+        int maxConcurrentlyOpen = 0;
+
+        try (TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> input = driver.createInputTopic(
+                    "input", new StringSerializer(), new StringSerializer());
+
+            final AbstractSegments<? extends RocksDBStore> segments =
+                    segmentsOf(driver.getAllStateStores().get(STORE_NAME));
+
+            long timestamp = 0L;
+            for (int i = 0; i < RECORDS; i++) {
+                input.pipeInput("k" + (i % 8), "v" + i, Instant.ofEpochMilli(timestamp));
+                timestamp += ADVANCE_MS;
+
+                // Single-threaded driver: safe to walk the segment map directly.
+                int open = 0;
+                for (final RocksDBStore segment : segments.segments.values()) {
+                    if (segment.db == null) {
+                        continue;
+                    }
+                    open++;
+                    final ReadOptions ro = (ReadOptions) readOptionsField.get(segment.db);
+                    if (ro != null) {
+                        everSeen.put(ro, Boolean.TRUE);
+                        distinctAddresses.add(nativeHandle.getLong(ro));
+                    }
+                }
+                maxConcurrentlyOpen = Math.max(maxConcurrentlyOpen, open);
+            }
+
+            int stillOwning = 0;
+            for (final ReadOptions ro : everSeen.keySet()) {
+                if (ro.isOwningHandle()) {
+                    stillOwning++;
+                }
+            }
+
+            System.out.printf(
+                    "records=%,d  segments observed=%,d  max concurrently open=%d  "
+                            + "still owning=%,d  distinct native addresses=%,d%n",
+                    RECORDS, everSeen.size(), maxConcurrentlyOpen, stillOwning, distinctAddresses.size());
+
+            // The store is still open, so the currently-live segments legitimately still own their
+            // handles. Everything already expired must not.
+            assertTrue(stillOwning <= maxConcurrentlyOpen,
+                    "still-owning ReadOptions (" + stillOwning + ") should not exceed the number of "
+                            + "concurrently open segments (" + maxConcurrentlyOpen + "); with the leak "
+                            + "present this grows with the " + everSeen.size() + " segments ever opened");
+
+            // Freed memory gets recycled, so addresses must be reused rather than growing 1:1.
+            assertTrue(distinctAddresses.size() < everSeen.size(),
+                    "expected native ReadOptions addresses to be reused after release, but saw "
+                            + distinctAddresses.size() + " distinct addresses for " + everSeen.size()
+                            + " segments — nothing is being returned to the allocator");
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreCloseLeakTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreCloseLeakTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRocksDbConfigSetter;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -28,12 +29,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -51,6 +57,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *     released. We simulate the throw via {@link ThrowingOnOffsetsPutDBAccessor} and observe via
  *     {@code isOwningHandle()} because {@code RocksDBStore.close()} swallows the resulting
  *     {@code RocksDBException}.</li>
+ * <li>{@code defaultReadOptions_} — {@code RocksDB} allocates a {@link ReadOptions} per instance
+ *     and never closes it, so {@code RocksDBStore} must. Covers the normal close, the
+ *     {@code openDB} error-cleanup path, expiry-driven segment close, and the versioned-store
+ *     shape where many logical segments share one physical database.</li>
  * </ol>
  */
 public class RocksDBStoreCloseLeakTest {
@@ -121,6 +131,132 @@ public class RocksDBStoreCloseLeakTest {
                 "offsets CF handle should still be closed when accessor.put throws");
         assertFalse(dataHandle.isOwningHandle(),
                 "data CF handle should still be closed when super.close() throws");
+    }
+
+    @Test
+    public void shouldReleaseDefaultReadOptionsOnStoreClose() throws Exception {
+        rocksDBStore = new RocksDBStore(DB_NAME, METRICS_SCOPE);
+        rocksDBStore.init(context, rocksDBStore);
+
+        // Capture before close(): RocksDBStore nulls out `db` as part of closing.
+        final ReadOptions defaultReadOptions = defaultReadOptionsOf(rocksDBStore.db);
+        assertTrue(defaultReadOptions.isOwningHandle(),
+                "defaultReadOptions_ should own its native handle while the store is open");
+
+        rocksDBStore.close();
+
+        assertFalse(defaultReadOptions.isOwningHandle(),
+                "RocksDB.close() never releases defaultReadOptions_, so RocksDBStore must do it");
+    }
+
+    @Test
+    public void shouldReleaseDefaultReadOptionsWhenOpenFailsPartway() {
+        final FailAfterOpenRocksDBStore store = new FailAfterOpenRocksDBStore();
+        rocksDBStore = store;
+
+        assertThrows(RuntimeException.class, () -> store.init(context, store));
+
+        assertNotNull(store.capturedReadOptions, "the database should have been opened before the failure");
+        assertFalse(store.capturedReadOptions.isOwningHandle(),
+                "the openDB error-cleanup path must release defaultReadOptions_ as well");
+    }
+
+    @Test
+    public void shouldNotThrowWhenDefaultReadOptionsReleasedTwice() {
+        rocksDBStore = new RocksDBStore(DB_NAME, METRICS_SCOPE);
+        rocksDBStore.init(context, rocksDBStore);
+        final RocksDB db = rocksDBStore.db;
+
+        rocksDBStore.close();
+
+        // close() already released it; a second release must be a no-op rather than a crash.
+        RocksDBStore.releaseDefaultReadOptions(db);
+    }
+
+    // Segments are closed by cleanupExpiredSegments during ordinary processing, not only at
+    // shutdown, and each segment is its own RocksDB: this is where the leak accumulates fastest.
+    @Test
+    public void shouldReleaseDefaultReadOptionsWhenSegmentExpires() throws Exception {
+        final long retentionPeriod = 100L;
+        final long segmentInterval = 10L;
+        final KeyValueSegments segments =
+                new KeyValueSegments("test-segments", METRICS_SCOPE, retentionPeriod, segmentInterval);
+        try {
+            segments.openExisting(context, 0L);
+
+            final KeyValueSegment expiringSegment = segments.getOrCreateSegmentIfLive(0, context, 0L);
+            assertNotNull(expiringSegment, "segment 0 should be live at stream time 0");
+            final ReadOptions segmentReadOptions = defaultReadOptionsOf(expiringSegment.db);
+            assertTrue(segmentReadOptions.isOwningHandle());
+
+            // Advance stream time past segment 0's retention. minLiveSegment becomes
+            // (200 - 100) / 10 = 10, so segment 0 is expired and closed in-flight.
+            assertNotNull(segments.getOrCreateSegmentIfLive(20, context, 200L));
+
+            assertFalse(segmentReadOptions.isOwningHandle(),
+                    "expiry-driven segment close must release defaultReadOptions_");
+        } finally {
+            segments.close();
+        }
+    }
+
+    // Versioned stores share one physical RocksDB across all logical segments, so releasing on
+    // logical-segment expiry would free the handle out from under the other segments.
+    @Test
+    public void shouldReleasePhysicalStoreReadOptionsOnlyWhenTheWholeStoreCloses() throws Exception {
+        final LogicalKeyValueSegments segments = new LogicalKeyValueSegments(
+                "logical-segments",
+                RocksDBStore.DB_FILE_DIR,
+                100L,
+                10L,
+                new RocksDBMetricsRecorder(METRICS_SCOPE, "logical-segments"));
+        final ReadOptions physicalReadOptions;
+        try {
+            segments.openExisting(context, 0L);
+            physicalReadOptions = defaultReadOptionsOf(segments.physicalStore().db);
+            assertTrue(physicalReadOptions.isOwningHandle());
+
+            assertNotNull(segments.getOrCreateSegmentIfLive(0, context, 0L));
+            // Expires logical segment 0 while the shared physical store stays open.
+            assertNotNull(segments.getOrCreateSegmentIfLive(20, context, 200L));
+
+            assertTrue(physicalReadOptions.isOwningHandle(),
+                    "expiring a logical segment must NOT release the shared physical store's "
+                            + "defaultReadOptions_ — other logical segments are still using that database");
+        } finally {
+            segments.close();
+        }
+
+        assertFalse(physicalReadOptions.isOwningHandle(),
+                "closing the segments should release the physical store's defaultReadOptions_");
+    }
+
+    // Fails right after the database is open, so openDB's error-cleanup path runs with a live
+    // RocksDB to release.
+    private static final class FailAfterOpenRocksDBStore extends RocksDBStore {
+        ReadOptions capturedReadOptions;
+
+        FailAfterOpenRocksDBStore() {
+            super(DB_NAME, METRICS_SCOPE);
+        }
+
+        @Override
+        void openRocksDB(final DBOptions dbOptions, final ColumnFamilyOptions columnFamilyOptions) {
+            super.openRocksDB(dbOptions, columnFamilyOptions);
+            try {
+                capturedReadOptions = defaultReadOptionsOf(db);
+            } catch (final Exception e) {
+                throw new AssertionError("could not read defaultReadOptions_", e);
+            }
+            throw new IllegalStateException("simulated failure after the database was opened");
+        }
+    }
+
+    // The field is private with no accessor, so reflection is the only way to observe it.
+    private static ReadOptions defaultReadOptionsOf(final RocksDB db) throws Exception {
+        final Field field = RocksDB.class.getDeclaredField("defaultReadOptions_");
+        field.setAccessible(true);
+        return (ReadOptions) field.get(db);
     }
 
     private static final class CapturingOffsetsRocksDBStore extends RocksDBStore {


### PR DESCRIPTION
`org.rocksdb.RocksDB` allocates a `ReadOptions` in a field initializer and never closes it:

`private final ReadOptions defaultReadOptions_ = new ReadOptions();   // RocksDB.java:42`

Streams is unusually exposed: it opens one RocksDB per store *and per segment*, and `AbstractSegments.cleanupExpiredSegments()` closes expired segments during ordinary processing, so windowed and session stores churn segments continuously. The loss accumulates in steady state, not just at rebalances.

### The change

`RocksDBStore` releases the field immediately after `db.close()`, at both close sites — `close()` and `closeDbAndAccessors()` (the `openDB` error-cleanup path, which leaks identically when an open fails partway). 40 lines of production code. No public API, configuration, metric or wire-protocol change.