### PR TITLE
KAFKA-14605: Change audit log level in StandardAuthorizer

### DIFF
--- a/docs/security/security-model.md
+++ b/docs/security/security-model.md
@@ -114,7 +114,7 @@ Apache Kafka does not encrypt log segments, indexes, snapshots, or controller me
 
 ## Audit Logging
 
-Apache Kafka emits authorizer decisions to the `kafka.authorizer.logger` log4j logger. Setting this logger to `INFO` records every denied request; `DEBUG` records every allowed request as well. In regulated environments this log should be shipped to durable, append-only storage off-broker. There is no built-in tamper-evident audit trail.
+Apache Kafka emits authorizer decisions to the `kafka.authorizer.logger` log4j logger. Setting this logger to `INFO` records every allowed request; `WARN` records every denied request as well. In regulated environments this log should be shipped to durable, append-only storage off-broker. There is no built-in tamper-evident audit trail.
 
 The request log (`kafka.request.logger`) provides finer detail on individual API calls and is useful for forensic investigation, but it is verbose and not enabled by default.
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerData.java
@@ -286,10 +286,10 @@ public class StandardAuthorizerData {
         switch (rule.result()) {
             case ALLOWED:
                 // logIfAllowed is true if access is granted to the resource as a result of this authorization.
-                // In this case, log at debug level. If false, no access is actually granted, the result is used
+                // In this case, log at info level. If false, no access is actually granted, the result is used
                 // only to determine authorized operations. So log only at trace level.
-                if (action.logIfAllowed() && auditLog.isDebugEnabled()) {
-                    auditLog.debug(buildAuditMessage(principal, requestContext, action, rule));
+                if (action.logIfAllowed() && auditLog.isInfoEnabled()) {
+                    auditLog.info(buildAuditMessage(principal, requestContext, action, rule));
                 } else if (auditLog.isTraceEnabled()) {
                     auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                 }
@@ -297,11 +297,11 @@ public class StandardAuthorizerData {
 
             case DENIED:
                 // logIfDenied is true if access to the resource was explicitly requested. Since this is an attempt
-                // to access unauthorized resources, log at info level. If false, this is either a request to determine
+                // to access unauthorized resources, log at warn level. If false, this is either a request to determine
                 // authorized operations or a filter (e.g for regex subscriptions) to filter out authorized resources.
                 // In this case, log only at trace level.
                 if (action.logIfDenied()) {
-                    auditLog.info(buildAuditMessage(principal, requestContext, action, rule));
+                    auditLog.warn(buildAuditMessage(principal, requestContext, action, rule));
                 } else if (auditLog.isTraceEnabled()) {
                     auditLog.trace(buildAuditMessage(principal, requestContext, action, rule));
                 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/authorizer/StandardAuthorizerTest.java
@@ -517,6 +517,8 @@ public class StandardAuthorizerTest {
                 .when(() -> LoggerFactory.getLogger(Mockito.any(Class.class)))
                 .thenReturn(otherLog);
 
+            Mockito.when(auditLog.isInfoEnabled()).thenReturn(true);
+            Mockito.when(auditLog.isWarnEnabled()).thenReturn(true);
             Mockito.when(auditLog.isDebugEnabled()).thenReturn(true);
             Mockito.when(auditLog.isTraceEnabled()).thenReturn(true);
 
@@ -538,7 +540,7 @@ public class StandardAuthorizerTest {
                 "permissionType=DENY])";
 
             if (logIfDenied) {
-                Mockito.verify(auditLog).info(expectedAuditLog);
+                Mockito.verify(auditLog).warn(expectedAuditLog);
             } else {
                 Mockito.verify(auditLog).trace(expectedAuditLog);
             }
@@ -559,7 +561,7 @@ public class StandardAuthorizerTest {
                 .when(() -> LoggerFactory.getLogger(Mockito.any(Class.class)))
                 .thenReturn(otherLog);
 
-            Mockito.when(auditLog.isDebugEnabled()).thenReturn(true);
+            Mockito.when(auditLog.isInfoEnabled()).thenReturn(true);
             Mockito.when(auditLog.isTraceEnabled()).thenReturn(true);
 
             StandardAuthorizer authorizer = createAndInitializeStandardAuthorizer();
@@ -580,7 +582,7 @@ public class StandardAuthorizerTest {
                 "permissionType=ALLOW])";
 
             if (logIfAllowed) {
-                Mockito.verify(auditLog).debug(expectedAuditLog);
+                Mockito.verify(auditLog).info(expectedAuditLog);
             } else {
                 Mockito.verify(auditLog).trace(expectedAuditLog);
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the audit log level in StandardAuthorizerData:
- ALLOWED operations: DEBUG → INFO (when logIfAllowed is set)
- DENIED operations: INFO → WARN (when logIfDenied is set)

## Why are the changes needed?

Audit logs are security-critical and should be visible at default log levels.

Currently:
- ALLOWED operations are logged at DEBUG level - too verbose, requires DEBUG logging to see
- DENIED operations are logged at INFO level - not prominent enough for security events

After this change:
- ALLOWED operations logged at INFO level - visible in default configuration
- DENIED operations logged at WARN level - stands out as security events

## Did this PR include tests?

Yes. Updated StandardAuthorizerTest:
- Stub isInfoEnabled() and isWarnEnabled() for the new log levels
- Verify info() for ALLOWED (was debug())
- Verify warn() for DENIED (was info())

## Documentation

Updated docs/security/security-model.md to reflect the new log level contract:
- INFO logs allowed requests (was DEBUG)
- WARN logs denied requests (was INFO)

## Performance Considerations

The default log4j2.yaml sets kafka.authorizer.logger to INFO. After this change, ALLOWED operations will be logged by default on brokers with ACLs enabled. This increases audit visibility but also increases log volume. Operators who want the previous behavior can set the logger level to WARN.

Fixes: KAFKA-14605