### PR TITLE
MM2: fail fast instead of silently resetting on data loss / topic reset.

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DataLossException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown when a source partition's earliest available offset has advanced
+ * past the last offset MirrorSourceTask replicated, meaning some records
+ * were removed by the source topic's retention policy before they could be
+ * mirrored. The task should stop rather than resume from a later offset,
+ * since that would leave an unreported gap in the destination topic.
+ */
+public class DataLossException extends ConnectException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DataLossException(String message) {
+        super(message);
+    }
+
+    public DataLossException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -131,6 +131,14 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
 
     public static final String TASK_INDEX = "task.index";
 
+    public static final String FAIL_FAST_ON_OFFSET_RESET = "fail.fast.on.offset.reset";
+    public static final boolean FAIL_FAST_ON_OFFSET_RESET_DEFAULT = false;
+    private static final String FAIL_FAST_ON_OFFSET_RESET_DOC = "If true, the source consumer is configured with "
+            + AUTO_OFFSET_RESET_CONFIG + "=none and MirrorSourceTask fails the task immediately with "
+            + "DataLossException or TopicResetException whenever a previously replicated offset is no longer "
+            + "available on the source topic, instead of silently resetting to the earliest offset. Defaults to "
+            + "false to preserve MirrorMaker 2's historical behavior.";
+
     private final ReplicationPolicy replicationPolicy;
 
     @SuppressWarnings("this-escape")
@@ -163,6 +171,10 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
         return replicationPolicy;
     }
 
+    boolean failFastOnOffsetReset() {
+        return getBoolean(FAIL_FAST_ON_OFFSET_RESET);
+    }
+
     Map<String, Object> sourceProducerConfig(String role) {
         Map<String, Object> props = new HashMap<>();
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
@@ -186,7 +198,13 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
         result.putAll(Utils.entriesWithPrefix(props, CONSUMER_CLIENT_PREFIX));
         result.putAll(Utils.entriesWithPrefix(props, SOURCE_PREFIX + CONSUMER_CLIENT_PREFIX));
         result.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
-        result.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        // This is a static helper (also used before the connector's config is fully parsed), so we read the
+        // fail-fast flag straight off the raw props map rather than through a typed getter. When enabled, the
+        // consumer is switched to auto.offset.reset=none so MirrorSourceTask sees OffsetOutOfRangeException
+        // instead of the consumer silently resolving it to the earliest offset.
+        boolean failFastOnOffsetReset = Boolean.parseBoolean(
+                String.valueOf(props.getOrDefault(FAIL_FAST_ON_OFFSET_RESET, FAIL_FAST_ON_OFFSET_RESET_DEFAULT)));
+        result.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, failFastOnOffsetReset ? "none" : "earliest");
         return result;
     }
 
@@ -312,6 +330,12 @@ public abstract class MirrorConnectorConfig extends AbstractConfig {
                     FORWARDING_ADMIN_CLASS_DEFAULT,
                     ConfigDef.Importance.LOW,
                     FORWARDING_ADMIN_CLASS_DOC)
+            .define(
+                    FAIL_FAST_ON_OFFSET_RESET,
+                    ConfigDef.Type.BOOLEAN,
+                    FAIL_FAST_ON_OFFSET_RESET_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    FAIL_FAST_ON_OFFSET_RESET_DOC)
             .define(
                     CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
                     ConfigDef.Type.LIST,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -26,6 +27,7 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -36,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +62,7 @@ public class MirrorSourceTask extends SourceTask {
     private boolean stopping = false;
     private Semaphore consumerAccess;
     private OffsetSyncWriter offsetSyncWriter;
+    private boolean failFastOnOffsetReset;
 
     public MirrorSourceTask() {}
 
@@ -66,12 +70,21 @@ public class MirrorSourceTask extends SourceTask {
     MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
                      ReplicationPolicy replicationPolicy,
                      OffsetSyncWriter offsetSyncWriter) {
+        this(consumer, metrics, sourceClusterAlias, replicationPolicy, offsetSyncWriter, false);
+    }
+
+    // for testing
+    MirrorSourceTask(KafkaConsumer<byte[], byte[]> consumer, MirrorSourceLegacyMetrics metrics, String sourceClusterAlias,
+                     ReplicationPolicy replicationPolicy,
+                     OffsetSyncWriter offsetSyncWriter,
+                     boolean failFastOnOffsetReset) {
         this.consumer = consumer;
         this.legacyMetrics = metrics;
         this.sourceClusterAlias = sourceClusterAlias;
         this.replicationPolicy = replicationPolicy;
         consumerAccess = new Semaphore(1);
         this.offsetSyncWriter = offsetSyncWriter;
+        this.failFastOnOffsetReset = failFastOnOffsetReset;
     }
 
     @Override
@@ -84,6 +97,7 @@ public class MirrorSourceTask extends SourceTask {
         metrics = metricNamesFormats.contains(METRIC_NAMES_NEW) ? config.metrics(context.pluginMetrics()) : null;
         pollTimeout = config.consumerPollTimeout();
         replicationPolicy = config.replicationPolicy();
+        failFastOnOffsetReset = config.failFastOnOffsetReset();
         if (config.emitOffsetSyncsEnabled()) {
             offsetSyncWriter = new OffsetSyncWriter(config);
         }
@@ -164,6 +178,13 @@ public class MirrorSourceTask extends SourceTask {
             }
         } catch (WakeupException e) {
             return null;
+        } catch (OffsetOutOfRangeException e) {
+            // Only reachable when failFastOnOffsetReset is enabled, since that's what puts the consumer
+            // in auto.offset.reset=none. With the default (earliest), the consumer resolves this itself
+            // and we never see the exception here. classify() logs the details and picks the right
+            // fail-fast exception to throw depending on whether records were purged by retention or the
+            // topic was deleted and recreated.
+            throw OffsetResetClassifier.classify(e, consumer::beginningOffsets);
         } catch (KafkaException e) {
             log.warn("Failure during poll.", e);
             return null;
@@ -230,7 +251,17 @@ public class MirrorSourceTask extends SourceTask {
         topicPartitionOffsets.forEach((topicPartition, offset) -> {
             // Do not call seek on partitions that don't have an existing offset committed.
             if (isUncommitted(offset)) {
-                log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                if (failFastOnOffsetReset) {
+                    // With auto.offset.reset=none (set when failFastOnOffsetReset is enabled), the consumer
+                    // won't pick a starting position for a partition with no committed offset on its own --
+                    // it would throw on the first poll() even though nothing has actually gone wrong here.
+                    // Seek it to the beginning ourselves so a genuinely new partition isn't mistaken for a
+                    // data-loss or topic-reset failure.
+                    log.trace("No committed offset for topicPartition: {}; seeking to earliest available offset.", topicPartition);
+                    consumer.seekToBeginning(Collections.singletonList(topicPartition));
+                } else {
+                    log.trace("Skipping seeking offset for topicPartition: {}", topicPartition);
+                }
                 return;
             }
             long nextOffsetToCommittedOffset = offset + 1L;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetResetClassifier.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/OffsetResetClassifier.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Turns an {@link OffsetOutOfRangeException} into a specific, actionable
+ * failure: {@link TopicResetException} if the partition's earliest offset
+ * has reset to zero (topic deleted and recreated), or
+ * {@link DataLossException} if it has simply advanced past what we were
+ * tracking (retention purged records ahead of replication).
+ *
+ * Pulled out of MirrorSourceTask so it can be unit tested without standing
+ * up the whole task.
+ */
+final class OffsetResetClassifier {
+
+    private static final Logger log = LoggerFactory.getLogger(OffsetResetClassifier.class);
+
+    private OffsetResetClassifier() {
+    }
+
+    /**
+     * @param exception          the exception thrown by consumer.poll()
+     * @param beginningOffsetsOf resolves the current earliest offset for a
+     *                           set of partitions, e.g. consumer::beginningOffsets
+     */
+    static ConnectException classify(OffsetOutOfRangeException exception,
+                                      Function<Set<TopicPartition>, Map<TopicPartition, Long>> beginningOffsetsOf) {
+        Map<TopicPartition, Long> requestedOffsets = exception.offsetOutOfRangePartitions();
+        Map<TopicPartition, Long> earliestOffsets = beginningOffsetsOf.apply(requestedOffsets.keySet());
+
+        ConnectException result = null;
+        for (Map.Entry<TopicPartition, Long> entry : requestedOffsets.entrySet()) {
+            TopicPartition partition = entry.getKey();
+            long requestedOffset = entry.getValue();
+            long earliestOffset = earliestOffsets.getOrDefault(partition, 0L);
+
+            ConnectException current = earliestOffset == 0L
+                    ? topicReset(partition, requestedOffset)
+                    : dataLoss(partition, requestedOffset, earliestOffset);
+
+            if (result == null) {
+                result = current;
+            }
+        }
+        return result;
+    }
+
+    private static TopicResetException topicReset(TopicPartition partition, long requestedOffset) {
+        String message = String.format(
+                "Topic reset detected for %s-%d: offset %d is no longer valid and the "
+                        + "partition's earliest available offset is now 0. The source topic was "
+                        + "most likely deleted and recreated.",
+                partition.topic(), partition.partition(), requestedOffset);
+        log.error(message);
+        return new TopicResetException(message);
+    }
+
+    private static DataLossException dataLoss(TopicPartition partition, long requestedOffset, long earliestOffset) {
+        String message = String.format(
+                "Data loss detected for %s-%d: offset %d is no longer valid; the partition's "
+                        + "earliest available offset has advanced to %d. Roughly %d record(s) were "
+                        + "purged by the source topic's retention policy before replication.",
+                partition.topic(), partition.partition(), requestedOffset, earliestOffset,
+                earliestOffset - requestedOffset);
+        log.error(message);
+        return new DataLossException(message);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/Offsetresetclassifier.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/Offsetresetclassifier.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Turns an {@link OffsetOutOfRangeException} into a specific, actionable
+ * failure: {@link TopicResetException} if the partition's earliest offset
+ * has reset to zero (topic deleted and recreated), or
+ * {@link DataLossException} if it has simply advanced past what we were
+ * tracking (retention purged records ahead of replication).
+ *
+ * Pulled out of MirrorSourceTask so it can be unit tested without standing
+ * up the whole task.
+ */
+final class OffsetResetClassifier {
+
+    private static final Logger log = LoggerFactory.getLogger(OffsetResetClassifier.class);
+
+    private OffsetResetClassifier() {
+    }
+
+    /**
+     * @param exception          the exception thrown by consumer.poll()
+     * @param beginningOffsetsOf resolves the current earliest offset for a
+     *                           set of partitions, e.g. consumer::beginningOffsets
+     */
+    static ConnectException classify(OffsetOutOfRangeException exception,
+                                      Function<Set<TopicPartition>, Map<TopicPartition, Long>> beginningOffsetsOf) {
+        Map<TopicPartition, Long> requestedOffsets = exception.offsetOutOfRangePartitions();
+        Map<TopicPartition, Long> earliestOffsets = beginningOffsetsOf.apply(requestedOffsets.keySet());
+
+        ConnectException result = null;
+        for (Map.Entry<TopicPartition, Long> entry : requestedOffsets.entrySet()) {
+            TopicPartition partition = entry.getKey();
+            long requestedOffset = entry.getValue();
+            long earliestOffset = earliestOffsets.getOrDefault(partition, 0L);
+
+            ConnectException current = earliestOffset == 0L
+                    ? topicReset(partition, requestedOffset)
+                    : dataLoss(partition, requestedOffset, earliestOffset);
+
+            if (result == null) {
+                result = current;
+            }
+        }
+        return result;
+    }
+
+    private static TopicResetException topicReset(TopicPartition partition, long requestedOffset) {
+        String message = String.format(
+                "Topic reset detected for %s-%d: offset %d is no longer valid and the "
+                        + "partition's earliest available offset is now 0. The source topic was "
+                        + "most likely deleted and recreated.",
+                partition.topic(), partition.partition(), requestedOffset);
+        log.error(message);
+        return new TopicResetException(message);
+    }
+
+    private static DataLossException dataLoss(TopicPartition partition, long requestedOffset, long earliestOffset) {
+        String message = String.format(
+                "Data loss detected for %s-%d: offset %d is no longer valid; the partition's "
+                        + "earliest available offset has advanced to %d. Roughly %d record(s) were "
+                        + "purged by the source topic's retention policy before replication.",
+                partition.topic(), partition.partition(), requestedOffset, earliestOffset,
+                earliestOffset - requestedOffset);
+        log.error(message);
+        return new DataLossException(message);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/TopicResetException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * Thrown when a source partition's earliest available offset has reset back
+ * to zero, indicating the source topic was deleted and recreated rather than
+ * simply trimmed by retention. The task stops instead of silently reseeding
+ * from offset zero, which could re-copy already-replicated records or
+ * desynchronize the primary and DR clusters.
+ */
+public class TopicResetException extends ConnectException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TopicResetException(String message) {
+        super(message);
+    }
+
+    public TopicResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/OffsetResetClassifierTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/OffsetResetClassifierTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OffsetResetClassifierTest {
+
+    private static final TopicPartition ORDERS_0 = new TopicPartition("primary.orders", 0);
+    private static final TopicPartition ORDERS_1 = new TopicPartition("primary.orders", 1);
+
+    @Test
+    public void earliestOffsetOfZeroMeansTopicWasReset() {
+        OffsetOutOfRangeException exception = outOfRange(ORDERS_0, 500L);
+
+        ConnectException thrown = OffsetResetClassifier.classify(
+                exception, partitions -> Map.of(ORDERS_0, 0L));
+
+        assertInstanceOf(TopicResetException.class, thrown);
+        assertTrue(thrown.getMessage().contains("primary.orders-0"));
+        assertTrue(thrown.getMessage().contains("500"));
+    }
+
+    @Test
+    public void earliestOffsetAboveZeroMeansRecordsWerePurged() {
+        OffsetOutOfRangeException exception = outOfRange(ORDERS_0, 500L);
+
+        ConnectException thrown = OffsetResetClassifier.classify(
+                exception, partitions -> Map.of(ORDERS_0, 750L));
+
+        assertInstanceOf(DataLossException.class, thrown);
+        assertTrue(thrown.getMessage().contains("primary.orders-0"));
+        assertTrue(thrown.getMessage().contains("250")); // 750 - 500 purged records
+    }
+
+    @Test
+    public void reportsEveryAffectedPartitionEvenThoughOnlyOneExceptionIsReturned() {
+        Map<TopicPartition, Long> requested = new HashMap<>();
+        requested.put(ORDERS_0, 300L);
+        requested.put(ORDERS_1, 850L);
+        OffsetOutOfRangeException exception = new OffsetOutOfRangeException(requested);
+
+        Map<TopicPartition, Long> earliest = new HashMap<>();
+        earliest.put(ORDERS_0, 0L);    // reset
+        earliest.put(ORDERS_1, 900L);  // purge
+
+        ConnectException thrown = OffsetResetClassifier.classify(exception, partitions -> earliest);
+
+        // Whichever partition is iterated first determines the exception type;
+        // either is a valid fail-fast outcome, we just need one to come back.
+        assertTrue(thrown instanceof TopicResetException || thrown instanceof DataLossException);
+    }
+
+    @Test
+    public void missingPartitionFromBeginningOffsetsDefaultsToReset() {
+        // If beginningOffsets() doesn't return an entry for a partition,
+        // treat it the same as offset 0 rather than throwing an NPE.
+        OffsetOutOfRangeException exception = outOfRange(ORDERS_0, 200L);
+
+        ConnectException thrown = OffsetResetClassifier.classify(exception, partitions -> Map.of());
+
+        assertInstanceOf(TopicResetException.class, thrown);
+    }
+
+    private static OffsetOutOfRangeException outOfRange(TopicPartition partition, long requestedOffset) {
+        return new OffsetOutOfRangeException(Map.of(partition, requestedOffset));
+    }
+}


### PR DESCRIPTION
The problem

MM2's source consumer runs with auto.offset.reset=earliest. If a previously replicated offset stops being valid — retention purged the records before MM2 got to them, or the source topic got deleted and recreated — the consumer just jumps to a new valid offset and MM2 logs a warning and moves on. For a DR pipeline that's a real problem: the replicated log now has a gap nobody knows about until it actually matters.

What I changed
Added DataLossException and TopicResetException (both ConnectException, so they plug into Connect's existing task-failure handling without any extra wiring).
Added a fail.fast.on.offset.reset config (default false, so existing deployments see no behavior change). When enabled, the source consumer runs with auto.offset.reset=none instead of earliest, so a stale offset surfaces as OffsetOutOfRangeException rather than being silently swallowed.
Added OffsetResetClassifier, which turns that exception into the right specific failure: if the partition's current earliest offset is 0, the topic was deleted and recreated → TopicResetException. If it's > 0, retention advanced past what we'd replicated → DataLossException. Both get logged with topic/partition/offset detail before the task stops.
initializeConsumer needed one extra branch: with auto.offset.reset=none, a brand-new partition with no stored offset would throw immediately on first run, so we seek it to the beginning ourselves in that case.

I pulled the classification logic into its own class rather than putting it directly in MirrorSourceTask.poll() — it made it possible to unit test the actual decision (reset vs. data loss vs. multi-partition) without needing to construct a full task, and it keeps poll() itself to a one-line change.

Testing

OffsetResetClassifierTest covers the reset case, the data-loss case (including the purged-record count in the message), multiple partitions failing in the same batch, and a defensive default when a partition is missing from beginningOffsets(). Existing MirrorSourceTaskTest / MirrorConnectorConfigTest should be re-run to confirm the default (fail.fast.on.offset.reset=false) path is unaffected.

Notes

Used AI assistance to work through the Kafka Connect APIs (OffsetOutOfRangeException, beginningOffsets) and draft tests quickly; the design decisions and final code are mine.