### PR TITLE
MINOR: Revert setup-gradle action to v5.0.2

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -42,7 +42,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       env:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
       with:


### PR DESCRIPTION
#22624 bumped setup-gradle from v5.0.2 to v6.2.0, because v5.0.2 had
expired out of the ASF allowed actions list at the time.

INFRA later added v5.0.2 back to the list and marked it `keep: true` so
that it never expires, as v6 changes the licensing model of the default
caching provider:
https://github.com/apache/infrastructure-actions/pull/953

This reverts to v5.0.2, which also avoids CI breaking again when the
v6.2.0 pin expires on 2026-10-30. The 4.0, 4.1 and 4.2 branches already
use v5.0.2, and the inputs of the action are unchanged.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
