### PR TITLE
KAFKA-20932: Track replaced remote log segments as unreferenced

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochState.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochState.java
@@ -118,10 +118,16 @@ class RemoteLogLeaderEpochState {
         }
 
         // Add the segment epochs mapping as the segment is copied successfully.
-        offsetToId.put(startOffset, remoteLogSegmentId);
+        RemoteLogSegmentId replacedSegmentId = offsetToId.put(startOffset, remoteLogSegmentId);
 
         // Remove the metadata from unreferenced entries as it is successfully copied and added to the offset mapping.
         unreferencedSegmentIds.remove(remoteLogSegmentId);
+
+        // The highest offset check above may retain later mappings that are not covered by this segment. In that case,
+        // put can still replace a different segment with the same start offset, so keep it available for cleanup.
+        if (replacedSegmentId != null && !replacedSegmentId.equals(remoteLogSegmentId)) {
+            unreferencedSegmentIds.add(replacedSegmentId);
+        }
 
         // Update the highest offset entry for this leader epoch as we added a new mapping.
         if (highestLogOffset == null || leaderEpochEndOffset > highestLogOffset) {

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochStateTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogLeaderEpochStateTest.java
@@ -172,6 +172,29 @@ class RemoteLogLeaderEpochStateTest {
     }
 
     @Test
+    void handleSegmentWithCopySegmentFinishedStateForReplacementBelowHighestOffset() {
+        RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(tpId, Uuid.randomUuid());
+        RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(tpId, Uuid.randomUuid());
+        RemoteLogSegmentId segmentId3 = new RemoteLogSegmentId(tpId, Uuid.randomUuid());
+        epochState.handleSegmentWithCopySegmentFinishedState(0L, segmentId1, 100L);
+        epochState.handleSegmentWithCopySegmentFinishedState(101L, segmentId2, 200L);
+        epochState.handleSegmentWithCopySegmentFinishedState(0L, segmentId3, 150L);
+
+        assertEquals(2, epochState.referencedSegmentIds().size());
+        assertTrue(epochState.referencedSegmentIds().containsAll(List.of(segmentId2, segmentId3)));
+        assertEquals(segmentId3, epochState.floorEntry(50L));
+        assertEquals(segmentId2, epochState.floorEntry(175L));
+        assertEquals(1, epochState.unreferencedSegmentIds().size());
+        assertTrue(epochState.unreferencedSegmentIds().contains(segmentId1));
+        assertEquals(200L, epochState.highestLogOffset());
+
+        // Replaying the same update must not make the referenced segment unreferenced.
+        epochState.handleSegmentWithCopySegmentFinishedState(0L, segmentId3, 150L);
+        assertEquals(1, epochState.unreferencedSegmentIds().size());
+        assertTrue(epochState.unreferencedSegmentIds().contains(segmentId1));
+    }
+
+    @Test
     void handleSegmentWithDeleteSegmentStartedState() {
         RemoteLogSegmentId segmentId1 = new RemoteLogSegmentId(tpId, Uuid.randomUuid());
         RemoteLogSegmentId segmentId2 = new RemoteLogSegmentId(tpId, Uuid.randomUuid());


### PR DESCRIPTION
`RemoteLogLeaderEpochState` could drop an existing segment from both the referenced offset map and the unreferenced set when a later overlapping segment reused its start offset while a higher tail segment remained.

The global `highestLogOffset` check prevents the overlap-removal loop from running in this case, and the previous value returned by `offsetToId.put` was ignored. This left the replaced segment in the partition metadata map but absent from leader-epoch listings used by remote retention cleanup.

This change records a distinct replaced segment as unreferenced and adds a regression test covering:

- `S0 = [0, 100]`
- `S1 = [101, 200]`
- `S2 = [0, 150]`
- replay of the `S2` completion update

Jira: https://issues.apache.org/jira/browse/KAFKA-20932

Testing:

- `./gradlew :storage:test --tests org.apache.kafka.server.log.remote.metadata.storage.RemoteLogLeaderEpochStateTest`
- `./gradlew :storage:spotlessCheck`

The contribution is my original work and I license it to the project under the project's open source license.