### PR TITLE
MINOR: Idempotent initialize share group state.

### DIFF
--- a/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
+++ b/share-coordinator/src/main/java/org/apache/kafka/coordinator/share/ShareCoordinatorShard.java
@@ -563,8 +563,9 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
         InitializeShareGroupStateRequestData.PartitionData partitionData = topicData.partitions().get(0);
         SharePartitionKey key = SharePartitionKey.getInstance(request.groupId(), topicData.topicId(), partitionData.partition());
 
-        CoordinatorRecord record = generateInitializeStateRecord(partitionData, key);
-        // build successful response if record is correctly created
+        Integer currentStateEpoch = stateEpochMap.get(key);
+        ShareGroupOffset currentState = shareStateMap.get(key);
+
         InitializeShareGroupStateResponseData responseData = new InitializeShareGroupStateResponseData().setResults(
             List.of(InitializeShareGroupStateResponse.toResponseInitializeStateResult(key.topicId(),
                 List.of(InitializeShareGroupStateResponse.toResponsePartitionResult(
@@ -572,6 +573,13 @@ public class ShareCoordinatorShard implements CoordinatorShard<CoordinatorRecord
             ))
         );
 
+        if (currentStateEpoch != null && currentStateEpoch == partitionData.stateEpoch() &&
+                currentState != null && currentState.startOffset() == partitionData.startOffset()) {
+            log.debug("Duplicate initialize request {}. Treating as no-op.", request);
+            return new CoordinatorResult<>(List.of(), responseData);
+        }
+
+        CoordinatorRecord record = generateInitializeStateRecord(partitionData, key);
         return new CoordinatorResult<>(List.of(record), responseData);
     }
 

--- a/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
+++ b/share-coordinator/src/test/java/org/apache/kafka/coordinator/share/ShareCoordinatorShardTest.java
@@ -1747,6 +1747,79 @@ class ShareCoordinatorShardTest {
     }
 
     @Test
+    public void testInitializeStateIdempotent() {
+        InitializeShareGroupStateRequestData request = new InitializeShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new InitializeShareGroupStateRequestData.InitializeStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new InitializeShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(10)
+                    .setStateEpoch(5)))
+            ));
+
+        // First call initializes the state and writes a record.
+        CoordinatorResult<InitializeShareGroupStateResponseData, CoordinatorRecord> result = shard.initializeState(request);
+        result.records().forEach(record -> shard.replay(0L, 0L, (short) 0, record));
+
+        InitializeShareGroupStateResponseData expectedData = InitializeShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+
+        assertEquals(expectedData, result.response());
+        assertEquals(1, result.records().size());
+
+        ShareGroupOffset stateAfterFirstCall = shard.getShareStateMapValue(SHARE_PARTITION_KEY);
+        Integer stateEpochAfterFirstCall = shard.getStateEpochMapValue(SHARE_PARTITION_KEY);
+        assertNotNull(stateAfterFirstCall);
+        assertNotNull(stateEpochAfterFirstCall);
+
+        // A retry of the exact same request (same stateEpoch and startOffset) should be
+        // treated as a no-op -- it should return the same successful response but generate
+        // no new record, and the in-memory state should remain unchanged.
+        CoordinatorResult<InitializeShareGroupStateResponseData, CoordinatorRecord> retryResult = shard.initializeState(request);
+
+        assertEquals(expectedData, retryResult.response());
+        assertEquals(List.of(), retryResult.records());
+
+        assertEquals(stateAfterFirstCall, shard.getShareStateMapValue(SHARE_PARTITION_KEY));
+        assertEquals(stateEpochAfterFirstCall, shard.getStateEpochMapValue(SHARE_PARTITION_KEY));
+    }
+
+    @Test
+    public void testInitializeStateNotIdempotentWhenStartOffsetChanges() {
+        InitializeShareGroupStateRequestData request = new InitializeShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new InitializeShareGroupStateRequestData.InitializeStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new InitializeShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(10)
+                    .setStateEpoch(5)))
+            ));
+
+        CoordinatorResult<InitializeShareGroupStateResponseData, CoordinatorRecord> result = shard.initializeState(request);
+        result.records().forEach(record -> shard.replay(0L, 0L, (short) 0, record));
+        assertEquals(1, result.records().size());
+
+        // Same stateEpoch but a different startOffset should not be treated as a duplicate
+        // and must produce a new record.
+        InitializeShareGroupStateRequestData sameEpochDifferentOffsetRequest = new InitializeShareGroupStateRequestData()
+            .setGroupId(GROUP_ID)
+            .setTopics(List.of(new InitializeShareGroupStateRequestData.InitializeStateData()
+                .setTopicId(TOPIC_ID)
+                .setPartitions(List.of(new InitializeShareGroupStateRequestData.PartitionData()
+                    .setPartition(PARTITION)
+                    .setStartOffset(20)
+                    .setStateEpoch(5)))
+            ));
+
+        CoordinatorResult<InitializeShareGroupStateResponseData, CoordinatorRecord> secondResult = shard.initializeState(sameEpochDifferentOffsetRequest);
+
+        InitializeShareGroupStateResponseData expectedData = InitializeShareGroupStateResponse.toResponseData(TOPIC_ID, PARTITION);
+        assertEquals(expectedData, secondResult.response());
+        assertEquals(1, secondResult.records().size());
+    }
+
+    @Test
     public void testInitializeStateInvalidRequestData() {
         // invalid partition
         int partition = -1;


### PR DESCRIPTION
Currently, the ShareCoordinatorShard.initializeState does not check for
dedup request resulting in overwriting the stored state, in case of an
out of order initializeState. This PR remedies the situation by
comparing the stateEpoch and startOffset of the incoming request with
the stored state and if both these values are equal, consider the
request as no-op.

This should not affect alterShareGroupOffsets as that request always
brings a bumped up epoch - https://github.com/apache/kafka/pull/23147.

New tests have been added to verify the changes.

Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>
