### PR TITLE
MINOR: Add trace logging for KIP-1242 invalid connections

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1571,7 +1571,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (invalid && isTraceEnabled) {
         trace(s"Rejecting ApiVersionsRequest v${apiVersionRequest.version} from ${request.context.connectionId} " +
           s"with clusterId=${apiVersionRequest.data.clusterId}, nodeId=${apiVersionRequest.data.nodeId}; " +
-          s"expected clusterId=$clusterId, nodeId=$brokerId")
+          s"expected clusterId=$clusterId, nodeId=$brokerId for clientId=${request.context.clientId}")
       }
       invalid
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1565,9 +1565,15 @@ class KafkaApis(val requestChannel: RequestChannel,
     // client is connecting to the correct broker. If both are specified, they must match
     // the expected values for this broker.
     def clusterIdOrNodeIdIsInvalid(apiVersionRequest: ApiVersionsRequest): Boolean = {
-      apiVersionRequest.version >= 5 &&
+      val invalid = apiVersionRequest.version >= 5 &&
         apiVersionRequest.data.clusterId != null &&
         (apiVersionRequest.data.clusterId != clusterId || apiVersionRequest.data.nodeId != brokerId)
+      if (invalid && isTraceEnabled) {
+        trace(s"Rejecting ApiVersionsRequest v${apiVersionRequest.version} from ${request.context.connectionId} " +
+          s"with clusterId=${apiVersionRequest.data.clusterId}, nodeId=${apiVersionRequest.data.nodeId}; " +
+          s"expected clusterId=$clusterId, nodeId=$brokerId")
+      }
+      invalid
     }
 
     requestHelper.sendResponseMaybeThrottle(request, createResponseCallback)


### PR DESCRIPTION
Adds trace logging for the situation where the broker rejects
ApiVersions due to a cluster ID or node ID mismatch.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
