### PR TITLE
KAFKA-20890: Restore dynamic broker configs before startup

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -79,7 +79,7 @@ import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
 
 
-private class InitialDynamicBrokerConfigPublisher(config: KafkaConfig) extends MetadataPublisher {
+private[server] class InitialDynamicBrokerConfigPublisher(config: KafkaConfig) extends MetadataPublisher {
   val firstPublishFuture = new CompletableFuture[Void]
 
   override def name(): String = s"InitialDynamicBrokerConfigPublisher id=${config.nodeId}"
@@ -98,7 +98,6 @@ private class InitialDynamicBrokerConfigPublisher(config: KafkaConfig) extends M
     } catch {
       case t: Throwable =>
         firstPublishFuture.completeExceptionally(t)
-        throw t
     }
   }
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -24,7 +24,7 @@ import kafka.network.SocketServer
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata._
 import kafka.server.share.{ReplicaManagerLogReader, ReplicaManagerPartitionMetadataProvider, ShareCoordinatorMetadataCacheHelperImpl, SharePartitionManager}
-import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.internals.Plugin
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.metrics.Metrics
@@ -41,6 +41,8 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfigProvider
 import org.apache.kafka.coordinator.share.metrics.{ShareCoordinatorMetrics, ShareCoordinatorRuntimeMetrics}
 import org.apache.kafka.coordinator.share.{ShareCoordinator, ShareCoordinatorRecordSerde, ShareCoordinatorService}
 import org.apache.kafka.coordinator.transaction.ProducerIdManager
+import org.apache.kafka.image.loader.LoaderManifest
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
 import org.apache.kafka.image.publisher.{BrokerRegistrationTracker, MetadataPublisher}
 import org.apache.kafka.metadata.{BrokerState, KRaftMetadataCache, ListenerInfo, MetadataCache, MetadataVersionConfigValidator}
 import org.apache.kafka.metadata.publisher.{AclPublisher, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicTopicClusterQuotaPublisher, ScramPublisher}
@@ -76,6 +78,30 @@ import scala.collection.Map
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOption
 
+
+private class InitialDynamicBrokerConfigPublisher(config: KafkaConfig) extends MetadataPublisher {
+  val firstPublishFuture = new CompletableFuture[Void]
+
+  override def name(): String = s"InitialDynamicBrokerConfigPublisher id=${config.nodeId}"
+
+  override def onMetadataUpdate(
+    delta: MetadataDelta,
+    newImage: MetadataImage,
+    manifest: LoaderManifest
+  ): Unit = {
+    try {
+      config.dynamicConfig.initializeFromPersistentProps(
+        newImage.configs.configProperties(new ConfigResource(ConfigResource.Type.BROKER, "")),
+        newImage.configs.configProperties(new ConfigResource(ConfigResource.Type.BROKER, config.nodeId.toString))
+      )
+      firstPublishFuture.complete(null)
+    } catch {
+      case t: Throwable =>
+        firstPublishFuture.completeExceptionally(t)
+        throw t
+    }
+  }
+}
 
 /**
  * A Kafka broker that runs in KRaft (Kafka Raft) mode.
@@ -209,8 +235,20 @@ class BrokerServer(
       val clientTelemetryExporterPlugin = new ClientTelemetryExporterPlugin()
 
       config.dynamicConfig.initialize(Some(clientTelemetryExporterPlugin))
+      val initialDynamicConfigPublisher = new InitialDynamicBrokerConfigPublisher(config)
+      FutureUtils.waitWithLogging(logger.underlying, logIdent,
+        "the initial dynamic broker configuration publisher to be installed",
+        sharedServer.loader.installPublishers(util.List.of(initialDynamicConfigPublisher)), startupDeadline, time)
+      try {
+        FutureUtils.waitWithLogging(logger.underlying, logIdent,
+          "the initial dynamic broker configuration to be loaded",
+          initialDynamicConfigPublisher.firstPublishFuture, startupDeadline, time)
+      } finally {
+        FutureUtils.waitWithLogging(logger.underlying, logIdent,
+          "the initial dynamic broker configuration publisher to be removed",
+          sharedServer.loader.removeAndClosePublisher(initialDynamicConfigPublisher), startupDeadline, time)
+      }
       quotaManagers = QuotaFactory.instantiate(config, metrics, time, s"broker-${config.nodeId}-", ProcessRole.BrokerRole.toString)
-      DynamicBrokerConfig.readDynamicBrokerConfigsFromSnapshot(raftManager, config, quotaManagers, logContext)
 
       /* start scheduler */
       kafkaScheduler = new KafkaScheduler(config.backgroundThreads)

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -22,34 +22,28 @@ import java.util.{Collections, Properties}
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kafka.network.DataPlaneAcceptor
-import kafka.raft.KafkaRaftManager
 import kafka.server.DynamicBrokerConfig._
 import kafka.utils.Logging
 import org.apache.kafka.common.{Endpoint, Reconfigurable, Uuid}
-import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource, SslConfigs}
-import org.apache.kafka.common.metadata.{ConfigRecord, MetadataRecordType}
+import org.apache.kafka.common.config.{ConfigDef, ConfigException, SslConfigs}
 import org.apache.kafka.common.metrics.{Metrics, MetricsReporter}
 import org.apache.kafka.common.network.{ListenerName, ListenerReconfigurable}
 import org.apache.kafka.common.security.authenticator.LoginManager
-import org.apache.kafka.common.utils.internals.LogContext
-import org.apache.kafka.common.utils.internals.BufferSupplier
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.utils.internals.ConfigUtils
 import org.apache.kafka.network.SocketServer
-import org.apache.kafka.raft.{KRaftConfigs, KafkaRaftClient}
+import org.apache.kafka.raft.KRaftConfigs
 import org.apache.kafka.server.{DynamicThreadPool, ProcessRole}
-import org.apache.kafka.server.common.{ApiMessageAndVersion, DirectoryEventHandler}
+import org.apache.kafka.server.common.DirectoryEventHandler
 import org.apache.kafka.server.config.{BrokerReconfigurable => JBrokerReconfigurable, DynamicConfig, DynamicProducerStateManagerConfig, ServerConfigs, ServerLogConfigs, DynamicBrokerConfig => JDynamicBrokerConfig}
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.metrics.{ClientTelemetryExporterPlugin, MetricConfigs}
 import org.apache.kafka.server.quota.QuotaFactory
 import org.apache.kafka.server.telemetry.{ClientTelemetry, ClientTelemetryExporterProvider}
 import org.apache.kafka.server.util.LockUtils.{inReadLock, inWriteLock}
-import org.apache.kafka.snapshot.RecordsSnapshotReader
 import org.apache.kafka.storage.internals.log.{LogConfig, LogManager}
 
 import java.util.stream.Collectors
-import scala.util.Using
 import scala.collection._
 import scala.jdk.CollectionConverters._
 
@@ -88,57 +82,6 @@ import scala.jdk.CollectionConverters._
 object DynamicBrokerConfig {
 
   private val ReloadableFileConfigs = Set(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG)
-
-  private[server] def readDynamicBrokerConfigsFromSnapshot(
-    raftManager: KafkaRaftManager[ApiMessageAndVersion],
-    config: KafkaConfig,
-    quotaManagers: QuotaFactory.QuotaManagers,
-    logContext: LogContext
-  ): Unit = {
-    def putOrRemoveIfNull(props: Properties, key: String, value: String): Unit = {
-      if (value == null) {
-        props.remove(key)
-      } else {
-        props.put(key, value)
-      }
-    }
-    raftManager.raftLog.latestSnapshotId().ifPresent { latestSnapshotId =>
-      raftManager.raftLog.readSnapshot(latestSnapshotId).ifPresent { rawSnapshotReader =>
-        Using.resource(
-          RecordsSnapshotReader.of(
-            rawSnapshotReader,
-            raftManager.recordSerde,
-            BufferSupplier.create(),
-            KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
-            true,
-            logContext
-          )
-        ) { reader =>
-          val dynamicPerBrokerConfigs = new Properties()
-          val dynamicDefaultConfigs = new Properties()
-          while (reader.hasNext) {
-            val batch = reader.next()
-            batch.forEach { record =>
-              if (record.message().apiKey() == MetadataRecordType.CONFIG_RECORD.id) {
-                val configRecord = record.message().asInstanceOf[ConfigRecord]
-                if (JDynamicBrokerConfig.ALL_DYNAMIC_CONFIGS.contains(configRecord.name()) &&
-                  configRecord.resourceType() == ConfigResource.Type.BROKER.id()) {
-                    if (configRecord.resourceName().isEmpty) {
-                      putOrRemoveIfNull(dynamicDefaultConfigs, configRecord.name(), configRecord.value())
-                    } else if (configRecord.resourceName() == config.brokerId.toString) {
-                      putOrRemoveIfNull(dynamicPerBrokerConfigs, configRecord.name(), configRecord.value())
-                    }
-                  }
-              }
-            }
-          }
-          val configHandler = new BrokerConfigHandler(config, quotaManagers)
-          configHandler.processConfigChanges("", dynamicDefaultConfigs)
-          configHandler.processConfigChanges(config.brokerId.toString, dynamicPerBrokerConfigs)
-        }
-      }
-    }
-  }
 }
 
 class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging {
@@ -275,25 +218,67 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
   })
 
   private[server] def updateBrokerConfig(brokerId: Int, persistentProps: Properties, doLog: Boolean = true): Unit = inWriteLock[Exception](lock, () => {
+    val previousBrokerConfigs = dynamicBrokerConfigs.clone()
+    val previousConfig = currentConfig
     try {
       val props = fromPersistentProps(persistentProps, perBrokerConfig = true)
       dynamicBrokerConfigs.clear()
       dynamicBrokerConfigs ++= props.asScala
       updateCurrentConfig(doLog)
     } catch {
-      case e: Exception => error(s"Per-broker configs of $brokerId could not be applied: ${persistentProps.keySet()}", e)
+      case e: Exception =>
+        if (currentConfig eq previousConfig) {
+          dynamicBrokerConfigs.clear()
+          dynamicBrokerConfigs ++= previousBrokerConfigs
+        }
+        error(s"Per-broker configs of $brokerId could not be applied: ${persistentProps.keySet()}", e)
     }
   })
 
   private[server] def updateDefaultConfig(persistentProps: Properties, doLog: Boolean = true): Unit = inWriteLock[Exception](lock, () => {
+    val previousDefaultConfigs = dynamicDefaultConfigs.clone()
+    val previousConfig = currentConfig
     try {
       val props = fromPersistentProps(persistentProps, perBrokerConfig = false)
       dynamicDefaultConfigs.clear()
       dynamicDefaultConfigs ++= props.asScala
       updateCurrentConfig(doLog)
     } catch {
-      case e: Exception => error(s"Cluster default configs could not be applied: ${persistentProps.keySet()}", e)
+      case e: Exception =>
+        if (currentConfig eq previousConfig) {
+          dynamicDefaultConfigs.clear()
+          dynamicDefaultConfigs ++= previousDefaultConfigs
+        }
+        error(s"Cluster default configs could not be applied: ${persistentProps.keySet()}", e)
     }
+  })
+
+  private[server] def initializeFromPersistentProps(
+    defaultPersistentProps: Properties,
+    brokerPersistentProps: Properties
+  ): Unit = inWriteLock[Exception](lock, () => {
+    val previousDefaultConfigs = dynamicDefaultConfigs.clone()
+    val previousBrokerConfigs = dynamicBrokerConfigs.clone()
+    val previousConfig = currentConfig
+    try {
+      val defaultProps = fromPersistentProps(defaultPersistentProps, perBrokerConfig = false)
+      val brokerProps = fromPersistentProps(brokerPersistentProps, perBrokerConfig = true)
+      dynamicDefaultConfigs.clear()
+      dynamicDefaultConfigs ++= defaultProps.asScala
+      dynamicBrokerConfigs.clear()
+      dynamicBrokerConfigs ++= brokerProps.asScala
+      updateCurrentConfig(doLog = false)
+    } catch {
+      case e: Exception =>
+        if (currentConfig eq previousConfig) {
+          dynamicDefaultConfigs.clear()
+          dynamicDefaultConfigs ++= previousDefaultConfigs
+          dynamicBrokerConfigs.clear()
+          dynamicBrokerConfigs ++= previousBrokerConfigs
+        }
+        error("Persisted dynamic broker configs could not be applied", e)
+    }
+    kafkaConfig.updateCurrentConfig(currentConfig)
   })
 
   /**
@@ -451,13 +436,18 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
       try {
         val customConfigs = new util.HashMap[String, Object](newConfig.originalsFromThisConfig) // non-Kafka configs
         newConfig.valuesFromThisConfig.keySet.forEach(k => customConfigs.remove(k))
-        reconfigurables.forEach {
-          case listenerReconfigurable: ListenerReconfigurable =>
-            processListenerReconfigurable(listenerReconfigurable, newConfig, customConfigs, validateOnly, reloadOnly = false)
-          case reconfigurable =>
-            if (needsReconfiguration(reconfigurable.reconfigurableConfigs, changeMap.keySet, deletedKeySet))
-              processReconfigurable(reconfigurable, changeMap.keySet, newConfig.valuesFromThisConfig, customConfigs, validateOnly)
+        def processPublicReconfigurables(validateOnly: Boolean, doValidate: Boolean): Unit = {
+          reconfigurables.forEach {
+            case listenerReconfigurable: ListenerReconfigurable =>
+              processListenerReconfigurable(listenerReconfigurable, newConfig, customConfigs,
+                validateOnly, reloadOnly = false, doValidate)
+            case reconfigurable =>
+              if (needsReconfiguration(reconfigurable.reconfigurableConfigs, changeMap.keySet, deletedKeySet))
+                processReconfigurable(reconfigurable, changeMap.keySet, newConfig.valuesFromThisConfig,
+                  customConfigs, validateOnly, doValidate)
+          }
         }
+        processPublicReconfigurables(validateOnly = true, doValidate = true)
 
         // BrokerReconfigurable updates are processed after config is updated. Only do the validation here.
         val brokerReconfigurablesToUpdate = mutable.Buffer[BrokerReconfigurable]()
@@ -468,6 +458,8 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
               brokerReconfigurablesToUpdate += reconfigurable
           }
         }
+        if (!validateOnly)
+          processPublicReconfigurables(validateOnly = false, doValidate = false)
         (newConfig, brokerReconfigurablesToUpdate.toList)
       } catch {
         case e: Exception =>
@@ -490,7 +482,8 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
                                             newConfig: KafkaConfig,
                                             customConfigs: util.Map[String, Object],
                                             validateOnly: Boolean,
-                                            reloadOnly:  Boolean): Unit = {
+                                            reloadOnly: Boolean,
+                                            doValidate: Boolean = true): Unit = {
     val listenerName = listenerReconfigurable.listenerName
     val oldValues = currentConfig.valuesWithPrefixOverride(listenerName.configPrefix)
     val newValues = newConfig.valuesFromThisConfigWithPrefixOverride(listenerName.configPrefix)
@@ -499,23 +492,26 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
     val configsChanged = needsReconfiguration(listenerReconfigurable.reconfigurableConfigs, updatedKeys, deletedKeys)
     // if `reloadOnly`, reconfigure if configs haven't changed. Otherwise reconfigure if configs have changed
     if (reloadOnly != configsChanged)
-      processReconfigurable(listenerReconfigurable, updatedKeys, newValues, customConfigs, validateOnly)
+      processReconfigurable(listenerReconfigurable, updatedKeys, newValues, customConfigs, validateOnly, doValidate)
   }
 
   private def processReconfigurable(reconfigurable: Reconfigurable,
                                     updatedConfigNames: Set[String],
                                     allNewConfigs: util.Map[String, _],
                                     newCustomConfigs: util.Map[String, Object],
-                                    validateOnly: Boolean): Unit = {
+                                    validateOnly: Boolean,
+                                    doValidate: Boolean): Unit = {
     val newConfigs = new util.HashMap[String, Object]
     allNewConfigs.forEach((k, v) => newConfigs.put(k, v.asInstanceOf[AnyRef]))
     newConfigs.putAll(newCustomConfigs)
-    try {
-      reconfigurable.validateReconfiguration(newConfigs)
-    } catch {
-      case e: ConfigException => throw e
-      case _: Exception =>
-        throw new ConfigException(s"Validation of dynamic config update of $updatedConfigNames failed with class ${reconfigurable.getClass}")
+    if (doValidate) {
+      try {
+        reconfigurable.validateReconfiguration(newConfigs)
+      } catch {
+        case e: ConfigException => throw e
+        case _: Exception =>
+          throw new ConfigException(s"Validation of dynamic config update of $updatedConfigNames failed with class ${reconfigurable.getClass}")
+      }
     }
 
     if (!validateOnly) {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -65,9 +65,9 @@ import org.apache.kafka.server.quota.{ClientQuotaEntity, ClientQuotaManager}
 import org.apache.kafka.storage.internals.log.{CleanerConfig, LogConfig, UnifiedLog}
 import org.apache.kafka.test.TestSslUtils
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach, TestInfo}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.{MethodSource, ValueSource}
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection._
@@ -1146,6 +1146,79 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     // If readDynamicBrokerConfigsFromSnapshot works correctly, the reporter should maintain its state.
     val reporterAfterRestart = TestNumReplicaFetcherMetricsReporter.waitForReporters(1).head
     reporterAfterRestart.verifyState(reconfigureCount = 0, numFetcher = 2)
+  }
+
+  @ParameterizedTest(name = "snapshot={0}")
+  @ValueSource(strings = Array("none", "stale", "current"))
+  def testRestoreDynamicConfigFromMetadataLog(snapshotState: String): Unit = {
+    val staticProps = defaultStaticConfig(numServers)
+    staticProps.put(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, "1")
+    val broker = createBroker(KafkaConfig.fromProps(staticProps)).asInstanceOf[BrokerServer]
+    servers += broker
+    TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
+    assertFalse(broker.raftManager.raftLog.latestSnapshotId().isPresent)
+
+    if (snapshotState == "stale")
+      writeMetadataSnapshot(broker)
+
+    Seq(2, 4).foreach { value =>
+      val props = new Properties
+      props.put(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, value.toString)
+      reconfigureServers(props, perBrokerConfig = false,
+        (ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, value.toString))
+      assertEquals(value, broker.config.numRecoveryThreadsPerDataDir)
+    }
+
+    if (snapshotState == "current")
+      writeMetadataSnapshot(broker)
+
+    broker.shutdown()
+    broker.awaitShutdown()
+    val restartedBroker = createBroker(KafkaConfig.fromProps(staticProps)).asInstanceOf[BrokerServer]
+    servers(servers.size - 1) = restartedBroker
+
+    assertEquals(4, restartedBroker.config.numRecoveryThreadsPerDataDir)
+    assertEquals("4", restartedBroker.config.dynamicConfig.currentDynamicDefaultConfigs(
+      ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG))
+    assertEquals("4", configEntry(describeConfig(adminClients.head, Seq(restartedBroker)),
+      ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG).value)
+  }
+
+  @Test
+  def testRemoveDynamicConfigWhileBrokerIsStopped(): Unit = {
+    val staticProps = defaultStaticConfig(numServers)
+    staticProps.put(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, "1")
+    val broker = createBroker(KafkaConfig.fromProps(staticProps)).asInstanceOf[BrokerServer]
+    servers += broker
+    TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
+    assertFalse(broker.raftManager.raftLog.latestSnapshotId().isPresent)
+
+    val props = new Properties
+    props.put(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, "2")
+    reconfigureServers(props, perBrokerConfig = false,
+      (ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, "2"))
+    broker.shutdown()
+    broker.awaitShutdown()
+
+    val resource = new ConfigResource(ConfigResource.Type.BROKER, "")
+    val delete = new AlterConfigOp(
+      new ConfigEntry(ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG, null),
+      OpType.DELETE
+    )
+    adminClients.head.incrementalAlterConfigs(util.Map.of(resource, util.List.of(delete))).all.get
+    broker.startup()
+
+    assertEquals(1, broker.config.numRecoveryThreadsPerDataDir)
+    assertFalse(broker.config.dynamicConfig.currentDynamicDefaultConfigs.contains(
+      ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG))
+    assertEquals("1", configEntry(describeConfig(adminClients.head, Seq(broker)),
+      ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG).value)
+  }
+
+  private def writeMetadataSnapshot(broker: BrokerServer): Unit = {
+    TestUtils.ensureConsistentKRaftMetadata(servers, controllerServer)
+    broker.sharedServer.snapshotEmitter.maybeEmit(broker.metadataCache.getImage)
+    assertTrue(broker.raftManager.raftLog.latestSnapshotId().isPresent)
   }
 
   private def awaitInitialPositions(consumer: Consumer[_, _]): Unit = {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -1182,6 +1182,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG))
     assertEquals("4", configEntry(describeConfig(adminClients.head, Seq(restartedBroker)),
       ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG).value)
+    val defaultResource = new ConfigResource(ConfigResource.Type.BROKER, "")
+    val defaultConfig = adminClients.head.describeConfigs(util.Set.of(defaultResource)).all.get.get(defaultResource)
+    assertEquals("4", configEntry(defaultConfig, ServerLogConfigs.NUM_RECOVERY_THREADS_PER_DATA_DIR_CONFIG).value)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -324,8 +324,17 @@ class DynamicBrokerConfigTest {
     }
     config.dynamicConfig.addReconfigurable(reconfigurable)
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, invalidProps)
+    assertTrue(config.dynamicConfig.currentDynamicBrokerConfigs.isEmpty)
     config.dynamicConfig.removeReconfigurable(reconfigurable)
 
+    var reconfigured = false
+    config.dynamicConfig.addReconfigurable(new Reconfigurable {
+      override def configure(configs: util.Map[String, _]): Unit = {}
+      override def reconfigurableConfigs(): util.Set[String] =
+        Set(CleanerConfig.LOG_CLEANER_THREADS_PROP).asJava
+      override def validateReconfiguration(configs: util.Map[String, _]): Unit = {}
+      override def reconfigure(configs: util.Map[String, _]): Unit = reconfigured = true
+    })
     val brokerReconfigurable = new BrokerReconfigurable {
       override def reconfigurableConfigs: util.Set[String] = util.Set.of(CleanerConfig.LOG_CLEANER_THREADS_PROP)
       override def validateReconfiguration(newConfig: KafkaConfig): Unit = validateLogCleanerConfig(newConfig.originals)
@@ -333,6 +342,67 @@ class DynamicBrokerConfigTest {
     }
     config.dynamicConfig.addBrokerReconfigurable(brokerReconfigurable)
     verifyConfigUpdateWithInvalidConfig(config, origProps, validProps, invalidProps)
+    assertTrue(config.dynamicConfig.currentDynamicBrokerConfigs.isEmpty)
+    assertFalse(reconfigured)
+
+    val invalidDefaultProps = new Properties
+    invalidProps.foreach { case (name, value) => invalidDefaultProps.put(name, value) }
+    config.dynamicConfig.updateDefaultConfig(invalidDefaultProps)
+    assertTrue(config.dynamicConfig.currentDynamicDefaultConfigs.isEmpty)
+  }
+
+  @Test
+  def testConfigUpdateWithReconfigurableFailureDoesNotUpdateCache(): Unit = {
+    val config = KafkaConfig(TestUtils.createBrokerConfig(0, port = 8181))
+    config.dynamicConfig.initialize(None)
+    config.dynamicConfig.addReconfigurable(new Reconfigurable {
+      override def configure(configs: util.Map[String, _]): Unit = {}
+      override def reconfigurableConfigs(): util.Set[String] =
+        Set(CleanerConfig.LOG_CLEANER_THREADS_PROP).asJava
+      override def validateReconfiguration(configs: util.Map[String, _]): Unit = {}
+      override def reconfigure(configs: util.Map[String, _]): Unit =
+        throw new ConfigException("reconfiguration failed")
+    })
+
+    val props = new Properties
+    props.put(CleanerConfig.LOG_CLEANER_THREADS_PROP, "2")
+    config.dynamicConfig.updateDefaultConfig(props)
+
+    assertEquals(CleanerConfig.LOG_CLEANER_THREADS, config.getInt(CleanerConfig.LOG_CLEANER_THREADS_PROP))
+    assertTrue(config.dynamicConfig.currentDynamicDefaultConfigs.isEmpty)
+  }
+
+  @Test
+  def testInitializeFromPersistentPropsAppliesBrokerOverride(): Unit = {
+    val config = KafkaConfig(TestUtils.createBrokerConfig(0, port = 8181))
+    config.dynamicConfig.initialize(None)
+    val defaultProps = new Properties
+    defaultProps.put(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, "100")
+    val brokerProps = new Properties
+    brokerProps.put(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, "200")
+
+    config.dynamicConfig.initializeFromPersistentProps(defaultProps, brokerProps)
+
+    assertEquals("100", config.dynamicConfig.currentDynamicDefaultConfigs(SocketServerConfigs.MAX_CONNECTIONS_CONFIG))
+    assertEquals("200", config.dynamicConfig.currentDynamicBrokerConfigs(SocketServerConfigs.MAX_CONNECTIONS_CONFIG))
+    assertEquals(200, config.maxConnections)
+  }
+
+  @Test
+  def testInitializeFromPersistentPropsRemovesOfflineConfig(): Unit = {
+    val config = KafkaConfig(TestUtils.createBrokerConfig(0, port = 8181))
+    config.dynamicConfig.initialize(None)
+    val props = new Properties
+    props.put(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, "100")
+    config.dynamicConfig.updateDefaultConfig(props)
+    assertEquals(100, config.maxConnections)
+
+    config.dynamicConfig.clear()
+    config.dynamicConfig.initialize(None)
+    config.dynamicConfig.initializeFromPersistentProps(new Properties, new Properties)
+
+    assertEquals(SocketServerConfigs.MAX_CONNECTIONS_DEFAULT, config.maxConnections)
+    assertTrue(config.dynamicConfig.currentDynamicDefaultConfigs.isEmpty)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -23,7 +23,7 @@ import java.util.Collections.{singleton, singletonList, singletonMap}
 import java.util.{OptionalInt, Properties}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import kafka.server.share.SharePartitionManager
-import kafka.server.{BrokerServer, KafkaConfig, ReplicaManager}
+import kafka.server.{BrokerServer, DynamicBrokerConfig, InitialDynamicBrokerConfigPublisher, KafkaConfig, ReplicaManager}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry, NewTopic}
@@ -45,16 +45,16 @@ import org.apache.kafka.raft.LeaderAndEpoch
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion, ShareVersion}
 import org.apache.kafka.server.fault.FaultHandler
 import org.apache.kafka.storage.internals.log.LogManager
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertSame, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{doThrow, mock, verify}
+import org.mockito.Mockito.{doThrow, mock, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import java.util
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ExecutionException, TimeUnit}
 import scala.jdk.CollectionConverters._
 
 class BrokerMetadataPublisherTest {
@@ -143,6 +143,35 @@ class BrokerMetadataPublisherTest {
       } finally {
         admin.close()
       }
+    } finally {
+      cluster.close()
+    }
+  }
+
+  @Test
+  def testInitialDynamicConfigFailureKeepsPublisherRemovable(): Unit = {
+    val cluster = new KafkaClusterTestKit.Builder(
+      new TestKitNodes.Builder().
+        setNumBrokerNodes(1).
+        setNumControllerNodes(1).build()).build()
+    try {
+      cluster.format()
+      cluster.startup()
+      cluster.waitForReadyBrokers()
+      val broker = cluster.brokers().values().iterator().next()
+      val config = mock(classOf[KafkaConfig])
+      val dynamicConfig = mock(classOf[DynamicBrokerConfig])
+      val failure = new AssertionError("initial config failure")
+      when(config.nodeId).thenReturn(broker.config.nodeId)
+      when(config.dynamicConfig).thenReturn(dynamicConfig)
+      doThrow(failure).when(dynamicConfig).initializeFromPersistentProps(any[Properties](), any[Properties]())
+      val publisher = new InitialDynamicBrokerConfigPublisher(config)
+
+      broker.sharedServer.loader.installPublishers(List(publisher).asJava).get(1, TimeUnit.MINUTES)
+      val exception = assertThrows(classOf[ExecutionException],
+        () => publisher.firstPublishFuture.get(1, TimeUnit.MINUTES))
+      assertSame(failure, exception.getCause)
+      broker.sharedServer.loader.removeAndClosePublisher(publisher).get(1, TimeUnit.MINUTES)
     } finally {
       cluster.close()
     }


### PR DESCRIPTION
Persisted dynamic broker configs can fail to return to the active runtime after a KRaft broker restart when the local metadata snapshot is missing or stale. A value rolled out safely as `1 -> 2 -> 4` restarts from the static value `1`; replay then rejects `1 -> 4`, while the dynamic cache and cluster-default `DescribeConfigs` still report `4`.

This loads cluster-default and per-broker configs together from `MetadataLoader`'s complete initial image before runtime components and quota managers are constructed. Live updates now validate public and broker reconfigurables before applying changes, and rejected pre-commit updates restore the prior dynamic maps. Same-instance restarts also clear values removed while the broker was offline.

Fixes https://issues.apache.org/jira/browse/KAFKA-20890

## Testing

<details>
<summary>Raw restart regression</summary>

```text
$ ./gradlew core:test --tests 'kafka.server.DynamicBrokerReconfigurationTest.testRestoreDynamicConfigFromMetadataLog'

# Before
snapshot=none FAILED
AssertionFailedError: active=1 cached=4 reportedDefault=4 namedBroker=1 ==> expected: <4> but was: <1>
snapshot=stale FAILED
AssertionFailedError: active=1 cached=4 reportedDefault=4 namedBroker=1 ==> expected: <4> but was: <1>
snapshot=current PASSED
3 tests completed, 2 failed
BUILD FAILED

# After
snapshot=none PASSED
snapshot=stale PASSED
snapshot=current PASSED
BUILD SUCCESSFUL
```

</details>

<details>
<summary>Raw focused and full test output</summary>

```text
$ ./gradlew core:test --tests 'kafka.server.metadata.BrokerMetadataPublisherTest'
testInitialDynamicConfigFailureKeepsPublisherRemovable() PASSED
BUILD SUCCESSFUL in 28s

$ ./gradlew core:test --tests 'kafka.server.DynamicBrokerConfigTest'
BUILD SUCCESSFUL in 4s

$ ./gradlew core:test --tests 'kafka.server.DynamicBrokerReconfigurationTest'
testRemoveDynamicConfigWhileBrokerIsStopped() PASSED
snapshot=none PASSED
snapshot=stale PASSED
snapshot=current PASSED
BUILD SUCCESSFUL in 5m 8s
```

</details>

<details>
<summary>Raw static checks</summary>

```text
$ ./gradlew core:checkstyleMain core:checkstyleTest core:spotbugsMain core:spotbugsTest -x test
> Task :core:checkstyleMain UP-TO-DATE
> Task :core:checkstyleTest UP-TO-DATE
> Task :core:spotbugsMain UP-TO-DATE
> Task :core:spotbugsTest SKIPPED
BUILD SUCCESSFUL in 3s

$ ./gradlew spotlessCheck
BUILD SUCCESSFUL in 2s
```

`spotbugsTest` is skipped because `core` has no Java test sources.

</details>
