### PR TITLE
KAFKA-20981: fail on an unknown status code in the Streams heartbeat response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManager.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.internals.events.AsyncPollEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
 import org.apache.kafka.clients.consumer.internals.metrics.HeartbeatMetricsManager;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.RetriableException;
@@ -649,6 +650,21 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
 
     private void onSuccessResponse(final StreamsGroupHeartbeatResponse response, final long currentTimeMs) {
         final StreamsGroupHeartbeatResponseData data = response.data();
+
+        final List<String> unknownStatuses = unknownStatuses(data.status());
+        if (!unknownStatuses.isEmpty()) {
+            final String errorMessage = String.format(
+                "The group coordinator returned status %s in the Streams group heartbeat response, which this client "
+                    + "cannot interpret; it knows the status codes %s. A status code must not be sent to a client that "
+                    + "cannot interpret it, so this is a bug on the group coordinator.",
+                unknownStatuses,
+                StreamsGroupHeartbeatResponse.Status.knownCodes()
+            );
+            logger.error(errorMessage);
+            handleFatalFailure(new KafkaException(errorMessage));
+            return;
+        }
+
         heartbeatRequestState.updateHeartbeatIntervalMs(data.heartbeatIntervalMs());
         heartbeatRequestState.onSuccessfulAttempt(currentTimeMs);
         heartbeatState.setEndpointInformationEpoch(data.endpointInformationEpoch());
@@ -683,6 +699,17 @@ public class StreamsGroupHeartbeatRequestManager implements RequestManager {
         maybeLogStatuses(data.status());
 
         membershipManager.onHeartbeatSuccess(response);
+    }
+
+    private static List<String> unknownStatuses(final List<StreamsGroupHeartbeatResponseData.Status> statuses) {
+        if (statuses == null) {
+            return List.of();
+        }
+        return statuses.stream()
+            .filter(status -> !StreamsGroupHeartbeatResponse.Status.isKnownCode(status.statusCode()))
+            .sorted(Comparator.comparing(StreamsGroupHeartbeatResponseData.Status::statusCode))
+            .map(status -> "(" + status.statusCode() + ") " + status.statusDetail())
+            .collect(Collectors.toList());
     }
 
     private void maybeLogStatuses(final List<StreamsGroupHeartbeatResponseData.Status> statuses) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatResponse.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.protocol.Readable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Possible error codes.
@@ -118,6 +120,14 @@ public class StreamsGroupHeartbeatResponse extends AbstractResponse {
                 throw new IllegalArgumentException("Unknown code " + code);
             }
             return status;
+        }
+
+        public static boolean isKnownCode(byte code) {
+            return CODE_TO_STATUS.containsKey(code);
+        }
+
+        public static SortedSet<Byte> knownCodes() {
+            return Collections.unmodifiableSortedSet(new TreeSet<>(CODE_TO_STATUS.keySet()));
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -19,8 +19,10 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.events.BackgroundEvent;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.DisconnectException;
@@ -2793,6 +2795,56 @@ class StreamsGroupHeartbeatRequestManagerTest {
                     .setErrorMessage(errorMessage)
             )
         );
+    }
+
+    @Test
+    public void testUnknownStatusCodeFailsMemberFatally() {
+        try (
+            final MockedConstruction<HeartbeatRequestState> ignored = mockConstruction(
+                HeartbeatRequestState.class,
+                (mock, context) -> when(mock.canSendRequest(time.milliseconds())).thenReturn(true))
+        ) {
+            final StreamsGroupHeartbeatRequestManager heartbeatRequestManager = createStreamsGroupHeartbeatRequestManager();
+            when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(coordinatorNode));
+            when(membershipManager.groupId()).thenReturn(GROUP_ID);
+            when(membershipManager.memberId()).thenReturn(MEMBER_ID);
+            when(membershipManager.memberEpoch()).thenReturn(MEMBER_EPOCH);
+            when(membershipManager.groupInstanceId()).thenReturn(Optional.of(INSTANCE_ID));
+
+            final byte unknownStatusCode = (byte) (StreamsGroupHeartbeatResponse.Status.knownCodes().last() + 1);
+            final NetworkClientDelegate.PollResult result = heartbeatRequestManager.poll(time.milliseconds());
+            assertEquals(1, result.unsentRequests.size());
+
+            result.unsentRequests.get(0).handler().onComplete(new ClientResponse(
+                new RequestHeader(ApiKeys.STREAMS_GROUP_HEARTBEAT, (short) 1, "", 1),
+                null, "-1", time.milliseconds(), time.milliseconds(), false, null, null,
+                new StreamsGroupHeartbeatResponse(
+                    new StreamsGroupHeartbeatResponseData()
+                        .setHeartbeatIntervalMs((int) RECEIVED_HEARTBEAT_INTERVAL_MS)
+                        .setStatus(List.of(new StreamsGroupHeartbeatResponseData.Status()
+                            .setStatusCode(unknownStatusCode)
+                            .setStatusDetail("a condition this client has never heard of")))
+                )
+            ));
+
+            // Fatal, not swallowed: the member must be told, and the error must reach the application.
+            verify(membershipManager).transitionToFatal();
+            final ArgumentCaptor<BackgroundEvent> eventCaptor = ArgumentCaptor.forClass(BackgroundEvent.class);
+            verify(backgroundEventHandler).add(eventCaptor.capture());
+            final ErrorEvent errorEvent = assertInstanceOf(ErrorEvent.class, eventCaptor.getValue());
+            assertInstanceOf(KafkaException.class, errorEvent.error());
+            final String message = errorEvent.error().getMessage();
+            assertTrue(message.contains("(" + unknownStatusCode + ") a condition this client has never heard of"),
+                "The unknown status should be named with its detail: " + message);
+            assertTrue(message.contains(StreamsGroupHeartbeatResponse.Status.knownCodes().toString()),
+                "The known status codes should be listed: " + message);
+
+            // Nothing from the rejected response is applied: the member epoch is not advanced, the assignment is not
+            // processed, and neither the statuses nor the group configuration carried by the response are stored.
+            verify(membershipManager, never()).onHeartbeatSuccess(any());
+            assertEquals(List.of(), streamsRebalanceData.statuses());
+            assertEquals(-1, streamsRebalanceData.heartbeatIntervalMs());
+        }
     }
 
     @Test


### PR DESCRIPTION
A new StreamsGroupHeartbeatResponse status code is a semantic contract
change: it requires a KIP and a request-version bump, and the broker
must gate the new code so it is only sent to clients that advertise the
introducing version (as it does today for MISSING_CLIENT_TAGS, withheld
from v0 clients). If a broker bug sends a code an older client does not
recognize, the client decodes every status via Status.fromCode, which
throws -- and that throw, raised while handling the heartbeat response,
is currently swallowed (KAFKA-20860): the client keeps heartbeating,
advances its member epoch, and silently ignores the assignment and every
one after it, while the coordinator sees a healthy member.

This PR rejects the response as a whole, before any of it is applied, if
it carries a status this client cannot interpret: log it, surface a
KafkaException through the uncaught-exception handler, and fail the
member, so the error is visible instead of silently dropping every
assignment.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
