### PR TITLE
MINOR: Replace Collections factory methods with Java 11+ equivalents in streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KeyQueryMetadata.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams;
 import org.apache.kafka.common.annotation.InterfaceAudience;
 import org.apache.kafka.streams.state.HostInfo;
 
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
@@ -37,7 +36,7 @@ public class KeyQueryMetadata {
      * operations.
      */
     public static final KeyQueryMetadata NOT_AVAILABLE =
-        new KeyQueryMetadata(HostInfo.unavailable(), Collections.emptySet(), -1);
+        new KeyQueryMetadata(HostInfo.unavailable(), Set.of(), -1);
 
     private final HostInfo activeHost;
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -43,9 +43,9 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -121,7 +121,7 @@ public class StreamsBuilder {
      * @return a {@link KStream} for the specified topic
      */
     public synchronized <K, V> KStream<K, V> stream(final String topic) {
-        return stream(Collections.singleton(topic));
+        return stream(Set.of(topic));
     }
 
     /**
@@ -139,7 +139,7 @@ public class StreamsBuilder {
      */
     public synchronized <K, V> KStream<K, V> stream(final String topic,
                                                     final Consumed<K, V> consumed) {
-        return stream(Collections.singleton(topic), consumed);
+        return stream(Set.of(topic), consumed);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1174,7 +1174,7 @@ public class StreamsConfig extends AbstractConfig {
                     RACK_AWARE_ASSIGNMENT_STRATEGY_DOC)
             .define(RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
                     Type.LIST,
-                    Collections.emptyList(),
+                    List.of(),
                     atMostOfSize(MAX_RACK_AWARE_ASSIGNMENT_TAG_LIST_SIZE),
                     Importance.LOW,
                     RACK_AWARE_ASSIGNMENT_TAGS_DOC)

--- a/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/DeserializationExceptionHandler.java
@@ -92,7 +92,7 @@ public interface DeserializationExceptionHandler extends Configurable {
      * @return a {@link Response} object
      */
     default Response handleError(final ErrorHandlerContext context, final ConsumerRecord<byte[], byte[]> record, final Exception exception) {
-        return new Response(Result.from(handle(context, record, exception)), Collections.emptyList());
+        return new Response(Result.from(handle(context, record, exception)), List.of());
     }
     /**
      * Enumeration that describes the response from the exception handler.
@@ -206,7 +206,7 @@ public interface DeserializationExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link DeserializationExceptionHandler.Result#FAIL} status.
          */
         public static Response fail() {
-            return fail(Collections.emptyList());
+            return fail(List.of());
         }
 
         /**
@@ -225,7 +225,7 @@ public interface DeserializationExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link DeserializationExceptionHandler.Result#RESUME} status.
          */
         public static Response resume() {
-            return resume(Collections.emptyList());
+            return resume(List.of());
         }
 
         /**
@@ -248,7 +248,7 @@ public interface DeserializationExceptionHandler extends Configurable {
          */
         public List<ProducerRecord<byte[], byte[]>> deadLetterQueueRecords() {
             if (deadLetterQueueRecords == null) {
-                return Collections.emptyList();
+                return List.of();
             }
             return Collections.unmodifiableList(deadLetterQueueRecords);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/ProcessingExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/ProcessingExceptionHandler.java
@@ -61,7 +61,7 @@ public interface ProcessingExceptionHandler extends Configurable {
      * @return a {@link Response} object
      */
     default Response handleError(final ErrorHandlerContext context, final Record<?, ?> record, final Exception exception) {
-        return new Response(ProcessingExceptionHandler.Result.from(handle(context, record, exception)), Collections.emptyList());
+        return new Response(ProcessingExceptionHandler.Result.from(handle(context, record, exception)), List.of());
     }
 
     @Deprecated
@@ -173,7 +173,7 @@ public interface ProcessingExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link ProcessingExceptionHandler.Result#FAIL} status.
          */
         public static Response fail() {
-            return fail(Collections.emptyList());
+            return fail(List.of());
         }
 
         /**
@@ -192,7 +192,7 @@ public interface ProcessingExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link ProcessingExceptionHandler.Result#RESUME} status.
          */
         public static Response resume() {
-            return resume(Collections.emptyList());
+            return resume(List.of());
         }
 
         /**
@@ -215,7 +215,7 @@ public interface ProcessingExceptionHandler extends Configurable {
          */
         public List<ProducerRecord<byte[], byte[]>> deadLetterQueueRecords() {
             if (deadLetterQueueRecords == null) {
-                return Collections.emptyList();
+                return List.of();
             }
             return Collections.unmodifiableList(deadLetterQueueRecords);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/ProductionExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/ProductionExceptionHandler.java
@@ -86,7 +86,7 @@ public interface ProductionExceptionHandler extends Configurable {
     default Response handleError(final ErrorHandlerContext context,
                                  final ProducerRecord<byte[], byte[]> record,
                                  final Exception exception) {
-        return new Response(Result.from(handle(context, record, exception)), Collections.emptyList());
+        return new Response(Result.from(handle(context, record, exception)), List.of());
     }
 
     /**
@@ -155,7 +155,7 @@ public interface ProductionExceptionHandler extends Configurable {
                                               final ProducerRecord record,
                                               final Exception exception,
                                               final SerializationExceptionOrigin origin) {
-        return new Response(Result.from(handleSerializationException(context, record, exception, origin)), Collections.emptyList());
+        return new Response(Result.from(handleSerializationException(context, record, exception, origin)), List.of());
     }
 
     @Deprecated
@@ -315,7 +315,7 @@ public interface ProductionExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link ProductionExceptionHandler.Result#FAIL} status.
          */
         public static Response fail() {
-            return fail(Collections.emptyList());
+            return fail(List.of());
         }
 
         /**
@@ -334,7 +334,7 @@ public interface ProductionExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link ProductionExceptionHandler.Result#RESUME} status.
          */
         public static Response resume() {
-            return resume(Collections.emptyList());
+            return resume(List.of());
         }
 
         /**
@@ -343,7 +343,7 @@ public interface ProductionExceptionHandler extends Configurable {
          * @return a {@code Response} with a {@link ProductionExceptionHandler.Result#RETRY} status.
          */
         public static Response retry() {
-            return new Response(Result.RETRY, Collections.emptyList());
+            return new Response(Result.RETRY, List.of());
         }
 
         /**
@@ -366,7 +366,7 @@ public interface ProductionExceptionHandler extends Configurable {
          */
         public List<ProducerRecord<byte[], byte[]>> deadLetterQueueRecords() {
             if (deadLetterQueueRecords == null) {
-                return Collections.emptyList();
+                return List.of();
             }
             return Collections.unmodifiableList(deadLetterQueueRecords);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/errors/internals/ExceptionHandlerUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/internals/ExceptionHandlerUtils.java
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.errors.ErrorHandlerContext;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -60,10 +59,10 @@ public class ExceptionHandlerUtils {
                                                                                  final ErrorHandlerContext context,
                                                                                  final Exception exception) {
         if (!shouldBuildDeadLetterQueueRecord(deadLetterQueueTopicName)) {
-            return Collections.emptyList();
+            return List.of();
         }
 
-        return Collections.singletonList(buildDeadLetterQueueRecord(deadLetterQueueTopicName, key, value, context, exception));
+        return List.of(buildDeadLetterQueueRecord(deadLetterQueueTopicName, key, value, context, exception));
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/internals/metrics/ClientMetrics.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -154,7 +153,7 @@ public class ClientMetrics {
         streamsMetrics.addClientLevelImmutableMetric(
                 RECORDING_LEVEL,
                 RECORDING_LEVEL_DESCRIPTION,
-                Collections.singletonMap(PROCESS_ID_TAG, processId),
+                Map.of(PROCESS_ID_TAG, processId),
                 RecordingLevel.INFO,
                 recordingLevel
         );

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.kstream.internals.suppress.StrictBufferConfigImp
 import org.apache.kafka.streams.kstream.internals.suppress.SuppressedInternal;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 
 @InterfaceAudience.Public
@@ -51,7 +50,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
          * Create a size-constrained buffer in terms of the maximum number of keys it will store.
          */
         static EagerBufferConfig maxRecords(final long recordLimit) {
-            return new EagerBufferConfigImpl(recordLimit, Long.MAX_VALUE, Collections.emptyMap());
+            return new EagerBufferConfigImpl(recordLimit, Long.MAX_VALUE, Map.of());
         }
 
         /**
@@ -63,7 +62,7 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
          * Create a size-constrained buffer in terms of the maximum number of bytes it will use.
          */
         static EagerBufferConfig maxBytes(final long byteLimit) {
-            return new EagerBufferConfigImpl(Long.MAX_VALUE, byteLimit, Collections.emptyMap());
+            return new EagerBufferConfigImpl(Long.MAX_VALUE, byteLimit, Map.of());
         }
 
         /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -35,9 +35,9 @@ import org.apache.kafka.streams.processor.internals.StoreFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.Map.Entry;
 
 import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.optimizableRepartitionNodeBuilder;
@@ -261,7 +261,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             mergeProcessorName,
             keySerde,
             valueSerde,
-            Collections.singleton(mergeNode.nodeName()),
+            Set.of(mergeNode.nodeName()),
             queryableName,
             passThrough,
             mergeNode,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -37,8 +37,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.optimizableRepartitionNodeBuilder;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder;
@@ -148,7 +147,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         return new KTableImpl<>(aggFunctionName,
                                 keySerde,
                                 valueSerde,
-                                sourceName.equals(this.name) ? subTopologySourceNodes : Collections.singleton(sourceName),
+                                sourceName.equals(this.name) ? subTopologySourceNodes : Set.of(sourceName),
                                 queryableStoreName,
                                 aggregateSupplier,
                                 aggProcessorNode,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -109,7 +108,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return new KStreamImpl<>(name,
                                  consumed.keySerde(),
                                  consumed.valueSerde(),
-                                 Collections.singleton(name),
+                                 Set.of(name),
                                  false,
                                  streamSourceNode,
                                  this);
@@ -125,7 +124,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return new KStreamImpl<>(name,
                                  consumed.keySerde(),
                                  consumed.valueSerde(),
-                                 Collections.singleton(name),
+                                 Set.of(name),
                                  false,
                                  streamPatternSourceNode,
                                  this);
@@ -160,7 +159,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return new KTableImpl<>(tableSourceName,
                                 consumed.keySerde(),
                                 consumed.valueSerde(),
-                                Collections.singleton(sourceName),
+                                Set.of(sourceName),
                                 materialized.queryableStoreName(),
                                 tableSource,
                                 tableSourceNode,
@@ -343,7 +342,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     private void optimizeTopology(final Properties props) {
         final Set<String> optimizationConfigs;
         if (props == null || !props.containsKey(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG)) {
-            optimizationConfigs = Collections.emptySet();
+            optimizationConfigs = Set.of();
         } else {
             optimizationConfigs = StreamsConfig.verifyTopologyOptimizationConfigs(
                 (String) props.get(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.VersionedBytesStoreSupplier;
 
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
@@ -102,7 +101,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K, V> implements KGr
         return new KTableImpl<>(funcName,
                                 materialized.keySerde(),
                                 materialized.valueSerde(),
-                                Collections.singleton(sourceName),
+                                Set.of(sourceName),
                                 materialized.queryableStoreName(),
                                 aggregateSupplier,
                                 statefulProcessorNode,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -35,7 +35,6 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -65,7 +64,7 @@ public class KStreamAggregate<KIn, VIn, VAgg> implements KStreamAggProcessorSupp
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -642,7 +642,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
             tableParentNode = repartitionNodeBuilder.build();
             builder.addGraphNode(graphNode, tableParentNode);
-            subTopologySourceNodes = Collections.singleton(sourceName);
+            subTopologySourceNodes = Set.of(sourceName);
         } else {
             tableParentNode = graphNode;
             subTopologySourceNodes = this.subTopologySourceNodes;
@@ -918,7 +918,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 name.name() != null);
         }
 
-        joinThis.ensureCopartitionWith(Collections.singleton(joinOther));
+        joinThis.ensureCopartitionWith(Set.of(joinOther));
 
         return join.join(
             joinThis,
@@ -961,7 +961,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             repartitionedSourceName,
             repartitionKeySerde,
             repartitionValueSerde,
-            Collections.singleton(repartitionedSourceName),
+            Set.of(repartitionedSourceName),
             false,
             repartitionNode,
             builder);
@@ -1118,7 +1118,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                               final ValueJoinerWithKey<? super K, ? super V, ? super VTable, ? extends VOut> joiner,
                                                               final JoinedInternal<K, V, VTable> joinedInternal,
                                                               final boolean leftJoin) {
-        final Set<String> allSourceNodes = ensureCopartitionWith(Collections.singleton((AbstractStream<K, VTable>) table));
+        final Set<String> allSourceNodes = ensureCopartitionWith(Set.of((AbstractStream<K, VTable>) table));
 
         final NamedInternal renamed = new NamedInternal(joinedInternal.name());
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinWindow.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamJoinWindow.java
@@ -27,7 +27,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 
-import java.util.Collections;
 import java.util.Set;
 
 class KStreamJoinWindow<K, V> implements ProcessorSupplier<K, V, K, V> {
@@ -40,7 +39,7 @@ class KStreamJoinWindow<K, V> implements ProcessorSupplier<K, V, K, V> {
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(thisWindowStoreFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(thisWindowStoreFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamSelfJoin.java
@@ -36,7 +36,6 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -67,7 +66,7 @@ class KStreamKStreamSelfJoin<K, V1, V2, VOut> implements ProcessorSupplier<K, V1
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(windowStoreFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(windowStoreFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -48,7 +47,7 @@ class KStreamKTableJoin<StreamKey, StreamValue, TableValue, VOut> implements Pro
         this.gracePeriod = gracePeriod;
         this.storeName = bufferStoreBuilder.map(StoreBuilder::name);
 
-        this.stores = bufferStoreBuilder.<Set<StoreBuilder<?>>>map(Collections::singleton).orElse(null);
+        this.stores = bufferStoreBuilder.<Set<StoreBuilder<?>>>map(Set::of).orElse(null);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -34,7 +34,6 @@ import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
@@ -60,7 +59,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, V, K,
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -49,7 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -89,7 +88,7 @@ public class KStreamSessionWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -43,7 +43,6 @@ import org.apache.kafka.streams.state.internals.WindowedTimestampedHeadersStoreT
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -77,7 +76,7 @@ public class KStreamSlidingWindowAggregate<KIn, VIn, VAgg> implements KStreamAgg
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -42,7 +42,6 @@ import org.apache.kafka.streams.state.internals.WindowedTimestampedHeadersStoreT
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,7 +82,7 @@ public class KStreamWindowAggregate<KIn, VIn, VAgg, W extends Window> implements
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableAggregate.java
@@ -31,7 +31,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.state.ValueTimestampHeaders.getValueOrNull;
@@ -69,7 +68,7 @@ public class KTableAggregate<KIn, VIn, VAgg> implements
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableFilter.java
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.state.ValueTimestampHeaders.getValueOrNull;
@@ -75,7 +74,7 @@ public class KTableFilter<KIn, VIn> implements KTableProcessorSupplier<KIn, VIn,
         if (storeFactory == null) {
             return null;
         }
-        return Collections.singleton(new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -83,7 +83,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -451,7 +450,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             // only materialize if materialized is specified and it has queryable name
             if (queryableStoreName != null) {
                 final StoreFactory storeFactory = new KeyValueStoreMaterializer<>(materializedInternal);
-                storeBuilder = Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+                storeBuilder = Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
             } else {
                 storeBuilder = null;
             }
@@ -601,7 +600,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             name,
             keySerde,
             valueSerde,
-            Collections.singleton(this.name),
+            Set.of(this.name),
             null,
             suppressionSupplier,
             node,
@@ -738,7 +737,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final NamedInternal renamed = new NamedInternal(joinName);
         final String joinMergeName = renamed.orElseGenerateWithPrefix(builder, MERGE_NAME);
-        final Set<String> allSourceNodes = ensureCopartitionWith(Collections.singleton((AbstractStream<K, VO>) other));
+        final Set<String> allSourceNodes = ensureCopartitionWith(Set.of((AbstractStream<K, VO>) other));
 
         if (leftOuter) {
             enableSendingOldValues(true);
@@ -1291,7 +1290,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final StreamSourceNode<KO, SubscriptionWrapper<K>> subscriptionSource = new StreamSourceNode<>(
             renamed.suffixWithOrElseGet("-subscription-registration-source", builder, SOURCE_NAME),
-            Collections.singleton(subscriptionTopicName),
+            Set.of(subscriptionTopicName),
             new ConsumedInternal<>(Consumed.with(foreignKeySerde, subscriptionWrapperSerde))
         );
         builder.addGraphNode(subscriptionSink, subscriptionSource);
@@ -1328,7 +1327,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                     ),
                     renamed.suffixWithOrElseGet("-subscription-join-foreign", builder, SUBSCRIPTION_PROCESSOR)
                 ),
-                Collections.singleton(foreignKeyValueGetter)
+                Set.of(foreignKeyValueGetter)
             );
         builder.addGraphNode(subscriptionReceiveNode, subscriptionJoinNode);
 
@@ -1364,7 +1363,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final StreamSourceNode<K, SubscriptionResponseWrapper<VO>> foreignResponseSource = new StreamSourceNode<>(
             renamed.suffixWithOrElseGet("-subscription-response-source", builder, SOURCE_NAME),
-            Collections.singleton(finalRepartitionTopicName),
+            Set.of(finalRepartitionTopicName),
             new ConsumedInternal<>(Consumed.with(keySerde, responseWrapperSerde))
         );
         builder.addGraphNode(foreignResponseSink, foreignResponseSource);
@@ -1386,7 +1385,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 ),
                 renamed.suffixWithOrElseGet("-subscription-response-resolver", builder, SUBSCRIPTION_RESPONSE_RESOLVER_PROCESSOR)
             ),
-            Collections.singleton(primaryKeyValueGetter)
+            Set.of(primaryKeyValueGetter)
         );
         builder.addGraphNode(foreignResponseSource, responseJoinNode);
 
@@ -1506,7 +1505,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                                                  final Headers headers,
                                                  final int numPartitions) {
             final Integer partition = value.primaryPartition();
-            return partition == null ? Optional.empty() : Optional.of(Collections.singleton(partition));
+            return partition == null ? Optional.empty() : Optional.of(Set.of(partition));
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -28,7 +28,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.state.ValueTimestampHeaders.getValueOrNull;
@@ -63,7 +62,7 @@ class KTableMapValues<KIn, VIn, VOut> implements KTableProcessorSupplier<KIn, VI
         if (storeFactory == null) {
             return null;
         }
-        return Collections.singleton(new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new StoreFactory.FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableReduce.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.apache.kafka.streams.state.internals.KeyValueStoreWrapper;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.kafka.streams.state.ValueTimestampHeaders.getValueOrNull;
@@ -64,7 +63,7 @@ public class KTableReduce<K, V> implements KTableProcessorSupplier<K, V, K, V> {
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(storeFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(storeFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,6 +57,6 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
 
         // stick with the same built-in partitioner util functions that producer used
         // to make sure its behavior is consistent with the producer
-        return Optional.of(Collections.singleton(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
+        return Optional.of(Set.of(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignTableJoinProcessorSupplier.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Set;
 
 public class ForeignTableJoinProcessorSupplier<KLeft, KRight, VRight>
@@ -59,7 +58,7 @@ public class ForeignTableJoinProcessorSupplier<KLeft, KRight, VRight>
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(subscriptionStoreFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(subscriptionStoreFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionReceiveProcessorSupplier.java
@@ -37,7 +37,6 @@ import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Set;
 
 public class SubscriptionReceiveProcessorSupplier<KLeft, KRight>
@@ -56,7 +55,7 @@ public class SubscriptionReceiveProcessorSupplier<KLeft, KRight>
 
     @Override
     public Set<StoreBuilder<?>> stores() {
-        return Collections.singleton(new FactoryWrappingStoreBuilder<>(subscriptionStoreFactory));
+        return Set.of(new FactoryWrappingStoreBuilder<>(subscriptionStoreFactory));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -22,8 +22,8 @@ import org.apache.kafka.streams.kstream.internals.KTableSource;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Used to represent either a KTable source or a GlobalKTable source. A boolean flag is used to indicate if this represents a GlobalKTable a {@link
@@ -44,7 +44,7 @@ public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
                             final boolean isGlobalKTable) {
 
         super(nodeName,
-              Collections.singletonList(topic),
+              List.of(topic),
               consumedInternal);
 
         this.sourceName = sourceName;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/EagerBufferConfigImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/EagerBufferConfigImpl.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals.suppress;
 
 import org.apache.kafka.streams.kstream.Suppressed;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -78,7 +77,7 @@ public class EagerBufferConfigImpl extends BufferConfigInternal<Suppressed.Eager
 
     @Override
     public Map<String, String> logConfig() {
-        return isLoggingEnabled() ? logConfig : Collections.emptyMap();
+        return isLoggingEnabled() ? logConfig : Map.of();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals.suppress;
 
 import org.apache.kafka.streams.kstream.Suppressed;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -46,7 +45,7 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
         this.maxRecords = Long.MAX_VALUE;
         this.maxBytes = Long.MAX_VALUE;
         this.bufferFullStrategy = SHUT_DOWN;
-        this.logConfig = Collections.emptyMap();
+        this.logConfig = Map.of();
     }
 
     @Override
@@ -91,7 +90,7 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
 
     @Override
     public Map<String, String> logConfig() {
-        return isLoggingEnabled() ? logConfig : Collections.emptyMap();
+        return isLoggingEnabled() ? logConfig : Map.of();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ConnectedStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ConnectedStoreProvider.java
@@ -59,7 +59,7 @@ import java.util.Set;
  *         }
  *
  *         Set<StoreBuilder<?>> stores() {
- *             return Collections.singleton(storeBuilder);
+ *             return Set.of(storeBuilder);
  *         }
  *     }
  *
@@ -83,7 +83,7 @@ import java.util.Set;
  *         }
  *
  *         Set<StoreBuilder<?>> stores() {
- *             return Collections.singleton(storeBuilder);
+ *             return Set.of(storeBuilder);
  *         }
  *     }
  * }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -272,7 +271,7 @@ class ActiveTaskCreator {
     }
 
     Map<MetricName, Metric> producerMetrics() {
-        return ClientUtils.producerMetrics(Collections.singleton(streamsProducer));
+        return ClientUtils.producerMetrics(Set.of(streamsProducer));
     }
 
     String producerClientIds() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
@@ -121,7 +121,7 @@ public class ChangelogTopics {
         if (preExistingChangelogPartitionsForTask.containsKey(taskId)) {
             return Collections.unmodifiableSet(preExistingChangelogPartitionsForTask.get(taskId));
         }
-        return Collections.emptySet();
+        return Set.of();
     }
 
     public Set<TopicPartition> preExistingSourceTopicBasedPartitions() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -113,7 +112,7 @@ public class ClientUtils {
     public static Map<TopicPartition, Long> fetchCommittedOffsets(final Set<TopicPartition> partitions,
                                                                   final Consumer<byte[], byte[]> consumer) {
         if (partitions.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         final Map<TopicPartition, Long> committedOffsets;
@@ -192,7 +191,7 @@ public class ClientUtils {
     public static Map<TopicPartition, ListOffsetsResultInfo> fetchEndOffsets(final Collection<TopicPartition> partitions,
                                                                              final Admin adminClient) {
         if (partitions.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
         return getEndOffsets(fetchEndOffsetsFuture(partitions, adminClient));
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdater.java
@@ -479,7 +479,7 @@ public class DefaultStateUpdater implements StateUpdater {
             if (!updatingTasks.isEmpty()) {
                 changelogEndOffsets = changelogReader.logicalChangelogEndOffsets();
             } else {
-                changelogEndOffsets = Collections.emptyMap();
+                changelogEndOffsets = Map.of();
             }
 
             final Map<StreamsRebalanceData.TaskId, Long> endOffsetSnapshot = new HashMap<>(updatingTasks.size());
@@ -1118,14 +1118,14 @@ public class DefaultStateUpdater implements StateUpdater {
     public Set<StandbyTask> updatingStandbyTasks() {
         return stateUpdaterThread != null
             ? Set.copyOf(stateUpdaterThread.updatingStandbyTasks())
-            : Collections.emptySet();
+            : Set.of();
     }
 
     @Override
     public Set<Task> updatingTasks() {
         return stateUpdaterThread != null
             ? Set.copyOf(stateUpdaterThread.updatingTasks())
-            : Collections.emptySet();
+            : Set.of();
     }
 
     public Set<StreamTask> restoredActiveTasks() {
@@ -1149,7 +1149,7 @@ public class DefaultStateUpdater implements StateUpdater {
     public Set<Task> pausedTasks() {
         return stateUpdaterThread != null
             ? Set.copyOf(stateUpdaterThread.pausedTasks())
-            : Collections.emptySet();
+            : Set.of();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/DefaultStreamPartitioner.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,7 +48,7 @@ public class DefaultStreamPartitioner<K, V> implements StreamPartitioner<K, V> {
         if (keyBytes == null) {
             return Optional.empty();
         } else {
-            return Optional.of(Collections.singleton(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
+            return Optional.of(Set.of(BuiltInPartitioner.partitionForKey(keyBytes, numPartitions)));
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -325,14 +325,14 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         for (final TopicPartition topicPartition : storeMetadata.changelogPartitions) {
             long currentDeadline = NO_DEADLINE;
 
-            globalConsumer.assign(Collections.singletonList(topicPartition));
+            globalConsumer.assign(List.of(topicPartition));
             long offset;
             final Long checkpoint = currentOffsets.get(topicPartition);
             if (checkpoint != null) {
                 globalConsumer.seek(topicPartition, checkpoint);
                 offset = checkpoint;
             } else {
-                globalConsumer.seekToBeginning(Collections.singletonList(topicPartition));
+                globalConsumer.seekToBeginning(List.of(topicPartition));
                 offset = getGlobalConsumerOffset(topicPartition);
             }
             final Long highWatermark = storeMetadata.highWatermarks.get(topicPartition);
@@ -467,14 +467,14 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         for (final TopicPartition topicPartition : storeMetadata.changelogPartitions) {
             long currentDeadline = NO_DEADLINE;
 
-            globalConsumer.assign(Collections.singletonList(topicPartition));
+            globalConsumer.assign(List.of(topicPartition));
             long offset;
             final Long checkpoint = currentOffsets.get(topicPartition);
             if (checkpoint != null) {
                 globalConsumer.seek(topicPartition, checkpoint);
                 offset = checkpoint;
             } else {
-                globalConsumer.seekToBeginning(Collections.singletonList(topicPartition));
+                globalConsumer.seekToBeginning(List.of(topicPartition));
                 offset = getGlobalConsumerOffset(topicPartition);
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -159,12 +159,12 @@ public class InternalTopicManager {
         final Set<String> topicDescriptionsStillToValidate = new HashSet<>(topicConfigs.keySet());
         final Set<String> topicConfigsStillToValidate = new HashSet<>(topicConfigs.keySet());
         while (!topicDescriptionsStillToValidate.isEmpty() || !topicConfigsStillToValidate.isEmpty()) {
-            Map<String, KafkaFuture<TopicDescription>> descriptionsForTopic = Collections.emptyMap();
+            Map<String, KafkaFuture<TopicDescription>> descriptionsForTopic = Map.of();
             if (!topicDescriptionsStillToValidate.isEmpty()) {
                 final DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(topicDescriptionsStillToValidate);
                 descriptionsForTopic = describeTopicsResult.topicNameValues();
             }
-            Map<String, KafkaFuture<Config>> configsForTopic = Collections.emptyMap();
+            Map<String, KafkaFuture<Config>> configsForTopic = Map.of();
             if (!topicConfigsStillToValidate.isEmpty()) {
                 final DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(
                     topicConfigsStillToValidate.stream()
@@ -751,7 +751,7 @@ public class InternalTopicManager {
 
             processCreateTopicResults(createTopicsResult, topicStillToCreate, createdTopics, deadline);
 
-            maybeSleep(Collections.singletonList(topicStillToCreate), deadline, "created");
+            maybeSleep(List.of(topicStillToCreate), deadline, "created");
         }
 
         log.info("Completed setup of internal topics {}.", topicConfigs.keySet());
@@ -885,7 +885,7 @@ public class InternalTopicManager {
             }
 
             maybeSleep(
-                Collections.singletonList(topicsStillToCleanup),
+                List.of(topicsStillToCleanup),
                 deadline,
                 "validated"
             );

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -327,7 +327,7 @@ public class InternalTopologyBuilder {
             // yet and hence the map from source node to topics is stale, in this case we put the pattern as a place holder;
             // this should only happen for debugging since during runtime this function should always be called after the metadata has updated.
             if (subscribedTopics.isEmpty()) {
-                return Collections.singletonList(String.valueOf(pattern));
+                return List.of(String.valueOf(pattern));
             }
 
             final List<String> matchedTopics = new ArrayList<>();
@@ -791,7 +791,7 @@ public class InternalTopologyBuilder {
                         .map(sourceGroup -> sourceGroup
                                 .stream()
                                 .flatMap(sourceNodeName -> nodeToSourceTopics.getOrDefault(sourceNodeName,
-                                        Collections.emptyList()).stream())
+                                        List.of()).stream())
                                 .collect(Collectors.toSet())
                         ).collect(Collectors.toList());
         for (final Set<String> copartition : allCopartitionedSourceTopics) {
@@ -1281,10 +1281,10 @@ public class InternalTopologyBuilder {
                                                                final Optional<Integer> numberOfPartitions) {
         return numberOfPartitions
             .map(partitions -> new RepartitionTopicConfig(internalTopic,
-                                                          Collections.emptyMap(),
+                                                          Map.of(),
                                                           partitions,
                                                           true))
-            .orElse(new RepartitionTopicConfig(internalTopic, Collections.emptyMap()));
+            .orElse(new RepartitionTopicConfig(internalTopic, Map.of()));
     }
 
     private void setRegexMatchedTopicsToSourceNodes() {
@@ -1440,7 +1440,7 @@ public class InternalTopologyBuilder {
 
     private List<String> maybeDecorateInternalSourceTopics(final Collection<String> sourceTopics) {
         if (sourceTopics == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         final List<String> decoratedTopics = new ArrayList<>();
         for (final String topic : sourceTopics) {
@@ -1715,8 +1715,8 @@ public class InternalTopologyBuilder {
                            final String storeName,
                            final String topicName,
                            final int id) {
-            source = new Source(sourceName, Collections.singleton(topicName), null);
-            processor = new Processor(processorName, Collections.singleton(storeName));
+            source = new Source(sourceName, Set.of(topicName), null);
+            processor = new Processor(processorName, Set.of(storeName));
             source.successors.add(processor);
             processor.predecessors.add(source);
             this.id = id;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -347,7 +347,7 @@ public class ProcessorStateManager implements StateManager {
                                 "treat it as a task corruption error and wipe out the local state of task {} " +
                                 "before re-bootstrapping", store.stateStore.name(), taskId);
 
-                        throw new TaskCorruptedException(Collections.singleton(taskId));
+                        throw new TaskCorruptedException(Set.of(taskId));
                     } else {
                         log.info("State store {} did not find checkpoint offset, hence would " +
                                         "default to the starting offset at changelog {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -254,6 +254,6 @@ public class ProcessorTopology {
             }
         }
 
-        return Collections.emptySet();
+        return Set.of();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -56,7 +56,6 @@ import org.apache.kafka.streams.processor.internals.metrics.TopicMetrics;
 import org.slf4j.Logger;
 
 import java.text.MessageFormat;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -529,7 +528,7 @@ public class RecordCollectorImpl implements RecordCollector {
                     "or the connection to broker was interrupted sending the request or receiving the response. " +
                     "\nConsider overwriting `max.block.ms` and /or " +
                     "`delivery.timeout.ms` to a larger value to wait longer for such scenarios and avoid timeout errors";
-                sendException.set(new TaskCorruptedException(Collections.singleton(taskId)));
+                sendException.set(new TaskCorruptedException(Set.of(taskId)));
             } else {
                 if (maybeFailResponse(response.result()) == ProductionExceptionHandler.Result.FAIL) {
                     errorMessage += "\nException handler choose to FAIL the processing, no more records would be sent.";

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -198,7 +198,7 @@ public class StandbyTask extends AbstractTask implements Task {
                 throw new IllegalStateException("Illegal state " + state() + " while preparing standby task " + id + " for committing ");
         }
 
-        return clean ? Collections.emptyMap() : null;
+        return clean ? Map.of() : null;
     }
 
     @Override
@@ -313,12 +313,12 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public Map<TopicPartition, Long> committedOffsets() {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     @Override
     public Map<TopicPartition, Long> highWaterMark() {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -874,7 +874,7 @@ public class StateDirectory implements AutoCloseable {
 
     private List<File> listNamedTopologyDirs() {
         final File[] namedTopologyDirectories = stateDir.listFiles(f -> f.getName().startsWith("__") &&  f.getName().endsWith("__"));
-        return namedTopologyDirectories != null ? Arrays.asList(namedTopologyDirectories) : Collections.emptyList();
+        return namedTopologyDirectories != null ? Arrays.asList(namedTopologyDirectories) : List.of();
     }
 
     private String parseNamedTopologyFromDirectory(final String dirName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -52,7 +52,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -750,7 +749,7 @@ public class StoreChangelogReader implements ChangelogReader {
             recordRestorationProgress(task, changelogMetadata, 0, storeMetadata.offset(), changelogMetadata.restoreEndOffset);
 
             changelogMetadata.transitTo(ChangelogState.COMPLETED);
-            pauseChangelogsFromRestoreConsumer(Collections.singleton(partition));
+            pauseChangelogsFromRestoreConsumer(Set.of(partition));
             if (storeMetadata.store() instanceof MeteredStateStore) {
                 ((MeteredStateStore) storeMetadata.store()).recordRestoreTime(changelogMetadata.calculateRestoreTime(time.nanoseconds()));
             }
@@ -811,7 +810,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private Map<TopicPartition, Long> committedOffsetForChangelogs(final Map<TaskId, Task> tasks, final Set<TopicPartition> partitions) {
         if (partitions.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         try {
@@ -822,7 +821,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 .topicPartitions(new ArrayList<>(partitions));
             final Map<TopicPartition, Long> committedOffsets =
                 adminClient.listConsumerGroupOffsets(
-                        Collections.singletonMap(groupId, spec),
+                        Map.of(groupId, spec),
                         options
                     )
                     .partitionsToOffsetAndMetadata(groupId).get().entrySet()
@@ -835,7 +834,7 @@ public class StoreChangelogReader implements ChangelogReader {
             log.debug("Could not retrieve the committed offsets for partitions {} due to {}, will retry in the next run loop",
                 partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
-            return Collections.emptyMap();
+            return Map.of();
         } catch (final KafkaException e) {
             throw new StreamsException(String.format("Failed to retrieve committed offsets for %s", partitions), e);
         }
@@ -848,7 +847,7 @@ public class StoreChangelogReader implements ChangelogReader {
 
     private Map<TopicPartition, Long> endOffsetForChangelogs(final Map<TaskId, Task> tasks, final Set<TopicPartition> partitions) {
         if (partitions.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
 
         try {
@@ -867,7 +866,7 @@ public class StoreChangelogReader implements ChangelogReader {
             log.debug("Could not fetch all end offsets for {} due to {}, will retry in the next run loop",
                 partitions, retriableException.toString());
             maybeInitTaskTimeoutOrThrow(getTasksFromPartitions(tasks, partitions), retriableException);
-            return Collections.emptyMap();
+            return Map.of();
         } catch (final KafkaException e) {
             throw new StreamsException(String.format("Failed to retrieve end offsets for %s", partitions), e);
         }
@@ -1152,7 +1151,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 for (final TopicPartition partition : windowedPartitionsRetention.keySet()) {
                     final Long endOffset = endOffsets.get(partition);
                     if (endOffset == null || endOffset <= 0) {
-                        restoreConsumer.seekToBeginning(Collections.singleton(partition));
+                        restoreConsumer.seekToBeginning(Set.of(partition));
                         seekToBeginningPartitions.add(partition);
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -63,7 +63,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singleton;
 import static org.apache.kafka.streams.StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeRecordSensor;
@@ -459,7 +458,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     return committableOffsetsAndMetadata();
                 } else {
                     log.debug("Skipped preparing {} task for commit since there is nothing to commit", state());
-                    return Collections.emptyMap();
+                    return Map.of();
                 }
 
             case CLOSED:
@@ -492,7 +491,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         switch (state()) {
             case CREATED:
             case RESTORING:
-                return Collections.emptyMap();
+                return Map.of();
 
             case RUNNING:
             case SUSPENDED:
@@ -826,7 +825,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 throw timeoutException;
             } else {
                 record = null;
-                throw new TaskCorruptedException(Collections.singleton(id));
+                throw new TaskCorruptedException(Set.of(id));
             }
         } catch (final FailedProcessingException failedProcessingException) {
             // Do not keep the failed processing exception in the stack trace
@@ -949,7 +948,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 throw timeoutException;
             } else {
                 record = null;
-                throw new TaskCorruptedException(Collections.singleton(id));
+                throw new TaskCorruptedException(Set.of(id));
             }
         } catch (final FailedProcessingException e) {
             throw createStreamsException(node.name(), e.getCause());
@@ -1161,7 +1160,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         // if after adding these records, its partition queue's buffered size has been
         // increased beyond the threshold, we can then pause the consumption for this partition
         if (newQueueSize > maxBufferedSize) {
-            mainConsumer.pause(singleton(partition));
+            mainConsumer.pause(Set.of(partition));
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -85,7 +85,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1781,7 +1780,7 @@ public class StreamThread extends Thread implements ProcessingThread {
                                 seekToTimestamps.get(partition),
                                 partition
                             );
-                            mainConsumer.seekToEnd(Collections.singleton(partitionAndOffset.getKey()));
+                            mainConsumer.seekToEnd(Set.of(partitionAndOffset.getKey()));
                         }
                     }
                 } catch (final TimeoutException timeoutException) {
@@ -2018,8 +2017,8 @@ public class StreamThread extends Thread implements ProcessingThread {
             restoreConsumerClientId(getName()),
             taskManager.producerClientIds(),
             adminClientId,
-            Collections.emptySet(),
-            Collections.emptySet());
+            Set.of(),
+            Set.of());
 
         return this;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -60,7 +60,7 @@ public class StreamsMetadataState {
     private final TopologyMetadata topologyMetadata;
     private final Set<String> globalStores;
     private final HostInfo thisHost;
-    private List<StreamsMetadata> allMetadata = Collections.emptyList();
+    private List<StreamsMetadata> allMetadata = List.of();
     private Map<String, List<PartitionInfo>> partitionsByTopic;
     private final AtomicReference<StreamsMetadata> localMetadata = new AtomicReference<>(null);
 
@@ -119,7 +119,7 @@ public class StreamsMetadataState {
         }
 
         if (!isInitialized()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         if (globalStores.contains(storeName)) {
@@ -128,7 +128,7 @@ public class StreamsMetadataState {
 
         final Collection<String> sourceTopics = topologyMetadata.sourceTopicsForStore(storeName, null);
         if (sourceTopics.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final ArrayList<StreamsMetadata> results = new ArrayList<>();
@@ -152,12 +152,12 @@ public class StreamsMetadataState {
         Objects.requireNonNull(topologyName, "topologyName cannot be null");
 
         if (!isInitialized()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final Collection<String> sourceTopics = topologyMetadata.sourceTopicsForStore(storeName, topologyName);
         if (sourceTopics.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final ArrayList<StreamsMetadata> results = new ArrayList<>();
@@ -175,7 +175,7 @@ public class StreamsMetadataState {
         Objects.requireNonNull(topologyName, "topologyName cannot be null");
 
         if (!isInitialized()) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final ArrayList<StreamsMetadata> results = new ArrayList<>();
@@ -272,9 +272,9 @@ public class StreamsMetadataState {
             // global stores are on every node. if we don't have the host info
             // for this host then just pick the first metadata
             if (thisHost.equals(UNKNOWN_HOST)) {
-                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), Collections.emptySet(), UNKNOWN_PARTITION);
+                return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), Set.of(), UNKNOWN_PARTITION);
             }
-            return new KeyQueryMetadata(localMetadata.get().hostInfo(), Collections.emptySet(), UNKNOWN_PARTITION);
+            return new KeyQueryMetadata(localMetadata.get().hostInfo(), Set.of(), UNKNOWN_PARTITION);
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -352,13 +352,13 @@ public class StreamsMetadataState {
     private void rebuildMetadata(final Map<HostInfo, Set<TopicPartition>> activePartitionHostMap,
                                  final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap) {
         if (activePartitionHostMap.isEmpty() && standbyPartitionHostMap.isEmpty()) {
-            allMetadata = Collections.emptyList();
+            allMetadata = List.of();
             localMetadata.set(new StreamsMetadataImpl(
                 thisHost,
-                Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet()
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of()
             ));
             return;
         }
@@ -583,7 +583,7 @@ public class StreamsMetadataState {
         private SourceTopicsInfo(final List<String> sourceTopics) {
             this.sourceTopics = sourceTopics;
             for (final String topic : sourceTopics) {
-                final List<PartitionInfo> partitions = partitionsByTopic.getOrDefault(topic, Collections.emptyList());
+                final List<PartitionInfo> partitions = partitionsByTopic.getOrDefault(topic, List.of());
                 if (partitions.size() > maxPartitions) {
                     maxPartitions = partitions.size();
                     topicWithMostPartitions = topic;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -92,7 +92,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Map.Entry.comparingByKey;
 import static org.apache.kafka.common.utils.Utils.filterMap;
@@ -274,7 +273,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     @Override
     public List<RebalanceProtocol> supportedProtocols() {
-        return singletonList(RebalanceProtocol.COOPERATIVE);
+        return List.of(RebalanceProtocol.COOPERATIVE);
     }
 
     @Override
@@ -312,12 +311,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         for (final ClientMetadata clientMetadata : clientsMetadata.values()) {
             for (final String consumerId : clientMetadata.consumers) {
                 assignment.put(consumerId, new Assignment(
-                    Collections.emptyList(),
+                    List.of(),
                     new AssignmentInfo(LATEST_SUPPORTED_VERSION,
-                        Collections.emptyList(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
+                        List.of(),
+                        Map.of(),
+                        Map.of(),
+                        Map.of(),
                         errorCode).encode()
                 ));
             }
@@ -376,7 +375,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 futureMetadataVersion = usedVersion;
                 processId = FUTURE_ID;
                 if (!clientMetadataMap.containsKey(FUTURE_ID)) {
-                    clientMetadataMap.put(FUTURE_ID, new ClientMetadata(FUTURE_ID, null, Collections.emptyMap(), subscription.rackId()));
+                    clientMetadataMap.put(FUTURE_ID, new ClientMetadata(FUTURE_ID, null, Map.of(), subscription.rackId()));
                 }
             } else {
                 processId = info.processId();
@@ -586,7 +585,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                                    final Map<ProcessId, ClientMetadata> clientMetadataMap,
                                                    final GroupSubscription groupSubscription) {
         if (assignmentError == AssignmentError.UNKNOWN_PROCESS_ID || assignmentError == AssignmentError.UNKNOWN_TASK_ID) {
-            assignor.onAssignmentComputed(new GroupAssignment(Collections.emptyMap()), groupSubscription, assignmentError);
+            assignor.onAssignmentComputed(new GroupAssignment(Map.of()), groupSubscription, assignmentError);
             log.error("Rebalance failed due to task assignor returning assignment with error {}, " +
                       "assignor callback will receive empty GroupAssignment due to this error", assignmentError);
             throw new StreamsException("Task assignment with " + assignor.getClass().getName() +
@@ -1495,9 +1494,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 validateActiveTaskEncoding(partitions, info, logPrefix);
 
                 activeTasks = getActiveTasks(partitions, info);
-                partitionsByHost = Collections.emptyMap();
-                standbyPartitionsByHost = Collections.emptyMap();
-                topicToPartitionInfo = Collections.emptyMap();
+                partitionsByHost = Map.of();
+                standbyPartitionsByHost = Map.of();
+                topicToPartitionInfo = Map.of();
                 encodedNextScheduledRebalanceMs = Long.MAX_VALUE;
                 break;
             case 2:
@@ -1508,7 +1507,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
                 activeTasks = getActiveTasks(partitions, info);
                 partitionsByHost = info.partitionsByHost();
-                standbyPartitionsByHost = Collections.emptyMap();
+                standbyPartitionsByHost = Map.of();
                 topicToPartitionInfo = getTopicPartitionInfo(partitionsByHost);
                 encodedNextScheduledRebalanceMs = Long.MAX_VALUE;
                 break;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -28,7 +28,6 @@ import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -212,7 +211,7 @@ public interface Task {
     void postCommit(boolean enforceCheckpoint);
 
     default Map<TopicPartition, Long> purgeableOffsets() {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -322,7 +322,7 @@ public class TaskManager {
 
             tasks.removeTask(task);
             task.revive();
-            tasks.addPendingTasksToInit(Collections.singleton(task));
+            tasks.addPendingTasksToInit(Set.of(task));
         }
     }
 
@@ -337,7 +337,7 @@ public class TaskManager {
             }
             return activeTaskCreator.createTasks(mainConsumer, assignedTasks);
         } else {
-            return Collections.emptySet();
+            return Set.of();
         }
     }
 
@@ -353,7 +353,7 @@ public class TaskManager {
             }
             return standbyTaskCreator.createTasks(assignedTasks);
         } else {
-            return Collections.emptySet();
+            return Set.of();
         }
     }
 
@@ -834,7 +834,7 @@ public class TaskManager {
                 if (oldTask.isActive()) {
                     final StandbyTask standbyTask = convertActiveToStandby((StreamTask) oldTask, inputPartitions);
                     tasks.removeTask(oldTask);
-                    tasks.addPendingTasksToInit(Collections.singleton(standbyTask));
+                    tasks.addPendingTasksToInit(Set.of(standbyTask));
                 } else {
                     final StreamTask activeTask = convertStandbyToActive((StandbyTask) oldTask, inputPartitions);
                     tasks.replaceStandbyWithActive(activeTask);
@@ -888,7 +888,7 @@ public class TaskManager {
             newTask = task.isActive() ?
                 convertActiveToStandby((StreamTask) task, inputPartitions) :
                 convertStandbyToActive((StandbyTask) task, inputPartitions);
-            tasks.addPendingTasksToInit(Collections.singleton(newTask));
+            tasks.addPendingTasksToInit(Set.of(newTask));
         } catch (final RuntimeException e) {
             final TaskId taskId = task.id();
             final String uncleanMessage = String.format("Failed to recycle task %s cleanly. " +
@@ -974,20 +974,20 @@ public class TaskManager {
                 stateUpdater.add(task);
             } else {
                 log.trace("Task {} is still not allowed to retry acquiring the state directory lock", task.id());
-                tasks.addPendingTasksToInit(Collections.singleton(task));
+                tasks.addPendingTasksToInit(Set.of(task));
             }
         } catch (final LockException lockException) {
             // The state directory may still be locked by another thread, when the rebalance just happened.
             // Retry in the next iteration.
             log.info("Encountered lock exception. Reattempting locking the state in the next iteration. Error message was: {}",
                      lockException.getMessage());
-            tasks.addPendingTasksToInit(Collections.singleton(task));
+            tasks.addPendingTasksToInit(Set.of(task));
             updateOrCreateBackoffRecord(task.id(), nowMs);
         } catch (final TimeoutException timeoutException) {
             // A timeout can occur either during producer initialization OR while fetching committed offsets.
             // Retry in the next iteration.
             task.maybeInitTaskTimeoutOrThrow(nowMs, timeoutException);
-            tasks.addPendingTasksToInit(Collections.singleton(task));
+            tasks.addPendingTasksToInit(Set.of(task));
             updateOrCreateBackoffRecord(task.id(), nowMs);
             log.info("Encountered timeout exception. Reattempting initialization in the next iteration. Error message was: {}",
                      timeoutException.getMessage());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
@@ -57,7 +57,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                               final Set<TaskMetadata> standbyTasks) {
         this.mainConsumerClientId = mainConsumerClientId;
         this.restoreConsumerClientId = restoreConsumerClientId;
-        this.producerClientIds = Collections.singleton(producerClientIds);
+        this.producerClientIds = Set.of(producerClientIds);
         this.adminClientId = adminClientId;
         this.threadName = threadName;
         this.threadState = threadState;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
@@ -57,7 +57,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                               final Set<TaskMetadata> standbyTasks) {
         this.mainConsumerClientId = mainConsumerClientId;
         this.restoreConsumerClientId = restoreConsumerClientId;
-        this.producerClientIds = Set.of(producerClientIds);
+        this.producerClientIds = producerClientIds != null ? Set.of(producerClientIds) : Set.of();
         this.adminClientId = adminClientId;
         this.threadName = threadName;
         this.threadState = threadState;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -59,8 +59,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptySet;
-
 public class TopologyMetadata {
     private Logger log;
 
@@ -398,7 +396,7 @@ public class TopologyMetadata {
     }
 
     public Set<String> namedTopologiesView() {
-        return hasNamedTopologies() ? Collections.unmodifiableSet(builders.keySet()) : emptySet();
+        return hasNamedTopologies() ? Collections.unmodifiableSet(builders.keySet()) : Set.of();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -63,10 +62,10 @@ public class AssignmentInfo {
                           final int commonlySupportedVersion) {
         this(version,
              commonlySupportedVersion,
-             Collections.emptyList(),
-             Collections.emptyMap(),
-             Collections.emptyMap(),
-             Collections.emptyMap(),
+             List.of(),
+             Map.of(),
+             Map.of(),
+             Map.of(),
              0);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,7 +38,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Comparator.comparing;
@@ -82,7 +80,7 @@ public class ClientState {
     }
 
     ClientState(final ProcessId processId, final int capacity) {
-        this(processId, capacity, Collections.emptyMap());
+        this(processId, capacity, Map.of());
     }
 
     ClientState(final ProcessId processId, final int capacity, final Map<String, String> clientTags) {
@@ -113,7 +111,7 @@ public class ClientState {
                        final ProcessId processId) {
         this.previousStandbyTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousStandbyTasks)));
         this.previousActiveTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousActiveTasks)));
-        taskOffsetSums = emptyMap();
+        taskOffsetSums = Map.of();
         this.taskLagTotals = unmodifiableMap(taskLagTotals);
         this.capacity = capacity;
         this.clientTags = unmodifiableMap(clientTags);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StandbyTaskAssignorFactory.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 import org.apache.kafka.streams.processor.assignment.AssignmentConfigs;
 import org.apache.kafka.streams.processor.assignment.ProcessId;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -37,7 +37,7 @@ class StandbyTaskAssignorFactory {
             final Map<ProcessId, String> racksForProcess = rackAwareTaskAssignor.racksForProcess();
             return new ClientTagAwareStandbyTaskAssignor(
                 (processId, clientState) -> mkMap(mkEntry("rack", racksForProcess.get(processId))),
-                assignmentConfigs -> Collections.singletonList("rack")
+                assignmentConfigs -> List.of("rack")
             );
         } else {
             return new DefaultStandbyTaskAssignor();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovement.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.processor.internals.assignment;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.assignment.ProcessId;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -144,7 +143,7 @@ final class TaskMovement {
             final ProcessId destination = clientStateEntry.getKey();
             final ClientState state = clientStateEntry.getValue();
             for (final TaskId task : state.standbyTasks()) {
-                if (warmups.getOrDefault(destination, Collections.emptySet()).contains(task)) {
+                if (warmups.getOrDefault(destination, Set.of()).contains(task)) {
                     // this is a warmup, so we won't move it.
                 } else if (taskIsNotCaughtUpOnClientAndOtherMoreCaughtUpClientsExist(task, destination, clientStates, tasksToCaughtUpClients, tasksToClientByLag)) {
                     // if the desired client is not caught up, and there is another client that _is_ more caught up, then

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -194,7 +194,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                   final String description,
                                                   final RecordingLevel recordingLevel,
                                                   final T value) {
-        addClientLevelImmutableMetric(name, description, Collections.emptyMap(), recordingLevel, value);
+        addClientLevelImmutableMetric(name, description, Map.of(), recordingLevel, value);
     }
 
     public <T> void addClientLevelImmutableMetric(final String name,
@@ -219,7 +219,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String description,
                                                 final RecordingLevel recordingLevel,
                                                 final Gauge<T> valueProvider) {
-        addClientLevelMutableMetric(name, description, Collections.emptyMap(), recordingLevel, valueProvider);
+        addClientLevelMutableMetric(name, description, Map.of(), recordingLevel, valueProvider);
     }
 
     public <T> void addClientLevelMutableMetric(final String name,
@@ -259,7 +259,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String description,
                                                 final String threadId,
                                                 final Gauge<T> valueProvider) {
-        addThreadLevelMutableMetric(name, description, threadId, Collections.emptyMap(), valueProvider);
+        addThreadLevelMutableMetric(name, description, threadId, Map.of(), valueProvider);
     }
     public <T> void addThreadLevelMutableMetric(final String name,
                                                 final String description,
@@ -306,7 +306,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     public Map<String, String> clientLevelTagMap() {
-        return clientLevelTagMap(Collections.emptyMap());
+        return clientLevelTagMap(Map.of());
     }
 
     public Map<String, String> clientLevelTagMap(final Map<String, String> additionalTags) {
@@ -316,7 +316,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     public Map<String, String> threadLevelTagMap(final String threadId) {
-        return threadLevelTagMap(threadId, Collections.emptyMap());
+        return threadLevelTagMap(threadId, Map.of());
     }
 
     public Map<String, String> threadLevelTagMap(final String threadId, final Map<String, String> additionalTags) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.StreamThreadTotalBlockedTime;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
@@ -311,7 +310,7 @@ public class ThreadMetrics {
             THREAD_STATE,
             THREAD_STATE_DESCRIPTION,
             threadId,
-            Collections.singletonMap(PROCESS_ID_TAG, processId),
+            Map.of(PROCESS_ID_TAG, processId),
             threadStateProvider
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +95,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
      * Start up Streams with a single initial NamedTopology
      */
     public void start(final NamedTopology initialTopology) {
-        start(Collections.singleton(initialTopology));
+        start(Set.of(initialTopology));
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/query/Position.java
+++ b/streams/src/main/java/org/apache/kafka/streams/query/Position.java
@@ -129,7 +129,7 @@ public class Position {
      */
     public Map<Integer, Long> getPartitionPositions(final String topic) {
         final ConcurrentHashMap<Integer, Long> bound = position.get(topic);
-        return bound == null ? Collections.emptyMap() : Collections.unmodifiableMap(bound);
+        return bound == null ? Map.of() : Collections.unmodifiableMap(bound);
     }
 
     private static ConcurrentHashMap<String, ConcurrentHashMap<Integer, Long>> deepCopy(

--- a/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/QueryableStoreTypes.java
@@ -27,7 +27,6 @@ import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
 import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStore;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -148,7 +147,7 @@ public final class QueryableStoreTypes {
     public static class KeyValueStoreType<K, V> extends QueryableStoreTypeMatcher<ReadOnlyKeyValueStore<K, V>> {
 
         KeyValueStoreType() {
-            super(Collections.singleton(ReadOnlyKeyValueStore.class));
+            super(Set.of(ReadOnlyKeyValueStore.class));
         }
 
         @Override
@@ -204,7 +203,7 @@ public final class QueryableStoreTypes {
     public static class WindowStoreType<K, V> extends QueryableStoreTypeMatcher<ReadOnlyWindowStore<K, V>> {
 
         WindowStoreType() {
-            super(Collections.singleton(ReadOnlyWindowStore.class));
+            super(Set.of(ReadOnlyWindowStore.class));
         }
 
         @Override
@@ -259,7 +258,7 @@ public final class QueryableStoreTypes {
     public static class SessionStoreType<K, V> extends QueryableStoreTypeMatcher<ReadOnlySessionStore<K, V>> {
 
         SessionStoreType() {
-            super(Collections.singleton(ReadOnlySessionStore.class));
+            super(Set.of(ReadOnlySessionStore.class));
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -42,31 +41,31 @@ public class GlobalStateStoreProvider implements StateStoreProvider {
     public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         final StateStore store = globalStateStores.get(storeName);
         if (store == null || !queryableStoreType.accepts(store)) {
-            return Collections.emptyList();
+            return List.of();
         }
         if (!store.isOpen()) {
             throw new InvalidStateStoreException("the state store, " + storeName + ", is not open.");
         }
         if (store instanceof TimestampedKeyValueStoreWithHeaders) {
             if (queryableStoreType instanceof QueryableStoreTypes.KeyValueStoreType) {
-                return (List<T>) Collections.singletonList(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store, ValueConverters.extractValueFromHeaders()));
+                return (List<T>) List.of(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store, ValueConverters.extractValueFromHeaders()));
             } else if (queryableStoreType instanceof QueryableStoreTypes.TimestampedKeyValueStoreType) {
-                return (List<T>) Collections.singletonList(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store, ValueConverters.extractValueAndTimestampFromHeaders()));
+                return (List<T>) List.of(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStoreWithHeaders<?, ?>) store, ValueConverters.extractValueAndTimestampFromHeaders()));
             }
         } else if (store instanceof TimestampedKeyValueStore && queryableStoreType instanceof QueryableStoreTypes.KeyValueStoreType) {
-            return (List<T>) Collections.singletonList(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStore<?, ?>) store, ValueConverters.extractValue()));
+            return (List<T>) List.of(new GenericReadOnlyKeyValueStoreFacade<>((TimestampedKeyValueStore<?, ?>) store, ValueConverters.extractValue()));
         } else if (store instanceof TimestampedWindowStoreWithHeaders) {
             if (queryableStoreType instanceof QueryableStoreTypes.WindowStoreType) {
-                return (List<T>) Collections.singletonList(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStoreWithHeaders<?, ?>) store, ValueConverters.extractValueFromHeaders()));
+                return (List<T>) List.of(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStoreWithHeaders<?, ?>) store, ValueConverters.extractValueFromHeaders()));
             } else if (queryableStoreType instanceof QueryableStoreTypes.TimestampedWindowStoreType) {
-                return (List<T>) Collections.singletonList(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStoreWithHeaders<?, ?>) store, ValueConverters.extractValueAndTimestampFromHeaders()));
+                return (List<T>) List.of(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStoreWithHeaders<?, ?>) store, ValueConverters.extractValueAndTimestampFromHeaders()));
             }
         } else if (store instanceof TimestampedWindowStore && queryableStoreType instanceof QueryableStoreTypes.WindowStoreType) {
-            return (List<T>) Collections.singletonList(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStore<?, ?>) store, ValueConverters.extractValue()));
+            return (List<T>) List.of(new GenericReadOnlyWindowStoreFacade<>((TimestampedWindowStore<?, ?>) store, ValueConverters.extractValue()));
         } else if (store instanceof SessionStoreWithHeaders && queryableStoreType instanceof QueryableStoreTypes.SessionStoreType) {
-            return (List<T>) Collections.singletonList(new ReadOnlySessionStoreFacade<>((SessionStoreWithHeaders<?, ?>) store));
+            return (List<T>) List.of(new ReadOnlySessionStoreFacade<>((SessionStoreWithHeaders<?, ?>) store));
         }
 
-        return (List<T>) Collections.singletonList(store);
+        return (List<T>) List.of(store);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBuffer.java
@@ -172,7 +172,7 @@ public final class InMemoryTimeOrderedKeyValueChangeBuffer<K, V, T> implements T
 
         @Override
         public Map<String, String> logConfig() {
-            return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Collections.emptyMap();
+            return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Map.of();
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ListValueStore.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -81,7 +80,7 @@ public class ListValueStore
     // this function assumes the addedValue is not null; callers should check null themselves
     private void putInternal(final Bytes key, final byte[] addedValue, final byte[] oldValue) {
         if (oldValue == null) {
-            wrapped().put(key, LIST_SERDE.serializer().serialize(null, Collections.singletonList(addedValue)));
+            wrapped().put(key, LIST_SERDE.serializer().serialize(null, List.of(addedValue)));
         } else {
             final List<byte[]> list = LIST_SERDE.deserializer().deserialize(null, oldValue);
             list.add(addedValue);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
@@ -32,7 +32,6 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -186,7 +185,7 @@ public class OffsetCheckpoint {
                         throw new IllegalArgumentException("Unknown offset checkpoint version: " + version);
                 }
             } catch (final NoSuchFileException e) {
-                return Collections.emptyMap();
+                return Map.of();
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBuffer.java
@@ -135,7 +135,7 @@ public class RocksDBTimeOrderedKeyValueBuffer<K, V> implements TimeOrderedKeyVal
 
         @Override
         public Map<String, String> logConfig() {
-            return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Collections.emptyMap();
+            return loggingEnabled() ? Collections.unmodifiableMap(logConfig) : Map.of();
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStore.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -296,7 +295,7 @@ public class RocksDBVersionedStore implements VersionedKeyValueStore<Bytes, byte
             // history retention exceeded. we still check the latest value store in case the
             // latest record version satisfies the timestamp bound, in which case it should
             // still be returned (i.e., the latest record version per key never expires).
-            return new LogicalSegmentIterator(Collections.singletonList(latestView).listIterator(), key, fromTimestamp, toTimestamp, order);
+            return new LogicalSegmentIterator(List.of(latestView).listIterator(), key, fromTimestamp, toTimestamp, order);
         } else {
             final List<LogicalKeyValueSegment> segments = new ArrayList<>();
             // add segment stores

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class StreamThreadStateStoreProvider {
@@ -48,7 +47,7 @@ public class StreamThreadStateStoreProvider {
     public <T> List<T> stores(final StoreQueryParameters storeQueryParams) {
         final StreamThread.State state = streamThread.state();
         if (state == StreamThread.State.DEAD) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final String storeName = storeQueryParams.storeName();
@@ -68,10 +67,10 @@ public class StreamThreadStateStoreProvider {
                         task.store(storeName) != null &&
                         storeName.equals(task.store(storeName).name())) {
                         final T typedStore = validateAndCastStores(task.store(storeName), queryableStoreType, storeName, task.id());
-                        return Collections.singletonList(typedStore);
+                        return List.of(typedStore);
                     }
                 }
-                return Collections.emptyList();
+                return List.of();
             } else {
                 final List<T> list = new ArrayList<>();
                 for (final Task task : tasks) {


### PR DESCRIPTION
This is the 5th part of improving replace collections factory methods
with its Java 11 equivalents in the streams module.

Reviewers: Ken Huang <s7133700@gmail.com>
