### PR TITLE
KAFKA-14672: Record queue time for expired accumulator batches

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -429,6 +429,7 @@ public class Sender implements Runnable {
         List<ProducerBatch> expiredInflightBatches = getExpiredInflightBatches(now);
         List<ProducerBatch> expiredBatches = this.accumulator.expiredBatches(now);
 
+        sensors.recordExpiredBatchQueueTime(expiredBatches, now);
         failExpiredBatches(expiredBatches, now, true);
         failExpiredBatches(expiredInflightBatches, now, false);
 
@@ -1092,13 +1093,23 @@ public class Sender implements Runnable {
 
                     // global metrics
                     this.batchSizeSensor.record(batch.estimatedSizeInBytes(), now);
-                    this.queueTimeSensor.record(batch.queueTimeMs(), now);
+                    recordQueueTime(batch.queueTimeMs(), now);
                     this.compressionRateSensor.record(batch.compressionRatio());
                     this.maxRecordSizeSensor.record(batch.maxRecordSize, now);
                     records += batch.recordCount;
                 }
                 this.recordsPerRequestSensor.record(records, now);
             }
+        }
+
+        public void recordExpiredBatchQueueTime(List<ProducerBatch> batches, long now) {
+            for (ProducerBatch batch : batches) {
+                recordQueueTime(Math.max(0, now - batch.createdMs), now);
+            }
+        }
+
+        private void recordQueueTime(long queueTimeMs, long now) {
+            this.queueTimeSensor.record(queueTimeMs, now);
         }
 
         public void recordRetries(String topic, int count) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -2553,6 +2553,24 @@ public class SenderTest {
     }
 
     @Test
+    public void testRecordQueueTimeIncludesBatchesExpiredInAccumulator() throws Exception {
+        Future<RecordMetadata> request = appendToAccumulator(tp0);
+
+        Node node = metadata.fetch().nodes().get(0);
+        client.delayReady(node, DELIVERY_TIMEOUT_MS + 100L);
+        time.sleep(DELIVERY_TIMEOUT_MS + 1L);
+
+        sender.runOnce();
+
+        assertFutureFailure(request, TimeoutException.class);
+        assertEquals(0, client.inFlightRequestCount());
+        assertEquals(0, sender.inFlightBatches(tp0).size());
+
+        KafkaMetric maxMetric = metrics.metrics().get(this.senderMetricsRegistry.recordQueueTimeMax);
+        assertEquals(DELIVERY_TIMEOUT_MS + 1.0, (Double) maxMetric.metricValue(), EPS);
+    }
+
+    @Test
     public void testRecordErrorPropagatedToApplication() throws InterruptedException {
         int recordCount = 5;
 


### PR DESCRIPTION
## Summary

  Record queue time for producer batches that expire in the accumulator before being sent. This ensures record-queue-time-max reflects time spent waiting by timed-out batches, not only batches included in produce requests.

  ## Testing

  - Added SenderTest.testRecordQueueTimeIncludesBatchesExpiredInAccumulator to verify the metric is updated when an unsent batch expires.
 