### PR TITLE
KAFKA-20951: Clean up sensor bookkeeping on individual removal

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -40,10 +40,12 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -92,14 +94,14 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     private final Version version;
     private final Deque<MetricName> clientLevelMetrics = new LinkedList<>();
-    private final Deque<String> clientLevelSensors = new LinkedList<>();
+    private final Set<String> clientLevelSensors = new LinkedHashSet<>();
     private final Map<String, Deque<MetricName>> threadLevelMetrics = new HashMap<>();
-    private final Map<String, Deque<String>> threadLevelSensors = new HashMap<>();
-    private final Map<String, Deque<String>> taskLevelSensors = new HashMap<>();
-    private final Map<String, Deque<String>> nodeLevelSensors = new HashMap<>();
-    private final Map<String, Deque<String>> topicLevelSensors = new HashMap<>();
-    private final Map<String, Deque<String>> cacheLevelSensors = new HashMap<>();
-    private final ConcurrentMap<String, Deque<String>> storeLevelSensors = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> threadLevelSensors = new HashMap<>();
+    private final Map<String, Set<String>> taskLevelSensors = new HashMap<>();
+    private final Map<String, Set<String>> nodeLevelSensors = new HashMap<>();
+    private final Map<String, Set<String>> topicLevelSensors = new HashMap<>();
+    private final Map<String, Set<String>> cacheLevelSensors = new HashMap<>();
+    private final ConcurrentMap<String, Set<String>> storeLevelSensors = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Deque<MetricName>> storeLevelMetrics = new ConcurrentHashMap<>();
 
     private final RocksDBMetricsRecordingTrigger rocksDBMetricsRecordingTrigger;
@@ -284,7 +286,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             final String fullSensorName = CLIENT_LEVEL_GROUP + SENSOR_NAME_DELIMITER + sensorName;
             final Sensor sensor = metrics.getSensor(fullSensorName);
             if (sensor == null) {
-                clientLevelSensors.push(fullSensorName);
+                clientLevelSensors.add(fullSensorName);
                 return metrics.sensor(fullSensorName, recordingLevel, parents);
             }
             return sensor;
@@ -340,18 +342,18 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     private void removeAllClientLevelSensors() {
         synchronized (clientLevelSensors) {
-            while (!clientLevelSensors.isEmpty()) {
-                metrics.removeSensor(clientLevelSensors.pop());
-            }
+            final List<String> sensorNames = List.copyOf(clientLevelSensors);
+            clientLevelSensors.clear();
+            sensorNames.forEach(metrics::removeSensor);
         }
     }
 
     public final void removeAllThreadLevelSensors(final String threadId) {
         final String key = threadSensorPrefix(threadId);
         synchronized (threadLevelSensors) {
-            final Deque<String> sensors = threadLevelSensors.remove(key);
-            while (sensors != null && !sensors.isEmpty()) {
-                metrics.removeSensor(sensors.pop());
+            final Set<String> sensors = threadLevelSensors.remove(key);
+            if (sensors != null) {
+                sensors.forEach(metrics::removeSensor);
             }
         }
     }
@@ -446,9 +448,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public final void removeAllTaskLevelSensors(final String threadId, final String taskId) {
         final String key = taskSensorPrefix(threadId, taskId);
         synchronized (taskLevelSensors) {
-            final Deque<String> sensors = taskLevelSensors.remove(key);
-            while (sensors != null && !sensors.isEmpty()) {
-                metrics.removeSensor(sensors.pop());
+            final Set<String> sensors = taskLevelSensors.remove(key);
+            if (sensors != null) {
+                sensors.forEach(metrics::removeSensor);
             }
         }
     }
@@ -475,9 +477,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String processorNodeName) {
         final String key = nodeSensorPrefix(threadId, taskId, processorNodeName);
         synchronized (nodeLevelSensors) {
-            final Deque<String> sensors = nodeLevelSensors.remove(key);
-            while (sensors != null && !sensors.isEmpty()) {
-                metrics.removeSensor(sensors.pop());
+            final Set<String> sensors = nodeLevelSensors.remove(key);
+            if (sensors != null) {
+                sensors.forEach(metrics::removeSensor);
             }
         }
     }
@@ -506,9 +508,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                  final String topicName) {
         final String key = topicSensorPrefix(threadId, taskId, processorNodeName, topicName);
         synchronized (topicLevelSensors) {
-            final Deque<String> sensors = topicLevelSensors.remove(key);
-            while (sensors != null && !sensors.isEmpty()) {
-                metrics.removeSensor(sensors.pop());
+            final Set<String> sensors = topicLevelSensors.remove(key);
+            if (sensors != null) {
+                sensors.forEach(metrics::removeSensor);
             }
         }
     }
@@ -547,9 +549,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public final void removeAllCacheLevelSensors(final String threadId, final String taskId, final String cacheName) {
         final String key = cacheSensorPrefix(threadId, taskId, cacheName);
         synchronized (cacheLevelSensors) {
-            final Deque<String> strings = cacheLevelSensors.remove(key);
-            while (strings != null && !strings.isEmpty()) {
-                metrics.removeSensor(strings.pop());
+            final Set<String> sensors = cacheLevelSensors.remove(key);
+            if (sensors != null) {
+                sensors.forEach(metrics::removeSensor);
             }
         }
     }
@@ -567,7 +569,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         final String sensorPrefix = storeSensorPrefix(Thread.currentThread().getName(), taskId, storeName);
             // since the keys in the map storeLevelSensors contain the name of the current thread and threads only
             // access keys in which their name is contained, the value in the maps do not need to be thread safe
-            // and we can use a LinkedList here.
+            // and we can use a LinkedHashSet here.
             // TODO: In future, we could use thread local maps since each thread will exclusively access the set of keys
             //  that contain its name. Similar is true for the other metric levels. Thread-level metrics need some
             //  special attention, since they are created before the thread is constructed. The creation of those
@@ -608,9 +610,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                             final String taskId,
                                             final String storeName) {
         final String key = storeSensorPrefix(threadId, taskId, storeName);
-        final Deque<String> sensors = storeLevelSensors.remove(key);
-        while (sensors != null && !sensors.isEmpty()) {
-            metrics.removeSensor(sensors.pop());
+        final Set<String> sensors = storeLevelSensors.remove(key);
+        if (sensors != null) {
+            sensors.forEach(metrics::removeSensor);
         }
     }
 
@@ -971,7 +973,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         }
     }
 
-    private Sensor getSensors(final Map<String, Deque<String>> sensors,
+    private Sensor getSensors(final Map<String, Set<String>> sensors,
                               final String sensorSuffix,
                               final String sensorPrefix,
                               final RecordingLevel recordingLevel,
@@ -979,7 +981,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         final String fullSensorName = sensorPrefix + SENSOR_NAME_DELIMITER + sensorSuffix;
         final Sensor sensor = metrics.getSensor(fullSensorName);
         if (sensor == null) {
-            sensors.computeIfAbsent(sensorPrefix, ignored -> new LinkedList<>()).push(fullSensorName);
+            sensors.computeIfAbsent(sensorPrefix, ignored -> new LinkedHashSet<>()).add(fullSensorName);
             return metrics.sensor(fullSensorName, recordingLevel, parents);
         }
         return sensor;
@@ -1004,6 +1006,25 @@ public class StreamsMetricsImpl implements StreamsMetrics {
      */
     Map<Sensor, Sensor> parentSensors() {
         return Collections.unmodifiableMap(parentSensors);
+    }
+
+    /**
+     * Visible for testing
+     */
+    Map<String, Set<String>> topicLevelSensors() {
+        synchronized (topicLevelSensors) {
+            return topicLevelSensors.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        }
+    }
+
+    /**
+     * Visible for testing
+     */
+    Set<String> clientLevelSensors() {
+        synchronized (clientLevelSensors) {
+            return Set.copyOf(clientLevelSensors);
+        }
     }
 
     private static String groupNameFromScope(final String scopeName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -89,7 +89,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     private final Metrics metrics;
-    private final Map<Sensor, Sensor> parentSensors;
     private final String clientId;
 
     private final Version version;
@@ -176,8 +175,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         this.clientId = clientId;
         version = Version.LATEST;
         rocksDBMetricsRecordingTrigger = new RocksDBMetricsRecordingTrigger(time);
-
-        this.parentSensors = new HashMap<>();
     }
 
     public Version version() {
@@ -987,26 +984,24 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         return sensor;
     }
 
-    /**
-     * Deletes a sensor and its parents, if any
-     */
     @Override
     public void removeSensor(final Sensor sensor) {
         Objects.requireNonNull(sensor, "Sensor is null");
         removeSensorName(sensor.name());
         metrics.removeSensor(sensor.name());
-
-        final Sensor parent = parentSensors.remove(sensor);
-        if (parent != null) {
-            metrics.removeSensor(parent.name());
-        }
     }
 
     /**
-     * Removes a sensor name from the bookkeeping collections used by the current
-     * individual-removal paths. Client-level names are handled directly; the
-     * per-entity paths use thread- and topic-level sensors. Other levels are
-     * removed in bulk, which drops the whole bookkeeping entry.
+     * Removes a sensor name from the bookkeeping collections. Client-level names are
+     * looked up directly; for the other levels the prefix is derived from the sensor
+     * name, which maps to exactly one level.
+     *
+     * Store-level sensors are left out on purpose: they are only removed in bulk and
+     * their collection is not guarded by a lock, because a store key contains the name
+     * of the thread that created it and only that thread accesses it.
+     *
+     * A sensor suffix that contains the delimiter is not resolved to its prefix; the
+     * name is then left in the collection until the bulk removal drops the whole entry.
      */
     private void removeSensorName(final String fullSensorName) {
         synchronized (clientLevelSensors) {
@@ -1019,9 +1014,19 @@ public class StreamsMetricsImpl implements StreamsMetrics {
             return;
         }
         final String sensorPrefix = fullSensorName.substring(0, index);
-        if (!removeSensorName(threadLevelSensors, sensorPrefix, fullSensorName)) {
-            removeSensorName(topicLevelSensors, sensorPrefix, fullSensorName);
+        if (removeSensorName(threadLevelSensors, sensorPrefix, fullSensorName)) {
+            return;
         }
+        if (removeSensorName(taskLevelSensors, sensorPrefix, fullSensorName)) {
+            return;
+        }
+        if (removeSensorName(nodeLevelSensors, sensorPrefix, fullSensorName)) {
+            return;
+        }
+        if (removeSensorName(topicLevelSensors, sensorPrefix, fullSensorName)) {
+            return;
+        }
+        removeSensorName(cacheLevelSensors, sensorPrefix, fullSensorName);
     }
 
     private boolean removeSensorName(final Map<String, Set<String>> sensors,
@@ -1042,8 +1047,31 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     /**
      * Visible for testing
      */
-    Map<Sensor, Sensor> parentSensors() {
-        return Collections.unmodifiableMap(parentSensors);
+    Map<String, Set<String>> taskLevelSensors() {
+        synchronized (taskLevelSensors) {
+            return taskLevelSensors.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        }
+    }
+
+    /**
+     * Visible for testing
+     */
+    Map<String, Set<String>> nodeLevelSensors() {
+        synchronized (nodeLevelSensors) {
+            return nodeLevelSensors.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        }
+    }
+
+    /**
+     * Visible for testing
+     */
+    Map<String, Set<String>> cacheLevelSensors() {
+        synchronized (cacheLevelSensors) {
+            return cacheLevelSensors.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -993,6 +993,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     @Override
     public void removeSensor(final Sensor sensor) {
         Objects.requireNonNull(sensor, "Sensor is null");
+        removeSensorName(sensor.name());
         metrics.removeSensor(sensor.name());
 
         final Sensor parent = parentSensors.remove(sensor);
@@ -1002,10 +1003,57 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     /**
+     * Removes a sensor name from the bookkeeping collections used by the current
+     * individual-removal paths. Client-level names are handled directly; the
+     * per-entity paths use thread- and topic-level sensors. Other levels are
+     * removed in bulk, which drops the whole bookkeeping entry.
+     */
+    private void removeSensorName(final String fullSensorName) {
+        synchronized (clientLevelSensors) {
+            if (clientLevelSensors.remove(fullSensorName)) {
+                return;
+            }
+        }
+        final int index = fullSensorName.lastIndexOf(SENSOR_NAME_DELIMITER);
+        if (index < 0) {
+            return;
+        }
+        final String sensorPrefix = fullSensorName.substring(0, index);
+        if (!removeSensorName(threadLevelSensors, sensorPrefix, fullSensorName)) {
+            removeSensorName(topicLevelSensors, sensorPrefix, fullSensorName);
+        }
+    }
+
+    private boolean removeSensorName(final Map<String, Set<String>> sensors,
+                                     final String sensorPrefix,
+                                     final String fullSensorName) {
+        synchronized (sensors) {
+            final Set<String> sensorNames = sensors.get(sensorPrefix);
+            if (sensorNames == null || !sensorNames.remove(fullSensorName)) {
+                return false;
+            }
+            if (sensorNames.isEmpty()) {
+                sensors.remove(sensorPrefix);
+            }
+            return true;
+        }
+    }
+
+    /**
      * Visible for testing
      */
     Map<Sensor, Sensor> parentSensors() {
         return Collections.unmodifiableMap(parentSensors);
+    }
+
+    /**
+     * Visible for testing
+     */
+    Map<String, Set<String>> threadLevelSensors() {
+        synchronized (threadLevelSensors) {
+            return threadLevelSensors.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())));
+        }
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -407,6 +407,45 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
+    public void shouldRemoveTaskLevelSensorNameWhenSensorIsRemoved() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor sensor = streamsMetrics.taskLevelSensor(
+                THREAD_ID1, TASK_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(sensor);
+        }
+
+        assertThat(streamsMetrics.taskLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldRemoveNodeLevelSensorNameWhenSensorIsRemoved() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor sensor = streamsMetrics.nodeLevelSensor(
+                THREAD_ID1, TASK_ID1, NODE_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(sensor);
+        }
+
+        assertThat(streamsMetrics.nodeLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldRemoveCacheLevelSensorNameWhenSensorIsRemoved() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor sensor = streamsMetrics.cacheLevelSensor(
+                THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(sensor);
+        }
+
+        assertThat(streamsMetrics.cacheLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
     public void shouldRemoveClientLevelSensorNameWhenSensorIsRemoved() {
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
 
@@ -903,7 +942,9 @@ public class StreamsMetricsImplTest {
         final Sensor sensor3 = streamsMetrics.addRateTotalSensor(scope, entity, operation, RecordingLevel.DEBUG);
         streamsMetrics.removeSensor(sensor3);
 
-        assertEquals(Collections.emptyMap(), streamsMetrics.parentSensors());
+        assertNull(metrics.getSensor(sensor1.name()));
+        assertNull(metrics.getSensor(sensor2.name()));
+        assertNull(metrics.getSensor(sensor3.name()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -339,6 +340,34 @@ public class StreamsMetricsImplTest {
         );
 
         assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldNotRetainDuplicateSensorNamesWhenSensorIsRecreated() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor recreated = streamsMetrics.topicLevelSensor(
+                THREAD_ID1, TASK_ID1, NODE_ID1, TOPIC_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(recreated);
+        }
+
+        final int retainedNames = streamsMetrics.topicLevelSensors().values().stream()
+            .mapToInt(Set::size)
+            .sum();
+        assertThat(retainedNames, is(1));
+    }
+
+    @Test
+    public void shouldNotRetainDuplicateClientLevelSensorNamesWhenSensorIsRecreated() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor recreated = streamsMetrics.clientLevelSensor(SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+            streamsMetrics.removeSensor(recreated);
+        }
+
+        assertThat(streamsMetrics.clientLevelSensors().size(), is(1));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -343,31 +343,79 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldNotRetainDuplicateSensorNamesWhenSensorIsRecreated() {
+    public void shouldRemoveSensorNameWhenSensorIsRemoved() {
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
 
         for (int i = 0; i < 5; i++) {
-            final Sensor recreated = streamsMetrics.topicLevelSensor(
+            final Sensor sensor = streamsMetrics.topicLevelSensor(
                 THREAD_ID1, TASK_ID1, NODE_ID1, TOPIC_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
-            streamsMetrics.removeSensor(recreated);
+            streamsMetrics.removeSensor(sensor);
         }
 
-        final int retainedNames = streamsMetrics.topicLevelSensors().values().stream()
-            .mapToInt(Set::size)
-            .sum();
-        assertThat(retainedNames, is(1));
+        assertThat(streamsMetrics.topicLevelSensors().isEmpty(), is(true));
     }
 
     @Test
-    public void shouldNotRetainDuplicateClientLevelSensorNamesWhenSensorIsRecreated() {
+    public void shouldRemoveSensorNamesOfDistinctSensorsWhenTheyAreRemoved() {
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
 
         for (int i = 0; i < 5; i++) {
-            final Sensor recreated = streamsMetrics.clientLevelSensor(SENSOR_NAME_1, INFO_RECORDING_LEVEL);
-            streamsMetrics.removeSensor(recreated);
+            final Sensor sensor = streamsMetrics.topicLevelSensor(
+                THREAD_ID1, TASK_ID1, NODE_ID1, TOPIC_ID1 + i, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(sensor);
         }
 
-        assertThat(streamsMetrics.clientLevelSensors().size(), is(1));
+        assertThat(streamsMetrics.topicLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldRemoveSensorNameWhenTopicContainsSensorNameDelimiter() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        final Sensor sensor = streamsMetrics.topicLevelSensor(
+            THREAD_ID1, TASK_ID1, NODE_ID1, "topic.s.with.delimiter", SENSOR_NAME_1, RecordingLevel.INFO);
+        streamsMetrics.removeSensor(sensor);
+
+        assertThat(streamsMetrics.topicLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldRemoveThreadLevelSensorNameWhenSensorIsRemoved() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor sensor = streamsMetrics.threadLevelSensor(THREAD_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
+            streamsMetrics.removeSensor(sensor);
+        }
+
+        assertThat(streamsMetrics.threadLevelSensors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldKeepRemainingSensorNamesOfTheSameEntity() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+        final Sensor removed = streamsMetrics.topicLevelSensor(
+            THREAD_ID1, TASK_ID1, NODE_ID1, TOPIC_ID1, SENSOR_NAME_1, RecordingLevel.INFO);
+        final Sensor remaining = streamsMetrics.topicLevelSensor(
+            THREAD_ID1, TASK_ID1, NODE_ID1, TOPIC_ID1, SENSOR_NAME_2, RecordingLevel.INFO);
+
+        streamsMetrics.removeSensor(removed);
+
+        final Map<String, Set<String>> topicLevelSensors = streamsMetrics.topicLevelSensors();
+        assertThat(topicLevelSensors.size(), is(1));
+        assertThat(topicLevelSensors.values().iterator().next(), is(Set.of(remaining.name())));
+    }
+
+    @Test
+    public void shouldRemoveClientLevelSensorNameWhenSensorIsRemoved() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), CLIENT_ID, time);
+
+        for (int i = 0; i < 5; i++) {
+            final Sensor sensor = streamsMetrics.clientLevelSensor(SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+            streamsMetrics.removeSensor(sensor);
+        }
+
+        assertThat(streamsMetrics.clientLevelSensors().isEmpty(), is(true));
     }
 
     @Test


### PR DESCRIPTION
StreamsMetricsImpl records sensor names in per-level collections so the
sensors can be removed later. `removeSensor(Sensor)` dropped the sensor
from the Metrics registry but left its name behind, so entries stayed
around for sensors that no longer exist. `RecordQueue#close()` and
`RecordCollectorImpl#removeAllProducedSensors()` remove topic-level
sensors that way, while
`DefaultStateUpdater.StateUpdaterMetrics#clear()` removes thread-level
sensors.

`removeSensor(Sensor)` now removes the name from bookkeeping as well and
drops the entry once it becomes empty. Following review feedback, the
lookup covers all synchronized level collections so individual removal
is not coupled to the current call sites. Store-level bookkeeping
remains excluded because store-level sensors are removed in bulk and
their bookkeeping relies on thread-confined access.

This also removes the unused `parentSensors` map, as suggested in
review. The map has had no writer since KAFKA-12808, so it was always
empty and its removal does not change behavior.

The tests fail without the change.

Reviewers: Matthias J. Sax <matthias@confluent.io>
