### PR TITLE
KAFKA-20922: Guard null values in key-value store iterators

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeaders.java
@@ -692,14 +692,19 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
 
             final KeyValue<Bytes, byte[]> keyValue = iter.next();
             final ValueTimestampHeaders<V> valueTimestampHeaders = valueTimestampHeadersDeserializer.apply(keyValue.value);
-            final Headers headers = valueTimestampHeaders.headers();
+            final Headers headers = valueTimestampHeaders != null
+                ? valueTimestampHeaders.headers()
+                : new RecordHeaders();
+            final K key = deserializeKey(keyValue.key.get(), headers);
 
-            if (returnPlainValue) {
-                return KeyValue.pair(deserializeKey(keyValue.key.get(), headers), valueTimestampHeaders.value());
+            if (valueTimestampHeaders == null) {
+                return KeyValue.pair(key, null);
+            } else if (returnPlainValue) {
+                return KeyValue.pair(key, valueTimestampHeaders.value());
             } else {
                 // Return as ValueAndTimestamp
                 return KeyValue.pair(
-                    deserializeKey(keyValue.key.get(), headers),
+                    key,
                     (V) ValueAndTimestamp.make(valueTimestampHeaders.value(), valueTimestampHeaders.timestamp())
                 );
             }
@@ -719,13 +724,15 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
      * {@link ReadOnlyRecord} (implemented by {@link Record}) carrying key, value, timestamp, and the
      * stored headers, with the headers frozen so a caller cannot mutate the read-only result.
      *
-     * <p>A {@link ReadOnlyRecord} timestamp is contractually non-negative, so an entry with a negative
-     * stored timestamp cannot be represented. The dominant, deterministic cause is a store that does
-     * not persist timestamps: a {@code WithHeaders} store built over a plain {@link KeyValueStore}
-     * supplier surfaces every entry with {@code NO_TIMESTAMP} (-1). A genuine negative write is
-     * otherwise blocked (the source {@code RecordQueue} drops negative-timestamp records at ingestion),
-     * though {@link ValueAndTimestamp#make}/{@link ValueTimestampHeaders#make} do not themselves reject
-     * one written directly.
+     * <p>A {@link ReadOnlyRecord} requires a value and a contractually non-negative timestamp, so an
+     * entry whose value deserializes to null or whose stored timestamp is negative cannot be represented.
+     * The null-value check is a fail-fast safety net because a native store cannot hold a null value. The
+     * dominant, deterministic cause of a negative timestamp is a store that does not persist timestamps:
+     * a {@code WithHeaders} store built over a plain {@link KeyValueStore} supplier surfaces every entry
+     * with {@code NO_TIMESTAMP} (-1). A genuine negative write is otherwise blocked (the source
+     * {@code RecordQueue} drops negative-timestamp records at ingestion), though
+     * {@link ValueAndTimestamp#make}/{@link ValueTimestampHeaders#make} do not themselves reject one
+     * written directly.
      *
      * <p>This mirrors the rule the point query {@link TimestampedKeyWithHeadersQuery} applies. But
      * because a lazily-evaluated range has already returned a successful {@link QueryResult} before any
@@ -755,8 +762,16 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
         public ReadOnlyRecord<K, V> next() {
             final KeyValue<Bytes, byte[]> keyValue = iter.next();
             final ValueTimestampHeaders<V> valueTimestampHeaders = valueTimestampHeadersDeserializer.apply(keyValue.value);
-            final Headers headers = valueTimestampHeaders.headers();
+            // Use empty headers for a null value so the key can still be deserialized for the error message.
+            final Headers headers = valueTimestampHeaders != null
+                ? valueTimestampHeaders.headers()
+                : new RecordHeaders();
             final K key = deserializeKey(keyValue.key.get(), headers);
+            if (valueTimestampHeaders == null) {
+                throw new StreamsException(
+                    "Cannot represent the stored record for key [" + key
+                        + "] as a ReadOnlyRecord: its value is null.");
+            }
             if (valueTimestampHeaders.timestamp() < 0) {
                 throw new StreamsException(
                     "Cannot represent the stored record for key [" + key + "] as a ReadOnlyRecord: its "
@@ -799,7 +814,10 @@ public class MeteredTimestampedKeyValueStoreWithHeaders<K, V>
 
             final KeyValue<Bytes, byte[]> keyValue = iter.next();
             final ValueTimestampHeaders<V> valueTimestampHeaders = deserializeValue(keyValue.value);
-            final K key = deserializeKey(keyValue.key.get(), valueTimestampHeaders.headers());
+            final Headers headers = valueTimestampHeaders != null
+                ? valueTimestampHeaders.headers()
+                : new RecordHeaders();
+            final K key = deserializeKey(keyValue.key.get(), headers);
             return KeyValue.pair(key, valueTimestampHeaders);
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreWithHeadersTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.streams.query.TimestampedRangeWithHeadersQuery;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.test.KeyValueIteratorStub;
 
@@ -78,6 +79,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -107,6 +109,7 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
     private static final byte[] VALUE_TIMESTAMP_HEADERS_BYTES = serializeValueTimestampHeaders(VALUE_TIMESTAMP_HEADERS);
     private static final byte[] NEGATIVE_TIMESTAMP_VALUE_TIMESTAMP_HEADERS_BYTES =
         serializeValueTimestampHeaders(ValueTimestampHeaders.make("value", -1L, HEADERS));
+    private static final byte[] NULL_DESERIALIZED_VALUE_BYTES = {0};
     private final String threadId = Thread.currentThread().getName();
     private final TaskId taskId = new TaskId(0, 0, "My-Topology");
     @Mock
@@ -320,6 +323,22 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
     }
 
     @Test
+    public void shouldReturnNullValueFromRangeWhenValueDeserializesToNull() {
+        setUp();
+        final KeyValue<Bytes, byte[]> nullValueEntry = KeyValue.pair(KEY_BYTES, NULL_DESERIALIZED_VALUE_BYTES);
+        when(inner.range(any(Bytes.class), any(Bytes.class)))
+            .thenReturn(new KeyValueIteratorStub<>(List.of(nullValueEntry).iterator()));
+        metered = createStoreWithMockSerdes();
+
+        try (final KeyValueIterator<String, ValueTimestampHeaders<String>> iterator = metered.range(KEY, KEY)) {
+            final KeyValue<String, ValueTimestampHeaders<String>> next = iterator.next();
+            assertEquals(KEY, next.key);
+            assertNull(next.value);
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Test
     public void shouldPropagateLowerBoundAndDescendingOrderForTimestampedRangeWithHeadersQuery() {
         setUp();
         init();
@@ -377,6 +396,70 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
 
         assertFalse(result.isSuccess());
         assertEquals(FailureReason.NOT_UP_TO_BOUND, result.getFailureReason());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnNullValueForRangeQueryWhenValueDeserializesToNull() {
+        setUp();
+        final KeyValue<Bytes, byte[]> nullValueEntry = KeyValue.pair(KEY_BYTES, NULL_DESERIALIZED_VALUE_BYTES);
+        when(inner.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn((QueryResult) QueryResult.forResult(
+                new KeyValueIteratorStub<>(List.of(nullValueEntry).iterator())));
+        metered = createStoreWithMockSerdes();
+
+        final QueryResult<KeyValueIterator<String, String>> result = metered.query(
+            RangeQuery.withNoBounds(), PositionBound.unbounded(), new QueryConfig(false));
+
+        try (final KeyValueIterator<String, String> iterator = result.getResult()) {
+            final KeyValue<String, String> next = iterator.next();
+            assertEquals(KEY, next.key);
+            assertNull(next.value);
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnNullValueForTimestampedRangeQueryWhenValueDeserializesToNull() {
+        setUp();
+        final KeyValue<Bytes, byte[]> nullValueEntry = KeyValue.pair(KEY_BYTES, NULL_DESERIALIZED_VALUE_BYTES);
+        when(inner.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn((QueryResult) QueryResult.forResult(
+                new KeyValueIteratorStub<>(List.of(nullValueEntry).iterator())));
+        metered = createStoreWithMockSerdes();
+
+        final QueryResult<KeyValueIterator<String, ValueAndTimestamp<String>>> result = metered.query(
+            TimestampedRangeQuery.withNoBounds(), PositionBound.unbounded(), new QueryConfig(false));
+
+        try (final KeyValueIterator<String, ValueAndTimestamp<String>> iterator = result.getResult()) {
+            final KeyValue<String, ValueAndTimestamp<String>> next = iterator.next();
+            assertEquals(KEY, next.key);
+            assertNull(next.value);
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldThrowDescriptiveExceptionForTimestampedRangeWithHeadersQueryWhenValueDeserializesToNull() {
+        setUp();
+        final KeyValue<Bytes, byte[]> nullValueEntry = KeyValue.pair(KEY_BYTES, NULL_DESERIALIZED_VALUE_BYTES);
+        when(inner.query(any(), any(PositionBound.class), any(QueryConfig.class)))
+            .thenReturn((QueryResult) QueryResult.forResult(
+                new KeyValueIteratorStub<>(List.of(nullValueEntry).iterator())));
+        metered = createStoreWithMockSerdes();
+
+        final QueryResult<ReadOnlyRecordIterator<String, String>> result = metered.query(
+            TimestampedRangeWithHeadersQuery.withNoBounds(), PositionBound.unbounded(), new QueryConfig(false));
+
+        try (final ReadOnlyRecordIterator<String, String> iterator = result.getResult()) {
+            final StreamsException exception = assertThrows(StreamsException.class, iterator::next);
+            assertEquals(
+                "Cannot represent the stored record for key [" + KEY
+                    + "] as a ReadOnlyRecord: its value is null.",
+                exception.getMessage());
+        }
     }
 
     // The num-open-iterators gauge is tracked by every metered iterator this store returns from query().
@@ -773,10 +856,12 @@ public class MeteredTimestampedKeyValueStoreWithHeadersTest {
 
         lenient().when(keySerializer.serialize(any(), any(RecordHeaders.class), any())).thenReturn(KEY.getBytes());
 
-        lenient().when(valueDeserializer.deserialize(any(), any(RecordHeaders.class), eq(VALUE_TIMESTAMP_HEADERS_BYTES)))
+        lenient().when(valueDeserializer.deserialize(any(), any(Headers.class), eq(VALUE_TIMESTAMP_HEADERS_BYTES)))
             .thenReturn(VALUE_TIMESTAMP_HEADERS);
+        lenient().when(valueDeserializer.deserialize(any(), any(Headers.class), eq(NULL_DESERIALIZED_VALUE_BYTES)))
+            .thenReturn(null);
 
-        lenient().when(keyDeserializer.deserialize(any(), eq(HEADERS), eq(KEY.getBytes())))
+        lenient().when(keyDeserializer.deserialize(any(), any(Headers.class), eq(KEY.getBytes())))
             .thenReturn(KEY);
 
         final MeteredTimestampedKeyValueStoreWithHeaders<String, String> mockStore = new MeteredTimestampedKeyValueStoreWithHeaders<>(


### PR DESCRIPTION
## Summary

- **guard null-deserialized values** in the range-query and plain key-value store iterators
- return a null value for `RangeQuery`, `TimestampedRangeQuery`, and plain range results where the query contract permits it
- **throw a descriptive `StreamsException`** containing the key when a `ReadOnlyRecord` cannot be constructed
- add regression coverage for all three iterator implementations

The handling mirrors the existing null guards in the window and session store iterators. Empty headers are used only to deserialize the key when the wrapped value is null.

## Testing

- `./gradlew :streams:test --tests org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStoreWithHeadersTest --no-daemon`
- `./gradlew :streams:spotlessCheck :streams:checkstyleMain :streams:checkstyleTest :streams:spotbugsMain :streams:spotbugsTest -x test --no-daemon`

I confirm that this contribution is my original work and I license it to the project under the project's open source license.

Reviewers: Matthias J. Sax <matthias@confluent.io>
