### PR TITLE
KAFKA-20851 Version updates for build dependencies

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -253,7 +253,7 @@ License Version 2.0:
 - scala-reflect-2.13.18
 - snappy-java-1.1.10.7
 - snakeyaml-2.5
-- swagger-annotations-2.2.52
+- swagger-annotations-2.2.53
 
 ===============================================================================
 This product bundles various third-party components under other open source

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id 'io.github.ben-manes.versions' version '0.56.0'
+  id 'io.github.ben-manes.versions' version '0.61.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'
@@ -38,10 +38,10 @@ plugins {
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
-  id "com.github.spotbugs" version '6.5.9' apply false
+  id "com.github.spotbugs" version '6.5.10' apply false
   id 'org.scoverage' version '9.1' apply false
   id 'com.gradleup.shadow' version '9.6.1' apply false
-  id 'com.diffplug.spotless' version "8.4.0"
+  id 'com.diffplug.spotless' version "8.10.0"
 
   // Pre-register the KIP-1265 checker so `apply plugin:` resolves it inside subprojects { }.
   // The plugin itself ships from the `:api-checker` included build (see settings.gradle's

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ group=org.apache.kafka
 version=4.5.0-SNAPSHOT
 scalaVersion=2.13.18
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
-swaggerVersion=2.2.52
+swaggerVersion=2.2.53
 task=build
 org.gradle.jvmargs=-Xmx4g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -64,7 +64,7 @@ versions += [
   httpclient: "4.5.14",
   jackson: "2.21.5",
   jacksonAnnotations: "2.21",
-  jacoco: "0.8.14",
+  jacoco: "0.8.15",
   javassist: "3.30.2-GA",
   // When upgrading Jetty, verify that it does not use the SLF4J 2.x fluent API
   // (e.g. Logger.atDebug()) in production code, as Kafka uses SLF4J 1.7.x.
@@ -133,7 +133,7 @@ versions += [
   testcontainers: "1.20.2",
   testcontainersKeycloak: "3.5.1",
   mockOAuth2Server: "2.3.0",
-  zinc: "1.12.0",
+  zinc: "1.12.1",
   // When updating the zstd version, please do as well in docker/native/native-image-configs/resource-config.json
   // Also make sure the compression levels in org.apache.kafka.common.record.CompressionType are still valid
   zstd: "1.5.6-10",


### PR DESCRIPTION
JIRA ticket: KAFKA-20851

details:
- jacoco: 0.8.14 -->> 0.8.15
- zinc: 1.12.0 -->> 1.12.1
- swagger: 2.2.52 -->> 2.2.53
- gradle-versions-plugin: 0.56.0 -->> 0.61.0 (to improve `./gradlew
dependencyUpdates` task result output)
- spotbugs gradle plugin: 6.5.9 -->> 6.5.10
- spotless gradle plugin: 8.4.0 -->> 8.10.0 (note: extensively tested)

Additional notes and remarques:
- spotless gradle plugin version update is verified locally:
   - `./gradlew build -x test` passes (spotlessCheck + checkstyle +
spotbugs + compile all green)
   - `./gradlew clean spotlessApply --rerun-tasks --no-build-cache` ran
1000 times with 0 failures
- gradle-versions-plugin:
   - dependencyUpdates task output looks better now
   - plugin developers used Kafka codebase for 0.57.0 and 0.58.0
versions

Release notes:
- jacoco: https://github.com/jacoco/jacoco/releases/tag/v0.8.15
- zinc: https://github.com/sbt/zinc/releases/tag/v1.12.1
- swagger:
   - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.53
   -
https://github.com/swagger-api/swagger-core/blob/v2.2.53/modules/swagger-gradle-plugin/README.md
- gradle-versions-plugin:
   -
https://github.com/ben-manes/gradle-versions-plugin/tree/v0.61.0#migrating-from-prior-versions
   -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.61.0
   -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.60.0
   -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.59.0
   -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.58.0
   -
https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.57.0
- spotbugs gradle plugin:
https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.10
- spotless gradle plugin:
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.10.0
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.9.0
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.8.0
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.7.0
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.6.0
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.1
   - https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.0

Reviewers: Luke Chen <showuon@gmail.com>
