### PR TITLE
MINOR: Fix missing % operator in assertion message in benchmark_test.py

### DIFF
--- a/tests/kafkatest/benchmarks/core/benchmark_test.py
+++ b/tests/kafkatest/benchmarks/core/benchmark_test.py
@@ -398,4 +398,4 @@ class Benchmark(Test):
         return compute_aggregate_throughput(self.share_consumer)
 
     def validate_versions(self, client_version, broker_version):
-        assert client_version <= broker_version, "Client version %s should be <= than broker version %s" (client_version, broker_version)
+        assert client_version <= broker_version, "Client version %s should be <= broker version %s" % (client_version, broker_version)


### PR DESCRIPTION
# Description
Fix a syntax error in the validate_versions method within
`benchmark_test.py`. The missing `%` operator that would cause
`TypeError` is being fixed.

# Verification
- Ran  a local sanity check to ensure things works correctly.

Reviewers: Uros (github:uros-b), yaodehuang (github:yaodehaung),
 Ming-Yen Chung <mingyen066@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
