### PR TITLE
MINOR: Fix fetch snapshot RPC topic partition check (#23185)

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1930,7 +1930,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return new FetchSnapshotResponseData().setErrorCode(Errors.INCONSISTENT_CLUSTER_ID.code());
         }
 
-        if (data.topics().size() != 1 && data.topics().get(0).partitions().size() != 1) {
+        if (!hasValidTopicPartition(data)) {
             return FetchSnapshotResponse.withTopLevelError(Errors.INVALID_REQUEST);
         }
 
@@ -2086,7 +2086,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
             return handleTopLevelError(topLevelError, responseMetadata);
         }
 
-        if (data.topics().size() != 1 && data.topics().get(0).partitions().size() != 1) {
+        if (!hasValidTopicPartition(data)) {
             return false;
         }
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -715,6 +715,14 @@ public class RaftUtil {
             data.responses().get(0).partitions().get(0).partitionIndex() == topicPartition.partition();
     }
 
+    static boolean hasValidTopicPartition(FetchSnapshotRequestData data) {
+        return data.topics().size() == 1 && data.topics().get(0).partitions().size() == 1;
+    }
+
+    static boolean hasValidTopicPartition(FetchSnapshotResponseData data) {
+        return data.topics().size() == 1 && data.topics().get(0).partitions().size() == 1;
+    }
+
     static boolean hasValidTopicPartition(VoteResponseData data, TopicPartition topicPartition) {
         return data.topics().size() == 1 &&
                    data.topics().get(0).topicName().equals(topicPartition.topic()) &&

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static org.apache.kafka.raft.RaftClientTestContext.RaftProtocol.KIP_1186_PROTOCOL;
 import static org.apache.kafka.raft.RaftClientTestContext.RaftProtocol.KIP_853_PROTOCOL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -765,6 +766,49 @@ public final class KafkaRaftClientSnapshotTest {
 
         FetchSnapshotResponseData.PartitionSnapshot response = context.assertSentFetchSnapshotResponse(topicPartition).get();
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.forCode(response.errorCode()));
+    }
+
+    @Test
+    public void testFetchSnapshotRequestWithoutTopics() throws Exception {
+        int localId = randomReplicaId();
+        Set<Integer> voters = Set.of(localId, localId + 1);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withUnknownLeader(3)
+            .withRaftProtocol(KIP_1186_PROTOCOL)
+            .build();
+
+        context.unattachedToLeader();
+        context.deliverRequest(new FetchSnapshotRequestData());
+        context.poll();
+        context.assertSentFetchSnapshotResponse(Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    public void testFetchSnapshotRequestWithoutPartitions() throws Exception {
+        int localId = randomReplicaId();
+        Set<Integer> voters = Set.of(localId, localId + 1);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withUnknownLeader(3)
+            .withRaftProtocol(KIP_1186_PROTOCOL)
+            .build();
+
+        context.unattachedToLeader();
+
+        // FetchSnapshot is invalid for a topic that doesn't contain any partition.
+        context.deliverRequest(
+            new FetchSnapshotRequestData()
+                .setTopics(
+                    List.of(
+                        new FetchSnapshotRequestData.TopicSnapshot()
+                            .setName(context.metadataPartition.topic())
+                    )
+                )
+        );
+
+        context.poll();
+        context.assertSentFetchSnapshotResponse(Errors.INVALID_REQUEST);
     }
 
     @ParameterizedTest

--- a/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftUtilTest.java
@@ -72,8 +72,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RaftUtilTest {
 
@@ -629,6 +631,45 @@ public class RaftUtilTest {
         );
         JsonNode json = DescribeQuorumResponseDataJsonConverter.write(describeQuorumResponseData, version);
         assertEquals(expectedJson, json.toString());
+    }
+
+    @Test
+    public void testHasValidTopicPartitionFetchSnapshotRequest() {
+        FetchSnapshotRequestData data = RaftUtil.singletonFetchSnapshotRequest(
+            clusterId,
+            ReplicaKey.of(1, ReplicaKey.NO_DIRECTORY_ID),
+            topicPartition,
+            1,
+            new OffsetAndEpoch(10, 1),
+            1000,
+            10
+        );
+        assertTrue(RaftUtil.hasValidTopicPartition(data));
+
+        data.topics().get(0).setPartitions(List.of());
+        assertFalse(RaftUtil.hasValidTopicPartition(data));
+
+        data.setTopics(List.of());
+        assertFalse(RaftUtil.hasValidTopicPartition(data));
+    }
+
+    @Test
+    public void testHasValidTopicPartitionFetchSnapshotResponse() {
+        FetchSnapshotResponseData data = RaftUtil.singletonFetchSnapshotResponse(
+            listenerName,
+            (short) 0,
+            topicPartition,
+            1,
+            Endpoints.fromInetSocketAddresses(Map.of(listenerName, address)),
+            responsePartitionSnapshot -> responsePartitionSnapshot
+        );
+        assertTrue(RaftUtil.hasValidTopicPartition(data));
+
+        data.topics().get(0).setPartitions(List.of());
+        assertFalse(RaftUtil.hasValidTopicPartition(data));
+
+        data.setTopics(List.of());
+        assertFalse(RaftUtil.hasValidTopicPartition(data));
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of #23185 to the `4.4` branch.

This PR fixes the check in `FetchSnapshot` RPC handling to be more like the existing `hasValidTopicPartition` check used by `Fetch` handlers.

Original PR: https://github.com/apache/kafka/pull/23185