### PR TITLE
MINOR: Fail fast on log truncation and topic reset in MirrorSourceTask

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown when a source partition's next offset to replicate is no longer available because
+ * earlier, unreplicated records were removed by the source topic's retention policy.
+ */
+public class DataLossException extends ConnectException {
+
+    public DataLossException(String message) {
+        super(message);
+    }
+
+    public DataLossException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConfig.java
@@ -98,6 +98,14 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
             "Partition Count * offset.lag.max = Approximate duplicated record count (Actual value can be lower or even higher depending on timing and consumer lag)";
     public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
 
+    public static final String OFFSET_VALIDATION_ENABLED = "offset.validation" + ENABLED_SUFFIX;
+    private static final String OFFSET_VALIDATION_ENABLED_DOC = "Whether to fail the task fast when the source consumer's next offset to replicate "
+            + "is no longer available. When enabled, the source consumer's auto.offset.reset is forced to none instead of the default earliest, "
+            + "so that log truncation or a topic reset raises an error instead of silently resuming from the earliest offset. "
+            + "The task then throws " + DataLossException.class.getSimpleName() + " if earlier records were purged by the retention policy, or "
+            + TopicResetException.class.getSimpleName() + " if the topic was deleted and recreated.";
+    public static final boolean OFFSET_VALIDATION_ENABLED_DEFAULT = false;
+
     public static final String HEARTBEATS_REPLICATION_ENABLED = "heartbeats.replication" + ENABLED_SUFFIX;
     private static final String HEARTBEATS_REPLICATION_ENABLED_DOC = "Whether to replicate the heartbeats topics even when the topic filter does not include them." +
             " If set to true, heartbeats topics identified by the replication policy will always be replicated, regardless of the topic filter configuration." +
@@ -221,6 +229,10 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
         return getBoolean(HEARTBEATS_REPLICATION_ENABLED);
     }
 
+    boolean offsetValidationEnabled() {
+        return getBoolean(OFFSET_VALIDATION_ENABLED);
+    }
+
     List<String> metricNamesFormats() {
         return getList(METRIC_NAMES_FORMAT);
     }
@@ -340,6 +352,13 @@ public class MirrorSourceConfig extends MirrorConnectorConfig {
                         HEARTBEATS_REPLICATION_ENABLED_DEFAULT,
                         ConfigDef.Importance.LOW,
                         HEARTBEATS_REPLICATION_ENABLED_DOC
+                )
+                .define(
+                        OFFSET_VALIDATION_ENABLED,
+                        ConfigDef.Type.BOOLEAN,
+                        OFFSET_VALIDATION_ENABLED_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        OFFSET_VALIDATION_ENABLED_DOC
                 )
                 .define(
                         METRIC_NAMES_FORMAT,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -36,12 +37,14 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.METRIC_NAMES_LEGACY;
 import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.METRIC_NAMES_NEW;
 
@@ -59,6 +62,7 @@ public class MirrorSourceTask extends SourceTask {
     private boolean stopping = false;
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
+    private boolean offsetValidationEnabled;
 
     public MirrorSourceTask() {}
 
@@ -66,12 +70,20 @@ public class MirrorSourceTask extends SourceTask {
     MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
                      ReplicationPolicy replicationPolicy,
                      OffsetSyncWriter offsetSyncWriter) {
+        this(consumer, metrics, sourceClusterAlias, replicationPolicy, offsetSyncWriter, false);
+    }
+
+    // for testing
+    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+                     ReplicationPolicy replicationPolicy,
+                     OffsetSyncWriter offsetSyncWriter, boolean offsetValidationEnabled) {
         this.consumer = consumer;
         this.legacyMetrics = metrics;
         this.sourceClusterAlias = sourceClusterAlias;
         this.replicationPolicy = replicationPolicy;
         consumerAccess = new Semaphore(1);
         this.offsetSyncWriter = offsetSyncWriter;
+        this.offsetValidationEnabled = offsetValidationEnabled;
     }
 
     @Override
@@ -84,10 +96,17 @@ public class MirrorSourceTask extends SourceTask {
         metrics = metricNamesFormats.contains(METRIC_NAMES_NEW) ? config.metrics(context.pluginMetrics()) : null;
         pollTimeout = config.consumerPollTimeout();
         replicationPolicy = config.replicationPolicy();
+        offsetValidationEnabled = config.offsetValidationEnabled();
         if (config.emitOffsetSyncsEnabled()) {
             offsetSyncWriter = new OffsetSyncWriter(config);
         }
-        consumer = MirrorUtils.newConsumer(config.sourceConsumerConfig("replication-consumer"));
+        Map<String, Object> consumerConfig = config.sourceConsumerConfig("replication-consumer");
+        if (offsetValidationEnabled) {
+            // Without a reset policy, a stale or invalid position raises OffsetOutOfRangeException
+            // instead of being silently repositioned to the earliest offset.
+            consumerConfig.put(AUTO_OFFSET_RESET_CONFIG, "none");
+        }
+        consumer = MirrorUtils.newConsumer(consumerConfig);
         Set<TopicPartition> taskTopicPartitions = config.taskTopicPartitions();
         initializeConsumer(taskTopicPartitions);
 
@@ -164,6 +183,12 @@ public class MirrorSourceTask extends SourceTask {
             }
         } catch (WakeupException e) {
             return null;
+        } catch (OffsetOutOfRangeException e) {
+            if (offsetValidationEnabled) {
+                throw classifyOffsetOutOfRange(e);
+            }
+            log.warn("Failure during poll.", e);
+            return null;
         } catch (KafkaException e) {
             log.warn("Failure during poll.", e);
             return null;
@@ -210,6 +235,33 @@ public class MirrorSourceTask extends SourceTask {
         }
     }
  
+    // visible for testing
+    KafkaException classifyOffsetOutOfRange(OffsetOutOfRangeException e) {
+        Map<TopicPartition, Long> requestedOffsets = e.offsetOutOfRangePartitions();
+        Map<TopicPartition, Long> earliestOffsets = consumer.beginningOffsets(requestedOffsets.keySet());
+        boolean dataLoss = false;
+        for (Map.Entry<TopicPartition, Long> entry : requestedOffsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            long requestedOffset = entry.getValue();
+            long earliestOffset = earliestOffsets.get(topicPartition);
+            if (earliestOffset > 0) {
+                dataLoss = true;
+                log.error("Data loss detected replicating {}: requested offset {} is no longer available; earliest available offset is {}. "
+                        + "Records were likely purged by the source topic's retention policy before they could be replicated.",
+                        topicPartition, requestedOffset, earliestOffset);
+            } else {
+                log.error("Topic reset detected replicating {}: requested offset {} is no longer available; earliest available offset is {}. "
+                        + "The source topic was likely deleted and recreated.",
+                        topicPartition, requestedOffset, earliestOffset);
+            }
+        }
+        return dataLoss
+                ? new DataLossException("Data loss detected replicating one or more partitions; earlier records were purged before "
+                        + "they could be replicated: " + requestedOffsets.keySet(), e)
+                : new TopicResetException("Topic reset detected replicating one or more partitions; the source topic was likely "
+                        + "deleted and recreated: " + requestedOffsets.keySet(), e);
+    }
+
     private Map<TopicPartition, Long> loadOffsets(Set<TopicPartition> topicPartitions) {
         return topicPartitions.stream().collect(Collectors.toMap(x -> x, this::loadOffset));
     }
@@ -230,7 +282,14 @@ public class MirrorSourceTask extends SourceTask {
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
             // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {
-                log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                if (offsetValidationEnabled) {
+                    // With auto.offset.reset=none, the consumer can't resolve a starting position on its
+                    // own, so replicate what the earliest reset policy used to do for free.
+                    log.trace("Seeking to beginning for topicPartition: {}", topicPartition);
+                    consumer.seekToBeginning(Collections.singleton(topicPartition));
+                } else {
+                    log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                }
                 return;
             }
             long nextOffsetToCommittedOffset = offset + 1L;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown when a source partition's next offset to replicate is no longer available because the
+ * source topic appears to have been deleted and recreated.
+ */
+public class TopicResetException extends ConnectException {
+
+    public TopicResetException(String message) {
+        super(message);
+    }
+
+    public TopicResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConfigTest.java
@@ -151,6 +151,25 @@ public class MirrorSourceConfigTest {
     }
 
     @Test
+    public void testOffsetValidationEnabled() {
+        MirrorSourceConfig defaultConfig = new MirrorSourceConfig(makeProps());
+        assertFalse(defaultConfig.offsetValidationEnabled(), "offset.validation.enabled should default to false");
+
+        MirrorSourceConfig enabledConfig = new MirrorSourceConfig(makeProps("offset.validation.enabled", "true"));
+        assertTrue(enabledConfig.offsetValidationEnabled(), "offset.validation.enabled should be settable to true");
+
+        assertTrue(
+                MirrorSourceConfig.CONNECTOR_CONFIG_DEF.names().contains(MirrorSourceConfig.OFFSET_VALIDATION_ENABLED),
+                MirrorSourceConfig.OFFSET_VALIDATION_ENABLED + " should be defined for connector ConfigDef"
+        );
+
+        Map<String, String> taskProps = enabledConfig.taskConfigForTopicPartitions(
+                List.of(new TopicPartition("topic1", 0)), 0);
+        MirrorSourceTaskConfig taskConfig = new MirrorSourceTaskConfig(taskProps);
+        assertTrue(taskConfig.offsetValidationEnabled(), "offset.validation.enabled should propagate to task config");
+    }
+
+    @Test
     public void testAdminConfigsForOffsetSyncsTopic() {
         Map<String, String> connectorProps = makeProps(
                 "source.admin.request.timeout.ms", "1",

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -20,7 +20,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -35,6 +37,7 @@ import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,12 +46,15 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -265,6 +271,96 @@ public class MirrorSourceTaskTest {
                 .seek(new TopicPartition("previouslyReplicatedTopic1", 0), offsetToSeek);
 
         verifyNoMoreInteractions(mockConsumer);
+    }
+
+    @Test
+    public void testSeekToBeginningForNewPartitionsWhenOffsetValidationEnabled() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> mockConsumer = mock(KafkaConsumer.class);
+
+        SourceTaskContext mockSourceTaskContext = mock(SourceTaskContext.class);
+        OffsetStorageReader mockOffsetStorageReader = mock(OffsetStorageReader.class);
+        when(mockSourceTaskContext.offsetStorageReader()).thenReturn(mockOffsetStorageReader);
+        when(mockOffsetStorageReader.offset(anyMap())).thenReturn(new HashMap<>());
+
+        TopicPartition newPartition = new TopicPartition("newTopicToReplicate", 0);
+        Set<TopicPartition> topicPartitions = Set.of(newPartition);
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(mockConsumer, null, null,
+                new DefaultReplicationPolicy(), null, true);
+        mirrorSourceTask.initialize(mockSourceTaskContext);
+
+        mirrorSourceTask.initializeConsumer(topicPartitions);
+
+        verify(mockConsumer, times(1)).assign(topicPartitions);
+        verify(mockConsumer, times(1)).seekToBeginning(Collections.singleton(newPartition));
+        verifyNoMoreInteractions(mockConsumer);
+    }
+
+    @Test
+    public void testPollThrowsDataLossExceptionWhenRetentionPurgedRecords() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        Map<TopicPartition, Long> requestedOffsets = Map.of(topicPartition, 42L);
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(requestedOffsets));
+        when(consumer.beginningOffsets(requestedOffsets.keySet())).thenReturn(Map.of(topicPartition, 10L));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        assertThrows(DataLossException.class, mirrorSourceTask::poll,
+                "should fail fast when earlier records were purged by retention");
+    }
+
+    @Test
+    public void testPollThrowsTopicResetExceptionWhenTopicWasRecreated() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        Map<TopicPartition, Long> requestedOffsets = Map.of(topicPartition, 42L);
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(requestedOffsets));
+        when(consumer.beginningOffsets(requestedOffsets.keySet())).thenReturn(Map.of(topicPartition, 0L));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        assertThrows(TopicResetException.class, mirrorSourceTask::poll,
+                "should fail fast when the topic appears to have been deleted and recreated");
+    }
+
+    @Test
+    public void testPollFallsBackToDefaultBehaviorWhenOffsetValidationDisabled() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        Map<TopicPartition, Long> requestedOffsets = Map.of(topicPartition, 42L);
+        when(consumer.poll(any())).thenThrow(new OffsetOutOfRangeException(requestedOffsets));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null);
+
+        assertNull(mirrorSourceTask.poll(), "default (disabled) behavior should swallow the exception, not fail the task");
+        verify(consumer, never()).beginningOffsets(any());
+    }
+
+    @Test
+    public void testClassifyOffsetOutOfRangePrefersDataLossWhenPartitionsAreMixed() {
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        TopicPartition resetPartition = new TopicPartition("resetTopic", 0);
+        TopicPartition purgedPartition = new TopicPartition("purgedTopic", 0);
+        Map<TopicPartition, Long> requestedOffsets = Map.of(resetPartition, 5L, purgedPartition, 20L);
+        when(consumer.beginningOffsets(requestedOffsets.keySet()))
+                .thenReturn(Map.of(resetPartition, 0L, purgedPartition, 15L));
+
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask(consumer, null, "cluster1",
+                new DefaultReplicationPolicy(), null, true);
+
+        KafkaException classified = mirrorSourceTask.classifyOffsetOutOfRange(new OffsetOutOfRangeException(requestedOffsets));
+
+        assertTrue(classified instanceof DataLossException,
+                "a mix of reset and purged partitions should be treated as the more severe data-loss case");
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/DedicatedMirrorIntegrationTest.java
@@ -17,16 +17,20 @@
 package org.apache.kafka.connect.mirror.integration;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.mirror.DataLossException;
 import org.apache.kafka.connect.mirror.MirrorHeartbeatConnector;
 import org.apache.kafka.connect.mirror.MirrorMaker;
 import org.apache.kafka.connect.mirror.MirrorSourceConfig;
 import org.apache.kafka.connect.mirror.MirrorSourceConnector;
 import org.apache.kafka.connect.mirror.SourceAndTarget;
+import org.apache.kafka.connect.mirror.TopicResetException;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
@@ -374,6 +378,152 @@ public class DedicatedMirrorIntegrationTest {
             awaitTaskConfigurations(mirrorMakers.get("node 0"), MirrorSourceConnector.class, sourceAndTarget,
                     config -> newConfigValue.equals(config.get(MirrorSourceConfig.REFRESH_TOPICS_INTERVAL_SECONDS)));
         }
+    }
+
+    /**
+     * Verifies that, with offset.validation.enabled turned on, a source task fails fast with a
+     * {@link DataLossException} when unreplicated records are purged from the source topic before
+     * the task could replicate them (e.g. by an aggressive retention policy), instead of silently
+     * resuming replication from a later offset.
+     */
+    @Test
+    public void testTaskFailsOnDataLossFromPurgedRecords() throws Exception {
+        Properties brokerProps = new Properties();
+        EmbeddedKafkaCluster clusterA = startKafkaCluster("A", 1, brokerProps);
+        EmbeddedKafkaCluster clusterB = startKafkaCluster("B", 1, brokerProps);
+
+        try (Admin adminA = clusterA.createAdminClient()) {
+            final String a = "A";
+            final String b = "B";
+            final String ab = a + "->" + b;
+            final String ba = b + "->" + a;
+            final String topic = "test-topic-data-loss";
+            final TopicPartition topicPartition = new TopicPartition(topic, 0);
+            final String mmName = "data-loss";
+
+            Map<String, String> mmProps = new HashMap<>() {{
+                    put("dedicated.mode.enable.internal.rest", "false");
+                    put("listeners", "http://localhost:0");
+                    put("refresh.topics.interval.seconds", "1");
+                    put("clusters", String.join(", ", a, b));
+                    put(a + ".bootstrap.servers", clusterA.bootstrapServers());
+                    put(b + ".bootstrap.servers", clusterB.bootstrapServers());
+                    put(ab + ".enabled", "true");
+                    put(ab + ".topics", topic);
+                    put(ab + "." + MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true");
+                    put(ba + ".enabled", "false");
+                    put(ba + ".emit.heartbeats.enabled", "false");
+                    put("replication.factor", "1");
+                    put("checkpoints.topic.replication.factor", "1");
+                    put("heartbeats.topic.replication.factor", "1");
+                    put("offset-syncs.topic.replication.factor", "1");
+                    put("offset.storage.replication.factor", "1");
+                    put("status.storage.replication.factor", "1");
+                    put("config.storage.replication.factor", "1");
+                }};
+
+            clusterA.createTopic(topic, 1);
+            final SourceAndTarget sourceAndTarget = new SourceAndTarget(a, b);
+
+            startMirrorMaker(mmName, mmProps);
+            awaitMirrorMakerStart(mirrorMakers.get(mmName), sourceAndTarget);
+            awaitConnectorTasksStart(mirrorMakers.get(mmName), MirrorSourceConnector.class, sourceAndTarget);
+
+            // Drain a first batch of records so the task's replicated position is persisted partway through the log
+            writeToTopic(clusterA, topic, 5);
+            awaitTopicContent(clusterB, b, a + "." + topic, 5);
+
+            // Stop the task so its position is frozen while more, unreplicated records are produced and then purged
+            stopMirrorMaker(mmName);
+            writeToTopic(clusterA, topic, 5);
+            long endOffset = clusterA.endOffset(topicPartition);
+            adminA.deleteRecords(Map.of(topicPartition, RecordsToDelete.beforeOffset(endOffset)))
+                    .lowWatermarks().get(topicPartition).get();
+
+            // On restart, the task resumes from its persisted (now-purged) position and should fail fast
+            startMirrorMaker(mmName, mmProps);
+            awaitTaskFailure(mirrorMakers.get(mmName), MirrorSourceConnector.class, sourceAndTarget,
+                    DataLossException.class.getSimpleName());
+        }
+    }
+
+    /**
+     * Verifies that, with offset.validation.enabled turned on, a source task fails fast with a
+     * {@link TopicResetException} when the source topic is deleted and recreated while the task
+     * isn't running, instead of silently resetting to the earliest offset of the new topic.
+     */
+    @Test
+    public void testTaskFailsOnTopicReset() throws Exception {
+        Properties brokerProps = new Properties();
+        EmbeddedKafkaCluster clusterA = startKafkaCluster("A", 1, brokerProps);
+        EmbeddedKafkaCluster clusterB = startKafkaCluster("B", 1, brokerProps);
+
+        final String a = "A";
+        final String b = "B";
+        final String ab = a + "->" + b;
+        final String ba = b + "->" + a;
+        final String topic = "test-topic-reset";
+        final String mmName = "topic-reset";
+
+        Map<String, String> mmProps = new HashMap<>() {{
+                put("dedicated.mode.enable.internal.rest", "false");
+                put("listeners", "http://localhost:0");
+                put("refresh.topics.interval.seconds", "1");
+                put("clusters", String.join(", ", a, b));
+                put(a + ".bootstrap.servers", clusterA.bootstrapServers());
+                put(b + ".bootstrap.servers", clusterB.bootstrapServers());
+                put(ab + ".enabled", "true");
+                put(ab + ".topics", topic);
+                put(ab + "." + MirrorSourceConfig.OFFSET_VALIDATION_ENABLED, "true");
+                put(ba + ".enabled", "false");
+                put(ba + ".emit.heartbeats.enabled", "false");
+                put("replication.factor", "1");
+                put("checkpoints.topic.replication.factor", "1");
+                put("heartbeats.topic.replication.factor", "1");
+                put("offset-syncs.topic.replication.factor", "1");
+                put("offset.storage.replication.factor", "1");
+                put("status.storage.replication.factor", "1");
+                put("config.storage.replication.factor", "1");
+            }};
+
+        clusterA.createTopic(topic, 1);
+        final SourceAndTarget sourceAndTarget = new SourceAndTarget(a, b);
+
+        startMirrorMaker(mmName, mmProps);
+        awaitMirrorMakerStart(mirrorMakers.get(mmName), sourceAndTarget);
+        awaitConnectorTasksStart(mirrorMakers.get(mmName), MirrorSourceConnector.class, sourceAndTarget);
+
+        // Drain a batch of records so the task's persisted position is beyond the start of the log
+        writeToTopic(clusterA, topic, 5);
+        awaitTopicContent(clusterB, b, a + "." + topic, 5);
+
+        // Stop the task, then delete and recreate the topic to simulate an irregular system reset
+        stopMirrorMaker(mmName);
+        clusterA.deleteTopic(topic);
+        clusterA.createTopic(topic, 1);
+
+        // On restart, the task resumes from its persisted (now-invalid) position on the recreated topic
+        startMirrorMaker(mmName, mmProps);
+        awaitTaskFailure(mirrorMakers.get(mmName), MirrorSourceConnector.class, sourceAndTarget,
+                TopicResetException.class.getSimpleName());
+    }
+
+    private <T extends SourceConnector> void awaitTaskFailure(MirrorMaker mm, Class<T> clazz, SourceAndTarget sourceAndTarget,
+            String expectedTraceSubstring) throws InterruptedException {
+        String connName = clazz.getSimpleName();
+        AtomicReference<String> lastTrace = new AtomicReference<>("");
+        waitForCondition(() -> {
+            ConnectorStateInfo connectorStatus = mm.connectorStatus(sourceAndTarget, connName);
+            return connectorStatus.tasks().stream().anyMatch(task -> {
+                if (AbstractStatus.State.FAILED.toString().equals(task.state())) {
+                    lastTrace.set(task.trace());
+                    return true;
+                }
+                return false;
+            });
+        }, MM_START_UP_TIMEOUT_MS, "Task for connector " + connName + " did not fail as expected in time");
+        assertTrue(lastTrace.get().contains(expectedTraceSubstring),
+                "expected task failure trace to mention " + expectedTraceSubstring + " but was: " + lastTrace.get());
     }
 
     private void awaitTopicCreation(String clusterName, Admin admin, String topic) throws Exception {


### PR DESCRIPTION
## Summary

MirrorMaker 2's default `auto.offset.reset=earliest` masks two operationally
dangerous scenarios in PR/DR replication: aggressive source-topic retention
purging records before they're replicated, and a source topic being deleted
and recreated. In both cases the source consumer silently jumps to a valid
offset and MM2 keeps running as if nothing happened, with no signal that a
gap now exists in the replicated log.

This PR adds an opt-in `offset.validation.enabled` connector config
(default `false`, fully backward compatible) that makes `MirrorSourceTask`
fail fast instead: a new `DataLossException` is thrown when earlier,
unreplicated records were purged, and a new `TopicResetException` when the
topic was deleted and recreated.

## Design Rationale

**Files/classes changed:**
- `MirrorSourceConfig`: new `offset.validation.enabled` config (default `false`).
- `MirrorSourceTask`:
  - `start()` — when enabled, overrides the consumer's `auto.offset.reset` to
    `none` instead of the default `earliest`, so the underlying
    `OffsetOutOfRangeException` reaches application code instead of being
    handled transparently by the consumer's built-in reset policy.
  - `initializeConsumer()` — with no reset policy, the consumer can no longer
    resolve a starting position on its own. For partitions with no previously
    committed Connect offset (first-ever startup), this now explicitly calls
    `seekToBeginning(...)` to reproduce what `earliest` used to do for free.
    Without this, brand-new tasks would fail immediately with
    `NoOffsetForPartitionException`.
  - `poll()` — new `catch (OffsetOutOfRangeException e)` ahead of the existing
    generic `KafkaException` catch (which today just logs a warning and
    silently returns, the root cause of the masking behavior). When enabled,
    delegates to `classifyOffsetOutOfRange(e)` and throws; otherwise preserves
    today's behavior unchanged.
  - `classifyOffsetOutOfRange()` — for each affected partition, compares the
    requested (now-invalid) offset against `consumer.beginningOffsets(...)`:
    `0` means the topic was recreated (`TopicResetException`), `> 0` means
    retention purged a prefix of the log (`DataLossException`). Logs topic,
    partition, requested offset, and earliest offset at `ERROR` before
    throwing. If a batch spans partitions with mixed causes, the task treats
    it as the more severe data-loss case.
- `DataLossException` / `TopicResetException` (new): unchecked, extend
  `ConnectException`, so throwing them from `poll()` fails the task the same
  way the file's existing `catch (Throwable e) { throw e; }` fallback already
  does — no new propagation plumbing needed.

**Why this strategy:** `auto.offset.reset=none` is the only setting under
which the consumer ever surfaces `OffsetOutOfRangeException` at all — under
`earliest`/`latest` the reset happens inside `FetchCollector` before the
exception type even exists, so there's no way to detect either scenario
without this consumer config change first. Everything else follows from
that: an explicit `seekToBeginning` to keep new-task startup behavior
identical, and a catch/classify step to turn the raised exception into a
specific, actionable failure.

**Integration with the MM2 lifecycle:** Entirely additive and opt-in — with
the config left at its default (`false`), `auto.offset.reset` stays
`earliest`, `initializeConsumer()` and `poll()` are byte-for-byte unchanged in
behavior, and `OffsetOutOfRangeException` (as a `KafkaException` subtype)
continues to fall through to the existing generic catch exactly as before.

**Known gap:** this adds a new public connector config, which per this
repo's contribution guidelines generally warrants a KIP before merging
upstream; none has been filed here since this work originated as a
self-contained take-home exercise against a personal fork.

## Test Plan

- [x] Unit tests (`MirrorSourceTaskTest`): `seekToBeginning` on enable,
      `DataLossException` thrown, `TopicResetException` thrown, disabled-flag
      fallback preserves today's warn-and-swallow behavior, mixed-partition
      classification prefers data loss.
- [x] Config test (`MirrorSourceConfigTest`): default `false`, settable to
      `true`, registered in `CONNECTOR_CONFIG_DEF`, propagates to
      `MirrorSourceTaskConfig`.
- [x] Integration tests (`DedicatedMirrorIntegrationTest`, embedded clusters):
  - `testTaskFailsOnDataLossFromPurgedRecords` — drains initial replication,
    stops MM2, writes further records and deletes them via
    `Admin#deleteRecords` before MM2 ever consumed them, restarts MM2, and
    asserts the task fails with `DataLossException` in its trace.
  - `testTaskFailsOnTopicReset` — drains initial replication, stops MM2,
    deletes and recreates the topic, restarts MM2, and asserts the task fails
    with `TopicResetException` in its trace.
- [x] `./gradlew :connect:mirror:test` — full module suite green.
- [x] `./gradlew :connect:mirror:spotlessApply :connect:mirror:checkstyleMain :connect:mirror:checkstyleTest` — clean.

## Evaluation Criteria (from project brief)

- **Functional correctness**: fail-fast logic implemented for both
  truncation and reset; all new and existing tests pass.
- **Technical excellence**: change is opt-in and additive, confined to
  `connect/mirror` (~148 LOC in `main`, excluding tests), reuses the file's
  existing "throw to fail the task" idiom rather than inventing new
  propagation machinery, and passes this repo's checkstyle/spotless gates.
- **Test quality**: unit tests isolate the classification and consumer-seek
  logic with mocks; integration tests exercise the real embedded-cluster
  failure paths end-to-end (deterministically, via `deleteRecords` and
  topic delete/recreate rather than waiting on real retention timers).
- **Documentation quality**: this description covers rationale, affected
  files, and lifecycle integration above.

## AI Usage Documentation

Implemented with Claude Code (Claude Sonnet 5): used to map the MM2 class
structure, analyze the consumer's `auto.offset.reset`/`OffsetOutOfRangeException`
semantics in `clients`, implement the config/task/exception changes, and
write the unit and integration tests. All design decisions (opt-in vs
default-on, the mixed-partition data-loss-wins policy) were reviewed and
confirmed interactively before implementation.
