### PR TITLE
MINOR: update sandboxed-trivy-action version to latest approved version

### DIFF
--- a/.github/workflows/docker_build_and_test.yml
+++ b/.github/workflows/docker_build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         python docker_build_test.py kafka/test -tag=test -type=$IMAGE_TYPE -u=$KAFKA_URL
     - name: Run CVE scan
-      uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb # v1.0.1
+      uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
       with:
         scan-type: 'image'
         scan-ref: 'kafka/test:test'

--- a/.github/workflows/docker_official_image_build_and_test.yml
+++ b/.github/workflows/docker_official_image_build_and_test.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         python docker_official_image_build_test.py kafka/test -tag=test -type=$IMAGE_TYPE -v=$KAFKA_VERSION
     - name: Run CVE scan
-      uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb # v1.0.1
+      uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
       with:
         scan-type: 'image'
         scan-ref: 'kafka/test:test'

--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -29,7 +29,7 @@ jobs:
         supported_image_tag: ['latest', '3.9.2', '4.0.2', '4.1.2', '4.2.1', '4.3.1']
     steps:
       - name: Run CVE scan
-        uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb # v1.0.1
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
         if: always()
         with:
           scan-type: 'image'


### PR DESCRIPTION
The Docker build workflows are currently failing because the existing
`lhotari/sandboxed-trivy-action` SHA is no longer allowed by ASF
infrastructure policies.

This PR updates the `sandboxed-trivy-action` to the latest version
(`v1.0.2` / SHA `f01374b...`) that is explicitly approved in the
https://github.com/apache/infrastructure-actions/blob/69afc125e535c4c41e7f1b7470f583087e0f344b/approved_patterns.yml#L255-L256

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
