### PR TITLE
KAFKA-20295: bridge pre-KIP-1312 controller decommissioning

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.ControllerIdNotRegisteredException;
 import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.InconsistentClusterIdException;
 import org.apache.kafka.common.errors.InvalidRegistrationException;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
@@ -41,6 +42,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
+import org.apache.kafka.image.writer.ImageWriterOptions;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.BrokerRegistrationFencingChange;
 import org.apache.kafka.metadata.BrokerRegistrationInControlledShutdownChange;
@@ -500,6 +502,47 @@ public class ClusterControlManager {
         return ControllerResult.atomicOf(records, null);
     }
 
+    /**
+     * Decommission a stopped controller that is no longer a quorum voter. Before KIP-1312 is
+     * enabled, retain its registration with an internal marker so feature validation ignores it.
+     * Once KIP-1312 is enabled, physically unregister it instead.
+     */
+    ControllerResult<Void> decommissionController(int controllerId) {
+        if (!featureControl.metadataVersionOrThrow().isControllerRegistrationSupported()) {
+            throw new UnsupportedVersionException("The current MetadataVersion is too old to " +
+                    "support controller registrations.");
+        }
+        ControllerRegistration registration = controllerRegistrations.get(controllerId);
+        if (registration == null) {
+            throw new ControllerIdNotRegisteredException("Controller ID " + controllerId +
+                    " is not currently registered.");
+        }
+        if (featureControl.isControllerId(controllerId)) {
+            throw new InvalidRequestException("Cannot decommission controller " + controllerId +
+                    " because it is present in the controller quorum. Remove it from the quorum " +
+                    "before decommissioning it.");
+        }
+        if (featureControl.metadataVersionOrThrow().isControllerUnregistrationSupported()) {
+            return unregisterController(controllerId);
+        }
+        if (registration.isDecommissioned()) {
+            log.info("Controller {} is already decommissioned. Taking no action.", controllerId);
+            return ControllerResult.of(List.of(), null);
+        }
+        ControllerRegistration decommissionedRegistration = new ControllerRegistration.Builder().
+            setId(registration.id()).
+            setIncarnationId(registration.incarnationId()).
+            setZkMigrationReady(registration.zkMigrationReady()).
+            setListeners(registration.listeners()).
+            setSupportedFeatures(registration.supportedFeatures()).
+            setDecommissioned(true).
+            build();
+        log.info("Decommissioning controller {}. Its registration remains for now, but it will " +
+                "not participate in feature or metadata.version upgrade decisions.", controllerId);
+        ImageWriterOptions options = new ImageWriterOptions.Builder(featureControl.metadataVersionOrThrow()).build();
+        return ControllerResult.atomicOf(List.of(decommissionedRegistration.toRecord(options)), null);
+    }
+
     ControllerResult<Void> unregisterController(int controllerId) {
         if (!featureControl.metadataVersionOrThrow().isControllerUnregistrationSupported()) {
             throw new UnsupportedVersionException("The current MetadataVersion is too old to " +
@@ -885,21 +928,17 @@ public class ClusterControlManager {
             throw new UnsupportedVersionException("The current MetadataVersion is too old to " +
                     "support controller registrations.");
         }
-        return new Iterator<>() {
-            private final Iterator<ControllerRegistration> iter = controllerRegistrations.values().iterator();
-
-            @Override
-            public boolean hasNext() {
-                return iter.hasNext();
+        List<Entry<Integer, Map<String, VersionRange>>> supportedControllers = new ArrayList<>();
+        for (ControllerRegistration registration : controllerRegistrations.values()) {
+            if (registration.isDecommissioned()) {
+                log.info("Skipping decommissioned controller {} when computing controller-supported " +
+                        "features.", registration.id());
+                continue;
             }
-
-            @Override
-            public Entry<Integer, Map<String, VersionRange>> next() {
-                ControllerRegistration registration = iter.next();
-                return new AbstractMap.SimpleImmutableEntry<>(registration.id(),
-                        registration.supportedFeatures());
-            }
-        };
+            supportedControllers.add(new AbstractMap.SimpleImmutableEntry<>(registration.id(),
+                    registration.supportedFeatures()));
+        }
+        return supportedControllers.iterator();
     }
 
     @FunctionalInterface

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -413,13 +413,14 @@ public interface Controller extends AclMutator, AutoCloseable {
     );
 
     /**
-     * Attempt to unregister the given controller.
+     * Decommission the given controller. Before KIP-1312 is enabled, this marks a stopped,
+     * non-voter registration so it is excluded from feature validation. At or above KIP-1312's
+     * metadata version, it physically unregisters the controller instead.
      *
      * @param context       The controller request context.
-     * @param controllerId  The controller id to unregister.
+     * @param controllerId  The controller id to decommission or unregister.
      *
-     * @return              A future that is completed successfully when the controller is
-     *                      unregistered.
+     * @return              A future that is completed successfully when the operation finishes.
      */
     CompletableFuture<Void> unregisterController(
         ControllerRequestContext context,

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -2162,12 +2162,12 @@ public final class QuorumController implements Controller {
         ControllerRequestContext context,
         int controllerId
     ) {
-        return appendWriteEvent("unregisterController", context.deadlineNs(),
+        return appendWriteEvent("decommissionController", context.deadlineNs(),
             () -> {
                 if (nodeId == controllerId) {
                     throw new InvalidRequestException("Controller cannot unregister itself while it is active.");
                 }
-                return clusterControl.unregisterController(controllerId);
+                return clusterControl.decommissionController(controllerId);
             },
             EnumSet.noneOf(ControllerOperationFlag.class));
     }

--- a/metadata/src/main/java/org/apache/kafka/metadata/ControllerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/ControllerRegistration.java
@@ -40,6 +40,14 @@ import java.util.stream.Collectors;
  * An immutable class which represents controller registrations.
  */
 public class ControllerRegistration {
+    /**
+     * A synthetic entry in a controller registration's existing feature array. It marks a
+     * stopped, non-voter controller as decommissioned during the pre-KIP-1312 transition.
+     */
+    public static final String DECOMMISSIONED_FEATURE_NAME = "__decommissioned_controller";
+
+    private static final VersionRange DECOMMISSIONED_MARKER_RANGE = VersionRange.of((short) 1, (short) 1);
+
     public static class Builder {
         private int id;
         private Uuid incarnationId;
@@ -105,6 +113,18 @@ public class ControllerRegistration {
             return this;
         }
 
+        public Builder setDecommissioned(boolean decommissioned) {
+            Map<String, VersionRange> newSupportedFeatures =
+                new HashMap<>(supportedFeatures == null ? Collections.emptyMap() : supportedFeatures);
+            if (decommissioned) {
+                newSupportedFeatures.put(DECOMMISSIONED_FEATURE_NAME, DECOMMISSIONED_MARKER_RANGE);
+            } else {
+                newSupportedFeatures.remove(DECOMMISSIONED_FEATURE_NAME);
+            }
+            this.supportedFeatures = newSupportedFeatures;
+            return this;
+        }
+
         public ControllerRegistration build() {
             if (incarnationId == null) throw new RuntimeException("You must set incarnationId.");
             if (listeners == null) throw new RuntimeException("You must set listeners.");
@@ -165,8 +185,21 @@ public class ControllerRegistration {
         return Optional.of(new Node(id, endpoint.host(), endpoint.port(), null));
     }
 
+    /**
+     * Return the effective feature ranges. The decommission marker is implementation metadata,
+     * not a Kafka feature, and must not be exposed to feature negotiation callers.
+     */
     public Map<String, VersionRange> supportedFeatures() {
-        return supportedFeatures;
+        if (!isDecommissioned()) {
+            return supportedFeatures;
+        }
+        Map<String, VersionRange> effectiveFeatures = new HashMap<>(supportedFeatures);
+        effectiveFeatures.remove(DECOMMISSIONED_FEATURE_NAME);
+        return Collections.unmodifiableMap(effectiveFeatures);
+    }
+
+    public boolean isDecommissioned() {
+        return supportedFeatures.containsKey(DECOMMISSIONED_FEATURE_NAME);
     }
 
     public ApiMessageAndVersion toRecord(ImageWriterOptions options) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.errors.ControllerIdNotRegisteredException;
 import org.apache.kafka.common.errors.DuplicateBrokerRegistrationException;
 import org.apache.kafka.common.errors.InconsistentClusterIdException;
 import org.apache.kafka.common.errors.InvalidRegistrationException;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
@@ -1173,6 +1174,67 @@ public class ClusterControlManagerTest {
         assertEquals(1, unregisterResult.records().size());
         RecordTestUtils.replayAll(clusterControl, unregisterResult.records());
         assertFalse(clusterControl.controllerRegistrations().containsKey(1));
+    }
+
+    @Test
+    public void testDecommissionControllerMarksBeforeKip1312AndUnregistersAfterwards() {
+        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
+        FeatureControlManager featureControl = new FeatureControlManager.Builder().
+            setSnapshotRegistry(snapshotRegistry).
+            setQuorumFeatures(new QuorumFeatures(0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(0))).
+            build();
+        featureControl.replay(new FeatureLevelRecord().
+            setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_4_0_IV3.featureLevel()));
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setSnapshotRegistry(snapshotRegistry).
+            setFeatureControlManager(featureControl).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            build();
+        clusterControl.activate();
+        RecordTestUtils.replayAll(clusterControl, clusterControl.registerController(
+            new ControllerRegistrationRequestData().setControllerId(1)).records());
+
+        ControllerResult<Void> decommissionResult = clusterControl.decommissionController(1);
+        assertEquals(1, decommissionResult.records().size());
+        RecordTestUtils.replayAll(clusterControl, decommissionResult.records());
+        assertTrue(clusterControl.controllerRegistrations().get(1).isDecommissioned());
+        assertFalse(clusterControl.controllerSupportedFeatures().hasNext());
+
+        // A pre-existing marker remains a no-op until KIP-1312 controller unregistration is enabled.
+        assertTrue(clusterControl.decommissionController(1).records().isEmpty());
+
+        featureControl.replay(new FeatureLevelRecord().
+            setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_4_4_IV2.featureLevel()));
+        ControllerResult<Void> unregisterResult = clusterControl.decommissionController(1);
+        assertEquals(1, unregisterResult.records().size());
+        assertTrue(unregisterResult.records().get(0).message() instanceof UnregisterControllerRecord);
+        RecordTestUtils.replayAll(clusterControl, unregisterResult.records());
+        assertFalse(clusterControl.controllerRegistrations().containsKey(1));
+    }
+
+    @Test
+    public void testDecommissionControllerRejectsQuorumVoter() {
+        FeatureControlManager featureControl = new FeatureControlManager.Builder().
+            setQuorumFeatures(new QuorumFeatures(0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(1))).
+            build();
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setFeatureControlManager(featureControl).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            build();
+        clusterControl.activate();
+        RecordTestUtils.replayAll(clusterControl, clusterControl.registerController(
+            new ControllerRegistrationRequestData().setControllerId(1)).records());
+
+        assertEquals("Cannot decommission controller 1 because it is present in the controller quorum. " +
+                "Remove it from the quorum before decommissioning it.",
+            assertThrows(InvalidRequestException.class,
+                () -> clusterControl.decommissionController(1)).getMessage());
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.FeatureUpdate;
+import org.apache.kafka.common.message.ControllerRegistrationRequestData;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
@@ -46,8 +47,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -188,6 +191,86 @@ public class FeatureControlManagerTest {
                 return controllerRanges.iterator();
             }
         };
+    }
+
+    @Test
+    public void testMetadataVersionUpgradeIgnoresStaleControllerRegistrations() {
+        AtomicReference<ClusterControlManager> clusterControlRef = new AtomicReference<>();
+        FeatureControlManager manager = new FeatureControlManager.Builder().
+            setQuorumFeatures(new QuorumFeatures(0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(0))).
+            setClusterFeatureSupportDescriber(new ClusterFeatureSupportDescriber() {
+                @Override
+                public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> brokerSupported() {
+                    return List.<Map.Entry<Integer, Map<String, VersionRange>>>of().iterator();
+                }
+
+                @Override
+                public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> controllerSupported() {
+                    return clusterControlRef.get().controllerSupportedFeatures();
+                }
+            }).
+            build();
+        manager.replay(new FeatureLevelRecord().
+            setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_4_0_IV3.featureLevel()));
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setFeatureControlManager(manager).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            build();
+        clusterControlRef.set(clusterControl);
+        clusterControl.activate();
+        RecordTestUtils.replayAll(clusterControl, clusterControl.registerController(
+            new ControllerRegistrationRequestData().setControllerId(1)).records());
+        RecordTestUtils.replayAll(clusterControl, clusterControl.decommissionController(1).records());
+
+        ControllerResult<ApiError> result = manager.updateFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_4_IV2.featureLevel()),
+            Map.of(MetadataVersion.FEATURE_NAME, FeatureUpdate.UpgradeType.UPGRADE),
+            true,
+            0);
+        assertEquals(ApiError.NONE, result.response());
+    }
+
+    @Test
+    public void testMetadataVersionUpgradeStillChecksLiveControllers() {
+        AtomicReference<ClusterControlManager> clusterControlRef = new AtomicReference<>();
+        FeatureControlManager manager = new FeatureControlManager.Builder().
+            setQuorumFeatures(new QuorumFeatures(0,
+                QuorumFeatures.defaultSupportedFeatureMap(true),
+                List.of(0))).
+            setClusterFeatureSupportDescriber(new ClusterFeatureSupportDescriber() {
+                @Override
+                public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> brokerSupported() {
+                    return List.<Map.Entry<Integer, Map<String, VersionRange>>>of().iterator();
+                }
+
+                @Override
+                public Iterator<Map.Entry<Integer, Map<String, VersionRange>>> controllerSupported() {
+                    return clusterControlRef.get().controllerSupportedFeatures();
+                }
+            }).
+            build();
+        manager.replay(new FeatureLevelRecord().
+            setName(MetadataVersion.FEATURE_NAME).
+            setFeatureLevel(MetadataVersion.IBP_4_0_IV3.featureLevel()));
+        ClusterControlManager clusterControl = new ClusterControlManager.Builder().
+            setFeatureControlManager(manager).
+            setBrokerShutdownHandler((brokerId, isCleanShutdown, records) -> { }).
+            build();
+        clusterControlRef.set(clusterControl);
+        clusterControl.activate();
+        RecordTestUtils.replayAll(clusterControl, clusterControl.registerController(
+            new ControllerRegistrationRequestData().setControllerId(1)).records());
+
+        ControllerResult<ApiError> result = manager.updateFeatures(
+            Map.of(MetadataVersion.FEATURE_NAME, MetadataVersion.IBP_4_4_IV2.featureLevel()),
+            Map.of(MetadataVersion.FEATURE_NAME, FeatureUpdate.UpgradeType.UPGRADE),
+            true,
+            0);
+        assertFalse(result.response().isSuccess());
+        assertTrue(result.response().message().contains("Controller 1 only supports"));
     }
 
     @Test

--- a/tools/src/main/java/org/apache/kafka/tools/ClusterTool.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClusterTool.java
@@ -81,11 +81,16 @@ public class ClusterTool {
                 .help("Unregister a broker.");
         Subparser unregisterControllerParser = subparsers.addParser("unregister-controller")
                 .help("Unregister a controller.");
+        Subparser decommissionControllerParser = subparsers.addParser("decommission-controller")
+                .help("Decommission a stopped, non-voter controller. Before metadata.version " +
+                        "4.4-IV2 this retains and marks its registration; afterwards it " +
+                        "unregisters the controller.");
         Subparser listEndpoints = subparsers.addParser("list-endpoints")
                 .help("List endpoints");
         Subparser apiVersionsParser = subparsers.addParser("api-versions")
                 .help("Get information about the api versions of the brokers or controllers.");
-        for (Subparser subpparser : List.of(clusterIdParser, unregisterParser, unregisterControllerParser, listEndpoints, apiVersionsParser)) {
+        for (Subparser subpparser : List.of(clusterIdParser, unregisterParser, unregisterControllerParser,
+                decommissionControllerParser, listEndpoints, apiVersionsParser)) {
             MutuallyExclusiveGroup connectionOptions = subpparser.addMutuallyExclusiveGroup().required(true);
             connectionOptions.addArgument("--bootstrap-server", "-b")
                     .action(store())
@@ -111,6 +116,11 @@ public class ClusterTool {
                 .action(store())
                 .required(true)
                 .help("The ID of the controller to unregister.");
+        decommissionControllerParser.addArgument("--id", "-i")
+                .type(Integer.class)
+                .action(store())
+                .required(true)
+                .help("The ID of the stopped controller to decommission. It must no longer be a quorum voter.");
         listEndpoints.addArgument("--include-fenced-brokers")
                 .action(storeTrue())
                 .help("Whether to include fenced brokers when listing broker endpoints");
@@ -148,6 +158,12 @@ public class ClusterTool {
             case "unregister-controller": {
                 try (Admin adminClient = Admin.create(properties)) {
                     unregisterControllerCommand(System.out, adminClient, namespace.getInt("id"));
+                }
+                break;
+            }
+            case "decommission-controller": {
+                try (Admin adminClient = Admin.create(properties)) {
+                    decommissionControllerCommand(System.out, adminClient, namespace.getInt("id"));
                 }
                 break;
             }
@@ -204,6 +220,26 @@ public class ClusterTool {
             Throwable cause = ee.getCause();
             if (cause instanceof UnsupportedVersionException) {
                 stream.println("The target cluster does not support the controller unregistration API.");
+            } else {
+                throw ee;
+            }
+        }
+    }
+
+    /**
+     * Invoke the upstream UnregisterController API with Aiven's transition semantics. The
+     * controller selects marking or physical unregistration from the finalized metadata version.
+     */
+    static void decommissionControllerCommand(PrintStream stream, Admin adminClient, int id) throws Exception {
+        try {
+            adminClient.unregisterController(id).all().get();
+            stream.println("Controller " + id + " was decommissioned. Before metadata.version " +
+                    "4.4-IV2 its registration remains but is excluded from feature validation; " +
+                    "at or above 4.4-IV2 it is unregistered.");
+        } catch (ExecutionException ee) {
+            Throwable cause = ee.getCause();
+            if (cause instanceof UnsupportedVersionException) {
+                stream.println("The target cluster does not support controller decommissioning.");
             } else {
                 throw ee;
             }

--- a/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ClusterToolTest.java
@@ -313,6 +313,18 @@ public class ClusterToolTest {
     }
 
     @Test
+    public void testDecommissionControllerUsesUpstreamUnregisterControllerApi() throws Exception {
+        Admin adminClient = new MockAdminClient.Builder().numBrokers(3).
+                usingRaftController(true).
+                build();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ClusterTool.decommissionControllerCommand(new PrintStream(stream), adminClient, 0);
+        assertEquals("Controller 0 was decommissioned. Before metadata.version 4.4-IV2 its " +
+                "registration remains but is excluded from feature validation; at or above " +
+                "4.4-IV2 it is unregistered.\n", stream.toString());
+    }
+
+    @Test
     public void testLegacyModeClusterCannotUnregisterController() throws Exception {
         Admin adminClient = new MockAdminClient.Builder().numBrokers(3).
                 usingRaftController(false).


### PR DESCRIPTION
KIP-1312 can unregister a controller only after `metadata.version`
reaches 4.4. Old, stopped controller registrations ("ghost
controllers") can advertise only older metadata versions, so feature
validation rejects the `metadata.version` upgrade needed to remove them
(deadlock situation).

This PR solves that deadlock by bridging the pre-KIP-1312 implementation
(PR #70) with KIP-1312.
Before 4.4-IV2, it marks a stopped controller that is no longer a quorum
voter with `__decommissioned_controller`. Patched controllers ignore
marked registrations during feature validation, allowing
`metadata.version` to reach 4.4. Afterwards, running the same operation
writes an `UnregisterControllerRecord` and deletes the registration
(KIP-1312 behavior).

This retains the useful marker from PR #70 and validation filter , but
changes its integration with Kafka. PR #70 introduced a fork-local
`DecommissionController` protocol and always retained the marked
registration, while also widening its advertised feature ranges. This
port reuses the upstream KIP-1312 UnregisterController API, preserves
the stored feature ranges, and physically removes the registration once
4.4 is finalized.

Without this PR, the following happens when doing a rolling upgrade for example
from 4.0 to 4.4:
1. Regular rolling upgrade operations (4.4 nodes up, 4.0 nodes down)
2. Unregister 4.0 brokers --> OK
3. Unregister 4.0 controllers using KIP-1312 --> KO
This fails because 4.0 ghost controllers don't have KIP-1312, so they cannot be unregistered:
```
[root@davide-armand-test-n1313 ~]# $K_BIN/kafka-cluster.sh unregister-controller --bootstrap-controller "$K_CONTROLLER_BOOTSTRAP" --id 6

Unregistering controller 10006
[2026-08-18 10:00:25,329] ERROR [AdminClient clientId=adminclient-1] Unregister controller request for controller ID 10006
  failed: The current MetadataVersion is too old to support controller unregistration.
(org.apache.kafka.clients.admin.KafkaAdminClient)
  The target cluster does not support the controller unregistration API.
  ```
4. Upgrade metadata version --> KO
This fails because 4.0 ghost controllers could not be unregistered at step 3:
```
[root@davide-armand-test-n1313 ~]#  $K_BIN/kafka-features.sh --bootstrap-server "$K_BOOTSTRAP" upgrade --release-version 4.4-IV2 --dry-run

Can not upgrade eligible.leader.replicas.version to 1. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade group.version to 1. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade kraft.version to 1. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade metadata.version to 33. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade share.version to 2. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade streams.version to 1. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
Can not upgrade transaction.version to 2. The update failed for all features since the following feature had an error: Invalid update version 33 for feature metadata.version. Controller 10006 only supports versions 7-25
7 out of 7 operation(s) failed.
```


Co-authored-by: Pi Agent (gpt-5.6-terra)