### PR TITLE
KAFKA-20985: Keep static member id when LeaveGroup is suppressed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1069,7 +1069,7 @@ public abstract class AbstractCoordinator implements Closeable {
         }
     }
 
-    synchronized void resetStateAndRejoin(final String reason, final boolean shouldResetMemberId) {
+    private synchronized void resetStateAndRejoin(final String reason, final boolean shouldResetMemberId) {
         resetStateAndGeneration(reason, shouldResetMemberId);
         requestRejoin(reason);
         needsJoinPrepare = true;
@@ -1177,13 +1177,10 @@ public abstract class AbstractCoordinator implements Closeable {
             client.pollNoWakeup();
         }
 
-        // A static member whose LeaveGroup is suppressed stays registered with the group
-        // coordinator under its current member id, so keep the id locally as well: resetting
-        // it would make the next rejoin carry UNKNOWN_MEMBER_ID, which the coordinator must
-        // treat as a new instance claiming this group.instance.id, fencing any still-pending
-        // join attempt of this same consumer (KAFKA-20985). State and generation are reset
-        // and a rejoin is requested exactly as before.
-        resetStateAndRejoin("consumer pro-actively leaving the group", shouldSendLeaveGroup || isDynamicMember());
+        // A static member whose LeaveGroup was suppressed is still registered under this member id,
+        // so keep it to avoid being treated as a new instance on the next rejoin (KAFKA-20985).
+        boolean shouldResetMemberId = shouldSendLeaveGroup || isDynamicMember();
+        resetStateAndRejoin("consumer pro-actively leaving the group", shouldResetMemberId);
 
         return future;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1069,7 +1069,7 @@ public abstract class AbstractCoordinator implements Closeable {
         }
     }
 
-    private synchronized void resetStateAndRejoin(final String reason, final boolean shouldResetMemberId) {
+    synchronized void resetStateAndRejoin(final String reason, final boolean shouldResetMemberId) {
         resetStateAndGeneration(reason, shouldResetMemberId);
         requestRejoin(reason);
         needsJoinPrepare = true;
@@ -1078,10 +1078,6 @@ public abstract class AbstractCoordinator implements Closeable {
     synchronized void resetStateOnResponseError(ApiKeys api, Errors error, boolean shouldResetMemberId) {
         final String reason = String.format("encountered %s from %s response", error, api);
         resetStateAndRejoin(reason, shouldResetMemberId);
-    }
-
-    synchronized void resetGenerationOnLeaveGroup() {
-        resetStateAndRejoin("consumer pro-actively leaving the group", true);
     }
 
     public synchronized void requestRejoinIfNecessary(final String shortReason,
@@ -1168,7 +1164,8 @@ public abstract class AbstractCoordinator implements Closeable {
     public synchronized RequestFuture<Void> maybeLeaveGroup(CloseOptions.GroupMembershipOperation membershipOperation, String leaveReason) {
         RequestFuture<Void> future = null;
 
-        if (shouldSendLeaveGroupRequest(membershipOperation)) {
+        boolean shouldSendLeaveGroup = shouldSendLeaveGroupRequest(membershipOperation);
+        if (shouldSendLeaveGroup) {
             log.info("Member {} sending LeaveGroup request to coordinator {} due to {}",
                 generation.memberId, coordinator, leaveReason);
             LeaveGroupRequest.Builder request = new LeaveGroupRequest.Builder(
@@ -1180,7 +1177,13 @@ public abstract class AbstractCoordinator implements Closeable {
             client.pollNoWakeup();
         }
 
-        resetGenerationOnLeaveGroup();
+        // A static member whose LeaveGroup is suppressed stays registered with the group
+        // coordinator under its current member id, so keep the id locally as well: resetting
+        // it would make the next rejoin carry UNKNOWN_MEMBER_ID, which the coordinator must
+        // treat as a new instance claiming this group.instance.id, fencing any still-pending
+        // join attempt of this same consumer (KAFKA-20985). State and generation are reset
+        // and a rejoin is requested exactly as before.
+        resetStateAndRejoin("consumer pro-actively leaving the group", shouldSendLeaveGroup || isDynamicMember());
 
         return future;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -87,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -712,7 +713,7 @@ public class AbstractCoordinatorTest {
             if (!(body instanceof SyncGroupRequest)) {
                 return false;
             }
-            coordinator.resetGenerationOnLeaveGroup();
+            coordinator.resetStateAndRejoin("clear generation before the sync response is handled", true);
 
             SyncGroupRequest syncGroupRequest = (SyncGroupRequest) body;
             return syncGroupRequest.data().protocolType().equals(PROTOCOL_TYPE)
@@ -1140,6 +1141,33 @@ public class AbstractCoordinatorTest {
             Arguments.of(Optional.of("groupInstanceId"), CloseOptions.GroupMembershipOperation.LEAVE_GROUP),
             Arguments.of(Optional.of("groupInstanceId"), CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP)
         );
+    }
+
+    @Test
+    public void testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed() {
+        setupCoordinator(RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS, Integer.MAX_VALUE,
+            Optional.of("groupInstanceId"), Optional.empty());
+
+        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        mockClient.prepareResponse(joinGroupFollowerResponse(1, memberId, leaderId, Errors.NONE));
+        mockClient.prepareResponse(syncGroupResponse(Errors.NONE));
+        coordinator.ensureActiveGroup();
+        assertEquals(memberId, coordinator.generation().memberId);
+
+        RequestFuture<Void> future = coordinator.maybeLeaveGroup(
+            CloseOptions.GroupMembershipOperation.DEFAULT, "test static member leaving");
+
+        // A static member must not send LeaveGroup on the DEFAULT membership operation...
+        assertNull(future);
+        assertFalse(mockClient.hasInFlightRequests());
+
+        // ...and must keep its member id, so that the next rejoin identifies as the existing
+        // member instead of a new instance claiming the same group.instance.id, which would
+        // fence a still-pending join attempt of this same consumer (KAFKA-20985). Generation
+        // and state are reset as before and a rejoin is requested.
+        assertEquals(memberId, coordinator.generation().memberId);
+        assertEquals(AbstractCoordinator.Generation.NO_GENERATION.generationId, coordinator.generation().generationId);
+        assertTrue(coordinator.rejoinNeededOrPending());
     }
 
     private void checkLeaveGroupRequestSent(Optional<String> groupInstanceId)  {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
@@ -713,7 +714,7 @@ public class AbstractCoordinatorTest {
             if (!(body instanceof SyncGroupRequest)) {
                 return false;
             }
-            coordinator.resetStateAndRejoin("clear generation before the sync response is handled", true);
+            coordinator.resetStateOnResponseError(ApiKeys.HEARTBEAT, Errors.UNKNOWN_MEMBER_ID, true);
 
             SyncGroupRequest syncGroupRequest = (SyncGroupRequest) body;
             return syncGroupRequest.data().protocolType().equals(PROTOCOL_TYPE)
@@ -1143,8 +1144,9 @@ public class AbstractCoordinatorTest {
         );
     }
 
-    @Test
-    public void testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed() {
+    @ParameterizedTest
+    @EnumSource(value = CloseOptions.GroupMembershipOperation.class, names = {"DEFAULT", "REMAIN_IN_GROUP"})
+    public void testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed(CloseOptions.GroupMembershipOperation operation) {
         setupCoordinator(RETRY_BACKOFF_MS, RETRY_BACKOFF_MAX_MS, Integer.MAX_VALUE,
             Optional.of("groupInstanceId"), Optional.empty());
 
@@ -1155,9 +1157,9 @@ public class AbstractCoordinatorTest {
         assertEquals(memberId, coordinator.generation().memberId);
 
         RequestFuture<Void> future = coordinator.maybeLeaveGroup(
-            CloseOptions.GroupMembershipOperation.DEFAULT, "test static member leaving");
+            operation, "test static member leaving");
 
-        // A static member must not send LeaveGroup on the DEFAULT membership operation...
+        // A static member must not send LeaveGroup for this membership operation...
         assertNull(future);
         assertFalse(mockClient.hasInFlightRequests());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -3730,7 +3730,15 @@ public abstract class ConsumerCoordinatorTest {
             // Imitating heartbeat thread that clears generation data.
             coordinator.maybeLeaveGroup(CloseOptions.GroupMembershipOperation.DEFAULT, "Clear generation data.");
 
-            assertEquals(AbstractCoordinator.Generation.NO_GENERATION, coordinator.generation());
+            // This member uses static membership, so member ID should not be reset.
+            assertEquals(
+                new AbstractCoordinator.Generation(
+                    AbstractCoordinator.Generation.NO_GENERATION.generationId,
+                    memberId,
+                    null
+                ),
+                coordinator.generation()
+            );
 
             client.respond(syncGroupResponse(partitions, Errors.NONE));
 


### PR DESCRIPTION
A static consumer that calls `unsubscribe()` suppresses the LeaveGroup
RPC in `AbstractCoordinator.maybeLeaveGroup()`, but
`resetGenerationOnLeaveGroup()` wiped the local member id anyway. The
subsequent rejoin therefore carries `UNKNOWN_MEMBER_ID` while the
coordinator still has the member registered under its old id, and the
coordinator has to treat such a join as a new process claiming the
`group.instance.id`: it evicts the current member and fences its pending
join/sync attempts with `FENCED_INSTANCE_ID`.

A lone consumer can hit this against itself. If its first blind rejoin
is abandoned client-side (for example during a coordinator stall) but
was already delivered, the broker still processes it later; whichever of
the two joins is processed last fences the other, and the pending
attempt of the same consumer receives `FencedInstanceIdException`, which
Kafka Streams treats as fatal (`SHUTDOWN_APPLICATION`). See KAFKA-20985
for the full failure sequence observed on a long-running Streams
application.

The fix keeps the member id whenever no LeaveGroup was actually sent,
reusing the existing keep-member-id branch of
`resetStateAndGeneration()`. State and generation are still reset and a
rejoin is requested exactly as before; only the id retention changes,
and only for the suppressed case. The next rejoin then identifies as the
existing member and is handled as a recognized rejoin instead of a
static replacement, so no ordering of connections and request queues can
make a consumer fence itself. Dynamic members and explicit `LEAVE_GROUP`
close operations keep the previous behavior.

**Behavior change for static group leaders.** Because the rejoin now
carries the existing member id, the coordinator handles it in
`classicGroupJoinExistingMember` rather than the static-replacement path
`updateStaticMemberThenRebalanceOrCompleteJoin`. When the group is
`STABLE`, the existing-member path always triggers a rebalance if the
joining member is the current leader, whereas the static-replacement
path skipped the rebalance as long as the group's selected protocol did
not change. So a static member that is the group leader and goes through
an `unsubscribe()`/`subscribe()` cycle (for example after a poll
timeout,
or `StreamThread.handleTaskMigrated`) now causes a full group rebalance
where it previously re-attached silently. Followers are unaffected: they
only rebalance if their subscription metadata changed. The old shortcut
compared only the protocol name and ignored subscription changes, so the
new behavior is the more correct one.

A residual, non-fatal race remains and is recorded on KAFKA-20985: if
both joins of the same member are processed while the group is in
`PREPARING_REBALANCE`, `ClassicGroup.updateMember` overwrites the
member's pending join future without completing it. If the request on
the surviving connection is the one whose future is overwritten, the
consumer receives no response and only retries after the client-side
JoinGroup timeout (rebalance timeout + 5s). This is a possible follow-up
and out of scope for this fix.

Testing: new regression test
`testStaticMemberKeepsMemberIdWhenLeaveGroupIsSuppressed`, parameterized
over the `DEFAULT` and `REMAIN_IN_GROUP` membership operations (static
member: no LeaveGroup sent, member id retained, generation reset, rejoin
requested); `testPrepareJoinAndRejoinAfterFailedRebalance` updated to
expect the retained id for a static member. `AbstractCoordinatorTest`,
`ConsumerCoordinatorTest`, clients checkstyle and spotless pass locally.

Reviewers: TengYao Chi <frankvicky@apache.org>, Lucas Brutschy <lbrutschy@confluent.io>, Lianet Magrans <lmagrans@confluent.io>, David Jacot <david.jacot@gmail.com>
