### PR TITLE
KAFKA-20893: Avoid reporting incorrect task-offsets to Kafka Streams assignor (#23082)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -343,7 +344,7 @@ public class ProcessorStateManager implements StateManager {
         }
 
         try {
-            stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+            stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
         } catch (final RuntimeException e) {
             throw new ProcessorStateException(format("%sError updating state directory offsets when creating the state manager",
                 logPrefix), e);
@@ -425,10 +426,18 @@ public class ProcessorStateManager implements StateManager {
 
     @Override
     public Map<TopicPartition, Long> changelogOffsets() {
+        return changelogOffsets(storeMetadata -> true);
+    }
+
+    private Map<TopicPartition, Long> persistentChangelogOffsets() {
+        return changelogOffsets(storeMetadata -> storeMetadata.stateStore.persistent());
+    }
+
+    private Map<TopicPartition, Long> changelogOffsets(final Predicate<StateStoreMetadata> storeFilter) {
         // return the current offsets for those logged stores
         final Map<TopicPartition, Long> changelogOffsets = new HashMap<>();
         for (final StateStoreMetadata storeMetadata : stores.values()) {
-            if (storeMetadata.changelogPartition != null) {
+            if (storeMetadata.changelogPartition != null && storeFilter.test(storeMetadata)) {
                 // for changelog whose offset is unknown, use 0L indicating earliest offset
                 // otherwise return the current offset + 1 as the next offset to fetch
                 changelogOffsets.put(
@@ -502,7 +511,7 @@ public class ProcessorStateManager implements StateManager {
                 storeMetadata.setEndOffset(optionalLag.getAsLong() + batchEndOffset);
             }
 
-            stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+            stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
         }
     }
 
@@ -718,7 +727,7 @@ public class ProcessorStateManager implements StateManager {
             }
         }
 
-        stateDirectory.updateTaskOffsets(taskId, changelogOffsets());
+        stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
     }
 
     // Commit a sentinel value when the changelog offset is not yet initialized/known

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -318,7 +318,7 @@ public class StateDirectory implements AutoCloseable {
         taskOffsetSums.remove(taskId);
     }
 
-    private long sumOfChangelogOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
+    static long sumOfChangelogOffsets(final TaskId taskId, final Map<TopicPartition, Long> changelogOffsets) {
         long offsetSum = 0L;
         for (final Map.Entry<TopicPartition, Long> changelogEntry : changelogOffsets.entrySet()) {
             final long offset = changelogEntry.getValue();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1255,11 +1255,20 @@ public class TaskManager {
 
         final Map<TaskId, Long> taskOffsetSums = stateDirectory.taskOffsetSums(lockedTaskDirectoriesOfNonOwnedTasksAndClosedAndCreatedTasks);
 
-        // overlay latest offsets from assigned tasks
+        // Overlay latest offsets from assigned tasks.
+        // `stateDirectory.taskOffsetSums` above only cover what is recoverable from disk (potentially stale),
+        // including offsets from persistent stores which tasks are owned by sibling thread, as well as dormant tasks;
+        // We update this (potentially state) information with latest changelog offset inforamtion for all other
+        // tasks assigned to this thread; this step also adds offset-sum information for in-memory state stores
         for (final Task task : tasks.values()) {
             // exclude stateless and non-logged tasks
             if (task.isActive() && task.state() == State.RUNNING && !task.changelogPartitions().isEmpty()) {
                 taskOffsetSums.put(task.id(), Task.LATEST_OFFSET);
+            } else if (task.state() != State.CREATED && task.state() != State.CLOSED) {
+                final Map<TopicPartition, Long> changelogOffsets = task.changelogOffsets();
+                if (!changelogOffsets.isEmpty()) {
+                    taskOffsetSums.put(task.id(), StateDirectory.sumOfChangelogOffsets(task.id(), changelogOffsets));
+                }
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -544,6 +544,69 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
+    public void shouldNotTrackInMemoryStoreOffsetsInStateDirectory() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Arrays.asList(persistentStore, nonPersistentStore), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(mkMap(
+                mkEntry(persistentStorePartition, 100L),
+                mkEntry(nonPersistentStorePartition, 200L)));
+
+            // the shared sums outlive this task, so they must only count state that outlives it too (KAFKA-20893);
+            // the in-memory store's 201 is reported from the live task by TaskManager instead
+            assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(mkMap(mkEntry(taskId, 101L))));
+            assertThat(stateMgr.changelogOffsets(), is(mkMap(
+                mkEntry(persistentStorePartition, 101L),
+                mkEntry(nonPersistentStorePartition, 201L))));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(mkMap(mkEntry(taskId, 101L))));
+    }
+
+    @Test
+    public void shouldNotTrackOffsetsInStateDirectoryWhenNoStoreIsPersistent() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Collections.singletonList(nonPersistentStore), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(Collections.singletonMap(nonPersistentStorePartition, 200L));
+
+            assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(Collections.emptyMap()));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldTrackPersistentStoreOffsetsInStateDirectory() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        contextRegistersStateStore(stateMgr);
+
+        try {
+            stateMgr.registerStateStores(Arrays.asList(persistentStore, persistentStoreTwo), context);
+            stateMgr.initializeStoreOffsets(true);
+            stateMgr.updateChangelogOffsets(mkMap(
+                mkEntry(persistentStorePartition, 100L),
+                mkEntry(persistentStoreTwoPartition, 200L)));
+
+            assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(mkMap(mkEntry(taskId, 302L))));
+        } finally {
+            stateMgr.close();
+        }
+
+        assertThat(stateDirectory.taskOffsetSums(Collections.singleton(taskId)), is(mkMap(mkEntry(taskId, 302L))));
+    }
+
+    @Test
     public void shouldGetRegisteredStore() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1993,6 +1993,21 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void shouldComputeOffsetSumFromLiveOffsetsForOwnTasks() {
+        final StandbyTask ownStandbyTask = standbyTask(taskId02, taskId02ChangelogPartitions).inState(State.RUNNING).build();
+        when(ownStandbyTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p2changelog, 90L)));
+
+        final TasksRegistry tasks = mock(TasksRegistry.class);
+        final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
+        when(tasks.allInitializedTasksPerId()).thenReturn(Collections.emptyMap());
+        when(stateUpdater.tasks()).thenReturn(Set.of(ownStandbyTask));
+        when(stateDirectory.taskOffsetSums(Collections.singleton(taskId02)))
+            .thenReturn(mkMap(mkEntry(taskId02, 30L)));
+
+        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId02, 90L))));
+    }
+
+    @Test
     public void shouldSkipUnknownOffsetsWhenComputingOffsetSum() {
         final StreamTask restoringStatefulTask = statefulTask(taskId01, taskId01ChangelogPartitions)
             .inState(State.RESTORING).build();


### PR DESCRIPTION
The `StateDirectory` offset cache should only contain data for
persistent state store. This PR avoids the offset from in-memory state
stores are added to the cache, and ensure that the read path fills in
missing information for other state stores (in particular in-memory
ones) on the fly.

Reviewers: Nick Telford <nick.telford@gmail.com>, Bill Bejeck
 <bbejeck@apache.org>
