### PR TITLE
KAFKA-20817: Add more ducktape system tests scenarios for topology description plugin

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1832,6 +1832,27 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             cmd += " --type %s" % type
         return self.run_cli_tool(node, cmd)
 
+    def delete_streams_group(self, group_id, node=None, command_config=None):
+        """ Delete a streams group via kafka-streams-groups.sh --delete. The group must have
+        no active members (callers should stop/leave first) or the delete request fails.
+        """
+        if node is None:
+            node = self.nodes[0]
+        streams_group_script = self.path.script("kafka-streams-groups.sh", node)
+
+        if command_config is None:
+            command_config = ""
+        else:
+            command_config = "--command-config " + command_config
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --bootstrap-server %s %s --delete --group %s" % \
+              (streams_group_script,
+               self.bootstrap_servers(self.security_protocol),
+               command_config,
+               group_id)
+        return self.run_cli_tool(node, cmd)
+
     def list_share_groups(self, node=None, command_config=None, state=None):
         """ Get list of share groups.
         """

--- a/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
+++ b/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
@@ -31,7 +31,6 @@ class StreamsTopologyDescriptionPluginTest(Test):
     PUSH_REQUESTED_LOG = "Broker requested topology description push"
     PUSH_SENDING_LOG = "Sending topology description for group"
     PUSH_SUCCESS_LOG = "Topology description pushed successfully"
-    PUSH_FAILED_LOG = "Topology description push failed with non-retriable exception"
     STREAMS_RUNNING_LOG = "State transition from REBALANCING to RUNNING"
     BROKER_SOLICITED_LOG = "Requested topology description push at topology epoch"
     BROKER_LOG_FILE = "%s/server.log" % KafkaService.OPERATIONAL_LOG_INFO_DIR
@@ -230,7 +229,6 @@ class StreamsTopologyDescriptionPluginTest(Test):
         self.setup_kafka(plugin_enabled=True)
         processor1 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
         processor2 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
-        
         with processor1.node.account.monitor_log(processor1.LOG_FILE) as monitor1, \
              processor2.node.account.monitor_log(processor2.LOG_FILE) as monitor2:
             processor1.start()

--- a/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
+++ b/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
@@ -166,28 +166,6 @@ class StreamsTopologyDescriptionPluginTest(Test):
 
     @cluster(num_nodes=2)
     @matrix(metadata_quorum=[quorum.combined_kraft])
-    def test_topology_description_resolicited_after_broker_bounce(self, metadata_quorum):
-        """InMemoryTopologyDescriptionPlugin loses its state on broker restart, so a bounce
-        must make the broker solicit again and the client push a second time."""
-        self.setup_kafka(plugin_enabled=True)
-        processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
-        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
-            processor.start()
-            monitor.wait_until(self.PUSH_SUCCESS_LOG, timeout_sec=120,
-                               err_msg="Streams client did not log a successful topology description push")
-
-        broker_node = self.kafka.nodes[0]
-        with broker_node.account.monitor_log(self.BROKER_LOG_FILE) as broker_monitor, \
-             processor.node.account.monitor_log(processor.LOG_FILE) as client_monitor:
-            self.kafka.restart_node(broker_node, clean_shutdown=True)  # confirm exact bounce API on KafkaService
-            broker_monitor.wait_until(self.BROKER_SOLICITED_LOG, timeout_sec=120,
-                                      err_msg="Broker never re-solicited after bounce")
-            client_monitor.wait_until(self.PUSH_SUCCESS_LOG, timeout_sec=120,
-                                      err_msg="Client never re-pushed after broker bounce")
-        processor.stop()
-
-    @cluster(num_nodes=2)
-    @matrix(metadata_quorum=[quorum.combined_kraft])
     def test_topology_description_not_resolicited_after_client_restart(self, metadata_quorum):
         """
         Test the situation when the client restarts after already having pushed its

--- a/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
+++ b/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
@@ -200,6 +202,15 @@ class StreamsTopologyDescriptionPluginTest(Test):
         assert int(next(solicited_after).strip()) == solicited_before_count, \
             "Broker re-solicited a topology push after a client restart despite an already-stored, matching-epoch description"
 
+        time.sleep(5)
+
+        # Check after a default heartbeat interval that broker still doesn't re-solicit a push
+        solicited_settled = broker_node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.BROKER_SOLICITED_LOG, self.BROKER_LOG_FILE),
+            allow_fail=False)
+        assert int(next(solicited_settled).strip()) == solicited_before_count, \
+            "Broker re-solicited a topology push on a later heartbeat after a client restart despite an already-stored, matching-epoch description"
+
         pushed = processor.node.account.ssh_capture(
             "grep -c '%s' %s || true" % (self.PUSH_SUCCESS_LOG, processor.LOG_FILE),
             allow_fail=False)
@@ -212,15 +223,24 @@ class StreamsTopologyDescriptionPluginTest(Test):
     def test_topology_description_only_one_member_pushes(self, metadata_quorum):
         """
         Test the situation when two members of the same streams group start up together.
-        StreamsGroupTopologyDescriptionManager.armIfNotActive must prevent every member
+        StreamsGroupTopologyDescriptionBackoff.armIfNotActive must prevent every member
         from pushing the same description; only one member's push should succeed,
         regardless of which member wins the race.
         """
         self.setup_kafka(plugin_enabled=True)
         processor1 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
         processor2 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
-        processor1.start()
-        processor2.start()
+        
+        with processor1.node.account.monitor_log(processor1.LOG_FILE) as monitor1, \
+             processor2.node.account.monitor_log(processor2.LOG_FILE) as monitor2:
+            processor1.start()
+            processor2.start()
+            monitor1.wait_until(self.STREAMS_RUNNING_LOG,
+                                timeout_sec=60,
+                                err_msg="Never saw 'REBALANCING -> RUNNING' message for the first client")
+            monitor2.wait_until(self.STREAMS_RUNNING_LOG,
+                                timeout_sec=60,
+                                err_msg="Never saw 'REBALANCING -> RUNNING' message for the second client")
 
         def total_push_successes():
             pushed1 = processor1.node.account.ssh_capture(
@@ -231,22 +251,12 @@ class StreamsTopologyDescriptionPluginTest(Test):
                 allow_fail=False)
             return int(next(pushed1).strip()) + int(next(pushed2).strip())
 
-        def total_push_failures():
-            failed1 = processor1.node.account.ssh_capture(
-                "grep -c '%s' %s || true" % (self.PUSH_FAILED_LOG, processor1.LOG_FILE),
-                allow_fail=False)
-            failed2 = processor2.node.account.ssh_capture(
-                "grep -c '%s' %s || true" % (self.PUSH_FAILED_LOG, processor2.LOG_FILE),
-                allow_fail=False)
-            return int(next(failed1).strip()) + int(next(failed2).strip())
-
         wait_until(lambda: total_push_successes() >= 1,
                    timeout_sec=120,
-                   err_msg=lambda: "Neither streams client logged a successful topology description push"
-                                   + (" (a non-retriable push failure was logged instead, see client logs)"
-                                      if total_push_failures() > 0 else ""))
-        assert total_push_failures() == 0, \
-            "A member logged a non-retriable push failure despite a push having succeeded"
+                   err_msg="Neither streams client logged a successful topology description push")
+
+        time.sleep(5)
+
         assert total_push_successes() == 1, \
             "Expected exactly one member to push the topology description successfully"
 
@@ -268,7 +278,7 @@ class StreamsTopologyDescriptionPluginTest(Test):
     def test_topology_description_resolicited_after_group_delete_and_recreate(self, metadata_quorum):
         """
         Test the situation when a streams group is deleted after a successful push, then a
-        new client joins under the same application.id. GroupCoordinatorShard.
+        new client joins under the same application.id. GroupMetadataManager.
         finalizeStoredDescriptionTopologyEpochAfterDelete clears the deleted group's stored
         epoch and back-off state, so the new incarnation must be freshly solicited rather
         than inheriting the "already stored" state left behind by the deleted group.
@@ -287,7 +297,7 @@ class StreamsTopologyDescriptionPluginTest(Test):
         def group_deleted():
             return "was successful" in self.kafka.delete_streams_group(group_id)
 
-        wait_until(group_deleted, timeout_sec=30, backoff_sec=2,
+        wait_until(group_deleted, timeout_sec=60, backoff_sec=2,
                    err_msg="kafka-streams-groups.sh --delete never reported success for group " + group_id)
 
         broker_node = self.kafka.nodes[0]

--- a/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
+++ b/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
@@ -16,6 +16,7 @@
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
 from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.streams import (
     INMEMORY_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS,
@@ -28,6 +29,7 @@ class StreamsTopologyDescriptionPluginTest(Test):
     PUSH_REQUESTED_LOG = "Broker requested topology description push"
     PUSH_SENDING_LOG = "Sending topology description for group"
     PUSH_SUCCESS_LOG = "Topology description pushed successfully"
+    PUSH_FAILED_LOG = "Topology description push failed with non-retriable exception"
     STREAMS_RUNNING_LOG = "State transition from REBALANCING to RUNNING"
     BROKER_SOLICITED_LOG = "Requested topology description push at topology epoch"
     BROKER_LOG_FILE = "%s/server.log" % KafkaService.OPERATIONAL_LOG_INFO_DIR
@@ -161,3 +163,165 @@ class StreamsTopologyDescriptionPluginTest(Test):
         assert int(next(pushed).strip()) == 0, \
             "Client logged a successful push despite no plugin being configured on the broker"
         processor.stop()
+
+    @cluster(num_nodes=2)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_topology_description_resolicited_after_broker_bounce(self, metadata_quorum):
+        """InMemoryTopologyDescriptionPlugin loses its state on broker restart, so a bounce
+        must make the broker solicit again and the client push a second time."""
+        self.setup_kafka(plugin_enabled=True)
+        processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            processor.start()
+            monitor.wait_until(self.PUSH_SUCCESS_LOG, timeout_sec=120,
+                               err_msg="Streams client did not log a successful topology description push")
+
+        broker_node = self.kafka.nodes[0]
+        with broker_node.account.monitor_log(self.BROKER_LOG_FILE) as broker_monitor, \
+             processor.node.account.monitor_log(processor.LOG_FILE) as client_monitor:
+            self.kafka.restart_node(broker_node, clean_shutdown=True)  # confirm exact bounce API on KafkaService
+            broker_monitor.wait_until(self.BROKER_SOLICITED_LOG, timeout_sec=120,
+                                      err_msg="Broker never re-solicited after bounce")
+            client_monitor.wait_until(self.PUSH_SUCCESS_LOG, timeout_sec=120,
+                                      err_msg="Client never re-pushed after broker bounce")
+        processor.stop()
+
+    @cluster(num_nodes=2)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_topology_description_not_resolicited_after_client_restart(self, metadata_quorum):
+        """
+        Test the situation when the client restarts after already having pushed its
+        topology description successfully. The broker still has storedDescriptionTopologyEpoch
+        matching currentTopologyEpoch, so it must not solicit a second push.
+        """
+        self.setup_kafka(plugin_enabled=True)
+        processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            processor.start()
+            monitor.wait_until(self.PUSH_SUCCESS_LOG,
+                               timeout_sec=120,
+                               err_msg="Streams client did not log a successful topology description push")
+
+        broker_node = self.kafka.nodes[0]
+        solicited_before = broker_node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.BROKER_SOLICITED_LOG, self.BROKER_LOG_FILE),
+            allow_fail=False)
+        solicited_before_count = int(next(solicited_before).strip())
+        assert solicited_before_count > 0, \
+            "Broker never solicited the initial topology push despite the plugin being configured"
+
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            processor.restart()
+            monitor.wait_until(self.STREAMS_RUNNING_LOG,
+                               timeout_sec=60,
+                               err_msg="Never saw 'REBALANCING -> RUNNING' message after client restart " + str(processor.node.account))
+
+        solicited_after = broker_node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.BROKER_SOLICITED_LOG, self.BROKER_LOG_FILE),
+            allow_fail=False)
+        assert int(next(solicited_after).strip()) == solicited_before_count, \
+            "Broker re-solicited a topology push after a client restart despite an already-stored, matching-epoch description"
+
+        pushed = processor.node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.PUSH_SUCCESS_LOG, processor.LOG_FILE),
+            allow_fail=False)
+        assert int(next(pushed).strip()) == 1, \
+            "Client pushed a topology description again after restart despite the broker not soliciting"
+        processor.stop()
+
+    @cluster(num_nodes=3)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_topology_description_only_one_member_pushes(self, metadata_quorum):
+        """
+        Test the situation when two members of the same streams group start up together.
+        StreamsGroupTopologyDescriptionManager.armIfNotActive must prevent every member
+        from pushing the same description; only one member's push should succeed,
+        regardless of which member wins the race.
+        """
+        self.setup_kafka(plugin_enabled=True)
+        processor1 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        processor2 = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        processor1.start()
+        processor2.start()
+
+        def total_push_successes():
+            pushed1 = processor1.node.account.ssh_capture(
+                "grep -c '%s' %s || true" % (self.PUSH_SUCCESS_LOG, processor1.LOG_FILE),
+                allow_fail=False)
+            pushed2 = processor2.node.account.ssh_capture(
+                "grep -c '%s' %s || true" % (self.PUSH_SUCCESS_LOG, processor2.LOG_FILE),
+                allow_fail=False)
+            return int(next(pushed1).strip()) + int(next(pushed2).strip())
+
+        def total_push_failures():
+            failed1 = processor1.node.account.ssh_capture(
+                "grep -c '%s' %s || true" % (self.PUSH_FAILED_LOG, processor1.LOG_FILE),
+                allow_fail=False)
+            failed2 = processor2.node.account.ssh_capture(
+                "grep -c '%s' %s || true" % (self.PUSH_FAILED_LOG, processor2.LOG_FILE),
+                allow_fail=False)
+            return int(next(failed1).strip()) + int(next(failed2).strip())
+
+        wait_until(lambda: total_push_successes() >= 1,
+                   timeout_sec=120,
+                   err_msg=lambda: "Neither streams client logged a successful topology description push"
+                                   + (" (a non-retriable push failure was logged instead, see client logs)"
+                                      if total_push_failures() > 0 else ""))
+        assert total_push_failures() == 0, \
+            "A member logged a non-retriable push failure despite a push having succeeded"
+        assert total_push_successes() == 1, \
+            "Expected exactly one member to push the topology description successfully"
+
+        sent1 = processor1.node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.PUSH_SENDING_LOG, processor1.LOG_FILE),
+            allow_fail=False)
+        sent2 = processor2.node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.PUSH_SENDING_LOG, processor2.LOG_FILE),
+            allow_fail=False)
+        total_sent = int(next(sent1).strip()) + int(next(sent2).strip())
+        assert total_sent == 1, \
+            "Expected exactly one member to send a topology description, got %d" % total_sent
+
+        processor1.stop()
+        processor2.stop()
+
+    @cluster(num_nodes=3)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_topology_description_resolicited_after_group_delete_and_recreate(self, metadata_quorum):
+        """
+        Test the situation when a streams group is deleted after a successful push, then a
+        new client joins under the same application.id. GroupCoordinatorShard.
+        finalizeStoredDescriptionTopologyEpochAfterDelete clears the deleted group's stored
+        epoch and back-off state, so the new incarnation must be freshly solicited rather
+        than inheriting the "already stored" state left behind by the deleted group.
+        """
+        self.setup_kafka(plugin_enabled=True)
+        group_id = "kafka-streams-system-test-topology-description-plugin"
+        processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            processor.start()
+            monitor.wait_until(self.PUSH_SUCCESS_LOG,
+                               timeout_sec=120,
+                               err_msg="Streams client did not log a successful topology description push")
+
+        processor.stop()
+
+        def group_deleted():
+            return "was successful" in self.kafka.delete_streams_group(group_id)
+
+        wait_until(group_deleted, timeout_sec=30, backoff_sec=2,
+                   err_msg="kafka-streams-groups.sh --delete never reported success for group " + group_id)
+
+        broker_node = self.kafka.nodes[0]
+        new_processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        with broker_node.account.monitor_log(self.BROKER_LOG_FILE) as broker_monitor, \
+             new_processor.node.account.monitor_log(new_processor.LOG_FILE) as client_monitor:
+            new_processor.start()
+            broker_monitor.wait_until(self.BROKER_SOLICITED_LOG,
+                                      timeout_sec=120,
+                                      err_msg="Broker never re-solicited the new_processor group despite the old "
+                                              "group having been deleted")
+            client_monitor.wait_until(self.PUSH_SUCCESS_LOG,
+                                      timeout_sec=120,
+                                      err_msg="new_processor group's client never pushed successfully")
+        new_processor.stop()


### PR DESCRIPTION
## Summary
This PR adds 3 more system test scenarios for streams topology test.
1. `test_topology_description_not_resolicited_after_client_restart`:
client start with description already stored, the broker is already
running -> client restarted and since `storedDescriptionTopologyEpoch ==
currentTopologyEpoch`, the broker does not solicit again.
2. `test_topology_description_only_one_member_pushes`: two members join
the same streams group at the same time and both heartbeat to the broker
-> since `StreamsGroupTopologyDescriptionBackoff.armIfNotActive`'s
check-and-arm on the group's back-off entry is atomic, only one member's
heartbeat gets `TopologyDescriptionRequired=true`; the other member
never sends a push.
3.
`test_topology_description_resolicited_after_group_delete_and_recreate`:
client pushes successfully, then the group is stopped and deleted -> a
new client joins under the same application.id and since the delete
clears the old group's `storedDescriptionTopologyEpoch`, the broker
treats it as a brand-new group and solicits again.

Reviewers: Alieh Saeedi <asaeedi@confluent.io>, TengYao Chi
 <frankvicky@apache.org>
