### PR TITLE
Fail fast in MirrorMaker 2 when source offsets become invalid

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.io.Serial;
+
+/**
+ * Thrown when MirrorMaker 2 determines that records which were never replicated have already been
+ * removed from the source cluster, i.e. the offset the replication consumer wanted to read from is
+ * below the log start offset of the source partition.
+ *
+ * <p>This is unrecoverable from the connector's point of view: the missing records cannot be
+ * produced to the target cluster, so the task fails fast rather than silently skipping ahead to a
+ * later offset and leaving an undetected gap in the replicated stream.
+ *
+ * <p>Only raised when {@link MirrorSourceConfig#OFFSET_VALIDATION_ENABLED} is set to {@code true}.
+ */
+public class DataLossException extends ConnectException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public DataLossException(String message) {
+        super(message);
+    }
+
+    public DataLossException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 public class MirrorSourceConfig extends MirrorConnectorConfig {
@@ -97,6 +98,16 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
             "but may result in excessive record duplication (consumer reprocessing) during a failover. " +
             "Partition Count * offset.lag.max = Approximate duplicated record count (Actual value can be lower or even higher depending on timing and consumer lag)";
     public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
+
+    public static final String OFFSET_VALIDATION_ENABLED = "offset.validation.enabled";
+    private static final String OFFSET_VALIDATION_ENABLED_DOC =
+            "Whether MirrorSourceTask should fail fast when the offset it wants to replicate from is no "
+            + "longer available on the source cluster. When enabled, the replication consumer is configured "
+            + "with auto.offset.reset=none and the task throws a DataLossException if source records were "
+            + "removed by the retention policy before they could be replicated, or a TopicResetException if "
+            + "the source topic was deleted and recreated. When disabled (the default), MirrorMaker 2 keeps "
+            + "its historical behaviour of silently resuming from the earliest available offset.";
+    public static final boolean OFFSET_VALIDATION_ENABLED_DEFAULT = false;
 
     public static final String HEARTBEATS_REPLICATION_ENABLED = "heartbeats.replication" + ENABLED_SUFFIX;
     private static final String HEARTBEATS_REPLICATION_ENABLED_DOC = "Whether to replicate the heartbeats topics even when the topic filter does not include them." +
@@ -213,6 +224,21 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
         return Duration.ofMillis(getLong(CONSUMER_POLL_TIMEOUT_MILLIS));
     }
 
+    boolean offsetValidationEnabled() {
+        return getBoolean(OFFSET_VALIDATION_ENABLED);
+    }
+
+    @Override
+    Map<String, Object> sourceConsumerConfig(String role) {
+        Map<String, Object> config = super.sourceConsumerConfig(role);
+        if (offsetValidationEnabled()) {
+            // Overriding the MirrorMaker 2 default of "earliest" is what lets the consumer surface an
+            // OffsetOutOfRangeException instead of silently rewinding to the start of the log.
+            config.put(AUTO_OFFSET_RESET_CONFIG, "none");
+        }
+        return config;
+    }
+
     boolean emitOffsetSyncsEnabled() {
         return getBoolean(EMIT_OFFSET_SYNCS_ENABLED);
     }
@@ -320,6 +346,12 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
                         OFFSET_LAG_MAX_DEFAULT,
                         ConfigDef.Importance.LOW,
                         OFFSET_LAG_MAX_DOC)
+                .define(
+                        OFFSET_VALIDATION_ENABLED,
+                        ConfigDef.Type.BOOLEAN,
+                        OFFSET_VALIDATION_ENABLED_DEFAULT,
+                        ConfigDef.Importance.MEDIUM,
+                        OFFSET_VALIDATION_ENABLED_DOC)
                 .define(
                         OFFSET_SYNCS_TOPIC_LOCATION,
                         ConfigDef.Type.STRING,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -36,9 +37,12 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
@@ -59,6 +63,7 @@ public class MirrorSourceTask extends SourceTask {
     private boolean stopping = false;
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
+    private boolean offsetValidationEnabled;
 
     public MirrorSourceTask() {}
 
@@ -66,12 +71,22 @@ public class MirrorSourceTask extends SourceTask {
     MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
                      ReplicationPolicy replicationPolicy,
                      OffsetSyncWriter offsetSyncWriter) {
+        this(consumer, metrics, sourceClusterAlias, replicationPolicy, offsetSyncWriter,
+                MirrorSourceConfig.OFFSET_VALIDATION_ENABLED_DEFAULT);
+    }
+
+    // for testing
+    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+                     ReplicationPolicy replicationPolicy,
+                     OffsetSyncWriter offsetSyncWriter,
+                     boolean offsetValidationEnabled) {
         this.consumer = consumer;
         this.legacyMetrics = metrics;
         this.sourceClusterAlias = sourceClusterAlias;
         this.replicationPolicy = replicationPolicy;
         consumerAccess = new Semaphore(1);
         this.offsetSyncWriter = offsetSyncWriter;
+        this.offsetValidationEnabled = offsetValidationEnabled;
     }
 
     @Override
@@ -84,6 +99,7 @@ public class MirrorSourceTask extends SourceTask {
         metrics = metricNamesFormats.contains(METRIC_NAMES_NEW) ? config.metrics(context.pluginMetrics()) : null;
         pollTimeout = config.consumerPollTimeout();
         replicationPolicy = config.replicationPolicy();
+        offsetValidationEnabled = config.offsetValidationEnabled();
         if (config.emitOffsetSyncsEnabled()) {
             offsetSyncWriter = new OffsetSyncWriter(config);
         }
@@ -164,6 +180,14 @@ public class MirrorSourceTask extends SourceTask {
             }
         } catch (WakeupException e) {
             return null;
+        } catch (OffsetOutOfRangeException e) {
+            // With auto.offset.reset=none the consumer surfaces invalid offsets instead of silently
+            // rewinding. Classify the cause and fail the task so the operator sees it.
+            if (!offsetValidationEnabled) {
+                log.warn("Failure during poll.", e);
+                return null;
+            }
+            throw classifyOffsetOutOfRange(e);
         } catch (KafkaException e) {
             log.warn("Failure during poll.", e);
             return null;
@@ -176,6 +200,91 @@ public class MirrorSourceTask extends SourceTask {
         }
     }
  
+    /**
+     * Works out why the replication consumer was left holding an out-of-range offset and builds the
+     * corresponding fail-fast exception.
+     *
+     * <p>For each affected partition the log start offset on the source cluster is the deciding
+     * signal:
+     * <ul>
+     *   <li>{@code logStartOffset > 0} -- records ahead of our position were removed by the
+     *       retention policy before they could be replicated, so data has been lost.</li>
+     *   <li>{@code logStartOffset == 0} -- the log begins at the very start again, meaning the topic
+     *       was deleted and recreated (or otherwise truncated to empty) and our tracked offset now
+     *       points past the end of the log.</li>
+     * </ul>
+     *
+     * <p>Data loss takes precedence when both conditions are present in a single batch, because it
+     * is the condition with unrecoverable consequences for the target cluster.
+     *
+     * @param cause the exception raised by the consumer
+     * @return a {@link DataLossException} or a {@link TopicResetException}, never {@code null}
+     */
+    // visible for testing
+    KafkaException classifyOffsetOutOfRange(OffsetOutOfRangeException cause) {
+        // Sort for deterministic logging and error messages.
+        Map<TopicPartition, Long> requestedOffsets = new TreeMap<>(
+                Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition));
+        requestedOffsets.putAll(cause.offsetOutOfRangePartitions());
+
+        Map<TopicPartition, Long> logStartOffsets = beginningOffsets(requestedOffsets.keySet());
+
+        Map<TopicPartition, Long> dataLoss = new LinkedHashMap<>();
+        Map<TopicPartition, Long> topicReset = new LinkedHashMap<>();
+
+        requestedOffsets.forEach((topicPartition, requestedOffset) -> {
+            Long logStartOffset = logStartOffsets.get(topicPartition);
+            if (logStartOffset != null && logStartOffset > 0L) {
+                log.error("Detected data loss on {}-{}: MirrorMaker 2 requested offset {} but the "
+                                + "earliest available offset on the source cluster is {}. {} record(s) were "
+                                + "removed by the retention policy before they could be replicated.",
+                        topicPartition.topic(), topicPartition.partition(), requestedOffset,
+                        logStartOffset, logStartOffset - requestedOffset);
+                dataLoss.put(topicPartition, requestedOffset);
+            } else {
+                log.error("Detected a topic reset on {}-{}: MirrorMaker 2 requested offset {} but the "
+                                + "log now starts at offset 0. The source topic was most likely deleted "
+                                + "and recreated.",
+                        topicPartition.topic(), topicPartition.partition(), requestedOffset);
+                topicReset.put(topicPartition, requestedOffset);
+            }
+        });
+
+        if (!dataLoss.isEmpty()) {
+            return new DataLossException("MirrorMaker 2 cannot replicate " + describe(dataLoss)
+                    + " from cluster '" + sourceClusterAlias + "': the requested offsets are no longer "
+                    + "available because the source records were removed by the retention policy. "
+                    + "Failing the task to avoid silently skipping the missing records. Reset the "
+                    + "connector offsets to resume replication and accept the gap.", cause);
+        }
+
+        return new TopicResetException("MirrorMaker 2 cannot replicate " + describe(topicReset)
+                + " from cluster '" + sourceClusterAlias + "': the source topic appears to have been "
+                + "deleted and recreated, so the tracked offsets are no longer valid. Failing the task "
+                + "to avoid replicating the new topic on top of the previously mirrored data. Reset the "
+                + "connector offsets to resume replication.", cause);
+    }
+
+    /**
+     * Looks up the log start offset for each partition. Any failure here is non-fatal: we fall back
+     * to an empty result, which classifies the failure as a topic reset and still fails the task.
+     */
+    private Map<TopicPartition, Long> beginningOffsets(Set<TopicPartition> topicPartitions) {
+        try {
+            return consumer.beginningOffsets(topicPartitions);
+        } catch (KafkaException e) {
+            log.warn("Unable to look up the earliest offsets for {} while classifying an "
+                    + "out-of-range offset.", topicPartitions, e);
+            return Map.of();
+        }
+    }
+
+    private static String describe(Map<TopicPartition, Long> offsets) {
+        return offsets.entrySet().stream()
+                .map(e -> e.getKey().topic() + "-" + e.getKey().partition() + " at offset " + e.getValue())
+                .collect(Collectors.joining(", "));
+    }
+
     @Override
     public void commitRecord(SourceRecord record, RecordMetadata metadata) {
         if (stopping) {
@@ -227,6 +336,11 @@ public class MirrorSourceTask extends SourceTask {
         log.info("Starting with {} previously uncommitted partitions.", topicPartitionOffsets.values().stream()
                 .filter(this::isUncommitted).count());
 
+        Set<TopicPartition> uncommittedPartitions = topicPartitionOffsets.entrySet().stream()
+                .filter(entry -> isUncommitted(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
             // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {
@@ -237,6 +351,15 @@ public class MirrorSourceTask extends SourceTask {
             log.trace("Seeking to offset {} for topicPartition: {}", nextOffsetToCommittedOffset, topicPartition);
             consumer.seek(topicPartition, nextOffsetToCommittedOffset);
         });
+
+        // Offset validation requires auto.offset.reset=none, which means the consumer has no
+        // fallback position for partitions we have never replicated before. Seek those explicitly to
+        // the beginning so that a first start behaves exactly as it does with the default settings.
+        if (offsetValidationEnabled && !uncommittedPartitions.isEmpty()) {
+            log.info("Seeking to the beginning of {} partition(s) with no previously committed offset: {}.",
+                    uncommittedPartitions.size(), uncommittedPartitions);
+            consumer.seekToBeginning(uncommittedPartitions);
+        }
     }
 
     // visible for testing 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.io.Serial;
+
+/**
+ * Thrown when MirrorMaker 2 determines that a source topic-partition has been reset -- typically
+ * because the topic was deleted and recreated -- while the connector still holds a committed offset
+ * from the previous incarnation of the topic.
+ *
+ * <p>The tell-tale signal is an out-of-range offset on a partition whose log start offset is
+ * {@code 0}: the partition has been rewound to the very beginning, so the previously tracked offset
+ * points past the end of the log rather than before its start.
+ *
+ * <p>Resuming from {@code earliest} in this situation would silently re-replicate the new topic on
+ * top of the old data on the target cluster, so the task fails fast and leaves the decision to an
+ * operator.
+ *
+ * <p>Only raised when {@link MirrorSourceConfig#OFFSET_VALIDATION_ENABLED} is set to {@code true}.
+ */
+public class TopicResetException extends ConnectException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public TopicResetException(String message) {
+        super(message);
+    }
+
+    public TopicResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
@@ -108,6 +108,44 @@ public class MirrorSourceConfigTest {
     }
 
     @Test
+    public void testOffsetValidationIsDisabledByDefault() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps());
+        assertFalse(config.offsetValidationEnabled(),
+                "offset validation should be opt-in so that upgrades do not change failure semantics");
+        assertEquals("earliest", config.sourceConsumerConfig("test").get("auto.offset.reset"),
+                "the replication consumer should keep the historical MirrorMaker 2 default");
+    }
+
+    @Test
+    public void testOffsetValidationEnabledDisablesAutoOffsetReset() {
+        MirrorSourceConfig config = new MirrorSourceConfig(
+                makeProps(MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true"));
+        assertTrue(config.offsetValidationEnabled());
+        assertEquals("none", config.sourceConsumerConfig("test").get("auto.offset.reset"),
+                "auto.offset.reset must be none so the consumer surfaces out-of-range offsets");
+    }
+
+    @Test
+    public void testOffsetValidationTakesPrecedenceOverExplicitAutoOffsetReset() {
+        // Offset validation cannot work with any other reset policy, so it wins over a user-supplied
+        // value rather than silently producing a configuration that never detects data loss.
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps(
+                MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true",
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "auto.offset.reset", "latest"));
+        assertEquals("none", config.sourceConsumerConfig("test").get("auto.offset.reset"));
+    }
+
+    @Test
+    public void testOffsetValidationDoesNotAffectOtherConsumerConfigs() {
+        MirrorSourceConfig config = new MirrorSourceConfig(makeProps(
+                MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true",
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "max.poll.records", "42"));
+        Map<String, Object> consumerConfig = config.sourceConsumerConfig("test");
+        assertEquals("42", consumerConfig.get("max.poll.records"));
+        assertEquals("false", consumerConfig.get("enable.auto.commit"));
+    }
+
+    @Test
     public void testOffsetSyncsTopic() {
         // Invalid location
         Map<String, String> connectorProps = makeProps("offset-syncs.topic.location", "something");

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskOffsetValidationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskOffsetValidationTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the log-truncation ({@link DataLossException}) and topic-reset
+ * ({@link TopicResetException}) detection added to {@link MirrorSourceTask}.
+ */
+public class MirrorSourceTaskOffsetValidationTest {
+
+    private static final String SOURCE_CLUSTER = "primary";
+    private static final TopicPartition TP0 = new TopicPartition("wal-topic", 0);
+    private static final TopicPartition TP1 = new TopicPartition("wal-topic", 1);
+
+    @SuppressWarnings("unchecked")
+    private static KafkaConsumer<byte[], byte[]> mockConsumer() {
+        return mock(KafkaConsumer.class);
+    }
+
+    private static MirrorSourceTask task(KafkaConsumer<byte[], byte[]> consumer, boolean offsetValidationEnabled) {
+        return new MirrorSourceTask(consumer, mock(MirrorSourceLegacyMetrics.class), SOURCE_CLUSTER,
+                new DefaultReplicationPolicy(), null, offsetValidationEnabled);
+    }
+
+    @Test
+    public void testDataLossDetectedWhenRecordsWerePurged() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        OffsetOutOfRangeException cause = new OffsetOutOfRangeException(Map.of(TP0, 5L));
+        when(consumer.poll(any())).thenThrow(cause);
+        // The log now starts at offset 10, so offsets 5..9 were removed by the retention policy.
+        when(consumer.beginningOffsets(anySet())).thenReturn(Map.of(TP0, 10L));
+
+        MirrorSourceTask task = task(consumer, true);
+
+        DataLossException e = assertThrows(DataLossException.class, task::poll);
+        assertSame(cause, e.getCause(), "the original consumer exception should be preserved");
+        assertTrue(e.getMessage().contains("wal-topic-0"), "message should name the topic-partition");
+        assertTrue(e.getMessage().contains("offset 5"), "message should name the problematic offset");
+        assertTrue(e.getMessage().contains(SOURCE_CLUSTER), "message should name the source cluster");
+    }
+
+    @Test
+    public void testTopicResetDetectedWhenLogStartsAtZero() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        OffsetOutOfRangeException cause = new OffsetOutOfRangeException(Map.of(TP0, 500L));
+        when(consumer.poll(any())).thenThrow(cause);
+        // The log begins at 0 again: the topic was deleted and recreated.
+        when(consumer.beginningOffsets(anySet())).thenReturn(Map.of(TP0, 0L));
+
+        MirrorSourceTask task = task(consumer, true);
+
+        TopicResetException e = assertThrows(TopicResetException.class, task::poll);
+        assertSame(cause, e.getCause(), "the original consumer exception should be preserved");
+        assertTrue(e.getMessage().contains("wal-topic-0"), "message should name the topic-partition");
+        assertTrue(e.getMessage().contains("offset 500"), "message should name the problematic offset");
+    }
+
+    @Test
+    public void testDataLossTakesPrecedenceWhenBothConditionsArePresent() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(Map.of(TP0, 5L, TP1, 500L)));
+        when(consumer.beginningOffsets(anySet())).thenReturn(Map.of(TP0, 10L, TP1, 0L));
+
+        MirrorSourceTask task = task(consumer, true);
+
+        DataLossException e = assertThrows(DataLossException.class, task::poll);
+        assertTrue(e.getMessage().contains("wal-topic-0"), "the purged partition should be reported");
+    }
+
+    @Test
+    public void testUnavailableLogStartOffsetIsTreatedAsTopicReset() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(Map.of(TP0, 5L)));
+        // Simulate the earliest-offset lookup failing; we must still fail the task rather than
+        // fall through to the default "log a warning and carry on" behaviour.
+        when(consumer.beginningOffsets(anySet())).thenThrow(new KafkaException("broker unavailable"));
+
+        MirrorSourceTask task = task(consumer, true);
+
+        assertThrows(TopicResetException.class, task::poll);
+    }
+
+    @Test
+    public void testOffsetOutOfRangeIsNotFatalWhenValidationIsDisabled() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(Map.of(TP0, 5L)));
+
+        MirrorSourceTask task = task(consumer, false);
+
+        // Default MM2 behaviour: log a warning and return no records.
+        assertNull(task.poll());
+        verify(consumer, never()).beginningOffsets(anySet());
+    }
+
+    @Test
+    public void testConsumerSeeksToBeginningForNewPartitionsWhenValidationIsEnabled() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        MirrorSourceTask task = task(consumer, true);
+        task.initialize(offsetStorageContext());
+
+        task.initializeConsumer(Set.of(TP0, TP1));
+
+        // TP0 has a committed offset of 4, so we resume from 5.
+        verify(consumer, times(1)).seek(TP0, 5L);
+        // TP1 has never been replicated: auto.offset.reset=none gives the consumer no starting
+        // position, so the task must seek to the beginning explicitly.
+        verify(consumer, times(1)).seekToBeginning(Set.of(TP1));
+    }
+
+    @Test
+    public void testConsumerDoesNotSeekToBeginningWhenValidationIsDisabled() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        MirrorSourceTask task = task(consumer, false);
+        task.initialize(offsetStorageContext());
+
+        task.initializeConsumer(Set.of(TP0, TP1));
+
+        verify(consumer, times(1)).seek(TP0, 5L);
+        // Unchanged from the default behaviour: auto.offset.reset=earliest handles new partitions.
+        verify(consumer, never()).seekToBeginning(anySet());
+    }
+
+    @Test
+    public void testClassificationIsIndependentOfPartitionOrdering() {
+        KafkaConsumer<byte[], byte[]> consumer = mockConsumer();
+        when(consumer.beginningOffsets(anySet())).thenReturn(Map.of(TP1, 0L, TP0, 0L));
+
+        MirrorSourceTask task = task(consumer, true);
+        KafkaException e = task.classifyOffsetOutOfRange(
+                new OffsetOutOfRangeException(Map.of(TP1, 9L, TP0, 7L)));
+
+        assertEquals(TopicResetException.class, e.getClass());
+        assertTrue(e.getMessage().indexOf("wal-topic-0") < e.getMessage().indexOf("wal-topic-1"),
+                "partitions should be reported in a deterministic order");
+    }
+
+    /**
+     * A task context whose offset store has a committed offset for {@link #TP0} only.
+     */
+    private static SourceTaskContext offsetStorageContext() {
+        SourceTaskContext context = mock(SourceTaskContext.class);
+        OffsetStorageReader offsetStorageReader = mock(OffsetStorageReader.class);
+        when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
+        when(offsetStorageReader.offset(anyMap())).thenAnswer(invocation -> {
+            Map<String, Object> wrappedPartition = invocation.getArgument(0);
+            if (Integer.valueOf(TP0.partition()).equals(wrappedPartition.get("partition"))) {
+                wrappedPartition.put("offset", 4L);
+            }
+            return wrappedPartition;
+        });
+        return context;
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationOffsetValidationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationOffsetValidationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror.integration;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.mirror.DataLossException;
+import org.apache.kafka.connect.mirror.MirrorSourceConfig;
+import org.apache.kafka.connect.mirror.MirrorSourceConnector;
+import org.apache.kafka.connect.mirror.TopicResetException;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+
+/**
+ * Integration tests for the fail-fast offset validation added to
+ * {@link org.apache.kafka.connect.mirror.MirrorSourceTask}.
+ *
+ * <p>Both scenarios follow the same shape: replicate a topic normally, stop the
+ * {@link MirrorSourceConnector}, engineer the failure on the source cluster, then restart the
+ * connector and assert the task fails with the expected exception rather than quietly rewinding to
+ * the earliest available offset.
+ */
+@Tag("integration")
+public class MirrorConnectorsIntegrationOffsetValidationTest extends MirrorConnectorsIntegrationBaseTest {
+
+    private static final String TOPIC = "test-topic-1";
+    private static final int TASK_FAILURE_DURATION_MS = 60_000;
+    private static final int ADMIN_REQUEST_TIMEOUT_MS = 60_000;
+
+    @BeforeEach
+    @Override
+    public void startClusters() throws Exception {
+        // One-way replication keeps the failure attribution unambiguous.
+        replicateBackupToPrimary = false;
+        Map<String, String> additionalConfig = new HashMap<>();
+        additionalConfig.put("topics", "test-topic-.*");
+        additionalConfig.put(MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true");
+        super.startClusters(additionalConfig);
+    }
+
+    /**
+     * The source topic's retention policy removes records that MirrorMaker 2 has not replicated yet.
+     * The task must fail with a {@link DataLossException} instead of skipping the gap.
+     */
+    @Test
+    public void testDataLossDetectedWhenUnreplicatedRecordsArePurged() throws Exception {
+        produceMessages(primaryProducer, TOPIC);
+        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+        backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS,
+                remoteTopicName(TOPIC, PRIMARY_CLUSTER_ALIAS));
+
+        stopMirrorMakerConnectors(backup, MirrorSourceConnector.class);
+
+        // Rewind the connector to the start of each partition, then purge the first half of every
+        // partition on the source cluster. The connector now points below the log start offset,
+        // which is exactly the state an aggressive retention policy would leave it in.
+        alterMirrorMakerSourceConnectorOffsets(backup, offset -> 0L, TOPIC);
+        deleteRecordsBefore();
+
+        backup.resumeConnector(MirrorSourceConnector.class.getSimpleName());
+
+        assertSourceTaskFailedWith(backup, DataLossException.class.getName());
+    }
+
+    /**
+     * The source topic is deleted and recreated, so the tracked offsets point past the end of a log
+     * that now starts at zero. The task must fail with a {@link TopicResetException} instead of
+     * re-replicating the new topic on top of the previously mirrored data.
+     */
+    @Test
+    public void testTopicResetDetectedWhenSourceTopicIsRecreated() throws Exception {
+        produceMessages(primaryProducer, TOPIC);
+        waitUntilMirrorMakerIsRunning(backup, CONNECTOR_LIST, mm2Config, PRIMARY_CLUSTER_ALIAS, BACKUP_CLUSTER_ALIAS);
+        backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS,
+                remoteTopicName(TOPIC, PRIMARY_CLUSTER_ALIAS));
+
+        stopMirrorMakerConnectors(backup, MirrorSourceConnector.class);
+
+        recreateSourceTopic();
+        // One record per partition, so the new log ends well before the committed offset of
+        // NUM_RECORDS_PER_PARTITION - 1 that the connector still holds.
+        produceMessages(primaryProducer, IntStream.range(0, NUM_PARTITIONS)
+                .mapToObj(partition -> new ProducerRecord<byte[], byte[]>(
+                        TOPIC, partition, null, "recreated".getBytes()))
+                .collect(Collectors.toList()));
+
+        backup.resumeConnector(MirrorSourceConnector.class.getSimpleName());
+
+        assertSourceTaskFailedWith(backup, TopicResetException.class.getName());
+    }
+
+    /**
+     * Deletes every record below {@code offset} on all partitions of the source topic, moving the
+     * log start offset forward the same way a retention-driven segment deletion would.
+     */
+    private void deleteRecordsBefore() throws Exception {
+        Map<TopicPartition, RecordsToDelete> toDelete = IntStream.range(0, NUM_PARTITIONS)
+                .boxed()
+                .collect(Collectors.toMap(
+                        partition -> new TopicPartition(TOPIC, partition),
+                        partition -> RecordsToDelete.beforeOffset(5)));
+        try (Admin admin = primary.kafka().createAdminClient()) {
+            admin.deleteRecords(toDelete).all().get(ADMIN_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Deletes and recreates the source topic with the same partition count, waiting for each step so
+     * the test does not race the controller.
+     */
+    private void recreateSourceTopic() throws Exception {
+        try (Admin admin = primary.kafka().createAdminClient()) {
+            admin.deleteTopics(Set.of(TOPIC)).all().get(ADMIN_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            waitForCondition(
+                    () -> !admin.listTopics().names().get(ADMIN_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS).contains(TOPIC),
+                    ADMIN_REQUEST_TIMEOUT_MS,
+                    "Source topic " + TOPIC + " was not deleted in time");
+        }
+        primary.kafka().createTopic(TOPIC, NUM_PARTITIONS);
+        waitForTopicPartitionCreated(primary, TOPIC, NUM_PARTITIONS);
+    }
+
+    /**
+     * Waits until at least one {@link MirrorSourceConnector} task has failed, and asserts the
+     * recorded stack trace names the expected exception.
+     */
+    private static void assertSourceTaskFailedWith(EmbeddedConnectCluster cluster, String expectedExceptionName)
+            throws InterruptedException {
+        String connectorName = MirrorSourceConnector.class.getSimpleName();
+        AtomicReference<String> lastObservedTrace = new AtomicReference<>("<no failed task observed>");
+
+        waitForCondition(() -> {
+            ConnectorStateInfo status = cluster.connectorStatus(connectorName);
+            if (status == null) {
+                return false;
+            }
+            List<ConnectorStateInfo.TaskState> failed = status.tasks().stream()
+                    .filter(task -> "FAILED".equals(task.state()))
+                    .toList();
+            if (failed.isEmpty()) {
+                return false;
+            }
+            lastObservedTrace.set(String.valueOf(failed.get(0).trace()));
+            return failed.stream()
+                    .anyMatch(task -> task.trace() != null && task.trace().contains(expectedExceptionName));
+        }, TASK_FAILURE_DURATION_MS, () -> "MirrorSourceConnector task did not fail with "
+                + expectedExceptionName + " in time. Last observed trace: " + lastObservedTrace.get());
+    }
+}


### PR DESCRIPTION
## Problem
 
MirrorMaker 2 masks two failure modes that matter when a Kafka topic is used as a write-ahead log
and replicated to a DR cluster.
 
**1. Silent data loss.** If the source topic's retention policy deletes records before MM2 replicates
them, the consumer's next fetch resumes at a valid-but-later offset. The gap in the replicated stream
is never reported.
 
**2. Source topic reset.** If a source topic is deleted and recreated, the tracked offset becomes
invalid. MM2 rewinds to the earliest offset and re-replicates the new topic on top of the previously
mirrored data.
 
Both share a root cause. MM2 applies `consumer.auto.offset.reset=earliest` to the replication
consumer (`MirrorConnectorConfig#sourceConsumerConfig`), so the broker's `OFFSET_OUT_OF_RANGE` error
is resolved inside the consumer and never reaches the connector. Even if it did, the only place that
could see it — the broad `catch (KafkaException e)` in `MirrorSourceTask#poll` — logs a warning and
returns `null`.
 
This PR adds opt-in offset validation: MM2 detects the invalid offset, logs the topic, partition and
problematic offset, and fails the task with a purpose-built exception.
 
---
 
## Design Rationale
 
### Files and classes modified
 
**New**
 
| File | Purpose |
| --- | --- |
| `connect/mirror/.../mirror/DataLossException.java` | Unreplicated records removed by retention |
| `connect/mirror/.../mirror/TopicResetException.java` | Source topic deleted and recreated |
| `connect/mirror/.../mirror/MirrorSourceTaskOffsetValidationTest.java` | Unit tests for detection and classification |
| `connect/mirror/.../mirror/integration/MirrorConnectorsIntegrationOffsetValidationTest.java` | End-to-end tests on embedded clusters |
 
**Modified**
 
| File | Change |
| --- | --- |
| `MirrorSourceConfig.java` | New `offset.validation.enabled` config; `sourceConsumerConfig` override that sets `auto.offset.reset=none` |
| `MirrorSourceTask.java` | Flag plumbing; `seekToBeginning` for uncommitted partitions; `OffsetOutOfRangeException` handling and classification |
| `MirrorSourceConfigTest.java` | Four tests covering the new config and its effect on the consumer config |
 
Both exceptions extend `ConnectException`. Roughly 120 lines of production code and 330 lines of
tests.
 
### Why this implementation strategy
 
**Let the consumer detect the problem, rather than checking offsets ourselves.**
The alternative is to track the last replicated offset per partition and compare it against the
offset of the next record returned by `poll()`, flagging a gap. That duplicates bookkeeping the
consumer already does, only notices a problem once records start flowing again — a purged *idle*
partition would never be flagged — and adds per-record cost on the hot path.
 
Setting `auto.offset.reset=none` makes the broker's own out-of-range signal the trigger. It costs
nothing when replication is healthy and it fires on the first fetch after the offset goes bad.
 
**Distinguish the two conditions by log start offset.**
Both surface as the same `OffsetOutOfRangeException`. The log start offset of the affected partition
separates them cleanly:
 
| Log start offset | Meaning | Exception |
| --- | --- | --- |
| `> 0` | Records ahead of our position were deleted by retention | `DataLossException` |
| `== 0` | The log begins at zero again — the topic was recreated | `TopicResetException` |
 
`MirrorSourceTask#classifyOffsetOutOfRange` queries `Consumer#beginningOffsets` for the affected
partitions and applies that rule. When a single batch contains both conditions, data loss wins,
because it is the one with unrecoverable consequences on the target cluster. If the `beginningOffsets`
lookup itself fails, the task still fails — as `TopicResetException` — rather than falling back to the
silent path.
 
**Fail fast rather than auto-recover.**
Neither situation has a safe automatic remedy. Skipping the gap loses records with no record of what
was lost; rewinding to `earliest` after a topic recreation duplicates or interleaves data on the DR
cluster. Both are operator decisions. Failing the task surfaces the problem through Connect's status
API with a message naming the topic, partition, requested offset and log start offset; the operator
resumes by resetting the connector offsets via the Connect offsets API.
 
> Note: the task description asks for a `TopicResetException` and fail-fast behaviour (Task 2), while
> the evaluation criteria mention "auto-recovery for topic resets". This PR implements fail-fast per
> the explicit task requirement. Auto-recovery would be a small follow-up given the detection logic is
> already in place.
 
**Ship it disabled by default.**
Enabling this unconditionally would change the failure semantics of every existing MM2 deployment: a
cluster quietly tolerating retention-driven gaps would start failing tasks after an upgrade.
`offset.validation.enabled` defaults to `false`, so upgrading is a no-op and operators of WAL-style
topics opt in deliberately.
 
**Let validation override an explicit reset policy.**
If a user sets both `offset.validation.enabled=true` and `consumer.auto.offset.reset=latest`, the
override wins and `none` is applied, because any other policy silently defeats the feature. Rejecting
the combination with a `ConfigException` would also be defensible; this is asserted in
`testOffsetValidationTakesPrecedenceOverExplicitAutoOffsetReset` so the choice is explicit rather
than incidental.
 
### How it integrates with the MirrorMaker 2 lifecycle
 
| Hook | Change |
| --- | --- |
| `MirrorSourceConfig#sourceConsumerConfig` (override) | Sets `auto.offset.reset=none` when enabled. The shared helper in `MirrorConnectorConfig` is untouched, so `MirrorCheckpointConnector` and `MirrorHeartbeatConnector` keep their existing consumer settings. |
| `MirrorSourceTask#start` | Reads the flag from the task config. |
| `MirrorSourceTask#initializeConsumer` | Collects partitions with no committed offset and calls `seekToBeginning` on them. |
| `MirrorSourceTask#poll` | New `catch (OffsetOutOfRangeException)` placed ahead of the existing `catch (KafkaException)`, so the specific case is handled before the generic warn-and-continue path. |
 
**Preserving first-start behaviour.** With `auto.offset.reset=none` the consumer has no fallback
position, so a partition MM2 has never replicated would fail on its first poll. `initializeConsumer`
therefore seeks those partitions to the beginning explicitly. This reproduces exactly what
`auto.offset.reset=earliest` did, but only for genuinely new partitions — an offset that exists and
is invalid is no longer silently repaired.
 
No changes to connector startup, task assignment, offset syncs, checkpoints, or heartbeats. Because
both exceptions extend `ConnectException`, the Connect runtime's existing task-failure handling
applies unchanged; no new lifecycle hooks were required.
 
---
 
## Configuration
 
| Name | Type | Default | Importance | Description |
| --- | --- | --- | --- | --- |
| `offset.validation.enabled` | boolean | `false` | medium | Fail the task with `DataLossException` / `TopicResetException` when the offset to replicate from is no longer available on the source cluster. Sets `consumer.auto.offset.reset=none` on the replication consumer. |
 
---
 
## Testing
 
**Unit — `MirrorSourceTaskOffsetValidationTest`** (mocked consumer)
 
- data loss when the log start offset is ahead of the requested offset
- topic reset when the log start offset is zero
- data loss takes precedence in a mixed batch
- a failed `beginningOffsets` lookup still fails the task
- with the flag off, `poll` returns `null` and never queries `beginningOffsets` — default behaviour preserved
- `seekToBeginning` is called for uncommitted partitions only when the flag is on
- deterministic partition ordering in the error message
**Unit — `MirrorSourceConfigTest`** (4 added)
 
- validation off by default, consumer still gets `auto.offset.reset=earliest`
- validation on yields `auto.offset.reset=none`
- validation overrides an explicitly configured reset policy
- other consumer configs (`max.poll.records`, `enable.auto.commit`) are unaffected
**Integration — `MirrorConnectorsIntegrationOffsetValidationTest`** (embedded Connect clusters)
 
- *Data loss*: replicate a topic, stop the source connector, rewind its offsets to the start of each
  partition, then `deleteRecords` past that point on the source cluster. Restarting the connector
  fails the task with `DataLossException`.
- *Topic reset*: replicate a topic, stop the source connector, delete and recreate the source topic
  with the same partition count, produce a short batch. Restarting the connector fails the task with
  `TopicResetException`.
Both drive the failure with `deleteRecords` and topic recreation rather than waiting on retention, so
they are deterministic and not timing-dependent.
 
---
 
## AI Usage Documentation
 
AI was used substantially on this change, in an agentic setup (Claude, via Anthropic's Cowork
desktop tool). Being specific about the split:
 
**What the AI did**
 
- Read the current `MirrorSourceTask`, `MirrorSourceConfig`, `MirrorConnectorConfig`,
  `MirrorSourceTaskConfig`, `MirrorSourceTaskTest` and `MirrorConnectorsIntegrationBaseTest` on
  `trunk`, and identified the two places responsible for the masking behaviour — the
  `putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest")` in `sourceConsumerConfig` and the
  `catch (KafkaException)` in `poll()`.
- Drafted all of the production code: the two exception classes, `classifyOffsetOutOfRange`, the
  `seekToBeginning` handling in `initializeConsumer`, and the config plumbing.
- Drafted all of the tests, including the `deleteRecords` / topic-recreation approach used to make
  the integration scenarios deterministic.
- Verified every external API it relied on against this checkout rather than from memory —
  `OffsetOutOfRangeException#offsetOutOfRangePartitions`, `RecordsToDelete#beforeOffset`,
  `EmbeddedKafkaCluster#createTopic`/`createAdminClient`/`consume`,
  `EmbeddedConnect#connectorStatus`/`stopConnector`/`resumeConnector`,
  `ConnectorStateInfo.TaskState#trace`, and the `TestUtils#waitForCondition` overloads.
- Checked whether the new config key would break existing assertions in `MirrorSourceConfigTest`,
  `MirrorMakerConfigTest` and `MirrorConnectorConfigTest`, and confirmed it would not — which also
  surfaced that `MirrorSourceConfig#sourceConsumerConfig` had no test coverage, prompting the four
  added config tests.
- Wrote this PR description.
**What the AI did not do**
 
- It never compiled or ran anything. Its sandbox had only JDK 11 and no usable access to the repo
  working tree, so every Gradle run — unit tests, integration tests and checkstyle — was executed
  locally by me.
- The design decisions were reviewed and accepted by me rather than taken on trust: opt-in default,
  fail-fast over auto-recovery, log start offset as the classification signal, overriding the shared
  `MirrorConnectorConfig` helper on the subclass instead of editing it, and validation taking
  precedence over an explicit `auto.offset.reset`. The AI flagged the last one as a genuine
  either-way choice rather than deciding it silently.
- The full diff was read and reviewed by me before commit.