### PR TITLE
MINOR: Add Protobuf message formatter for kafka-console-consumer

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -311,6 +311,7 @@ BSD 3-Clause
 - jline-reader-3.30.16, see: licenses/jline-BSD-3-clause
 - jline-terminal-3.30.16, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
+- protobuf-java-util-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 
 ---------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -2704,6 +2704,8 @@ project(':tools') {
     implementation project(':share-coordinator')
     implementation project(':raft')
     implementation libs.argparse4j
+    implementation libs.protobuf
+    implementation libs.protobufJavaUtil
     implementation libs.jacksonDatabind
     implementation libs.jacksonDataformatCsv
     implementation libs.joptSimple

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -340,6 +340,7 @@
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.coordinator.common.runtime" />
+      <allow pkg="com.google.protobuf" />
       <subpackage name="group">
         <allow pkg="kafka.api"/>
         <allow pkg="kafka.security"/>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -230,6 +230,7 @@ libs += [
   pcollections: "org.pcollections:pcollections:$versions.pcollections",
   opentelemetryProto: "io.opentelemetry.proto:opentelemetry-proto:$versions.opentelemetryProto",
   protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",
+  protobufJavaUtil: "com.google.protobuf:protobuf-java-util:$versions.protobuf",
   re2j: "com.google.re2j:re2j:$versions.re2j",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",

--- a/tools/src/main/java/org/apache/kafka/tools/consumer/ProtobufMessageFormatter.java
+++ b/tools/src/main/java/org/apache/kafka/tools/consumer/ProtobufMessageFormatter.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class ProtobufMessageFormatter implements MessageFormatter {
+
+    private Descriptors.Descriptor messageDescriptor;
+    private JsonFormat.Printer jsonPrinter;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        String protoDir = (String) configs.get("proto.dir");
+        String messageType = (String) configs.get("message.type");
+        if (protoDir == null) {
+            throw new ConfigException("Missing required formatter property: proto.dir");
+        }
+        if (messageType == null) {
+            throw new ConfigException("Missing required formatter property: message.type");
+        }
+
+        Path protoDirPath = Paths.get(protoDir);
+        if (!Files.isDirectory(protoDirPath)) {
+            throw new ConfigException("proto.dir is not a directory: " + protoDir);
+        }
+
+        FileDescriptorSet descriptorSet = compileProtoDir(protoDirPath);
+
+        Map<String, Descriptors.FileDescriptor> builtFiles = new HashMap<>();
+        for (FileDescriptorProto proto : descriptorSet.getFileList()) {
+            Descriptors.FileDescriptor[] deps = proto.getDependencyList().stream()
+                    .map(builtFiles::get)
+                    .toArray(Descriptors.FileDescriptor[]::new);
+            try {
+                Descriptors.FileDescriptor fd = Descriptors.FileDescriptor.buildFrom(proto, deps);
+                builtFiles.put(proto.getName(), fd);
+            } catch (Descriptors.DescriptorValidationException e) {
+                throw new ConfigException("Invalid .proto definitions in proto.dir: " + protoDir, e);
+            }
+        }
+
+        Descriptors.Descriptor found = null;
+        for (Descriptors.FileDescriptor fd : builtFiles.values()) {
+            found = findMessageType(fd.getMessageTypes(), messageType);
+            if (found != null) {
+                break;
+            }
+        }
+        if (found == null) {
+            throw new ConfigException("message.type not found under proto.dir: " + messageType);
+        }
+
+        this.messageDescriptor = found;
+        this.jsonPrinter = JsonFormat.printer();
+    }
+
+    private static FileDescriptorSet compileProtoDir(Path protoDirPath) {
+        List<String> protoFiles;
+        try (Stream<Path> paths = Files.walk(protoDirPath)) {
+            protoFiles = paths.filter(p -> p.toString().endsWith(".proto"))
+                    .map(p -> protoDirPath.relativize(p).toString())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new ConfigException("Unable to scan proto.dir: " + protoDirPath, e);
+        }
+        if (protoFiles.isEmpty()) {
+            throw new ConfigException("No .proto files found in proto.dir: " + protoDirPath);
+        }
+
+        Path descriptorSetFile;
+        try {
+            descriptorSetFile = Files.createTempFile("kafka-protobuf-formatter-", ".desc");
+            descriptorSetFile.toFile().deleteOnExit();
+        } catch (IOException e) {
+            throw new ConfigException("Unable to create a temporary file for protoc output", e);
+        }
+
+        List<String> command = new ArrayList<>();
+        command.add("protoc");
+        command.add("--proto_path=" + protoDirPath);
+        command.add("--descriptor_set_out=" + descriptorSetFile);
+        command.add("--include_imports");
+        command.addAll(protoFiles);
+
+        try {
+            Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+            String output;
+            try (InputStream processOutput = process.getInputStream()) {
+                output = new String(processOutput.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new ConfigException("protoc failed to compile proto.dir (" + protoDirPath + "):\n" + output);
+            }
+        } catch (IOException e) {
+            throw new ConfigException("Unable to run protoc - is it installed and on PATH?", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConfigException("Interrupted while running protoc", e);
+        }
+
+        try (InputStream in = Files.newInputStream(descriptorSetFile)) {
+            return FileDescriptorSet.parseFrom(in);
+        } catch (IOException e) {
+            throw new ConfigException("Unable to read descriptor set produced by protoc for proto.dir: " + protoDirPath, e);
+        } finally {
+            try {
+                Files.deleteIfExists(descriptorSetFile);
+            } catch (IOException e) {
+                // Best-effort cleanup; the file is also marked deleteOnExit above.
+            }
+        }
+    }
+
+    private static Descriptors.Descriptor findMessageType(List<Descriptors.Descriptor> candidates, String fullName) {
+        for (Descriptors.Descriptor d : candidates) {
+            if (d.getFullName().equals(fullName)) {
+                return d;
+            }
+            Descriptors.Descriptor nested = findMessageType(d.getNestedTypes(), fullName);
+            if (nested != null) {
+                return nested;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void writeTo(ConsumerRecord<byte[], byte[]> record, PrintStream output) {
+        if (record.value() == null) {
+            output.println("null");
+            return;
+        }
+        try {
+            DynamicMessage message = DynamicMessage.parseFrom(messageDescriptor, record.value());
+            output.println(jsonPrinter.print(message));
+        } catch (InvalidProtocolBufferException e) {
+            throw new SerializationException("Failed to parse Protobuf record", e);
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ConsoleConsumerOptionsTest.java
@@ -23,9 +23,11 @@ import org.apache.kafka.test.MockDeserializer;
 import org.apache.kafka.tools.ToolsTestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -473,6 +475,26 @@ public class ConsoleConsumerOptionsTest {
         assertEquals(1, keyDeserializer.configs.size());
         assertEquals("abc", keyDeserializer.configs.get("my-props"));
         assertTrue(keyDeserializer.isKey);
+    }
+
+    @Test
+    public void shouldInstantiateProtobufMessageFormatterWithItsProperties(@TempDir Path tempDir) throws Exception {
+        Path protoDir = ProtobufMessageFormatterTest.writeProtoDir(tempDir);
+
+        String[] args = new String[]{
+            "--bootstrap-server", "localhost:9092",
+            "--topic", "test",
+            "--formatter", "org.apache.kafka.tools.consumer.ProtobufMessageFormatter",
+            "--formatter-property", "proto.dir=" + protoDir,
+            "--formatter-property", "message.type=com.example.MyEvent"
+        };
+
+        ConsoleConsumerOptions config = new ConsoleConsumerOptions(args);
+
+        // This test only proves the --formatter/--formatter-property mechanism can instantiate and
+        // configure ProtobufMessageFormatter. Decoding behavior itself is covered by
+        // ProtobufMessageFormatterTest.
+        assertInstanceOf(ProtobufMessageFormatter.class, config.formatter());
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/ProtobufMessageFormatterTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/ProtobufMessageFormatterTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.MessageFormatter;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ProtobufMessageFormatterTest {
+
+    private static final String MESSAGE_TYPE = "com.example.MyEvent";
+    private static final String PROTO_SOURCE =
+            "syntax = \"proto3\";\n"
+                    + "package com.example;\n"
+                    + "\n"
+                    + "message MyEvent {\n"
+                    + "  int32 id = 1;\n"
+                    + "  string name = 2;\n"
+                    + "}\n";
+
+    @Test
+    public void testHappyPath(@TempDir Path tempDir) throws Exception {
+        // Given: a proto.dir containing com.example.MyEvent { int32 id = 1; string name = 2; }
+        Path protoDir = writeProtoDir(tempDir);
+        Descriptors.Descriptor descriptor = buildDescriptor();
+
+        // and a real Protobuf-encoded record matching that schema
+        DynamicMessage sourceMessage = DynamicMessage.newBuilder(descriptor)
+                .setField(descriptor.findFieldByName("id"), 42)
+                .setField(descriptor.findFieldByName("name"), "alice")
+                .build();
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                "topic", 0, 0, null, sourceMessage.toByteArray());
+
+        // When
+        MessageFormatter formatter = configuredFormatter(protoDir);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+
+        // Then
+        String expected = "{\n  \"id\": 42,\n  \"name\": \"alice\"\n}\n";
+        assertEquals(expected, out.toString());
+    }
+
+    @Test
+    public void testConfigureMissingProtoDirThrows() {
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("message.type", MESSAGE_TYPE);
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testConfigureMissingMessageTypeThrows(@TempDir Path tempDir) throws Exception {
+        Path protoDir = writeProtoDir(tempDir);
+
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", protoDir.toString());
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testConfigureProtoDirNotFoundThrows(@TempDir Path tempDir) {
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", tempDir.resolve("does-not-exist").toString());
+        configs.put("message.type", MESSAGE_TYPE);
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testConfigureNoProtoFilesFoundThrows(@TempDir Path tempDir) throws Exception {
+        Path emptyDir = Files.createDirectory(tempDir.resolve("empty-protos"));
+
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", emptyDir.toString());
+        configs.put("message.type", MESSAGE_TYPE);
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testConfigureInvalidProtoSyntaxThrows(@TempDir Path tempDir) throws Exception {
+        Path protoDir = Files.createDirectory(tempDir.resolve("protos"));
+        Files.writeString(protoDir.resolve("broken.proto"), "this is not valid proto syntax {{{");
+
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", protoDir.toString());
+        configs.put("message.type", MESSAGE_TYPE);
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testConfigureMessageTypeNotFoundThrows(@TempDir Path tempDir) throws Exception {
+        Path protoDir = writeProtoDir(tempDir);
+
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", protoDir.toString());
+        configs.put("message.type", "com.example.DoesNotExist");
+
+        assertThrows(ConfigException.class, () -> formatter.configure(configs));
+    }
+
+    @Test
+    public void testWriteToMalformedBytesThrows(@TempDir Path tempDir) throws Exception {
+        Path protoDir = writeProtoDir(tempDir);
+        MessageFormatter formatter = configuredFormatter(protoDir);
+
+        // A single 0xFF byte is an incomplete varint - not valid Protobuf for any message.
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                "topic", 0, 0, null, new byte[] {(byte) 0xFF});
+
+        assertThrows(SerializationException.class,
+                () -> formatter.writeTo(record, new PrintStream(new ByteArrayOutputStream())));
+    }
+
+    @Test
+    public void testWriteToNullValuePrintsNullLiteral(@TempDir Path tempDir) throws Exception {
+        Path protoDir = writeProtoDir(tempDir);
+        MessageFormatter formatter = configuredFormatter(protoDir);
+
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                "topic", 0, 0, null, null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+
+        assertEquals("null\n", out.toString());
+    }
+
+    @Test
+    public void testWriteToEmptyValuePrintsEmptyMessage(@TempDir Path tempDir) throws Exception {
+        // An empty (non-null) byte[] is a valid Protobuf message with every field at its
+        // proto3 default - distinct from a null/tombstone value.
+        Path protoDir = writeProtoDir(tempDir);
+        MessageFormatter formatter = configuredFormatter(protoDir);
+
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                "topic", 0, 0, null, new byte[0]);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        formatter.writeTo(record, new PrintStream(out));
+
+        assertEquals("{\n}\n", out.toString());
+    }
+
+    private static MessageFormatter configuredFormatter(Path protoDir) {
+        MessageFormatter formatter = new ProtobufMessageFormatter();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("proto.dir", protoDir.toString());
+        configs.put("message.type", MESSAGE_TYPE);
+        formatter.configure(configs);
+        return formatter;
+    }
+
+    static Path writeProtoDir(Path tempDir) throws Exception {
+        Path protoDir = Files.createDirectory(tempDir.resolve("protos"));
+        Files.writeString(protoDir.resolve("myevent.proto"), PROTO_SOURCE);
+        return protoDir;
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() throws Descriptors.DescriptorValidationException {
+        FileDescriptorProto fileProto = FileDescriptorProto.newBuilder()
+                .setName("myevent.proto")
+                .setSyntax("proto3")
+                .setPackage("com.example")
+                .addMessageType(DescriptorProto.newBuilder()
+                        .setName("MyEvent")
+                        .addField(FieldDescriptorProto.newBuilder()
+                                .setName("id")
+                                .setNumber(1)
+                                .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL))
+                        .addField(FieldDescriptorProto.newBuilder()
+                                .setName("name")
+                                .setNumber(2)
+                                .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)))
+                .build();
+
+        Descriptors.FileDescriptor fd = Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[0]);
+        return fd.findMessageTypeByName("MyEvent");
+    }
+}


### PR DESCRIPTION
Implements [KIP-1337](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/421958161/KIP-1337+Add+Protobuf+MessageFormatter+for+Kafka+Console+Consumer) (currently Under Discussion) as a reference
  implementation to make the proposal concrete for discussion.
  
  ## What 
  Adds ProtobufMessageFormatter for kafka-console-consumer, implementing the existing
  org.apache.kafka.common.MessageFormatter extension point.
  
  ## Why
  Allows inspecting Protobuf payloads from the console consumer using local .proto
  schema files, without requiring a schema registry.
  
  ## How
  --formatter org.apache.kafka.tools.consumer.ProtobufMessageFormatter
  --formatter-property proto.dir=/path/to/protos
  --formatter-property message.type=com.example.MyEvent
  
  At configure() time, compiles every *.proto file under proto.dir via protoc
  (--descriptor_set_out, --include_imports), resolves the configured message.type
  against the resulting descriptors, and caches both. At writeTo() time, decodes
  each record with DynamicMessage.parseFrom and prints canonical ProtoJSON via
  protobuf-java-util JsonFormat. Requires protoc on PATH.
  
  ## Testing 
  - ProtobufMessageFormatterTest: happy path, missing/invalid config, no .proto files
    found, invalid .proto syntax, message.type not found, malformed record bytes,
    null (tombstone) and empty-value records - compiling real .proto sources via
    protoc, not synthetic descriptors
  - ConsoleConsumerOptionsTest: --formatter/--formatter-property CLI wiring
    without --skip-message-on-error, tombstone)
  - checkstyleMain/checkstyleTest, spotlessCheck, spotbugsMain/spotbugsTest all pass

  ## Open questions from the KIP not yet resolved here
  - Import resolution across multiple proto.dir files/subdirectories is supported
    via protoc --proto_path but not exercised by a dedicated test yet
  - google.protobuf.Any scope is not addressed
  - Tombstone (null value) behavior (currently prints the literal null) is a
    placeholder pending KIP agreement