### PR TITLE
MINOR: `gradle-versions-plugin` reference has been moved from `build.gradle` to `settings.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ buildscript {
 }
 
 plugins {
-  id 'io.github.ben-manes.versions' version '0.61.0'
   id 'idea'
   id 'jacoco'
   id 'java-library'

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ pluginManagement {
 plugins {
     id 'com.gradle.develocity' version '3.19'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
+    id 'io.github.ben-manes.versions.settings' version '0.61.0'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null


### PR DESCRIPTION
related link: https://github.com/ben-manes/gradle-versions-plugin/tree/v0.61.0#applying-the-plugin
> The recommended way to add the Gradle Versions Plugin to any build is to apply the settings plugin once in the _`settings`_ script.


**Rationale (showcase):**
- Kafka trunk:
```
./gradlew dU | grep com.gradle
 - com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.6.1
 ``` 
- This PR: 
```
 ./gradlew dU | grep com.gradle
 - com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.6.1
 - com.gradle.common-custom-user-data-gradle-plugin:com.gradle.common-custom-user-data-gradle-plugin.gradle.plugin [2.0.2 -> 2.8.0]
 - com.gradle.develocity:com.gradle.develocity.gradle.plugin [3.19 -> 4.5.0]
```