### PR TITLE
KAFKA-20950: Remove hamcrest from org.apache.kafka.streams.state package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/HostInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/HostInfoTest.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -34,8 +33,8 @@ public class HostInfoTest {
         final String endPoint = "host:9090";
         final HostInfo hostInfo = HostInfo.buildFromEndpoint(endPoint);
 
-        assertThat(hostInfo.host(), is("host"));
-        assertThat(hostInfo.port(), is(9090));
+        assertEquals("host", hostInfo.host());
+        assertEquals(9090, hostInfo.port());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -112,12 +110,11 @@ public class StateSerdesTest {
         final StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
         final Integer myInt = 123;
         final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(myInt, new RecordHeaders()));
-        assertThat(
-            e.getMessage(),
-            equalTo(
+        assertEquals(
                 "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                 "is not compatible to the actual value type (value type: java.lang.Integer). " +
-                "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+                "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters.",
+                e.getMessage());
     }
 
     @Test
@@ -129,12 +126,11 @@ public class StateSerdesTest {
             new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), new ValueAndTimestampSerde(Serdes.serdeFrom(myClass)));
         final Integer myInt = 123;
         final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(ValueAndTimestamp.make(myInt, 0L), new RecordHeaders()));
-        assertThat(
-            e.getMessage(),
-            equalTo(
-                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
-                    "is not compatible to the actual value type (value type: java.lang.Integer). " +
-                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+        assertEquals(
+            "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
+                "is not compatible to the actual value type (value type: java.lang.Integer). " +
+                "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters.",
+            e.getMessage());
     }
 
     @Test
@@ -144,12 +140,11 @@ public class StateSerdesTest {
         final StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
         final Integer myInt = 123;
         final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawKey(myInt, new RecordHeaders()));
-        assertThat(
-            e.getMessage(),
-            equalTo(
-                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
-                    "is not compatible to the actual key type (key type: java.lang.Integer). " +
-                    "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters."));
+        assertEquals(
+            "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
+                "is not compatible to the actual key type (key type: java.lang.Integer). " +
+                "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters.",
+            e.getMessage());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -111,10 +111,10 @@ public class StateSerdesTest {
         final Integer myInt = 123;
         final Exception e = assertThrows(StreamsException.class, () -> stateSerdes.rawValue(myInt, new RecordHeaders()));
         assertEquals(
-                "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
+            "A serializer (org.apache.kafka.common.serialization.StringSerializer) " +
                 "is not compatible to the actual value type (value type: java.lang.Integer). " +
                 "Change the default Serdes in StreamConfig or provide correct Serdes via method parameters.",
-                e.getMessage());
+            e.getMessage());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
@@ -33,14 +33,12 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofMillis;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StoresTest {
 
@@ -175,52 +173,53 @@ public class StoresTest {
 
     @Test
     public void shouldCreateInMemoryKeyValueStore() {
-        assertThat(Stores.inMemoryKeyValueStore("memory").get(), instanceOf(InMemoryKeyValueStore.class));
+        assertInstanceOf(InMemoryKeyValueStore.class, Stores.inMemoryKeyValueStore("memory").get());
     }
 
     @Test
     public void shouldCreateMemoryNavigableCache() {
-        assertThat(Stores.lruMap("map", 10).get(), instanceOf(MemoryNavigableLRUCache.class));
+        assertInstanceOf(MemoryNavigableLRUCache.class, Stores.lruMap("map", 10).get());
     }
 
     @Test
     public void shouldCreateRocksDbStore() {
-        assertThat(
-            Stores.persistentKeyValueStore("store").get(),
-            allOf(not(instanceOf(RocksDBTimestampedStore.class)), instanceOf(RocksDBStore.class)));
+        final KeyValueStore<Bytes, byte[]> store = Stores.persistentKeyValueStore("store").get();
+        assertInstanceOf(RocksDBStore.class, store);
+        assertFalse(store instanceof RocksDBTimestampedStore);
     }
 
     @Test
     public void shouldCreateRocksDbTimestampedStore() {
-        assertThat(Stores.persistentTimestampedKeyValueStore("store").get(), instanceOf(RocksDBTimestampedStore.class));
+        assertInstanceOf(RocksDBTimestampedStore.class, Stores.persistentTimestampedKeyValueStore("store").get());
     }
 
     @Test
     public void shouldCreateRocksDbVersionedStore() {
         final KeyValueStore<Bytes, byte[]> store = Stores.persistentVersionedKeyValueStore("store", ofMillis(1)).get();
-        assertThat(store, instanceOf(VersionedBytesStore.class));
-        assertThat(store.persistent(), equalTo(true));
+        assertInstanceOf(VersionedBytesStore.class, store);
+        assertTrue(store.persistent());
     }
 
     @Test
     public void shouldCreateRocksDbWindowStore() {
-        final WindowStore store = Stores.persistentWindowStore("store", ofMillis(1L), ofMillis(1L), false).get();
+        final WindowStore<Bytes, byte[]> store = Stores.persistentWindowStore("store", ofMillis(1L), ofMillis(1L), false).get();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(RocksDBWindowStore.class));
-        assertThat(wrapped, allOf(not(instanceOf(RocksDBTimestampedSegmentedBytesStore.class)), instanceOf(RocksDBSegmentedBytesStore.class)));
+        assertInstanceOf(RocksDBWindowStore.class, store);
+        assertInstanceOf(RocksDBSegmentedBytesStore.class, wrapped);
+        assertFalse(wrapped instanceof RocksDBTimestampedSegmentedBytesStore);
     }
 
     @Test
     public void shouldCreateRocksDbTimestampedWindowStore() {
-        final WindowStore store = Stores.persistentTimestampedWindowStore("store", ofMillis(1L), ofMillis(1L), false).get();
+        final WindowStore<Bytes, byte[]> store = Stores.persistentTimestampedWindowStore("store", ofMillis(1L), ofMillis(1L), false).get();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(RocksDBWindowStore.class));
-        assertThat(wrapped, instanceOf(RocksDBTimestampedSegmentedBytesStore.class));
+        assertInstanceOf(RocksDBWindowStore.class, store);
+        assertInstanceOf(RocksDBTimestampedSegmentedBytesStore.class, wrapped);
     }
 
     @Test
     public void shouldCreateRocksDbSessionStore() {
-        assertThat(Stores.persistentSessionStore("store", ofMillis(1)).get(), instanceOf(RocksDBSessionStore.class));
+        assertInstanceOf(RocksDBSessionStore.class, Stores.persistentSessionStore("store", ofMillis(1)).get());
     }
 
     @Test
@@ -230,7 +229,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -240,7 +239,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -250,7 +249,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -260,8 +259,8 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).withLoggingDisabled().withCachingDisabled().build();
-        assertThat(store, not(nullValue()));
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(TimestampedBytesStore.class));
+        assertNotNull(store);
+        assertInstanceOf(TimestampedBytesStore.class, ((WrappedStateStore) store).wrapped());
     }
 
     @Test
@@ -271,7 +270,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -281,7 +280,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -291,7 +290,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -301,7 +300,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -311,8 +310,8 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).withLoggingDisabled().withCachingDisabled().build();
-        assertThat(store, not(nullValue()));
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(TimestampedBytesStore.class));
+        assertNotNull(store);
+        assertInstanceOf(TimestampedBytesStore.class, ((WrappedStateStore) store).wrapped());
     }
 
     @Test
@@ -322,7 +321,7 @@ public class StoresTest {
             Serdes.String(),
             Serdes.String()
         ).build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -391,33 +390,33 @@ public class StoresTest {
     @Test
     public void shouldCreatePersistentTimestampedKeyValueStoreWithHeadersSupplier() {
         final KeyValueBytesStoreSupplier supplier = Stores.persistentTimestampedKeyValueStoreWithHeaders("store");
-        assertThat(supplier.name(), equalTo("store"));
-        assertThat(supplier.metricsScope(), equalTo("rocksdb"));
-        assertThat(supplier.get(), not(nullValue()));
-        assertThat(supplier.get().persistent(), equalTo(true));
+        assertEquals("store", supplier.name());
+        assertEquals("rocksdb", supplier.metricsScope());
+        assertNotNull(supplier.get());
+        assertTrue(supplier.get().persistent());
     }
 
     @Test
     public void shouldCreatePersistentTimestampedWindowStoreWithHeadersSupplier() {
         final WindowBytesStoreSupplier supplier =
             Stores.persistentTimestampedWindowStoreWithHeaders("store", ofMillis(10L), ofMillis(5L), false);
-        assertThat(supplier.name(), equalTo("store"));
-        assertThat(supplier.windowSize(), equalTo(5L));
-        assertThat(supplier.retentionPeriod(), equalTo(10L));
-        assertThat(supplier.retainDuplicates(), equalTo(false));
-        assertThat(supplier.get(), not(nullValue()));
-        assertThat(supplier.get().persistent(), equalTo(true));
+        assertEquals("store", supplier.name());
+        assertEquals(5L, supplier.windowSize());
+        assertEquals(10L, supplier.retentionPeriod());
+        assertFalse(supplier.retainDuplicates());
+        assertNotNull(supplier.get());
+        assertTrue(supplier.get().persistent());
     }
 
     @Test
     public void shouldCreatePersistentSessionStoreWithHeadersSupplier() {
         final SessionBytesStoreSupplier supplier =
             Stores.persistentSessionStoreWithHeaders("store", ofMillis(100L));
-        assertThat(supplier.name(), equalTo("store"));
-        assertThat(supplier.metricsScope(), equalTo("rocksdb-session"));
-        assertThat(supplier.retentionPeriod(), equalTo(100L));
-        assertThat(supplier.get(), not(nullValue()));
-        assertThat(supplier.get().persistent(), equalTo(true));
+        assertEquals("store", supplier.name());
+        assertEquals("rocksdb-session", supplier.metricsScope());
+        assertEquals(100L, supplier.retentionPeriod());
+        assertNotNull(supplier.get());
+        assertTrue(supplier.get().persistent());
     }
 
     @Test
@@ -428,7 +427,7 @@ public class StoresTest {
                 Serdes.String(),
                 Serdes.String()
             ).withLoggingDisabled().build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -439,7 +438,7 @@ public class StoresTest {
                 Serdes.String(),
                 Serdes.String()
             ).withLoggingDisabled().build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 
     @Test
@@ -450,6 +449,6 @@ public class StoresTest {
                 Serdes.String(),
                 Serdes.String()
             ).withLoggingDisabled().build();
-        assertThat(store, not(nullValue()));
+        assertNotNull(store);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/StreamsMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StreamsMetadataTest.java
@@ -27,10 +27,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamsMetadataTest {
 
@@ -57,10 +56,10 @@ public class StreamsMetadataTest {
 
     @Test
     public void shouldNotAllowModificationOfInternalStateViaGetters() {
-        assertThat(isUnmodifiable(streamsMetadata.stateStoreNames()), is(true));
-        assertThat(isUnmodifiable(streamsMetadata.topicPartitions()), is(true));
-        assertThat(isUnmodifiable(streamsMetadata.standbyTopicPartitions()), is(true));
-        assertThat(isUnmodifiable(streamsMetadata.standbyStateStoreNames()), is(true));
+        assertTrue(isUnmodifiable(streamsMetadata.stateStoreNames()));
+        assertTrue(isUnmodifiable(streamsMetadata.topicPartitions()));
+        assertTrue(isUnmodifiable(streamsMetadata.standbyTopicPartitions()));
+        assertTrue(isUnmodifiable(streamsMetadata.standbyStateStoreNames()));
     }
 
     @Test
@@ -71,8 +70,8 @@ public class StreamsMetadataTest {
             TOPIC_PARTITIONS,
             STAND_BY_STORE_NAMES,
             STANDBY_TOPIC_PARTITIONS);
-        assertThat(streamsMetadata, equalTo(same));
-        assertThat(streamsMetadata.hashCode(), equalTo(same.hashCode()));
+        assertEquals(same, streamsMetadata);
+        assertEquals(same.hashCode(), streamsMetadata.hashCode());
     }
 
     @Test
@@ -83,8 +82,8 @@ public class StreamsMetadataTest {
             TOPIC_PARTITIONS,
             STAND_BY_STORE_NAMES,
             STANDBY_TOPIC_PARTITIONS);
-        assertThat(streamsMetadata, not(equalTo(differHostInfo)));
-        assertThat(streamsMetadata.hashCode(), not(equalTo(differHostInfo.hashCode())));
+        assertNotEquals(differHostInfo, streamsMetadata);
+        assertNotEquals(differHostInfo.hashCode(), streamsMetadata.hashCode());
     }
 
     @Test
@@ -95,8 +94,8 @@ public class StreamsMetadataTest {
             TOPIC_PARTITIONS,
             STAND_BY_STORE_NAMES,
             STANDBY_TOPIC_PARTITIONS);
-        assertThat(streamsMetadata, not(equalTo(differStateStoreNames)));
-        assertThat(streamsMetadata.hashCode(), not(equalTo(differStateStoreNames.hashCode())));
+        assertNotEquals(differStateStoreNames, streamsMetadata);
+        assertNotEquals(differStateStoreNames.hashCode(), streamsMetadata.hashCode());
     }
 
     @Test
@@ -107,8 +106,8 @@ public class StreamsMetadataTest {
             Set.of(TP_0),
             STAND_BY_STORE_NAMES,
             STANDBY_TOPIC_PARTITIONS);
-        assertThat(streamsMetadata, not(equalTo(differTopicPartitions)));
-        assertThat(streamsMetadata.hashCode(), not(equalTo(differTopicPartitions.hashCode())));
+        assertNotEquals(differTopicPartitions, streamsMetadata);
+        assertNotEquals(differTopicPartitions.hashCode(), streamsMetadata.hashCode());
     }
 
     @Test
@@ -119,8 +118,8 @@ public class StreamsMetadataTest {
             TOPIC_PARTITIONS,
             Set.of("store1"),
             STANDBY_TOPIC_PARTITIONS);
-        assertThat(streamsMetadata, not(equalTo(differStandByStores)));
-        assertThat(streamsMetadata.hashCode(), not(equalTo(differStandByStores.hashCode())));
+        assertNotEquals(differStandByStores, streamsMetadata);
+        assertNotEquals(differStandByStores.hashCode(), streamsMetadata.hashCode());
     }
 
     @Test
@@ -131,8 +130,8 @@ public class StreamsMetadataTest {
             TOPIC_PARTITIONS,
             STAND_BY_STORE_NAMES,
             Set.of(TP_0));
-        assertThat(streamsMetadata, not(equalTo(differStandByTopicPartitions)));
-        assertThat(streamsMetadata.hashCode(), not(equalTo(differStandByTopicPartitions.hashCode())));
+        assertNotEquals(differStandByTopicPartitions, streamsMetadata);
+        assertNotEquals(differStandByTopicPartitions.hashCode(), streamsMetadata.hashCode());
     }
 
     private static boolean isUnmodifiable(final Collection<?> collection) {


### PR DESCRIPTION
Migrate usages of hamcrest to junit

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
