### PR TITLE
MINOR: Do not advertise describe APIs on the controller listener

### DIFF
--- a/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+++ b/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 41,
   "type": "request",
-  "listeners": ["broker", "controller"],
+  "listeners": ["broker"],
   "name": "DescribeDelegationTokenRequest",
   // Version 0 was removed in Apache Kafka 4.0, Version 1 is the new baseline.
   // Version 1 is the same as version 0.

--- a/clients/src/main/resources/common/message/DescribeUserScramCredentialsRequest.json
+++ b/clients/src/main/resources/common/message/DescribeUserScramCredentialsRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 50,
   "type": "request",
-  "listeners": ["broker", "controller"],
+  "listeners": ["broker"],
   "name": "DescribeUserScramCredentialsRequest",
   "validVersions": "0",
   "flexibleVersions": "0+",

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -1315,6 +1315,21 @@ class ControllerApisTest {
     assertTrue(exception.getMessage.contains("needs ALTER permission"))
   }
 
+  @Test
+  def testDescribeDelegationTokenIsNotExposedOnTheControllerListener(): Unit = {
+    // ControllerApis.handle has no case for DESCRIBE_DELEGATION_TOKEN, so advertising it on the
+    // controller listener would make the controller answer UNKNOWN_SERVER_ERROR for an API it just
+    // told the client it supported. Keep the two in sync: either add a handler or leave it off.
+    assertFalse(ApiKeys.apisForListener(ListenerType.CONTROLLER).contains(ApiKeys.DESCRIBE_DELEGATION_TOKEN))
+    assertTrue(ApiKeys.apisForListener(ListenerType.BROKER).contains(ApiKeys.DESCRIBE_DELEGATION_TOKEN))
+  }
+
+  @Test
+  def testDescribeUserScramCredentialsIsNotExposedOnTheControllerListener(): Unit = {
+    assertFalse(ApiKeys.apisForListener(ListenerType.CONTROLLER).contains(ApiKeys.DESCRIBE_USER_SCRAM_CREDENTIALS))
+    assertTrue(ApiKeys.apisForListener(ListenerType.BROKER).contains(ApiKeys.DESCRIBE_USER_SCRAM_CREDENTIALS))
+  }
+
   @AfterEach
   def tearDown(): Unit = {
     quotasNeverThrottleControllerMutations.shutdown()


### PR DESCRIPTION
DescribeDelegationToken and DescribeUserScramCredentials declare the controller listener, so the controller advertises them in ApiVersions, but `ControllerApis.handle` has no case for either and clients get UNKNOWN_SERVER_ERROR for an API that was just advertised.

Dropped the controller listener so the advertised set matches what is implemented. Adding handlers instead would be new functionality. Happy to route this through a KIP if the ApiVersions change counts as a protocol change.

Both were introduced with their KRaft features (KAFKA-15219, KAFKA-14084), which wired up the mutating APIs but not the describes. Added two regression tests in `ControllerApisTest`.