### PR TITLE
KAFKA-20895: Grant pre-vote once the leader has resigned

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -49,6 +49,10 @@ public final class FollowerState implements EpochState {
      * it may be able to grant PreVotes.
      */
     private boolean hasFetchedFromLeader = false;
+    /* Used to track if the leader has resigned in this epoch. Once it has, granting a PreVote is
+     * no longer disruptive, so the replica may grant one even if it has already fetched.
+     */
+    private boolean hasLeaderResigned = false;
     private Optional<LogOffsetMetadata> highWatermark;
     /* For kraft.version 0, track if the leader has received updated voter information from this
      * follower.
@@ -154,6 +158,14 @@ public final class FollowerState implements EpochState {
         fetchTimer.reset(timeoutMs);
     }
 
+    /**
+     * Record that the leader of this epoch has resigned, after receiving an `EndQuorumEpoch`
+     * request from it.
+     */
+    public void setLeaderHasResigned() {
+        hasLeaderResigned = true;
+    }
+
     private long updateVoterPeriodMs() {
         // Allow for a few rounds of fetch request before attempting to update
         // the voter state
@@ -232,17 +244,18 @@ public final class FollowerState implements EpochState {
 
     @Override
     public boolean canGrantVote(ReplicaKey replicaKey, boolean isLogUpToDate, boolean isPreVote) {
-        if (isPreVote && !hasFetchedFromLeader && isLogUpToDate) {
+        if (isPreVote && (!hasFetchedFromLeader || hasLeaderResigned) && isLogUpToDate) {
             return true;
         }
         log.debug(
             "Rejecting Vote request (preVote={}) from replica ({}) since we are in FollowerState with leader {} in " +
-                "epoch {}, hasFetchedFromLeader={}, replica's log is up-to-date={}",
+                "epoch {}, hasFetchedFromLeader={}, hasLeaderResigned={}, replica's log is up-to-date={}",
             isPreVote,
             replicaKey,
             leaderId,
             epoch,
             hasFetchedFromLeader,
+            hasLeaderResigned,
             isLogUpToDate
         );
         return false;

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1309,6 +1309,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                     requestLeaderId,
                     requestEpoch
                 );
+                state.setLeaderHasResigned();
                 state.overrideFetchTimeout(currentTimeMs, electionBackoffMs);
             }
         }

--- a/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/FollowerStateTest.java
@@ -124,6 +124,24 @@ public class FollowerStateTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    public void testPreVoteAfterLeaderResigned(boolean isLogUpToDate) {
+        FollowerState state = newFollowerState(Set.of(1, 2, 3));
+        state.resetFetchTimeoutForSuccessfulFetch(time.milliseconds());
+        state.setLeaderHasResigned();
+
+        assertEquals(isLogUpToDate, state.canGrantVote(ReplicaKey.of(1, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, true));
+        assertEquals(isLogUpToDate, state.canGrantVote(ReplicaKey.of(2, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, true));
+        assertEquals(isLogUpToDate, state.canGrantVote(ReplicaKey.of(3, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, true));
+        assertEquals(isLogUpToDate, state.canGrantVote(ReplicaKey.of(10, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, true));
+
+        assertFalse(state.canGrantVote(ReplicaKey.of(1, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, false));
+        assertFalse(state.canGrantVote(ReplicaKey.of(2, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, false));
+        assertFalse(state.canGrantVote(ReplicaKey.of(3, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, false));
+        assertFalse(state.canGrantVote(ReplicaKey.of(10, ReplicaKey.NO_DIRECTORY_ID), isLogUpToDate, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     public void testGrantStandardVote(boolean isLogUpToDate) {
         FollowerState state = newFollowerState(Set.of(1, 2, 3));
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -42,6 +42,8 @@ import org.apache.kafka.snapshot.SnapshotReader;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;
@@ -193,6 +195,83 @@ public class RaftEventSimulationTest {
             cluster.start(leaderId);
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(highWatermark + 10));
         });
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {4, 5, 6, 7, 8, 9})
+    void preferredSuccessorWinsElectionAfterGracefulLeaderShutdown(int numVoters) {
+        Cluster cluster = new Cluster(numVoters, 0, 1234L);
+        /* The other simulations lower this to keep their runtime down, but here the whole point is
+         * that the nominated successors stand for election one at a time, so use the production
+         * default to keep the gap between them wide enough to be meaningful.
+         */
+        cluster.electionBackoffMaxMs = QuorumConfig.DEFAULT_QUORUM_ELECTION_BACKOFF_MAX_MS;
+        MessageRouter router = new MessageRouter(cluster);
+        EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
+
+        cluster.startAll();
+        schedulePolling(scheduler, cluster, 3, 5);
+        scheduler.schedule(router::deliverAll, 0, 2, 1);
+        scheduler.runUntil(cluster::hasConsistentLeader);
+        // Every replica has fetched from the leader and is caught up with it
+        scheduler.runUntil(() -> cluster.allReachedHighWatermark(1));
+
+        int leaderId = cluster.latestLeader().orElseThrow(() ->
+            new AssertionError("Failed to find current leader")
+        );
+
+        // Read the ranking that the leader will put into its EndQuorumEpoch requests
+        LeaderState<Integer> leaderState = cluster
+            .nodeIfRunning(leaderId)
+            .orElseThrow(() -> new AssertionError("Leader " + leaderId + " is not running"))
+            .client
+            .quorum()
+            .leaderStateOrThrow();
+        List<Integer> preferredSuccessors = leaderState
+            .nonLeaderVotersByDescendingFetchOffset()
+            .stream()
+            .map(ReplicaKey::id)
+            .collect(Collectors.toList());
+
+        // A clean shutdown, so the leader resigns and nominates the successors above
+        long resignedAtMs = cluster.time.milliseconds();
+        cluster.shutdown(leaderId);
+
+        scheduler.runUntil(() ->
+            cluster.latestLeader().isPresent() && cluster.latestLeader().getAsInt() != leaderId
+        );
+
+        int newLeaderId = cluster.latestLeader().getAsInt();
+        long electionDurationMs = cluster.time.milliseconds() - resignedAtMs;
+        int position = preferredSuccessors.indexOf(newLeaderId);
+        int backoffBaseMs = cluster.electionBackoffMaxMs >> (preferredSuccessors.size() - 1);
+        long backoffOfWinnerMs = position <= 0 ? 0 : (long) backoffBaseMs << (position - 1);
+
+        System.out.printf(
+            "%s voters: leader %s resigned nominating %s. Node %s won at position %s, whose " +
+            "election backoff is %s ms, and the election took %s ms%n",
+            numVoters,
+            leaderId,
+            preferredSuccessors,
+            newLeaderId,
+            position,
+            backoffOfWinnerMs,
+            electionDurationMs
+        );
+
+        assertEquals(
+            preferredSuccessors.get(0).intValue(),
+            newLeaderId,
+            String.format(
+                "Leader %s resigned nominating %s in order of preference, so the first entry was " +
+                "expected to win, but %s won instead at position %s of that list, after %s ms",
+                leaderId,
+                preferredSuccessors,
+                newLeaderId,
+                position,
+                electionDurationMs
+            )
+        );
     }
 
     @Test
@@ -590,6 +669,7 @@ public class RaftEventSimulationTest {
         final Map<Integer, Node> voters = new HashMap<>();
         final Map<Integer, PersistentState> nodes = new HashMap<>();
         final Map<Integer, RaftNode> running = new HashMap<>();
+        int electionBackoffMaxMs = ELECTION_JITTER_MS;
 
         private Cluster(int numVoters, int numObservers, long seed) {
             this.random = new Random(seed);
@@ -820,7 +900,7 @@ public class RaftEventSimulationTest {
             configMap.put(QuorumConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS);
             configMap.put(QuorumConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, RETRY_BACKOFF_MS);
             configMap.put(QuorumConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG, ELECTION_TIMEOUT_MS);
-            configMap.put(QuorumConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, ELECTION_JITTER_MS);
+            configMap.put(QuorumConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, electionBackoffMaxMs);
             configMap.put(QuorumConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG, FETCH_TIMEOUT_MS);
             configMap.put(QuorumConfig.QUORUM_LINGER_MS_CONFIG, LINGER_MS);
             QuorumConfig quorumConfig = new QuorumConfig(new AbstractConfig(QuorumConfig.CONFIG_DEF, configMap));


### PR DESCRIPTION
## Summary

`FollowerState.canGrantVote()` rejects a pre-vote whenever
`hasFetchedFromLeader` is true, ignoring that the leader may have
already announced it is resigning. On a clean shutdown that means the
first preferred successor only collects its own vote plus the resigned
leader's, which is not a majority once the quorum is larger than three,
so it loses and a lower-ranked node wins instead. Every graceful
controller shutdown wastes an election round.

The fix is to let a follower know its leader has stepped down, and treat
that as grounds to grant a pre-vote:

- `FollowerState` gains a `hasLeaderResigned` flag plus a
`setLeaderHasResigned()` setter.
- `KafkaRaftClient.handleEndQuorumEpochRequest()` calls that setter next
to the existing `overrideFetchTimeout()`
    call, inside the block already guarded by "still a follower" and
"the request came from our own leader", so the flag is
    only ever set on a genuine resignation from the leader we are
following.
- The grant condition becomes `isPreVote && (!hasFetchedFromLeader ||
hasLeaderResigned) && isLogUpToDate`.

## Test plan
Added
`RaftEventSimulationTest.preferredSuccessorWinsElectionAfterGracefulLeaderShutdown`,
which reproduces the bug: with the production change reverted the test
fails, and with the change applied the same test passes.

Result summary
--------------
| | WITHOUT FIX | WITH FIX |
|---|---|---|
| Gradle exit code | 1 (6 tests completed, 6 failed) | 0 (6 tests
passed) |
| numVoters=4 | Node 1 won, position 1, 288 ms | Node 0 won, position 0,
33 ms |
| numVoters=5 | Node 1 won, position 1, 151 ms | Node 0 won, position 0,
33 ms |
| numVoters=6 | Node 3 won, position 2, 156 ms | Node 0 won, position 0,
33 ms |
| numVoters=7 | Node 3 won, position 2, 102 ms | Node 0 won, position 0,
33 ms |
| numVoters=8 | Node 4 won, position 3, 105 ms | Node 0 won, position 0,
34 ms |
| numVoters=9 | Node 4 won, position 3, 50 ms | Node 0 won, position 0,
24 ms |

The observed winner position matches the prediction in the JIRA
description exactly: 2nd entry for 4-5 voters, 3rd entry for 6-7 voters,
4th entry for 8-9 voters.

@mimaison you reported this one, could you please take a look when you
get a chance?

Reviewers: @mimaison / @bbejeck, Mickael Maison
 <mickael.maison@gmail.com>
