### PR TITLE
MINOR: Bump LATEST_PRODUCTION to 4.4-IV2 for 4.4.0

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/FormatterTest.java
@@ -416,7 +416,7 @@ public class FormatterTest {
                 setFeatureLevel(GroupVersion.GV_1.featureLevel()), (short) 0));
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(ShareVersion.FEATURE_NAME).
-                setFeatureLevel(ShareVersion.SV_1.featureLevel()), (short) 0));
+                setFeatureLevel(ShareVersion.SV_2.featureLevel()), (short) 0));
             expected.add(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName(StreamsVersion.FEATURE_NAME).
                 setFeatureLevel(StreamsVersion.SV_1.featureLevel()), (short) 0));

--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -124,13 +124,6 @@ public enum MetadataVersion {
     // BrokerRegistrationChangeRecord and RegisterBrokerRecord are updated
     IBP_4_3_IV0(30, "4.3", "IV0", true),
 
-    //
-    // NOTE: MetadataVersions after this point are unstable and may be changed.
-    // If users attempt to use an unstable MetadataVersion, they will get an error unless
-    // they have set the configuration unstable.feature.versions.enable=true.
-    // Please move this comment when updating the LATEST_PRODUCTION constant.
-    //
-
     // IBP_4_4_IV0 enables dead-letter queue support for share groups (KIP-1191).
     IBP_4_4_IV0(31, "4.4", "IV0", false),
 
@@ -138,7 +131,15 @@ public enum MetadataVersion {
     IBP_4_4_IV1(32, "4.4", "IV1", true),
 
     // Add support for controller unregistration (KIP-1312).
-    IBP_4_4_IV2(33, "4.4", "IV2", true);
+    IBP_4_4_IV2(33, "4.4", "IV2", true),
+
+    //
+    // NOTE: MetadataVersions after this point are unstable and may be changed.
+    // If users attempt to use an unstable MetadataVersion, they will get an error unless
+    // they have set the configuration unstable.feature.versions.enable=true.
+    // Please move this comment when updating the LATEST_PRODUCTION constant.
+    //
+    IBP_4_5_IV0(34, "4.5", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version
@@ -157,7 +158,7 @@ public enum MetadataVersion {
      * <strong>Think carefully before you update this value. ONCE A METADATA VERSION IS PRODUCTION,
      * IT CANNOT BE CHANGED.</strong>
      */
-    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_3_IV0;
+    public static final MetadataVersion LATEST_PRODUCTION = IBP_4_4_IV2;
     // If you change the value above please also update
     // LATEST_STABLE_METADATA_VERSION version in tests/kafkatest/version.py
 

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
@@ -52,7 +52,7 @@ public @interface ClusterTest {
     String brokerListener() default DEFAULT_BROKER_LISTENER_NAME;
     SecurityProtocol controllerSecurityProtocol() default SecurityProtocol.PLAINTEXT;
     String controllerListener() default DEFAULT_CONTROLLER_LISTENER_NAME;
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_4_IV2;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_5_IV0;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -137,7 +137,7 @@ DEV_VERSION = KafkaVersion("4.4.0")
 
 LATEST_STABLE_TRANSACTION_VERSION = 2
 # This should match the LATEST_PRODUCTION version defined in MetadataVersion.java
-LATEST_STABLE_METADATA_VERSION = "4.3-IV0"
+LATEST_STABLE_METADATA_VERSION = "4.4-IV2"
 
 # 2.1.x versions
 V_2_1_0 = KafkaVersion("2.1.0")


### PR DESCRIPTION
Reported on the [vote thread](https://lists.apache.org/thread/tdmkdx9yvqzpymr8x7337h2q2yq6wvbr): metadata.version in RC0 shipped as 4.3-IV0 instead of 4.4-IV2

- Bump LATEST_PRODUCTION to IBP_4_4_IV2
- Add IBP_4_5_IV0 as an unstable placeholder (same as trunk in #23244) so the MetadataVersionTest invariants hold unchanged, and point the @ClusterTest default at it.
- Update LATEST_STABLE_METADATA_VERSION in tests/kafkatest/version.py to 4.4-IV2.
- FormatterTest now expects ShareVersion.SV_2, since the default share.version at 4.4-IV2 moves from 1 to 2.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Andrew Schofield
 <aschofield@confluent.io>
