### PR TITLE
MINOR: Implement optional content size field in LZ4 frame header per LZ4 spec

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockOutputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/Lz4BlockOutputStream.java
@@ -49,6 +49,7 @@ public final class Lz4BlockOutputStream extends OutputStream {
     private final FLG flg;
     private final BD bd;
     private final int maxBlockSize;
+    private final long contentSize;
     private OutputStream out;
     private byte[] buffer;
     private byte[] compressedBuffer;
@@ -69,6 +70,26 @@ public final class Lz4BlockOutputStream extends OutputStream {
      * @throws IOException
      */
     public Lz4BlockOutputStream(OutputStream out, int blockSize, int level, boolean blockChecksum, boolean useBrokenFlagDescriptorChecksum) throws IOException {
+        this(out, blockSize, level, blockChecksum, useBrokenFlagDescriptorChecksum, -1);
+    }
+
+    /**
+     * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+     *
+     * @param out The output stream to compress
+     * @param blockSize Default: 4. The block size used during compression. 4=64kb, 5=256kb, 6=1mb, 7=4mb. All other
+     *            values will generate an exception
+     * @param level The compression level to use
+     * @param blockChecksum Default: false. When true, a XXHash32 checksum is computed and appended to the stream for
+     *            every block of data
+     * @param useBrokenFlagDescriptorChecksum Default: false. When true, writes an incorrect FrameDescriptor checksum
+     *            compatible with older kafka clients.
+     * @param contentSize The uncompressed content size to write in the frame header, or a negative value to omit.
+     *            Per the LZ4 frame format specification, this is an optional 8-byte unsigned little-endian value
+     *            that allows decompressors to pre-allocate buffers.
+     * @throws IOException
+     */
+    public Lz4BlockOutputStream(OutputStream out, int blockSize, int level, boolean blockChecksum, boolean useBrokenFlagDescriptorChecksum, long contentSize) throws IOException {
         this.out = out;
         /*
          * lz4-java provides two types of compressors; fastCompressor, which requires less memory but fast compression speed (with default compression level only),
@@ -79,8 +100,9 @@ public final class Lz4BlockOutputStream extends OutputStream {
         compressor = level == CompressionType.LZ4.defaultLevel() ? LZ4Factory.fastestInstance().fastCompressor() : LZ4Factory.fastestInstance().highCompressor(level);
         checksum = XXHashFactory.fastestInstance().hash32();
         this.useBrokenFlagDescriptorChecksum = useBrokenFlagDescriptorChecksum;
+        this.contentSize = contentSize;
         bd = new BD(blockSize);
-        flg = new FLG(blockChecksum);
+        flg = new FLG(blockChecksum, contentSize >= 0);
         bufferOffset = 0;
         maxBlockSize = bd.getBlockMaximumSize();
         buffer = new byte[maxBlockSize];
@@ -122,7 +144,14 @@ public final class Lz4BlockOutputStream extends OutputStream {
         bufferOffset = 4;
         buffer[bufferOffset++] = flg.toByte();
         buffer[bufferOffset++] = bd.toByte();
-        // TODO write uncompressed content size, update flg.validate()
+
+        // Write the uncompressed content size as an 8-byte little-endian value when the flag is set.
+        // Per the LZ4 frame format spec, this is placed between the BD byte and the HC checksum.
+        if (flg.isContentSizeSet()) {
+            for (int i = 0; i < Long.BYTES; i++) {
+                buffer[bufferOffset++] = (byte) (contentSize >>> (i * 8));
+            }
+        }
 
         // compute checksum on all descriptor fields
         int offset = 4;
@@ -271,7 +300,11 @@ public final class Lz4BlockOutputStream extends OutputStream {
         private final int version;
 
         public FLG(boolean blockChecksum) {
-            this(0, 0, 0, blockChecksum ? 1 : 0, 1, VERSION);
+            this(blockChecksum, false);
+        }
+
+        public FLG(boolean blockChecksum, boolean contentSize) {
+            this(0, 0, contentSize ? 1 : 0, blockChecksum ? 1 : 0, 1, VERSION);
         }
 
         private FLG(int reserved,

--- a/clients/src/test/java/org/apache/kafka/common/compress/Lz4CompressionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/compress/Lz4CompressionTest.java
@@ -451,4 +451,94 @@ public class Lz4CompressionTest {
         }
         return output.toByteArray();
     }
+
+    @Test
+    public void testContentSizeWrittenInHeader() throws IOException {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        long expectedContentSize = data.length;
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Lz4BlockOutputStream lz4 = new Lz4BlockOutputStream(
+            output,
+            Lz4BlockOutputStream.BLOCKSIZE_64KB,
+            LZ4.defaultLevel(),
+            false,
+            false,
+            expectedContentSize
+        );
+        lz4.write(data);
+        lz4.close();
+
+        byte[] compressed = output.toByteArray();
+
+        // Byte 4 is the FLG byte; bit 3 (Content Size flag) should be set
+        byte flgByte = compressed[4];
+        int contentSizeFlag = (flgByte >>> 3) & 1;
+        assertEquals(1, contentSizeFlag, "Content size flag (FLG bit 3) should be set");
+
+        // Bytes 6..13 are the 8-byte little-endian content size (after FLG at 4 and BD at 5)
+        ByteBuffer buf = ByteBuffer.wrap(compressed, 6, 8).order(ByteOrder.LITTLE_ENDIAN);
+        long writtenContentSize = buf.getLong();
+        assertEquals(expectedContentSize, writtenContentSize, "Content size in header should match");
+    }
+
+    @Test
+    public void testContentSizeRoundTrip() throws IOException {
+        byte[] data = String.join("", Collections.nCopies(256, "data")).getBytes(StandardCharsets.UTF_8);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Lz4BlockOutputStream lz4 = new Lz4BlockOutputStream(
+            output,
+            Lz4BlockOutputStream.BLOCKSIZE_64KB,
+            LZ4.defaultLevel(),
+            false,
+            false,
+            data.length
+        );
+        lz4.write(data);
+        lz4.close();
+
+        byte[] compressed = output.toByteArray();
+
+        // Decompress and verify the data round-trips correctly
+        Lz4BlockInputStream decompressed = new Lz4BlockInputStream(
+            ByteBuffer.wrap(compressed), BufferSupplier.create(), false);
+        byte[] result = new byte[data.length];
+        int totalRead = 0;
+        int n;
+        while ((n = decompressed.read(result, totalRead, result.length - totalRead)) != -1) {
+            totalRead += n;
+        }
+        assertEquals(data.length, totalRead);
+        assertArrayEquals(data, result);
+    }
+
+    @Test
+    public void testDefaultConstructorOmitsContentSize() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Lz4BlockOutputStream lz4 = new Lz4BlockOutputStream(
+            output,
+            Lz4BlockOutputStream.BLOCKSIZE_64KB,
+            LZ4.defaultLevel(),
+            false,
+            false
+        );
+        lz4.write(new byte[]{1, 2, 3});
+        lz4.close();
+
+        byte[] compressed = output.toByteArray();
+
+        // FLG byte is at offset 4; bit 3 should NOT be set when using default constructor
+        byte flgByte = compressed[4];
+        int contentSizeFlag = (flgByte >>> 3) & 1;
+        assertEquals(0, contentSizeFlag, "Content size flag should not be set for default constructor");
+
+        // Header should be 7 bytes (magic=4 + FLG=1 + BD=1 + HC=1), not 15 (with 8-byte content size)
+        // Verify by checking the frame can be decompressed
+        Lz4BlockInputStream decompressed = new Lz4BlockInputStream(
+            ByteBuffer.wrap(compressed), BufferSupplier.create(), false);
+        byte[] result = new byte[3];
+        assertEquals(3, decompressed.read(result));
+        assertArrayEquals(new byte[]{1, 2, 3}, result);
+    }
 }


### PR DESCRIPTION
This PR implements the optional Content Size field in the LZ4 frame header as defined by the LZ4 Frame Format specification.

Previously, `Lz4BlockOutputStream` had a TODO to write the uncompressed content size. This change:
- Adds a new constructor to `Lz4BlockOutputStream` that accepts an optional `contentSize` parameter.
- Updates the `FLG` byte to set the content size flag (bit 3) when a valid size is provided.
- Writes the 8-byte little-endian content size between the BD byte and the HC checksum in the header.

The existing constructors are left unchanged and default to omitting the content size, ensuring full backward compatibility. `Lz4BlockInputStream` already correctly skips these bytes when the flag is set.

Testing Strategy:
Added new unit tests in `Lz4CompressionTest`:
- `testContentSizeWrittenInHeader`: Verifies the FLG bit is set and the 8-byte content size is correctly formatted in the header.
- `testContentSizeRoundTrip`: Ensures successful round-trip compression and decompression when the content size is included.
- `testDefaultConstructorOmitsContentSize`: Confirms existing default constructors do not set the flag and maintain the original 7-byte header format.
