### PR TITLE
KAFKA-20967: RemoteLogManager.read() leaks the remote segment InputStream when reading a batch fails

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1899,6 +1899,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                 enrichedRecordBatch = findFirstBatch(remoteLogInputStream, offset);
                 if (enrichedRecordBatch.batch == null) {
                     Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
+                    remoteSegInputStream = null;
                     rlsMetadataOptional = findNextSegmentMetadata(rlsMetadataOptional.get(), logOptional.get().leaderEpochCache());
                 }
             }
@@ -1942,9 +1943,9 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
             return fetchDataInfo;
         } finally {
-            if (enrichedRecordBatch.batch != null) {
-                Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
-            }
+            // The stream is set to null after it is closed within the loop above, so this closes the
+            // currently-open segment stream exactly once, including when findFirstBatch throws.
+            Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
         }
     }
     // for testing

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.ReplicaNotAvailableException;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
@@ -3780,6 +3781,72 @@ public class RemoteLogManagerTest {
             // Verify that the byte buffer has capacity equal to the size of the first batch
             assertEquals(recordBatchSizeInBytes, capture.getValue().capacity());
 
+        }
+    }
+
+    @Test
+    public void testReadClosesRemoteSegmentInputStreamWhenReadingBatchFails() throws RemoteStorageException, IOException {
+        FileInputStream fileInputStream = mock(FileInputStream.class);
+        RemoteLogInputStream remoteLogInputStream = mock(RemoteLogInputStream.class);
+        ClassLoaderAwareRemoteStorageManager rsmManager = mock(ClassLoaderAwareRemoteStorageManager.class);
+        RemoteLogSegmentMetadata segmentMetadata = mock(RemoteLogSegmentMetadata.class);
+        LeaderEpochFileCache cache = mock(LeaderEpochFileCache.class);
+        when(cache.epochForOffset(anyLong())).thenReturn(OptionalInt.of(1));
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+
+        int fetchOffset = 0;
+        int fetchMaxBytes = 10;
+
+        FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(
+                Uuid.randomUuid(), fetchOffset, 0, fetchMaxBytes, Optional.empty()
+        );
+
+        when(rsmManager.fetchLogSegment(any(), anyInt())).thenReturn(fileInputStream);
+        when(segmentMetadata.topicIdPartition()).thenReturn(new TopicIdPartition(Uuid.randomUuid(), tp));
+        // Reading the batch fails, as it would for a corrupted remote segment or when the remote
+        // storage plugin hits an I/O error part-way through the segment.
+        when(remoteLogInputStream.nextBatch()).thenThrow(new CorruptRecordException("Simulated corrupt batch"));
+
+        RemoteStorageFetchInfo fetchInfo = new RemoteStorageFetchInfo(
+                0, true, tpId, partitionData, FetchIsolation.HIGH_WATERMARK
+        );
+
+        try (RemoteLogManager remoteLogManager = new RemoteLogManager(
+                config,
+                brokerId,
+                logDir,
+                clusterId,
+                time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> {
+                },
+                brokerTopicStats,
+                metrics,
+                endPoint) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return rsmManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            public Optional<RemoteLogSegmentMetadata> fetchRemoteLogSegmentMetadata(TopicPartition topicPartition, int epochForOffset, long offset) {
+                return Optional.of(segmentMetadata);
+            }
+            @Override
+            public RemoteLogInputStream getRemoteLogInputStream(InputStream in) {
+                return remoteLogInputStream;
+            }
+            @Override
+            int lookupPositionForOffset(RemoteLogSegmentMetadata remoteLogSegmentMetadata, long offset) {
+                return 1;
+            }
+        }) {
+            assertThrows(CorruptRecordException.class, () -> remoteLogManager.read(fetchInfo));
+            // The segment stream must be closed even though no batch was successfully read from it.
+            verify(fileInputStream).close();
         }
     }
 


### PR DESCRIPTION
`RemoteLogManager.read()` opens an `InputStream` from the pluggable `RemoteStorageManager` and closes it in a `finally` block gated on a condition that is not satisfied when an exception is thrown:

```java
EnrichedRecordBatch enrichedRecordBatch = new EnrichedRecordBatch(null, 0);
InputStream remoteSegInputStream = null;
try {
    while (enrichedRecordBatch.batch == null && rlsMetadataOptional.isPresent()) {
        ...
        remoteSegInputStream = remoteStorageManagerPlugin.get().fetchLogSegment(remoteLogSegmentMetadata, startPos);
        RemoteLogInputStream remoteLogInputStream = getRemoteLogInputStream(remoteSegInputStream);
        enrichedRecordBatch = findFirstBatch(remoteLogInputStream, offset);    // can throw
        ...
    }
    ...
} finally {
    if (enrichedRecordBatch.batch != null) {
        Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream");
    }
}
```

`findFirstBatch()` calls `RemoteLogInputStream.nextBatch()` in a loop. That method declares `throws IOException` and can also throw the unchecked `CorruptRecordException`. When either is thrown, the assignment to `enrichedRecordBatch` never completes, so it keeps its stale null-batch value — the initial `new EnrichedRecordBatch(null, 0)` on the first iteration, or the previous iteration's value. The `finally` block then evaluates that same stale `enrichedRecordBatch.batch != null` as false and skips the close, even though the stream was opened moments earlier in that iteration.

For real tiered-storage plugins the leaked resource is typically a socket or file handle. `read()` is on the consumer fetch path — invoked for every fetch that misses the local log and falls through to tiered storage — so sustained remote I/O flakiness, or a corrupted segment being repeatedly requested, leaks one handle per failed read and risks file-descriptor or connection-pool exhaustion.

The sibling method `lookupTimestamp()` in the same class closes its stream unconditionally and does not have this problem.

### Changes

The conditional guard appears to have been intended to avoid a double close on the path where the loop advances to the next segment, since that path already closes the stream before looking up the next segment's metadata. Rather than widening the condition, this sets `remoteSegInputStream = null` after that in-loop close and makes the `finally` close unconditional. `Utils.closeQuietly` ignores a null argument, so each stream is now closed exactly once on every path:

- a batch is found — the stream stays open for the subsequent `Utils.readFully`, and `finally` closes it
- the loop exhausts all segments without finding a batch — each stream is closed in the loop, and `finally` sees null
- `findFirstBatch` throws — the stream is still open and non-null, so `finally` now closes it (this is the leak being fixed)
- `lookupPositionForOffset` or `fetchLogSegment` throws on a later iteration — the previous stream was already closed and nulled, so `finally` sees null
- anything after the loop throws (`readFully`, `addAbortedTransactions`) — the batch is non-null and the stream is open, so `finally` closes it

### Testing

Added `RemoteLogManagerTest#testReadClosesRemoteSegmentInputStreamWhenReadingBatchFails`, which stubs `nextBatch()` to throw `CorruptRecordException` — standing in for a corrupted remote segment or a plugin I/O error part-way through a segment — and asserts the segment stream is closed even though no batch was read.

The test was confirmed to fail against the unfixed code, with Mockito reporting `Wanted but not invoked: fileInputStream.close(); Actually, there were zero interactions with this mock`, and to pass with the fix applied. The full `RemoteLogManagerTest` suite passes (96 tests, 0 failures), covering the existing success and log-compaction paths through `read()` that exercise the other close paths described above.

Co-Authored-By: Claude Sonnet 5