### PR TITLE
MINOR: Upgrade setup-gradle action to enable the CI (4.0)

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -42,7 +42,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       env:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
       with:


### PR DESCRIPTION
The 4.0 branch pins `gradle/actions/setup-gradle` to v4.1.0, which is no
longer on the list of actions allowed in the apache organization. As a
result, the "Compile and Check Java" job is rejected before it runs and
CI fails for every pull request against 4.0.

This patch bumps the action to v5.0.2, the version used on the 4.1 and
4.2 branches. The inputs of the action are unchanged.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
