### PR TITLE
MINOR: ensure ps output is unlimited width for remaining cases

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -40,7 +40,7 @@ else
   if [ -z "$INPUT_PROCESS_ROLE" ] && [ -z "$INPUT_NID" ]; then
     kill -s $SIGNAL $PIDS
   else
-    RelativePathToConfig=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | sed 's/--override property=[^ ]*//g' | awk 'NF>1{print $NF}' | xargs)
+    RelativePathToConfig=$(ps axww | grep ' kafka\.Kafka ' | grep java | grep -v grep | sed 's/--override property=[^ ]*//g' | awk 'NF>1{print $NF}' | xargs)
     IFS=' ' read -ra PIDSArray <<< "$PIDS"
     IFS=' ' read -ra RelativePathArray <<< "$RelativePathToConfig"
     for ((i = 0; i < ${#RelativePathArray[@]}; i++)); do

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -57,7 +57,7 @@ def is_version(node, version_list, proc_grep_string="kafka", logger=None):
     """Heuristic to check that only the specified version appears in the classpath of the process
     A useful tool to aid in checking that service version apis are working correctly.
     """
-    lines = [l for l in node.account.ssh_capture("ps ax | grep %s | grep -v grep" % proc_grep_string)]
+    lines = [l for l in node.account.ssh_capture("ps axww | grep %s | grep -v grep" % proc_grep_string)]
     assert len(lines) == 1, "lines: %s" % lines
     psLine = lines[0]
 


### PR DESCRIPTION
Follow up to #22990 for selective stop config lookup and kafkatest
is_version()

Basically #22990 fixed the part where script call was direct. I found 2
left overs of similar problem.

1. When script is passed node-id or process-role it needs the full line
to read its config
2. Python system tests also use ps to read process meta for checking
Kafka version

Same small fix as previous PR

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
