### PR TITLE
KAFKA-6621: Updated Javadocs for UncaughtExceptionHandler in Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -463,6 +463,8 @@ public class KafkaStreams implements AutoCloseable {
      * <p>
      * Note, this handler must be thread safe, since it will be shared among all threads, and invoked from any
      * thread that encounters such an exception.
+     * Using {@link KafkaStreams#close()} within same thread as the Handler call-back will result in a deadlock,
+     * either set a flag and move {@code close()} outside or place it using a timeout {@link KafkaStreams#close(Duration)}
      *
      * @param userStreamsUncaughtExceptionHandler the uncaught exception handler of type {@link StreamsUncaughtExceptionHandler} for all internal threads
      * @throws IllegalStateException if this {@code KafkaStreams} instance has already been started.


### PR DESCRIPTION
Added a note on setUncaughtExceptionHandler when `streams#close()` is used on the same thread causing and deadlock and not shutting down as expected

Solution:

To move the `close()` outside after flagging the error or use it with a timeout


Note:
Local `./gradlew streams:test` 35 of the tests were failling, I believe JavaDoc changes are not the cause.

Reviewers: Uros (github:uros-b)
