### PR TITLE
KAFKA-8377: Materialize stateful KTable value transforms

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -763,10 +763,11 @@ public interface KTable<K, V> {
      * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can be observed and additional
      * periodic actions can be performed.
      * <p>
-     * If the downstream topology uses aggregation functions, (e.g. {@link KGroupedTable#reduce}, {@link KGroupedTable#aggregate}, etc),
-     * care must be taken when dealing with state, (either held in state-stores or transformer instances), to ensure correct aggregate results.
-     * In contrast, if the resulting KTable is materialized, (cf. {@link #transformValues(ValueTransformerWithKeySupplier, Materialized, String...)}),
-     * such concerns are handled for you.
+     * If {@code stateStoreNames} are provided, the resulting {@code KTable} is internally materialized to ensure that
+     * downstream lookups return the value computed with the state at the time the input record was processed.
+     * If state is held only in the transformer instance, callers should explicitly materialize the result (cf.
+     * {@link #transformValues(ValueTransformerWithKeySupplier, Materialized, String...)}) before using a downstream
+     * operation that performs table lookups.
      * <p>
      * In order to assign a state, the state must be created and registered beforehand:
      * <pre>{@code
@@ -836,10 +837,11 @@ public interface KTable<K, V> {
      * Furthermore, via {@link org.apache.kafka.streams.processor.Punctuator#punctuate(long)} the processing progress can be observed and additional
      * periodic actions can be performed.
      * <p>
-     * If the downstream topology uses aggregation functions, (e.g. {@link KGroupedTable#reduce}, {@link KGroupedTable#aggregate}, etc),
-     * care must be taken when dealing with state, (either held in state-stores or transformer instances), to ensure correct aggregate results.
-     * In contrast, if the resulting KTable is materialized, (cf. {@link #transformValues(ValueTransformerWithKeySupplier, Materialized, String...)}),
-     * such concerns are handled for you.
+     * If {@code stateStoreNames} are provided, the resulting {@code KTable} is internally materialized to ensure that
+     * downstream lookups return the value computed with the state at the time the input record was processed.
+     * If state is held only in the transformer instance, callers should explicitly materialize the result (cf.
+     * {@link #transformValues(ValueTransformerWithKeySupplier, Materialized, String...)}) before using a downstream
+     * operation that performs table lookups.
      * <p>
      * In order to assign a state, the state must be created and registered beforehand:
      * <pre>{@code

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -439,6 +439,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final Serde<K> keySerde;
         final Serde<VR> valueSerde;
         final String queryableStoreName;
+        final String materializedStoreName;
         final Set<StoreBuilder<?>> storeBuilder;
 
         if (materializedInternal != null) {
@@ -448,6 +449,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             // we preserve the value following the order of 1) materialized, 2) null
             valueSerde = materializedInternal.valueSerde();
             queryableStoreName = materializedInternal.queryableStoreName();
+            materializedStoreName = queryableStoreName;
             // only materialize if materialized is specified and it has queryable name
             if (queryableStoreName != null) {
                 final StoreFactory storeFactory = new KeyValueStoreMaterializer<>(materializedInternal);
@@ -459,7 +461,16 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             keySerde = this.keySerde;
             valueSerde = null;
             queryableStoreName = null;
-            storeBuilder = null;
+            if (stateStoreNames.length > 0) {
+                final MaterializedInternal<K, VR, KeyValueStore<Bytes, byte[]>> implicitMaterialized =
+                    new MaterializedInternal<>(Materialized.with(keySerde, null), builder, TRANSFORMVALUES_NAME);
+                materializedStoreName = implicitMaterialized.storeName();
+                final StoreFactory storeFactory = new KeyValueStoreMaterializer<>(implicitMaterialized);
+                storeBuilder = Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+            } else {
+                materializedStoreName = null;
+                storeBuilder = null;
+            }
         }
 
         final String name = namedInternal.orElseGenerateWithPrefix(builder, TRANSFORMVALUES_NAME);
@@ -467,7 +478,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final KTableProcessorSupplier<K, V, K, VR> processorSupplier = new KTableTransformValues<>(
             this,
             transformerSupplier,
-            queryableStoreName);
+            materializedStoreName);
 
         final ProcessorParameters<K, VR, ?, ?> processorParameters =
             unsafeCastProcessorParametersToCompletelyDifferentType(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.TopologyTestDriverBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
@@ -370,7 +371,7 @@ public class KTableTransformValuesTest {
             .toStream()
             .process(capture);
 
-        driver = new TopologyTestDriverBuilder(builder.build()).withConfig(props(withHeaders)).build();
+        driver = new TopologyTestDriverBuilder(builder.build()).withConfig(propsWithStringDefaults(withHeaders)).build();
         final TestInputTopic<String, String> inputTopic =
                 driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
 
@@ -424,6 +425,38 @@ public class KTableTransformValuesTest {
             assertThat(keyValueStore.get("B"), is(ValueAndTimestamp.make("B->b!", 10L)));
             assertThat(keyValueStore.get("C"), is(ValueAndTimestamp.make("C->null!", 15L)));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void shouldMaterializeStatefulTransformForDownstreamLookup(final boolean withHeaders) {
+        final String counterStoreName = "counter-store";
+        builder.addStateStore(Stores.keyValueStoreBuilder(
+            Stores.inMemoryKeyValueStore(counterStoreName),
+            Serdes.String(),
+            Serdes.Integer()
+        ));
+
+        final KTable<String, String> transformed = builder
+            .table(INPUT_TOPIC, CONSUMED)
+            .transformValues(new StoreBackedCounterTransformerSupplier(counterStoreName), counterStoreName);
+
+        builder
+            .stream("probe", CONSUMED)
+            .join(transformed, (probe, transformedValue) -> probe + "->" + transformedValue)
+            .process(capture);
+
+        driver = new TopologyTestDriverBuilder(builder.build()).withConfig(propsWithStringDefaults(withHeaders)).build();
+        final TestInputTopic<String, String> inputTopic =
+            driver.createInputTopic(INPUT_TOPIC, new StringSerializer(), new StringSerializer());
+        final TestInputTopic<String, String> probeTopic =
+            driver.createInputTopic("probe", new StringSerializer(), new StringSerializer());
+
+        inputTopic.pipeInput("A", "ignored", 5L);
+        inputTopic.pipeInput("B", "ignored", 10L);
+        probeTopic.pipeInput("A", "lookup", 15L);
+
+        assertThat(output(), equalTo(List.of(new KeyValueTimestamp<>("A", "lookup->1", 15L))));
     }
 
     @ParameterizedTest
@@ -541,6 +574,13 @@ public class KTableTransformValuesTest {
         return props;
     }
 
+    private static Properties propsWithStringDefaults(final boolean withHeaders) {
+        final Properties props = props(withHeaders);
+        props.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        props.setProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        return props;
+    }
+
     private static void throwIfStoresNotAvailable(final ProcessorContext context,
                                                   final List<String> expectedStoredNames) {
         final List<String> missing = new ArrayList<>();
@@ -637,5 +677,37 @@ public class KTableTransformValuesTest {
 
         @Override
         public void close() {}
+    }
+
+    private static class StoreBackedCounterTransformerSupplier
+        implements ValueTransformerWithKeySupplier<String, String, String> {
+        private final String storeName;
+
+        private StoreBackedCounterTransformerSupplier(final String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public ValueTransformerWithKey<String, String, String> get() {
+            return new ValueTransformerWithKey<>() {
+                private KeyValueStore<String, Integer> store;
+
+                @Override
+                public void init(final ProcessorContext context) {
+                    store = context.getStateStore(storeName);
+                }
+
+                @Override
+                public String transform(final String readOnlyKey, final String value) {
+                    final Integer currentCount = store.get("count");
+                    final int nextCount = currentCount == null ? 1 : currentCount + 1;
+                    store.put("count", nextCount);
+                    return Integer.toString(nextCount);
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
     }
 }


### PR DESCRIPTION
KAFKA-8377 A non-materialized `KTable#transformValues()` recomputes values from its parent when a downstream operation performs a table lookup. This can produce an incorrect result when the transformer uses a connected state store whose contents have changed since the original record was processed.

This change internally materializes the result of `transformValues()` when state-store names are supplied. Downstream lookups therefore return the value computed when the input record was processed instead of invoking the stateful transformer again.

The `KTable` documentation now describes this behavior and clarifies that transformations relying only on transformer-local state still need to be explicitly materialized before downstream table lookups.

Testing adds coverage for both DSL store formats. The regression test uses a store-backed counter transformer followed by a downstream join and verifies that the join reads the originally transformed value rather than recomputing it against the updated state.