### PR TITLE
KAFKA-20975: Remove hamcrest from streams test-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3097,7 +3097,6 @@ project(':streams:test-utils') {
     testImplementation testFixtures(project(':clients'))
     testImplementation libs.junitJupiter
     testImplementation libs.mockitoCore
-    testImplementation libs.hamcrest
     testImplementation testLog4j2Libs
 
     testRuntimeOnly runtimeTestLibs

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/KeyValueStoreFacadeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/KeyValueStoreFacadeTest.java
@@ -35,9 +35,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,7 +87,7 @@ public class KeyValueStoreFacadeTest {
             .putIfAbsent("key", ValueAndTimestamp.make("value", ConsumerRecord.NO_TIMESTAMP));
 
         assertNull(keyValueStoreFacade.putIfAbsent("key", "value"));
-        assertThat(keyValueStoreFacade.putIfAbsent("key", "value"), is("oldValue"));
+        assertEquals("oldValue", keyValueStoreFacade.putIfAbsent("key", "value"));
         verify(mockedKeyValueTimestampStore, times(2))
             .putIfAbsent("key", ValueAndTimestamp.make("value", ConsumerRecord.NO_TIMESTAMP));
     }
@@ -111,7 +110,7 @@ public class KeyValueStoreFacadeTest {
             .when(mockedKeyValueTimestampStore).delete("key");
 
         assertNull(keyValueStoreFacade.delete("key"));
-        assertThat(keyValueStoreFacade.delete("key"), is("oldValue"));
+        assertEquals("oldValue", keyValueStoreFacade.delete("key"));
         verify(mockedKeyValueTimestampStore, times(2)).delete("key");
     }
 
@@ -149,7 +148,7 @@ public class KeyValueStoreFacadeTest {
     public void shouldReturnName() {
         when(mockedKeyValueTimestampStore.name()).thenReturn("name");
 
-        assertThat(keyValueStoreFacade.name(), is("name"));
+        assertEquals("name", keyValueStoreFacade.name());
         verify(mockedKeyValueTimestampStore).name();
     }
 
@@ -158,8 +157,8 @@ public class KeyValueStoreFacadeTest {
         when(mockedKeyValueTimestampStore.persistent())
             .thenReturn(true, false);
 
-        assertThat(keyValueStoreFacade.persistent(), is(true));
-        assertThat(keyValueStoreFacade.persistent(), is(false));
+        assertTrue(keyValueStoreFacade.persistent());
+        assertFalse(keyValueStoreFacade.persistent());
         verify(mockedKeyValueTimestampStore, times(2)).persistent();
     }
 
@@ -168,8 +167,8 @@ public class KeyValueStoreFacadeTest {
         when(mockedKeyValueTimestampStore.isOpen())
             .thenReturn(true, false);
 
-        assertThat(keyValueStoreFacade.isOpen(), is(true));
-        assertThat(keyValueStoreFacade.isOpen(), is(false));
+        assertTrue(keyValueStoreFacade.isOpen());
+        assertFalse(keyValueStoreFacade.isOpen());
         verify(mockedKeyValueTimestampStore, times(2)).isOpen();
     }
 
@@ -178,7 +177,7 @@ public class KeyValueStoreFacadeTest {
         when(mockedKeyValueTimestampStore.getPosition())
             .thenReturn(Position.emptyPosition());
 
-        assertThat(keyValueStoreFacade.getPosition(), is(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), keyValueStoreFacade.getPosition());
         verify(mockedKeyValueTimestampStore, times(1)).getPosition();
     }
 
@@ -189,13 +188,13 @@ public class KeyValueStoreFacadeTest {
         final QueryResult<Integer> queryResult = QueryResult.forResult(42);
         when(mockedKeyValueTimestampStore.<Integer>query(any(), any(), any())).thenReturn(queryResult);
 
-        assertThat(
+        assertEquals(
+            queryResult,
             keyValueStoreFacade.query(
                 query,
                 PositionBound.unbounded(),
                 queryConfig
-            ),
-            is(queryResult));
+            ));
         verify(mockedKeyValueTimestampStore).query(query, PositionBound.unbounded(), queryConfig);
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -43,14 +43,9 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTopicsTest {
     private static final String INPUT_TOPIC = "input";
@@ -92,9 +87,9 @@ public class TestTopicsTest {
             testDriver.createOutputTopic(OUTPUT_TOPIC, stringSerde.deserializer(), stringSerde.deserializer());
         //Feed word "Hello" to inputTopic and no kafka key, timestamp is irrelevant in this case
         inputTopic.pipeInput("Hello");
-        assertThat(outputTopic.readValue(), equalTo("Hello"));
+        assertEquals("Hello", outputTopic.readValue());
         //No more output in topic
-        assertThat(outputTopic.isEmpty(), is(true));
+        assertTrue(outputTopic.isEmpty());
     }
 
     @Test
@@ -107,8 +102,7 @@ public class TestTopicsTest {
         //Feed list of words to inputTopic and no kafka key, timestamp is irrelevant in this case
         inputTopic.pipeValueList(inputList);
         final List<String> output = outputTopic.readValuesToList();
-        assertThat(output, hasItems("This", "is", "an", "example"));
-        assertThat(output, is(equalTo(inputList)));
+        assertEquals(inputList, output);
     }
 
     @Test
@@ -118,8 +112,8 @@ public class TestTopicsTest {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput(1L, "Hello");
-        assertThat(outputTopic.readKeyValue(), equalTo(new KeyValue<>(1L, "Hello")));
-        assertThat(outputTopic.isEmpty(), is(true));
+        assertEquals(new KeyValue<>(1L, "Hello"), outputTopic.readKeyValue());
+        assertTrue(outputTopic.isEmpty());
     }
 
     @Test
@@ -139,7 +133,7 @@ public class TestTopicsTest {
         }
         inputTopic.pipeKeyValueList(input);
         final List<KeyValue<String, Long>> output = outputTopic.readKeyValuesToList();
-        assertThat(output, is(equalTo(expected)));
+        assertEquals(expected, output);
     }
 
     @Test
@@ -159,7 +153,7 @@ public class TestTopicsTest {
         }
         inputTopic.pipeKeyValueList(input);
         final Map<String, Long> output = outputTopic.readKeyValuesToMap();
-        assertThat(output, is(equalTo(expected)));
+        assertEquals(expected, output);
     }
 
     @Test
@@ -192,7 +186,7 @@ public class TestTopicsTest {
         }
         inputTopic.pipeKeyValueList(input, testBaseTime, advance);
         final List<TestRecord<String, Long>> output = outputTopic.readRecordsToList();
-        assertThat(output, is(equalTo(expected)));
+        assertEquals(expected, output);
     }
 
     @Test
@@ -215,7 +209,7 @@ public class TestTopicsTest {
         }
         inputTopic.pipeRecordList(input);
         final List<TestRecord<String, Long>> output = outputTopic.readRecordsToList();
-        assertThat(output, is(equalTo(expected)));
+        assertEquals(expected, output);
     }
 
     @Test
@@ -226,21 +220,21 @@ public class TestTopicsTest {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput(null, "Hello", baseTime);
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(null, "Hello", null, baseTime))));
+        assertEquals(new TestRecord<>(null, "Hello", null, baseTime), outputTopic.readRecord());
 
         inputTopic.pipeInput(2L, "Kafka", ++baseTime);
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(2L, "Kafka", null, baseTime))));
+        assertEquals(new TestRecord<>(2L, "Kafka", null, baseTime), outputTopic.readRecord());
 
         inputTopic.pipeInput(2L, "Kafka", testBaseTime);
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(2L, "Kafka", testBaseTime))));
+        assertEquals(new TestRecord<>(2L, "Kafka", testBaseTime), outputTopic.readRecord());
 
         final List<String> inputList = Arrays.asList("Advancing", "time");
         //Feed list of words to inputTopic and no kafka key, timestamp advancing from testInstant
         final Duration advance = Duration.ofSeconds(15);
         final Instant recordInstant = testBaseTime.plus(Duration.ofDays(1));
         inputTopic.pipeValueList(inputList, recordInstant, advance);
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(null, "Advancing", recordInstant))));
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(null, "time", null, recordInstant.plus(advance)))));
+        assertEquals(new TestRecord<>(null, "Advancing", recordInstant), outputTopic.readRecord());
+        assertEquals(new TestRecord<>(null, "time", null, recordInstant.plus(advance)), outputTopic.readRecord());
     }
 
     @Test
@@ -257,12 +251,12 @@ public class TestTopicsTest {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput(new TestRecord<>(1L, "Hello", headers));
-        assertThat(outputTopic.readRecord(), allOf(
-                hasProperty("key", equalTo(1L)),
-                hasProperty("value", equalTo("Hello")),
-                hasProperty("headers", equalTo(headers))));
+        final TestRecord<Long, String> headerRecord = outputTopic.readRecord();
+        assertEquals(1L, headerRecord.getKey());
+        assertEquals("Hello", headerRecord.getValue());
+        assertEquals(headers, headerRecord.getHeaders());
         inputTopic.pipeInput(new TestRecord<>(2L, "Kafka", headers, ++baseTime));
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(2L, "Kafka", headers, baseTime))));
+        assertEquals(new TestRecord<>(2L, "Kafka", headers, baseTime), outputTopic.readRecord());
     }
 
     @Test
@@ -273,12 +267,12 @@ public class TestTopicsTest {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput(1L, "Hello");
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(1L, "Hello", testBaseTime))));
+        assertEquals(new TestRecord<>(1L, "Hello", testBaseTime), outputTopic.readRecord());
         inputTopic.pipeInput(2L, "World");
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(2L, "World", null, testBaseTime.toEpochMilli()))));
+        assertEquals(new TestRecord<>(2L, "World", null, testBaseTime.toEpochMilli()), outputTopic.readRecord());
         inputTopic.advanceTime(advance);
         inputTopic.pipeInput(3L, "Kafka");
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(3L, "Kafka", testBaseTime.plus(advance)))));
+        assertEquals(new TestRecord<>(3L, "Kafka", testBaseTime.plus(advance)), outputTopic.readRecord());
     }
 
     @Test
@@ -289,9 +283,9 @@ public class TestTopicsTest {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput("Hello");
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(null, "Hello", testBaseTime))));
+        assertEquals(new TestRecord<>(null, "Hello", testBaseTime), outputTopic.readRecord());
         inputTopic.pipeInput(2L, "Kafka");
-        assertThat(outputTopic.readRecord(), is(equalTo(new TestRecord<>(2L, "Kafka", testBaseTime.plus(advance)))));
+        assertEquals(new TestRecord<>(2L, "Kafka", testBaseTime.plus(advance)), outputTopic.readRecord());
     }
 
 
@@ -306,15 +300,15 @@ public class TestTopicsTest {
         final TestOutputTopic<String, Long> outputTopic2 =
             testDriver.createOutputTopic(OUTPUT_TOPIC_MAP, stringSerde.deserializer(), longSerde.deserializer());
         inputTopic1.pipeInput(1L, "Hello");
-        assertThat(outputTopic1.readKeyValue(), equalTo(new KeyValue<>(1L, "Hello")));
-        assertThat(outputTopic2.readKeyValue(), equalTo(new KeyValue<>("Hello", 1L)));
-        assertThat(outputTopic1.isEmpty(), is(true));
-        assertThat(outputTopic2.isEmpty(), is(true));
+        assertEquals(new KeyValue<>(1L, "Hello"), outputTopic1.readKeyValue());
+        assertEquals(new KeyValue<>("Hello", 1L), outputTopic2.readKeyValue());
+        assertTrue(outputTopic1.isEmpty());
+        assertTrue(outputTopic2.isEmpty());
         inputTopic2.pipeInput(1L, "Hello");
         //This is not visible in outputTopic1 even it is the same topic
-        assertThat(outputTopic2.readKeyValue(), equalTo(new KeyValue<>("Hello", 1L)));
-        assertThat(outputTopic1.isEmpty(), is(true));
-        assertThat(outputTopic2.isEmpty(), is(true));
+        assertEquals(new KeyValue<>("Hello", 1L), outputTopic2.readKeyValue());
+        assertTrue(outputTopic1.isEmpty());
+        assertTrue(outputTopic2.isEmpty());
     }
 
     @Test
@@ -339,7 +333,7 @@ public class TestTopicsTest {
             testDriver.createOutputTopic(OUTPUT_TOPIC, stringSerde.deserializer(), stringSerde.deserializer());
         //Feed word "Hello" to inputTopic and no kafka key, timestamp is irrelevant in this case
         inputTopic.pipeInput("Hello");
-        assertThat(outputTopic.readValue(), equalTo("Hello"));
+        assertEquals("Hello", outputTopic.readValue());
         //No more output in topic
         assertThrows(NoSuchElementException.class, outputTopic::readRecord, "Empty topic");
     }
@@ -386,10 +380,10 @@ public class TestTopicsTest {
     public void testInputToString() {
         final TestInputTopic<String, String> inputTopic =
             testDriver.createInputTopic("topicName", stringSerde.serializer(), stringSerde.serializer());
-        assertThat(inputTopic.toString(), allOf(
-                containsString("TestInputTopic"),
-                containsString("topic='topicName'"),
-                containsString("StringSerializer")));
+        final String inputTopicString = inputTopic.toString();
+        assertTrue(inputTopicString.contains("TestInputTopic"));
+        assertTrue(inputTopicString.contains("topic='topicName'"));
+        assertTrue(inputTopicString.contains("StringSerializer"));
     }
 
     @Test
@@ -416,11 +410,11 @@ public class TestTopicsTest {
     public void testOutputToString() {
         final TestOutputTopic<String, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, stringSerde.deserializer(), stringSerde.deserializer());
-        assertThat(outputTopic.toString(), allOf(
-                containsString("TestOutputTopic"),
-                containsString("topic='output1'"),
-                containsString("size=0"),
-                containsString("StringDeserializer")));
+        final String outputTopicString = outputTopic.toString();
+        assertTrue(outputTopicString.contains("TestOutputTopic"));
+        assertTrue(outputTopicString.contains("topic='output1'"));
+        assertTrue(outputTopicString.contains("size=0"));
+        assertTrue(outputTopicString.contains("StringDeserializer"));
     }
 
     @Test
@@ -443,7 +437,7 @@ public class TestTopicsTest {
         }
         inputTopic.pipeKeyValueList(input, Instant.parse("2019-06-01T10:00:00Z"), advance);
         final List<TestRecord<String, Long>> output = outputTopic.readRecordsToList();
-        assertThat(output, is(equalTo(expected)));
+        assertEquals(expected, output);
     }
 
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -82,11 +82,6 @@ import java.util.regex.Pattern;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -506,10 +501,10 @@ public abstract class TopologyTestDriverTest {
             .withConfig(config)
             .build();
 
-        assertThat(testDriver.producedTopicNames(), is(Collections.emptySet()));
+        assertEquals(Collections.emptySet(), testDriver.producedTopicNames());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
-        assertThat(testDriver.producedTopicNames(), hasItem(SINK_TOPIC_1));
+        assertTrue(testDriver.producedTopicNames().contains(SINK_TOPIC_1));
     }
 
     @Test
@@ -520,28 +515,28 @@ public abstract class TopologyTestDriverTest {
                 .build();
 
 
-        assertThat(testDriver.producedTopicNames(), is(Collections.emptySet()));
+        assertEquals(Collections.emptySet(), testDriver.producedTopicNames());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
-        assertThat(
-            testDriver.producedTopicNames(),
-            equalTo(Set.of(
+        assertEquals(
+            Set.of(
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-table1-repartition",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-table1-changelog"
-            ))
+            ),
+            testDriver.producedTopicNames()
         );
 
         pipeRecord(SOURCE_TOPIC_2, testRecord1);
-        assertThat(
-            testDriver.producedTopicNames(),
-            equalTo(Set.of(
+        assertEquals(
+            Set.of(
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-table1-repartition",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-table1-changelog",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-table2-changelog",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-join-subscription-registration-topic",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-join-subscription-store-changelog",
                 config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-join-subscription-response-topic"
-            ))
+            ),
+            testDriver.producedTopicNames()
         );
     }
 
@@ -555,12 +550,12 @@ public abstract class TopologyTestDriverTest {
             .withConfig(config)
             .build();
 
-        assertThat(testDriver.producedTopicNames(), is(Collections.emptySet()));
+        assertEquals(Collections.emptySet(), testDriver.producedTopicNames());
 
         pipeRecord(SOURCE_TOPIC_2, testRecord1);
-        assertThat(
-            testDriver.producedTopicNames(),
-            equalTo(Collections.singleton(SOURCE_TOPIC_1))
+        assertEquals(
+            Collections.singleton(SOURCE_TOPIC_1),
+            testDriver.producedTopicNames()
         );
     }
 
@@ -592,7 +587,7 @@ public abstract class TopologyTestDriverTest {
         final TTDTestRecord record = processedRecords.get(0);
         final TTDTestRecord expectedResult = new TTDTestRecord(SOURCE_TOPIC_1, testRecord1, 0L);
 
-        assertThat(record, equalTo(expectedResult));
+        assertEquals(expectedResult, record);
     }
 
     private void pipeRecord(final String topic, final TestRecord<byte[], byte[]> record) {
@@ -621,7 +616,7 @@ public abstract class TopologyTestDriverTest {
 
         TTDTestRecord record = processedRecords1.get(0);
         TTDTestRecord expectedResult = new TTDTestRecord(key1, value1, headers, timestamp1, 0L, SOURCE_TOPIC_1);
-        assertThat(record, equalTo(expectedResult));
+        assertEquals(expectedResult, record);
 
         inputTopic2.pipeInput(new TestRecord<>(key2, value2, Instant.ofEpochMilli(timestamp2)));
 
@@ -630,7 +625,7 @@ public abstract class TopologyTestDriverTest {
 
         record = processedRecords2.get(0);
         expectedResult = new TTDTestRecord(key2, value2, new RecordHeaders((Iterable<Header>) null), timestamp2, 0L, SOURCE_TOPIC_2);
-        assertThat(record, equalTo(expectedResult));
+        assertEquals(expectedResult, record);
     }
 
     @SuppressWarnings("resource")
@@ -679,8 +674,8 @@ public abstract class TopologyTestDriverTest {
                 Instant.now());
         final TestRecord<Long, String> result1 =
             testDriver.readRecord(SINK_TOPIC_1, new LongDeserializer(), new StringDeserializer());
-        assertThat(result1.getKey(), equalTo(source1Key));
-        assertThat(result1.getValue(), equalTo(source1Value));
+        assertEquals(source1Key, result1.getKey());
+        assertEquals(source1Value, result1.getValue());
 
         testDriver.pipeRecord(SOURCE_TOPIC_2,
                 consumerRecord2,
@@ -689,8 +684,8 @@ public abstract class TopologyTestDriverTest {
                 Instant.now());
         final TestRecord<Integer, Double> result2 =
             testDriver.readRecord(SINK_TOPIC_1, new IntegerDeserializer(), new DoubleDeserializer());
-        assertThat(result2.getKey(), equalTo(source2Key));
-        assertThat(result2.getValue(), equalTo(source2Value));
+        assertEquals(source2Key, result2.getKey());
+        assertEquals(source2Value, result2.getValue());
     }
 
     @Test
@@ -739,10 +734,10 @@ public abstract class TopologyTestDriverTest {
         inputTopic.pipeInput(testRecord1);
         outputTopic.readRecord();
 
-        assertThat(passedHeadersToKeySerializer.get(), equalTo(true));
-        assertThat(passedHeadersToValueSerializer.get(), equalTo(true));
-        assertThat(passedHeadersToKeyDeserializer.get(), equalTo(true));
-        assertThat(passedHeadersToValueDeserializer.get(), equalTo(true));
+        assertTrue(passedHeadersToKeySerializer.get());
+        assertTrue(passedHeadersToValueSerializer.get());
+        assertTrue(passedHeadersToKeyDeserializer.get());
+        assertTrue(passedHeadersToValueDeserializer.get());
     }
 
     @Test
@@ -774,8 +769,8 @@ public abstract class TopologyTestDriverTest {
                 Instant.now());
         final TestRecord<Long, String> result1 =
                 testDriver.readRecord(SINK_TOPIC_1, new LongDeserializer(), new StringDeserializer());
-        assertThat(result1.getKey(), equalTo(source1Key));
-        assertThat(result1.getValue(), equalTo(source1Value));
+        assertEquals(source1Key, result1.getKey());
+        assertEquals(source1Value, result1.getValue());
 
         testDriver.pipeRecord(SOURCE_TOPIC_2,
                 consumerRecord2,
@@ -784,8 +779,8 @@ public abstract class TopologyTestDriverTest {
                 Instant.now());
         final TestRecord<Integer, Double> result2 =
                 testDriver.readRecord(SINK_TOPIC_2, new IntegerDeserializer(), new DoubleDeserializer());
-        assertThat(result2.getKey(), equalTo(source2Key));
-        assertThat(result2.getValue(), equalTo(source2Value));
+        assertEquals(source2Key, result2.getKey());
+        assertEquals(source2Value, result2.getValue());
     }
 
     @Test
@@ -817,7 +812,7 @@ public abstract class TopologyTestDriverTest {
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
 
-        assertThat(globalStore.get(testRecord1.key()), is(testRecord1.value()));
+        assertEquals(testRecord1.value(), globalStore.get(testRecord1.key()));
     }
 
     @Test
@@ -832,42 +827,42 @@ public abstract class TopologyTestDriverTest {
 
         expectedPunctuations.add(42L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 42L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 42L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(51L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 51L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 52L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(61L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 61L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 65L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(71L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 71L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 72L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(95L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 95L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(101L);
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 101L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         pipeRecord(SOURCE_TOPIC_1, new TestRecord<>(key1, value1, null, 102L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
     }
 
     @Test
@@ -882,22 +877,22 @@ public abstract class TopologyTestDriverTest {
         final List<Long> expectedPunctuations = new LinkedList<>();
 
         testDriver.advanceWallClockTime(Duration.ofMillis(5L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(14L);
         testDriver.advanceWallClockTime(Duration.ofMillis(9L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         testDriver.advanceWallClockTime(Duration.ofMillis(1L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(35L);
         testDriver.advanceWallClockTime(Duration.ofMillis(20L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
 
         expectedPunctuations.add(40L);
         testDriver.advanceWallClockTime(Duration.ofMillis(5L));
-        assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
+        assertEquals(expectedPunctuations, mockPunctuator.punctuatedAt);
     }
 
     @Test
@@ -930,7 +925,7 @@ public abstract class TopologyTestDriverTest {
         expectedStoreNames.add("store");
         expectedStoreNames.add("globalStore");
         final Map<String, StateStore> allStores = testDriver.getAllStateStores();
-        assertThat(allStores.keySet(), equalTo(expectedStoreNames));
+        assertEquals(expectedStoreNames, allStores.keySet());
         for (final StateStore store : allStores.values()) {
             assertNotNull(store);
         }
@@ -1169,82 +1164,73 @@ public abstract class TopologyTestDriverTest {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(keyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + keyValueStoreName
-                    + " is a key-value store and should be accessed via `getKeyValueStore()`"));
+            assertEquals("Store " + keyValueStoreName
+                    + " is a key-value store and should be accessed via `getKeyValueStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(timestampedKeyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + timestampedKeyValueStoreName
-                    + " is a timestamped key-value store and should be accessed via `getTimestampedKeyValueStore()`"));
+            assertEquals("Store " + timestampedKeyValueStoreName
+                    + " is a timestamped key-value store and should be accessed via `getTimestampedKeyValueStore()`",
+                e.getMessage());
         }
         if (persistent) { // versioned stores do not offer an in-memory version yet, so nothing to test/verify unless persistent
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(versionedKeyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + versionedKeyValueStoreName
-                    + " is a versioned key-value store and should be accessed via `getVersionedKeyValueStore()`"));
+            assertEquals("Store " + versionedKeyValueStoreName
+                    + " is a versioned key-value store and should be accessed via `getVersionedKeyValueStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(windowStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + windowStoreName
-                    + " is a window store and should be accessed via `getWindowStore()`"));
+            assertEquals("Store " + windowStoreName
+                    + " is a window store and should be accessed via `getWindowStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(timestampedWindowStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + timestampedWindowStoreName
-                    + " is a timestamped window store and should be accessed via `getTimestampedWindowStore()`"));
+            assertEquals("Store " + timestampedWindowStoreName
+                    + " is a timestamped window store and should be accessed via `getTimestampedWindowStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(sessionStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + sessionStoreName
-                    + " is a session store and should be accessed via `getSessionStore()`"));
+            assertEquals("Store " + sessionStoreName
+                    + " is a session store and should be accessed via `getSessionStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(globalKeyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + globalKeyValueStoreName
-                    + " is a key-value store and should be accessed via `getKeyValueStore()`"));
+            assertEquals("Store " + globalKeyValueStoreName
+                    + " is a key-value store and should be accessed via `getKeyValueStore()`",
+                e.getMessage());
         }
         {
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(globalTimestampedKeyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + globalTimestampedKeyValueStoreName
-                    + " is a timestamped key-value store and should be accessed via `getTimestampedKeyValueStore()`"));
+            assertEquals("Store " + globalTimestampedKeyValueStoreName
+                    + " is a timestamped key-value store and should be accessed via `getTimestampedKeyValueStore()`",
+                e.getMessage());
         }
         if (persistent) { // versioned stores do not offer an in-memory version yet, so nothing to test/verify unless persistent
             final IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> testDriver.getStateStore(globalVersionedKeyValueStoreName));
-            assertThat(
-                e.getMessage(),
-                equalTo("Store " + globalVersionedKeyValueStoreName
-                    + " is a versioned key-value store and should be accessed via `getVersionedKeyValueStore()`"));
+            assertEquals("Store " + globalVersionedKeyValueStoreName
+                    + " is a versioned key-value store and should be accessed via `getVersionedKeyValueStore()`",
+                e.getMessage());
         }
     }
 
@@ -1439,7 +1425,7 @@ public abstract class TopologyTestDriverTest {
         final Set<String> expectedStoreNames = new HashSet<>();
         expectedStoreNames.add("store");
         expectedStoreNames.add("globalStore");
-        assertThat(testDriver.getAllStateStores().keySet(), equalTo(expectedStoreNames));
+        assertEquals(expectedStoreNames, testDriver.getAllStateStores().keySet());
     }
 
     private void setup() {
@@ -1471,8 +1457,8 @@ public abstract class TopologyTestDriverTest {
     }
 
     private void compareKeyValue(final TestRecord<String, Long> record, final String key, final Long value) {
-        assertThat(record.getKey(), equalTo(key));
-        assertThat(record.getValue(), equalTo(value));
+        assertEquals(key, record.getKey());
+        assertEquals(value, record.getValue());
     }
 
     @Test
@@ -1487,7 +1473,7 @@ public abstract class TopologyTestDriverTest {
     public void shouldNotUpdateStoreForSmallerValue() {
         setup();
         pipeInput("input-topic", "a", 1L, 9999L);
-        assertThat(store.get("a"), equalTo(21L));
+        assertEquals(21L, store.get("a"));
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 21L);
         assertTrue(testDriver.isEmpty("result-topic"));
     }
@@ -1496,7 +1482,7 @@ public abstract class TopologyTestDriverTest {
     public void shouldNotUpdateStoreForLargerValue() {
         setup();
         pipeInput("input-topic", "a", 42L, 9999L);
-        assertThat(store.get("a"), equalTo(42L));
+        assertEquals(42L, store.get("a"));
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 42L);
         assertTrue(testDriver.isEmpty("result-topic"));
     }
@@ -1505,7 +1491,7 @@ public abstract class TopologyTestDriverTest {
     public void shouldUpdateStoreForNewKey() {
         setup();
         pipeInput("input-topic", "b", 21L, 9999L);
-        assertThat(store.get("b"), equalTo(21L));
+        assertEquals(21L, store.get("b"));
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 21L);
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "b", 21L);
         assertTrue(testDriver.isEmpty("result-topic"));
@@ -1756,7 +1742,7 @@ public abstract class TopologyTestDriverTest {
 
         final TTDTestRecord record1 = processedRecords1.get(0);
         final TTDTestRecord expectedResult1 = new TTDTestRecord(SOURCE_TOPIC_1, testRecord1, 0L);
-        assertThat(record1, equalTo(expectedResult1));
+        assertEquals(expectedResult1, record1);
 
         pipeRecord(consumerTopic2, consumerRecord2);
 
@@ -1765,7 +1751,7 @@ public abstract class TopologyTestDriverTest {
 
         final TTDTestRecord record2 = processedRecords2.get(0);
         final TTDTestRecord expectedResult2 = new TTDTestRecord(consumerTopic2, consumerRecord2, 0L);
-        assertThat(record2, equalTo(expectedResult2));
+        assertEquals(expectedResult2, record2);
     }
 
     @Test
@@ -1869,12 +1855,12 @@ public abstract class TopologyTestDriverTest {
 
             in.pipeInput("B", "beta");
             final List<KeyValue<String, String>> events = out.readKeyValuesToList();
-            assertThat(
-                events,
-                is(Arrays.asList(
+            assertEquals(
+                Arrays.asList(
                     new KeyValue<>("B", "beta"),
                     new KeyValue<>("B", "recurse-beta")
-                ))
+                ),
+                events
             );
 
         }
@@ -1939,17 +1925,17 @@ public abstract class TopologyTestDriverTest {
 
             // expect the global store to correctly reflect the last update
             final KeyValueStore<String, String> keyValueStore = topologyTestDriver.getKeyValueStore("global-store");
-            assertThat(keyValueStore, notNullValue());
-            assertThat(keyValueStore.get("A"), is("recurse-alpha"));
+            assertNotNull(keyValueStore);
+            assertEquals("recurse-alpha", keyValueStore.get("A"));
 
             // and also just make sure the test really sent both events to the topic.
             final List<KeyValue<String, String>> events = globalTopic.readKeyValuesToList();
-            assertThat(
-                events,
-                is(Arrays.asList(
+            assertEquals(
+                Arrays.asList(
                     new KeyValue<>("A", "alpha"),
                     new KeyValue<>("A", "recurse-alpha")
-                ))
+                ),
+                events
             );
         }
     }
@@ -1975,28 +1961,28 @@ public abstract class TopologyTestDriverTest {
             topologyTestDriver.advanceWallClockTime(Duration.ofMillis(1));
 
             // only one input has records, and it's only been one ms
-            assertThat(out.readKeyValuesToList(), is(Collections.emptyList()));
+            assertEquals(Collections.emptyList(), out.readKeyValuesToList());
 
             in2.pipeInput("B", "beta");
 
             // because both topics have records, we can process (even though it's only been one ms)
             // but after processing A (the earlier record), we now only have one input queued, so
             // task idling takes effect again
-            assertThat(
-                out.readKeyValuesToList(),
-                is(Collections.singletonList(
+            assertEquals(
+                Collections.singletonList(
                     new KeyValue<>("A", "alpha")
-                ))
+                ),
+                out.readKeyValuesToList()
             );
 
             topologyTestDriver.advanceWallClockTime(Duration.ofSeconds(1));
 
             // now that one second has elapsed, the idle time has expired, and we can process B
-            assertThat(
-                out.readKeyValuesToList(),
-                is(Collections.singletonList(
+            assertEquals(
+                Collections.singletonList(
                     new KeyValue<>("B", "beta")
-                ))
+                ),
+                out.readKeyValuesToList()
             );
         }
     }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/WindowStoreFacadeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/WindowStoreFacadeTest.java
@@ -39,9 +39,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -118,7 +117,7 @@ public class WindowStoreFacadeTest {
     public void shouldReturnName() {
         when(mockedWindowTimestampStore.name()).thenReturn("name");
 
-        assertThat(windowStoreFacade.name(), is("name"));
+        assertEquals("name", windowStoreFacade.name());
         verify(mockedWindowTimestampStore).name();
     }
 
@@ -127,8 +126,8 @@ public class WindowStoreFacadeTest {
         when(mockedWindowTimestampStore.persistent())
             .thenReturn(true, false);
 
-        assertThat(windowStoreFacade.persistent(), is(true));
-        assertThat(windowStoreFacade.persistent(), is(false));
+        assertTrue(windowStoreFacade.persistent());
+        assertFalse(windowStoreFacade.persistent());
         verify(mockedWindowTimestampStore, times(2)).persistent();
     }
 
@@ -137,8 +136,8 @@ public class WindowStoreFacadeTest {
         when(mockedWindowTimestampStore.isOpen())
             .thenReturn(true, false);
 
-        assertThat(windowStoreFacade.isOpen(), is(true));
-        assertThat(windowStoreFacade.isOpen(), is(false));
+        assertTrue(windowStoreFacade.isOpen());
+        assertFalse(windowStoreFacade.isOpen());
         verify(mockedWindowTimestampStore, times(2)).isOpen();
     }
 
@@ -156,8 +155,8 @@ public class WindowStoreFacadeTest {
             .thenReturn(KeyValue.pair(150L, ValueAndTimestamp.make("value2", 20L)));
 
         try (final WindowStoreIterator<String> iterator = windowStoreFacade.fetch("key", from, to)) {
-            assertThat(iterator.next(), is(KeyValue.pair(100L, "value1")));
-            assertThat(iterator.next(), is(KeyValue.pair(150L, "value2")));
+            assertEquals(KeyValue.pair(100L, "value1"), iterator.next());
+            assertEquals(KeyValue.pair(150L, "value2"), iterator.next());
         }
     }
 
@@ -175,7 +174,7 @@ public class WindowStoreFacadeTest {
             .thenReturn(KeyValue.pair(windowedKey, ValueAndTimestamp.make("value", 10L)));
 
         try (final KeyValueIterator<Windowed<String>, String> iterator = windowStoreFacade.fetchAll(from, to)) {
-            assertThat(iterator.next(), is(KeyValue.pair(windowedKey, "value")));
+            assertEquals(KeyValue.pair(windowedKey, "value"), iterator.next());
         }
     }
 
@@ -193,7 +192,7 @@ public class WindowStoreFacadeTest {
             .thenReturn(KeyValue.pair(windowedKey, ValueAndTimestamp.make("value", 10L)));
 
         try (final KeyValueIterator<Windowed<String>, String> iterator = windowStoreFacade.fetch("key", "key", from, to)) {
-            assertThat(iterator.next(), is(KeyValue.pair(windowedKey, "value")));
+            assertEquals(KeyValue.pair(windowedKey, "value"), iterator.next());
         }
     }
 
@@ -202,7 +201,7 @@ public class WindowStoreFacadeTest {
         when(mockedWindowTimestampStore.getPosition())
             .thenReturn(Position.emptyPosition());
 
-        assertThat(windowStoreFacade.getPosition(), is(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), windowStoreFacade.getPosition());
         verify(mockedWindowTimestampStore).getPosition();
     }
 
@@ -213,13 +212,13 @@ public class WindowStoreFacadeTest {
         final QueryResult<Integer> queryResult = QueryResult.forResult(42);
         when(mockedWindowTimestampStore.<Integer>query(any(), any(), any())).thenReturn(queryResult);
 
-        assertThat(
+        assertEquals(
+            queryResult,
             windowStoreFacade.query(
                 query,
                 PositionBound.unbounded(),
                 queryConfig
-            ),
-            is(queryResult));
+            ));
         verify(mockedWindowTimestampStore).query(query, PositionBound.unbounded(), queryConfig);
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
@@ -59,9 +59,9 @@ import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MockProcessorContextAPITest {
     @Test
@@ -93,11 +93,11 @@ public class MockProcessorContextAPITest {
             new CapturedForward<>(new Record<>("foo5", 8L, 0L)),
             new CapturedForward<>(new Record<>("barbaz50", 56L, 0L))
         );
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
 
         context.resetForwards();
 
-        assertThat(context.forwarded(), empty());
+        assertTrue(context.forwarded().isEmpty());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("barbaz50", 56L, 0L), Optional.of("pete"))
             );
 
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
         {
             final List<CapturedForward<? extends String, ? extends Long>> forwarded = context.forwarded("george");
@@ -150,7 +150,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("foo5", 8L, 0L), Optional.of("george"))
             );
 
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
         {
             final List<CapturedForward<? extends String, ? extends Long>> forwarded = context.forwarded("pete");
@@ -159,7 +159,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("barbaz50", 56L, 0L), Optional.of("pete"))
             );
 
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
         {
             final List<CapturedForward<? extends String, ? extends Long>> forwarded = context.forwarded("steve");
@@ -167,7 +167,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("start", -1L, 0L))
             );
 
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
     }
 
@@ -197,15 +197,15 @@ public class MockProcessorContextAPITest {
         processor.process(new Record<>("foo", 5L, 0L));
         processor.process(new Record<>("barbaz", 50L, 0L));
 
-        assertThat(context.committed(), is(false));
+        assertFalse(context.committed());
 
         processor.process(new Record<>("foobar", 500L, 0L));
 
-        assertThat(context.committed(), is(true));
+        assertTrue(context.committed());
 
         context.resetCommit();
 
-        assertThat(context.committed(), is(false));
+        assertFalse(context.committed());
     }
 
     @SuppressWarnings("unchecked")
@@ -306,9 +306,9 @@ public class MockProcessorContextAPITest {
         processor.process(new Record<>("foo", 5L, 0L));
         processor.process(new Record<>("bar", 50L, 0L));
 
-        assertThat(store.get("foo"), is(5L));
-        assertThat(store.get("bar"), is(50L));
-        assertThat(store.get("all"), is(55L));
+        assertEquals(5L, store.get("foo"));
+        assertEquals(50L, store.get("bar"));
+        assertEquals(55L, store.get("all"));
     }
 
 
@@ -356,7 +356,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("taskId", new TaskId(0, 0), 0L)),
                 new CapturedForward<>(new Record<>("record", new Record<>("foo", 5L, 0L), 0L))
             );
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
         context.resetForwards();
         context.setRecordMetadata("t1", 0, 0L);
@@ -371,7 +371,7 @@ public class MockProcessorContextAPITest {
                 new CapturedForward<>(new Record<>("offset", 0L, 0L)),
                 new CapturedForward<>(new Record<>("record", new Record<>("foo", 5L, 0L), 0L))
             );
-            assertThat(forwarded, is(expected));
+            assertEquals(expected, forwarded);
         }
     }
 
@@ -396,14 +396,14 @@ public class MockProcessorContextAPITest {
         processor.init(context);
 
         final MockProcessorContext.CapturedPunctuator capturedPunctuator = context.scheduledPunctuators().get(0);
-        assertThat(capturedPunctuator.getInterval(), is(Duration.ofMillis(1000L)));
-        assertThat(capturedPunctuator.getType(), is(PunctuationType.WALL_CLOCK_TIME));
-        assertThat(capturedPunctuator.cancelled(), is(false));
+        assertEquals(Duration.ofMillis(1000L), capturedPunctuator.getInterval());
+        assertEquals(PunctuationType.WALL_CLOCK_TIME, capturedPunctuator.getType());
+        assertFalse(capturedPunctuator.cancelled());
 
         final Punctuator punctuator = capturedPunctuator.getPunctuator();
-        assertThat(context.committed(), is(false));
+        assertFalse(context.committed());
         punctuator.punctuate(1234L);
-        assertThat(context.committed(), is(true));
+        assertTrue(context.committed());
     }
 
     @SuppressWarnings("resource")
@@ -419,12 +419,12 @@ public class MockProcessorContextAPITest {
         final MockProcessorContext<Void, Void> context =
             new MockProcessorContext<>(config, new TaskId(1, 1), dummyFile);
 
-        assertThat(context.applicationId(), is("testFullConstructor"));
-        assertThat(context.taskId(), is(new TaskId(1, 1)));
-        assertThat(context.appConfigs().get(StreamsConfig.APPLICATION_ID_CONFIG), is("testFullConstructor"));
-        assertThat(context.appConfigsWithPrefix("application.").get("id"), is("testFullConstructor"));
-        assertThat(context.keySerde().getClass(), is(Serdes.StringSerde.class));
-        assertThat(context.valueSerde().getClass(), is(Serdes.LongSerde.class));
-        assertThat(context.stateDir(), is(dummyFile));
+        assertEquals("testFullConstructor", context.applicationId());
+        assertEquals(new TaskId(1, 1), context.taskId());
+        assertEquals("testFullConstructor", context.appConfigs().get(StreamsConfig.APPLICATION_ID_CONFIG));
+        assertEquals("testFullConstructor", context.appConfigsWithPrefix("application.").get("id"));
+        assertEquals(Serdes.StringSerde.class, context.keySerde().getClass());
+        assertEquals(Serdes.LongSerde.class, context.valueSerde().getClass());
+        assertEquals(dummyFile, context.stateDir());
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
@@ -29,10 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -55,35 +51,32 @@ public class TestRecordTest {
     @Test
     public void testFields() {
         final TestRecord<String, Integer> testRecord = new TestRecord<>(key, value, headers, recordTime);
-        assertThat(testRecord.key(), equalTo(key));
-        assertThat(testRecord.value(), equalTo(value));
-        assertThat(testRecord.headers(), equalTo(headers));
-        assertThat(testRecord.timestamp(), equalTo(recordMs));
+        assertEquals(key, testRecord.key());
+        assertEquals(value, testRecord.value());
+        assertEquals(headers, testRecord.headers());
+        assertEquals(recordMs, testRecord.timestamp());
 
-        assertThat(testRecord.getKey(), equalTo(key));
-        assertThat(testRecord.getValue(), equalTo(value));
-        assertThat(testRecord.getHeaders(), equalTo(headers));
-        assertThat(testRecord.getRecordTime(), equalTo(recordTime));
+        assertEquals(key, testRecord.getKey());
+        assertEquals(value, testRecord.getValue());
+        assertEquals(headers, testRecord.getHeaders());
+        assertEquals(recordTime, testRecord.getRecordTime());
     }
 
     @Test
     public void testMultiFieldMatcher() {
         final TestRecord<String, Integer> testRecord = new TestRecord<>(key, value, headers, recordTime);
 
-        assertThat(testRecord, allOf(
-                hasProperty("key", equalTo(key)),
-                hasProperty("value", equalTo(value)),
-                hasProperty("headers", equalTo(headers))));
+        assertEquals(key, testRecord.getKey());
+        assertEquals(value, testRecord.getValue());
+        assertEquals(headers, testRecord.getHeaders());
 
-        assertThat(testRecord, allOf(
-                hasProperty("key", equalTo(key)),
-                hasProperty("value", equalTo(value)),
-                hasProperty("headers", equalTo(headers)),
-                hasProperty("recordTime", equalTo(recordTime))));
+        assertEquals(key, testRecord.getKey());
+        assertEquals(value, testRecord.getValue());
+        assertEquals(headers, testRecord.getHeaders());
+        assertEquals(recordTime, testRecord.getRecordTime());
 
-        assertThat(testRecord, allOf(
-                hasProperty("key", equalTo(key)),
-                hasProperty("value", equalTo(value))));
+        assertEquals(key, testRecord.getKey());
+        assertEquals(value, testRecord.getValue());
     }
 
 
@@ -126,16 +119,16 @@ public class TestRecordTest {
     @Test
     public void testPartialConstructorEquals() {
         final TestRecord<String, Integer> record1 = new TestRecord<>(value);
-        assertThat(record1, equalTo(new TestRecord<>(null, value, null, (Instant) null)));
+        assertEquals(new TestRecord<>(null, value, null, (Instant) null), record1);
 
         final TestRecord<String, Integer> record2 = new TestRecord<>(key, value);
-        assertThat(record2, equalTo(new TestRecord<>(key, value, null, (Instant) null)));
+        assertEquals(new TestRecord<>(key, value, null, (Instant) null), record2);
 
         final TestRecord<String, Integer> record3 = new TestRecord<>(key, value, headers);
-        assertThat(record3, equalTo(new TestRecord<>(key, value, headers, (Long) null)));
+        assertEquals(new TestRecord<>(key, value, headers, (Long) null), record3);
 
         final TestRecord<String, Integer> record4 = new TestRecord<>(key, value, recordTime);
-        assertThat(record4, equalTo(new TestRecord<>(key, value, null, recordMs)));
+        assertEquals(new TestRecord<>(key, value, null, recordMs), record4);
     }
 
     @Test
@@ -147,10 +140,10 @@ public class TestRecordTest {
     @Test
     public void testToString() {
         final TestRecord<String, Integer> testRecord = new TestRecord<>(key, value, headers, recordTime);
-        assertThat(testRecord.toString(), equalTo("TestRecord[key=testKey, value=1, "
+        assertEquals("TestRecord[key=testKey, value=1, "
                 + "headers=RecordHeaders(headers = [RecordHeader(key = foo, value = [118, 97, 108, 117, 101]), "
                 + "RecordHeader(key = bar, value = null), RecordHeader(key = \"A\\u00ea\\u00f1\\u00fcC\", value = [118, 97, 108, 117, 101])], isReadOnly = false), "
-                + "recordTime=2019-06-01T10:00:00Z, partition=-1]"));
+                + "recordTime=2019-06-01T10:00:00Z, partition=-1]", testRecord.toString());
     }
 
     @Test
@@ -286,9 +279,9 @@ public class TestRecordTest {
     @Test
     public void testToStringIncludesPartitionWhenSet() {
         final TestRecord<String, Integer> testRecord = new TestRecord<>(key, value, headers, recordTime, 2);
-        assertThat(testRecord.toString(), equalTo("TestRecord[key=testKey, value=1, "
+        assertEquals("TestRecord[key=testKey, value=1, "
             + "headers=RecordHeaders(headers = [RecordHeader(key = foo, value = [118, 97, 108, 117, 101]), "
             + "RecordHeader(key = bar, value = null), RecordHeader(key = \"A\\u00ea\\u00f1\\u00fcC\", value = [118, 97, 108, 117, 101])], isReadOnly = false), "
-            + "recordTime=2019-06-01T10:00:00Z, partition=2]"));
+            + "recordTime=2019-06-01T10:00:00Z, partition=2]", testRecord.toString());
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -39,8 +39,8 @@ import java.util.List;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -77,7 +77,7 @@ public class WindowedWordCountProcessorTest {
         processor.process(new Record<>("key", "gamma delta", 221L));
 
         // note that the processor does not forward during process()
-        assertThat(context.forwarded().isEmpty(), is(true));
+        assertTrue(context.forwarded().isEmpty());
 
         // now, we trigger the punctuator, which iterates over the state store and forwards the contents.
         context.scheduledPunctuators().get(0).getPunctuator().punctuate(1_000L);
@@ -92,7 +92,7 @@ public class WindowedWordCountProcessorTest {
             new CapturedForward<>(new Record<>("[gamma@200/300]", "1", 1_000L))
         );
 
-        assertThat(capturedForwards, is(expected));
+        assertEquals(expected, capturedForwards);
 
         store.close();
     }
@@ -134,7 +134,7 @@ public class WindowedWordCountProcessorTest {
             processor.process(new Record<>("key", "gamma delta", 221L));
 
             // note that the processor does not forward during process()
-            assertThat(context.forwarded().isEmpty(), is(true));
+            assertTrue(context.forwarded().isEmpty());
 
             // now, we trigger the punctuator, which iterates over the state store and forwards the contents.
             context.scheduledPunctuators().get(0).getPunctuator().punctuate(1_000L);
@@ -149,7 +149,7 @@ public class WindowedWordCountProcessorTest {
                 new CapturedForward<>(new Record<>("[gamma@200/300]", "1", 1_000L))
             );
 
-            assertThat(capturedForwards, is(expected));
+            assertEquals(expected, capturedForwards);
 
             store.close();
         } finally {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-20975
Parent: https://issues.apache.org/jira/browse/KAFKA-20948

Migrate hamcrest `assertThat` usage in `streams/test-utils` tests to JUnit 5. This slice is not covered by the existing package-scoped subtasks under KAFKA-20948.

No production code changes.


### Tests
```
./gradlew :streams:test-utils:clean :streams:test-utils:test :streams:test-utils:checkstyleTest :streams:test-utils:spotlessCheck
```
BUILD SUCCESSFUL.

Reviewers: Uros (github:uros-b), Ken Huang <s7133700@gmail.com>
