### PR TITLE
KAFKA-20904: Don't bound the poll wait while a fetch is in flight

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -971,7 +971,6 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
                     return interceptors.onConsume(new ConsumerRecords<>(fetch.records(), fetch.nextOffsets()));
                 }
-                // We will wait for retryBackoffMs
             } while (timer.notExpired());
 
             return ConsumerRecords.empty();
@@ -1989,6 +1988,15 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
         // Bound the wait when background progress may make fetching possible soon.
         // Use the current application-thread state to avoid relying on stale state from the network thread.
+        //
+        // Do not clamp just because there are fetchable partitions without buffered data. That is the
+        // steady-state in-flight fetch case: FetchRequestManager.maximumTimeToWait() is already
+        // Long.MAX_VALUE and the in-flight request's completion wakes the buffer. Clamping to
+        // retryBackoffMs here, combined with submitting a new AsyncPollEvent on each inner poll
+        // iteration (KAFKA-20780), caused the application and network threads to cycle every
+        // retryBackoffMs while waiting for a fetch (KAFKA-20904). Transient skip reasons such as
+        // reconnect backoff or an unknown leader already surface as retryBackoffMs via
+        // FetchRequestManager.maximumTimeToWait() when nothing is in flight.
         if (pollTimeout > retryBackoffMs) {
             if (subscriptions.numAssignedPartitions() == 0) {
                 // If there are no assigned partitions, reduce the fetch buffer wait time. This may happen when
@@ -2001,14 +2009,6 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
                 // failure. Reduce the wait time so the application thread can consume data promptly once positions are
                 // resolved.
                 pollTimeout = retryBackoffMs;
-            } else {
-                Set<TopicPartition> buffered = fetchBuffer.bufferedPartitions();
-                if (subscriptions.hasFetchablePartitions(tp -> !buffered.contains(tp))) {
-                    // If any fetchable partition has no buffered data, it may have been skipped due to reconnect
-                    // backoff, an in-flight request, or a missing leader. Bound the wait so the application thread
-                    // can retry once the condition clears.
-                    pollTimeout = retryBackoffMs;
-                }
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -2168,6 +2168,51 @@ public class AsyncKafkaConsumerTest {
     }
 
     /**
+     * Waiting for an in-flight fetch (fetchable partitions, empty buffer, {@code maximumTimeToWait} unbounded)
+     * must use the full user poll timeout. Clamping that wait to {@code retry.backoff.ms} made {@code poll()}
+     * re-enter every backoff interval and, with KAFKA-20780, submit a new {@link AsyncPollEvent} each time,
+     * doubling CPU versus the classic consumer (KAFKA-20904).
+     */
+    @Test
+    public void testPollDoesNotBoundWaitWhileFetchIsInFlight() {
+        FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        ConsumerInterceptors<String, String> interceptors = mock(ConsumerInterceptors.class);
+        ConsumerRebalanceListenerInvoker rebalanceListenerInvoker = mock(ConsumerRebalanceListenerInvoker.class);
+        SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
+        consumer = newConsumer(fetchBuffer, interceptors, rebalanceListenerInvoker, subscriptions);
+
+        final TopicPartition tp = new TopicPartition("topic1", 0);
+        subscriptions.assignFromUser(singleton(tp));
+        subscriptions.seek(tp, 0);
+
+        // FetchRequestManager.maximumTimeToWait() is Long.MAX_VALUE while a fetch request is in flight.
+        doReturn(Long.MAX_VALUE).when(applicationEventHandler).maximumTimeToWait();
+
+        doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
+        doReturn(LeaderAndEpoch.noLeaderOrEpoch()).when(metadata).currentLeader(any());
+        // Partition is fetchable and not buffered: the application thread is waiting for the in-flight fetch.
+        doReturn(Collections.emptySet()).when(fetchBuffer).bufferedPartitions();
+
+        AtomicReference<Long> awaitTimerInitialMs = new AtomicReference<>();
+        doAnswer(invocation -> {
+            Timer pollTimer = invocation.getArgument(0, Timer.class);
+            awaitTimerInitialMs.compareAndSet(null, pollTimer.remainingMs());
+            time.sleep(pollTimer.remainingMs());
+            pollTimer.update();
+            return null;
+        }).when(fetchBuffer).awaitWakeup(any(Timer.class));
+
+        final long pollTimeoutMs = 500;
+        consumer.poll(Duration.ofMillis(pollTimeoutMs));
+
+        assertNotNull(awaitTimerInitialMs.get(), "fetchBuffer.awaitWakeup was never called");
+        assertEquals(pollTimeoutMs, awaitTimerInitialMs.get(),
+            "Expected poll wait timer to use the full user timeout while a fetch is in flight, but was "
+                + awaitTimerInitialMs.get());
+        verify(fetchBuffer, times(1)).awaitWakeup(any(Timer.class));
+    }
+
+    /**
      * Tests {@link AsyncKafkaConsumer#processBackgroundEvents(Future, Timer, Predicate, boolean) processBackgroundEvents}
      * handles the case where the {@link Future} takes a bit of time to complete, but does within the timeout.
      */

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -475,6 +475,32 @@ public class FetchRequestManagerTest {
     }
 
     @Test
+    public void testInflightFetchDoesNotWakeUpBuffer() throws InterruptedException {
+        buildFetcher();
+
+        assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, sendFetches());
+
+        Thread blockedOnBuffer = new Thread(() -> fetcher.fetchBuffer.awaitWakeup(time.timer(3_600_000L)));
+        blockedOnBuffer.setDaemon(true);
+        blockedOnBuffer.start();
+
+        // The node already has a request in flight, so prepare() skips the partition. Waking here would
+        // busy-loop the application thread for as long as the request is outstanding (KAFKA-20904 / KAFKA-20915).
+        assertEquals(0, sendFetches());
+
+        blockedOnBuffer.join(500);
+        assertTrue(blockedOnBuffer.isAlive(),
+                "In-flight fetch must not wake the thread blocked on the fetch buffer");
+
+        fetcher.fetchBuffer.wakeup();
+        blockedOnBuffer.join(2_000);
+        assertFalse(blockedOnBuffer.isAlive());
+    }
+
+    @Test
     public void testInflightFetchOnPendingPartitions() {
         buildFetcher();
 


### PR DESCRIPTION
`AsyncKafkaConsumer.pollForFetches()` clamps its wait on the fetch
buffer to  `retry.backoff.ms` whenever a fetchable partition has no
buffered data. That  condition is true in the ordinary steady state of
simply waiting for an  in-flight fetch response, where nothing can
change until that response  arrives.

Combined with KAFKA-20780, which clears a completed inflight poll on
every  iteration of the internal poll loop so a new `AsyncPollEvent` is
submitted,  this makes the application and network threads cycle every
`retry.backoff.ms` for the whole `fetch.max.wait.ms` window. On each
cycle  the application thread wakes with an empty buffer and submits a
new poll  event, and the background thread re-runs the reconciliation
check, position  validation and fetch request creation, only to find a
request already in  flight and produce nothing. With default configs
that is up to five wasted  round trips per fetch.

The clamp is also unnecessary. `FetchRequestManager.maximumTimeToWait()`
already returns `retryBackoffMs` when nothing is in flight, which covers
reconnect backoff, an unknown leader, and the other transient reasons a
partition may be skipped, and returns `Long.MAX_VALUE` while a request
is in  flight, whose completion always wakes the buffer regardless of
the outcome.  This PR drops the clamp and lets `maximumTimeToWait()`
bound the wait.

Note this is separate from the fetch buffer wakeup spin reported in
KAFKA-20915, which was fixed as a duplicate of KAFKA-20854 in #23014.
That  fix stopped `FetchRequestManager` from waking the buffer when it
cannot  generate a request, but it also introduced the clamp removed
here, so the  application thread still woke on the backoff interval
while a fetch was  outstanding.

Testing:

- `AsyncKafkaConsumerTest.testPollDoesNotBoundWaitWhileFetchIsInFlight`
  asserts the wait uses the full caller timeout when a fetch is in
flight.
  Against unmodified trunk it fails with `expected: <500> but was:
<100>`,
  which is the clamp firing.
- `FetchRequestManagerTest.testInflightFetchDoesNotWakeUpBuffer` guards
the
  behaviour this change depends on: an in-flight request must not wake
the
  buffer, while its completion must. This one already passes on trunk
after
  #23014 and is added to keep that contract covered.
- `AsyncKafkaConsumerTest`, `FetchRequestManagerTest`,
  `ConsumerNetworkThreadTest` and `FetchBufferTest` pass, along with
  `checkstyleMain`, `checkstyleTest` and `spotlessCheck`.

Reviewers: Ken Huang <s7133700@gmail.com>
