### PR TITLE
MINOR: Make RocksDBStore.putAll a synchronized method for lock symmetry with put

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -511,7 +511,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
     }
 
     @Override
-    public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+    public synchronized void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
         Objects.requireNonNull(entries, "entries cannot be null");
         // Validate up front so a null key rejects the whole batch. An accessor may apply the entries
         // one at a time, and failing part-way through would otherwise leave the batch half-applied.


### PR DESCRIPTION
`RocksDBStore.putAll` currently guards only its `synchronized
(position)` block, whereas put and the read/mutate paths (`get`,
`delete`, `range`, `reverseRange`, `all`, `close`) are
method-synchronized on this.

This isn't a correctness bug today — `AbstractTransactionBuffer` guards
its `TreeMap` with its own read/write lock (owner stage() → write lock,
non-owner get/scan → read lock) and `DirectDBAccessor` delegates to
thread-safe RocksDB, so the buffer is protected regardless.   But it
leaves putAll relying on the lower layer for exclusion instead of the
store-level lock every sibling uses.

This PR makes putAll a synchronized method (keeping the inner
synchronized (position)), matching put and removing the asymmetry. Lock
ordering is unchanged — put and commit already establish this →
position, and putAll follows the same order, so no new deadlock risk.

No new tests: behavior is unchanged; this only widens the existing lock
scope to match the sibling methods.

Reviewers: Matthias J. Sax <matthias@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
