### PR TITLE
KAFKA-20770: Return UNDEFINED_EPOCH from LocalLeaderEndPoint when the epoch cannot be resolved

### DIFF
--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -119,21 +119,21 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val logStartOffset = partition.localLogOrException.logStartOffset
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(logStartOffset)
-    new OffsetAndEpoch(logStartOffset, epoch.orElse(0))
+    new OffsetAndEpoch(logStartOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchLatestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val logEndOffset = partition.localLogOrException.logEndOffset
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(logEndOffset)
-    new OffsetAndEpoch(logEndOffset, epoch.orElse(0))
+    new OffsetAndEpoch(logEndOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
     val partition = replicaManager.getPartitionOrException(topicPartition)
     val localLogStartOffset = partition.localLogOrException.localLogStartOffset()
     val epoch = partition.localLogOrException.leaderEpochCache.epochForOffset(localLogStartOffset)
-    new OffsetAndEpoch(localLogStartOffset, epoch.orElse(0))
+    new OffsetAndEpoch(localLogStartOffset, epoch.orElse(UNDEFINED_EPOCH))
   }
 
   override def fetchEarliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
@@ -159,7 +159,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
         case _ =>
           val earliestPendingUploadOffset = Math.max(highestRemoteOffset + 1, Math.max(logStartOffset.offset(), localLogStartOffset.offset()))
           val epoch = log.leaderEpochCache.epochForOffset(earliestPendingUploadOffset)
-          new OffsetAndEpoch(earliestPendingUploadOffset, epoch.orElse(0))
+          new OffsetAndEpoch(earliestPendingUploadOffset, epoch.orElse(UNDEFINED_EPOCH))
       }
     }
   }

--- a/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
+++ b/core/src/test/scala/kafka/server/LocalLeaderEndPointTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metadata.{FeatureLevelRecord, PartitionChangeReco
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.internal.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
@@ -167,6 +168,25 @@ class LocalLeaderEndPointTest extends Logging {
     replicaManager.logManager.getLog(topicPartition).ifPresent(_.updateLocalLogStartOffset(3))
     assertEquals(new OffsetAndEpoch(0L, 0), endPoint.fetchEarliestOffset(topicPartition, 7))
     assertEquals(new OffsetAndEpoch(3L, 1), endPoint.fetchEarliestLocalOffset(topicPartition, 7))
+  }
+
+  @Test
+  def testFetchOffsetsReturnUndefinedEpochWhenEpochIsUnresolvable(): Unit = {
+    appendRecords(replicaManager, topicIdPartition, records)
+      .onFire(response => assertEquals(Errors.NONE, response.error))
+
+    val log = replicaManager.getPartitionOrException(topicPartition).localLogOrException
+    // Simulate a leader whose epoch cache cannot resolve an epoch for the queried offsets,
+    // e.g. after the cache was cleared on a full truncation.
+    log.leaderEpochCache().clearAndFlush()
+
+    assertEquals(new OffsetAndEpoch(0L, UNDEFINED_EPOCH), endPoint.fetchEarliestOffset(topicPartition, 0))
+    assertEquals(new OffsetAndEpoch(3L, UNDEFINED_EPOCH), endPoint.fetchLatestOffset(topicPartition, 0))
+    assertEquals(new OffsetAndEpoch(0L, UNDEFINED_EPOCH), endPoint.fetchEarliestLocalOffset(topicPartition, 0))
+
+    // The same contract applies to the earliest pending upload offset.
+    log.updateHighestOffsetInRemoteStorage(1)
+    assertEquals(new OffsetAndEpoch(2L, UNDEFINED_EPOCH), endPoint.fetchEarliestPendingUploadOffset(topicPartition, 0))
   }
 
   @Test


### PR DESCRIPTION
LocalLeaderEndPoint falls back to epoch 0 when the leader epoch cache cannot
resolve an epoch for the queried offset, while RemoteLeaderEndPoint (via
ListOffsets) reports -1 in the same case. Epoch 0 is meaningful to
TierStateMachine#buildRemoteLogAuxState, which short-circuits the
earlier-epoch lookup on epoch 0 instead of failing the aux state build
explicitly. This PR aligns the local path with the remote one by falling back
to UNDEFINED_EPOCH (-1) in the four offset fetch methods, and adds a unit
test that exercises the unresolvable-epoch case for all four.

Jira: https://issues.apache.org/jira/browse/KAFKA-20770

### Testing

- New unit test `testFetchOffsetsReturnUndefinedEpochWhenEpochIsUnresolvable`
  fails before the fix (`expected epoch=-1 but was epoch=0`) and passes after.
- Targeted suites green: LocalLeaderEndPointTest, RemoteLeaderEndPointTest,
  ReplicaAlterLogDirsThreadTest, AbstractFetcherThreadTest,
  TierStateMachineTest, ReplicaFetcherThreadTest (156 tests, 0 failures).
