### PR TITLE
KAFKA-20938: Complete stale JoinGroup/SyncGroup future on superseded classic-group request

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -7706,15 +7706,6 @@ public class GroupMetadataManager {
         String joinReason,
         CompletableFuture<JoinGroupResponseData> responseFuture
     ) {
-        // A prior JoinGroup for this member may still be pending; complete it before
-        // group.updateMember discards it, or it would never resolve on its own.
-        if (member.isAwaitingJoin()) {
-            group.completeJoinFuture(member, new JoinGroupResponseData()
-                .setMemberId(member.memberId())
-                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code())
-            );
-        }
-
         group.updateMember(
             member,
             request.protocols(),
@@ -8296,16 +8287,7 @@ public class GroupMetadataManager {
             responseFuture.complete(new SyncGroupResponseData()
                 .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
         } else if (group.isInState(COMPLETING_REBALANCE)) {
-            ClassicGroupMember syncingMember = group.member(memberId);
-            // A prior SyncGroup for this member may still be pending; complete it before
-            // it's discarded below, or it would never resolve on its own.
-            if (syncingMember.isAwaitingSync()) {
-                group.completeSyncFuture(syncingMember, new SyncGroupResponseData()
-                    .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code())
-                );
-            }
-
-            syncingMember.setAwaitingSyncFuture(responseFuture);
+            group.member(memberId).setAwaitingSyncFuture(responseFuture);
             removePendingSyncMember(group, request.memberId());
 
             // If this is the leader, then we can attempt to persist state and transition to stable

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -8150,20 +8150,19 @@ public class GroupMetadataManager {
                             "group instance id {} due to {}. Reverting to old member id {}.",
                             group.groupId(), newMemberId, groupInstanceId, t.getMessage(), oldMemberId);
 
+                        group.completeJoinFuture(newMember, new JoinGroupResponseData()
+                            .setMemberId(UNKNOWN_MEMBER_ID)
+                            .setGenerationId(group.generationId())
+                            .setProtocolName(group.protocolName().orElse(null))
+                            .setProtocolType(group.protocolType().orElse(null))
+                            .setLeader(currentLeader)
+                            .setSkipAssignment(false)
+                            .setErrorCode(appendGroupMetadataErrorToResponseError(Errors.forException(t)).code()));
+
                         // Failed to persist the member id of the given static member, revert the update of the static member in the group.
                         group.updateMember(newMember, oldProtocols, oldRebalanceTimeoutMs, oldSessionTimeoutMs, null);
                         ClassicGroupMember oldMember = group.replaceStaticMember(groupInstanceId, newMemberId, oldMemberId);
                         rescheduleClassicGroupMemberHeartbeat(group, oldMember);
-
-                        responseFuture.complete(
-                            new JoinGroupResponseData()
-                                .setMemberId(UNKNOWN_MEMBER_ID)
-                                .setGenerationId(group.generationId())
-                                .setProtocolName(group.protocolName().orElse(null))
-                                .setProtocolType(group.protocolType().orElse(null))
-                                .setLeader(currentLeader)
-                                .setSkipAssignment(false)
-                                .setErrorCode(appendGroupMetadataErrorToResponseError(Errors.forException(t)).code()));
 
                     } else if (JoinGroupRequest.supportsSkippingAssignment(context.requestVersion())) {
                         boolean isLeader = group.isLeader(newMemberId);

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -7706,6 +7706,15 @@ public class GroupMetadataManager {
         String joinReason,
         CompletableFuture<JoinGroupResponseData> responseFuture
     ) {
+        // A prior JoinGroup for this member may still be pending; complete it before
+        // group.updateMember discards it, or it would never resolve on its own.
+        if (member.isAwaitingJoin()) {
+            group.completeJoinFuture(member, new JoinGroupResponseData()
+                .setMemberId(member.memberId())
+                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code())
+            );
+        }
+
         group.updateMember(
             member,
             request.protocols(),
@@ -8287,7 +8296,16 @@ public class GroupMetadataManager {
             responseFuture.complete(new SyncGroupResponseData()
                 .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
         } else if (group.isInState(COMPLETING_REBALANCE)) {
-            group.member(memberId).setAwaitingSyncFuture(responseFuture);
+            ClassicGroupMember syncingMember = group.member(memberId);
+            // A prior SyncGroup for this member may still be pending; complete it before
+            // it's discarded below, or it would never resolve on its own.
+            if (syncingMember.isAwaitingSync()) {
+                group.completeSyncFuture(syncingMember, new SyncGroupResponseData()
+                    .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code())
+                );
+            }
+
+            syncingMember.setAwaitingSyncFuture(responseFuture);
             removePendingSyncMember(group, request.memberId());
 
             // If this is the leader, then we can attempt to persist state and transition to stable

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroup.java
@@ -1228,9 +1228,7 @@ public class ClassicGroup implements Group {
         ClassicGroupMember member,
         JoinGroupResponseData response
     ) {
-        if (member.isAwaitingJoin()) {
-            member.awaitingJoinFuture().complete(response);
-            member.setAwaitingJoinFuture(null);
+        if (member.completeJoinFuture(response)) {
             numMembersAwaitingJoinResponse--;
             return true;
         }
@@ -1264,12 +1262,7 @@ public class ClassicGroup implements Group {
         ClassicGroupMember member,
         SyncGroupResponseData response
     ) {
-        if (member.isAwaitingSync()) {
-            member.awaitingSyncFuture().complete(response);
-            member.setAwaitingSyncFuture(null);
-            return true;
-        }
-        return false;
+        return member.completeSyncFuture(response);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProt
 import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProtocolCollection;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Bytes;
 
 import java.util.HashSet;
@@ -397,16 +398,35 @@ public class ClassicGroupMember {
     }
 
     /**
+     * Set the member's join future. If a join future is already pending when a new,
+     * non-null one is set, the new request supersedes it, so the earlier one is
+     * completed with REBALANCE_IN_PROGRESS first -- otherwise it would never resolve
+     * on its own.
+     *
      * @param value the updated join future.
      */
     public void setAwaitingJoinFuture(CompletableFuture<JoinGroupResponseData> value) {
+        if (value != null && awaitingJoinFuture != null) {
+            awaitingJoinFuture.complete(new JoinGroupResponseData()
+                .setMemberId(memberId)
+                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
+        }
         this.awaitingJoinFuture = value;
     }
 
     /**
+     * Set the member's sync future. If a sync future is already pending when a new,
+     * non-null one is set, the new request supersedes it, so the earlier one is
+     * completed with REBALANCE_IN_PROGRESS first -- otherwise it would never resolve
+     * on its own.
+     *
      * @param value the updated sync future.
      */
     public void setAwaitingSyncFuture(CompletableFuture<SyncGroupResponseData> value) {
+        if (value != null && awaitingSyncFuture != null) {
+            awaitingSyncFuture.complete(new SyncGroupResponseData()
+                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
+        }
         this.awaitingSyncFuture = value;
     }
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
@@ -398,18 +398,14 @@ public class ClassicGroupMember {
     }
 
     /**
-     * Set the member's join future, completing a pending one with NOT_COORDINATOR if it's
-     * being replaced, but leaving it untouched if cleared to null.
+     * Set the member's join future, completing any pending one with NOT_COORDINATOR.
      *
      * @param value the updated join future.
      */
     public void setAwaitingJoinFuture(CompletableFuture<JoinGroupResponseData> value) {
-        // null detaches without completing -- the caller (e.g. a revert) is expected to complete it itself.
-        if (value != null) {
-            completeJoinFuture(new JoinGroupResponseData()
-                .setMemberId(memberId)
-                .setErrorCode(Errors.NOT_COORDINATOR.code()));
-        }
+        completeJoinFuture(new JoinGroupResponseData()
+            .setMemberId(memberId)
+            .setErrorCode(Errors.NOT_COORDINATOR.code()));
         this.awaitingJoinFuture = value;
     }
 
@@ -429,7 +425,7 @@ public class ClassicGroupMember {
     }
 
     /**
-     * Set the member's sync future, completing any pending one with NOT_COORDINATOR first.
+     * Set the member's sync future, completing any pending one with NOT_COORDINATOR.
      *
      * @param value the updated sync future.
      */

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/classic/ClassicGroupMember.java
@@ -398,36 +398,60 @@ public class ClassicGroupMember {
     }
 
     /**
-     * Set the member's join future. If a join future is already pending when a new,
-     * non-null one is set, the new request supersedes it, so the earlier one is
-     * completed with REBALANCE_IN_PROGRESS first -- otherwise it would never resolve
-     * on its own.
+     * Set the member's join future, completing a pending one with NOT_COORDINATOR if it's
+     * being replaced, but leaving it untouched if cleared to null.
      *
      * @param value the updated join future.
      */
     public void setAwaitingJoinFuture(CompletableFuture<JoinGroupResponseData> value) {
-        if (value != null && awaitingJoinFuture != null) {
-            awaitingJoinFuture.complete(new JoinGroupResponseData()
+        // null detaches without completing -- the caller (e.g. a revert) is expected to complete it itself.
+        if (value != null) {
+            completeJoinFuture(new JoinGroupResponseData()
                 .setMemberId(memberId)
-                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
+                .setErrorCode(Errors.NOT_COORDINATOR.code()));
         }
         this.awaitingJoinFuture = value;
     }
 
     /**
-     * Set the member's sync future. If a sync future is already pending when a new,
-     * non-null one is set, the new request supersedes it, so the earlier one is
-     * completed with REBALANCE_IN_PROGRESS first -- otherwise it would never resolve
-     * on its own.
+     * Complete the member's join future, if one is pending, with the given response, and clear it.
+     *
+     * @param response the join response to complete the future with.
+     * @return true if a join future was completed.
+     */
+    public boolean completeJoinFuture(JoinGroupResponseData response) {
+        if (isAwaitingJoin()) {
+            awaitingJoinFuture.complete(response);
+            awaitingJoinFuture = null;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set the member's sync future, completing any pending one with NOT_COORDINATOR first.
      *
      * @param value the updated sync future.
      */
     public void setAwaitingSyncFuture(CompletableFuture<SyncGroupResponseData> value) {
-        if (value != null && awaitingSyncFuture != null) {
-            awaitingSyncFuture.complete(new SyncGroupResponseData()
-                .setErrorCode(Errors.REBALANCE_IN_PROGRESS.code()));
-        }
+        completeSyncFuture(new SyncGroupResponseData()
+            .setErrorCode(Errors.NOT_COORDINATOR.code()));
         this.awaitingSyncFuture = value;
+    }
+
+    /**
+     * Complete the member's sync future, if one is pending, with the given response, and clear it.
+     *
+     * @param response the sync response to complete the future with.
+     * @return true if a sync future was completed.
+     */
+    public boolean completeSyncFuture(SyncGroupResponseData response) {
+        if (isAwaitingSync()) {
+            awaitingSyncFuture.complete(response);
+            awaitingSyncFuture = null;
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -7173,6 +7173,65 @@ public class GroupMetadataManagerTest {
     }
 
     @Test
+    public void testJoinGroupExistingMemberRejoinDuringPreparingRebalanceCompletesPreviousJoinFuture() throws Exception {
+        // A member re-joining (same memberId) while its previous JoinGroup is still pending must have
+        // that stale future completed with a retriable error, not silently discarded.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        ClassicGroup group = context.createClassicGroup("group-id");
+
+        JoinGroupRequestData leaderRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        JoinGroupResponseData leaderResponse = context.joinClassicGroupAsDynamicMemberAndCompleteJoin(leaderRequest);
+        assertEquals(Errors.NONE.code(), leaderResponse.errorCode());
+        String leaderId = leaderResponse.leader();
+        assertEquals(1, group.generationId());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        // A second member joins, forcing a new rebalance; the join phase doesn't complete since the
+        // leader hasn't rejoined, so this member's join future is left pending.
+        JoinGroupRequestData memberRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .build();
+
+        GroupMetadataManagerTestContext.JoinResult firstJoin = context.sendClassicGroupJoin(memberRequest);
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+        assertFalse(firstJoin.joinFuture.isDone());
+
+        String memberId = group.allMemberIds().stream()
+            .filter(id -> !id.equals(leaderId))
+            .findFirst()
+            .orElseThrow();
+
+        // Same member retries JoinGroup while its first join is still pending.
+        GroupMetadataManagerTestContext.JoinResult secondJoin = context.sendClassicGroupJoin(
+            memberRequest.setMemberId(memberId)
+        );
+        assertTrue(group.isInState(PREPARING_REBALANCE));
+
+        // Superseded first join must be completed promptly with a retriable error.
+        assertTrue(firstJoin.joinFuture.isDone());
+        assertEquals(Errors.REBALANCE_IN_PROGRESS.code(), firstJoin.joinFuture.get().errorCode());
+        assertFalse(secondJoin.joinFuture.isDone());
+
+        // Leader rejoins, completing the rebalance.
+        context.sendClassicGroupJoin(leaderRequest.setMemberId(leaderId));
+
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+        assertEquals(2, group.generationId());
+
+        // The second join completes normally.
+        assertTrue(secondJoin.joinFuture.isDone());
+        assertEquals(Errors.NONE.code(), secondJoin.joinFuture.get().errorCode());
+    }
+
+    @Test
     public void testJoinGroupExistingMemberDoesNotTriggerRebalanceInStableState() throws Exception {
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .build();
@@ -9846,6 +9905,82 @@ public class GroupMetadataManagerTest {
         assertEquals(Errors.NONE.code(), followerSyncResult.syncFuture.get().errorCode());
         assertEquals(followerAssignment, followerSyncResult.syncFuture.get().assignment());
         assertTrue(group.isInState(STABLE));
+    }
+
+    @Test
+    public void testSyncGroupDuplicateFollowerSyncDuringCompletingRebalanceCompletesPreviousSyncFuture() throws Exception {
+        // Mirrors testJoinGroupExistingMemberRejoinDuringPreparingRebalanceCompletesPreviousJoinFuture,
+        // but for SyncGroup: a member's stale, still-pending sync future must be completed with a
+        // retriable error rather than silently orphaned when superseded.
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .build();
+        JoinGroupResponseData leaderJoinResponse = context.joinClassicGroupAsDynamicMemberAndCompleteRebalance("group-id");
+        ClassicGroup group = context.groupMetadataManager.getOrMaybeCreateClassicGroup("group-id", false);
+
+        JoinGroupRequestData joinRequest = new GroupMetadataManagerTestContext.JoinGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(UNKNOWN_MEMBER_ID)
+            .withDefaultProtocolTypeAndProtocols()
+            .withRebalanceTimeoutMs(10000)
+            .withSessionTimeoutMs(5000)
+            .build();
+
+        GroupMetadataManagerTestContext.JoinResult followerJoinResult = context.sendClassicGroupJoin(joinRequest);
+        assertFalse(followerJoinResult.joinFuture.isDone());
+
+        GroupMetadataManagerTestContext.JoinResult leaderJoinResult = context.sendClassicGroupJoin(
+            joinRequest.setMemberId(leaderJoinResponse.memberId())
+        );
+        assertTrue(leaderJoinResult.joinFuture.isDone());
+        assertTrue(followerJoinResult.joinFuture.isDone());
+        assertTrue(group.isInState(COMPLETING_REBALANCE));
+
+        int nextGenerationId = leaderJoinResult.joinFuture.get().generationId();
+        String followerId = followerJoinResult.joinFuture.get().memberId();
+
+        SyncGroupRequestData syncRequest = new GroupMetadataManagerTestContext.SyncGroupRequestBuilder()
+            .withGroupId("group-id")
+            .withMemberId(followerId)
+            .withGenerationId(nextGenerationId)
+            .build();
+
+        // Follower syncs once, pending on the leader.
+        GroupMetadataManagerTestContext.SyncResult firstSync = context.sendClassicGroupSync(syncRequest);
+        assertTrue(firstSync.records.isEmpty());
+        assertFalse(firstSync.syncFuture.isDone());
+
+        // Same follower retries SyncGroup before the first sync has completed.
+        GroupMetadataManagerTestContext.SyncResult secondSync = context.sendClassicGroupSync(syncRequest);
+        assertTrue(secondSync.records.isEmpty());
+
+        // Superseded first sync must be completed promptly with a retriable error.
+        assertTrue(firstSync.syncFuture.isDone());
+        assertEquals(Errors.REBALANCE_IN_PROGRESS.code(), firstSync.syncFuture.get().errorCode());
+        assertFalse(secondSync.syncFuture.isDone());
+
+        // Leader syncs, completing the rebalance.
+        List<SyncGroupRequestAssignment> assignment = new ArrayList<>();
+        assignment.add(new SyncGroupRequestAssignment()
+            .setMemberId(leaderJoinResponse.memberId())
+            .setAssignment(new byte[]{0})
+        );
+        assignment.add(new SyncGroupRequestAssignment()
+            .setMemberId(followerId)
+            .setAssignment(new byte[]{1})
+        );
+
+        GroupMetadataManagerTestContext.SyncResult leaderSync = context.sendClassicGroupSync(
+            syncRequest
+                .setMemberId(leaderJoinResponse.memberId())
+                .setAssignments(assignment)
+        );
+        leaderSync.appendFuture.complete(null);
+
+        assertTrue(group.isInState(STABLE));
+
+        // The second sync completes normally.
+        assertTrue(secondSync.syncFuture.isDone());
+        assertEquals(Errors.NONE.code(), secondSync.syncFuture.get().errorCode());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -7217,7 +7217,7 @@ public class GroupMetadataManagerTest {
 
         // Superseded first join must be completed promptly with a retriable error.
         assertTrue(firstJoin.joinFuture.isDone());
-        assertEquals(Errors.REBALANCE_IN_PROGRESS.code(), firstJoin.joinFuture.get().errorCode());
+        assertEquals(Errors.NOT_COORDINATOR.code(), firstJoin.joinFuture.get().errorCode());
         assertFalse(secondJoin.joinFuture.isDone());
 
         // Leader rejoins, completing the rebalance.
@@ -9955,18 +9955,17 @@ public class GroupMetadataManagerTest {
 
         // Superseded first sync must be completed promptly with a retriable error.
         assertTrue(firstSync.syncFuture.isDone());
-        assertEquals(Errors.REBALANCE_IN_PROGRESS.code(), firstSync.syncFuture.get().errorCode());
+        assertEquals(Errors.NOT_COORDINATOR.code(), firstSync.syncFuture.get().errorCode());
         assertFalse(secondSync.syncFuture.isDone());
 
         // Leader syncs, completing the rebalance.
-        List<SyncGroupRequestAssignment> assignment = new ArrayList<>();
-        assignment.add(new SyncGroupRequestAssignment()
-            .setMemberId(leaderJoinResponse.memberId())
-            .setAssignment(new byte[]{0})
-        );
-        assignment.add(new SyncGroupRequestAssignment()
-            .setMemberId(followerId)
-            .setAssignment(new byte[]{1})
+        List<SyncGroupRequestAssignment> assignment = List.of(
+            new SyncGroupRequestAssignment()
+                .setMemberId(leaderJoinResponse.memberId())
+                .setAssignment(new byte[]{0}),
+            new SyncGroupRequestAssignment()
+                .setMemberId(followerId)
+                .setAssignment(new byte[]{1})
         );
 
         GroupMetadataManagerTestContext.SyncResult leaderSync = context.sendClassicGroupSync(


### PR DESCRIPTION
When a classic-group member sends a second JoinGroup or SyncGroup before
its first request completes, ClassicGroup silently overwrote the pending
future with the new one. The discarded future was never completed by
anything, so it only resolved via the original caller's own timeout —
surfacing as a stale-generation timeout well after the member had
already rejoined under a newer generation. Fixed by completing the
superseded future with NOT_COORDINATOR before replacing it, for both
JoinGroup and SyncGroup.

Jira: https://issues.apache.org/jira/browse/KAFKA-20938 Reviewers: Sean
Quah <squah@confluent.io>

Reviewers: David Jacot <david.jacot@gmail.com>, Sean Quah
 <squah@confluent.io>
