### PR TITLE
KAFKA-15591: Reject out-of-order first produce request on empty partitions

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerBounceTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ConsumerBounceTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.ClusterTests;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
@@ -296,7 +297,7 @@ public class ConsumerBounceTest {
         receiveExactRecords(poller2, numRecords, 60000L);
     }
 
-
+    @Flaky("KAFKA-21050")
     @ClusterTest
     public void testClassicClose() throws Exception {
         testClose(GroupProtocol.CLASSIC);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1533,6 +1533,95 @@ public class SenderTest {
     }
 
     @Test
+    public void testEpochBumpWhenOutOfOrderBatchesRetriedAndFirstBatchExpires() throws Exception {
+        // KAFKA-15591: Tests the situation where a producer sends a sequence of requests to a newly created
+        // partition before the creation of the partition has entirely completed. The first request arrives
+        // before the partition is ready and fails with NOT_LEADER_OR_FOLLOWER without reaching the log.
+        // The next two requests arrive after the partition creation is complete, but the sequence numbers
+        // do not start at zero so the requests fail with OUT_OF_ORDER_SEQUENCE_NUMBER. The first request
+        // could still fill the sequence gap, but it expires before being retried. Once the first request
+        // expires, the producer bumps the epoch, renumbers the remaining requests from sequence 0 and
+        // sends them again.
+        final long producerId = 343434L;
+        TransactionManager transactionManager = createTransactionManager();
+        setupWithTransactionState(transactionManager);
+        prepareAndReceiveInitProducerId(producerId, Errors.NONE);
+        assertTrue(transactionManager.hasProducerId());
+        assertEquals(0, transactionManager.sequenceNumber(tp0));
+
+        // Send the first ProduceRequest with sequence 0. It is created 1000ms before the others so that it expires
+        // first (deliveryTimeoutMs is 1500).
+        Future<RecordMetadata> request1 = appendToAccumulator(tp0);
+        sender.runOnce();
+
+        time.sleep(1000L);
+
+        // Send the second and third ProduceRequests with sequences 1 and 2.
+        Future<RecordMetadata> request2 = appendToAccumulator(tp0);
+        sender.runOnce();
+        Future<RecordMetadata> request3 = appendToAccumulator(tp0);
+        sender.runOnce();
+        assertEquals(3, client.inFlightRequestCount());
+
+        // The first request fails because the partition completion has not completed on the leader broker yet.
+        sendIdempotentProducerResponse(0, tp0, Errors.NOT_LEADER_OR_FOLLOWER, -1L);
+        sender.runOnce(); // receive response 0
+
+        // The partition creation completes afterwards, so the request with sequence 0 does not reach the partition
+        // and the broker rejects the in-flight second and third requests. They are retried without an epoch bump
+        // since the retry of th first request could still fill the gap in the expected sequence.
+        sendIdempotentProducerResponse(1, tp0, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1L);
+        sender.runOnce(); // receive response 1
+        sendIdempotentProducerResponse(2, tp0, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1L);
+        sender.runOnce(); // receive response 2
+
+        assertEquals((short) 0, transactionManager.producerIdAndEpoch().epoch);
+        assertFalse(transactionManager.hasUnresolvedSequence(tp0));
+        assertFalse(request1.isDone());
+        assertFalse(request2.isDone());
+        assertFalse(request3.isDone());
+
+        // The first request is retried once the retry backoff elapses, but the delivery timeout expires while
+        // the retry is in-flight. Its sequence range will never be filled, so the partition has an unresolved
+        // sequence.
+        time.sleep(50L);
+        sender.runOnce(); // resend the first request (sequence 0)
+        time.sleep(450L);
+        sender.runOnce(); // resend the second request (sequence 1)
+        assertFutureFailure(request1, TimeoutException.class);
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals((short) 0, transactionManager.producerIdAndEpoch().epoch);
+
+        // The response for the first expired request arrives and is ignored.
+        sendIdempotentProducerResponse(0, tp0, Errors.NOT_LEADER_OR_FOLLOWER, -1L);
+        sender.runOnce();
+        assertTrue(transactionManager.hasUnresolvedSequence(tp0));
+
+        // The retry of the second request is rejected again. This causes the producer to realise that the gap
+        // in the sequence will never be filled, so it bumps the epoch and renumbers the request sequences starting at 0.
+        sendIdempotentProducerResponse(1, tp0, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1L);
+        sender.runOnce(); // receive the rejection
+        sender.runOnce(); // bump the epoch, renumber the remaining batches and resend
+
+        assertEquals((short) 1, transactionManager.producerIdAndEpoch().epoch);
+        assertFalse(transactionManager.hasUnresolvedSequence(tp0));
+        assertEquals(2, transactionManager.sequenceNumber(tp0));
+
+        // The remaining requests are delivered with the new epoch, starting at sequence 0.
+        sendIdempotentProducerResponse(1, 0, tp0, Errors.NONE, 0L, -1L);
+        sender.runOnce();
+        assertTrue(request2.isDone());
+        assertEquals(0, request2.get().offset());
+
+        sender.runOnce(); // send the third request with the new epoch
+        sendIdempotentProducerResponse(1, 1, tp0, Errors.NONE, 1L, -1L);
+        sender.runOnce();
+        assertTrue(request3.isDone());
+        assertEquals(1, request3.get().offset());
+        assertEquals(OptionalInt.of(1), transactionManager.lastAckedSequence(tp0));
+    }
+
+    @Test
     public void testUnresolvedSequencesAreNotFatal() throws Exception {
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         apiVersions.update("0", NodeApiVersions.create(ApiKeys.INIT_PRODUCER_ID.id, (short) 0, (short) 3));

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1569,7 +1569,7 @@ public class SenderTest {
 
         // The partition creation completes afterwards, so the request with sequence 0 does not reach the partition
         // and the broker rejects the in-flight second and third requests. They are retried without an epoch bump
-        // since the retry of th first request could still fill the gap in the expected sequence.
+        // since the retry of the first request could still fill the gap in the expected sequence.
         sendIdempotentProducerResponse(1, tp0, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1L);
         sender.runOnce(); // receive response 1
         sendIdempotentProducerResponse(2, tp0, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1L);

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -705,7 +705,7 @@ class ReplicaManagerTest {
       // Start a transaction
       val producerId = 234L
       val epoch = 5.toShort
-      val sequence = 9
+      val sequence = 0
       val records = MemoryRecords.withTransactionalRecords(Compression.NONE, producerId, epoch, sequence,
         new SimpleRecord(time.milliseconds(), s"message $sequence".getBytes))
       handleProduceAppend(replicaManager, new TopicPartition(topic, 0), records, transactionalId = transactionalId).onFire { response =>
@@ -1870,7 +1870,7 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L
     val producerEpoch = 0.toShort
-    val sequence = 6
+    val sequence = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
     val brokerList = Seq[Integer](0, 1).asJava
 
@@ -2072,7 +2072,7 @@ class ReplicaManagerTest {
     val producerId        = 24L
     val producerEpoch     = 5.toShort
     val lowerProducerEpoch= 4.toShort
-    val sequence          = 6
+    val sequence          = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
     val brokerList = Seq[Integer](0, 1).asJava
 
@@ -2282,7 +2282,7 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val producerId = 24L
     val producerEpoch = 0.toShort
-    val sequence = 6
+    val sequence = 0
     val addPartitionsToTxnManager = mock(classOf[AddPartitionsToTxnManager])
     val brokerList = Seq[Integer](0, 1).asJava
 

--- a/server/src/test/java/org/apache/kafka/server/requests/ProduceRequestTest.java
+++ b/server/src/test/java/org/apache/kafka/server/requests/ProduceRequestTest.java
@@ -82,13 +82,13 @@ public class ProduceRequestTest {
         sendAndCheckProduceResponse(leaderId, partition,
             MemoryRecords.withRecords(Compression.NONE,
                 new SimpleRecord(System.currentTimeMillis(), "key".getBytes(), "value".getBytes())),
-            0L);
+            0L, Errors.NONE);
 
         sendAndCheckProduceResponse(leaderId, partition,
             MemoryRecords.withRecords(Compression.gzip().build(),
                 new SimpleRecord(System.currentTimeMillis(), "key1".getBytes(), "value1".getBytes()),
                 new SimpleRecord(System.currentTimeMillis(), "key2".getBytes(), "value2".getBytes())),
-            1L);
+            1L, Errors.NONE);
     }
 
     @ClusterTest
@@ -224,6 +224,44 @@ public class ProduceRequestTest {
         assertEquals(-1L, partitionResponse.logAppendTimeMs());
     }
 
+    @ClusterTest
+    public void testIdempotentProduceWithNonZeroFirstSequenceOnNewPartition() throws Exception {
+        // KAFKA-15591: A producer with no state on a partition which has never contained any records
+        // must start at sequence 0. A non-zero first sequence means the requests were reordered
+        // (such as an earlier in-flight request failing with NOT_LEADER_OR_FOLLOWER while the partition
+        // creation was completing, and then being retried), and accepting the non-zero first sequence
+        // would permanently prevent the retried first request from being appended to the log.
+        cluster.createTopic(TOPIC, 1, (short) 1);
+        int leaderId = cluster.getLeaderBrokerId(new TopicPartition(TOPIC, 0));
+
+        long producerId = 1000L;
+        short producerEpoch = 0;
+
+        // The later in-flight request (sequences 17-18) arrives first and is rejected.
+        sendAndCheckProduceResponse(leaderId, 0,
+            idempotentRecords(producerId, producerEpoch, 17, 2),
+            -1L, Errors.OUT_OF_ORDER_SEQUENCE_NUMBER);
+
+        // The retry of the earlier request (sequences 0-16) is accepted.
+        sendAndCheckProduceResponse(leaderId, 0,
+            idempotentRecords(producerId, producerEpoch, 0, 17),
+            0L, Errors.NONE);
+
+        // The retry of the later request is then accepted in order.
+        sendAndCheckProduceResponse(leaderId, 0,
+            idempotentRecords(producerId, producerEpoch, 17, 2),
+            17L, Errors.NONE);
+    }
+
+    private MemoryRecords idempotentRecords(long producerId, short producerEpoch, int baseSequence, int recordCount) {
+        SimpleRecord[] records = new SimpleRecord[recordCount];
+        for (int i = 0; i < recordCount; i++) {
+            records[i] = new SimpleRecord(System.currentTimeMillis(), ("key" + (baseSequence + i)).getBytes(),
+                ("value" + (baseSequence + i)).getBytes());
+        }
+        return MemoryRecords.withIdempotentRecords(Compression.NONE, producerId, producerEpoch, baseSequence, records);
+    }
+
     private ProduceResponse sendProduceRequest(int brokerId, ProduceRequest request) throws IOException {
         KafkaBroker broker = cluster.brokers().get(brokerId);
         int port = broker.socketServer().boundPort(cluster.clientListener());
@@ -231,7 +269,7 @@ public class ProduceRequestTest {
     }
 
     private void sendAndCheckProduceResponse(int leaderId, int partition,
-                                             MemoryRecords records, long expectedOffset) throws IOException, ExecutionException, InterruptedException {
+                                             MemoryRecords records, long expectedOffset, Errors expectedError) throws IOException, ExecutionException, InterruptedException {
         Uuid topicId = getTopicId();
         ProduceRequest request = ProduceRequest.builder(new ProduceRequestData()
             .setTopicData(new ProduceRequestData.TopicProduceDataCollection(Collections.singletonList(
@@ -254,7 +292,7 @@ public class ProduceRequestTest {
         var partitionResponse = topicResponse.partitionResponses().get(0);
         assertEquals(topicId, topicResponse.topicId());
         assertEquals(partition, partitionResponse.index());
-        assertEquals(Errors.NONE, Errors.forCode(partitionResponse.errorCode()));
+        assertEquals(expectedError, Errors.forCode(partitionResponse.errorCode()));
         assertEquals(expectedOffset, partitionResponse.baseOffset());
         assertEquals(-1L, partitionResponse.logAppendTimeMs());
         assertTrue(partitionResponse.recordErrors().isEmpty());

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerAppendInfo.java
@@ -51,6 +51,7 @@ public class ProducerAppendInfo {
     private final ProducerStateEntry currentEntry;
     private final AppendOrigin origin;
     private final VerificationStateEntry verificationStateEntry;
+    private final boolean logEmpty;
 
     private final List<TxnMetadata> transactions = new ArrayList<>();
     private final ProducerStateEntry updatedEntry;
@@ -69,17 +70,21 @@ public class ProducerAppendInfo {
      *                               only producer epoch validation is done. Appends which come through replication are not validated
      *                               (we assume the validation has already been done) and appends from clients require full validation.
      * @param verificationStateEntry The most recent entry used for verification if no append has been completed yet otherwise null
+     * @param logEmpty               True if no records have ever been appended to the log. In this case, no producer state
+     *                               can ever have been lost, so the first sequence for any producer must be 0
      */
     public ProducerAppendInfo(TopicPartition topicPartition,
                               long producerId,
                               ProducerStateEntry currentEntry,
                               AppendOrigin origin,
-                              VerificationStateEntry verificationStateEntry) {
+                              VerificationStateEntry verificationStateEntry,
+                              boolean logEmpty) {
         this.topicPartition = topicPartition;
         this.producerId = producerId;
         this.currentEntry = currentEntry;
         this.origin = origin;
         this.verificationStateEntry = verificationStateEntry;
+        this.logEmpty = logEmpty;
 
         updatedEntry = currentEntry.withProducerId(producerId);
     }
@@ -153,6 +158,7 @@ public class ProducerAppendInfo {
         }
     }
 
+    @SuppressWarnings({"NPathComplexity", "CyclomaticComplexity"})
     private void checkSequence(short producerEpoch, int appendFirstSeq, long offset) {
         // For transactions v2 idempotent producers, reject non-zero sequences when there is no producer ID state
         if (verificationStateEntry != null && verificationStateEntry.supportsEpochBump() &&
@@ -165,6 +171,12 @@ public class ProducerAppendInfo {
             throw new OutOfOrderSequenceException("Out of order sequence number for producer " + producerId + " at " +
                     "offset " + offset + " in partition " + topicPartition + ": " + appendFirstSeq +
                     " (incoming seq. number), " + verificationStateEntry.lowestSequence() + " (earliest seen sequence)");
+        }
+        // If no records have ever been appended to the log, reject non-zero sequences when there is no producer ID state (KAFKA-15591)
+        if (logEmpty && appendFirstSeq != 0 && currentEntry.isEmpty()) {
+            throw new OutOfOrderSequenceException("Invalid sequence number for producer " + producerId + " at " +
+                "offset " + offset + " in partition " + topicPartition + ": " + appendFirstSeq +
+                " (incoming seq. number). Expected sequence 0 for a producer with no state on a partition with no records.");
         }
         if (producerEpoch != updatedEntry.producerEpoch()) {
             if (appendFirstSeq != 0) {
@@ -308,6 +320,7 @@ public class ProducerAppendInfo {
                 ", coordinatorEpoch=" + updatedEntry.coordinatorEpoch() +
                 ", lastTimestamp=" + updatedEntry.lastTimestamp() +
                 ", startedTransactions=" + transactions +
+                ", logEmpty=" + logEmpty +
                 ')';
     }
 }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/ProducerStateManager.java
@@ -375,7 +375,12 @@ public class ProducerStateManager {
 
     public ProducerAppendInfo prepareUpdate(long producerId, AppendOrigin origin) {
         ProducerStateEntry currentEntry = lastEntry(producerId).orElse(ProducerStateEntry.empty(producerId));
-        return new ProducerAppendInfo(topicPartition, producerId, currentEntry, origin, verificationStateEntry(producerId));
+        // mapEndOffset() == 0 means no records have ever been appended to the log. It is advanced on every append
+        // (including from producers without idempotence enabled) and by producer state rebuilds, so it tracks the
+        // log end offset, and is advanced to the log start offset when producer state is loaded without a snapshot
+        // or when the log start offset is incremented, so any deletion of records leaves it non-zero.
+        return new ProducerAppendInfo(topicPartition, producerId, currentEntry, origin,
+            verificationStateEntry(producerId), mapEndOffset() == 0);
     }
 
     /**

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
@@ -1212,7 +1212,7 @@ public class ProducerStateManagerTest {
         // contained any records, since no state can have been lost. A non-zero first sequence means the
         // request arrived out of order, and accepting it would permanently prevent the earlier request
         // from being appended
-        ProducerAppendInfo laterRequest = new ProducerAppendInfo(
+        ProducerAppendInfo currentProducerAppendInfo = new ProducerAppendInfo(
             partition,
             producerId,
             ProducerStateEntry.empty(producerId),
@@ -1222,7 +1222,7 @@ public class ProducerStateManagerTest {
         );
 
         OutOfOrderSequenceException exception = assertThrows(OutOfOrderSequenceException.class,
-            () -> laterRequest.appendDataBatch(
+            () -> currentProducerAppendInfo.appendDataBatch(
                 epoch,
                 17,
                 21,
@@ -1232,28 +1232,19 @@ public class ProducerStateManagerTest {
         assertTrue(exception.getMessage().contains("Expected sequence 0 for a producer with no state on a partition with no records"));
 
         // The retried earlier request starting at sequence 0 is accepted
-        ProducerAppendInfo earlierRequest = new ProducerAppendInfo(
-            partition,
-            producerId,
-            ProducerStateEntry.empty(producerId),
-            AppendOrigin.CLIENT,
-            null,
-            true
-        );
-
-        assertDoesNotThrow(() -> earlierRequest.appendDataBatch(
+        assertDoesNotThrow(() -> currentProducerAppendInfo.appendDataBatch(
             epoch,
             0,
             16,
             time.milliseconds(),
             new LogOffsetMetadata(0L), 16L, false)
         );
-        stateManager.update(earlierRequest);
+        stateManager.update(currentProducerAppendInfo);
         stateManager.updateMapEndOffset(17L);
 
         // The retry of the later request is then accepted
-        ProducerAppendInfo retriedLaterRequest = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
-        assertDoesNotThrow(() -> retriedLaterRequest.appendDataBatch(
+        ProducerAppendInfo updatedProducerAppendInfo = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        assertDoesNotThrow(() -> updatedProducerAppendInfo.appendDataBatch(
             epoch,
             17,
             21,

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/ProducerStateManagerTest.java
@@ -235,7 +235,7 @@ public class ProducerStateManagerTest {
         long offset = 992342L;
         ProducerAppendInfo appendInfo = new ProducerAppendInfo(partition, producerId,
                 ProducerStateEntry.empty(producerId), AppendOrigin.CLIENT,
-                stateManager.maybeCreateVerificationStateEntry(producerId, defaultSequence, epoch, true));
+                stateManager.maybeCreateVerificationStateEntry(producerId, defaultSequence, epoch, true), false);
 
         LogOffsetMetadata firstOffsetMetadata = new LogOffsetMetadata(offset, 990000L, 234224);
         appendInfo.appendDataBatch(epoch, defaultSequence, defaultSequence, 
@@ -552,11 +552,16 @@ public class ProducerStateManagerTest {
         stateManager.takeSnapshot();
         ProducerStateManager recoveredMapping = new ProducerStateManager(partition, logDir,
                 maxTransactionTimeoutMs, producerStateManagerConfig, time);
-        recoveredMapping.truncateAndReload(0L, 1L, 70000);
+        long timeAfterExpiration = producerStateManagerConfig.producerIdExpirationMs() + 1;
+        recoveredMapping.truncateAndReload(0L, 2L, timeAfterExpiration);
+
+        // the snapshot is reloaded, but the pid is expired and is not added to the mapping
+        assertEquals(0, recoveredMapping.activeProducers().size());
+        assertEquals(2L, recoveredMapping.mapEndOffset());
 
         // entry added after recovery. The pid should be expired now, and would not exist in the pid mapping. Hence,
         // we should accept the append and add the pid back in
-        appendClientEntry(recoveredMapping, producerId, epoch, 2, 2L, 70001, false);
+        appendClientEntry(recoveredMapping, producerId, epoch, 2, 2L, timeAfterExpiration + 1, false);
 
         assertEquals(1, recoveredMapping.activeProducers().size());
         assertEquals(2, recoveredMapping.activeProducers().values().iterator().next().lastSeq());
@@ -652,15 +657,15 @@ public class ProducerStateManagerTest {
 
     @Test
     public void testReloadSnapshots() throws IOException {
-        appendClientEntry(stateManager, producerId, epoch, 1, 1L, false);
-        appendClientEntry(stateManager, producerId, epoch, 2, 2L, false);
+        appendClientEntry(stateManager, producerId, epoch, 0, 1L, false);
+        appendClientEntry(stateManager, producerId, epoch, 1, 2L, false);
         stateManager.takeSnapshot();
         Map<Path, byte[]> pathAndDataList = Arrays.stream(Objects.requireNonNull(logDir.listFiles()))
                 .map(File::toPath)
                 .collect(Collectors.toMap(path -> path, path -> assertDoesNotThrow(() -> Files.readAllBytes(path))));
 
-        appendClientEntry(stateManager, producerId, epoch, 3, 3L, false);
-        appendClientEntry(stateManager, producerId, epoch, 4, 4L, false);
+        appendClientEntry(stateManager, producerId, epoch, 2, 3L, false);
+        appendClientEntry(stateManager, producerId, epoch, 3, 4L, false);
         stateManager.takeSnapshot();
         assertEquals(2, Objects.requireNonNull(logDir.listFiles()).length);
         assertEquals(Set.of(3L, 5L), currentSnapshotOffsets());
@@ -1132,9 +1137,10 @@ public class ProducerStateManagerTest {
             producerId,
             ProducerStateEntry.empty(producerId),
             AppendOrigin.CLIENT,
-            verificationEntry
+            verificationEntry,
+            false
         );
-        
+
         // Attempting to append with non-zero sequence number should fail for transactions v2
         OutOfOrderSequenceException exception = assertThrows(
             OutOfOrderSequenceException.class,
@@ -1185,9 +1191,10 @@ public class ProducerStateManagerTest {
             producerId + 1,
             ProducerStateEntry.empty(producerId + 1),
             AppendOrigin.CLIENT,
-            verificationEntry
+            verificationEntry,
+            false
         );
-        
+
         // Attempting to append with non-zero sequence number should succeed for transactions v1
         // (our validation should not trigger)
         assertDoesNotThrow(() -> appendInfo.appendDataBatch(
@@ -1196,6 +1203,107 @@ public class ProducerStateManagerTest {
             5,
             time.milliseconds(),
             new LogOffsetMetadata(0L), 0L, false)
+        );
+    }
+
+    @Test
+    public void testRejectNonZeroFirstSequenceWithEmptyStateOnEmptyLog() {
+        // KAFKA-15591: A producer with no state must start at sequence 0 on a partition which has never
+        // contained any records, since no state can have been lost. A non-zero first sequence means the
+        // request arrived out of order, and accepting it would permanently prevent the earlier request
+        // from being appended
+        ProducerAppendInfo laterRequest = new ProducerAppendInfo(
+            partition,
+            producerId,
+            ProducerStateEntry.empty(producerId),
+            AppendOrigin.CLIENT,
+            null,
+            true
+        );
+
+        OutOfOrderSequenceException exception = assertThrows(OutOfOrderSequenceException.class,
+            () -> laterRequest.appendDataBatch(
+                epoch,
+                17,
+                21,
+                time.milliseconds(),
+                new LogOffsetMetadata(0L), 4L, false)
+        );
+        assertTrue(exception.getMessage().contains("Expected sequence 0 for a producer with no state on a partition with no records"));
+
+        // The retried earlier request starting at sequence 0 is accepted
+        ProducerAppendInfo earlierRequest = new ProducerAppendInfo(
+            partition,
+            producerId,
+            ProducerStateEntry.empty(producerId),
+            AppendOrigin.CLIENT,
+            null,
+            true
+        );
+
+        assertDoesNotThrow(() -> earlierRequest.appendDataBatch(
+            epoch,
+            0,
+            16,
+            time.milliseconds(),
+            new LogOffsetMetadata(0L), 16L, false)
+        );
+        stateManager.update(earlierRequest);
+        stateManager.updateMapEndOffset(17L);
+
+        // The retry of the later request is then accepted
+        ProducerAppendInfo retriedLaterRequest = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        assertDoesNotThrow(() -> retriedLaterRequest.appendDataBatch(
+            epoch,
+            17,
+            21,
+            time.milliseconds(),
+            new LogOffsetMetadata(17L), 21L, false)
+        );
+    }
+
+    @Test
+    public void testAllowNonZeroFirstSequenceWithEmptyStateOnNonEmptyLog() {
+        // If records have ever been added to the log, producer state may have been lost due to producer
+        // expiration or retention, so a producer may legitimately continue with a non-zero sequence
+        ProducerAppendInfo appendInfo = new ProducerAppendInfo(
+            partition,
+            producerId,
+            ProducerStateEntry.empty(producerId),
+            AppendOrigin.CLIENT,
+            null,
+            false
+        );
+
+        assertDoesNotThrow(() -> appendInfo.appendDataBatch(
+            epoch,
+            17,
+            21,
+            time.milliseconds(),
+            new LogOffsetMetadata(42L), 46L, false)
+        );
+    }
+
+    @Test
+    public void testPrepareUpdateRequiresZeroSequenceOnlyBeforeFirstAppend() {
+        ProducerAppendInfo appendInfo = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        assertThrows(OutOfOrderSequenceException.class,
+            () -> appendInfo.appendDataBatch(
+                epoch,
+                5,
+                5,
+                time.milliseconds(),
+                new LogOffsetMetadata(0L), 0L, false)
+        );
+
+        stateManager.updateMapEndOffset(1L);
+        ProducerAppendInfo appendInfoAfterAppend = stateManager.prepareUpdate(producerId, AppendOrigin.CLIENT);
+        assertDoesNotThrow(() -> appendInfoAfterAppend.appendDataBatch(
+            epoch,
+            5,
+            5,
+            time.milliseconds(),
+            new LogOffsetMetadata(1L), 1L, false)
         );
     }
 
@@ -1524,7 +1632,8 @@ public class ProducerStateManagerTest {
                 producerId,
                 ProducerStateEntry.empty(producerId),
                 AppendOrigin.CLIENT,
-                stateManager.maybeCreateVerificationStateEntry(producerId, 0, epoch, true)
+                stateManager.maybeCreateVerificationStateEntry(producerId, 0, epoch, true),
+                false
         );
         LogOffsetMetadata firstOffsetMetadata = new LogOffsetMetadata(startOffset, segmentBaseOffset, 50 * relativeOffset);
         appendInfo.appendDataBatch(epoch, 0, 0, time.milliseconds(),

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -1260,6 +1260,63 @@ public class UnifiedLogTest {
     }
 
     @Test
+    public void testRejectOutOfOrderFirstRequestOnNewlyCreatedLog() throws IOException {
+        // KAFKA-15591: A producer with multiple in-flight produce requests on a newly created partition sends
+        // request A (sequences 0-3) and request B (sequences 4-5). Because topic creation occurs asynchronously,
+        // request A can fail with NOT_LEADER_OR_FOLLOWER briefly because the broker has not yet completed
+        // the topic creation, so request B is the first to reach the log. If B were accepted, every retry of A
+        // would fail with OUT_OF_ORDER_SEQUENCE_NUMBER until it expires, losing its records.
+        UnifiedLog log = createLog(logDir, new LogConfig(new Properties()));
+        long pid = 1L;
+        short epoch = 0;
+
+        MemoryRecords requestB = LogTestUtils.records(
+            List.of(new SimpleRecord("a".getBytes(), "b".getBytes()),
+                    new SimpleRecord("a".getBytes(), "b".getBytes())),
+            pid, epoch, 4, 0L);
+        assertThrows(OutOfOrderSequenceException.class, () -> log.appendAsLeader(requestB, 0));
+
+        MemoryRecords requestA = LogTestUtils.records(
+            List.of(new SimpleRecord("a".getBytes(), "b".getBytes()),
+                    new SimpleRecord("a".getBytes(), "b".getBytes()),
+                    new SimpleRecord("a".getBytes(), "b".getBytes()),
+                    new SimpleRecord("a".getBytes(), "b".getBytes())),
+            pid, epoch, 0, 0L);
+        log.appendAsLeader(requestA, 0);
+
+        log.appendAsLeader(requestB, 0);
+        assertEquals(6L, log.logEndOffset());
+    }
+
+    @Test
+    public void testNonZeroFirstSequenceAcceptedAfterProducerStateExpiration() throws IOException {
+        // KAFKA-15591: Once records exist in the log, a producer with no state may start at a non-zero sequence.
+        // Its state may have legitimately been lost, such as through producer expiration.
+        ProducerStateManagerConfig customPSMConfig = new ProducerStateManagerConfig(200, false);
+        int producerIdExpirationCheckIntervalMs = 100;
+
+        LogConfig logConfig = new LogTestUtils.LogConfigBuilder().segmentBytes(TEN_KB).build();
+        UnifiedLog log = createLog(logDir, logConfig, 0L, 0L, brokerTopicStats,
+            mockTime.scheduler, mockTime, customPSMConfig, true, Optional.empty(), false,
+            producerIdExpirationCheckIntervalMs);
+        long pid = 1L;
+        short epoch = 0;
+
+        log.appendAsLeader(LogTestUtils.records(List.of(new SimpleRecord("foo".getBytes())),
+            pid, epoch, 0, 0L), 0);
+        assertEquals(Set.of(pid), log.activeProducersWithLastSequence().keySet());
+
+        mockTime.sleep(producerIdExpirationCheckIntervalMs);
+        mockTime.sleep(producerIdExpirationCheckIntervalMs);
+        assertEquals(Set.of(), log.activeProducersWithLastSequence().keySet());
+
+        // The producer continues from sequence 1 with no state, which is accepted because the log is not empty
+        log.appendAsLeader(LogTestUtils.records(List.of(new SimpleRecord("foo".getBytes())),
+            pid, epoch, 1, 0L), 0);
+        assertEquals(2L, log.logEndOffset());
+    }
+
+    @Test
     public void testTruncateToEndOffsetClearsEpochCache() throws IOException {
         UnifiedLog log = createLog(logDir, new LogConfig(new Properties()));
 
@@ -5353,8 +5410,7 @@ public class UnifiedLogTest {
 
         long producerId = 23L;
         short producerEpoch = 1;
-        // For TV1, can start with non-zero sequences even with non-zero epoch when no existing producer state
-        int sequence = appendOrigin == AppendOrigin.CLIENT ? 3 : 0;
+        int sequence = 0;
         LogConfig logConfig = new LogTestUtils.LogConfigBuilder().segmentBytes(TEN_KB).build();
         UnifiedLog log = createLog(logDir, logConfig, psmConfig);
         assertFalse(log.hasOngoingTransaction(producerId, producerEpoch));
@@ -5522,6 +5578,10 @@ public class UnifiedLogTest {
         UnifiedLog log = createLog(logDir, logConfig, psmConfig);
         assertFalse(log.hasOngoingTransaction(producerId, producerEpoch));
         assertEquals(VerificationGuard.SENTINEL, log.verificationGuard(producerId));
+
+        // Seed the log so that it is non-empty. Producer state can only have been lost on a partition which
+        // has had records at some point, and a non-zero first sequence is rejected on an empty log (KAFKA-15591).
+        log.appendAsLeader(singletonRecords("seed".getBytes()), 0);
 
         MemoryRecords transactionalRecords = MemoryRecords.withTransactionalRecords(
                 Compression.NONE, producerId, producerEpoch, sequence,

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -1307,7 +1307,6 @@ public class UnifiedLogTest {
         assertEquals(Set.of(pid), log.activeProducersWithLastSequence().keySet());
 
         mockTime.sleep(producerIdExpirationCheckIntervalMs);
-        mockTime.sleep(producerIdExpirationCheckIntervalMs);
         assertEquals(Set.of(), log.activeProducersWithLastSequence().keySet());
 
         // The producer continues from sequence 1 with no state, which is accepted because the log is not empty

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/UnifiedLogTest.java
@@ -1292,8 +1292,9 @@ public class UnifiedLogTest {
     public void testNonZeroFirstSequenceAcceptedAfterProducerStateExpiration() throws IOException {
         // KAFKA-15591: Once records exist in the log, a producer with no state may start at a non-zero sequence.
         // Its state may have legitimately been lost, such as through producer expiration.
-        ProducerStateManagerConfig customPSMConfig = new ProducerStateManagerConfig(200, false);
         int producerIdExpirationCheckIntervalMs = 100;
+        int producerIdExpirationMs = 200;
+        ProducerStateManagerConfig customPSMConfig = new ProducerStateManagerConfig(producerIdExpirationMs, false);
 
         LogConfig logConfig = new LogTestUtils.LogConfigBuilder().segmentBytes(TEN_KB).build();
         UnifiedLog log = createLog(logDir, logConfig, 0L, 0L, brokerTopicStats,
@@ -1306,7 +1307,7 @@ public class UnifiedLogTest {
             pid, epoch, 0, 0L), 0);
         assertEquals(Set.of(pid), log.activeProducersWithLastSequence().keySet());
 
-        mockTime.sleep(producerIdExpirationCheckIntervalMs);
+        mockTime.sleep(producerIdExpirationMs);
         assertEquals(Set.of(), log.activeProducersWithLastSequence().keySet());
 
         // The producer continues from sequence 1 with no state, which is accepted because the log is not empty


### PR DESCRIPTION
A producer with multiple in-flight requests producing to a newly created
partition can have its requests reordered around the moment the broker
applies the partition metadata. This is particularly evident for tests
such as Trogdor which start producing records immediately on topics
which have been auto-created. The flow is like this:

1. The producer creates a topic and immediately sends produce request A
(sequences 0–16) and request B (sequences 17–21) to the same partition.
2. Request A arrives before the broker has applied the topic creation
from the metadata log and fails with a retriable NOT_LEADER_OR_FOLLOWER.
3. Request B arrives after the partition creation has completed. The
broker has no producer state and accepted any first sequence in that
case, so B is appended.
4. Every retry of request A now fails with OUT_OF_ORDER_SEQUENCE_NUMBER:
its sequence range was never written, so it is not in the duplicate
cache, and the broker expects sequence 22. The client retries without an
epoch bump (it assumes a lower-sequence batch will fill the gap), so A
spins until delivery.timeout.ms expires it.

The result is silent loss of request A's records despite
enable.idempotence=true, acks=all and retries=MAX_INT. The same defect
was reported independently in KAFKA-14312, KAFKA-15591 and KAFKA-19880.
KAFKA-18202 fixed it for TV2 producers only.

If no records have ever been appended to a partition, no producer state
can have been lost, so the only valid first sequence for any producer is
0. ProducerAppendInfo now rejects a non-zero first sequence from a
client when the producer has no state and the log has never contained a
record, with a retriable OutOfOrderSequenceException.

The rejected later request is retried, the earlier request's retry
(sequence 0) is accepted as soon as the partition is ready, and the
later request then lands in order. If the earlier request instead
expires, the unresolved-sequence handling bumps the idempotent producer
epoch and rewrites the later request to sequence 0, so the producer
never gets stuck.

Partitions which have ever contained records are unaffected, even for
situations where producer state is lost due to retention, record
deletion or producer state expiration. Log emptiness is derived from
`ProducerStateManager#mapEndOffset`, which tracks the log end offset on
the leader and is advanced to the log start offset on reload without a
snapshot and when the log start offset is incremented, so it is zero
only for a log which has never contained a record.

Reviewers: Jun Rao <junrao@gmail.com>
