### PR TITLE
MINOR: Restore metadata version tests and add IBP_4_5_IV0

### DIFF
--- a/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
+++ b/server-common/src/main/java/org/apache/kafka/server/common/MetadataVersion.java
@@ -131,7 +131,7 @@ public enum MetadataVersion {
     IBP_4_4_IV1(32, "4.4", "IV1", true),
 
     // Add support for controller unregistration (KIP-1312).
-    IBP_4_4_IV2(33, "4.4", "IV2", true);
+    IBP_4_4_IV2(33, "4.4", "IV2", true),
 
     //
     // NOTE: MetadataVersions after this point are unstable and may be changed.
@@ -139,6 +139,9 @@ public enum MetadataVersion {
     // they have set the configuration unstable.feature.versions.enable=true.
     // Please move this comment when updating the LATEST_PRODUCTION constant.
     //
+
+    // New version for the Kafka 4.5.0 release.
+    IBP_4_5_IV0(34, "4.5", "IV0", false);
 
     // NOTES when adding a new version:
     //   Update the default version in @ClusterTest annotation to point to the latest version

--- a/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
+++ b/server-common/src/test/java/org/apache/kafka/server/common/MetadataVersionTest.java
@@ -76,14 +76,12 @@ class MetadataVersionTest {
     @Test
     public void testFromVersionStringUnstableDisabled() {
         MetadataVersion latestTesting = MetadataVersion.latestTesting();
-        if (!latestTesting.isProduction()) {
-            String expectedMsg = "Unknown metadata.version '" + latestTesting.version()
-                + "'. Supported metadata.version are: "
-                + MetadataVersion.metadataVersionsToString(MINIMUM_VERSION, LATEST_PRODUCTION);
-            assertEquals(expectedMsg,
-                assertThrows(IllegalArgumentException.class,
-                    () -> MetadataVersion.fromVersionString(latestTesting.version(), false)).getMessage());
-        }
+        String expectedMsg = "Unknown metadata.version '" + latestTesting.version()
+            + "'. Supported metadata.version are: "
+            + MetadataVersion.metadataVersionsToString(MINIMUM_VERSION, LATEST_PRODUCTION);
+        assertEquals(expectedMsg,
+            assertThrows(IllegalArgumentException.class,
+                () -> MetadataVersion.fromVersionString(latestTesting.version(), false)).getMessage());
     }
 
     @Test
@@ -207,10 +205,10 @@ class MetadataVersionTest {
     }
 
     @Test
-    public void assertLatestProductionIsNotAfterLatestTesting() {
-        assertTrue(LATEST_PRODUCTION.ordinal() <= MetadataVersion.latestTesting().ordinal(),
+    public void assertLatestProductionIsLessThanLatest() {
+        assertTrue(LATEST_PRODUCTION.ordinal() < MetadataVersion.latestTesting().ordinal(),
             "Expected LATEST_PRODUCTION " + LATEST_PRODUCTION +
-            " to not be after the latest of " + MetadataVersion.latestTesting());
+            " to be less than the latest of " + MetadataVersion.latestTesting());
     }
 
     /**
@@ -231,11 +229,8 @@ class MetadataVersionTest {
     }
 
     @Test
-    public void assertLatestTestingIsUnstable() {
-        MetadataVersion latestTesting = MetadataVersion.latestTesting();
-        if (LATEST_PRODUCTION.isLessThan(latestTesting)) {
-            assertFalse(latestTesting.isProduction());
-        }
+    public void assertLatestIsNotProduction() {
+        assertFalse(MetadataVersion.latestTesting().isProduction());
     }
 
     @ParameterizedTest

--- a/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
+++ b/test-common/test-common-internal-api/src/main/java/org/apache/kafka/common/test/api/ClusterTest.java
@@ -52,7 +52,7 @@ public @interface ClusterTest {
     String brokerListener() default DEFAULT_BROKER_LISTENER_NAME;
     SecurityProtocol controllerSecurityProtocol() default SecurityProtocol.PLAINTEXT;
     String controllerListener() default DEFAULT_CONTROLLER_LISTENER_NAME;
-    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_4_IV2;
+    MetadataVersion metadataVersion() default MetadataVersion.IBP_4_5_IV0;
     ClusterConfigProperty[] serverProperties() default {};
     // users can add tags that they want to display in test
     String[] tags() default {};


### PR DESCRIPTION
Follow up for
https://github.com/apache/kafka/pull/23125#discussion_r3838319636.

The metadata version tests should continue to verify that the latest
testing  version is newer than the latest production version and is
unstable.

Tests
- `./gradlew :server-common:test --tests
org.apache.kafka.server.common.MetadataVersionTest`

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>, Maros Orsak
 <maros.orsak159@gmail.com>
