### PR TITLE
MINOR: Suppress header-less partitioner deprecation

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -406,7 +406,7 @@ public class KStreamRepartitionIntegrationTest {
         final Repartitioned<Integer, String> repartitioned = Repartitioned
             .<Integer, String>as(repartitionName)
             .withStreamPartitioner(new StreamPartitioner<>() {
-                @SuppressWarnings({"removal"})
+                @SuppressWarnings("removal")
                 @Override
                 public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
                     throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -409,7 +409,7 @@ public class KStreamRepartitionIntegrationTest {
                 @SuppressWarnings({"removal"})
                 @Override
                 public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
-                    return Optional.empty();
+                    throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
                 }
 
                 @Override

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionIntegrationTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
@@ -335,8 +336,14 @@ public class KStreamRepartitionIntegrationTest {
         final List<KeyValue<Integer, String>> expectedRecords = expectedRecordsOnRepartition.subList(3, 5);
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
+            @SuppressWarnings("removal")
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
+                throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final Headers headers, final int numPartitions) {
                 partitionerInvocation.incrementAndGet();
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
@@ -398,9 +405,18 @@ public class KStreamRepartitionIntegrationTest {
 
         final Repartitioned<Integer, String> repartitioned = Repartitioned
             .<Integer, String>as(repartitionName)
-            .withStreamPartitioner((topic, key, value, numPartitions) -> {
-                partitionerInvocation.incrementAndGet();
-                return Optional.of(Collections.singleton(partition));
+            .withStreamPartitioner(new StreamPartitioner<>() {
+                @SuppressWarnings({"removal"})
+                @Override
+                public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final Headers headers, final int numPartitions) {
+                    partitionerInvocation.incrementAndGet();
+                    return Optional.of(Collections.singleton(partition));
+                }
             });
 
         builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()))

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -64,6 +65,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Function;
 
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
@@ -96,8 +98,14 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
     static class MultiPartitioner implements StreamPartitioner<String, Void> {
 
+        @SuppressWarnings("removal")
         @Override
         public Optional<Set<Integer>> partitions(final String topic, final String key, final Void value, final int numPartitions) {
+            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final String key, final Void value, final Headers headers, final int numPartitions) {
             return Optional.of(Set.of(0, 1, 2));
         }
     }
@@ -281,8 +289,8 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         final ValueJoiner<String, String, String> joiner = (value1, value2) -> "value1=" + value1 + ",value2=" + value2;
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
-            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)),
-            (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
+            new KeyHashStreamPartitioner<>(KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB),
+            new KeyHashStreamPartitioner<>()
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -324,7 +332,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         final TableJoined<String, String> tableJoined = TableJoined.with(
                 new MultiPartitioner(),
-                (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions))
+                new KeyHashStreamPartitioner<>()
         );
 
         table1.join(table2, KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB, joiner, tableJoined, materialized)
@@ -339,14 +347,14 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
     private static Repartitioned<String, String> repartitionA() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("a");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(getKeyB(key).hashCode()) % numPartitions)))
+            .withStreamPartitioner(new KeyHashStreamPartitioner<>(KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest::getKeyB))
             .withNumberOfPartitions(4);
     }
 
     private static Repartitioned<String, String> repartitionB() {
         final Repartitioned<String, String> repartitioned = Repartitioned.as("b");
         return repartitioned.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
-            .withStreamPartitioner((topic, key, value, numPartitions) -> Optional.of(Collections.singleton(Math.abs(key.hashCode()) % numPartitions)))
+            .withStreamPartitioner(new KeyHashStreamPartitioner<>())
             .withNumberOfPartitions(4);
     }
 
@@ -354,4 +362,27 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
         return value.substring(0, value.indexOf("-"));
     }
 
+    private static class KeyHashStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
+        private final Function<K, Object> keyExtractor;
+
+        KeyHashStreamPartitioner() {
+            this(key -> key);
+        }
+
+        KeyHashStreamPartitioner(final Function<K, Object> keyExtractor) {
+            this.keyExtractor = keyExtractor;
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
+            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final Headers headers, final int numPartitions) {
+            final Object extractedKey = keyExtractor.apply(key);
+            return Optional.of(Collections.singleton(Math.abs(extractedKey.hashCode()) % numPartitions));
+        }
+    }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -32,6 +33,7 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -57,6 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -138,8 +141,7 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
-                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                        .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
 
                 try {
                     // Assert that the current value in store reflects all messages being processed
@@ -221,5 +223,24 @@ public class OptimizedKTableIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         return config;
+    }
+
+    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
+        private final int partition;
+
+        FixedPartitionPartitioner(final int partition) {
+            this.partition = partition;
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
+            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
+            return Optional.of(Collections.singleton(partition));
+        }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -18,11 +18,11 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.FixedPartitionPartitioner;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.KeyValue;
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -55,11 +54,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -141,7 +137,7 @@ public class OptimizedKTableIntegrationTest {
                 final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams1, QueryableStoreTypes.keyValueStore());
                 final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(TABLE_NAME, kafkaStreams2, QueryableStoreTypes.keyValueStore());
 
-                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
+                final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
 
                 try {
                     // Assert that the current value in store reflects all messages being processed
@@ -223,24 +219,5 @@ public class OptimizedKTableIntegrationTest {
         config.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 200);
         config.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000);
         return config;
-    }
-
-    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
-        private final int partition;
-
-        FixedPartitionPartitioner(final int partition) {
-            this.partition = partition;
-        }
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
-            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
-            return Optional.of(Collections.singleton(partition));
-        }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -154,8 +155,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
 
-            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
 
             final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
@@ -203,7 +203,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                    .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
 
             //key belongs to this partition
             final int keyPartition = keyQueryMetadata.partition();
@@ -322,7 +322,7 @@ public class StoreQueryIntegrationTest {
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                .queryMetadataForKey(TABLE_NAME, key, (topic, somekey, value, numPartitions) -> Optional.of(Collections.singleton(0)));
+                .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
 
         //key belongs to this partition
         final int keyPartition = keyQueryMetadata.partition();
@@ -569,8 +569,14 @@ public class StoreQueryIntegrationTest {
     public void shouldFailWithIllegalArgumentExceptionWhenIQPartitionerReturnsMultiplePartitions(final boolean withHeaders) throws Exception {
 
         class BroadcastingPartitioner implements StreamPartitioner<Integer, String> {
+            @SuppressWarnings("removal")
             @Override
             public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final int numPartitions) {
+                throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+            }
+
+            @Override
+            public Optional<Set<Integer>> partitions(final String topic, final Integer key, final String value, final Headers headers, final int numPartitions) {
                 return Optional.of(IntStream.range(0, numPartitions).boxed().collect(Collectors.toSet()));
             }
         }
@@ -684,5 +690,24 @@ public class StoreQueryIntegrationTest {
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         StreamsTestUtils.maybeSetDslStoreFormatHeaders(config, withHeaders);
         return config;
+    }
+
+    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
+        private final int partition;
+
+        FixedPartitionPartitioner(final int partition) {
+            this.partition = partition;
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
+            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
+            return Optional.of(Collections.singleton(partition));
+        }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.FixedPartitionPartitioner;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyQueryMetadata;
@@ -155,7 +156,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
 
-            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
+            final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
 
             final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
@@ -203,7 +204,7 @@ public class StoreQueryIntegrationTest {
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         until(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                    .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
+                    .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
 
             //key belongs to this partition
             final int keyPartition = keyQueryMetadata.partition();
@@ -322,7 +323,7 @@ public class StoreQueryIntegrationTest {
         // Assert that all messages in the first batch were processed in a timely manner
         assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
-                .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner(0));
+                .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
 
         //key belongs to this partition
         final int keyPartition = keyQueryMetadata.partition();
@@ -690,24 +691,5 @@ public class StoreQueryIntegrationTest {
         config.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
         StreamsTestUtils.maybeSetDslStoreFormatHeaders(config, withHeaders);
         return config;
-    }
-
-    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
-        private final int partition;
-
-        FixedPartitionPartitioner(final int partition) {
-            this.partition = partition;
-        }
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
-            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
-            return Optional.of(Collections.singleton(partition));
-        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -33,7 +33,7 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
         this.serializer = serializer;
     }
 
-    @SuppressWarnings({"removal"})
+    @SuppressWarnings("removal")
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final Windowed<K> windowedKey, final V value, final int numPartitions) {
         throw new UnsupportedOperationException("This method is deprecated and should not be called.");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -33,7 +33,7 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
         this.keySerializer = keySerializer;
     }
 
-    @SuppressWarnings({"removal"})
+    @SuppressWarnings("removal")
     @Override
     public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
         throw new UnsupportedOperationException("This method is deprecated and should not be called.");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -1074,23 +1074,18 @@ public class ProcessorTopologyTest {
         assertEquals(headers, record.headers());
     }
 
-    @SuppressWarnings({"deprecation", "removal"})
-    private StreamPartitioner<String, String> constantPartitioner(final Integer partition) {
-        return (topic, key, value, numPartitions) -> Optional.of(Collections.singleton(partition));
-    }
-
     private Topology createSimpleTopology(final int partition) {
         return topology
             .addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
             .addProcessor("processor", ForwardingProcessor::new, "source")
-            .addSink("sink", OUTPUT_TOPIC_1, constantPartitioner(partition), "processor");
+            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor");
     }
 
     private Topology createTimestampTopology(final int partition) {
         return topology
             .addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
             .addProcessor("processor", TimestampProcessor::new, "source")
-            .addSink("sink", OUTPUT_TOPIC_1, constantPartitioner(partition), "processor");
+            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor");
     }
 
     private Topology createMultiProcessorTimestampTopology(final int partition) {
@@ -1099,8 +1094,8 @@ public class ProcessorTopologyTest {
             .addProcessor("processor", () -> new FanOutTimestampProcessor("child1", "child2"), "source")
             .addProcessor("child1", ForwardingProcessor::new, "processor")
             .addProcessor("child2", TimestampProcessor::new, "processor")
-            .addSink("sink1", OUTPUT_TOPIC_1, constantPartitioner(partition), "child1")
-            .addSink("sink2", OUTPUT_TOPIC_2, constantPartitioner(partition), "child2");
+            .addSink("sink1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "child1")
+            .addSink("sink2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner(partition), "child2");
     }
 
     static class DroppingPartitioner implements StreamPartitioner<String, String> {
@@ -1183,10 +1178,10 @@ public class ProcessorTopologyTest {
     private Topology createSimpleMultiSourceTopology(final int partition) {
         return topology.addSource("source-1", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
                 .addProcessor("processor-1", ForwardingProcessor::new, "source-1")
-                .addSink("sink-1", OUTPUT_TOPIC_1, constantPartitioner(partition), "processor-1")
+                .addSink("sink-1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor-1")
                 .addSource("source-2", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_2)
                 .addProcessor("processor-2", ForwardingProcessor::new, "source-2")
-                .addSink("sink-2", OUTPUT_TOPIC_2, constantPartitioner(partition), "processor-2");
+                .addSink("sink-2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner(partition), "processor-2");
     }
 
     private Topology createAddHeaderTopology() {
@@ -1369,6 +1364,25 @@ public class ProcessorTopologyTest {
             }
 
             return DEFAULT_TIMESTAMP;
+        }
+    }
+    
+    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
+        private final int partition;
+
+        FixedPartitionPartitioner(final int partition) {
+            this.partition = partition;
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
+            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+        }
+
+        @Override
+        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
+            return Optional.of(Collections.singleton(partition));
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.FixedPartitionPartitioner;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
@@ -1078,14 +1079,14 @@ public class ProcessorTopologyTest {
         return topology
             .addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
             .addProcessor("processor", ForwardingProcessor::new, "source")
-            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor");
+            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner<>(partition), "processor");
     }
 
     private Topology createTimestampTopology(final int partition) {
         return topology
             .addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
             .addProcessor("processor", TimestampProcessor::new, "source")
-            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor");
+            .addSink("sink", OUTPUT_TOPIC_1, new FixedPartitionPartitioner<>(partition), "processor");
     }
 
     private Topology createMultiProcessorTimestampTopology(final int partition) {
@@ -1094,8 +1095,8 @@ public class ProcessorTopologyTest {
             .addProcessor("processor", () -> new FanOutTimestampProcessor("child1", "child2"), "source")
             .addProcessor("child1", ForwardingProcessor::new, "processor")
             .addProcessor("child2", TimestampProcessor::new, "processor")
-            .addSink("sink1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "child1")
-            .addSink("sink2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner(partition), "child2");
+            .addSink("sink1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner<>(partition), "child1")
+            .addSink("sink2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner<>(partition), "child2");
     }
 
     static class DroppingPartitioner implements StreamPartitioner<String, String> {
@@ -1178,10 +1179,10 @@ public class ProcessorTopologyTest {
     private Topology createSimpleMultiSourceTopology(final int partition) {
         return topology.addSource("source-1", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_1)
                 .addProcessor("processor-1", ForwardingProcessor::new, "source-1")
-                .addSink("sink-1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner(partition), "processor-1")
+                .addSink("sink-1", OUTPUT_TOPIC_1, new FixedPartitionPartitioner<>(partition), "processor-1")
                 .addSource("source-2", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC_2)
                 .addProcessor("processor-2", ForwardingProcessor::new, "source-2")
-                .addSink("sink-2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner(partition), "processor-2");
+                .addSink("sink-2", OUTPUT_TOPIC_2, new FixedPartitionPartitioner<>(partition), "processor-2");
     }
 
     private Topology createAddHeaderTopology() {
@@ -1364,25 +1365,6 @@ public class ProcessorTopologyTest {
             }
 
             return DEFAULT_TIMESTAMP;
-        }
-    }
-    
-    private static class FixedPartitionPartitioner implements StreamPartitioner<Integer, Object> {
-        private final int partition;
-
-        FixedPartitionPartitioner(final int partition) {
-            this.partition = partition;
-        }
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final int numPartitions) {
-            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final Integer key, final Object value, final Headers headers, final int numPartitions) {
-            return Optional.of(Collections.singleton(partition));
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.streams.FixedPartitionPartitioner;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsMetadata;
@@ -136,7 +137,7 @@ public class StreamsMetadataStateTest {
         topologyMetadata.buildAndRewriteTopology();
         metadataState = new StreamsMetadataState(topologyMetadata, hostOne, logContext);
         metadataState.onChange(hostToActivePartitions, hostToStandbyPartitions, partitionInfos);
-        partitioner = new FixedPartitionPartitioner(1);
+        partitioner = new FixedPartitionPartitioner<>(1);
         storeNames = Set.of("table-one", "table-two", "merged-table", globalTable);
     }
 
@@ -307,7 +308,7 @@ public class StreamsMetadataStateTest {
                 "merged-table",
                 "the-key",
                 new RecordHeaders(),
-                new FixedPartitionPartitioner(2)
+                new FixedPartitionPartitioner<>(2)
         );
 
         assertEquals(expected, actual);
@@ -518,25 +519,6 @@ public class StreamsMetadataStateTest {
             partitions.add(0);
             partitions.add(1);
             return Optional.of(partitions);
-        }
-    }
-
-    private static class FixedPartitionPartitioner implements StreamPartitioner<String, Object> {
-        private final int partition;
-
-        FixedPartitionPartitioner(final int partition) {
-            this.partition = partition;
-        }
-
-        @SuppressWarnings("removal")
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final int numPartitions) {
-            throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
-        }
-
-        @Override
-        public Optional<Set<Integer>> partitions(final String topic, final String key, final Object value, final Headers headers, final int numPartitions) {
-            return Optional.of(Collections.singleton(partition));
         }
     }
 }

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/FixedPartitionPartitioner.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/FixedPartitionPartitioner.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.streams;
 
 import org.apache.kafka.common.header.Headers;

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/FixedPartitionPartitioner.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/FixedPartitionPartitioner.java
@@ -1,0 +1,28 @@
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class FixedPartitionPartitioner<K, V> implements StreamPartitioner<K, V> {
+
+    private final int partition;
+
+    public FixedPartitionPartitioner(final int partition) {
+        this.partition = partition;
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final int numPartitions) {
+        throw new AssertionError("Deprecated 4-argument partitions method was called instead of 5-argument method containing headers.");
+    }
+
+    @Override
+    public Optional<Set<Integer>> partitions(final String topic, final K key, final V value, final Headers headers, final int numPartitions) {
+        return Optional.of(Collections.singleton(partition));
+    }
+}


### PR DESCRIPTION
Follow up code cleanup for now deprecated APIs usage, to get rid of build warnings.

Reviewers: Matthias J. Sax <matthias@confluent.io>
