### PR TITLE
KAFKA-20963: Remove hamcrest from org.apache.kafka.streams.processor

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/LogAndSkipOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/LogAndSkipOnInvalidTimestampTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LogAndSkipOnInvalidTimestampTest extends TimestampExtractorTest {
 
@@ -55,7 +54,7 @@ public class LogAndSkipOnInvalidTimestampTest extends TimestampExtractorTest {
             0
         );
 
-        assertThat(timestamp, is(invalidMetadataTimestamp));
+        assertEquals(invalidMetadataTimestamp, timestamp);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/ReadOnlyStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/ReadOnlyStoreTest.java
@@ -39,8 +39,7 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReadOnlyStoreTest {
 
@@ -121,14 +120,14 @@ public class ReadOnlyStoreTest {
                 expectedResult.add(KeyValue.pair(1, "foo"));
                 expectedResult.add(KeyValue.pair(2, "bar"));
 
-                assertThat(storeContent, equalTo(expectedResult));
+                assertEquals(expectedResult, storeContent);
             }
 
             final List<KeyValue<Integer, String>> expectedResult = new LinkedList<>();
             expectedResult.add(KeyValue.pair(1, "bar -- foo"));
             expectedResult.add(KeyValue.pair(2, "foo -- bar"));
 
-            assertThat(output.readKeyValuesToList(), equalTo(expectedResult));
+            assertEquals(expectedResult, output.readKeyValuesToList());
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TimestampExtractorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TimestampExtractorTest.java
@@ -22,8 +22,7 @@ import org.apache.kafka.common.record.TimestampType;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TimestampExtractorTest {
 
@@ -46,7 +45,7 @@ class TimestampExtractorTest {
             0
         );
 
-        assertThat(timestamp, is(metadataTimestamp));
+        assertEquals(metadataTimestamp, timestamp);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/UsePartitionTimeOnInvalidTimestampTest.java
@@ -21,8 +21,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class UsePartitionTimeOnInvalidTimestampTest extends TimestampExtractorTest {
@@ -42,7 +41,7 @@ public class UsePartitionTimeOnInvalidTimestampTest extends TimestampExtractorTe
                 partitionTime
         );
 
-        assertThat(timestamp, is(partitionTime));
+        assertEquals(partitionTime, timestamp);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
@@ -18,12 +18,9 @@ package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WallclockTimestampExtractorTest {
 
@@ -35,29 +32,8 @@ public class WallclockTimestampExtractorTest {
         final long timestamp = extractor.extract(new ConsumerRecord<>("anyTopic", 0, 0, null, null), 42);
         final long after = System.currentTimeMillis();
 
-        assertThat(timestamp, is(new InBetween(before, after)));
-    }
-
-    private static class InBetween extends BaseMatcher<Long> {
-        private final long before;
-        private final long after;
-
-        public InBetween(final long before, final long after) {
-            this.before = before;
-            this.after = after;
-        }
-
-        @Override
-        public boolean matches(final Object item) {
-            final long timestamp = (Long) item;
-            return before <= timestamp && timestamp <= after;
-        }
-
-        @Override
-        public void describeMismatch(final Object item, final Description mismatchDescription) {}
-
-        @Override
-        public void describeTo(final Description description) {}
+        assertTrue(before <= timestamp);
+        assertTrue(timestamp <= after);
     }
 
 }


### PR DESCRIPTION
Migrate usages of hamcrest to junit

Reviewers: Uros (github:uros-b), Ken Huang <s7133700@gmail.com>
