### PR TITLE
KAFKA-20943 Develocity related Gradle plugin versions are updated

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,8 +23,8 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.develocity' version '3.19'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
+    id 'com.gradle.develocity' version '4.5.1'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.8.0'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null


### PR DESCRIPTION
Jira ticket: KAFKA-20943

details:

```
- com.gradle.develocity: 3.19 -->> 4.5.1
- com.gradle.common-custom-user-data-gradle-plugin: 2.0.2 -->> 2.8.0
```
:warning:
https://docs.gradle.org/9.7.1/userguide/upgrading_version_9.html#deprecated_develocity_plugin_pre_4_0

Reviewers: Clay Johnson <cjohnson@gradle.com>
