### PR TITLE
KAFKA-20901: Enforce cordoned log directories configured with relative paths

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -602,14 +602,18 @@ class DynamicLogConfig(logManager: LogManager, directoryEventHandler: DirectoryE
     }
 
     def validateCordonedLogDirs(): Unit = {
-      val logDirs = newConfig.logDirs()
+      val absoluteLogDirSet = newConfig.absoluteLogDirs().asScala.toSet
       val cordonedLogDirs = newConfig.cordonedLogDirs()
-      cordonedLogDirs.asScala.foreach(dir =>
-        if (!logDirs.contains(dir)) {
-          throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs, s"Invalid entry in ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG}: $dir. " +
-            s"All cordoned log dirs must be entries of ${ServerLogConfigs.LOG_DIRS_CONFIG} or ${ServerLogConfigs.LOG_DIR_CONFIG}.")
-        }
-      )
+      val absoluteCordonedLogDirs = newConfig.absoluteCordonedLogDirs()
+      cordonedLogDirs.asScala.zip(absoluteCordonedLogDirs.asScala).foreach {
+        case (cordonedLogDir, absoluteCordonedLogDir) =>
+          if (!absoluteLogDirSet.contains(absoluteCordonedLogDir)) {
+            val invalidLogDir = if (cordonedLogDir == absoluteCordonedLogDir) cordonedLogDir else s"$cordonedLogDir (absolute path: $absoluteCordonedLogDir)"
+
+            throw new ConfigException(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, cordonedLogDirs, s"Invalid entry in ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG}: " +
+              s"$invalidLogDir. All cordoned log dirs must match ${ServerLogConfigs.LOG_DIRS_CONFIG} or ${ServerLogConfigs.LOG_DIR_CONFIG} entries by absolute path.")
+          }
+      }
     }
 
     validateLogLocalRetentionMs()
@@ -638,9 +642,10 @@ class DynamicLogConfig(logManager: LogManager, directoryEventHandler: DirectoryE
     logManager.reconfigureDefaultLogConfig(new LogConfig(newBrokerDefaults))
     updateLogsConfig(newBrokerDefaults.asScala)
 
-    logManager.updateCordonedLogDirs(util.Set.copyOf(newConfig.cordonedLogDirs))
-    directoryEventHandler.handleCordoned(newConfig.cordonedLogDirs.stream
-      .flatMap[Uuid](dir => logManager.directoryId(dir).stream)
+    val absoluteCordonedLogDirs = newConfig.absoluteCordonedLogDirs
+    logManager.updateCordonedLogDirs(util.Set.copyOf(absoluteCordonedLogDirs))
+    directoryEventHandler.handleCordoned(absoluteCordonedLogDirs.stream
+      .flatMap[Uuid](absoluteCordonedLogDir => logManager.directoryId(absoluteCordonedLogDir).stream)
       .collect(Collectors.toSet[Uuid]))
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -425,8 +425,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     if (cordonedLogDirs.contains(ServerLogConfigs.CORDONED_LOG_DIRS_ALL)) {
       require(cordonedLogDirs.size == 1, s"When ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG} is set to ${ServerLogConfigs.CORDONED_LOG_DIRS_ALL}, it must not contain other values")
     } else {
-      val unknownLogDirs = cordonedLogDirs.asScala.filter(!logDirs().contains(_))
-      require(unknownLogDirs.isEmpty, s"All entries in ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG} must be present in ${ServerLogConfigs.LOG_DIRS_CONFIG} or ${ServerLogConfigs.LOG_DIR_CONFIG}. Missing entries : ${unknownLogDirs.mkString(", ")}")
+      val absoluteLogDirSet = absoluteLogDirs().asScala.toSet
+      val unknownLogDirs = cordonedLogDirs.asScala.zip(absoluteCordonedLogDirs().asScala).collect {
+        case (cordonedLogDir, absoluteCordonedLogDir) if !absoluteLogDirSet.contains(absoluteCordonedLogDir) =>
+          if (cordonedLogDir == absoluteCordonedLogDir) cordonedLogDir else s"$cordonedLogDir (absolute path: $absoluteCordonedLogDir)"
+      }
+      require(unknownLogDirs.isEmpty, s"All entries in ${ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG} must match ${ServerLogConfigs.LOG_DIRS_CONFIG} or ${ServerLogConfigs.LOG_DIR_CONFIG} entries by absolute path. Missing entries: ${unknownLogDirs.mkString(", ")}")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import java.io.File
 import java.util
 import java.util.{Collections, OptionalLong, Properties}
 import kafka.utils.TestUtils
@@ -301,6 +302,38 @@ class BrokerLifecycleManagerTest {
 
     nextHeartbeatRequest()
     assertEquals(1200L, manager.brokerEpoch)
+  }
+
+  @Test
+  def testRelativeCordonedLogDirsIncludedInHeartbeatAfterInitialCatchUp(): Unit = {
+    val relativeLogDir = "relative-log-dir"
+    val logDirId = Uuid.fromString("ad5FLIeCTnaQdai5vOjeng")
+    val props = configProperties
+    props.setProperty(ServerLogConfigs.LOG_DIRS_CONFIG, relativeLogDir)
+    props.setProperty(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, relativeLogDir)
+
+    val ctx = new RegistrationTestContext(props)
+    val logDirIdsByAbsolutePath = util.Map.of(new File(relativeLogDir).getAbsolutePath, logDirId)
+    manager = new BrokerLifecycleManager(ctx.config, ctx.time, "relative-cordoned-dirs-sent-in-heartbeat-",
+      logDirIdsByAbsolutePath, () => {}, () => true)
+    val controllerNode = new Node(3000, "localhost", 8021)
+    ctx.controllerNodeProvider.node.set(controllerNode)
+
+    val registration = prepareResponse(ctx, new BrokerRegistrationResponse(new BrokerRegistrationResponseData().setBrokerEpoch(1000)))
+    manager.start(() => ctx.highestMetadataOffset.get(),
+      ctx.mockChannelManager, ctx.clusterId, ctx.advertisedListeners,
+      Collections.emptyMap(), OptionalLong.empty())
+    poll(ctx, manager, registration)
+
+    // This request is created before the response indicating catch-up is processed.
+    val beforeCatchUp = poll(ctx, manager, prepareResponse[BrokerHeartbeatRequest](ctx,
+      new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData().setIsCaughtUp(true))))
+    assertNull(beforeCatchUp.data().cordonedLogDirs())
+
+    // The next request reflects the broker having processed the catch-up response.
+    val afterCatchUp = poll(ctx, manager, prepareResponse[BrokerHeartbeatRequest](ctx,
+      new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData())))
+    assertEquals(Set(logDirId), afterCatchUp.data().cordonedLogDirs().asScala.toSet)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import java.io.File
 import java.{lang, util}
 import java.util.{Optional, Properties, Map => JMap}
 import java.util.concurrent.{CompletionStage, TimeUnit}
@@ -1217,6 +1218,32 @@ class DynamicBrokerConfigTest {
     ctx.config.dynamicConfig.updateBrokerConfig(0, props)
     assertEquals(logDirs, ctx.config.cordonedLogDirs)
     verify(ctx.directoryEventHandler, times(4)).handleCordoned(anySet)
+  }
+
+  @Test
+  def testDynamicLogConfigRelativeCordonedLogDir(): Unit = {
+    // createBrokerConfig uses a mix of relative and absolute log dirs when logDirCount is greater than one.
+    val origProps = TestUtils.createBrokerConfig(0, logDirCount = 2)
+    val ctx = new DynamicLogConfigContext(origProps)
+    val relativeLogDir = ctx.config.logDirs().asScala.find(dir => !new File(dir).isAbsolute).get
+    val absoluteLogDir = new File(relativeLogDir).getAbsolutePath
+    val directoryId = Uuid.randomUuid()
+    // Only the absolute path resolves to an ID, matching how LogManager keys its directory ID map.
+    Mockito.when(ctx.logManagerMock.directoryId(ArgumentMatchers.anyString())).thenAnswer(invocation =>
+      if (absoluteLogDir == invocation.getArgument[String](0)) Optional.of(directoryId) else Optional.empty())
+
+    val props = new Properties()
+    props.put(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, relativeLogDir)
+    ctx.config.dynamicConfig.updateBrokerConfig(0, props)
+    assertEquals(util.List.of(relativeLogDir), ctx.config.cordonedLogDirs)
+    verify(ctx.logManagerMock).updateCordonedLogDirs(util.Set.of(absoluteLogDir))
+    verify(ctx.directoryEventHandler).handleCordoned(util.Set.of(directoryId))
+
+    props.put(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, absoluteLogDir)
+    ctx.config.dynamicConfig.updateBrokerConfig(0, props)
+    assertEquals(util.List.of(absoluteLogDir), ctx.config.cordonedLogDirs)
+    verify(ctx.logManagerMock, times(2)).updateCordonedLogDirs(util.Set.of(absoluteLogDir))
+    verify(ctx.directoryEventHandler, times(2)).handleCordoned(util.Set.of(directoryId))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import java.io.File
 import java.net.InetSocketAddress
 import java.util
 import java.util.{Arrays, Collections, Properties}
@@ -1613,6 +1614,32 @@ class KafkaConfigTest {
     val config = KafkaConfig.fromProps(props)
     assertEquals(dataDir1, config.metadataLogDir)
     assertEquals(util.List.of(dataDir1, dataDir2), config.logDirs)
+  }
+
+  @Test
+  def testRelativeLogDirWithRelativeOrAbsoluteCordon(): Unit = {
+    val relativeLogDir = "relative/path/to/data/dir"
+
+    val props = new Properties()
+    props.setProperty(KRaftConfigs.PROCESS_ROLES_CONFIG, "broker")
+    props.setProperty(KRaftConfigs.CONTROLLER_LISTENER_NAMES_CONFIG, "SSL")
+    props.setProperty(ServerLogConfigs.LOG_DIR_CONFIG, relativeLogDir)
+    props.setProperty(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, relativeLogDir)
+    props.setProperty(KRaftConfigs.NODE_ID_CONFIG, "1")
+    props.setProperty(QuorumConfig.QUORUM_VOTERS_CONFIG, "2@localhost:9093")
+
+    val config = KafkaConfig.fromProps(props)
+    val absoluteLogDir = new File(relativeLogDir).getAbsolutePath
+    assertEquals(util.List.of(relativeLogDir), config.logDirs())
+    assertEquals(util.List.of(absoluteLogDir), config.absoluteLogDirs())
+    assertEquals(util.List.of(relativeLogDir), config.cordonedLogDirs())
+    assertEquals(util.List.of(absoluteLogDir), config.absoluteCordonedLogDirs())
+
+    props.setProperty(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG, absoluteLogDir)
+    val configWithAbsoluteCordon = KafkaConfig.fromProps(props)
+    assertEquals(util.List.of(relativeLogDir), configWithAbsoluteCordon.logDirs())
+    assertEquals(util.List.of(absoluteLogDir), configWithAbsoluteCordon.cordonedLogDirs())
+    assertEquals(util.List.of(absoluteLogDir), configWithAbsoluteCordon.absoluteCordonedLogDirs())
   }
 
   @Test

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerLogConfigs.java
@@ -53,7 +53,7 @@ public class ServerLogConfigs {
 
     public static final String CORDONED_LOG_DIRS_CONFIG = "cordoned.log.dirs";
     public static final List<String> CORDONED_LOG_DIRS_DEFAULT = List.of();
-    public static final String CORDONED_LOG_DIRS_DOC = "A comma-separated list of the directories that are cordoned. Entries in this list must be entries in log.dirs or log.dir configuration. This can also be set to * to cordon all log directories.";
+    public static final String CORDONED_LOG_DIRS_DOC = "A comma-separated list of the directories that are cordoned. Entries in this list must match log.dirs or log.dir entries by absolute path. This can also be set to * to cordon all log directories.";
     public static final String CORDONED_LOG_DIRS_ALL = "*";
 
     public static final String LOG_SEGMENT_BYTES_CONFIG = ServerTopicConfigSynonyms.serverSynonym(TopicConfig.SEGMENT_BYTES_CONFIG);

--- a/server/src/main/java/org/apache/kafka/server/BrokerLifecycleManager.java
+++ b/server/src/main/java/org/apache/kafka/server/BrokerLifecycleManager.java
@@ -651,7 +651,7 @@ public class BrokerLifecycleManager {
                                 // Now that the broker has caught up with the latest metadata, the configuration should
                                 // be up to date, so we can retrieve the cordoned log dirs to include them in the
                                 // next heartbeat request
-                                cordonedLogDirs = config.cordonedLogDirs().stream()
+                                cordonedLogDirs = config.absoluteCordonedLogDirs().stream()
                                     .flatMap(logDir -> Optional.ofNullable(logDirs.get(logDir)).stream())
                                     .collect(Collectors.toSet());
                             } else {

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -48,6 +48,7 @@ import org.apache.kafka.storage.internals.log.LogConfig;
 
 import org.apache.commons.validator.routines.InetAddressValidator;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -106,12 +107,26 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         return Optional.ofNullable(getList(ServerLogConfigs.LOG_DIRS_CONFIG)).orElse(getList(ServerLogConfigs.LOG_DIR_CONFIG));
     }
 
+    public List<String> absoluteLogDirs() {
+        return toAbsolutePaths(logDirs());
+    }
+
     public List<String> cordonedLogDirs() {
         List<String> configuredCordonedLogDirs = getList(ServerLogConfigs.CORDONED_LOG_DIRS_CONFIG);
         if (configuredCordonedLogDirs.contains(ServerLogConfigs.CORDONED_LOG_DIRS_ALL)) {
             return logDirs();
         }
         return configuredCordonedLogDirs;
+    }
+
+    public List<String> absoluteCordonedLogDirs() {
+        return toAbsolutePaths(cordonedLogDirs());
+    }
+
+    private static List<String> toAbsolutePaths(List<String> paths) {
+        return paths.stream()
+            .map(path -> new File(path).getAbsolutePath())
+            .toList();
     }
 
     public int numIoThreads() {

--- a/server/src/test/java/org/apache/kafka/server/CordonedLogDirsIntegrationTest.java
+++ b/server/src/test/java/org/apache/kafka/server/CordonedLogDirsIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.admin.UpdateFeaturesOptions;
 import org.apache.kafka.clients.admin.UpdateFeaturesResult;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionReplica;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
@@ -42,11 +43,14 @@ import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
+import org.apache.kafka.metadata.KRaftMetadataCache;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -198,6 +202,49 @@ public class CordonedLogDirsIntegrationTest {
             // We can create topics and partitions again
             admin.createTopics(newTopics).all().get();
             admin.createPartitions(newPartitions).all().get();
+        }
+    }
+
+    @ClusterTest(types = Type.KRAFT)
+    public void testCordonRelativeLogDir() throws Exception {
+        int brokerId = 0;
+        List<String> initialLogDirs = clusterInstance.brokers().get(brokerId).config().logDirs();
+        String metadataLogDir = clusterInstance.brokers().get(brokerId).config().metadataLogDir();
+        Path workingDirectory = Path.of("").toAbsolutePath();
+        String relativeLogDir = initialLogDirs.stream()
+            .filter(logDir -> !logDir.equals(metadataLogDir))
+            .map(logDir -> workingDirectory.relativize(Path.of(logDir).toAbsolutePath()).toString())
+            .findFirst()
+            .orElseThrow();
+        assertFalse(Path.of(relativeLogDir).isAbsolute());
+
+        clusterInstance.restartBroker(brokerId, Map.of(LOG_DIRS_CONFIG, relativeLogDir));
+        clusterInstance.waitForReadyBrokers();
+        assertEquals(List.of(relativeLogDir), clusterInstance.brokers().get(brokerId).config().logDirs());
+
+        String absoluteLogDir = new File(relativeLogDir).getAbsolutePath();
+        Set<Uuid> expectedDirectoryIds = Set.copyOf(clusterInstance.brokers().get(brokerId).logManager().directoryIds().values());
+
+        try (Admin admin = clusterInstance.admin()) {
+            setCordonedLogDirs(admin, List.of(relativeLogDir), BROKER_0);
+
+            // Wait until the broker marks the resolved absolute log directory as cordoned.
+            TestUtils.waitForCondition(() -> {
+                Map<String, LogDirDescription> descriptions = admin.describeLogDirs(List.of(brokerId)).allDescriptions().get().get(brokerId);
+                return descriptions.containsKey(absoluteLogDir) && descriptions.get(absoluteLogDir).isCordoned();
+            }, 10_000, "Relative log directories were not marked as cordoned by the broker");
+
+            // Wait until controller metadata reflects the broker's cordoned directory IDs.
+            TestUtils.waitForCondition(() -> {
+                KRaftMetadataCache metadataCache = (KRaftMetadataCache) clusterInstance.brokers().get(brokerId).metadataCache();
+                var registration = metadataCache.getImage().cluster().broker(brokerId);
+                return registration != null
+                    && registration.cordonedDirectories() != null
+                    && expectedDirectoryIds.equals(Set.copyOf(registration.cordonedDirectories()));
+            }, 10_000, "Relative cordoned log directories were not propagated to the controller");
+
+            Throwable exception = assertThrows(ExecutionException.class, () -> admin.createTopics(newTopic(TOPIC1, (short) 1)).all().get());
+            assertInstanceOf(InvalidReplicationFactorException.class, exception.getCause());
         }
     }
 


### PR DESCRIPTION
Kafka allows `log.dirs `to be configured with relative paths, but `cordoned.log.dirs` was validated and applied using the original configuration strings, whereas `LogManager` converts log directories to absolute paths and uses those paths for directory ID lookups.

As a result, configuring `cordoned.log.dirs` with the absolute path reported by `DescribeLogDirs` was rejected when `log.dirs` contained the equivalent relative path. Using the relative path passed validation, but it did not match the absolute path used internally, so the directory was not reported as cordoned to the controller.


This change consistently uses absolute paths when validating and applying `cordoned.log.dirs`, including during dynamic reconfiguration and broker heartbeat propagation.