### PR TITLE
MINOR: Remove unnecessary props.asScala in DynamicBrokerConfig

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -369,7 +369,6 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
   private def removeInvalidConfigs(props: Properties, perBrokerConfig: Boolean): Unit = {
     try {
       JDynamicBrokerConfig.validateConfigTypes(props)
-      props.asScala
     } catch {
       case e: Exception =>
         val invalidProps = props.asScala.filter { case (k, v) =>


### PR DESCRIPTION
Removed the dead `props.asScala` line.

### Testing
```bash
./gradlew core:test --tests kafka.server.DynamicBrokerConfigTest 
```
All tests passed successfully.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>
