### PR TITLE
KAFKA-16245: Fix flaky DescribeConsumerGroupTest

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
@@ -202,7 +202,7 @@ public class DescribeConsumerGroupTest {
                     TestUtils.waitForCondition(() -> {
                         Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
                         String[] lines = res.getKey().trim().split("\n");
-                        if (lines.length != 2 && !res.getValue().isEmpty()) {
+                        if (lines.length != 2 || !res.getValue().isEmpty()) {
                             return false;
                         }
                         ConsumerGroupDescription consumerGroupDescription = admin.describeConsumerGroups(Set.of(group)).describedGroups().get(group).get();
@@ -245,7 +245,7 @@ public class DescribeConsumerGroupTest {
                     TestUtils.waitForCondition(() -> {
                         Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
                         String[] lines = res.getKey().trim().split("\n");
-                        if (lines.length != 2 && !res.getValue().isEmpty()) {
+                        if (lines.length != 2 || !res.getValue().isEmpty()) {
                             return false;
                         }
                         ConsumerGroupDescription consumerGroupDescription = admin.describeConsumerGroups(Set.of(group)).describedGroups().get(group).get();
@@ -298,7 +298,7 @@ public class DescribeConsumerGroupTest {
                 TestUtils.waitForCondition(() -> {
                     Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
                     String[] lines = res.getKey().trim().split("\n");
-                    if (lines.length != 3 && !res.getValue().isEmpty()) {
+                    if (lines.length != 3 || !res.getValue().isEmpty()) {
                         return false;
                     }
 
@@ -340,7 +340,7 @@ public class DescribeConsumerGroupTest {
                     TestUtils.waitForCondition(() -> {
                         Entry<String, String> res = ToolsTestUtils.grabConsoleOutputAndError(describeGroups(service));
                         String[] lines = res.getKey().trim().split("\n");
-                        if (lines.length != 2 && !res.getValue().isEmpty()) {
+                        if (lines.length != 2 || !res.getValue().isEmpty()) {
                             return false;
                         }
                         ConsumerGroupDescription consumerGroupDescription = admin.describeConsumerGroups(Set.of(group)).describedGroups().get(group).get();


### PR DESCRIPTION
Changes the logic in 4 test cases so that they retry whenever either the
line count is wrong or there is stderr content.

Reviewers: Ronit Sabhaya (github:Ronitsabhaya75), Mickael Maison
 <mickael.maison@gmail.com>
