### PR TITLE
KAFKA-20961: Carry leader epoch history over when replacing the current log with the future log

### DIFF
--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -3494,6 +3494,74 @@ class PartitionTest extends AbstractPartitionTest {
   }
 
   @Test
+  def testLeaderEpochCacheIsRetainedWhenCurrentIsReplacedWithFutureLog(): Unit = {
+    // Moving a partition to another log directory on the leader must not drop leader epoch history.
+    // An epoch which has no records behind it exists only in the current log's epoch cache, since
+    // the future log's cache is populated from the record batches copied into it.
+    val leaderEpoch = 5
+    makeLeaderAndReplaceCurrentWithFutureLog(leaderEpoch)
+
+    assertEquals(Optional.of(leaderEpoch), partition.log.get.latestEpoch,
+      "Leader epoch history was lost when the current log was replaced with the future log")
+    val epochEndOffset =
+      partition.lastOffsetForLeaderEpoch(Optional.of(leaderEpoch), leaderEpoch, fetchOnlyFromLeader = true)
+    assertEquals(Errors.NONE.code, epochEndOffset.errorCode)
+    assertEquals(leaderEpoch, epochEndOffset.leaderEpoch)
+    assertEquals(0L, epochEndOffset.endOffset)
+  }
+
+  @Test
+  def testFollowerFetchIsServedAfterCurrentIsReplacedWithFutureLog(): Unit = {
+    // A follower keeps reporting the epoch it last fetched. If the leader can no longer resolve that
+    // epoch after the log directory move, it answers OffsetOutOfRangeException. The follower then
+    // resets to the same offset without truncating anything, so its next fetch is identical and the
+    // pair loops until records are appended.
+    val leaderEpoch = 5
+    makeLeaderAndReplaceCurrentWithFutureLog(leaderEpoch)
+
+    val logReadInfo = fetchFollower(
+      partition,
+      replicaId = remoteReplicaId,
+      fetchOffset = 0L,
+      leaderEpoch = Some(leaderEpoch),
+      lastFetchedEpoch = Some(leaderEpoch)
+    )
+    assertEquals(Optional.empty, logReadInfo.divergingEpoch)
+    assertEquals(0L, logReadInfo.logEndOffset)
+  }
+
+  /**
+   * Makes the local replica the leader of an empty partition at the given epoch and then moves the
+   * partition to the second log directory. The future log is empty and therefore already caught up
+   * with the equally empty current log, so the replacement happens right away.
+   */
+  private def makeLeaderAndReplaceCurrentWithFutureLog(leaderEpoch: Int): Unit = {
+    logManager.maybeUpdatePreferredLogDir(topicPartition, logDir1.getAbsolutePath)
+    partition.createLogIfNotExists(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = topicId)
+
+    val replicas = Array(brokerId, remoteReplicaId)
+    addBrokerEpochToMockMetadataCache(metadataCache, replicas)
+    val partitionRegistration = new PartitionRegistration.Builder()
+      .setLeader(brokerId)
+      .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+      .setLeaderEpoch(leaderEpoch)
+      .setIsr(replicas)
+      .setReplicas(replicas)
+      .setDirectories(DirectoryId.unassignedArray(replicas.length))
+      .setPartitionEpoch(1)
+      .build()
+    assertTrue(partition.makeLeader(partitionRegistration, isNew = true, offsetCheckpoints, None))
+
+    // No records are ever appended, so the epoch is only known through the epoch cache.
+    assertEquals(Optional.of(leaderEpoch), partition.log.get.latestEpoch)
+
+    logManager.maybeUpdatePreferredLogDir(topicPartition, logDir2.getAbsolutePath)
+    assertTrue(partition.maybeCreateFutureReplica(logDir2.getAbsolutePath, offsetCheckpoints))
+    assertTrue(partition.maybeReplaceCurrentWithFutureReplica())
+    assertEquals(logDir2.getAbsolutePath, partition.log.get.parentDir)
+  }
+
+  @Test
   def testMaybeStartTransactionVerification(): Unit = {
     val leaderEpoch = 5
     val replicas = Array(brokerId, brokerId + 1)

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogManager.java
@@ -1520,15 +1520,23 @@ public class LogManager {
         }
     }
 
-    private void replaceCurrentWithFutureLog(Optional<UnifiedLog> sourceLog, UnifiedLog destLog, boolean updateHighWatermark) throws IOException {
+    private void replaceCurrentWithFutureLog(Optional<UnifiedLog> sourceLog, UnifiedLog destLog, boolean futureLogCaughtUp) throws IOException {
         TopicPartition topicPartition = destLog.topicPartition();
 
         destLog.renameDir(UnifiedLog.logDirName(topicPartition), true);
         // the metrics tags still contain "future", so we have to remove it.
         // we will add metrics back after sourceLog remove the metrics
         destLog.removeLogMetrics();
-        if (updateHighWatermark && sourceLog.isPresent()) {
+        if (futureLogCaughtUp && sourceLog.isPresent()) {
             destLog.updateHighWatermark(sourceLog.get().highWatermark());
+            // The future log only learns about leader epochs from the record batches copied into it, so
+            // epochs which have no records behind them are missing from its cache. One is assigned on
+            // every leader election, which means a partition that is moved between log directories while
+            // it has no incoming traffic ends up with a leader that cannot answer the end offset of the
+            // epoch a follower last fetched, and answers OffsetOutOfRangeException instead. Carry the
+            // history over. This is sound only because the future log has caught up with the current one,
+            // so both hold the same offsets.
+            destLog.leaderEpochCache().assign(sourceLog.get().leaderEpochCache().epochEntries());
         }
 
         // Now that future replica has been successfully renamed to be the current replica

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogManagerTest.java
@@ -1270,6 +1270,34 @@ public class LogManagerTest {
         verifyMetrics(1,  logMetrics.get(), metricTag);
     }
 
+    /**
+     * The future log only learns about leader epochs from the record batches copied into it, so epochs
+     * with no records behind them exist only in the current log's cache. They have to survive the swap,
+     * otherwise a leader that moved a partition between log directories can no longer answer the end
+     * offset of the epoch a follower last fetched.
+     */
+    @Test
+    public void testLeaderEpochCacheIsCarriedOverWhenMovingCurrentToFutureLog() throws Exception {
+        File dir1 = TestUtils.tempDirectory();
+        File dir2 = TestUtils.tempDirectory();
+        logManager = createLogManager(List.of(dir1, dir2));
+        logManager.startup(Set.of());
+
+        TopicPartition tp = new TopicPartition("future-log", 0);
+        logManager.maybeUpdatePreferredLogDir(tp, dir1.getAbsolutePath());
+        UnifiedLog currentLog = logManager.getOrCreateLog(tp, Optional.empty());
+        List<EpochEntry> epochEntries = List.of(new EpochEntry(1, 0L), new EpochEntry(2, 5L), new EpochEntry(4, 9L));
+        currentLog.leaderEpochCache().assign(epochEntries);
+
+        logManager.maybeUpdatePreferredLogDir(tp, dir2.getAbsolutePath());
+        UnifiedLog futureLog = logManager.getOrCreateLog(tp, false, true, Optional.empty());
+        assertEquals(List.of(), futureLog.leaderEpochCache().epochEntries());
+
+        logManager.replaceCurrentWithFutureLog(tp);
+
+        assertEquals(epochEntries, futureLog.leaderEpochCache().epochEntries());
+    }
+
     private void verifyMetrics(int logCount, Set<MetricName> logMetrics, String metricTag) {
         assertEquals(LogMetricNames.ALL_METRIC_NAMES.size() * logCount, logMetrics.size());
         logMetrics.forEach(metric -> assertTrue(metric.getMBeanName().contains(metricTag)));


### PR DESCRIPTION
Moving a partition between log directories replaces the current log with the
future log, but the future log's leader epoch cache is only ever populated from
the record batches copied into it. Epochs with no records behind them - such as
the one Partition#makeLeader assigns on every leader election - therefore exist
only in the current log's cache and are dropped by the swap.

A leader whose cache no longer holds the epoch a follower reports as its last
fetched epoch cannot determine that epoch's end offset, so it answers the fetch
with OffsetOutOfRangeException. The follower then resets its fetch offset to the
higher of its own log end offset and the leader's log start offset, which on an
idle partition is the offset it already had, so nothing is truncated and its next
fetch is identical. The two loop until records are appended to the partition.

This PR copies the epoch history from the log being replaced. This is sound
because the swap only happens once the future log has caught up, so both logs
hold the same offsets. The parameter guarding the high watermark transfer is
renamed to say why the inheritance is valid.

This appears to be the same defect as KAFKA-15608 (analysis posted on both
tickets). It differs from the earlier attempt in #14553 in two ways: the full
epoch history is carried over rather than only the latest entry (dropping
intermediate record-less epochs would still leave the follower subject to
spurious diverging-epoch truncation), and the transfer is confined to the
caught-up swap path - recoverAbandonedFutureLogs offers no LEO-equality
guarantee, so inheriting there could fabricate epoch entries beyond the log end.

### Testing

- New Partition test reproduces the reported symptom deterministically on
  trunk: after moving an idle partition to another log directory, a follower
  fetch with its last fetched epoch fails with
  `OffsetOutOfRangeException: Could not determine the end offset of the last
  fetched epoch Optional[5]` before this change and is served after it.
- New LogManager test pins the full-history transfer (three epoch entries).
- Targeted suites green: PartitionTest, ReplicaManagerTest, UnifiedLogTest,
  LogManagerTest, LeaderEpochFileCacheTest, ReplicaAlterLogDirsThreadTest,
  LeaderEpochIntegrationTest, OffsetsForLeaderEpochTest (526 tests, 0 failures).
