### PR TITLE
KAFKA-20939: Client applications broken by DNS resolution failure behaviour change

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -118,6 +118,24 @@ public final class ClientUtils {
         return parseAndValidateAddresses(urls, ClientDnsLookup.forConfig(clientDnsLookupConfig));
     }
 
+    /**
+     * If {@code bootstrap.resolve.timeout.ms=0} (the default), resolves DNS for the given bootstrap
+     * servers synchronously and primes {@code metadata} with the resulting cluster. A DNS failure
+     * surfaces as {@link ConfigException} and no client instance is created.
+     * <p>
+     * A positive value opts in to asynchronous bootstrap resolution, in which case this method is
+     * a no-op — {@link NetworkClient} will resolve DNS on the first poll and defer failures to
+     * subsequent API calls as {@link org.apache.kafka.common.errors.BootstrapResolutionException}.
+     */
+    public static void maybeBootstrapMetadataSynchronously(AbstractConfig config,
+                                                           List<String> bootstrapServers,
+                                                           Metadata metadata) {
+        if (config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG) == 0L) {
+            metadata.bootstrap(parseAndValidateAddresses(bootstrapServers,
+                config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)));
+        }
+    }
+
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, ClientDnsLookup clientDnsLookup) {
         List<InetSocketAddress> addresses = new ArrayList<>();
         for (String url : urls) {
@@ -243,11 +261,17 @@ public final class ClientUtils {
                     logContext);
             ClientDnsLookup dnsLookup = ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
 
-            BootstrapConfiguration bootstrapConfiguration = BootstrapConfiguration.enabled(
-                bootstrapServers,
-                dnsLookup,
-                config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG),
-                config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG));
+            // bootstrap.resolve.timeout.ms=0 means the caller has already resolved and bootstrapped
+            // metadata synchronously in the client constructor, so the NetworkClient does no async
+            // bootstrap resolution of its own.
+            long bootstrapResolveTimeoutMs = config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG);
+            BootstrapConfiguration bootstrapConfiguration = bootstrapResolveTimeoutMs == 0L
+                ? BootstrapConfiguration.DISABLED
+                : BootstrapConfiguration.enabled(
+                    bootstrapServers,
+                    dnsLookup,
+                    bootstrapResolveTimeoutMs,
+                    config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG));
 
             return new NetworkClient(metadataUpdater,
                     metadata,

--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -136,6 +136,24 @@ public final class ClientUtils {
         }
     }
 
+    /**
+     * Returns {@link BootstrapConfiguration#DISABLED} when {@code bootstrap.resolve.timeout.ms=0}
+     * (the caller is expected to have primed metadata synchronously via
+     * {@link #maybeBootstrapMetadataSynchronously}), otherwise an enabled configuration that
+     * lets {@link NetworkClient} resolve DNS asynchronously up to the configured budget.
+     */
+    public static BootstrapConfiguration bootstrapConfiguration(AbstractConfig config, List<String> bootstrapServers) {
+        long bootstrapResolveTimeoutMs = config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG);
+        if (bootstrapResolveTimeoutMs == 0L) {
+            return BootstrapConfiguration.DISABLED;
+        }
+        return BootstrapConfiguration.enabled(
+            bootstrapServers,
+            ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)),
+            bootstrapResolveTimeoutMs,
+            config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG));
+    }
+
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, ClientDnsLookup clientDnsLookup) {
         List<InetSocketAddress> addresses = new ArrayList<>();
         for (String url : urls) {
@@ -259,19 +277,7 @@ public final class ClientUtils {
                     metricsGroupPrefix,
                     channelBuilder,
                     logContext);
-            ClientDnsLookup dnsLookup = ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
-
-            // bootstrap.resolve.timeout.ms=0 means the caller has already resolved and bootstrapped
-            // metadata synchronously in the client constructor, so the NetworkClient does no async
-            // bootstrap resolution of its own.
-            long bootstrapResolveTimeoutMs = config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG);
-            BootstrapConfiguration bootstrapConfiguration = bootstrapResolveTimeoutMs == 0L
-                ? BootstrapConfiguration.DISABLED
-                : BootstrapConfiguration.enabled(
-                    bootstrapServers,
-                    dnsLookup,
-                    bootstrapResolveTimeoutMs,
-                    config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG));
+            BootstrapConfiguration bootstrapConfiguration = bootstrapConfiguration(config, bootstrapServers);
 
             return new NetworkClient(metadataUpdater,
                     metadata,

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -61,12 +61,14 @@ public class CommonClientConfigs {
                                                        + "the bootstrap phase, this behaves the same as <code>use_all_dns_ips</code>.";
 
     public static final String BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG = "bootstrap.resolve.timeout.ms";
-    public static final long DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS = 2 * 60 * 1000L;
-    public static final String BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC = "Maximum amount of time clients can spend trying to" +
-        " resolve DNS for the bootstrap server address. If the resolution cannot be completed within this timeframe, a " +
-        "<code>BootstrapResolutionException</code> will be thrown. This failure is unrecoverable — the exception is" +
-        " re-thrown on every subsequent API call, so the client must be closed and re-created after fixing the" +
-        " underlying DNS or <code>bootstrap.servers</code> configuration issue.";
+    public static final long DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS = 0L;
+    public static final String BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC = "Selects the client's bootstrap DNS resolution mode." +
+        " When set to <code>0</code> (the default), DNS is resolved synchronously during client construction; any" +
+        " failure surfaces as <code>ConfigException</code> and no client instance is created. When set to a positive" +
+        " value, DNS is resolved asynchronously and this is the maximum amount of time the client will spend" +
+        " retrying resolution before failing with an unrecoverable <code>BootstrapResolutionException</code> from" +
+        " subsequent API calls (the client must then be closed and re-created after fixing the underlying DNS or" +
+        " <code>bootstrap.servers</code> configuration issue).";
 
     public static final String METADATA_MAX_AGE_CONFIG = "metadata.max.age.ms";
     public static final String METADATA_MAX_AGE_DOC = "The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.";

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -207,7 +207,7 @@ public class AdminClientConfig extends AbstractConfig {
                                 .define(BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG,
                                         Type.LONG,
                                         CommonClientConfigs.DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS,
-                                        atLeast(1L),
+                                        atLeast(0L),
                                         Importance.HIGH,
                                         BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC)
                                 .define(ENABLE_METRICS_PUSH_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -273,6 +273,7 @@ import org.apache.kafka.common.utils.internals.ProducerIdAndEpoch;
 
 import org.slf4j.Logger;
 
+import java.net.InetSocketAddress;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -589,8 +590,18 @@ public class KafkaAdminClient extends AdminClient {
                 ? config.getList(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG)
                 : config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
 
-            // Don't create bootstrap cluster here - let NetworkClient.ensureBootstrapped() handle it
-            // during the first poll after DNS resolution succeeds
+            // bootstrap.resolve.timeout.ms=0 resolves DNS synchronously here and primes the
+            // metadata manager, so any DNS failure surfaces as a ConfigException and no admin
+            // client instance is created. A positive value opts in to asynchronous bootstrap
+            // resolution, where resolution is deferred to the first poll.
+            if (config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG) == 0L) {
+                List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
+                    bootstrapAddressesToUse,
+                    config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
+                metadataManager.update(Cluster.bootstrap(addresses), time.milliseconds());
+            }
+            // Otherwise, let NetworkClient.ensureBootstrapped() handle it during the first poll
+            // after DNS resolution succeeds.
             List<MetricsReporter> reporters = CommonClientConfigs.metricsReporters(clientId, config);
             clientTelemetryReporter = CommonClientConfigs.telemetryReporter(clientId, config);
             clientTelemetryReporter.ifPresent(reporters::add);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -454,7 +454,7 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG,
                                         Type.LONG,
                                         CommonClientConfigs.DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS,
-                                        atLeast(1L),
+                                        atLeast(0L),
                                         Importance.HIGH,
                                         CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC)
                                 .define(GROUP_ID_CONFIG, Type.STRING, null, Importance.HIGH, GROUP_ID_DOC)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -500,6 +500,8 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                     interceptorList,
                     Arrays.asList(deserializers.keyDeserializer(), deserializers.valueDeserializer()));
             this.metadata = metadataFactory.build(config, subscriptions, logContext, clusterResourceListeners);
+            ClientUtils.maybeBootstrapMetadataSynchronously(config,
+                config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), this.metadata);
 
             this.fetchMetricsManager = createFetchMetricsManager(metrics);
             FetchConfig fetchConfig = new FetchConfig(config);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ClassicKafkaConsumer.java
@@ -190,6 +190,8 @@ public class ClassicKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                     interceptorList,
                     Arrays.asList(this.deserializers.keyDeserializer(), this.deserializers.valueDeserializer()));
             this.metadata = new ConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+            ClientUtils.maybeBootstrapMetadataSynchronously(config,
+                config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), this.metadata);
 
             this.fetchMetricsManager = createFetchMetricsManager(metrics);
             FetchConfig fetchConfig = new FetchConfig(config);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ShareConsumerImpl.java
@@ -272,6 +272,8 @@ public class ShareConsumerImpl<K, V> implements ShareConsumerDelegate<K, V> {
                     metrics.reporters(),
                     Arrays.asList(deserializers.keyDeserializer(), deserializers.valueDeserializer()));
             this.metadata = new ShareConsumerMetadata(config, subscriptions, logContext, clusterResourceListeners);
+            ClientUtils.maybeBootstrapMetadataSynchronously(config,
+                config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), this.metadata);
 
             this.shareFetchMetricsManager = createShareFetchMetricsManager(metrics);
             ApiVersions apiVersions = new ApiVersions();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -443,6 +443,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         config.getLong(ProducerConfig.METADATA_MAX_IDLE_CONFIG),
                         logContext,
                         clusterResourceListeners);
+                ClientUtils.maybeBootstrapMetadataSynchronously(config,
+                    config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), this.metadata);
             }
             this.transactionManager = configureTransactionState(config, logContext);
             // There is no need to do work required for adaptive partitioning, if we use a custom partitioner.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -471,7 +471,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG,
                                         Type.LONG,
                                         CommonClientConfigs.DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS,
-                                        atLeast(1L),
+                                        atLeast(0L),
                                         Importance.HIGH,
                                         CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC)
                                 .define(ENABLE_METRICS_PUSH_CONFIG,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1843,4 +1843,17 @@ public class KafkaAdminClientTest extends KafkaAdminClientTestBase {
             assertInstanceOf(BootstrapResolutionException.class, e.getCause());
         }
     }
+
+    @Test
+    public void testAdminConstructorFailsWithConfigExceptionOnUnresolvableBootstrapWhenTimeoutZero() {
+        // Default bootstrap.resolve.timeout.ms=0 resolves DNS synchronously in the constructor;
+        // any failure surfaces as ConfigException (wrapped in KafkaException by the constructor's
+        // outer try/catch), so no admin client instance is created.
+        String invalidHost = "unresolvable.invalid:9092";
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, invalidHost);
+
+        KafkaException e = assertThrows(KafkaException.class, () -> Admin.create(configs));
+        assertInstanceOf(ConfigException.class, e.getCause());
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.AuthenticationException;
@@ -4396,6 +4397,25 @@ public void testPollIdleRatio(GroupProtocol groupProtocol) {
             // accidentally clearing the bootstrap error from the metadata layer.
             assertThrows(BootstrapResolutionException.class, () -> consumer.poll(Duration.ofMillis(100)));
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = GroupProtocol.class)
+    public void testConsumerConstructorFailsWithConfigExceptionOnUnresolvableBootstrapWhenTimeoutZero(GroupProtocol protocol) {
+        // Default bootstrap.resolve.timeout.ms=0 resolves DNS synchronously in the constructor;
+        // any failure surfaces as ConfigException (wrapped in KafkaException by the constructor's
+        // outer try/catch), so no consumer instance is created.
+        String invalidHost = "unresolvable.invalid:9092";
+        Map<String, Object> configs = Map.of(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, invalidHost,
+            ConsumerConfig.GROUP_PROTOCOL_CONFIG, protocol.name(),
+            ConsumerConfig.GROUP_ID_CONFIG, "test-group"
+        );
+
+        KafkaException e = assertThrows(KafkaException.class, () -> new KafkaConsumer<>(configs));
+        assertInstanceOf(ConfigException.class, e.getCause());
     }
 
     private MetricName expectedMetricName(String clientId, String config, Class<?> clazz) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaShareConsumerTest.java
@@ -23,11 +23,13 @@ import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.GroupCoordinatorNode;
 import org.apache.kafka.clients.consumer.internals.ShareConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.BootstrapResolutionException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.ShareAcknowledgeResponseData;
@@ -68,6 +70,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -456,5 +459,22 @@ public class KafkaShareConsumerTest {
         } finally {
             consumer.close();
         }
+    }
+
+    @Test
+    public void testShareConsumerConstructorFailsWithConfigExceptionOnUnresolvableBootstrapWhenTimeoutZero() {
+        // Default bootstrap.resolve.timeout.ms=0 resolves DNS synchronously in the constructor;
+        // any failure surfaces as ConfigException (wrapped in KafkaException by the constructor's
+        // outer try/catch), so no share consumer instance is created.
+        String invalidHost = "unresolvable.invalid:9092";
+        Map<String, Object> configs = Map.of(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName(),
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, invalidHost,
+            ConsumerConfig.GROUP_ID_CONFIG, "test-share-group"
+        );
+
+        KafkaException e = assertThrows(KafkaException.class, () -> new KafkaShareConsumer<>(configs));
+        assertInstanceOf(ConfigException.class, e.getCause());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -3462,4 +3462,20 @@ public class KafkaProducerTest {
                 () -> producer.sendOffsetsToTransaction(offsets, groupMetadata));
         }
     }
+
+    @Test
+    public void testProducerConstructorFailsWithConfigExceptionOnUnresolvableBootstrapWhenTimeoutZero() {
+        // Default bootstrap.resolve.timeout.ms=0 resolves DNS synchronously in the constructor;
+        // any failure surfaces as ConfigException (wrapped in KafkaException by the constructor's
+        // outer try/catch), so no producer instance is created.
+        String invalidHost = "unresolvable.invalid:9092";
+        Map<String, Object> configs = Map.of(
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, invalidHost
+        );
+
+        KafkaException e = assertThrows(KafkaException.class, () -> new KafkaProducer<>(configs));
+        assertInstanceOf(ConfigException.class, e.getCause());
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -408,7 +408,7 @@ public final class DistributedConfig extends WorkerConfig {
             .define(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG,
                     ConfigDef.Type.LONG,
                     CommonClientConfigs.DEFAULT_BOOTSTRAP_RESOLVE_TIMEOUT_MS,
-                    atLeast(1L),
+                    atLeast(0L),
                     ConfigDef.Importance.HIGH,
                     CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_DOC)
             .define(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -18,7 +18,6 @@ package org.apache.kafka.connect.runtime.distributed;
 
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.BootstrapConfiguration;
-import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.GroupRebalanceConfig;
@@ -101,13 +100,11 @@ public class WorkerGroupMember {
             long retryBackoffMaxMs = config.getLong(CommonClientConfigs.RETRY_BACKOFF_MAX_MS_CONFIG);
             Metadata metadata = new Metadata(retryBackoffMs, retryBackoffMaxMs, config.getLong(CommonClientConfigs.METADATA_MAX_AGE_CONFIG),
                     logContext, new ClusterResourceListeners());
+            List<String> bootstrapServers = config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
+            ClientUtils.maybeBootstrapMetadataSynchronously(config, bootstrapServers, metadata);
             String metricGrpPrefix = "connect";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
-            BootstrapConfiguration bootstrapConfiguration = BootstrapConfiguration.enabled(
-                config.getList(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
-                ClientDnsLookup.forConfig(config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)),
-                config.getLong(CommonClientConfigs.BOOTSTRAP_RESOLVE_TIMEOUT_MS_CONFIG),
-                config.getLong(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG));
+            BootstrapConfiguration bootstrapConfiguration = ClientUtils.bootstrapConfiguration(config, bootstrapServers);
             NetworkClient netClient = new NetworkClient(
                     new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
                     metadata,


### PR DESCRIPTION
JIRA: KAFKA-20939  KIP-909 changed DNS bootstrap resolution from
synchronous (in the client constructor) to asynchronous (deferred to the
first `poll()`). This introduced a silent breaking change: callers that
previously relied on "constructor throws => no instance created" would
now receive a permanently-broken client instance that raises
`BootstrapResolutionException` from every subsequent API call, requiring
new error-handling paths and an explicit close-and-recreate cycle.

Reuse the existing `bootstrap.resolve.timeout.ms` config to make the
mode selectable:

  * `= 0` (new default) — resolve DNS synchronously in the constructor,
surface any failure as `ConfigException` (wrapped in `KafkaException` by
the constructor's outer try/catch); no client instance is created.    *
`> 0`                — resolve DNS asynchronously; failures surface as
`BootstrapResolutionException` from subsequent API calls, after which
the client must be closed and re-created.

This preserves the pre-KIP-909 behavior for every user who does not
explicitly opt in to the async model, while keeping the async model
available for those who need it.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>
