### PR TITLE
KAFKA-20933: RocksDB.putAll bypasses the transactional buffer

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -1083,15 +1083,11 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
         /**
          * Applies a batch of writes through {@code cfAccessor}, which owns the column-family layout.
-         * The default applies the entries one at a time; accessors that can write them as a single
-         * batch — or that must stage them instead of writing them — override this.
+         * Deliberately has no default. Each accessor must state how it makes the batch atomic — a single
+         * batch write, or staging it.
          */
-        default void putAll(final ColumnFamilyAccessor cfAccessor,
-                            final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException {
-            for (final KeyValue<Bytes, byte[]> entry : entries) {
-                cfAccessor.put(this, entry.key.get(), entry.value);
-            }
-        }
+        void putAll(final ColumnFamilyAccessor cfAccessor,
+                    final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException;
 
         default DBAccessor readOnly(final IsolationLevel isolationLevel) {
             Objects.requireNonNull(isolationLevel, "isolationLevel cannot be null");
@@ -1283,13 +1279,13 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         @Override
         public void putAll(final ColumnFamilyAccessor cfAccessor,
                            final List<KeyValue<Bytes, byte[]>> entries) {
-            // Batch writes must be staged like single-key puts, or they would land in the store
-            // uncommitted: visible at READ_COMMITTED, surviving a rollback, and uncounted by
-            // approximateNumUncommittedBytes(). Staging the batch under one write-lock acquisition
-            // also keeps it invisible to a concurrent IQ reader until it is complete, matching the
-            // atomicity of the direct accessor's single db.write(batch); the buffer's own WriteBatch
-            // then applies it atomically on commit. Reusing cfAccessor.put() keeps the column-family
-            // layout — including the dual-CF upgrade path — identical to a single-key put.
+            // Batch writes must be staged like single-key puts. If written directly to RocksDB
+            // (what the direct accessor does), the uncommitted data would sit in the store rather
+            // than the buffer so would not get removed on error. Staging under one write-lock
+            // acquisition also hides the batch from a concurrent IQ reader until complete,
+            // matching the atomicity of the direct accessor's single db.write(batch). Reusing
+            // cfAccessor.put() keeps the column-family layout — including the dual-CF upgrade
+            // path — identical to a single-key put.
             buffer.stageAll(() -> {
                 for (final KeyValue<Bytes, byte[]> entry : entries) {
                     cfAccessor.put(this, entry.key.get(), entry.value);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -512,10 +512,14 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
     @Override
     public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+        // Validate up front so a null key rejects the whole batch. An accessor may apply the entries
+        // one at a time, and failing part-way through would otherwise leave the batch half-applied.
+        for (final KeyValue<Bytes, byte[]> entry : entries) {
+            Objects.requireNonNull(entry.key, "key cannot be null");
+        }
         synchronized (position) {
-            try (final WriteBatch batch = new WriteBatch()) {
-                cfAccessor.prepareBatch(entries, batch);
-                write(batch);
+            try {
+                dbAccessor.putAll(cfAccessor, entries);
                 dbAccessor.updatePosition(position, context);
             } catch (final RocksDBException e) {
                 throw new ProcessorStateException("Error while batch writing to store " + name, e);
@@ -1074,6 +1078,18 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         void reset();
         void close();
 
+        /**
+         * Applies a batch of writes through {@code cfAccessor}, which owns the column-family layout.
+         * The default applies the entries one at a time; accessors that can write them as a single
+         * batch — or that must stage them instead of writing them — override this.
+         */
+        default void putAll(final ColumnFamilyAccessor cfAccessor,
+                            final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException {
+            for (final KeyValue<Bytes, byte[]> entry : entries) {
+                cfAccessor.put(this, entry.key.get(), entry.value);
+            }
+        }
+
         default DBAccessor readOnly(final IsolationLevel isolationLevel) {
             Objects.requireNonNull(isolationLevel, "isolationLevel cannot be null");
             return this;
@@ -1167,6 +1183,16 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         }
 
         @Override
+        public void putAll(final ColumnFamilyAccessor cfAccessor,
+                           final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException {
+            // A single atomic batch write, so a crash part-way through leaves nothing behind.
+            try (final WriteBatch batch = new WriteBatch()) {
+                cfAccessor.prepareBatch(entries, batch);
+                db.write(wOptions, batch);
+            }
+        }
+
+        @Override
         public long approximateNumEntries(final ColumnFamilyHandle columnFamily) throws RocksDBException {
             return db.getLongProperty(columnFamily, "rocksdb.estimate-num-keys");
         }
@@ -1249,6 +1275,23 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         @Override
         public void deleteRange(final ColumnFamilyHandle columnFamily, final byte[] from, final byte[] to) throws RocksDBException {
             buffer.stageDeleteRange(columnFamily, Bytes.wrap(from), Bytes.wrap(to));
+        }
+
+        @Override
+        public void putAll(final ColumnFamilyAccessor cfAccessor,
+                           final List<KeyValue<Bytes, byte[]>> entries) {
+            // Batch writes must be staged like single-key puts, or they would land in the store
+            // uncommitted: visible at READ_COMMITTED, surviving a rollback, and uncounted by
+            // approximateNumUncommittedBytes(). Staging the batch under one write-lock acquisition
+            // also keeps it invisible to a concurrent IQ reader until it is complete, matching the
+            // atomicity of the direct accessor's single db.write(batch); the buffer's own WriteBatch
+            // then applies it atomically on commit. Reusing cfAccessor.put() keeps the column-family
+            // layout — including the dual-CF upgrade path — identical to a single-key put.
+            buffer.stageAll(() -> {
+                for (final KeyValue<Bytes, byte[]> entry : entries) {
+                    cfAccessor.put(this, entry.key.get(), entry.value);
+                }
+            });
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -512,11 +512,14 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
 
     @Override
     public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+        Objects.requireNonNull(entries, "entries cannot be null");
         // Validate up front so a null key rejects the whole batch. An accessor may apply the entries
         // one at a time, and failing part-way through would otherwise leave the batch half-applied.
         for (final KeyValue<Bytes, byte[]> entry : entries) {
+            Objects.requireNonNull(entry, "entry cannot be null");
             Objects.requireNonNull(entry.key, "key cannot be null");
         }
+        validateStoreOpen();
         synchronized (position) {
             try {
                 dbAccessor.putAll(cfAccessor, entries);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBuffer.java
@@ -114,6 +114,25 @@ class RocksDBTransactionBuffer extends AbstractTransactionBuffer<Bytes> {
     }
 
     /**
+     * Runs a sequence of {@link #stage} calls as one batch, holding the {@code snapshotLock} write
+     * lock for the whole batch so a non-owner (IQ) read observes either none or all of it. Without
+     * this, a multi-write operation would stage entry-by-entry and a reader could interleave with a
+     * half-staged batch, which the equivalent non-transactional {@code WriteBatch} write never
+     * exposes. The lock is reentrant, so the per-write acquisitions nested inside are uncontended.
+     *
+     * @param stagingOperations the batch to stage; must only call {@code stage}/{@code stageDeleteRange}
+     *                          on this buffer, and must not block
+     */
+    void stageAll(final Runnable stagingOperations) {
+        snapshotLock.writeLock().lock();
+        try {
+            stagingOperations.run();
+        } finally {
+            snapshotLock.writeLock().unlock();
+        }
+    }
+
+    /**
      * Stages a range deletion for an explicit column family. Updates the shared
      * {@code pendingWrites} and {@code rangeTombstones} so iterators opened before
      * commit hide the deleted range, and appends the range delete to the shared

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryRocksDBAccessor.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryRocksDBAccessor.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
@@ -26,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -79,6 +83,17 @@ public class InMemoryRocksDBAccessor implements RocksDBStore.DBAccessor {
             delete(columnFamily, key);
         } else {
             storeFor(columnFamily).put(key, value);
+        }
+    }
+
+    @Override
+    public void putAll(final RocksDBStore.ColumnFamilyAccessor cfAccessor,
+                       final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException {
+        // Single-threaded in-memory maps, so applying the entries one at a time is already atomic
+        // from a test's point of view. Routing through cfAccessor keeps the column-family layout
+        // identical to a single-key put.
+        for (final KeyValue<Bytes, byte[]> entry : entries) {
+            cfAccessor.put(this, entry.key.get(), entry.value);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1773,6 +1773,16 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         assertNull(rocksDBStore.get(k1));
     }
 
+    @Test
+    public void putAllShouldThrowOnClosedStore() {
+        rocksDBStore.init(context, rocksDBStore);
+        rocksDBStore.close();
+
+        assertThrows(InvalidStateStoreException.class, () -> rocksDBStore.putAll(List.of(
+            KeyValue.pair(new Bytes(stringSerializer.serialize(null, "k1")),
+                stringSerializer.serialize(null, "v1")))));
+    }
+
     private List<String> keysOf(final KeyValueIterator<Bytes, byte[]> it) {
         final List<String> keys = new ArrayList<>();
         while (it.hasNext()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1711,16 +1711,18 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.commit(Map.of());
 
         rocksDBStore.putAll(List.of(
-            KeyValue.pair(k1, stringSerializer.serialize(null, "rolled-back")),
-            KeyValue.pair(k2, stringSerializer.serialize(null, "rolled-back"))));
+            KeyValue.pair(k1, stringSerializer.serialize(null, "k1-new-staged")),
+            KeyValue.pair(k2, stringSerializer.serialize(null, "k2-staged"))));
+
+        final ReadOnlyKeyValueStore<Bytes, byte[]> readUncommittedView =
+            rocksDBStore.readOnly(IsolationLevel.READ_UNCOMMITTED);
+        assertEquals("k1-new-staged", stringDeserializer.deserialize(null, readUncommittedView.get(k1)));
+        assertEquals("k2-staged", stringDeserializer.deserialize(null, readUncommittedView.get(k2)));
+
         rocksDBStore.dbAccessor.rollbackStagedWrites();
 
-        // an aborted batch must leave nothing behind: the committed value is intact and the new key is gone
         assertEquals("committed", stringDeserializer.deserialize(null, rocksDBStore.get(k1)));
         assertNull(rocksDBStore.get(k2));
-        assertEquals("committed", stringDeserializer.deserialize(null,
-            rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED).get(k1)));
-        assertNull(rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED).get(k2));
     }
 
     @Test
@@ -1742,10 +1744,10 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             KeyValue.pair(k2, stringSerializer.serialize(null, "v2-updated"))));
 
         final ReadOnlyKeyValueStore<Bytes, byte[]> committed = rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED);
-        assertNull(rocksDBStore.get(k1));
+        final ReadOnlyKeyValueStore<Bytes, byte[]> uncommitted = rocksDBStore.readOnly(IsolationLevel.READ_UNCOMMITTED);
+        assertNull(uncommitted.get(k1));
         assertEquals("v1", stringDeserializer.deserialize(null, committed.get(k1)));
-        assertEquals("v2-updated", stringDeserializer.deserialize(null,
-            rocksDBStore.readOnly(IsolationLevel.READ_UNCOMMITTED).get(k2)));
+        assertEquals("v2-updated", stringDeserializer.deserialize(null, uncommitted.get(k2)));
         assertEquals("v2", stringDeserializer.deserialize(null, committed.get(k2)));
 
         rocksDBStore.commit(Map.of());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -1664,6 +1664,115 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         }
     }
 
+    @Test
+    public void putAllShouldStageWritesUntilCommitWhenTransactional() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        // An empty RocksDB WriteBatch already reports a fixed header size, so the baseline is non-zero.
+        final long emptyBufferBytes = rocksDBStore.approximateNumUncommittedBytes();
+
+        final Bytes k1 = new Bytes(stringSerializer.serialize(null, "k1"));
+        final Bytes k2 = new Bytes(stringSerializer.serialize(null, "k2"));
+        rocksDBStore.putAll(List.of(
+            KeyValue.pair(k1, stringSerializer.serialize(null, "v1")),
+            KeyValue.pair(k2, stringSerializer.serialize(null, "v2"))));
+
+        final ReadOnlyKeyValueStore<Bytes, byte[]> uncommitted = rocksDBStore.readOnly(IsolationLevel.READ_UNCOMMITTED);
+        final ReadOnlyKeyValueStore<Bytes, byte[]> committed = rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED);
+
+        // the batch is staged rather than written: it counts towards the uncommitted byte total ...
+        assertTrue(rocksDBStore.approximateNumUncommittedBytes() > emptyBufferBytes);
+        // ... is visible to the owner and at READ_UNCOMMITTED ...
+        assertEquals("v1", stringDeserializer.deserialize(null, rocksDBStore.get(k1)));
+        assertEquals("v2", stringDeserializer.deserialize(null, uncommitted.get(k2)));
+        // ... and stays hidden at READ_COMMITTED until the store commits.
+        assertNull(committed.get(k1));
+        assertNull(committed.get(k2));
+
+        rocksDBStore.commit(Map.of());
+
+        assertEquals("v1", stringDeserializer.deserialize(null, committed.get(k1)));
+        assertEquals("v2", stringDeserializer.deserialize(null, committed.get(k2)));
+    }
+
+    @Test
+    public void putAllShouldBeDiscardedOnRollbackWhenTransactional() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        final Bytes k1 = new Bytes(stringSerializer.serialize(null, "k1"));
+        final Bytes k2 = new Bytes(stringSerializer.serialize(null, "k2"));
+        rocksDBStore.put(k1, stringSerializer.serialize(null, "committed"));
+        rocksDBStore.commit(Map.of());
+
+        rocksDBStore.putAll(List.of(
+            KeyValue.pair(k1, stringSerializer.serialize(null, "rolled-back")),
+            KeyValue.pair(k2, stringSerializer.serialize(null, "rolled-back"))));
+        rocksDBStore.dbAccessor.rollbackStagedWrites();
+
+        // an aborted batch must leave nothing behind: the committed value is intact and the new key is gone
+        assertEquals("committed", stringDeserializer.deserialize(null, rocksDBStore.get(k1)));
+        assertNull(rocksDBStore.get(k2));
+        assertEquals("committed", stringDeserializer.deserialize(null,
+            rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED).get(k1)));
+        assertNull(rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED).get(k2));
+    }
+
+    @Test
+    public void putAllShouldStageTombstonesWhenTransactional() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        final Bytes k1 = new Bytes(stringSerializer.serialize(null, "k1"));
+        final Bytes k2 = new Bytes(stringSerializer.serialize(null, "k2"));
+        rocksDBStore.put(k1, stringSerializer.serialize(null, "v1"));
+        rocksDBStore.put(k2, stringSerializer.serialize(null, "v2"));
+        rocksDBStore.commit(Map.of());
+
+        // a null value in the batch is a delete, and must be staged like any other write
+        rocksDBStore.putAll(Arrays.asList(
+            KeyValue.pair(k1, null),
+            KeyValue.pair(k2, stringSerializer.serialize(null, "v2-updated"))));
+
+        final ReadOnlyKeyValueStore<Bytes, byte[]> committed = rocksDBStore.readOnly(IsolationLevel.READ_COMMITTED);
+        assertNull(rocksDBStore.get(k1));
+        assertEquals("v1", stringDeserializer.deserialize(null, committed.get(k1)));
+        assertEquals("v2-updated", stringDeserializer.deserialize(null,
+            rocksDBStore.readOnly(IsolationLevel.READ_UNCOMMITTED).get(k2)));
+        assertEquals("v2", stringDeserializer.deserialize(null, committed.get(k2)));
+
+        rocksDBStore.commit(Map.of());
+
+        assertNull(committed.get(k1));
+        assertEquals("v2-updated", stringDeserializer.deserialize(null, committed.get(k2)));
+    }
+
+    @Test
+    public void putAllShouldRejectNullKeyWithoutStagingAnyEntryWhenTransactional() {
+        rocksDBStore.close();
+        final InternalMockProcessorContext<?, ?> eosContext = getTransactionalEOSProcessorContext(dir);
+        rocksDBStore = getRocksDBStore();
+        rocksDBStore.init(eosContext, rocksDBStore);
+
+        final long emptyBufferBytes = rocksDBStore.approximateNumUncommittedBytes();
+        final Bytes k1 = new Bytes(stringSerializer.serialize(null, "k1"));
+
+        assertThrows(NullPointerException.class, () -> rocksDBStore.putAll(Arrays.asList(
+            KeyValue.pair(k1, stringSerializer.serialize(null, "v1")),
+            KeyValue.pair(null, stringSerializer.serialize(null, "v2")))));
+
+        // the batch is rejected whole: the valid entry ahead of the null key was never staged
+        assertEquals(emptyBufferBytes, rocksDBStore.approximateNumUncommittedBytes());
+        assertNull(rocksDBStore.get(k1));
+    }
+
     private List<String> keysOf(final KeyValueIterator<Bytes, byte[]> it) {
         final List<String> keys = new ArrayList<>();
         while (it.hasNext()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTransactionBufferTest.java
@@ -314,6 +314,53 @@ public class RocksDBTransactionBufferTest {
     }
 
     @Test
+    public void stageAllShouldNotExposeAPartiallyStagedBatchToNonOwnerReads() throws Exception {
+        final int batchSize = 50;
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        // A non-owner read takes the read lock, which stageAll holds off for the whole batch, so the
+        // batch is either wholly absent or wholly present -- the all-or-nothing view a caller would
+        // otherwise get from a single WriteBatch write. Keys are scanned in the "k" range so the
+        // base-store keys (a, b, c) are excluded from the count.
+        final Thread reader = new Thread(() -> {
+            try {
+                while (!stop.get()) {
+                    int staged = 0;
+                    try (KeyValueIterator<Bytes, byte[]> iter = buffer.range(key("k000"), key("k999"), true, true)) {
+                        while (iter.hasNext()) {
+                            iter.next();
+                            staged++;
+                        }
+                    }
+                    if (staged != 0 && staged != batchSize) {
+                        throw new AssertionError("non-owner read observed a partially staged batch of " + staged
+                            + " of " + batchSize + " writes");
+                    }
+                }
+            } catch (final Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        });
+        reader.start();
+        try {
+            for (int i = 0; i < 1_000 && failure.get() == null; i++) {
+                buffer.stageAll(() -> {
+                    for (int k = 0; k < batchSize; k++) {
+                        buffer.stage(key(String.format("k%03d", k)), val("v" + k));
+                    }
+                });
+                buffer.rollback();
+            }
+        } finally {
+            stop.set(true);
+            reader.join();
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("concurrent non-owner reader failed", failure.get());
+        }
+    }
+
+    @Test
     public void shouldNotShowStagedWritesInBaseAfterRollback() throws RocksDBException {
         buffer.stage(key("x"), val("staged-x"));
         buffer.rollback();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThrowingOnOffsetsPutDBAccessor.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThrowingOnOffsetsPutDBAccessor.java
@@ -16,11 +16,15 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -64,6 +68,16 @@ final class ThrowingOnOffsetsPutDBAccessor implements RocksDBStore.DBAccessor {
             throw new RocksDBException("simulated put failure on offsets CF");
         }
         delegate.put(columnFamily, key, value);
+    }
+
+    @Override
+    public void putAll(final RocksDBStore.ColumnFamilyAccessor cfAccessor,
+                       final List<KeyValue<Bytes, byte[]>> entries) throws RocksDBException {
+        // Routed through this wrapper's put() rather than delegated, so the simulated offsets-CF
+        // failure still applies to batch writes.
+        for (final KeyValue<Bytes, byte[]> entry : entries) {
+            cfAccessor.put(this, entry.key.get(), entry.value);
+        }
     }
 
     @Override


### PR DESCRIPTION
During the KIP-892 implementation we missed the `RocksDB.putAll` to put
entries in the transactional buffer, while not reachable via the DSL
PAPI users can use it via `KeyValueStore.putAll`.

This PR updates the `RocksDB.putAll` write to the transactional buffer
if transactional stores are enabled.

Reviewers: Matthias J. Sax <matthias@confluent.io>
