### PR TITLE
KAFKA-20966: RemoteLogInputStream can attempt an unbounded memory allocation when reading a corrupted remote log segment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/internal/RemoteLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/RemoteLogInputStream.java
@@ -30,11 +30,13 @@ import static org.apache.kafka.common.record.internal.Records.SIZE_OFFSET;
 
 public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
     private final InputStream inputStream;
+    private final int maxMessageSize;
     // LogHeader buffer up to magic.
     private final ByteBuffer logHeaderBuffer = ByteBuffer.allocate(HEADER_SIZE_UP_TO_MAGIC);
 
-    public RemoteLogInputStream(InputStream inputStream) {
+    public RemoteLogInputStream(InputStream inputStream, int maxMessageSize) {
         this.inputStream = inputStream;
+        this.maxMessageSize = maxMessageSize;
     }
 
     @Override
@@ -52,6 +54,10 @@ public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
         if (size < LegacyRecord.RECORD_OVERHEAD_V0)
             throw new CorruptRecordException(String.format("Found record size %d smaller than minimum record " +
                                                                    "overhead (%d).", size, LegacyRecord.RECORD_OVERHEAD_V0));
+
+        if (size > maxMessageSize)
+            throw new CorruptRecordException(String.format("Found record size %d larger than the maximum allowable " +
+                                                                   "message size (%d).", size, maxMessageSize));
 
         // Total size is: "LOG_OVERHEAD + the size of the rest of the content"
         int bufferSize = LOG_OVERHEAD + size;

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/RemoteLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/RemoteLogInputStreamTest.java
@@ -17,10 +17,12 @@
 package org.apache.kafka.common.record.internal;
 
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.test.TestUtils;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,6 +32,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RemoteLogInputStreamTest {
@@ -99,7 +103,7 @@ public class RemoteLogInputStreamTest {
         }
 
         try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, Integer.MAX_VALUE);
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecord);
@@ -143,7 +147,7 @@ public class RemoteLogInputStreamTest {
         }
 
         try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, Integer.MAX_VALUE);
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertNoProducerData(firstBatch);
@@ -194,7 +198,7 @@ public class RemoteLogInputStreamTest {
         }
 
         try (FileInputStream is = new FileInputStream(file)) {
-            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, Integer.MAX_VALUE);
 
             RecordBatch firstBatch = logInputStream.nextBatch();
             assertProducerData(firstBatch, producerId, producerEpoch, baseSequence, false, firstBatchRecords);
@@ -235,6 +239,28 @@ public class RemoteLogInputStreamTest {
             assertGenericRecordBatchData(args, firstBatch, 0L, 100L, firstBatchRecord);
 
             assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @Test
+    public void testNextBatchThrowsCorruptRecordExceptionWhenSizeExceedsMaxMessageSize() throws IOException {
+        SimpleRecord record = new SimpleRecord(100L, "foo".getBytes());
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(MAGIC_VALUE_V2, 0L, Compression.NONE, CREATE_TIME, record));
+            fileRecords.flush();
+        }
+
+        // Corrupt the on-disk size field so that it exceeds a deliberately small maxMessageSize.
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.seek(Records.SIZE_OFFSET);
+            raf.writeInt(1000);
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is, 100);
+            assertThrows(CorruptRecordException.class, logInputStream::nextBatch);
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -643,7 +643,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         return remoteLogMetadataManagerPlugin.get().nextSegmentWithTxnIndex(tpId, epochForOffset, offset);
     }
 
-    Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset)
+    Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset,
+                                                              int maxMessageSize)
             throws RemoteStorageException, IOException {
         int startPos = indexCache.lookupTimestamp(rlsMetadata, timestamp, startingOffset);
 
@@ -651,7 +652,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         try {
             // Search forward for the position of the last offset that is greater than or equal to the startingOffset
             remoteSegInputStream = remoteStorageManagerPlugin.get().fetchLogSegment(rlsMetadata, startPos);
-            RemoteLogInputStream remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream);
+            RemoteLogInputStream remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream, maxMessageSize);
 
             while (true) {
                 RecordBatch batch = remoteLogInputStream.nextBatch();
@@ -751,7 +752,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                     List<LogSegment> segmentsCopy = unifiedLog.logSegments();
                     if (segmentsCopy.isEmpty() || rlsMetadata.startOffset() < segmentsCopy.get(0).baseOffset()) {
                         // search in remote-log
-                        return lookupTimestamp(rlsMetadata, timestamp, startingOffset);
+                        return lookupTimestamp(rlsMetadata, timestamp, startingOffset, unifiedLog.config().maxMessageSize());
                     } else {
                         // search in local-log
                         for (LogSegment segment : segmentsCopy) {
@@ -1895,7 +1896,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 // Search forward for the position of the last offset that is greater than or equal to the target offset
                 startPos = lookupPositionForOffset(remoteLogSegmentMetadata, offset);
                 remoteSegInputStream = remoteStorageManagerPlugin.get().fetchLogSegment(remoteLogSegmentMetadata, startPos);
-                RemoteLogInputStream remoteLogInputStream = getRemoteLogInputStream(remoteSegInputStream);
+                RemoteLogInputStream remoteLogInputStream = getRemoteLogInputStream(remoteSegInputStream, logOptional.get().config().maxMessageSize());
                 enrichedRecordBatch = findFirstBatch(remoteLogInputStream, offset);
                 if (enrichedRecordBatch.batch == null) {
                     Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
@@ -1948,8 +1949,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         }
     }
     // for testing
-    RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
-        return new RemoteLogInputStream(in);
+    RemoteLogInputStream getRemoteLogInputStream(InputStream in, int maxMessageSize) {
+        return new RemoteLogInputStream(in, maxMessageSize);
     }
 
     // Visible for testing

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -1807,7 +1807,8 @@ public class RemoteLogManagerTest {
                 return remoteLogMetadataManager;
             }
             @Override
-            Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset) {
+            Optional<FileRecords.TimestampAndOffset> lookupTimestamp(RemoteLogSegmentMetadata rlsMetadata, long timestamp, long startingOffset,
+                                                                      int maxMessageSize) {
                 return Optional.of(expectedRemoteResult);
             }
         };
@@ -3763,7 +3764,7 @@ public class RemoteLogManagerTest {
                 return Optional.of(segmentMetadata);
             }
             @Override
-            public RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
+            public RemoteLogInputStream getRemoteLogInputStream(InputStream in, int maxMessageSize) {
                 return remoteLogInputStream;
             }
             @Override


### PR DESCRIPTION
`RemoteLogInputStream.nextBatch()` reads a 4-byte batch-size field off the `InputStream` returned by the pluggable `RemoteStorageManager` and uses it to size an allocation, checking only a lower bound:

```java
int size = logHeaderBuffer.getInt(SIZE_OFFSET);

// V0 has the smallest overhead, stricter checking is done later
if (size < LegacyRecord.RECORD_OVERHEAD_V0)
    throw new CorruptRecordException(...);

int bufferSize = LOG_OVERHEAD + size;
ByteBuffer buffer = ByteBuffer.allocate(bufferSize);   // no upper bound on size
```

Nothing verifies that `size` is not absurdly large before allocating. Since `size` is a signed int read directly from the remote segment's bytes, a corrupted or bit-rotted segment — or a buggy `RemoteStorageManager` implementation — can drive a single allocation of up to ~2GB, per batch read.

The sibling class `ByteBufferLogInputStream` parses the identical length-prefixed header format and already guards against exactly this:

```java
if (recordSize > maxMessageSize)
    throw new CorruptRecordException(String.format(
        "Record size %d exceeds the largest allowable message size (%d).",
        recordSize, maxMessageSize));
```

`RemoteLogInputStream` has no equivalent check, and is the more exposed of the two: `ByteBufferLogInputStream` only slices an already-in-memory, already-bounded `ByteBuffer`, whereas `RemoteLogInputStream` calls `ByteBuffer.allocate()` on the untrusted value before confirming the stream even holds that many bytes.

Both reachable call sites are hot server-side paths, not test-only code:
- `RemoteLogManager.read()` — consumer fetches that fall through to tiered storage
- `RemoteLogManager.lookupTimestamp()` — offset-by-timestamp lookups against tiered segments

### Changes

- `RemoteLogInputStream` now takes a `maxMessageSize` in its constructor and throws `CorruptRecordException` when the declared batch size exceeds it, mirroring the existing `ByteBufferLogInputStream` check so the two paths validate consistently.
- `RemoteLogManager` threads `UnifiedLog.config().maxMessageSize()` into both call sites. That value is already available at each one, so no new configuration or plumbing is introduced.

The bound is the same one the local-log read path already enforces, so a segment that could legitimately be written locally still reads back from remote storage unchanged; only sizes that could never correspond to a valid batch are rejected.

### Testing

- Added `RemoteLogInputStreamTest#testNextBatchThrowsCorruptRecordExceptionWhenSizeExceedsMaxMessageSize`, which writes a valid record, patches the on-disk size field to exceed a deliberately small `maxMessageSize`, and asserts `CorruptRecordException` is raised instead of the oversized allocation being attempted. This mirrors `ByteBufferLogInputStreamTest#iteratorRaisesOnTooLargeRecords`, keeping the two classes' coverage symmetric.
- Existing `RemoteLogInputStreamTest` cases were updated for the new constructor and pass unchanged (61 tests, 0 failures), confirming that valid segments across all magic values and compression types still read back correctly.
- `RemoteLogManagerTest` passes (95 tests, 0 failures), covering both updated call sites including the log-compaction retry path in `read()`.

Co-Authored-By: Claude Sonnet 5
