### PR TITLE
KAFKA-19762 Gradle feature for reproducible archives is turned *ON*

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,12 +358,6 @@ subprojects {
     tasks.register('uploadArchives').configure { dependsOn(publish) }
   }
 
-  tasks.withType(AbstractArchiveTask).configureEach {
-    reproducibleFileOrder = false
-    preserveFileTimestamps = true
-    useFileSystemPermissions()
-  }
-
   tasks.withType(AbstractTestTask).configureEach {
     failOnNoDiscoveredTests = false
   }
@@ -1426,6 +1420,16 @@ project(':core') {
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtimeClasspath) { into("libs/") }
     duplicatesStrategy = 'exclude'
+    filePermissions {
+      user {
+        read = true
+        execute = true
+      }
+      other.execute = true
+    }
+    dirPermissions {
+      unix('rwxr-xr-x')
+    }
   }
 
   jar {

--- a/build.gradle
+++ b/build.gradle
@@ -1420,15 +1420,13 @@ project(':core') {
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtimeClasspath) { into("libs/") }
     duplicatesStrategy = 'exclude'
-    filePermissions {
-      user {
-        read = true
-        execute = true
+    eachFile {
+      if (name.endsWith(".sh") || name.endsWith(".bat")) {
+        permissions {
+          user.execute = true
+          other.execute = true
+        }
       }
-      other.execute = true
-    }
-    dirPermissions {
-      unix('rwxr-xr-x')
     }
   }
 


### PR DESCRIPTION
Prologue: https://github.com/apache/kafka/pull/19513#discussion_r2405757923 

JIRA ticket: KAFKA-19762

Rationale: 
- https://docs.gradle.org/9.7.1/userguide/best_practices_security.html#builds_should_be_reproducible
- https://docs.gradle.org/9.7.1/userguide/best_practices_security.html#dont_do_this
- https://github.com/gradle/gradle/issues/30871 Reproducible archives enabled by default

Other related links:
 - https://reproducible-builds.org
 - https://github.com/gradle/gradle/issues/34643 
 - https://docs.gradle.org/9.7.1/userguide/working_with_files.html#sec:reproducible_archives
 - https://docs.gradle.org/9.7.1/userguide/working_with_files.html#sec:revert_reproducible_archives
 - https://docs.gradle.org/9.7.1/userguide/upgrading_major_version_9.html#reproducible_archives_by_default
 - https://docs.gradle.org/9.7.1/dsl/org.gradle.api.tasks.bundling.Tar.html#org.gradle.api.tasks.bundling.Tar:preserveFileTimestamps
 - https://github.com/gradle/gradle/blob/v9.7.1/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java#L95

___
Before and after:
- trunk `/kafka/core/build/distributions/kafka_2.13-4.5.0-SNAPSHOT/libs`: <img width="1005" height="424" alt="image" src="https://github.com/user-attachments/assets/1e73c666-958c-481a-a5e5-18d5197ace0d" />
- this PR `/kafka/core/build/distributions/kafka_2.13-4.5.0-SNAPSHOT/libs`: <img width="998" height="404" alt="image" src="https://github.com/user-attachments/assets/00e0be02-cf93-41df-80b6-3146ef76601a" />

___

Definition of done (at the minimum):
- ./gradlew releaseTarGz works as expected
- produced archive works as expected for:
  - a user who **_created that archive_** (Kafka cluster starts, messages can be produced/consumed, etc): https://kafka.apache.org/quickstart
  -  another user on a **_same operating_** system (Linux)
  - yet another user on a **_different_** operating system (Windows)