### PR TITLE
KAFKA-20949: Remove hamcrest from org.apache.kafka.streams.query package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -75,7 +75,7 @@ public class PositionBoundTest {
     @Test
     public void shouldNotEqualNull() {
         final PositionBound bound1 = PositionBound.at(Position.emptyPosition());
-        assertNotEquals(null, bound1);
+        assertNotEquals(bound1, null);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -23,11 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,8 +36,8 @@ public class PositionBoundTest {
         final PositionBound positionBound = PositionBound.at(position);
         position.withComponent("topic", 1, 2L);
 
-        assertThat(position.getTopics(), equalTo(Set.of("topic")));
-        assertThat(positionBound.position().getTopics(), empty());
+        assertEquals(Set.of("topic"), position.getTopics());
+        assertTrue(positionBound.position().isEmpty());
     }
 
     @Test
@@ -52,7 +49,7 @@ public class PositionBoundTest {
     @Test
     public void unboundedShouldReturnEmptyPosition() {
         final PositionBound bound = PositionBound.unbounded();
-        assertThat(bound.position(), equalTo(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), bound.position());
     }
 
     @Test
@@ -78,7 +75,7 @@ public class PositionBoundTest {
     @Test
     public void shouldNotEqualNull() {
         final PositionBound bound1 = PositionBound.at(Position.emptyPosition());
-        assertNotEquals(bound1, null);
+        assertNotNull(bound1);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -75,7 +75,7 @@ public class PositionBoundTest {
     @Test
     public void shouldNotEqualNull() {
         final PositionBound bound1 = PositionBound.at(Position.emptyPosition());
-        assertNotEquals(bound1, null);
+        assertNotEquals(null, bound1);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionBoundTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,7 +76,7 @@ public class PositionBoundTest {
     @Test
     public void shouldNotEqualNull() {
         final PositionBound bound1 = PositionBound.at(Position.emptyPosition());
-        assertNotNull(bound1);
+        assertNotEquals(bound1, null);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -210,7 +210,7 @@ public class PositionTest {
     @Test
     public void shouldNotMatchNull() {
         final Position position = Position.emptyPosition();
-        assertNotEquals(null, position);
+        assertNotEquals(position, null);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -66,8 +66,8 @@ public class PositionTest {
 
         // so the position is still the original one
         assertEquals(mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            mkEntry(0, 5L),
+            mkEntry(7, 0L)
         ), position.getPartitionPositions("topic1"));
     }
 
@@ -98,9 +98,9 @@ public class PositionTest {
         assertEquals(Set.of("topic", "topic1", "topic2"), merged.getTopics());
         assertEquals(mkMap(mkEntry(0, 7L)), merged.getPartitionPositions("topic"));
         assertEquals(mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L),
-                mkEntry(8, 1L)
+            mkEntry(0, 5L),
+            mkEntry(7, 0L),
+            mkEntry(8, 1L)
         ), merged.getPartitionPositions("topic1"));
         assertEquals(mkMap(mkEntry(9, 5L)), merged.getPartitionPositions("topic2"));
     }
@@ -136,17 +136,17 @@ public class PositionTest {
         assertEquals(Set.of("topic", "topic1"), copy.getTopics());
         assertEquals(mkMap(mkEntry(0, 5L)), copy.getPartitionPositions("topic"));
         assertEquals(mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            mkEntry(0, 5L),
+            mkEntry(7, 0L)
         ), copy.getPartitionPositions("topic1"));
 
         // original has changed
         assertEquals(Set.of("topic", "topic1", "topic2"), position.getTopics());
         assertEquals(mkMap(mkEntry(0, 6L)), position.getPartitionPositions("topic"));
         assertEquals(mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L),
-                mkEntry(8, 1L)
+            mkEntry(0, 5L),
+            mkEntry(7, 0L),
+            mkEntry(8, 1L)
         ), position.getPartitionPositions("topic1"));
         assertEquals(mkMap(mkEntry(2, 4L)), position.getPartitionPositions("topic2"));
     }
@@ -166,8 +166,8 @@ public class PositionTest {
         assertEquals(Set.of("topic", "topic1"), merged.getTopics());
         assertEquals(mkMap(mkEntry(0, 5L)), merged.getPartitionPositions("topic"));
         assertEquals(mkMap(
-                mkEntry(0, 5L),
-                mkEntry(7, 0L)
+            mkEntry(0, 5L),
+            mkEntry(7, 0L)
         ), merged.getPartitionPositions("topic1"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -38,7 +38,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -211,7 +210,7 @@ public class PositionTest {
     @Test
     public void shouldNotMatchNull() {
         final Position position = Position.emptyPosition();
-        assertNotNull(position);
+        assertNotEquals(null, position);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/PositionTest.java
@@ -20,7 +20,6 @@ package org.apache.kafka.streams.query;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,10 +36,9 @@ import java.util.concurrent.TimeoutException;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,24 +57,24 @@ public class PositionTest {
         );
 
         final Position position = Position.fromMap(map);
-        assertThat(position.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
+        assertEquals(Set.of("topic", "topic1"), position.getTopics());
+        assertEquals(mkMap(mkEntry(0, 5L)), position.getPartitionPositions("topic"));
 
         // Should be a copy of the constructor map
 
         map.get("topic1").put(99, 99L);
 
         // so the position is still the original one
-        assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
-        )));
+        assertEquals(mkMap(
+                mkEntry(0, 5L),
+                mkEntry(7, 0L)
+        ), position.getPartitionPositions("topic1"));
     }
 
     @Test
     public void shouldCreateFromNullMap() {
         final Position position = Position.fromMap(null);
-        assertThat(position.getTopics(), equalTo(Collections.emptySet()));
+        assertTrue(position.getTopics().isEmpty());
     }
 
     @Test
@@ -97,14 +95,14 @@ public class PositionTest {
 
         final Position merged = position.merge(position1);
 
-        assertThat(merged.getTopics(), equalTo(Set.of("topic", "topic1", "topic2")));
-        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 7L))));
-        assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L),
-            mkEntry(8, 1L)
-        )));
-        assertThat(merged.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(9, 5L))));
+        assertEquals(Set.of("topic", "topic1", "topic2"), merged.getTopics());
+        assertEquals(mkMap(mkEntry(0, 7L)), merged.getPartitionPositions("topic"));
+        assertEquals(mkMap(
+                mkEntry(0, 5L),
+                mkEntry(7, 0L),
+                mkEntry(8, 1L)
+        ), merged.getPartitionPositions("topic1"));
+        assertEquals(mkMap(mkEntry(9, 5L)), merged.getPartitionPositions("topic2"));
     }
 
     @Test
@@ -112,9 +110,9 @@ public class PositionTest {
         final Position position = Position.emptyPosition();
         position.withComponent("topic", 3, 5L);
         position.withComponent("topic", 3, 4L);
-        assertThat(position.getPartitionPositions("topic").get(3), equalTo(5L));
+        assertEquals(5L, position.getPartitionPositions("topic").get(3));
         position.withComponent("topic", 3, 6L);
-        assertThat(position.getPartitionPositions("topic").get(3), equalTo(6L));
+        assertEquals(6L, position.getPartitionPositions("topic").get(3));
     }
 
     @Test
@@ -135,22 +133,22 @@ public class PositionTest {
         position.withComponent("topic2", 2, 4L);
 
         // copy has not changed
-        assertThat(copy.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(copy.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
-        assertThat(copy.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
-        )));
+        assertEquals(Set.of("topic", "topic1"), copy.getTopics());
+        assertEquals(mkMap(mkEntry(0, 5L)), copy.getPartitionPositions("topic"));
+        assertEquals(mkMap(
+                mkEntry(0, 5L),
+                mkEntry(7, 0L)
+        ), copy.getPartitionPositions("topic1"));
 
         // original has changed
-        assertThat(position.getTopics(), equalTo(Set.of("topic", "topic1", "topic2")));
-        assertThat(position.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 6L))));
-        assertThat(position.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L),
-            mkEntry(8, 1L)
-        )));
-        assertThat(position.getPartitionPositions("topic2"), equalTo(mkMap(mkEntry(2, 4L))));
+        assertEquals(Set.of("topic", "topic1", "topic2"), position.getTopics());
+        assertEquals(mkMap(mkEntry(0, 6L)), position.getPartitionPositions("topic"));
+        assertEquals(mkMap(
+                mkEntry(0, 5L),
+                mkEntry(7, 0L),
+                mkEntry(8, 1L)
+        ), position.getPartitionPositions("topic1"));
+        assertEquals(mkMap(mkEntry(2, 4L)), position.getPartitionPositions("topic2"));
     }
 
     @Test
@@ -165,12 +163,12 @@ public class PositionTest {
 
         final Position merged = position.merge(null);
 
-        assertThat(merged.getTopics(), equalTo(Set.of("topic", "topic1")));
-        assertThat(merged.getPartitionPositions("topic"), equalTo(mkMap(mkEntry(0, 5L))));
-        assertThat(merged.getPartitionPositions("topic1"), equalTo(mkMap(
-            mkEntry(0, 5L),
-            mkEntry(7, 0L)
-        )));
+        assertEquals(Set.of("topic", "topic1"), merged.getTopics());
+        assertEquals(mkMap(mkEntry(0, 5L)), merged.getPartitionPositions("topic"));
+        assertEquals(mkMap(
+                mkEntry(0, 5L),
+                mkEntry(7, 0L)
+        ), merged.getPartitionPositions("topic1"));
     }
 
     @Test
@@ -213,7 +211,7 @@ public class PositionTest {
     @Test
     public void shouldNotMatchNull() {
         final Position position = Position.emptyPosition();
-        assertNotEquals(position, null);
+        assertNotNull(position);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/StateQueryResultTest.java
@@ -22,10 +22,10 @@ import org.apache.kafka.streams.query.internals.SucceededQueryResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class StateQueryResultTest {
@@ -44,21 +44,21 @@ class StateQueryResultTest {
     void getOnlyPartitionResultNoResultsTest() {
         stringStateQueryResult.addResult(0, noResultsFound);
         final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
-        assertThat("Zero query results shouldn't error", result, nullValue());
+        assertNull(result, "Zero query results shouldn't error");
     }
 
     @Test
     void getOnlyPartitionResultWithSingleResultTest() {
         stringStateQueryResult.addResult(0, validResult);
         final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
-        assertThat("Valid query results still works", result.getResult(), is("Foo"));
+        assertEquals("Foo", result.getResult(), "Valid query results still works");
     }
 
     @Test
     void getOnlyPartitionResultWithSingleFailureResultTest() {
         stringStateQueryResult.addResult(0, invalidResult);
         final QueryResult<String> result = stringStateQueryResult.getOnlyPartitionResult();
-        assertThat("Invalid query result should be a failure", result.isFailure(), is(true));
+        assertTrue(result.isFailure(), "Invalid query result should be a failure");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/query/VersionedKeyQueryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/query/VersionedKeyQueryTest.java
@@ -31,7 +31,7 @@ public class VersionedKeyQueryTest {
     }
 
     @Test
-    public void shouldThrowNPEWithNullAsOftimestamp() {
+    public void shouldThrowNPEWithNullAsOfTimestamp() {
         final VersionedKeyQuery<Integer, VersionedRecord<Integer>> query = VersionedKeyQuery.withKey(1);
         final Exception exception = assertThrows(NullPointerException.class, () -> query.asOf(null));
         assertEquals("asOf timestamp cannot be null.", exception.getMessage());


### PR DESCRIPTION
Migrate usages of hamcrest to junit

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
