### PR TITLE
MINOR: Verify live changelog offsets for restoring active tasks in TaskManager offset-sum snapshot

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2040,6 +2040,7 @@ public class TaskManagerTest {
     public void shouldPublishTaskOffsetSumSnapshotFromStateDirectoryExcludingRunningActiveTasks() {
         final StreamTask runningActiveTask = statefulTask(taskId00, taskId00ChangelogPartitions).inState(State.RUNNING).build();
         final StreamTask restoringActiveTask = statefulTask(taskId01, taskId01ChangelogPartitions).inState(State.RESTORING).build();
+        when(restoringActiveTask.changelogOffsets()).thenReturn(mkMap(mkEntry(t1p1changelog, 25L)));
         final StandbyTask standbyTask = standbyTask(taskId02, taskId02ChangelogPartitions).inState(State.RUNNING).build();
 
         final TasksRegistry tasks = mock(TasksRegistry.class);
@@ -2058,9 +2059,26 @@ public class TaskManagerTest {
 
         taskManager.maybeUpdateTaskOffsetSumSnapshot();
 
-        // running-active taskId00 is omitted; restoring-active, standby, and dormant tasks are reported with their sums
+        // running-active taskId00 is omitted; restoring-active taskId01 reports its live sum (25L) rather than the
+        // stale 20L on disk; standby and dormant tasks are reported with their disk sums
         assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
-            mkEntry(new StreamsRebalanceData.TaskId("0", 1), 20L),
+            mkEntry(new StreamsRebalanceData.TaskId("0", 1), 25L),
+            mkEntry(new StreamsRebalanceData.TaskId("0", 2), 30L),
+            mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
+        )));
+
+        // once restoration completes, taskId01 moves from the state updater to the stream thread, just like taskId00
+        when(restoringActiveTask.state()).thenReturn(State.RUNNING);
+        when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(
+            mkEntry(taskId00, runningActiveTask),
+            mkEntry(taskId01, restoringActiveTask)
+        ));
+        when(stateUpdater.tasks()).thenReturn(Set.of(standbyTask));
+
+        taskManager.maybeUpdateTaskOffsetSumSnapshot();
+
+        // taskId01 is now dropped entirely, not merely left unrefreshed at its last restoring sum
+        assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
             mkEntry(new StreamsRebalanceData.TaskId("0", 2), 30L),
             mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
         )));


### PR DESCRIPTION
The existing test for maybeUpdateTaskOffsetSumSnapshot() left
changelogOffsets() unstubbed for the restoring-active task, so the
assertion only proved the task survived the running-active exclusion,
not that its live offsets were actually computed. Stub a live value
distinct from the on-disk sum, and add a follow-up assertion that the
task is dropped entirely once it transitions to RUNNING.

Reviewers: Bill Bejeck <bbejeck@apache.org>, Omnia Ibrahim <o.g.h.ibrahim@gmail.com>
