### PR TITLE
KAFKA-20889: reject empty group.instance.id values in Kafka Streams.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1933,7 +1933,15 @@ public class StreamsConfig extends AbstractConfig {
         // add group id, client id with stream client id prefix, and group instance id
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerProps.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
-        final String groupInstanceId = (String) consumerProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG);
+        final String groupInstanceId = (String) parseType(
+            ConsumerConfig.GROUP_INSTANCE_ID_CONFIG,
+            consumerProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG),
+            Type.STRING
+        );
+        new ConfigDef.NonEmptyString().ensureValid(
+            ConsumerConfig.GROUP_INSTANCE_ID_CONFIG,
+            groupInstanceId
+        );
         // Suffix each thread consumer with thread.id to enforce uniqueness of group.instance.id.
         if (groupInstanceId != null) {
             consumerProps.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId + "-" + threadIdx);

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -245,6 +245,19 @@ public class StreamsConfigTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"", StreamsConfig.CONSUMER_PREFIX, StreamsConfig.MAIN_CONSUMER_PREFIX})
+    public void shouldRejectEmptyGroupInstanceId(final String prefix) {
+        props.put(prefix + ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "");
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+
+        final ConfigException exception = assertThrows(
+            ConfigException.class,
+            () -> streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx)
+        );
+        assertTrue(exception.getMessage().contains(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", StreamsConfig.CONSUMER_PREFIX, StreamsConfig.MAIN_CONSUMER_PREFIX})
     public void shouldAllowStaticMembershipWhenStreamsProtocolUsed(final String prefix) {
         props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, "streams");
         props.put(prefix + ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, "static-member-1");


### PR DESCRIPTION
### Introduction
`ConsumerConfig` only permits `non-empty` `group.instance.id` values, and a regular KafkaConsumer rejects an empty value with a `ConfigException`.

Kafka Streams currently appends the stream thread index before consumer validation. As a result:
- group.instance.id="" → "-1", "-2", ...

These derived values pass validation and enable static membership. Multiple application instances may then generate the same instance IDs. 

### Changes
- `StreamsConfig` throws an `ConfigException` when group.instance.id is empty string.
- Add unit tests.
