### PR TITLE
KAFKA-20921: Make ScramImage mechanism maps unmodifiable

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ScramImage.java
@@ -46,7 +46,10 @@ public record ScramImage(Map<ScramMechanism, Map<String, ScramCredentialData>> m
     public static final ScramImage EMPTY = new ScramImage(Map.of());
 
     public ScramImage {
-        mechanisms = Collections.unmodifiableMap(mechanisms);
+        Map<ScramMechanism, Map<String, ScramCredentialData>> copiedMechanisms = new HashMap<>();
+        mechanisms.forEach((mechanism, credentials) ->
+            copiedMechanisms.put(mechanism, Collections.unmodifiableMap(new HashMap<>(credentials))));
+        mechanisms = Collections.unmodifiableMap(copiedMechanisms);
     }
 
     public void write(ImageWriter writer, ImageWriterOptions options) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/ScramCredentialData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/ScramCredentialData.java
@@ -25,11 +25,17 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Represents the ACLs in the metadata image.
+ * Represents SCRAM credential data in the metadata image.
  * <p>
  * This class is thread-safe.
  */
 public record ScramCredentialData(byte[] salt, byte[] storedKey, byte[] serverKey, int iterations) {
+    public ScramCredentialData {
+        salt = Arrays.copyOf(salt, salt.length);
+        storedKey = Arrays.copyOf(storedKey, storedKey.length);
+        serverKey = Arrays.copyOf(serverKey, serverKey.length);
+    }
+
     public static ScramCredentialData fromRecord(
         UserScramCredentialRecord record
     ) {
@@ -40,6 +46,21 @@ public record ScramCredentialData(byte[] salt, byte[] storedKey, byte[] serverKe
             record.iterations());
     }
 
+    @Override
+    public byte[] salt() {
+        return Arrays.copyOf(salt, salt.length);
+    }
+
+    @Override
+    public byte[] storedKey() {
+        return Arrays.copyOf(storedKey, storedKey.length);
+    }
+
+    @Override
+    public byte[] serverKey() {
+        return Arrays.copyOf(serverKey, serverKey.length);
+    }
+
     public UserScramCredentialRecord toRecord(
         String userName,
         ScramMechanism mechanism
@@ -47,14 +68,14 @@ public record ScramCredentialData(byte[] salt, byte[] storedKey, byte[] serverKe
         return new UserScramCredentialRecord().
             setName(userName).
             setMechanism(mechanism.type()).
-            setSalt(salt).
-            setStoredKey(storedKey).
-            setServerKey(serverKey).
+            setSalt(salt()).
+            setStoredKey(storedKey()).
+            setServerKey(serverKey()).
             setIterations(iterations);
     }
 
     public ScramCredential toCredential() {
-        return new ScramCredential(salt, storedKey, serverKey, iterations);
+        return new ScramCredential(salt(), storedKey(), serverKey(), iterations);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/image/ScramImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ScramImageTest.java
@@ -17,16 +17,20 @@
 
 package org.apache.kafka.image;
 
+import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.image.writer.RecordListWriter;
 import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.ScramCredentialData;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,6 +69,27 @@ public class ScramImageTest {
     @Test
     public void testImage2RoundTrip() {
         testToImage(IMAGE2);
+    }
+
+    @Test
+    public void testMechanismsAreDeeplyImmutable() {
+        ScramCredentialData credential = new ScramCredentialData(
+            new byte[] {1}, new byte[] {2}, new byte[] {3}, 4096);
+        Map<String, ScramCredentialData> credentials = new HashMap<>();
+        credentials.put("alice", credential);
+        Map<ScramMechanism, Map<String, ScramCredentialData>> mechanisms = new HashMap<>();
+        mechanisms.put(ScramMechanism.SCRAM_SHA_256, credentials);
+
+        ScramImage image = new ScramImage(mechanisms);
+
+        mechanisms.clear();
+        credentials.clear();
+        assertEquals(
+            Map.of(ScramMechanism.SCRAM_SHA_256, Map.of("alice", credential)),
+            image.mechanisms());
+        assertThrows(UnsupportedOperationException.class, () -> image.mechanisms().clear());
+        assertThrows(UnsupportedOperationException.class,
+            () -> image.mechanisms().get(ScramMechanism.SCRAM_SHA_256).clear());
     }
 
     private static void testToImage(ScramImage image) {

--- a/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/ScramCredentialDataTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.metadata;
 
 import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.common.metadata.UserScramCredentialRecord;
+import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.util.MockRandom;
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.List;
 import java.util.Random;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -144,6 +146,61 @@ public class ScramCredentialDataTest {
         // Test equals method for same instance
         assertEquals(data, data);
         assertEquals(data.hashCode(), data.hashCode());
+    }
+
+    @Test
+    public void testConstructorDefensivelyCopiesArrays() {
+        byte[] salt = {1, 2, 3};
+        byte[] storedKey = {4, 5, 6};
+        byte[] serverKey = {7, 8, 9};
+        ScramCredentialData data = new ScramCredentialData(salt, storedKey, serverKey, 4096);
+        int hashCode = data.hashCode();
+
+        salt[0] = 10;
+        storedKey[0] = 11;
+        serverKey[0] = 12;
+
+        assertArrayEquals(new byte[] {1, 2, 3}, data.salt());
+        assertArrayEquals(new byte[] {4, 5, 6}, data.storedKey());
+        assertArrayEquals(new byte[] {7, 8, 9}, data.serverKey());
+        assertEquals(hashCode, data.hashCode());
+    }
+
+    @Test
+    public void testAccessorsReturnCopies() {
+        ScramCredentialData data = new ScramCredentialData(
+            new byte[] {1, 2, 3}, new byte[] {4, 5, 6}, new byte[] {7, 8, 9}, 4096);
+        int hashCode = data.hashCode();
+
+        data.salt()[0] = 10;
+        data.storedKey()[0] = 11;
+        data.serverKey()[0] = 12;
+
+        assertArrayEquals(new byte[] {1, 2, 3}, data.salt());
+        assertArrayEquals(new byte[] {4, 5, 6}, data.storedKey());
+        assertArrayEquals(new byte[] {7, 8, 9}, data.serverKey());
+        assertEquals(hashCode, data.hashCode());
+    }
+
+    @Test
+    public void testConversionsDoNotExposeArrays() {
+        ScramCredentialData data = new ScramCredentialData(
+            new byte[] {1, 2, 3}, new byte[] {4, 5, 6}, new byte[] {7, 8, 9}, 4096);
+        UserScramCredentialRecord record = data.toRecord("alice", ScramMechanism.SCRAM_SHA_256);
+        ScramCredential credential = data.toCredential();
+        int hashCode = data.hashCode();
+
+        record.salt()[0] = 10;
+        record.storedKey()[0] = 11;
+        record.serverKey()[0] = 12;
+        credential.salt()[0] = 13;
+        credential.storedKey()[0] = 14;
+        credential.serverKey()[0] = 15;
+
+        assertArrayEquals(new byte[] {1, 2, 3}, data.salt());
+        assertArrayEquals(new byte[] {4, 5, 6}, data.storedKey());
+        assertArrayEquals(new byte[] {7, 8, 9}, data.serverKey());
+        assertEquals(hashCode, data.hashCode());
     }
 
     private void testRoundTrip(ScramCredentialData scramCredentialData) {


### PR DESCRIPTION
This change makes the mechanism maps exposed by `ScramImage`
unmodifiable.

Previously, only the outer mechanisms map was wrapped, while the nested
per-mechanism credential maps remained mutable. A caller could clear a
nested map returned by `mechanisms()` and change an existing image.
`ScramDelta.apply()` supplies mutable `HashMap` instances.

The change:
- copies the outer mechanism map and wraps it as unmodifiable;
- wraps each nested credential map with `Collections.unmodifiableMap`
without copying its contents, following the existing metadata ownership
convention;
- adds regression coverage that both map levels exposed by
`mechanisms()` are unmodifiable;
- corrects the `ScramCredentialData` Javadoc description.

During review, defensive copies of the nested maps and
`ScramCredentialData` byte arrays were withdrawn to keep the change
consistent with the metadata ownership convention. No credential array
behavior is changed.

Related work: KAFKA-19305 mentioned `ScramImage` immutability, but PR
#19847 only updated `ClientQuotaImage` and `TopicImage`.

Validation:
- `./gradlew :metadata:test :metadata:spotlessCheck` (passed)

This contribution is my original work and I license it to the project
under the project's open source license.

Reviewers: Kevin Wu <kwu@confluent.io>, José Armando García Sancio
 <jsancio@apache.org>
