### PR TITLE
KAFKA-20983: Keep static member id when LeaveGroup is suppressed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1168,7 +1168,8 @@ public abstract class AbstractCoordinator implements Closeable {
     public synchronized RequestFuture<Void> maybeLeaveGroup(CloseOptions.GroupMembershipOperation membershipOperation, String leaveReason) {
         RequestFuture<Void> future = null;
 
-        if (shouldSendLeaveGroupRequest(membershipOperation)) {
+        boolean shouldSendLeaveGroup = shouldSendLeaveGroupRequest(membershipOperation);
+        if (shouldSendLeaveGroup) {
             log.info("Member {} sending LeaveGroup request to coordinator {} due to {}",
                 generation.memberId, coordinator, leaveReason);
             LeaveGroupRequest.Builder request = new LeaveGroupRequest.Builder(
@@ -1180,7 +1181,13 @@ public abstract class AbstractCoordinator implements Closeable {
             client.pollNoWakeup();
         }
 
-        resetGenerationOnLeaveGroup();
+        // A static member whose LeaveGroup is suppressed stays registered with the group
+        // coordinator under its current member id, so keep the id locally as well: resetting
+        // it would make the next rejoin carry UNKNOWN_MEMBER_ID, which the coordinator must
+        // treat as a new instance claiming this group.instance.id, fencing any still-pending
+        // join attempt of this same consumer (KAFKA-20983). State and generation are reset
+        // and a rejoin is requested exactly as before.
+        resetStateAndRejoin("consumer pro-actively leaving the group", shouldSendLeaveGroup || isDynamicMember());
 
         return future;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -87,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1140,6 +1141,33 @@ public class AbstractCoordinatorTest {
             Arguments.of(Optional.of("groupInstanceId"), CloseOptions.GroupMembershipOperation.LEAVE_GROUP),
             Arguments.of(Optional.of("groupInstanceId"), CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP)
         );
+    }
+
+    @Test
+    public void testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed() {
+        setupCoordinator(RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS, Integer.MAX_VALUE,
+            Optional.of("groupInstanceId"), Optional.empty());
+
+        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        mockClient.prepareResponse(joinGroupFollowerResponse(1, memberId, leaderId, Errors.NONE));
+        mockClient.prepareResponse(syncGroupResponse(Errors.NONE));
+        coordinator.ensureActiveGroup();
+        assertEquals(memberId, coordinator.generation().memberId);
+
+        RequestFuture<Void> future = coordinator.maybeLeaveGroup(
+            CloseOptions.GroupMembershipOperation.DEFAULT, "test static member leaving");
+
+        // A static member must not send LeaveGroup on the DEFAULT membership operation...
+        assertNull(future);
+        assertFalse(mockClient.hasInFlightRequests());
+
+        // ...and must keep its member id, so that the next rejoin identifies as the existing
+        // member instead of a new instance claiming the same group.instance.id, which would
+        // fence a still-pending join attempt of this same consumer (KAFKA-20983). Generation
+        // and state are reset as before and a rejoin is requested.
+        assertEquals(memberId, coordinator.generation().memberId);
+        assertEquals(AbstractCoordinator.Generation.NO_GENERATION.generationId, coordinator.generation().generationId);
+        assertTrue(coordinator.rejoinNeededOrPending());
     }
 
     private void checkLeaveGroupRequestSent(Optional<String> groupInstanceId)  {


### PR DESCRIPTION
A static consumer that calls `unsubscribe()` suppresses the LeaveGroup RPC in `AbstractCoordinator.maybeLeaveGroup()`, but `resetGenerationOnLeaveGroup()` wiped the local member id anyway. The subsequent rejoin therefore carries `UNKNOWN_MEMBER_ID` while the coordinator still has the member registered under its old id, and the coordinator has to treat such a join as a new process claiming the `group.instance.id`: it evicts the current member and fences its pending join/sync attempts with `FENCED_INSTANCE_ID`.

A lone consumer can hit this against itself. If its first blind rejoin is abandoned client-side (for example during a coordinator stall) but was already delivered, the broker still processes it later; whichever of the two joins is processed last fences the other, and the pending attempt of the same consumer receives `FencedInstanceIdException`, which Kafka Streams treats as fatal (`SHUTDOWN_APPLICATION`). See KAFKA-20985 for the full failure sequence observed on a long-running Streams application.

The fix keeps the member id whenever no LeaveGroup was actually sent, reusing the existing keep-member-id branch of `resetStateAndGeneration()`. State and generation are still reset and a rejoin is requested exactly as before; only the id retention changes, and only for the suppressed case. The next rejoin then identifies as the existing member and is handled as a recognized rejoin instead of a static replacement, so no ordering of connections and request queues can make a consumer fence itself. Dynamic members and explicit `LEAVE_GROUP` close operations keep the previous behavior.

Testing: new regression test `testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed` (static member, DEFAULT membership operation: no LeaveGroup sent, member id retained, generation reset, rejoin requested); `AbstractCoordinatorTest`, `ConsumerCoordinatorTest` and clients checkstyle pass locally.