### PR TITLE
KAFKA-20979: Ensure indexes resize are fsynced when shutting down

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -198,6 +198,15 @@ public abstract class AbstractIndex implements Closeable {
      * @return a boolean indicating whether the size of the memory map and the underneath file is changed or not.
      */
     public boolean resize(int newSize) throws IOException {
+        return resize(newSize, false);
+    }
+
+    /**
+     * @param newSize new size of the index file
+     * @param sync if true, fsync the file after resizing to ensure both content and size are durable
+     * @return true if the index was resized, false otherwise
+     */
+    public boolean resize(int newSize, boolean sync) throws IOException {
         return inLock(() ->
                 inRemapWriteLock(() -> {
                     int roundedNewSize = roundDownToExactMultiple(newSize, entrySize());
@@ -216,6 +225,9 @@ public abstract class AbstractIndex implements Closeable {
                             mmap = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, roundedNewSize);
                             this.maxEntries = mmap.limit() / entrySize();
                             mmap.position(position);
+                            if (sync) {
+                                raf.getChannel().force(true);
+                            }
                             log.debug("Resized {} to {}, position is {} and limit is {}", file.getAbsolutePath(), roundedNewSize,
                                     mmap.position(), mmap.limit());
                             return true;
@@ -261,13 +273,13 @@ public abstract class AbstractIndex implements Closeable {
     }
 
     /**
-     * Trim this segment to fit just the valid entries, deleting all trailing unwritten bytes from
-     * the file.
+     * Trim this index to fit just the valid entries, deleting all trailing unwritten bytes from the file.
+     * @param sync if true, fsync the file after resizing to ensure both content and size are durable
      */
-    public void trimToValidSize() throws IOException {
+    public void trimToValidSize(boolean sync) throws IOException {
         inLock(() -> {
             if (mmap != null) {
-                resize(entrySize() * entries);
+                resize(entrySize() * entries, sync);
             }
         });
     }
@@ -280,7 +292,7 @@ public abstract class AbstractIndex implements Closeable {
     }
 
     public void close() throws IOException {
-        trimToValidSize();
+        trimToValidSize(true);
         closeHandler();
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -203,7 +203,7 @@ public abstract class AbstractIndex implements Closeable {
 
     /**
      * @param newSize new size of the index file
-     * @param sync if true, fsync the file after resizing to ensure both content and size are durable
+     * @param sync if true, fsync the file after resizing to ensure the size is durable
      * @return true if the index was resized, false otherwise
      */
     public boolean resize(int newSize, boolean sync) throws IOException {
@@ -292,6 +292,7 @@ public abstract class AbstractIndex implements Closeable {
     }
 
     public void close() throws IOException {
+        flush(); // Ensure the index content is flushed to disk as LogSegment.close may append an entry
         trimToValidSize(true);
         closeHandler();
     }

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/AbstractIndex.java
@@ -256,7 +256,9 @@ public abstract class AbstractIndex implements Closeable {
      */
     public void flush() {
         inLock(() -> {
-            mmap.force();
+            if (mmap != null) {
+                mmap.force();
+            }
         });
     }
 

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogSegment.java
@@ -521,10 +521,10 @@ public class LogSegment implements Closeable {
             LOGGER.debug("Truncated {} invalid bytes at the end of segment {} during recovery", truncated, log.file().getAbsolutePath());
 
         log.truncateTo(validBytes);
-        offsetIndex().trimToValidSize();
+        offsetIndex().trimToValidSize(false);
         // A normally closed segment always appends the biggest timestamp ever seen into log segment, we do this as well.
         timeIndex().maybeAppend(maxTimestampSoFar(), shallowOffsetOfMaxTimestampSoFar(), true);
-        timeIndex().trimToValidSize();
+        timeIndex().trimToValidSize(false);
         return truncated;
     }
 
@@ -685,8 +685,8 @@ public class LogSegment implements Closeable {
      */
     public void onBecomeInactiveSegment() throws IOException {
         timeIndex().maybeAppend(maxTimestampSoFar(), shallowOffsetOfMaxTimestampSoFar(), true);
-        offsetIndex().trimToValidSize();
-        timeIndex().trimToValidSize();
+        offsetIndex().trimToValidSize(false);
+        timeIndex().trimToValidSize(false);
         log.trim();
     }
 

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/AbstractIndexTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/AbstractIndexTest.java
@@ -35,9 +35,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AbstractIndexTest {
     private static class TestIndex extends AbstractIndex {
         private boolean unmapInvoked = false;
+        private boolean flushInvoked = false;
         private MappedByteBuffer unmappedBuffer = null;
         public TestIndex(File file, long baseOffset, int maxIndexSize, boolean writable) throws IOException {
             super(file, baseOffset, maxIndexSize, writable);
+        }
+
+        @Override
+        public void flush() {
+            flushInvoked = true;
+            super.flush();
         }
 
         @Override
@@ -85,5 +92,15 @@ public class AbstractIndexTest {
         assertTrue(idx.unmapInvoked, "Unmap should have been invoked after resize");
         assertSame(oldMmap, idx.unmappedBuffer, "old mmap should be unmapped");
         assertNotSame(idx.unmappedBuffer, idx.mmap());
+    }
+
+    @Test
+    public void testCloseInvokeFlush() throws IOException {
+        File f = new File(TestUtils.tempDirectory(), "test-index");
+        TestIndex idx = new TestIndex(f, 0L, 100, true);
+        assertFalse(idx.flushInvoked, "Flush should not have been invoked yet");
+
+        idx.close();
+        assertTrue(idx.flushInvoked, "Flush should have been invoked during close");
     }
 }


### PR DESCRIPTION
This avoids reading invalid length for the index files after a clean
shut down

This does not prevent the issue happening on an unclean shutdown. For
validating indexes at startup, we have
https://issues.apache.org/jira/browse/KAFKA-19200

Reviewers: Gaurav Narula <gaurav_narula2@apple.com>, Luke Chen <showuon@gmail.com>, Jun Rao <junrao@gmail.com>, Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
