### PR TITLE
KAFKA-20845: Don't flush empty batch when appending large records in group coordinator (4.1)

### DIFF
--- a/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
+++ b/coordinator-common/src/main/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntime.java
@@ -789,7 +789,7 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                     if (currentBatch.builder.numRecords() == 0) {
                         // The only way we can get here is if append() has failed in an unexpected
                         // way and left an empty batch. Try to clean it up.
-                        log.debug("Tried to flush an empty batch for {}.", tp);
+                        log.warn("Tried to flush an empty batch for {}.", tp);
                         // There should not be any deferred events attached to the batch. We fail
                         // the batch just in case. As a side effect, coordinator state is also
                         // reverted, but there should be no changes since the batch was empty.
@@ -1035,7 +1035,8 @@ public class CoordinatorRuntime<S extends CoordinatorShard<U>, U> implements Aut
                         recordsToAppend
                     );
 
-                    if (!currentBatch.builder.hasRoomFor(estimatedSizeUpperBound)) {
+                    if (currentBatch.builder.numRecords() > 0 &&
+                        !currentBatch.builder.hasRoomFor(estimatedSizeUpperBound)) {
                         // Start a new batch when the total uncompressed data size would exceed
                         // the max batch size. We still allow atomic writes with an uncompressed size
                         // larger than the max batch size as long as they compress down to under the max

--- a/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
+++ b/coordinator-common/src/test/java/org/apache/kafka/coordinator/common/runtime/CoordinatorRuntimeTest.java
@@ -4464,6 +4464,73 @@ public class CoordinatorRuntimeTest {
     }
 
     @Test
+    public void testLargeCompressibleRecordDoesNotFlushEmptyBatch() throws Exception {
+        MockTimer timer = new MockTimer();
+        MockPartitionWriter writer = new MockPartitionWriter();
+        Compression compression = Compression.gzip().build();
+
+        CoordinatorRuntime<MockCoordinatorShard, String> runtime =
+            new CoordinatorRuntime.Builder<MockCoordinatorShard, String>()
+                .withTime(timer.time())
+                .withTimer(timer)
+                .withDefaultWriteTimeOut(Duration.ofMillis(30))
+                .withLoader(new MockCoordinatorLoader())
+                .withEventProcessor(new DirectEventProcessor())
+                .withPartitionWriter(writer)
+                .withCoordinatorShardBuilderSupplier(new MockCoordinatorShardBuilderSupplier())
+                .withCoordinatorRuntimeMetrics(mock(CoordinatorRuntimeMetrics.class))
+                .withCoordinatorMetrics(mock(CoordinatorMetrics.class))
+                .withCompression(compression)
+                .withSerializer(new StringSerializer())
+                .withAppendLingerMs(10)
+                .withExecutorService(mock(ExecutorService.class))
+                .build();
+
+        // Schedule the loading.
+        runtime.scheduleLoadOperation(TP, 10);
+
+        // Verify the initial state.
+        CoordinatorRuntime<MockCoordinatorShard, String>.CoordinatorContext ctx = runtime.contextOrThrow(TP);
+        assertNull(ctx.currentBatch);
+
+        // Get the max batch size.
+        int maxBatchSize = writer.config(TP).maxMessageSize();
+
+        // Create a large record of highly compressible data.
+        List<String> largeRecord = List.of("a".repeat(3 * maxBatchSize));
+
+        // Write the large record with a non-replaying write operation which applies its
+        // in-memory changes directly. The record does not fit in an empty batch uncompressed,
+        // but it fits once compressed, so it goes into a batch on its own. The batch is
+        // flushed immediately because it has no room left.
+        long batchTimestamp = timer.time().milliseconds();
+        CompletableFuture<String> write = runtime.scheduleWriteOperation("write#1", TP, Duration.ofMillis(50),
+            state -> {
+                state.replay(0, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, largeRecord.get(0));
+                return new CoordinatorResult<>(largeRecord, "response1", null, false);
+            }
+        );
+
+        // Verify the state. Only a single batch must have been created and flushed so the
+        // in-memory changes made by the write operation are attached to the same batch as
+        // its records and are not reverted by the flush of an empty batch.
+        assertEquals(1L, ctx.coordinator.lastWrittenOffset());
+        assertEquals(0L, ctx.coordinator.lastCommittedOffset());
+        assertEquals(List.of(
+            new MockCoordinatorShard.RecordAndMetadata(0, largeRecord.get(0))
+        ), ctx.coordinator.coordinator().fullRecords());
+        assertEquals(List.of(
+            records(batchTimestamp, compression, largeRecord)
+        ), writer.entries(TP));
+
+        // Commit and verify that the write is completed.
+        writer.commit(TP);
+        assertTrue(write.isDone());
+        assertEquals(1L, ctx.coordinator.lastCommittedOffset());
+        assertEquals("response1", write.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void testLargeCompressibleRecordTriggersFlushAndSucceeds() throws Exception {
         MockTimer timer = new MockTimer();
         MockPartitionWriter writer = new MockPartitionWriter();


### PR DESCRIPTION
When appending records, we create a new batch if no batch exists.
KAFKA-19760 introduced a flush of any existing batch when appending
large records, to maximize our chances of compressing the records under
the max.message.bytes. When these two things happen in the same append
operation, we flush an empty batch.

Flushing an empty batch is written to fail and revert the coordinator
state. This would be harmless, except some group coordinator operations
update the coordinator state directly without replay. Upon appending
their records and triggering the empty batch flush, their state changes
are then reverted while their records are written. The group
coordinator's in-memory state diverges from the on-disk state and
subsequent writes for the group can be invalid for the on-disk state.
eg. we may have a consumer group downgraded to a classic group, followed
by consumer group records which is invalid.

Do not flush empty batches when appending large records.

Backport of #22969 to 4.1. `CoordinatorContext.batchEpoch` does not
exist on this branch, so the test cannot assert that a single batch was
created. Instead, it uses a non-replaying write operation which applies
its in-memory changes directly and verifies that they are not reverted
by the flush of an empty batch.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
