### PR TITLE
KAFKA-20941: Replace HTMLTestRunner with pytest-html

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -108,7 +108,7 @@ supported_image_tag: ['3.6.1', 'latest', '3.7.0-rc1']
 Local Setup
 -----------
 
-Make sure you have python (>= 3.7.x) and java (>= 17) (java needed only for running tests) installed before running the tests and scripts.
+Make sure you have python (>= 3.10.x) and java (>= 17) (java needed only for running tests) installed before running the tests and scripts.
 
 Run `pip install -r requirements.txt` to get all the requirements for running the scripts.
 
@@ -216,4 +216,3 @@ python generate_kafka_pr_template.py --image-type=jvm
 - kafka-version - This is the version to create the Docker official images static Dockerfile and assets for, as well as the version to build and test the Docker official image for.
 - image-type - This is the type of image that we intend to build. This will be dropdown menu type selection in the workflow. `jvm` image type is for official docker image (to be hosted on apache/kafka) as described in [KIP-975](https://cwiki.apache.org/confluence/x/z5izDw). 
   - **NOTE:** As of now [KIP-1028](https://cwiki.apache.org/confluence/x/0AmpEQ) only aims to release JVM based Docker Official Images and not GraalVM based native Apache Kafka docker image.
-

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -61,18 +61,15 @@ def run_docker_tests(image, tag, kafka_url, kafka_archive, image_type, container
             raise ValueError("Either --kafka-url or --kafka-archive must be passed")
         execute(["mkdir", f"{temp_dir_path}/fixtures/kafka"])
         execute(["tar", "xfz", f"{temp_dir_path}/kafka.tgz", "-C", f"{temp_dir_path}/fixtures/kafka", "--strip-components", "1"])
-        failure_count, error_count = run_tests(f"{image}:{tag}", image_type, temp_dir_path, container_runtime)
+        test_exit_code = run_tests(f"{image}:{tag}", image_type, temp_dir_path, container_runtime)
     except:
         raise SystemError("Failed to run the tests")
     finally:
         shutil.rmtree(temp_dir_path)
     test_report_location_text = f"To view test report please check {current_dir}/test/report_{image_type}.html"
-    if failure_count != 0:
-        raise SystemError(f"{failure_count} tests have failed. {test_report_location_text}")
-    elif error_count != 0:
-        raise SystemError(f"{error_count} tests have errored. {test_report_location_text}")
-    else:
-        print(f"All tests passed successfully. {test_report_location_text}")
+    if test_exit_code != 0:
+        raise SystemError(f"Tests failed with pytest exit code {test_exit_code}. {test_report_location_text}")
+    print(f"All tests passed successfully. {test_report_location_text}")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 requests
-HTMLTestRunner-Python3
+pytest
+pytest-html

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -226,7 +226,7 @@ class DockerSanityTestIsolatedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
-def run_tests(image, mode, fixtures_dir, container_runtime="docker", report_path=None):
+def run_tests(image, mode, fixtures_dir, container_runtime="docker"):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
     DockerSanityTest.MODE = mode

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -232,9 +232,8 @@ def run_tests(image, mode, fixtures_dir, container_runtime="docker"):
     DockerSanityTest.MODE = mode
     DockerSanityTest.CONTAINER_RUNTIME = container_runtime
 
-    if report_path is None:
-        cur_directory = os.path.dirname(os.path.realpath(__file__))
-        report_path = f"{cur_directory}/report_{mode}.html"
+    cur_directory = os.path.dirname(os.path.realpath(__file__))
+    report_path = f"{cur_directory}/report_{mode}.html"
 
     class ReportTitlePlugin:
         @pytest.hookimpl(optionalhook=True)

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -246,6 +246,7 @@ def run_tests(image, mode, fixtures_dir, container_runtime="docker", report_path
         __name__,
         f"--html={report_path}",
         "--self-contained-html",
+        "--capture=tee-sys",
         "-p",
         "no:cacheprovider",
     ], plugins=[ReportTitlePlugin()])

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -209,7 +209,7 @@ class DockerSanityTest(unittest.TestCase):
             total_errors.append(str(e))
         
         self.assertEqual(total_errors, [])
-    
+
 class DockerSanityTestCombinedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.COMBINED_MODE_COMPOSE}")

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -209,8 +209,8 @@ class DockerSanityTest(unittest.TestCase):
             total_errors.append(str(e))
         
         self.assertEqual(total_errors, [])
-
-class TestDockerSanityCombinedMode(DockerSanityTest):
+    
+class DockerSanityTestCombinedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.COMBINED_MODE_COMPOSE}")
     def tearDown(self) -> None:
@@ -218,7 +218,7 @@ class TestDockerSanityCombinedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
-class TestDockerSanityIsolatedMode(DockerSanityTest):
+class DockerSanityTestIsolatedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.ISOLATED_MODE_COMPOSE}")
     def tearDown(self) -> None:

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -15,11 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import subprocess
-from HTMLTestRunner import HTMLTestRunner
-import test.constants as constants
 import os
+import subprocess
+import unittest
+
+import pytest
+import test.constants as constants
 
 class DockerSanityTest(unittest.TestCase):
     IMAGE="apache/kafka"
@@ -209,7 +210,7 @@ class DockerSanityTest(unittest.TestCase):
         
         self.assertEqual(total_errors, [])
 
-class DockerSanityTestCombinedMode(DockerSanityTest):
+class TestDockerSanityCombinedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.COMBINED_MODE_COMPOSE}")
     def tearDown(self) -> None:
@@ -217,7 +218,7 @@ class DockerSanityTestCombinedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
-class DockerSanityTestIsolatedMode(DockerSanityTest):
+class TestDockerSanityIsolatedMode(DockerSanityTest):
     def setUp(self) -> None:
         self.start_compose(f"{self.FIXTURES_DIR}/{constants.ISOLATED_MODE_COMPOSE}")
     def tearDown(self) -> None:
@@ -225,28 +226,26 @@ class DockerSanityTestIsolatedMode(DockerSanityTest):
     def test_bed(self):
         self.execute()
 
-def run_tests(image, mode, fixtures_dir, container_runtime="docker"):
+def run_tests(image, mode, fixtures_dir, container_runtime="docker", report_path=None):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
     DockerSanityTest.MODE = mode
     DockerSanityTest.CONTAINER_RUNTIME = container_runtime
 
-    test_classes_to_run = []
-    if mode == "jvm" or mode == "native":
-        test_classes_to_run = [DockerSanityTestCombinedMode, DockerSanityTestIsolatedMode]
-    
-    loader = unittest.TestLoader()
-    suites_list = []
-    for test_class in test_classes_to_run:
-        suite = loader.loadTestsFromTestCase(test_class)
-        suites_list.append(suite)
-    combined_suite = unittest.TestSuite(suites_list)
-    cur_directory = os.path.dirname(os.path.realpath(__file__))
-    outfile = open(f"{cur_directory}/report_{mode}.html", "w")
-    runner = HTMLTestRunner.HTMLTestRunner(
-                stream=outfile,
-                title=f'Test Report: Apache Kafka {mode.capitalize()} Docker Image',
-                description='This demonstrates the report output.'
-                )
-    result = runner.run(combined_suite)
-    return (result.failure_count, result.error_count)
+    if report_path is None:
+        cur_directory = os.path.dirname(os.path.realpath(__file__))
+        report_path = f"{cur_directory}/report_{mode}.html"
+
+    class ReportTitlePlugin:
+        @pytest.hookimpl(optionalhook=True)
+        def pytest_html_report_title(self, report):
+            report.title = f"Test Report: Apache Kafka {mode.capitalize()} Docker Image"
+
+    return pytest.main([
+        "--pyargs",
+        __name__,
+        f"--html={report_path}",
+        "--self-contained-html",
+        "-p",
+        "no:cacheprovider",
+    ], plugins=[ReportTitlePlugin()])


### PR DESCRIPTION
Replaces the inactive `HTMLTestRunner-Python3` dependency with `pytest`
and `pytest-html` for Docker sanity tests.

The existing unittest-based tests and HTML report paths remain
unchanged. Test results are now determined using the pytest exit code.

pytest 9.0+ requires Python 3.10 or later.

Testing:

* Verified successful and failing pytest runs.
* Verified HTML report generation.
* Ran the JVM Docker sanity suite.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
