### PR TITLE
KAFKA-20785: Return PRODUCER_FENCED when EndTxn commit races with coordinator-side abort

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -747,9 +747,13 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     CompleteAbort + Commit + Retry returns IPE rather than ITS because the coordinator may abort an open
     transaction on its own (e.g. when it exceeds transaction.timeout.ms), bumping the epoch without the
     producer's knowledge. A commit that was already in flight when such an abort completed arrives with the
-    pre-abort epoch and is indistinguishable from a retry. The commit is guaranteed not to have taken effect,
-    so the recoverable INVALID_PRODUCER_EPOCH is returned, matching the transaction V1 behavior for this race,
-    instead of the fatal INVALID_TXN_STATE (KAFKA-20785).
+    pre-abort epoch and is indistinguishable from a retry. The commit is guaranteed not to have taken effect.
+    Under transaction V1 this race fails the strict epoch check above and returns the recoverable
+    PRODUCER_FENCED; V2's retry-tolerant epoch check accepts the request instead, so the recoverable outcome
+    is restored here at the state check. INVALID_PRODUCER_EPOCH is used rather than PRODUCER_FENCED because
+    no newer producer exists (the epoch is merely stale), mirroring the produce path's fix for the same race
+    (KAFKA-19690, UnifiedLog); the producer client treats the two errors identically on EndTxn responses
+    (KAFKA-20785).
    */
 
   /**
@@ -889,11 +893,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                 } else {
                   // Commit.
                   if (isRetry) {
-                    // The commit raced with an abort the producer did not request (e.g. the coordinator aborted the
-                    // transaction after transaction.timeout.ms elapsed) and lost: the abort bumped the epoch, so the
-                    // commit arrives with the pre-abort epoch. The commit is guaranteed not to have taken effect, so
-                    // return the recoverable INVALID_PRODUCER_EPOCH, matching the transaction V1 behavior for this
-                    // race, rather than the fatal INVALID_TXN_STATE (KAFKA-20785).
+                    // The commit raced with a coordinator-side abort (e.g. on transaction.timeout.ms) and is guaranteed
+                    // not to have taken effect; see the CompleteAbort + Commit + Retry note under the state table above (KAFKA-20785).
                     info(s"TransactionalId: $transactionalId's state is ${txnMetadata.state}, but received a COMMIT at " +
                       s"the pre-abort epoch $producerEpoch. The transaction was likely aborted by the coordinator on " +
                       s"timeout while the commit was in flight. Returning ${Errors.INVALID_PRODUCER_EPOCH}.")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -749,12 +749,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     pre-abort epoch and is indistinguishable from a retry. The commit is guaranteed not to have taken effect.
     Under transaction V1 this race fails the strict epoch check above and returns the recoverable
     PRODUCER_FENCED; V2's retry-tolerant epoch check accepts the request instead, so the recoverable outcome
-    is restored here at the state check (KAFKA-20785). Strictly speaking no newer producer took over the
-    transactional.id — the epoch is merely stale after the coordinator-side bump — but transactional requests
-    conventionally return PRODUCER_FENCED for epoch mismatches, and the producer client folds
-    INVALID_PRODUCER_EPOCH into ProducerFencedException on EndTxn responses anyway, so the two codes behave
-    identically. The produce path's fix for the same race returns INVALID_PRODUCER_EPOCH, following the
-    produce-path convention (KAFKA-19690, UnifiedLog).
+    is restored here at the state check (KAFKA-20785).
    */
 
   /**

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -716,6 +716,7 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     Note:
     PF = PRODUCER_FENCED
     ITS = INVALID_TXN_STATE
+    IPE = INVALID_PRODUCER_EPOCH
     NONE = No error and no epoch bump
     EB = No error and epoch bump
 
@@ -738,10 +739,17 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     +----------------+-------+---------+-------+---------+
     | Empty          | PF    | EB      | PF    | ITS     |
     +----------------+-------+---------+-------+---------+
-    | CompleteAbort  | NONE  | EB      | ITS   | ITS     |
+    | CompleteAbort  | NONE  | EB      | IPE   | ITS     |
     +----------------+-------+---------+-------+---------+
     | CompleteCommit | ITS   | EB      | NONE  | ITS     |
     +----------------+-------+---------+-------+---------+
+
+    CompleteAbort + Commit + Retry returns IPE rather than ITS because the coordinator may abort an open
+    transaction on its own (e.g. when it exceeds transaction.timeout.ms), bumping the epoch without the
+    producer's knowledge. A commit that was already in flight when such an abort completed arrives with the
+    pre-abort epoch and is indistinguishable from a retry. The commit is guaranteed not to have taken effect,
+    so the recoverable INVALID_PRODUCER_EPOCH is returned, matching the transaction V1 behavior for this race,
+    instead of the fatal INVALID_TXN_STATE (KAFKA-20785).
    */
 
   /**
@@ -880,7 +888,19 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                     generateTxnTransitMetadataForTxnCompletion(TransactionState.PREPARE_ABORT, true)
                 } else {
                   // Commit.
-                  logInvalidStateTransitionAndReturnError(transactionalId, txnMetadata.state, txnMarkerResult)
+                  if (isRetry) {
+                    // The commit raced with an abort the producer did not request (e.g. the coordinator aborted the
+                    // transaction after transaction.timeout.ms elapsed) and lost: the abort bumped the epoch, so the
+                    // commit arrives with the pre-abort epoch. The commit is guaranteed not to have taken effect, so
+                    // return the recoverable INVALID_PRODUCER_EPOCH, matching the transaction V1 behavior for this
+                    // race, rather than the fatal INVALID_TXN_STATE (KAFKA-20785).
+                    info(s"TransactionalId: $transactionalId's state is ${txnMetadata.state}, but received a COMMIT at " +
+                      s"the pre-abort epoch $producerEpoch. The transaction was likely aborted by the coordinator on " +
+                      s"timeout while the commit was in flight. Returning ${Errors.INVALID_PRODUCER_EPOCH}.")
+                    Left(Errors.INVALID_PRODUCER_EPOCH)
+                  } else {
+                    logInvalidStateTransitionAndReturnError(transactionalId, txnMetadata.state, txnMarkerResult)
+                  }
                 }
               case TransactionState.PREPARE_COMMIT =>
                 if (txnMarkerResult == TransactionResult.COMMIT)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -716,7 +716,6 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     Note:
     PF = PRODUCER_FENCED
     ITS = INVALID_TXN_STATE
-    IPE = INVALID_PRODUCER_EPOCH
     NONE = No error and no epoch bump
     EB = No error and epoch bump
 
@@ -739,21 +738,23 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
     +----------------+-------+---------+-------+---------+
     | Empty          | PF    | EB      | PF    | ITS     |
     +----------------+-------+---------+-------+---------+
-    | CompleteAbort  | NONE  | EB      | IPE   | ITS     |
+    | CompleteAbort  | NONE  | EB      | PF    | ITS     |
     +----------------+-------+---------+-------+---------+
     | CompleteCommit | ITS   | EB      | NONE  | ITS     |
     +----------------+-------+---------+-------+---------+
 
-    CompleteAbort + Commit + Retry returns IPE rather than ITS because the coordinator may abort an open
+    CompleteAbort + Commit + Retry returns PF rather than ITS because the coordinator may abort an open
     transaction on its own (e.g. when it exceeds transaction.timeout.ms), bumping the epoch without the
     producer's knowledge. A commit that was already in flight when such an abort completed arrives with the
     pre-abort epoch and is indistinguishable from a retry. The commit is guaranteed not to have taken effect.
     Under transaction V1 this race fails the strict epoch check above and returns the recoverable
     PRODUCER_FENCED; V2's retry-tolerant epoch check accepts the request instead, so the recoverable outcome
-    is restored here at the state check. INVALID_PRODUCER_EPOCH is used rather than PRODUCER_FENCED because
-    no newer producer exists (the epoch is merely stale), mirroring the produce path's fix for the same race
-    (KAFKA-19690, UnifiedLog); the producer client treats the two errors identically on EndTxn responses
-    (KAFKA-20785).
+    is restored here at the state check (KAFKA-20785). Strictly speaking no newer producer took over the
+    transactional.id — the epoch is merely stale after the coordinator-side bump — but transactional requests
+    conventionally return PRODUCER_FENCED for epoch mismatches, and the producer client folds
+    INVALID_PRODUCER_EPOCH into ProducerFencedException on EndTxn responses anyway, so the two codes behave
+    identically. The produce path's fix for the same race returns INVALID_PRODUCER_EPOCH, following the
+    produce-path convention (KAFKA-19690, UnifiedLog).
    */
 
   /**
@@ -897,8 +898,8 @@ class TransactionCoordinator(txnConfig: TransactionConfig,
                     // not to have taken effect; see the CompleteAbort + Commit + Retry note under the state table above (KAFKA-20785).
                     info(s"TransactionalId: $transactionalId's state is ${txnMetadata.state}, but received a COMMIT at " +
                       s"the pre-abort epoch $producerEpoch. The transaction was likely aborted by the coordinator on " +
-                      s"timeout while the commit was in flight. Returning ${Errors.INVALID_PRODUCER_EPOCH}.")
-                    Left(Errors.INVALID_PRODUCER_EPOCH)
+                      s"timeout while the commit was in flight. Returning ${Errors.PRODUCER_FENCED}.")
+                    Left(Errors.PRODUCER_FENCED)
                   } else {
                     logInvalidStateTransitionAndReturnError(transactionalId, txnMetadata.state, txnMarkerResult)
                   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -668,8 +668,51 @@ class TransactionCoordinatorTest {
     when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
       .thenReturn(Right(Some(new CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
 
-    coordinator.handleEndTransaction(transactionalId, producerId, requestEpoch(clientTransactionVersion), TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
+    // A commit at the current epoch is the next EndTxnRequest, not a retry, so the state transition is invalid.
+    coordinator.handleEndTransaction(transactionalId, producerId, producerEpoch, TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
     assertEquals(Errors.INVALID_TXN_STATE, error)
+    verify(transactionManager).getTransactionState(ArgumentMatchers.eq(transactionalId))
+  }
+
+  @Test
+  def shouldReturnInvalidProducerEpochOnEndTxnWhenStatusIsCompleteAbortAndCommitAtPreAbortEpochInV2(): Unit = {
+    val clientTransactionVersion = TransactionVersion.fromFeatureLevel(2)
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, RecordBatch.NO_PRODUCER_ID,
+      producerEpoch, (producerEpoch - 1).toShort, 1, TransactionState.COMPLETE_ABORT, util.Set.of, 0, time.milliseconds(), clientTransactionVersion)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(new CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+
+    // The coordinator aborted the transaction (e.g. on timeout) and bumped the epoch while the commit was in
+    // flight, so the commit arrives with the pre-abort epoch. This must not be the fatal INVALID_TXN_STATE:
+    // the commit did not take effect, and the producer can recover by aborting (KAFKA-20785).
+    coordinator.handleEndTransaction(transactionalId, producerId, (producerEpoch - 1).toShort, TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
+    assertEquals(Errors.INVALID_PRODUCER_EPOCH, error)
+    verify(transactionManager, never()).appendTransactionToLog(
+      ArgumentMatchers.eq(transactionalId),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any()
+    )
+    verify(transactionManager).getTransactionState(ArgumentMatchers.eq(transactionalId))
+  }
+
+  @Test
+  def shouldReturnInvalidProducerEpochOnEndTxnWhenStatusIsCompleteAbortAndCommitOnRetryOverflowInV2(): Unit = {
+    val clientTransactionVersion = TransactionVersion.fromFeatureLevel(2)
+    // The coordinator-side abort exhausted the epoch, rotating to a new producer ID with epoch 0 and recording
+    // the old producer ID in prevProducerId.
+    val newProducerId = producerId + 1
+    val txnMetadata = new TransactionMetadata(transactionalId, newProducerId, producerId, RecordBatch.NO_PRODUCER_ID,
+      0.toShort, RecordBatch.NO_PRODUCER_EPOCH, 1, TransactionState.COMPLETE_ABORT, util.Set.of, 0, time.milliseconds(), clientTransactionVersion)
+    when(transactionManager.getTransactionState(ArgumentMatchers.eq(transactionalId)))
+      .thenReturn(Right(Some(new CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+
+    // Same race as above, but the pre-abort epoch was Short.MaxValue - 1, so the stale commit matches the
+    // retry-on-overflow condition instead of the epoch-bump one.
+    coordinator.handleEndTransaction(transactionalId, producerId, (Short.MaxValue - 1).toShort, TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
+    assertEquals(Errors.INVALID_PRODUCER_EPOCH, error)
     verify(transactionManager).getTransactionState(ArgumentMatchers.eq(transactionalId))
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -675,7 +675,7 @@ class TransactionCoordinatorTest {
   }
 
   @Test
-  def shouldReturnInvalidProducerEpochOnEndTxnWhenStatusIsCompleteAbortAndCommitAtPreAbortEpochInV2(): Unit = {
+  def shouldReturnProducerFencedOnEndTxnWhenStatusIsCompleteAbortAndCommitAtPreAbortEpochInV2(): Unit = {
     val clientTransactionVersion = TransactionVersion.fromFeatureLevel(2)
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, RecordBatch.NO_PRODUCER_ID,
       producerEpoch, (producerEpoch - 1).toShort, 1, TransactionState.COMPLETE_ABORT, util.Set.of, 0, time.milliseconds(), clientTransactionVersion)
@@ -684,9 +684,10 @@ class TransactionCoordinatorTest {
 
     // The coordinator aborted the transaction (e.g. on timeout) and bumped the epoch while the commit was in
     // flight, so the commit arrives with the pre-abort epoch. This must not be the fatal INVALID_TXN_STATE:
-    // the commit did not take effect, and the producer can recover by aborting (KAFKA-20785).
+    // the commit did not take effect, and the producer can recover by aborting. PRODUCER_FENCED follows the
+    // transactional-request convention and matches what V1's strict epoch check returns for this race (KAFKA-20785).
     coordinator.handleEndTransaction(transactionalId, producerId, (producerEpoch - 1).toShort, TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
-    assertEquals(Errors.INVALID_PRODUCER_EPOCH, error)
+    assertEquals(Errors.PRODUCER_FENCED, error)
     verify(transactionManager, never()).appendTransactionToLog(
       ArgumentMatchers.eq(transactionalId),
       ArgumentMatchers.any(),
@@ -699,7 +700,7 @@ class TransactionCoordinatorTest {
   }
 
   @Test
-  def shouldReturnInvalidProducerEpochOnEndTxnWhenStatusIsCompleteAbortAndCommitOnRetryOverflowInV2(): Unit = {
+  def shouldReturnProducerFencedOnEndTxnWhenStatusIsCompleteAbortAndCommitOnRetryOverflowInV2(): Unit = {
     val clientTransactionVersion = TransactionVersion.fromFeatureLevel(2)
     // The coordinator-side abort exhausted the epoch, rotating to a new producer ID with epoch 0 and recording
     // the old producer ID in prevProducerId.
@@ -712,7 +713,7 @@ class TransactionCoordinatorTest {
     // Same race as above, but the pre-abort epoch was Short.MaxValue - 1, so the stale commit matches the
     // retry-on-overflow condition instead of the epoch-bump one.
     coordinator.handleEndTransaction(transactionalId, producerId, (Short.MaxValue - 1).toShort, TransactionResult.COMMIT, clientTransactionVersion, endTxnCallback)
-    assertEquals(Errors.INVALID_PRODUCER_EPOCH, error)
+    assertEquals(Errors.PRODUCER_FENCED, error)
     verify(transactionManager).getTransactionState(ArgumentMatchers.eq(transactionalId))
   }
 


### PR DESCRIPTION
Under transactions V2, when the transaction coordinator aborts an open
transaction on its own (e.g. after `transaction.timeout.ms` elapses),
the abort bumps the producer epoch. A commit that was already in flight
when the abort completed arrives with the pre-abort epoch, which matches
the V2 EndTxn retry condition (stored epoch == request epoch + 1). It
therefore passes the epoch check and fails the state check instead: the
coordinator logs "state is COMPLETE_ABORT, but received transaction
marker result to send: COMMIT" and returns `INVALID_TXN_STATE`, which
producer clients treat as unconditionally fatal. Kafka Streams cannot
recover from it and the affected StreamThread dies, even though the
transaction was fully rolled back server-side and the commit never took
effect.

Under transactions V1 the same race fails the strict epoch check and
returns `PRODUCER_FENCED`, which applications such as Kafka Streams
handle gracefully by rebalancing; the fatal outcome is V2-only.

This change returns the recoverable `PRODUCER_FENCED` instead of
`INVALID_TXN_STATE` when a commit arrives in `COMPLETE_ABORT` at a retry
epoch (both the epoch-bump and the producer-id-overflow variants). Only
a coordinator-initiated abort can produce this combination: a client
retrying its own EndTxn always carries the operation it originally sent,
so a COMMIT at the pre-abort epoch means the producer never requested
the abort. `PRODUCER_FENCED` matches what V1 returns for this race and
follows the existing convention that transactional requests return
`PRODUCER_FENCED` on epoch mismatches while produce requests return
`INVALID_PRODUCER_EPOCH`; the producer client folds
`INVALID_PRODUCER_EPOCH` into `ProducerFencedException` on EndTxn
responses anyway, so the two codes behave identically for clients —
Kafka Streams recovers by rebalancing, restoring the V1 behavior for
this race. A commit in `COMPLETE_ABORT` at the current epoch still
returns `INVALID_TXN_STATE`, since that indicates a client-side bug
rather than this race. Only transactions-V2 clients reach this code
path, so no protocol or version-gating changes are needed.

This is the EndTxn-path analogue of KAFKA-19690 (#20534), which made the
same correction on the Produce path for producers that were mid-produce
when the timeout abort landed, returning `INVALID_PRODUCER_EPOCH` per
the produce-path convention.

Reviewers: Justine Olshan <jolshan@confluent.io>, Ken Huang <s7133700@gmail.com>
