### PR TITLE
KAFKA-20914: Clear append and fetch purgatories when a leader resigns or becomes unattached

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -760,16 +760,17 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         completeLeaderPurgatoriesExceptionally();
     }
 
+    /**
+     * Completes pending appends and fetches exceptionally on every leader-exit path (follower,
+     * resigned, unattached) so callers fail fast instead of waiting out their timeout. No-op when not leader.
+     */
     private void completeLeaderPurgatoriesExceptionally() {
-        // After becoming a follower, we need to complete all pending fetches so that
-        // they can be re-sent to the leader without waiting for their expirations
         fetchPurgatory.completeAllExceptionally(
             Errors.NOT_LEADER_OR_FOLLOWER.exception(
                 "Cannot process the fetch request because the node is no longer the leader"
             )
         );
 
-        // Clearing the append purgatory should complete all futures exceptionally since this node is no longer the leader
         appendPurgatory.completeAllExceptionally(
             Errors.NOT_LEADER_OR_FOLLOWER.exception(
                 "Failed to receive sufficient acknowledgments for this append before leader change"

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -745,23 +745,22 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
         quorum.transitionToUnattached(epoch, leaderId);
         maybeFireLeaderChange();
         resetConnections();
+        completeLeaderPurgatoriesExceptionally();
     }
 
     private void transitionToResigned(List<ReplicaKey> preferredSuccessors) {
-        fetchPurgatory.completeAllExceptionally(
-            Errors.NOT_LEADER_OR_FOLLOWER.exception(
-                "Not handling request since this node is resigning"
-            )
-        );
         quorum.transitionToResigned(preferredSuccessors);
         resetConnections();
+        completeLeaderPurgatoriesExceptionally();
     }
 
     private void onBecomeFollower(long currentTimeMs) {
         kafkaRaftMetrics.maybeUpdateElectionLatency(currentTimeMs);
-
         resetConnections();
+        completeLeaderPurgatoriesExceptionally();
+    }
 
+    private void completeLeaderPurgatoriesExceptionally() {
         // After becoming a follower, we need to complete all pending fetches so that
         // they can be re-sent to the leader without waiting for their expirations
         fetchPurgatory.completeAllExceptionally(
@@ -3904,6 +3903,11 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     QuorumState quorum() {
         // It's okay to return null since this method is only called by tests
         return quorum;
+    }
+
+    // Visible only for test
+    int appendPurgatoryNumWaiting() {
+        return appendPurgatory.numWaiting();
     }
 
     private boolean isInitialized() {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -550,6 +550,110 @@ class KafkaRaftClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    public void testTransitionToUnattachedWillCompleteFetchPurgatory(boolean withKip853Rpc) throws Exception {
+        int localId = randomReplicaId();
+        int remoteId = localId + 1;
+        ReplicaKey otherNodeKey = replicaKey(remoteId, withKip853Rpc);
+        Set<Integer> voters = Set.of(localId, otherNodeKey.id());
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withKip853Rpc(withKip853Rpc)
+            .build();
+
+        context.unattachedToLeader();
+        assertEquals(OptionalInt.of(localId), context.currentLeader());
+        int epoch = context.currentEpoch();
+
+        // Park a fetch from the other voter in the fetch purgatory: it is caught up, so there is no
+        // data to return yet.
+        context.deliverRequest(
+            context.fetchRequest(epoch, otherNodeKey, context.log.endOffset().offset(), epoch, 1000)
+        );
+        context.poll();
+
+        context.deliverRequest(
+            context.voteRequest(
+                epoch + 1,
+                otherNodeKey,
+                context.log.lastFetchedEpoch(),
+                context.log.endOffset().offset()
+            )
+        );
+        context.poll();
+
+        context.assertSentFetchPartitionResponse(Errors.NOT_LEADER_OR_FOLLOWER, epoch + 1, OptionalInt.empty());
+        assertTrue(context.client.quorum().isUnattached());
+        assertEquals(epoch + 1, context.currentEpoch());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testResignWillCompleteAppendPurgatory(boolean withKip853Rpc) throws Exception {
+        int localId = randomReplicaId();
+        int remoteId = localId + 1;
+        ReplicaKey otherNodeKey = replicaKey(remoteId, withKip853Rpc);
+        Set<Integer> voters = Set.of(localId, otherNodeKey.id());
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withAppendLingerMs(0)
+            .withKip853Rpc(withKip853Rpc)
+            .build();
+
+        context.unattachedToLeader();
+        int epoch = context.currentEpoch();
+
+        context.client.prepareAppend(epoch, List.of("a"));
+        context.client.schedulePreparedAppend();
+        context.poll();
+        assertTrue(context.client.appendPurgatoryNumWaiting() > 0, "expected a pending append in purgatory");
+
+        // Resigning must complete the pending append exceptionally rather than leaving it to expire.
+        context.client.shutdown(1000);
+        context.poll();
+
+        assertEquals(0, context.client.appendPurgatoryNumWaiting());
+        context.assertResignedLeader(epoch, localId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testTransitionToUnattachedWillCompleteAppendPurgatory(boolean withKip853Rpc) throws Exception {
+        int localId = randomReplicaId();
+        int remoteId = localId + 1;
+        ReplicaKey otherNodeKey = replicaKey(remoteId, withKip853Rpc);
+        Set<Integer> voters = Set.of(localId, otherNodeKey.id());
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withAppendLingerMs(0)
+            .withKip853Rpc(withKip853Rpc)
+            .build();
+
+        context.unattachedToLeader();
+        int epoch = context.currentEpoch();
+
+        // Park an append in the append purgatory (uncommitted; the other voter never replicates it).
+        context.client.prepareAppend(epoch, List.of("a"));
+        context.client.schedulePreparedAppend();
+        context.poll();
+        assertTrue(context.client.appendPurgatoryNumWaiting() > 0, "expected a pending append in purgatory");
+
+        context.deliverRequest(
+            context.voteRequest(
+                epoch + 1,
+                otherNodeKey,
+                context.log.lastFetchedEpoch(),
+                context.log.endOffset().offset()
+            )
+        );
+        context.poll();
+
+        assertEquals(0, context.client.appendPurgatoryNumWaiting());
+        assertTrue(context.client.quorum().isUnattached());
+        assertEquals(epoch + 1, context.currentEpoch());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     public void testResignInOlderEpochIgnored(boolean withKip853Rpc) throws Exception {
         int localId = randomReplicaId();
         int otherNodeId = localId + 1;


### PR DESCRIPTION
## Problem

When a `KafkaRaftClient` leader stops being the leader, its parked requests can no longer complete normally: pending appends can't gather the acknowledgments to commit at the old epoch, and held fetches should be failed so callers retry against the new leader. Both purgatories should therefore be completed exceptionally on any leader → non-leader transition. Only `onBecomeFollower` did this; the other two leader-exit paths did not.

So a leader that resigns, or drops to unattached (e.g. on seeing a higher epoch with no known leader), left pending appends. And, for unattached, pending fetches, sitting in purgatory until their request timeout expired.

## Impact

The parked futures eventually expire via `request.timeout.ms`. But until then, callers wait the full timeout for a failure that is already certain, and each pending append future keeps its `CompletedBatch` (and backing `ByteBuffer`) pinned in memory for that duration.

## Testing

- `testResignWillCompleteAppendPurgatory` and `testTransitionToUnattachedWillCompleteAppendPurgatory`
  (new): park an uncommitted append and assert the append purgatory goes from non-empty to empty
  across the transition (via a new test-only `appendPurgatoryNumWaiting()` accessor).
- `testTransitionToUnattachedWillCompleteFetchPurgatory` (new): asserts a held fetch is completed
  with `NOT_LEADER_OR_FOLLOWER` on the unattached path (mirrors the existing
  `testResignWillCompleteFetchPurgatory`).
