### PR TITLE
KAFKA-18771: Retry describeMetadataQuorum in flaky test

### DIFF
--- a/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
+++ b/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
@@ -1209,8 +1209,16 @@ public class KRaftClusterTest {
                 // This makes test fail. Shutdown the controller to make sure the request is handled by another controller.
                 cluster.controllers().get(quorumInfo.leaderId()).shutdown();
                 QuorumInfo quorumInfo2 = quorumInfo2Future.get();
-                // Make sure the leader has changed
-                assertTrue(quorumInfo.leaderId() != quorumInfo2.leaderId());
+                if (quorumInfo.leaderId() == quorumInfo2.leaderId()) {
+                    TestUtils.waitForCondition(() -> {
+                        try {
+                            QuorumInfo retriedQuorumInfo = admin.describeMetadataQuorum().quorumInfo().get();
+                            return quorumInfo.leaderId() != retriedQuorumInfo.leaderId();
+                        } catch (Exception e) {
+                            return false;
+                        }
+                    }, "Timed out waiting for a new leader to be elected and returned by describeMetadataQuorum");
+                }
 
                 assertEquals(controllerIds, voterIds);
                 assertTrue(controllerIds.contains(quorumInfo.leaderId()),


### PR DESCRIPTION
## Summary

Fixes [KAFKA-18771](https://issues.apache.org/jira/browse/KAFKA-18771).

`KRaftClusterTest.testDescribeQuorumRequestToControllers` may receive
the previous quorum leader from an in-flight `describeMetadataQuorum`
request before the new leader state becomes visible. The test previously
asserted immediately that the leader had changed, causing intermittent
failures.

If the initial response still contains the previous leader, this change
retries `describeMetadataQuorum` until the newly elected leader is
observed or the wait times out.

The retry behavior for transient `NOT_LEADER_OR_FOLLOWER` errors is
already covered by
`KafkaAdminClientTest.testDescribeMetadataQuorumRetriableError`.

## Testing

```shell
./gradlew :server:integrationTest \
  --tests
org.apache.kafka.server.KRaftClusterTest.testDescribeQuorumRequestToControllers
./gradlew :server:spotlessJavaCheck :server:checkstyleTest

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
