### PR TITLE
KAFKA-20902: Fix oldest-iterator-open-since-ms for same-ms iterators

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractMeteredIterator.java
@@ -51,6 +51,7 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
     private final Set<MeteredIterator> openIterators;
     private final long startNs;
     private final long startTimestampMs;
+    private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
 
     AbstractMeteredIterator(final KeyValueIterator<RawKey, byte[]> iter,
                             final Sensor operationSensor,
@@ -76,6 +77,13 @@ abstract class AbstractMeteredIterator<RawKey> implements MeteredIterator {
     @Override
     public final long startTimestamp() {
         return startTimestampMs;
+    }
+
+    // Final: openIterators.add(this) in the constructor sorts through this via the set's
+    // comparator, which also uses sequenceNumber for tie-breaking within the same millisecond.
+    @Override
+    public final long sequenceNumber() {
+        return sequenceNumber;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredIterator.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Common super-interface of all Metered Iterator types.
  *
@@ -23,8 +26,25 @@ package org.apache.kafka.streams.state.internals;
  */
 public interface MeteredIterator {
 
+    AtomicLong SEQUENCE_NUMBERS = new AtomicLong();
+
+    /**
+     * Orders Iterators by the time they were opened, oldest first, falling back to the sequence
+     * number for Iterators opened within the same millisecond. The fallback is what makes this
+     * ordering total: any two distinct Iterators must compare as unequal, or a sorted set of open
+     * Iterators would discard one of them as a duplicate.
+     */
+    Comparator<MeteredIterator> OPENED_FIRST = Comparator
+        .comparingLong(MeteredIterator::startTimestamp)
+        .thenComparingLong(MeteredIterator::sequenceNumber);
+
     /**
      * @return The UNIX timestamp, in milliseconds, that this Iterator was created/opened.
      */
     long startTimestamp();
+
+    /**
+     * @return A number, unique across all Iterators, that increases in the order Iterators are created.
+     */
+    long sequenceNumber();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -52,7 +52,6 @@ import org.apache.kafka.streams.state.internals.StoreQueryUtils.QueryHandler;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +104,7 @@ public class MeteredKeyValueStore<K, V>
     private Sensor restoreSensor;
 
     protected LongAdder numOpenIterators = new LongAdder();
-    protected NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(Comparator.comparingLong(MeteredIterator::startTimestamp));
+    protected NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(MeteredIterator.OPENED_FIRST);
 
 
     private final Map<Class<?>, QueryHandler<?>> queryHandlers =
@@ -569,6 +568,7 @@ public class MeteredKeyValueStore<K, V>
         private final Sensor sensor;
         private final long startNs;
         private final long startTimestamp;
+        private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
 
         private MeteredKeyValueStoreIterator(final KeyValueIterator<Bytes, byte[]> iter,
                                              final Sensor sensor) {
@@ -583,6 +583,11 @@ public class MeteredKeyValueStore<K, V>
         @Override
         public long startTimestamp() {
             return startTimestamp;
+        }
+
+        @Override
+        public long sequenceNumber() {
+            return sequenceNumber;
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredMultiVersionedKeyQueryIterator.java
@@ -33,6 +33,7 @@ class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterato
     private final Time time;
     private final long startNs;
     private final long startTimestampMs;
+    private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
     private final Set<MeteredIterator> openIterators;
     private final LongAdder numOpenIterators;
 
@@ -57,6 +58,11 @@ class MeteredMultiVersionedKeyQueryIterator<V> implements VersionedRecordIterato
     @Override
     public long startTimestamp() {
         return startTimestampMs;
+    }
+
+    @Override
+    public long sequenceNumber() {
+        return sequenceNumber;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -47,7 +47,6 @@ import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.internals.StoreQueryUtils.QueryHandler;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -81,7 +80,7 @@ public class MeteredSessionStore<K, V>
     protected Sensor restoreSensor;
 
     protected final LongAdder numOpenIterators = new LongAdder();
-    protected final NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(Comparator.comparingLong(MeteredIterator::startTimestamp));
+    protected final NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(MeteredIterator.OPENED_FIRST);
 
     private final Map<Class<?>, QueryHandler<?>> queryHandlers =
         mkMap(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -304,6 +304,7 @@ public class MeteredTimestampedKeyValueStore<K, V>
         private final Sensor sensor;
         private final long startNs;
         private final long startTimestampMs;
+        private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
         private final Function<byte[], ValueAndTimestamp<V>> valueAndTimestampDeserializer;
 
         private final boolean returnPlainValue;
@@ -324,6 +325,11 @@ public class MeteredTimestampedKeyValueStore<K, V>
         @Override
         public long startTimestamp() {
             return startTimestampMs;
+        }
+
+        @Override
+        public long sequenceNumber() {
+            return sequenceNumber;
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -50,7 +50,6 @@ import org.apache.kafka.streams.state.internals.StoreQueryUtils.QueryHandler;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -84,7 +83,7 @@ public class MeteredWindowStore<K, V>
     private Sensor restoreSensor;
 
     protected final LongAdder numOpenIterators = new LongAdder();
-    protected final NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(Comparator.comparingLong(MeteredIterator::startTimestamp));
+    protected final NavigableSet<MeteredIterator> openIterators = new ConcurrentSkipListSet<>(MeteredIterator.OPENED_FIRST);
 
     private final Map<Class<?>, QueryHandler<?>> queryHandlers =
         mkMap(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreIterator.java
@@ -33,6 +33,7 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V>, MeteredIt
     private final Function<byte[], V> valueFrom;
     private final long startNs;
     private final long startTimestampMs;
+    private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
     private final Time time;
     private final LongAdder numOpenIterators;
     private final Set<MeteredIterator> openIterators;
@@ -60,6 +61,11 @@ class MeteredWindowStoreIterator<V> implements WindowStoreIterator<V>, MeteredIt
     @Override
     public long startTimestamp() {
         return startTimestampMs;
+    }
+
+    @Override
+    public long sequenceNumber() {
+        return sequenceNumber;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowedKeyValueIterator.java
@@ -36,6 +36,7 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
     final Function<byte[], V> deserializeValue;
     private final long startNs;
     private final long startTimestampMs;
+    private final long sequenceNumber = SEQUENCE_NUMBERS.getAndIncrement();
     private final Time time;
     private final LongAdder numOpenIterators;
     private final Set<MeteredIterator> openIterators;
@@ -65,6 +66,11 @@ class MeteredWindowedKeyValueIterator<K, V> implements KeyValueIterator<Windowed
     @Override
     public long startTimestamp() {
         return this.startTimestampMs;
+    }
+
+    @Override
+    public long sequenceNumber() {
+        return sequenceNumber;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -651,6 +651,54 @@ public class MeteredKeyValueStoreTest {
         assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
     }
 
+    @Test
+    public void shouldTrackOldestOpenIteratorWhenTwoOpenedInSameMillisecond() {
+        setUp();
+        when(inner.all()).thenReturn(KeyValueIterators.emptyIterator());
+        init();
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+        final KafkaMetric numOpenIteratorsMetric = metric("num-open-iterators");
+
+        final long openTimestamp = mockTime.milliseconds();
+        final KeyValueIterator<String, String> first = metered.all();
+        final KeyValueIterator<String, String> second = metered.all();
+
+        assertThat((Long) numOpenIteratorsMetric.metricValue(), equalTo(2L));
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(openTimestamp));
+
+        first.close();
+
+        // the second iterator was opened in the same millisecond and is still open, so it must
+        // still be tracked as the oldest open iterator
+        assertThat((Long) numOpenIteratorsMetric.metricValue(), equalTo(1L));
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(openTimestamp));
+
+        second.close();
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+    }
+
+    @Test
+    public void shouldTrackOldestOpenIteratorWhenYoungerIteratorInSameMillisecondIsClosedFirst() {
+        setUp();
+        when(inner.all()).thenReturn(KeyValueIterators.emptyIterator());
+        init();
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+
+        final long openTimestamp = mockTime.milliseconds();
+        final KeyValueIterator<String, String> first = metered.all();
+        final KeyValueIterator<String, String> second = metered.all();
+
+        second.close();
+
+        // closing the younger iterator must not stop the older one, which is still open, from being tracked
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(openTimestamp));
+
+        first.close();
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void shouldReadOnlyViewGetApplySerdesAndRecordGetMetric() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -44,6 +44,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -583,6 +584,27 @@ public class MeteredWindowStoreTest {
         }
 
         assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+    }
+
+    @Test
+    public void shouldTrackOldestOpenIteratorWhenDifferentIteratorTypesOpenedInSameMillisecond() {
+        when(innerStoreMock.all()).thenReturn(KeyValueIterators.emptyIterator());
+        when(innerStoreMock.fetch(KEY_BYTES, 1, 1)).thenReturn(KeyValueIterators.emptyWindowStoreIterator());
+        store.init(context, store);
+
+        final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
+
+        final long openTimestamp = mockTime.milliseconds();
+        // all() and fetch() return different MeteredIterator implementations that share one openIterators set
+        final KeyValueIterator<Windowed<String>, String> windowedIterator = store.all();
+        final WindowStoreIterator<String> timeRangeIterator = store.fetch(KEY, ofEpochMilli(1), ofEpochMilli(1));
+
+        windowedIterator.close();
+
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(openTimestamp));
+
+        timeRangeIterator.close();
+        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Make the `openIterators` comparator total by tie-breaking on a per-iterator sequence id, so iterators opened in the same millisecond are tracked uniquely in metered store wrappers.
- Add regression tests covering same-ms iterators (close older first, close younger first) and different iterator types sharing one `openIterators` set.

Fixes [KAFKA-20902](https://issues.apache.org/jira/browse/KAFKA-20902).

## Test plan
- [x] `./gradlew :streams:build` (compile, checkstyle, all streams unit tests)
- [x] New regression tests fail without the fix and pass with it:
  - `MeteredKeyValueStoreTest.shouldTrackOldestOpenIteratorWhenTwoOpenedInSameMillisecond`
  - `MeteredKeyValueStoreTest.shouldTrackOldestOpenIteratorWhenYoungerIteratorInSameMillisecondIsClosedFirst`
  - `MeteredWindowStoreTest.shouldTrackOldestOpenIteratorWhenDifferentIteratorTypesOpenedInSameMillisecond`
  
  Reviewers: @aliehsaeedii (flagged the issue in #22975) / @bbejeck

Reviewers: Mickael Maison <mickael.maison@gmail.com>
