### PR TITLE
MINOR: Fix typos in Streams configuration docs

### DIFF
--- a/docs/streams/developer-guide/config-streams.md
+++ b/docs/streams/developer-guide/config-streams.md
@@ -208,7 +208,7 @@ Producer (for version <=2.8)
 </td>  
 <td>
 
-`acks="1")`
+`acks="1"`
 </td>  
 <td>
 
@@ -855,7 +855,7 @@ Medium
 <td>
 
 The processing mode. Can be either `"at_least_once"` or `"exactly_once_v2"` (for EOS version 2, requires broker version 2.5+). See Processing Guarantee.
-</td>.   
+</td>   
 <td>
 
 `"at_least_once"`
@@ -918,7 +918,7 @@ Low
 </td>  
 <td>
 
-The strategy used for rack aware assignment. Acceptable value are `"none"` (default), `"min_traffic"`, and `"balance_suttopology"`. See Rack Aware Assignment Strategy.
+The strategy used for rack aware assignment. Acceptable values are `"none"` (default), `"min_traffic"`, and `"balance_subtopology"`. See Rack Aware Assignment Strategy.
 </td>  
 <td>
 
@@ -961,7 +961,7 @@ Cost associated with moving tasks from existing assignment. See Rack Aware Assig
 <tr>  
 <td>
 
-rack.aware.assignment.non_overlap_cost
+rack.aware.assignment.traffic_cost
 </td>  
 <td>
 
@@ -1429,8 +1429,8 @@ Serde for the inner class of a windowed record. Must implement the `Serde` inter
 > This configuration sets the strategy Kafka Streams uses for rack aware task assignment so that cross traffic from broker to client can be reduced. This config will only take effect when `broker.rack` is set on the brokers and `client.rack` is set on Kafka Streams side. There are two settings for this config: 
 > 
 >   * `none`. This is the default value which means rack aware task assignment will be disabled.
->   * `min_traffic`. This settings means that the rack aware task assigner will compute an assignment which tries to minimize cross rack traffic.
->   * `balance_subtopology`. This settings means that the rack aware task assigner will compute an assignment which will try to balance tasks from same subtopology to different clients and minimize cross rack traffic on top of that.
+>   * `min_traffic`. This setting means that the rack aware task assigner will compute an assignment which tries to minimize cross rack traffic.
+>   * `balance_subtopology`. This setting means that the rack aware task assigner will compute an assignment which will try to balance tasks from same subtopology to different clients and minimize cross rack traffic on top of that.
 > 
 
 > 
@@ -1688,7 +1688,7 @@ Serde for the inner class of a windowed record. Must implement the `Serde` inter
 >     }
 >     
 >     Properties streamsSettings = new Properties();
->     streamsConfig.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, CustomRocksDBConfig.class);
+>     streamsSettings.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, CustomRocksDBConfig.class);
 > 
 > Notes for example:
 >     
@@ -1796,7 +1796,7 @@ If you call `streamsBuilder.build()` without passing the `Properties` object, op
      // alternatively, you can use
      streamsSettings.put(StreamsConfig.restoreConsumerPrefix("PARAMETER_NAME"), "restore-consumer-value");
  
- Same applied to `main.consumer.` and `main.consumer.`, if you only want to specify one consumer type config.
+ Same applied to `main.consumer.` and `global.consumer.`, if you only want to specify one consumer type config.
  
  Additionally, to configure the internal repartition/changelog topics, you could use the `topic.` prefix, followed by any of the standard topic configs.
      


### PR DESCRIPTION
## Summary

Docs-only typo and copy-paste fixes in `docs/streams/developer-guide/config-streams.md`:

- Rename the duplicate `rack.aware.assignment.non_overlap_cost` table row (cross-rack traffic description) to `rack.aware.assignment.traffic_cost`
- `balance_suttopology` → `balance_subtopology`
- Remove the stray `)` in `acks="1")`
- `main.consumer.` / `main.consumer.` → `main.consumer.` / `global.consumer.`
- Remove the stray period after the `processing.guarantee` table cell
- `streamsConfig.put` → `streamsSettings.put` in the RocksDB example
- `Acceptable value are` → `Acceptable values are`; `This settings means` → `This setting means`

No JIRA ticket: these are trivial docs typos, which [Contributing Code Changes](https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Code+Changes) says do not require one.

This is original work and is licensed to the project under the Apache License 2.0.

## Test plan

- [x] Docs-only change; no code or tests
- [x] Confirmed each old string existed on `trunk` before editing
- [x] Diff is limited to `docs/streams/developer-guide/config-streams.md`

Generated-by: Cursor Agent (version unavailable; the exact model was not recorded)

## Human-in-the-loop

Luis Felipe Abarca is the human contributor responsible for the original-work and Apache License 2.0 certification above. He personally reviewed the exact patch at `0b056ce84263fd11a021cdf4bd3e3f59bbc9337b`, authorizes publication and public follow-up, and remains accountable for the contribution. Arca's agents assisted with research, drafting, and checks but do not independently decide what is submitted or merged.