### PR TITLE
MINOR: assert on sampled metric values in MetricsDuringTopicCreationDeletionTest

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
@@ -41,7 +41,7 @@ public class MetricsDuringTopicCreationDeletionTest {
     private static final String TOPIC_NAME_PREFIX = "topic";
     private static final int TOPIC_NUM = 2;
     private static final int CREATE_DELETE_ITERATIONS = 3;
-    private static final short REPLICATION_FACTOR = 1;
+    private static final short REPLICATION_FACTOR = 3;
     private static final int PARTITION_NUM = 3;
 
     private final ClusterInstance clusterInstance;
@@ -61,7 +61,7 @@ public class MetricsDuringTopicCreationDeletionTest {
      */
     @ClusterTest(
         types = {Type.KRAFT},
-        brokers = 1,
+        brokers = 3,
         serverProperties = {
             @ClusterConfigProperty(key = ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG, value = "true"),
             @ClusterConfigProperty(key = "log.initial.task.delay.ms", value = "100"),
@@ -76,7 +76,7 @@ public class MetricsDuringTopicCreationDeletionTest {
 
         final int initialOfflinePartitionsCount = getGauge("OfflinePartitionsCount").value();
         final int initialPreferredReplicaImbalanceCount = getGauge("PreferredReplicaImbalanceCount").value();
-        final int initialUnderReplicatedPartitionsCount = getGauge("UnderReplicatedPartitions").value();
+        final int initialUnderReplicatedPartitionsCount = underReplicatedPartitionCount();
 
         AtomicInteger offlinePartitionsCount = new AtomicInteger(initialOfflinePartitionsCount);
         AtomicInteger preferredReplicaImbalanceCount = new AtomicInteger(initialPreferredReplicaImbalanceCount);
@@ -88,7 +88,7 @@ public class MetricsDuringTopicCreationDeletionTest {
                 preferredReplicaImbalanceCount.set(
                     getGauge("PreferredReplicaImbalanceCount").value());
                 underReplicatedPartitionsCount.set(
-                    getGauge("UnderReplicatedPartitions").value());
+                    underReplicatedPartitionCount());
 
                 if (offlinePartitionsCount.get() != initialOfflinePartitionsCount ||
                     preferredReplicaImbalanceCount.get() != initialPreferredReplicaImbalanceCount ||
@@ -151,5 +151,11 @@ public class MetricsDuringTopicCreationDeletionTest {
             .findFirst()
             .map(entry -> (Gauge<Integer>) entry.getValue())
             .orElseThrow(() -> new AssertionError("Unable to find metric " + metricName));
+    }
+
+    private int underReplicatedPartitionCount() {
+        return clusterInstance.brokers().values().stream()
+            .mapToInt(broker -> broker.replicaManager().underReplicatedPartitionCount())
+            .sum();
     }
 }

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
@@ -78,12 +78,9 @@ public class MetricsDuringTopicCreationDeletionTest {
         final int initialPreferredReplicaImbalanceCount = getGauge("PreferredReplicaImbalanceCount").value();
         final int initialUnderReplicatedPartitionsCount = getGauge("UnderReplicatedPartitions").value();
 
-        AtomicInteger offlinePartitionsCount =
-            new AtomicInteger(initialOfflinePartitionsCount);
-        AtomicInteger preferredReplicaImbalanceCount =
-            new AtomicInteger(initialPreferredReplicaImbalanceCount);
-        AtomicInteger underReplicatedPartitionsCount =
-            new AtomicInteger(initialUnderReplicatedPartitionsCount);
+        AtomicInteger offlinePartitionsCount = new AtomicInteger(initialOfflinePartitionsCount);
+        AtomicInteger preferredReplicaImbalanceCount = new AtomicInteger(initialPreferredReplicaImbalanceCount);
+        AtomicInteger underReplicatedPartitionsCount = new AtomicInteger(initialUnderReplicatedPartitionsCount);
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             while (running) {

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/MetricsDuringTopicCreationDeletionTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -77,23 +78,33 @@ public class MetricsDuringTopicCreationDeletionTest {
         final int initialPreferredReplicaImbalanceCount = getGauge("PreferredReplicaImbalanceCount").value();
         final int initialUnderReplicatedPartitionsCount = getGauge("UnderReplicatedPartitions").value();
 
+        AtomicInteger offlinePartitionsCount =
+            new AtomicInteger(initialOfflinePartitionsCount);
+        AtomicInteger preferredReplicaImbalanceCount =
+            new AtomicInteger(initialPreferredReplicaImbalanceCount);
+        AtomicInteger underReplicatedPartitionsCount =
+            new AtomicInteger(initialUnderReplicatedPartitionsCount);
+
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             while (running) {
-                int offlinePartitionsCount = getGauge("OfflinePartitionsCount").value();
-                int preferredReplicaImbalanceCount = getGauge("PreferredReplicaImbalanceCount").value();
-                int underReplicatedPartitionsCount = getGauge("UnderReplicatedPartitions").value();
+                offlinePartitionsCount.set(getGauge("OfflinePartitionsCount").value());
+                preferredReplicaImbalanceCount.set(
+                    getGauge("PreferredReplicaImbalanceCount").value());
+                underReplicatedPartitionsCount.set(
+                    getGauge("UnderReplicatedPartitions").value());
 
-                if (offlinePartitionsCount != initialOfflinePartitionsCount ||
-                    preferredReplicaImbalanceCount != initialPreferredReplicaImbalanceCount ||
-                    underReplicatedPartitionsCount != initialUnderReplicatedPartitionsCount) {
+                if (offlinePartitionsCount.get() != initialOfflinePartitionsCount ||
+                    preferredReplicaImbalanceCount.get() != initialPreferredReplicaImbalanceCount ||
+                    underReplicatedPartitionsCount.get() != initialUnderReplicatedPartitionsCount) {
                     running = false;
                 }
 
                 try {
                     // Avoid busy loop
                     TimeUnit.MILLISECONDS.sleep(100);
-                } catch (InterruptedException ignored) {
-
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    running = false;
                 }
             }
         });
@@ -107,16 +118,15 @@ public class MetricsDuringTopicCreationDeletionTest {
             createAndDeleteTopics();
         }
 
-        final int finalOfflinePartitionsCount = getGauge("OfflinePartitionsCount").value();
-        final int finalPreferredReplicaImbalanceCount = getGauge("PreferredReplicaImbalanceCount").value();
-        final int finalUnderReplicatedPartitionsCount = getGauge("UnderReplicatedPartitions").value();
-
-        assertEquals(initialOfflinePartitionsCount, finalOfflinePartitionsCount,
-            "Expect offlinePartitionsCount to be " + initialOfflinePartitionsCount + ", but got: " + finalOfflinePartitionsCount);
-        assertEquals(initialPreferredReplicaImbalanceCount, finalPreferredReplicaImbalanceCount,
-            "Expect PreferredReplicaImbalanceCount to be " + initialPreferredReplicaImbalanceCount + ", but got: " + finalPreferredReplicaImbalanceCount);
-        assertEquals(initialUnderReplicatedPartitionsCount, finalUnderReplicatedPartitionsCount,
-            "Expect UnderReplicatedPartitionCount to be " + initialUnderReplicatedPartitionsCount + ", but got: " + finalUnderReplicatedPartitionsCount);
+        assertEquals(initialOfflinePartitionsCount, offlinePartitionsCount.get(),
+            "Expect offlinePartitionsCount to be " + initialOfflinePartitionsCount
+                + ", but got: " + offlinePartitionsCount.get());
+        assertEquals(initialPreferredReplicaImbalanceCount, preferredReplicaImbalanceCount.get(),
+            "Expect PreferredReplicaImbalanceCount to be " + initialPreferredReplicaImbalanceCount
+                + ", but got: " + preferredReplicaImbalanceCount.get());
+        assertEquals(initialUnderReplicatedPartitionsCount, underReplicatedPartitionsCount.get(),
+            "Expect UnderReplicatedPartitionCount to be " + initialUnderReplicatedPartitionsCount
+                + ", but got: " + underReplicatedPartitionsCount.get());
     }
 
     private void createAndDeleteTopics() {


### PR DESCRIPTION
Follow-up to
https://github.com/apache/kafka/pull/19528#discussion_r3832670432

The original Scala test asserted on the metric values observed by the
background thread. After the port, the assertions re-read the gauges at
the  end instead. Since the background thread stops as soon as it sees a
deviation, and the gauges settle back once the topics are deleted, that
deviation is discarded and the test still passes.

Store each sample in an `AtomicInteger` and assert on those, restoring
the  original semantics. Also re-set the interrupt flag on
`InterruptedException`  instead of ignoring it.

### Testing

`./gradlew :clients:clients-integration-tests:test --tests
'*MetricsDuringTopicCreationDeletionTest*'`  `./gradlew
:clients:clients-integration-tests:checkstyleTest`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
