### PR TITLE
KAFKA-20965: Remove hamcrest from org.apache.kafka.streams.state.internals.metrics package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -27,8 +27,7 @@ import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -65,7 +64,7 @@ public class NamedCacheMetricsTest {
                     HIT_RATIO_MAX_DESCRIPTION
                 )
             );
-            assertThat(sensor, is(expectedSensor));
+            assertEquals(expectedSensor, sensor);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
@@ -59,9 +59,8 @@ import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.PI
 import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.SIZE_OF_ALL_MEMTABLES;
 import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.TOTAL_SST_FILES_SIZE;
 import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.USAGE_OF_BLOCK_CACHE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -267,7 +266,7 @@ public class RocksDBMetricsRecorderGaugesTest {
             tagMap
         ));
 
-        assertThat(metric, notNullValue());
-        assertThat(metric.metricValue(), is(BigInteger.valueOf(expectedValue)));
+        assertNotNull(metric);
+        assertEquals(BigInteger.valueOf(expectedValue), metric.metricValue());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderTest.java
@@ -41,8 +41,7 @@ import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 import org.rocksdb.TickerType;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -162,7 +161,7 @@ public class RocksDBMetricsRecorderTest {
         dbMetrics.verify(() -> RocksDBMetrics.addEstimateNumKeysMetric(eq(streamsMetrics), eq(metricsContext), any()));
         dbMetrics.verify(() -> RocksDBMetrics.addEstimateTableReadersMemMetric(eq(streamsMetrics), eq(metricsContext), any()));
         dbMetrics.verify(() -> RocksDBMetrics.addBackgroundErrorsMetric(eq(streamsMetrics), eq(metricsContext), any()));
-        assertThat(recorder.taskId(), is(TASK_ID1));
+        assertEquals(TASK_ID1, recorder.taskId());
     }
 
     @Test
@@ -220,11 +219,11 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_1, dbToAdd1, cacheToAdd1, statisticsToAdd2)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Value providers for store " + SEGMENT_STORE_NAME_1 + " of task " + TASK_ID1 +
+        assertEquals(
+            "Value providers for store " + SEGMENT_STORE_NAME_1 + " of task " + TASK_ID1 +
                 " has been already added. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -236,12 +235,12 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd2, cacheToAdd2, statisticsToAdd2)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Statistics for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
+        assertEquals(
+            "Statistics for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
                 " is not null although the statistics of another segment in this metrics recorder is null. " +
                 "This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -253,12 +252,12 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd2, cacheToAdd2, null)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Statistics for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
+        assertEquals(
+            "Statistics for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
                 " is null although the statistics of another segment in this metrics recorder is not null. " +
                 "This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -270,12 +269,12 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd2, cacheToAdd1, statisticsToAdd1)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Cache for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
+        assertEquals(
+            "Cache for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
                 " is not null although the cache of another segment in this metrics recorder is null. " +
                 "This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -287,12 +286,12 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd2, null, statisticsToAdd2)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Cache for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
+        assertEquals(
+            "Cache for segment " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
                 " is null although the cache of another segment in this metrics recorder is not null. " +
                 "This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -305,11 +304,11 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_3, dbToAdd3, cacheToAdd2, statisticsToAdd3)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Caches for store " + STORE_NAME + " of task " + TASK_ID1 +
+        assertEquals(
+            "Caches for store " + STORE_NAME + " of task " + TASK_ID1 +
                 " are either not all distinct or do not all refer to the same cache. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -322,11 +321,11 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_3, dbToAdd3, cacheToAdd1, statisticsToAdd3)
         );
-        assertThat(
-            exception.getMessage(),
-            is("Caches for store " + STORE_NAME + " of task " + TASK_ID1 +
+        assertEquals(
+            "Caches for store " + STORE_NAME + " of task " + TASK_ID1 +
                 " are either not all distinct or do not all refer to the same cache. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 
@@ -338,11 +337,11 @@ public class RocksDBMetricsRecorderTest {
             IllegalStateException.class,
             () -> recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd1, cacheToAdd2, statisticsToAdd2)
         );
-        assertThat(
-            exception.getMessage(),
-            is("DB instance for store " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
+        assertEquals(
+            "DB instance for store " + SEGMENT_STORE_NAME_2 + " of task " + TASK_ID1 +
                 " was already added for another segment as a value provider. This is a bug in Kafka Streams. " +
-                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues")
+                "Please open a bug report under https://issues.apache.org/jira/projects/KAFKA/issues",
+            exception.getMessage()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -29,8 +29,7 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -543,6 +542,6 @@ public class RocksDBMetricsTest {
         final Sensor sensor = sensorCreator.sensor(streamsMetrics, ROCKSDB_METRIC_CONTEXT);
 
 
-        assertThat(sensor, is(this.sensor));
+        assertEquals(this.sensor, sensor);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
@@ -27,8 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -283,7 +282,7 @@ public class StateStoreMetricsTest {
                     descriptionOfMax
                 )
             );
-            assertThat(sensor, is(expectedSensor));
+            assertEquals(expectedSensor, sensor);
         }
     }
 
@@ -362,7 +361,7 @@ public class StateStoreMetricsTest {
                     descriptionOfMax
                 )
             );
-            assertThat(sensor, is(expectedSensor));
+            assertEquals(expectedSensor, sensor);
         }
     }
 
@@ -398,7 +397,7 @@ public class StateStoreMetricsTest {
                     descriptionOfMax
                 )
             );
-            assertThat(sensor, is(expectedSensor));
+            assertEquals(expectedSensor, sensor);
         }
     }
 
@@ -432,7 +431,7 @@ public class StateStoreMetricsTest {
                     descriptionOfMax
                 )
             );
-            assertThat(sensor, is(expectedSensor));
+            assertEquals(expectedSensor, sensor);
         }
     }
 }


### PR DESCRIPTION
Migrated hamcrest to junit

Reviewers: Uros (github:uros-b), Ken Huang <s7133700@gmail.com>
