### PR TITLE
KAFKA-17929: Handle spurious wakeups while awaiting processable tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManager.java
@@ -126,32 +126,23 @@ public final class DefaultTaskManager implements TaskManager {
     @Override
     public void awaitProcessableTasks(final Supplier<Boolean> isShuttingDown) throws InterruptedException {
         final boolean interrupted = returnWithTasksLocked(() -> {
-            for (final StreamTask task : tasks.activeInitializedTasks()) {
-                if (!assignedTasks.containsKey(task.id()) &&
-                    !lockedTasks.contains(task.id()) &&
-                    canProgress(task, time.milliseconds()) &&
-                    !hasUncaughtException(task.id())
-                ) {
-                    log.debug("Await unblocked: returning early from await since a processable task {} was found", task.id());
-                    return false;
-                }
-            }
-            try {
-                // We re-check the shutdownRequest atomic boolean to avoid a race condition. If this thread was
-                // previously interrupted while awaiting tasksCondition, it is possible to miss the signalAll that
-                // is called during shutdown. If this happens, we end up blocking in the await forever.
-                if (!isShuttingDown.get()) {
+            // Condition.await may wake spuriously, so keep checking whether any task can actually make progress.
+            while (!isShuttingDown.get() && !hasProcessableTask()) {
+                try {
                     log.debug("Await blocking");
                     tasksCondition.await();
-                } else {
-                    log.debug("Not awaiting since shutdown was requested");
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Await unblocked: Interrupted while waiting for processable tasks", e);
+                    return true;
                 }
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.warn("Await unblocked: Interrupted while waiting for processable tasks", e);
-                return true;
+
+                log.debug("Await unblocked: Woken up to check for processable tasks");
             }
-            log.debug("Await unblocked: Woken up to check for processable tasks");
+
+            if (isShuttingDown.get()) {
+                log.debug("Not awaiting since shutdown was requested");
+            }
             return false;
         });
 
@@ -359,6 +350,21 @@ public final class DefaultTaskManager implements TaskManager {
         } finally {
             tasksLock.unlock();
         }
+    }
+
+    private boolean hasProcessableTask() {
+        for (final StreamTask task : tasks.activeInitializedTasks()) {
+            if (!assignedTasks.containsKey(task.id()) &&
+                !lockedTasks.contains(task.id()) &&
+                canProgress(task, time.milliseconds()) &&
+                !hasUncaughtException(task.id())
+            ) {
+                log.debug("Await unblocked: returning early from await since a processable task {} was found", task.id());
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private boolean canProgress(final StreamTask task, final long nowMs) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/tasks/DefaultTaskManagerTest.java
@@ -162,11 +162,28 @@ public class DefaultTaskManagerTest {
         awaitingThread.start();
         verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
+        ensureTaskMakesProgress();
         taskManager.signalTaskExecutors();
 
         assertTrue(awaitingRunnable.awaitDone.await(VERIFICATION_TIMEOUT, TimeUnit.MILLISECONDS));
 
         awaitingRunnable.shutdown();
+        awaitingThread.join();
+    }
+
+    @Test
+    public void shouldContinueAwaitingAfterSignalWithoutProcessableTasks() throws InterruptedException {
+        final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
+        final Thread awaitingThread = new Thread(awaitingRunnable);
+        awaitingThread.start();
+        verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
+
+        taskManager.signalTaskExecutors();
+
+        assertFalse(awaitingRunnable.awaitDone.await(100, TimeUnit.MILLISECONDS));
+
+        awaitingRunnable.shutdown();
+        assertTrue(awaitingRunnable.awaitDone.await(VERIFICATION_TIMEOUT, TimeUnit.MILLISECONDS));
         awaitingThread.join();
     }
 
@@ -197,6 +214,7 @@ public class DefaultTaskManagerTest {
         awaitingThread.start();
         verify(tasks, timeout(VERIFICATION_TIMEOUT).atLeastOnce()).activeInitializedTasks();
 
+        ensureTaskMakesProgress();
         taskManager.add(Collections.singleton(task));
 
         assertTrue(awaitingRunnable.awaitDone.await(VERIFICATION_TIMEOUT, TimeUnit.MILLISECONDS));
@@ -209,6 +227,7 @@ public class DefaultTaskManagerTest {
     public void shouldReturnFromAwaitOnUnlocking() throws InterruptedException {
         taskManager.add(Collections.singleton(task));
         taskManager.lockTasks(Collections.singleton(task.id()));
+        ensureTaskMakesProgress();
         final AwaitingRunnable awaitingRunnable = new AwaitingRunnable();
         final Thread awaitingThread = new Thread(awaitingRunnable);
         awaitingThread.start();


### PR DESCRIPTION
### Summary

  `DefaultTaskManager.awaitProcessableTasks` used a single `Condition.await()` call after checking for processable tasks. Since condition waits may wake spuriously, the method could return even when there were still no processable tasks available.

  This change keeps awaiting in a loop until one of these is true:
  - a task can make progress
  - shutdown is requested
  - the waiter is interrupted

  A regression test verifies that a signal without any processable task does not release the waiter.

  ### Testing

  ```bash
  ./gradlew :streams:spotlessApply :streams:test --tests org.apache.kafka.streams.processor.internals.tasks.DefaultTaskManagerTest

  Result: BUILD SUCCESSFUL.