### PR TITLE
KAFKA-20929: Use SHA512SUM instead of MD5SUM in the ducktape connect tests

### DIFF
--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -128,7 +128,7 @@ class ConnectStandaloneFileTest(Test):
     def validate_output(self, value):
         try:
             output_hash = list(self.sink.node.account.ssh_capture("sha512sum " + self.OUTPUT_FILE))[0].strip().split()[0]
-            return output_hash == hashlib.md5(value.encode('utf-8')).hexdigest()
+            return output_hash == hashlib.sha512(value.encode('utf-8')).hexdigest()
         except RemoteCommandError:
             return False
 

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -127,7 +127,7 @@ class ConnectStandaloneFileTest(Test):
 
     def validate_output(self, value):
         try:
-            output_hash = list(self.sink.node.account.ssh_capture("md5sum " + self.OUTPUT_FILE))[0].strip().split()[0]
+            output_hash = list(self.sink.node.account.ssh_capture("sha512sum " + self.OUTPUT_FILE))[0].strip().split()[0]
             return output_hash == hashlib.md5(value.encode('utf-8')).hexdigest()
         except RemoteCommandError:
             return False


### PR DESCRIPTION
Solves https://issues.apache.org/jira/browse/KAFKA-20929.

```python
Consider enabling configuration cache to speed up this build:
https://docs.gradle.org/9.6.1/userguide/configuration_cache_enabling.html
podman exec ducker01 bash -c "cd /opt/kafka-dev && ducktape
--cluster-file /opt/kafka-dev/tests/docker/build/cluster.json
./tests/kafkatest/tests/connect/connect_test.py::ConnectStandaloneFileTest.test_file_source_and_sink
"
[INFO:2026-08-12 03:21:35,994]: Discovered 1 tests to run
[INFO:2026-08-12 03:21:35,995]: starting test run with session id
2026-08-12--009...
[INFO:2026-08-12 03:21:35,995]: running 1 tests...
[INFO:2026-08-12 03:21:35,995]: Triggering test 1 of 1...
[INFO:2026-08-12 03:21:36,002]: RunnerClient: Loading test {'directory':
'/opt/kafka-dev/tests/kafkatest/tests/connect', 'file_name':
'connect_test.py', 'cls_name': 'ConnectStandaloneFileTest',
'method_name': 'test_file_source_and_sink', 'injected_args':
{'security_protocol': 'SASL_SSL', 'metadata_quorum': 'ISOLATED_KRAFT'}}
[INFO:2026-08-12 03:21:36,008]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
on run 1/1
[INFO:2026-08-12 03:21:36,009]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
Setting up...
[INFO:2026-08-12 03:21:36,009]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
Running...
[INFO:2026-08-12 03:22:35,470]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
Tearing down...
[INFO:2026-08-12 03:22:43,163]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
PASS
[INFO:2026-08-12 03:22:43,164]: RunnerClient:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT:
Data: None
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.14.0
session_id:       2026-08-12--009
run time:         1 minute 7.286 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:
kafkatest.tests.connect.connect_test.ConnectStandaloneFileTest.test_file_source_and_sink.security_protocol=SASL_SSL.metadata_quorum=ISOLATED_KRAFT
status:     PASS
run time:   1 minute 7.155 seconds
```

Reviewers: Mickael Maison <mickael.maison@gmail.com>
