### PR TITLE
MINOR: Fix invalid {@param} Javadoc tags in streams and connect

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -634,12 +634,12 @@ public class Plugins {
 
     /**
      * If the given class names are available in the classloader, return a list of new configured
-     * instances. If the instances implement {@link Configurable}, they are configured with provided {@param config}
+     * instances. If the instances implement {@link Configurable}, they are configured with provided {@code config}
      *
      * @param klassNames         the list of class names of plugins that needs to instantiated and configured
      * @param config             the configuration containing the {@link org.apache.kafka.connect.runtime.Worker}'s configuration; may not be {@code null}
      * @param pluginKlass        the type of the plugin class that is being instantiated
-     * @return the instantiated and configured list of plugins of type <T>; empty list if the {@param klassNames} is {@code null} or empty
+     * @return the instantiated and configured list of plugins of type <T>; empty list if the {@code klassNames} is {@code null} or empty
      * @throws ConnectException if the implementation class could not be found
      */
     public <T> List<T> newPlugins(List<String> klassNames, AbstractConfig config, Class<T> pluginKlass) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/TaskAssignmentUtils.java
@@ -628,7 +628,7 @@ public final class TaskAssignmentUtils {
 
     /**
      *
-     * @return the traffic cost of assigning this {@param task} to the client {@param streamsState}.
+     * @return the traffic cost of assigning this {@code task} to the client {@code streamsState}.
      */
     private static int getCrossRackTrafficCost(final Set<TaskTopicPartition> topicPartitions,
                                                final String clientRack,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientTagAwareStandbyTaskAssignor.java
@@ -65,7 +65,7 @@ class ClientTagAwareStandbyTaskAssignor implements StandbyTaskAssignor {
     }
 
     /**
-     * The algorithm distributes standby tasks for the {@param statefulTaskIds} over different tag dimensions.
+     * The algorithm distributes standby tasks for the {@code statefulTaskIds} over different tag dimensions.
      * For each stateful task, the number of standby tasks will be assigned based on configured {@link AssignmentConfigs#numStandbyReplicas()}.
      * Rack aware standby tasks distribution only takes into account tags specified via {@link AssignmentConfigs#rackAwareAssignmentTags()}.
      * Ideally, all standby tasks for any given stateful task will be located on different tag dimensions to have the best possible distribution.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignor.java
@@ -170,8 +170,8 @@ public class RackAwareTaskAssignor {
     }
 
     /**
-     * This function populates the {@param racksForPartition} parameter passed into the function by using both
-     * the {@code Cluster} metadata as well as the {@param internalTopicManager} for topics that have stale
+     * This function populates the {@code racksForPartition} parameter passed into the function by using both
+     * the {@code Cluster} metadata as well as the {@code internalTopicManager} for topics that have stale
      * information.
      *
      * @return whether the operation successfully completed and the rack information is valid.
@@ -220,8 +220,8 @@ public class RackAwareTaskAssignor {
     }
 
     /**
-     * Verifies that within the {@param racksForProcessConsumer}, a single process is only running on a single
-     * rack. This function mutates the parameter {@param racksForProcess} to contain the resulting process
+     * Verifies that within the {@code racksForProcessConsumer}, a single process is only running on a single
+     * rack. This function mutates the parameter {@code rackForProcess} to contain the resulting process
      * to rack mapping.
      *
      * @return true if the validation was successful, and false otherwise.


### PR DESCRIPTION
Several Javadoc comments in streams and connect/runtime use {@param x},
which is not a valid Javadoc tag. Replace them with {@code x}, the
convention already used elsewhere in these same comments.

Also fixes RackAwareTaskAssignor#validateClientRack: the doc referenced
racksForProcess, but the actual parameter is named rackForProcess.

Verified with: ./gradlew :streams:javadoc :connect:runtime:javadoc
spotlessCheck

Co-Authored-By: Claude Sonnet 5 <claude@anthropic.com>
Reviewers: Uros (github:uros-b)
