### PR TITLE
MINOR: Fix bug related to topicId comparison in SharePartition.

### DIFF
--- a/core/src/main/java/kafka/server/share/SharePartition.java
+++ b/core/src/main/java/kafka/server/share/SharePartition.java
@@ -472,7 +472,7 @@ public class SharePartition {
                 }
 
                 TopicData<PartitionAllData> state = result.topicsData().get(0);
-                if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1) {
+                if (!Objects.equals(state.topicId(), topicIdPartition.topicId()) || state.partitions().size() != 1) {
                     log.error("Failed to initialize the share partition: {}-{}. Invalid topic partition response: {}.",
                         groupId, topicIdPartition, result);
                     throwable = new IllegalStateException(String.format("Failed to initialize the share partition %s-%s", groupId, topicIdPartition));
@@ -2881,7 +2881,7 @@ public class SharePartition {
                 }
 
                 TopicData<PartitionErrorData> state = result.topicsData().get(0);
-                if (state.topicId() != topicIdPartition.topicId() || state.partitions().size() != 1
+                if (!Objects.equals(state.topicId(), topicIdPartition.topicId()) || state.partitions().size() != 1
                     || state.partitions().get(0).partition() != topicIdPartition.partition()) {
                     log.error("Failed to write the share group state for share partition: {}-{}. Invalid topic partition response: {}",
                         groupId, topicIdPartition, result);

--- a/core/src/test/java/kafka/server/share/SharePartitionTest.java
+++ b/core/src/test/java/kafka/server/share/SharePartitionTest.java
@@ -1035,6 +1035,31 @@ public class SharePartitionTest {
     }
 
     @Test
+    public void testMaybeInitializeWithEqualButDistinctTopicIdResponse() {
+        // The response's topicId is a different Uuid instance than TOPIC_ID_PARTITION.topicId()
+        // but represents the same UUID value. Initialization should succeed since topicId is
+        // compared by value, not by reference.
+        Uuid equalButDistinctTopicId = new Uuid(
+            TOPIC_ID_PARTITION.topicId().getMostSignificantBits(),
+            TOPIC_ID_PARTITION.topicId().getLeastSignificantBits());
+        Persister persister = Mockito.mock(Persister.class);
+        ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
+        Mockito.when(readShareGroupStateResult.topicsData()).thenReturn(List.of(
+            new TopicData<>(equalButDistinctTopicId, List.of(
+                PartitionFactory.newPartitionAllData(0, 3, 5L, Errors.NONE.code(), Errors.NONE.message(),
+                    List.of(
+                        new PersisterStateBatch(5L, 10L, RecordState.AVAILABLE.id, (short) 2),
+                        new PersisterStateBatch(11L, 15L, RecordState.ARCHIVED.id, (short) 3)))))));
+        Mockito.when(persister.readState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(readShareGroupStateResult));
+        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+
+        CompletableFuture<Void> result = sharePartition.maybeInitialize();
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        assertEquals(SharePartitionState.ACTIVE, sharePartition.partitionState());
+    }
+
+    @Test
     public void testMaybeInitializeWithInvalidPartitionResponse() {
         Persister persister = Mockito.mock(Persister.class);
         ReadShareGroupStateResult readShareGroupStateResult = Mockito.mock(ReadShareGroupStateResult.class);
@@ -7721,6 +7746,29 @@ public class SharePartitionTest {
         writeResult = sharePartition.writeShareGroupState(anyList());
         assertTrue(writeResult.isCompletedExceptionally());
         assertFutureThrows(IllegalStateException.class, writeResult);
+    }
+
+    @Test
+    public void testWriteShareGroupStateWithEqualButDistinctTopicIdResponse() {
+        // The response's topicId is a different Uuid instance than TOPIC_ID_PARTITION.topicId()
+        // but represents the same UUID value. The write should succeed since topicId is
+        // compared by value, not by reference.
+        Uuid equalButDistinctTopicId = new Uuid(
+            TOPIC_ID_PARTITION.topicId().getMostSignificantBits(),
+            TOPIC_ID_PARTITION.topicId().getLeastSignificantBits());
+        Persister persister = Mockito.mock(Persister.class);
+        mockPersisterReadStateMethod(persister);
+        SharePartition sharePartition = SharePartitionBuilder.builder().withPersister(persister).build();
+
+        WriteShareGroupStateResult writeShareGroupStateResult = Mockito.mock(WriteShareGroupStateResult.class);
+        Mockito.when(writeShareGroupStateResult.topicsData()).thenReturn(List.of(
+                new TopicData<>(equalButDistinctTopicId, List.of(
+                        PartitionFactory.newPartitionErrorData(0, Errors.NONE.code(), Errors.NONE.message())))));
+        Mockito.when(persister.writeState(Mockito.any())).thenReturn(CompletableFuture.completedFuture(writeShareGroupStateResult));
+
+        CompletableFuture<Void> result = sharePartition.writeShareGroupState(anyList());
+        assertNull(result.join());
+        assertFalse(result.isCompletedExceptionally());
     }
 
     @Test


### PR DESCRIPTION
There were 2 occurrences where topicId (a Uuid) was being compared using
operator comparison (`!=`). This is an issue since Uuid is a user
defined type defining its own equals.  This PR remedies the issue and
adds a test to catch regressions.

Co-authored-by: varunv-cflt <vvelamuri@confluent.io>
Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
