### PR TITLE
MINOR: Use KafkaException instead of RuntimeException in admin result classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClassicGroupsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 
@@ -57,7 +58,7 @@ public class DescribeClassicGroupsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 import org.apache.kafka.common.config.ConfigResource;
@@ -59,7 +60,7 @@ public class DescribeConfigsResult {
                         } catch (InterruptedException | ExecutionException e) {
                             // This should be unreachable, because allOf ensured that all the futures
                             // completed successfully.
-                            throw new RuntimeException(e);
+                            throw new KafkaException(e);
                         }
                     }
                     return configs;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 
@@ -57,7 +58,7 @@ public class DescribeConsumerGroupsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 
@@ -58,7 +59,7 @@ public class DescribeLogDirsResult {
                         descriptions.put(entry.getKey(), entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, because allOf ensured that all the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 }
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartitionReplica;
 import org.apache.kafka.common.annotation.InterfaceAudience;
@@ -56,7 +57,7 @@ public class DescribeReplicaLogDirsResult {
                         replicaLogDirInfos.put(entry.getKey(), entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, because allOf ensured that all the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 }
                 return replicaLogDirInfos;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeShareGroupsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 
@@ -57,7 +58,7 @@ public class DescribeShareGroupsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeStreamsGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeStreamsGroupsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 import org.apache.kafka.common.annotation.InterfaceStability;
@@ -61,7 +62,7 @@ public class DescribeStreamsGroupsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.Uuid;
@@ -108,7 +109,7 @@ public class DescribeTopicsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, because allOf ensured that all the futures
                         // completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 }
                 return descriptions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 
@@ -71,7 +72,7 @@ public class DescribeTransactionsResult {
                         results.put(entry.getKey().idValue, entry.getValue().get());
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, because allOf ensured that all the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 }
                 return results;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsResult.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceAudience;
@@ -81,7 +82,7 @@ public class ListConsumerGroupOffsetsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return listedConsumerGroupOffsets;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListOffsetsResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceAudience;
@@ -63,7 +64,7 @@ public class ListOffsetsResult {
                             offsets.put(entry.getKey(), entry.getValue().get());
                         } catch (InterruptedException | ExecutionException e) {
                             // This should be unreachable, because allOf ensured that all the futures completed successfully.
-                            throw new RuntimeException(e);
+                            throw new KafkaException(e);
                         }
                     }
                     return offsets;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListShareGroupOffsetsResult.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.admin.internals.CoordinatorKey;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceAudience;
@@ -55,7 +56,7 @@ public class ListShareGroupOffsetsResult {
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all the futures completed successfully.
-                        throw new RuntimeException(e);
+                        throw new KafkaException(e);
                     }
                 });
                 return offsets;


### PR DESCRIPTION
## Description

When catching `InterruptedException | ExecutionException` in the
KafkaFuture.allOf() path, these exceptions were wrapped in a bare
`RuntimeException`, losing the cause chain and exception type.

This PR replaces `RuntimeException(e)` with `KafkaException(e)` in 12
admin result classes for consistency with `DescribeProducersResult`
which already uses `KafkaException`.

### Files changed (12)
- DescribeClassicGroupsResult.java
- DescribeConfigsResult.java
- DescribeConsumerGroupsResult.java
- DescribeLogDirsResult.java
- DescribeReplicaLogDirsResult.java
- DescribeShareGroupsResult.java
- DescribeStreamsGroupsResult.java
- DescribeTopicsResult.java
- DescribeTransactionsResult.java
- ListConsumerGroupOffsetsResult.java
- ListOffsetsResult.java
- ListShareGroupOffsetsResult.java

### Validation
- Compiles cleanly
- All 13 related unit tests pass
- Spotless, checkstyle, SpotBugs pass

### Diff
12 files changed, 24 insertions(+), 12 deletions(-)

Reviewers: Uros (github:uros-b), Maros Orsak <maros.orsak159@gmail.com>, Andrew Schofield <aschofield@confluent.io>
