### PR TITLE
MINOR: Prevent delivery complete count regression in share coord.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -661,6 +661,18 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         int newLeaderEpoch = updateLeaderEpoch ? partitionData.leaderEpoch() : currentState.leaderEpoch();
         long newStartOffset = Math.max(partitionData.startOffset(), currentState.startOffset());
 
+        // Based on the start offset value of the incoming request and the
+        // current state, the deliveryCompleteCount needs to be chosen carefully.
+        int deliveryCompleteCount = partitionData.deliveryCompleteCount();
+
+        if (partitionData.startOffset() == currentState.startOffset()) {
+            // Incoming request has start offset equal to the current state.
+            deliveryCompleteCount = Math.max(partitionData.deliveryCompleteCount(), currentState.deliveryCompleteCount());
+        } else if (partitionData.startOffset() < currentState.startOffset()) {
+            // Incoming request has start offset behind the current state.
+            deliveryCompleteCount = currentState.deliveryCompleteCount();
+        }
+
         if (snapshotUpdateCount.getOrDefault(key, 0) >= updatesPerSnapshotLimit) {
             // Since the number of update records for this share part key exceeds snapshotUpdateRecordsPerSnapshot
             // or state epoch has incremented, we should be creating a share snapshot record.
@@ -670,7 +682,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 new ShareGroupOffset.Builder()
                     .setSnapshotEpoch(currentState.snapshotEpoch() + 1)   // We must increment snapshot epoch as this is new snapshot.
                     .setStartOffset(newStartOffset)
-                    .setDeliveryCompleteCount(partitionData.deliveryCompleteCount())
+                    .setDeliveryCompleteCount(deliveryCompleteCount)
                     .setLeaderEpoch(newLeaderEpoch)
                     .setStateEpoch(currentState.stateEpoch())
                     .setStateBatches(mergeBatches(currentState.stateBatches(), partitionData, newStartOffset))
@@ -686,7 +698,7 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 new ShareGroupOffset.Builder()
                     .setSnapshotEpoch(currentState.snapshotEpoch()) // Use same snapshotEpoch as last share snapshot.
                     .setStartOffset(newStartOffset) // Prevents start offset from regressing.
-                    .setDeliveryCompleteCount(partitionData.deliveryCompleteCount())
+                    .setDeliveryCompleteCount(deliveryCompleteCount)
                     .setLeaderEpoch(newLeaderEpoch)
                     .setStateBatches(mergeBatches(List.of(), partitionData, newStartOffset))
                     .build());

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -718,6 +718,311 @@ class ShareCoordinatorShardTest {
         assertEquals(expectedFinalValue, shard.getShareStateMapValue(SHARE_PARTITION_KEY));
     }
 
+    /**
+     * This test validates that the delivery complete count advances correctly, in relation to
+     * start offset.
+     * case 1: incoming request start offset > current state
+     * <p>
+     * For example,
+     * req1: {
+     *  startOffset: 5,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 10
+     *  stateBatches: []
+     * }
+     * <p>
+     * req2: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 4
+     *  stateBatches: []
+     * }
+     * <p>
+     * Then, final state would be
+     * result: {
+     *  startOffset: 5,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 4    // req2 delivery count preferred as start offset advanced
+     *  stateBatches: []
+     * }
+     *
+     */
+    @Test
+    public void testWriteStateDiscardsDeliveryCompleteCountRegressionIncomingStartOffsetGreater() {
+        initSharePartition(shard, SHARE_PARTITION_KEY, 5);
+        writeAndReplayRecord(shard, 3);
+        int request1StartOffset = 5;
+        int request2StartOffset = 11;
+        int request2DeliveryCompleteCount = 4;
+
+        WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request1StartOffset)
+                    .setDeliveryCompleteCount(10)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request2StartOffset)    // higher start offset than req1
+                    .setDeliveryCompleteCount(request2DeliveryCompleteCount)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result = shard.writeState(request1);
+        shard.replay(0L, 0L, (short) 0, result.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0), TIME.milliseconds())
+        ));
+
+        assertEquals(expectedData, result.response());
+        assertEquals(expectedRecords, result.records());
+
+        // Verify request2
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result2 = shard.writeState(request2);
+        shard.replay(0L, 0L, (short) 0, result2.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData2 = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords2 = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request2.topics().get(0).partitions().get(0), TIME.milliseconds()).builderSupplier()
+                .setStartOffset(request2StartOffset)
+                .setDeliveryCompleteCount(request2DeliveryCompleteCount)
+                .build()
+        ));
+
+        assertEquals(expectedData2, result2.response());
+        assertEquals(expectedRecords2, result2.records());
+
+        ShareGroupOffset expectedFinalValue = new ShareGroupOffset.Builder()
+            .setStartOffset(request2StartOffset)
+            .setStateEpoch(5)
+            .setLeaderEpoch(3)
+            .setDeliveryCompleteCount(request2DeliveryCompleteCount)
+            .setStateBatches(List.of())
+            .build();
+
+        assertEquals(expectedFinalValue, shard.getShareStateMapValue(SHARE_PARTITION_KEY));
+    }
+
+    /**
+     * This test validates that the delivery complete count advances correctly, in relation to
+     * start offset.
+     * case 1: incoming request start offset > current state
+     * <p>
+     * For example,
+     * req1: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 10
+     *  stateBatches: []
+     * }
+     * <p>
+     * req2: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 5
+     *  stateBatches: []
+     * }
+     * <p>
+     * Then, final state would be
+     * result: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 10    // req1 delivery count preferred as start offsets equal
+     *  stateBatches: []
+     * }
+     *
+     */
+    @Test
+    public void testWriteStateDiscardsDeliveryCompleteCountRegressionIncomingStartOffsetEqual() {
+        initSharePartition(shard, SHARE_PARTITION_KEY, 5);
+        writeAndReplayRecord(shard, 3);
+        int request1StartOffset = 11;
+        int request2StartOffset = 11;
+        int request1DeliveryCompleteCount = 10;
+        int request2DeliveryCompleteCount = 5;
+
+        WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request1StartOffset)
+                    .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request2StartOffset)    // same start offset than req1
+                    .setDeliveryCompleteCount(request2DeliveryCompleteCount)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result = shard.writeState(request1);
+        shard.replay(0L, 0L, (short) 0, result.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0), TIME.milliseconds())
+        ));
+
+        assertEquals(expectedData, result.response());
+        assertEquals(expectedRecords, result.records());
+
+        // Verify request2
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result2 = shard.writeState(request2);
+        shard.replay(0L, 0L, (short) 0, result2.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData2 = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords2 = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request2.topics().get(0).partitions().get(0), TIME.milliseconds()).builderSupplier()
+                .setStartOffset(request2StartOffset)
+                .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+                .build()
+        ));
+
+        assertEquals(expectedData2, result2.response());
+        assertEquals(expectedRecords2, result2.records());
+
+        ShareGroupOffset expectedFinalValue = new ShareGroupOffset.Builder()
+            .setStartOffset(request2StartOffset)
+            .setStateEpoch(5)
+            .setLeaderEpoch(3)
+            .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+            .setStateBatches(List.of())
+            .build();
+
+        assertEquals(expectedFinalValue, shard.getShareStateMapValue(SHARE_PARTITION_KEY));
+    }
+
+    /**
+     * This test validates that the delivery complete count advances correctly, in relation to
+     * start offset.
+     * case 1: incoming request start offset > current state
+     * <p>
+     * For example,
+     * req1: {
+     *  startOffset: 15,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 10
+     *  stateBatches: []
+     * }
+     * <p>
+     * req2: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 20
+     *  stateBatches: []
+     * }
+     * <p>
+     * Then, final state would be
+     * result: {
+     *  startOffset: 11,
+     *  stateEpoch: 5,
+     *  leaderEpoch: 3,
+     *  deliveryCompleteCount: 10    // req1 delivery count preferred as incoming start offset smaller
+     *  stateBatches: []
+     * }
+     *
+     */
+    @Test
+    public void testWriteStateDiscardsDeliveryCompleteCountRegressionIncomingStartOffsetSmaller() {
+        initSharePartition(shard, SHARE_PARTITION_KEY, 5);
+        writeAndReplayRecord(shard, 3);
+        int request1StartOffset = 15;
+        int request2StartOffset = 11;
+        int request1DeliveryCompleteCount = 10;
+        int request2DeliveryCompleteCount = 20;
+
+        WriteShareGroupStateRequestData request1 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request1StartOffset)
+                    .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        WriteShareGroupStateRequestData request2 = new WriteShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new WriteShareGroupStateRequestData.WriteStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new WriteShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(request2StartOffset)    // same start offset than req1
+                    .setDeliveryCompleteCount(request2DeliveryCompleteCount)
+                    .setStateEpoch(5)
+                    .setLeaderEpoch(3)
+                    .setStateBatches(List.of())))));
+
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result = shard.writeState(request1);
+        shard.replay(0L, 0L, (short) 0, result.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request1.topics().get(0).partitions().get(0), TIME.milliseconds())
+        ));
+
+        assertEquals(expectedData, result.response());
+        assertEquals(expectedRecords, result.records());
+
+        // Verify request2
+        CoordinatorResult<WriteShareGroupStateResponseData, CoordinatorRecord> result2 = shard.writeState(request2);
+        shard.replay(0L, 0L, (short) 0, result2.records().get(0));
+
+        WriteShareGroupStateResponseData expectedData2 = WriteShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        List<CoordinatorRecord> expectedRecords2 = List.of(ShareCoordinatorRecordHelpers.newShareUpdateRecord(
+            GROUP_ID, TOPIC_ID, PARTITION, ShareGroupOffset.fromRequest(request2.topics().get(0).partitions().get(0), TIME.milliseconds()).builderSupplier()
+                .setStartOffset(request1StartOffset)
+                .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+                .build()
+        ));
+
+        assertEquals(expectedData2, result2.response());
+        assertEquals(expectedRecords2, result2.records());
+
+        ShareGroupOffset expectedFinalValue = new ShareGroupOffset.Builder()
+            .setStartOffset(request1StartOffset)
+            .setStateEpoch(5)
+            .setLeaderEpoch(3)
+            .setDeliveryCompleteCount(request1DeliveryCompleteCount)
+            .setStateBatches(List.of())
+            .build();
+
+        assertEquals(expectedFinalValue, shard.getShareStateMapValue(SHARE_PARTITION_KEY));
+    }
+
     @Test
     public void testReadFailsOnUninitializedPartition() {
         ReadShareGroupStateRequestData request = new ReadShareGroupStateRequestData()


### PR DESCRIPTION
Similar to https://github.com/apache/kafka/pull/23074, the writeState
handler in the ShareCoordinator, directly writes the
`deliveryCompleteCount` into the state.
This might result in deliveryCompleteCount regressing momentarily if an
out or order request with a lower delivery complete count than the
actual value updates the state.
This PR remedies the issue by leveraging the start offset - based on the
start offset value in the incoming request, we should choose the
delivery complete count value:
- incoming(startOffset) > current(startOffset) - take incoming delivery
complete count
- incoming(startOffset) == current(startOffset) - take Max(incoming
delivery complete count, current delivery complete count)
- incoming(startOffset) < current(startOffset) - take current delivery
count

We cannot compare the delivery complete counts directly as they are non
non-monotonic sequences.

Reviewers: Andrew Schofield <aschofield@confluent.io>
