### PR TITLE
KAFKA-15976: Allow specifying initial offsets while creating connectors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -90,6 +90,7 @@ public class ConnectStandalone extends AbstractConnectCli<StandaloneHerder, Stan
                 connect.herder().putConnectorConfig(
                     createConnectorRequest.name(), createConnectorRequest.config(),
                     createConnectorRequest.initialTargetState(),
+                    createConnectorRequest.initialOffsetsMap(),
                     false, cb);
                 cb.get();
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -1316,6 +1316,66 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
      */
     protected abstract void modifyConnectorOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb);
 
+    /**
+     * Validate the offsets supplied via the {@code initial_offsets} field of a connector creation request. Performs no
+     * I/O, so that an invalid request is rejected before any of the connector's existing offsets are wiped.
+     *
+     * @param connName the name of the connector being created
+     * @param initialOffsets the offsets supplied by the user; may not be {@code null}
+     * @throws BadRequestException if the offsets cannot be used as a connector's initial offsets
+     */
+    protected void validateInitialOffsets(String connName, Map<Map<String, ?>, Map<String, ?>> initialOffsets) {
+        if (initialOffsets.isEmpty()) {
+            throw new BadRequestException("The initial offsets for connector " + connName + " may not be empty");
+        }
+        // A null offset means "delete this partition's offset" when altering, but is meaningless on create: every offset
+        // the connector has is wiped before these are written, so there is nothing left to delete. Issuing the delete
+        // anyway targets the consumer group our own wipe just removed, which the alter path (unlike the reset path) does
+        // not tolerate. This is deliberately stricter than PATCH /connectors/{connector}/offsets.
+        // Not Map::containsValue, which throws rather than returning false on the immutable maps Map.of(...) produces.
+        if (initialOffsets.values().stream().anyMatch(offset -> offset == null)) {
+            throw new BadRequestException("The initial offsets for connector " + connName + " may not contain null offset "
+                    + "values. All existing offsets for the connector are removed before the initial offsets are written, "
+                    + "so a null offset has nothing to delete.");
+        }
+    }
+
+    /**
+     * Wipe every offset the connector currently has and write {@code initialOffsets} in their place.
+     * <p>
+     * Unlike {@link #alterConnectorOffsets} and {@link #resetConnectorOffsets}, this skips the usual preconditions (that
+     * the connector exists and is STOPPED with no running tasks): the connector is being created, so it is not expected
+     * to exist and has no tasks. Its config has not been written yet, so nothing can be running under this name.
+     */
+    protected void setInitialConnectorOffsets(String connName, Map<String, String> config,
+                                              Map<Map<String, ?>, Map<String, ?>> initialOffsets, Callback<Message> cb) {
+        worker.modifyConnectorOffsets(connName, config, initialOffsets, true, cb);
+    }
+
+    /**
+     * Remove the initial offsets written for a connector whose config could not subsequently be written, so that a
+     * failed creation does not leave offsets behind for a connector that does not exist, and then complete
+     * {@code callback} with the original failure rather than with any error from the cleanup itself.
+     */
+    protected void wipeInitialOffsetsAfterFailedCreate(String connName, Map<String, String> config,
+                                                       Throwable configWriteError, Callback<Created<ConnectorInfo>> callback) {
+        log.error("Failed to write the configuration for connector {} after its initial offsets had been written; "
+                + "removing those offsets so that the failed creation does not leave them behind", connName, configWriteError);
+        Callback<Message> cleanupCallback = (wipeError, ignored) -> {
+            if (wipeError != null) {
+                log.error("Failed to remove the initial offsets for connector {} after its creation failed. Offsets may "
+                        + "remain for a connector that was not created; re-submitting the identical creation request is "
+                        + "safe and will overwrite them.", connName, wipeError);
+            }
+            callback.onCompletion(configWriteError, null);
+        };
+        try {
+            worker.modifyConnectorOffsets(connName, config, null, cleanupCallback);
+        } catch (Throwable t) {
+            cleanupCallback.onCompletion(t, null);
+        }
+    }
+
     @Override
     public LoggerLevel loggerLevel(String logger) {
         return loggers.level(logger);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -127,6 +127,25 @@ public interface Herder {
                             Callback<Created<ConnectorInfo>> callback);
 
     /**
+     * Set the configuration for a connector, along with a target state and initial offsets optionally. This supports
+     * creation and updating.
+     * @param connName name of the connector
+     * @param config the connector's configuration
+     * @param targetState the desired target state for the connector; may be {@code null} if no target state change is desired. Note that the default
+     *                    target state is {@link TargetState#STARTED} if no target state exists previously
+     * @param initialOffsets the offsets the connector should start from; may be {@code null}, in which case the connector's
+     *                       existing offsets (if any) are left untouched. When non-null, every offset the connector currently
+     *                       has is wiped before these are written, so the connector ends up with exactly these offsets rather
+     *                       than a merge of old and new. Only meaningful when creating a connector.
+     * @param allowReplace if true, allow overwriting previous configs; if false, throw {@link AlreadyExistsException}
+     *                     if a connector with the same name already exists
+     * @param callback callback to invoke when the configuration has been written
+     */
+    void putConnectorConfig(String connName, Map<String, String> config, TargetState targetState,
+                            Map<Map<String, ?>, Map<String, ?>> initialOffsets, boolean allowReplace,
+                            Callback<Created<ConnectorInfo>> callback);
+
+    /**
      * Patch the configuration for a connector.
      * @param connName name of the connector
      * @param configPatch the connector's configuration patch.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -1354,6 +1354,15 @@ public final class Worker {
     }
 
     /**
+     * Equivalent to {@link #modifyConnectorOffsets(String, Map, Map, boolean, Callback)} with
+     * {@code replaceAllOffsets = false}.
+     */
+    public void modifyConnectorOffsets(String connName, Map<String, String> connectorConfig,
+                                      Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb) {
+        modifyConnectorOffsets(connName, connectorConfig, offsets, false, cb);
+    }
+
+    /**
      * Modify (alter / reset) a connector's offsets.
      *
      * @param connName the name of the connector whose offsets are to be modified
@@ -1361,22 +1370,32 @@ public final class Worker {
      * @param offsets a mapping from partitions (either source partitions for source connectors, or Kafka topic
      *                partitions for sink connectors) to offsets that need to be written; this should be {@code null}
      *                for offsets reset requests
+     * @param replaceAllOffsets if {@code true}, every offset the connector currently has is wiped before {@code offsets}
+     *                          is written, so the result is exactly {@code offsets} rather than a merge of old and new.
+     *                          Only meaningful when {@code offsets} is non-null; ignored for reset requests, which
+     *                          already wipe everything.
      * @param cb callback to invoke upon completion
      */
     public void modifyConnectorOffsets(String connName, Map<String, String> connectorConfig,
-                                      Map<Map<String, ?>, Map<String, ?>> offsets, Callback<Message> cb) {
+                                      Map<Map<String, ?>, Map<String, ?>> offsets, boolean replaceAllOffsets, Callback<Message> cb) {
 
         final Connector connector = instantiateConnector(connectorConfig);
         ClassLoader connectorLoader = connectorClassLoader(connectorConfig);
         try (LoaderSwap loaderSwap = plugins.withClassLoader(connectorLoader)) {
             if (ConnectUtils.isSinkConnector(connector)) {
                 log.debug("Modifying offsets for sink connector: {}", connName);
-                modifySinkConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
+                modifySinkConnectorOffsets(connName, connector, connectorConfig, offsets, replaceAllOffsets, connectorLoader, cb);
             } else {
                 log.debug("Modifying offsets for source connector: {}", connName);
-                modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, connectorLoader, cb);
+                modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, replaceAllOffsets, connectorLoader, cb);
             }
         }
+    }
+
+    // Visible for testing; equivalent to the overload below with replaceAllOffsets = false
+    void modifySinkConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
+                                    Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
+        modifySinkConnectorOffsets(connName, connector, connectorConfig, offsets, false, connectorLoader, cb);
     }
 
     /**
@@ -1389,11 +1408,13 @@ public final class Worker {
      * @param connectorConfig the sink connector's configuration
      * @param offsets a mapping from topic partitions to offsets that need to be written; this should be {@code null}
      *                for offsets reset requests
+     * @param replaceAllOffsets if {@code true} and {@code offsets} is non-null, every existing offset for the
+     *                          connector's consumer group is wiped before {@code offsets} is written
      * @param connectorLoader the connector plugin's classloader to be used as the thread context classloader
      * @param cb callback to invoke upon completion
      */
     void modifySinkConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
-                                    Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
+                                    Map<Map<String, ?>, Map<String, ?>> offsets, boolean replaceAllOffsets, ClassLoader connectorLoader, Callback<Message> cb) {
         executor.submit(plugins.withClassLoader(connectorLoader, () -> {
             try {
                 Timer timer = time.timer(Duration.ofMillis(RestServer.DEFAULT_REST_REQUEST_TIMEOUT_MS));
@@ -1418,7 +1439,13 @@ public final class Worker {
 
                 try {
                     Map<TopicPartition, Long> offsetsToWrite;
-                    if (isReset) {
+                    // Both a reset and a replace start by tombstoning every offset the consumer group currently has;
+                    // a replace then overlays the requested offsets on top of those tombstones.
+                    if (isReset || replaceAllOffsets) {
+                        String modification = isReset ? "resetting" : "replacing";
+                        // Parse the requested offsets before doing any admin client work, so that a malformed request
+                        // fails fast and doesn't cost a round trip to list the consumer group's existing offsets.
+                        Map<TopicPartition, Long> requestedOffsets = isReset ? Map.of() : SinkUtils.parseSinkConnectorOffsets(offsets);
                         offsetsToWrite = new HashMap<>();
                         ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions = new ListConsumerGroupOffsetsOptions()
                                 .timeoutMs((int) timer.remainingMs());
@@ -1429,14 +1456,17 @@ public final class Worker {
                                     .forEach((topicPartition, offsetAndMetadata) -> offsetsToWrite.put(topicPartition, null));
 
                             timer.update();
-                            log.debug("Found the following topic partitions (to reset offsets) for sink connector {} and consumer group ID {}: {}",
+                            log.debug("Found the following existing topic partitions for sink connector {} and consumer group ID {}: {}",
                                     connName, groupId, offsetsToWrite.keySet());
                         } catch (Exception e) {
-                            Utils.closeQuietly(admin, "Offset reset admin for sink connector " + connName);
-                            log.error("Failed to list offsets prior to resetting offsets for sink connector {}", connName, e);
-                            cb.onCompletion(new ConnectException("Failed to list offsets prior to resetting offsets for sink connector " + connName, e), null);
+                            Utils.closeQuietly(admin, "Offset modification admin for sink connector " + connName);
+                            log.error("Failed to list offsets prior to {} offsets for sink connector {}", modification, connName, e);
+                            cb.onCompletion(new ConnectException("Failed to list offsets prior to " + modification
+                                    + " offsets for sink connector " + connName, e), null);
                             return;
                         }
+                        // Requested offsets win over the tombstones for any partition that appears in both
+                        offsetsToWrite.putAll(requestedOffsets);
                     } else {
                         offsetsToWrite = SinkUtils.parseSinkConnectorOffsets(offsets);
                     }
@@ -1455,7 +1485,8 @@ public final class Worker {
                     if (isReset) {
                         resetSinkConnectorOffsets(connName, groupId, admin, cb, alterOffsetsResult, timer);
                     } else {
-                        alterSinkConnectorOffsets(connName, groupId, admin, offsetsToWrite, cb, alterOffsetsResult, timer);
+                        alterSinkConnectorOffsets(connName, groupId, admin, offsetsToWrite, cb, alterOffsetsResult, timer,
+                                offsetModificationType(offsets, replaceAllOffsets));
                     }
                 } catch (Throwable t) {
                     Utils.closeQuietly(admin, "Offset modification admin for sink connector " + connName);
@@ -1479,9 +1510,10 @@ public final class Worker {
      * @param cb callback to invoke upon completion
      * @param alterOffsetsResult the result of the call to {@link SinkConnector#alterOffsets} for the connector
      * @param timer {@link Timer} to bound the total runtime of admin client requests
+     * @param modificationType the verb ("altered" or "set") to use in the completion message
      */
     private void alterSinkConnectorOffsets(String connName, String groupId, Admin admin, Map<TopicPartition, Long> offsetsToWrite,
-                                           Callback<Message> cb, boolean alterOffsetsResult, Timer timer) {
+                                           Callback<Message> cb, boolean alterOffsetsResult, Timer timer, String modificationType) {
         List<KafkaFuture<Void>> adminFutures = new ArrayList<>();
 
         Map<TopicPartition, OffsetAndMetadata> offsetsToAlter = offsetsToWrite.entrySet()
@@ -1538,7 +1570,7 @@ public final class Worker {
                     cb.onCompletion(new ConnectException("Failed to alter consumer group offsets for connector " + connName, error), null);
                 }
             } else {
-                completeModifyOffsetsCallback(alterOffsetsResult, false, cb);
+                completeModifyOffsetsCallback(alterOffsetsResult, modificationType, cb);
             }
         }).whenComplete((ignored, ignoredError) -> {
             // errors originating from the original future are handled in the prior whenComplete invocation which isn't expected to throw
@@ -1581,7 +1613,7 @@ public final class Worker {
                             cb.onCompletion(new ConnectException("Failed to reset consumer group offsets for sink connector " + connName, error), null);
                         }
                     } else {
-                        completeModifyOffsetsCallback(alterOffsetsResult, true, cb);
+                        completeModifyOffsetsCallback(alterOffsetsResult, "reset", cb);
                     }
                 }).whenComplete((ignored, ignoredError) -> {
                     // errors originating from the original future are handled in the prior whenComplete invocation which isn't expected to throw
@@ -1598,11 +1630,14 @@ public final class Worker {
      * @param connectorConfig the source connector's configuration
      * @param offsets a mapping from partitions to offsets that need to be written; this should be {@code null} for
      *                offsets reset requests
+     * @param replaceAllOffsets if {@code true} and {@code offsets} is non-null, every existing offset for the
+     *                          connector is wiped before {@code offsets} is written
      * @param connectorLoader the connector plugin's classloader to be used as the thread context classloader
      * @param cb callback to invoke upon completion
      */
     private void modifySourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
-                                              Map<Map<String, ?>, Map<String, ?>> offsets, ClassLoader connectorLoader, Callback<Message> cb) {
+                                              Map<Map<String, ?>, Map<String, ?>> offsets, boolean replaceAllOffsets,
+                                              ClassLoader connectorLoader, Callback<Message> cb) {
         SourceConnectorConfig sourceConfig = new SourceConnectorConfig(plugins, connectorConfig, config.topicCreationEnable());
         Map<String, Object> producerProps = config.exactlyOnceSourceEnabled()
                 ? exactlyOnceSourceTaskProducerConfigs(new ConnectorTaskId(connName, 0), config, sourceConfig,
@@ -1617,12 +1652,20 @@ public final class Worker {
         offsetStore.configure(config);
 
         OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetStore, connName, internalKeyConverter, internalValueConverter);
-        modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, offsetStore, producer, offsetWriter, connectorLoader, cb);
+        modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, replaceAllOffsets, offsetStore, producer, offsetWriter, connectorLoader, cb);
     }
 
     // Visible for testing
     void modifySourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
                                       Map<Map<String, ?>, Map<String, ?>> offsets, ConnectorOffsetBackingStore offsetStore,
+                                      KafkaProducer<byte[], byte[]> producer, OffsetStorageWriter offsetWriter,
+                                      ClassLoader connectorLoader, Callback<Message> cb) {
+        modifySourceConnectorOffsets(connName, connector, connectorConfig, offsets, false, offsetStore, producer, offsetWriter, connectorLoader, cb);
+    }
+
+    // Visible for testing
+    void modifySourceConnectorOffsets(String connName, Connector connector, Map<String, String> connectorConfig,
+                                      Map<Map<String, ?>, Map<String, ?>> offsets, boolean replaceAllOffsets, ConnectorOffsetBackingStore offsetStore,
                                       KafkaProducer<byte[], byte[]> producer, OffsetStorageWriter offsetWriter,
                                       ClassLoader connectorLoader, Callback<Message> cb) {
         executor.submit(plugins.withClassLoader(connectorLoader, () -> {
@@ -1634,16 +1677,19 @@ public final class Worker {
                         "offsets for source connector " + connName);
                 Map<Map<String, ?>, Map<String, ?>> offsetsToWrite;
 
-                // If the offsets argument is null, it indicates an offsets reset operation - i.e. a null offset should
-                // be written for every source partition of the connector
-                boolean isReset;
-                if (offsets == null) {
-                    isReset = true;
+                String modificationType = offsetModificationType(offsets, replaceAllOffsets);
+
+                // A null offsets argument indicates a reset - i.e. a null offset should be written for every source
+                // partition of the connector. A replace tombstones those same partitions and then overlays the
+                // requested offsets on top of them.
+                if (offsets == null || replaceAllOffsets) {
+                    Map<Map<String, ?>, Map<String, ?>> requestedOffsets = offsets == null ? Map.of() : offsets;
                     offsetsToWrite = new HashMap<>();
                     offsetStore.connectorPartitions(connName).forEach(partition -> offsetsToWrite.put(partition, null));
-                    log.debug("Found the following partitions (to reset offsets) for source connector {}: {}", connName, offsetsToWrite.keySet());
+                    log.debug("Found the following existing partitions for source connector {}: {}", connName, offsetsToWrite.keySet());
+                    // Requested offsets win over the tombstones for any partition that appears in both
+                    offsetsToWrite.putAll(requestedOffsets);
                 } else {
-                    isReset = false;
                     offsetsToWrite = offsets;
                 }
 
@@ -1666,7 +1712,7 @@ public final class Worker {
                 if (normalizedOffsets.isEmpty()) {
                     log.info("No offsets found for source connector {} - this can occur due to a prior attempt to reset offsets or if the " +
                             "source connector hasn't committed any offsets yet", connName);
-                    completeModifyOffsetsCallback(alterOffsetsResult, isReset, cb);
+                    completeModifyOffsetsCallback(alterOffsetsResult, modificationType, cb);
                     return;
                 }
 
@@ -1700,7 +1746,7 @@ public final class Worker {
                     throw new ConnectException("Unexpectedly interrupted while attempting to modify offsets for source connector " + connName, e);
                 }
 
-                completeModifyOffsetsCallback(alterOffsetsResult, isReset, cb);
+                completeModifyOffsetsCallback(alterOffsetsResult, modificationType, cb);
             } catch (Throwable t) {
                 log.error("Failed to modify offsets for source connector {}", connName, t);
                 cb.onCompletion(ConnectUtils.maybeWrap(t, "Failed to modify offsets for source connector " + connName), null);
@@ -1708,6 +1754,14 @@ public final class Worker {
                 Utils.closeQuietly(offsetStore::stop, "Offset store for offset modification request for connector " + connName);
             }
         }));
+    }
+
+    // The verb ("reset", "altered", or "set") used in the message reported back to the user.
+    private static String offsetModificationType(Map<Map<String, ?>, Map<String, ?>> offsets, boolean replaceAllOffsets) {
+        if (offsets == null) {
+            return "reset";
+        }
+        return replaceAllOffsets ? "set" : "altered";
     }
 
     /**
@@ -1756,13 +1810,12 @@ public final class Worker {
      * Complete the alter / reset offsets callback with a potential-success or a definite-success message.
      *
      * @param alterOffsetsResult the result of the call to {@link SinkConnector#alterOffsets} / {@link SourceConnector#alterOffsets}
-     * @param isReset whether this callback if for an offsets reset operation
+     * @param modificationType the verb describing what was done to the offsets ("reset", "altered", or "set")
      * @param cb the callback to complete
      *
      * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect">KIP-875</a>
      */
-    private void completeModifyOffsetsCallback(boolean alterOffsetsResult, boolean isReset, Callback<Message> cb) {
-        String modificationType = isReset ? "reset" : "altered";
+    private void completeModifyOffsetsCallback(boolean alterOffsetsResult, String modificationType, Callback<Message> cb) {
         if (alterOffsetsResult) {
             cb.onCompletion(null, new Message("The offsets for this connector have been " + modificationType + " successfully"));
         } else {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1088,16 +1088,23 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     @Override
     public void putConnectorConfig(final String connName, final Map<String, String> config, final boolean allowReplace,
                                    final Callback<Created<ConnectorInfo>> callback) {
-        putConnectorConfig(connName, config, null, allowReplace, callback);
+        putConnectorConfig(connName, config, null, null, allowReplace, callback);
     }
 
     @Override
     public void putConnectorConfig(final String connName, final Map<String, String> config, final TargetState targetState,
                                    final boolean allowReplace, final Callback<Created<ConnectorInfo>> callback) {
+        putConnectorConfig(connName, config, targetState, null, allowReplace, callback);
+    }
+
+    @Override
+    public void putConnectorConfig(final String connName, final Map<String, String> config, final TargetState targetState,
+                                   final Map<Map<String, ?>, Map<String, ?>> initialOffsets, final boolean allowReplace,
+                                   final Callback<Created<ConnectorInfo>> callback) {
         log.trace("Submitting connector config write request {}", connName);
         addRequest(
             () -> {
-                doPutConnectorConfig(connName, config, targetState, allowReplace, callback);
+                doPutConnectorConfig(connName, config, targetState, initialOffsets, allowReplace, callback);
                 return null;
             },
             forwardErrorAndTickThreadStages(callback)
@@ -1119,7 +1126,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 callback.onCompletion(new NotFoundException("Connector " + connName + " not found", null), null);
             } else {
                 Map<String, String> patchedConfig = ConnectUtils.patchConfig(connectorInfo.config(), configPatch);
-                doPutConnectorConfig(connName, patchedConfig, null, true, callback);
+                doPutConnectorConfig(connName, patchedConfig, null, null, true, callback);
             }
             return null;
         }, forwardErrorAndTickThreadStages(callback));
@@ -1128,7 +1135,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private void doPutConnectorConfig(
             String connName,
             Map<String, String> config,
-            TargetState targetState, boolean allowReplace,
+            TargetState targetState,
+            Map<Map<String, ?>, Map<String, ?>> initialOffsets,
+            boolean allowReplace,
             Callback<Created<ConnectorInfo>> callback) {
         validateConnectorConfig(config, callback.chainStaging((error, configInfos) -> {
             if (error != null) {
@@ -1146,33 +1155,110 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         }
 
                         log.trace("Handling connector config request {}", connName);
-                        if (!isLeader()) {
-                            callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
-                            return null;
-                        }
-                        boolean exists = configState.contains(connName);
-                        if (!allowReplace && exists) {
-                            callback.onCompletion(new AlreadyExistsException("Connector " + connName + " already exists"), null);
+                        if (!putConnectorConfigChecks(connName, allowReplace, callback)) {
                             return null;
                         }
 
-                        log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
-                        writeToConfigTopicAsLeader(
-                                "writing a config for connector " + connName + " to the config topic",
-                                () -> configBackingStore.putConnectorConfig(connName, config, targetState)
-                        );
-
-                        // Note that we use the updated connector config despite the fact that we don't have an updated
-                        // snapshot yet. The existing task info should still be accurate.
-                        ConnectorInfo info = new ConnectorInfo(connName, config, configState.tasks(connName),
-                                connectorType(config));
-                        callback.onCompletion(null, new Created<>(!exists, info));
+                        if (initialOffsets == null) {
+                            writeConnectorConfigAndComplete(connName, config, targetState, allowReplace, null, callback);
+                        } else {
+                            setInitialOffsetsThenWriteConfig(connName, config, targetState, initialOffsets, allowReplace, callback);
+                        }
                         return null;
                     },
                     forwardErrorAndTickThreadStages(callback)
             );
         }));
     }
+
+    /**
+     * Perform the checks required before writing a connector's config as the leader, completing {@code callback}
+     * exceptionally if any of them fail.
+     *
+     * @param connName the name of the connector whose config is to be written
+     * @param allowReplace whether an existing connector with this name may be overwritten
+     * @param callback callback to complete exceptionally if a check fails
+     * @return true if all the checks passed, false otherwise
+     */
+    private boolean putConnectorConfigChecks(String connName, boolean allowReplace, Callback<Created<ConnectorInfo>> callback) {
+        if (!isLeader()) {
+            callback.onCompletion(new NotLeaderException("Only the leader can set connector configs.", leaderUrl()), null);
+            return false;
+        }
+        if (!allowReplace && configState.contains(connName)) {
+            callback.onCompletion(new AlreadyExistsException("Connector " + connName + " already exists"), null);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Write a connector's initial offsets and, once they are durable, write its config. Must be invoked on the tick thread.
+     * <p>
+     * The offsets are written asynchronously, so the config write is handed back to the tick thread via a nested request
+     * rather than blocking it; this mirrors the {@link #modifyConnectorOffsets} plus zombie fencing flow, including the
+     * re-check of preconditions that may have changed while the offsets were being written.
+     */
+    private void setInitialOffsetsThenWriteConfig(String connName, Map<String, String> config, TargetState targetState,
+                                                  Map<Map<String, ?>, Map<String, ?>> initialOffsets, boolean allowReplace,
+                                                  Callback<Created<ConnectorInfo>> callback) {
+        // Validate before anything destructive happens, so an invalid request can't wipe the connector's offsets. This
+        // performs no I/O and is safe to run on the tick thread; throwing here is forwarded to the callback by the
+        // enclosing herder request.
+        validateInitialOffsets(connName, initialOffsets);
+
+        try (TickThreadStage stage = new TickThreadStage("setting initial offsets for connector " + connName)) {
+            setInitialConnectorOffsets(connName, config, initialOffsets, (offsetsError, message) -> {
+                if (offsetsError != null) {
+                    callback.onCompletion(offsetsError, null);
+                    return;
+                }
+                addRequest(
+                    () -> {
+                        if (!putConnectorConfigChecks(connName, allowReplace, callback)) {
+                            return null;
+                        }
+                        try {
+                            writeConnectorConfigAndComplete(connName, config, targetState, allowReplace, message.message(), callback);
+                        } catch (Throwable t) {
+                            // The offsets are durable but the connector was not created, so wipe them back
+                            // out to avoid leaving offsets behind for a connector that doesn't exist
+                            wipeInitialOffsetsAfterFailedCreate(connName, config, t, callback);
+                        }
+                        return null;
+                    },
+                    forwardErrorAndTickThreadStages(callback)
+                );
+            });
+        }
+    }
+
+    /**
+     * Write a connector's config to the config topic and complete {@code callback} with the resulting
+     * {@link ConnectorInfo}. Must be invoked on the tick thread.
+     *
+     * @param offsetsStatus the outcome of writing the connector's initial offsets, to be reported back on the created
+     *                      {@link ConnectorInfo}; {@code null} if the request did not supply initial offsets, in which
+     *                      case the response is identical to one for a creation without initial offsets
+     */
+    private void writeConnectorConfigAndComplete(String connName, Map<String, String> config, TargetState targetState,
+                                                 boolean allowReplace, String offsetsStatus, Callback<Created<ConnectorInfo>> callback) {
+        // Must be read before the write, which may update the snapshot and make every connector look pre-existing
+        boolean exists = configState.contains(connName);
+
+        log.trace("Submitting connector config {} {} {}", connName, allowReplace, configState.connectors());
+        writeToConfigTopicAsLeader(
+                "writing a config for connector " + connName + " to the config topic",
+                () -> configBackingStore.putConnectorConfig(connName, config, targetState)
+        );
+
+        // Note that we use the updated connector config despite the fact that we don't have an updated
+        // snapshot yet. The existing task info should still be accurate.
+        ConnectorInfo info = new ConnectorInfo(connName, config, configState.tasks(connName),
+                connectorType(config), offsetsStatus);
+        callback.onCompletion(null, new Created<>(!exists, info));
+    }
+
     @Override
     public void stopConnector(final String connName, final Callback<Void> callback) {
         log.trace("Submitting request to transition connector {} to STOPPED state", connName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1215,14 +1215,16 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 }
                 addRequest(
                     () -> {
-                        if (!putConnectorConfigChecks(connName, allowReplace, callback)) {
+                        // The offsets are already durable, so wipe them back out if the create can't be completed,
+                        // whether because the precondition re-check fails here or the config write below throws.
+                        Callback<Created<ConnectorInfo>> wipeOnFailure = (error, ignored) ->
+                            wipeInitialOffsetsAfterFailedCreate(connName, config, error, callback);
+                        if (!putConnectorConfigChecks(connName, allowReplace, wipeOnFailure)) {
                             return null;
                         }
                         try {
                             writeConnectorConfigAndComplete(connName, config, targetState, allowReplace, message.message(), callback);
                         } catch (Throwable t) {
-                            // The offsets are durable but the connector was not created, so wipe them back
-                            // out to avoid leaving offsets behind for a connector that doesn't exist
                             wipeInitialOffsetsAfterFailedCreate(connName, config, t, callback);
                         }
                         return null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorInfo.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorInfo.java
@@ -18,15 +18,56 @@ package org.apache.kafka.connect.runtime.rest.entities;
 
 import org.apache.kafka.connect.util.ConnectorTaskId;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Information about a connector, returned by several REST endpoints. {@code offsetsStatus} is populated only by
+ * {@code POST /connectors} when the request supplied {@code initial_offsets}, and is omitted from the response
+ * otherwise, so the other endpoints returning this type are unchanged.
+ */
 public record ConnectorInfo(
     @JsonProperty("name") String name,
     @JsonProperty("config") Map<String, String> config,
     @JsonProperty("tasks") List<ConnectorTaskId> tasks,
-    @JsonProperty("type") ConnectorType type
+    @JsonProperty("type") ConnectorType type,
+    @JsonProperty("offsets_status") @JsonInclude(JsonInclude.Include.NON_NULL) String offsetsStatus
 ) {
+    /**
+     * Canonical constructor, declared explicitly and annotated so that Jackson unambiguously uses it as the creator
+     * rather than having to choose between this and the convenience constructor below. Deserialization matters here
+     * because a worker that is not the leader forwards requests and parses the leader's response body into this type.
+     */
+    @JsonCreator
+    public ConnectorInfo(
+        @JsonProperty("name") String name,
+        @JsonProperty("config") Map<String, String> config,
+        @JsonProperty("tasks") List<ConnectorTaskId> tasks,
+        @JsonProperty("type") ConnectorType type,
+        @JsonProperty("offsets_status") String offsetsStatus
+    ) {
+        this.name = name;
+        this.config = config;
+        this.tasks = tasks;
+        this.type = type;
+        this.offsetsStatus = offsetsStatus;
+    }
+
+    /**
+     * Convenience constructor for the endpoints that have no offsets status to report.
+     */
+    public ConnectorInfo(String name, Map<String, String> config, List<ConnectorTaskId> tasks, ConnectorType type) {
+        this(name, config, tasks, type, null);
+    }
+
+    /**
+     * @return a copy of this instance carrying the given offsets status
+     */
+    public ConnectorInfo withOffsetsStatus(String offsetsStatus) {
+        return new ConnectorInfo(name, config, tasks, type, offsetsStatus);
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequest.java
@@ -21,16 +21,52 @@ import org.apache.kafka.connect.runtime.TargetState;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 public record CreateConnectorRequest(
     @JsonProperty("name") String name,
     @JsonProperty("config") Map<String, String> config,
-    @JsonProperty("initial_state") InitialState initialState
+    @JsonProperty("initial_state") InitialState initialState,
+    @JsonProperty("initial_offsets") List<ConnectorOffset> initialOffsets
 ) {
+    /**
+     * Canonical constructor, declared explicitly and annotated so that Jackson unambiguously uses it as the creator
+     * rather than having to choose between this and the convenience constructor below.
+     */
+    @JsonCreator
+    public CreateConnectorRequest(
+        @JsonProperty("name") String name,
+        @JsonProperty("config") Map<String, String> config,
+        @JsonProperty("initial_state") InitialState initialState,
+        @JsonProperty("initial_offsets") List<ConnectorOffset> initialOffsets
+    ) {
+        this.name = name;
+        this.config = config;
+        this.initialState = initialState;
+        this.initialOffsets = initialOffsets;
+    }
+
+    /**
+     * Convenience constructor for requests that do not specify initial offsets.
+     */
+    public CreateConnectorRequest(String name, Map<String, String> config, InitialState initialState) {
+        this(name, config, initialState, null);
+    }
+
     public TargetState initialTargetState() {
         return initialState != null ? initialState.toTargetState() : null;
+    }
+
+    /**
+     * @return the initial offsets for this connector in the form used by the {@link org.apache.kafka.connect.runtime.Herder}
+     * and {@link org.apache.kafka.connect.runtime.Worker} offset APIs, or null if no initial offsets were specified.
+     * Note that a null return value (field absent) is distinct from an empty map (field present but empty), which is
+     * rejected as an invalid request.
+     */
+    public Map<Map<String, ?>, Map<String, ?>> initialOffsetsMap() {
+        return initialOffsets != null ? new ConnectorOffsets(initialOffsets).toMap() : null;
     }
 
     public enum InitialState {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -148,7 +148,7 @@ public class ConnectorsResource {
         checkAndPutConnectorConfigName(name, configs);
 
         FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>();
-        herder.putConnectorConfig(name, configs, createRequest.initialTargetState(), false, cb);
+        herder.putConnectorConfig(name, configs, createRequest.initialTargetState(), createRequest.initialOffsetsMap(), false, cb);
         Herder.Created<ConnectorInfo> info = requestHandler.completeOrForwardRequest(cb, "/connectors", "POST", headers, createRequest,
                 new TypeReference<>() { }, new CreatedConnectorInfoTranslator(), forward);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -197,12 +197,19 @@ public final class StandaloneHerder extends AbstractHerder {
                                                 final Map<String, String> config,
                                                 boolean allowReplace,
                                                 final Callback<Created<ConnectorInfo>> callback) {
-        putConnectorConfig(connName, config, null, allowReplace, callback);
+        putConnectorConfig(connName, config, null, null, allowReplace, callback);
     }
 
     @Override
     public void putConnectorConfig(final String connName, final Map<String, String> config, final TargetState targetState,
                                    final boolean allowReplace, final Callback<Created<ConnectorInfo>> callback) {
+        putConnectorConfig(connName, config, targetState, null, allowReplace, callback);
+    }
+
+    @Override
+    public void putConnectorConfig(final String connName, final Map<String, String> config, final TargetState targetState,
+                                   final Map<Map<String, ?>, Map<String, ?>> initialOffsets, final boolean allowReplace,
+                                   final Callback<Created<ConnectorInfo>> callback) {
         try {
             validateConnectorConfig(config, (error, configInfos) -> {
                 if (error != null) {
@@ -211,7 +218,7 @@ public final class StandaloneHerder extends AbstractHerder {
                 }
 
                 requestExecutorService.submit(
-                    () -> putConnectorConfig(connName, config, targetState, allowReplace, callback, configInfos)
+                    () -> putConnectorConfig(connName, config, targetState, initialOffsets, allowReplace, callback, configInfos)
                 );
             });
         } catch (Throwable t) {
@@ -222,6 +229,7 @@ public final class StandaloneHerder extends AbstractHerder {
     private synchronized void putConnectorConfig(String connName,
                                                  final Map<String, String> config,
                                                  TargetState targetState,
+                                                 Map<Map<String, ?>, Map<String, ?>> initialOffsets,
                                                  boolean allowReplace,
                                                  final Callback<Created<ConnectorInfo>> callback,
                                                  ConfigInfos configInfos) {
@@ -242,8 +250,55 @@ public final class StandaloneHerder extends AbstractHerder {
                 created = true;
             }
 
-            configBackingStore.putConnectorConfig(connName, config, targetState);
+            if (initialOffsets == null) {
+                writeConfigAndStartConnector(connName, config, targetState, created, null, callback);
+                return;
+            }
 
+            // Validate before anything destructive happens, so an invalid request can't wipe the connector's offsets
+            validateInitialOffsets(connName, initialOffsets);
+            setInitialConnectorOffsets(connName, config, initialOffsets, (error, message) -> {
+                if (error != null) {
+                    callback.onCompletion(error, null);
+                    return;
+                }
+                // The offsets callback fires on the worker's executor, so hop back onto the herder's single-threaded
+                // executor before writing the config; writeConfigAndStartConnector must hold this herder's monitor.
+                requestExecutorService.submit(
+                    () -> writeConfigAndStartConnector(connName, config, targetState, created, message.message(), callback)
+                );
+            });
+        } catch (Throwable t) {
+            callback.onCompletion(t, null);
+        }
+    }
+
+    /**
+     * Write the connector's config and start it. This is the last step of a connector creation, and for a creation that
+     * supplied initial offsets it runs only after those offsets have been written.
+     *
+     * @param offsetsStatus the outcome of writing the connector's initial offsets, to be reported back on the created
+     *                      {@link ConnectorInfo}; {@code null} if the request did not supply initial offsets, in which
+     *                      case the response is identical to one for a creation without initial offsets
+     */
+    private synchronized void writeConfigAndStartConnector(String connName,
+                                                           Map<String, String> config,
+                                                           TargetState targetState,
+                                                           boolean created,
+                                                           String offsetsStatus,
+                                                           Callback<Created<ConnectorInfo>> callback) {
+        try {
+            configBackingStore.putConnectorConfig(connName, config, targetState);
+        } catch (Throwable t) {
+            if (offsetsStatus != null) {
+                wipeInitialOffsetsAfterFailedCreate(connName, config, t, callback);
+            } else {
+                callback.onCompletion(t, null);
+            }
+            return;
+        }
+
+        try {
             startConnector(connName, (error, result) -> {
                 if (error != null) {
                     callback.onCompletion(error, null);
@@ -252,7 +307,11 @@ public final class StandaloneHerder extends AbstractHerder {
 
                 requestExecutorService.submit(() -> {
                     updateConnectorTasks(connName);
-                    callback.onCompletion(null, new Created<>(created, createConnectorInfo(connName)));
+                    ConnectorInfo info = createConnectorInfo(connName);
+                    if (offsetsStatus != null) {
+                        info = info.withOffsetsStatus(offsetsStatus);
+                    }
+                    callback.onCompletion(null, new Created<>(created, info));
                 });
             });
         } catch (Throwable t) {
@@ -277,7 +336,7 @@ public final class StandaloneHerder extends AbstractHerder {
                 }
 
                 requestExecutorService.submit(
-                        () -> putConnectorConfig(connName, patchedConfig, null, true, callback, configInfos)
+                        () -> putConnectorConfig(connName, patchedConfig, null, null, true, callback, configInfos)
                 );
             });
         } catch (Throwable e) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -49,6 +49,7 @@ import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.FutureCallback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -257,17 +259,19 @@ public final class StandaloneHerder extends AbstractHerder {
 
             // Validate before anything destructive happens, so an invalid request can't wipe the connector's offsets
             validateInitialOffsets(connName, initialOffsets);
-            setInitialConnectorOffsets(connName, config, initialOffsets, (error, message) -> {
-                if (error != null) {
-                    callback.onCompletion(error, null);
-                    return;
-                }
-                // The offsets callback fires on the worker's executor, so hop back onto the herder's single-threaded
-                // executor before writing the config; writeConfigAndStartConnector must hold this herder's monitor.
-                requestExecutorService.submit(
-                    () -> writeConfigAndStartConnector(connName, config, targetState, created, message.message(), callback)
-                );
-            });
+            // Block until the offsets are written so the whole creation completes under this herder's monitor;
+            // otherwise a concurrent request for the same connector could interleave between the offsets write
+            // and the config write.
+            FutureCallback<Message> offsetsCallback = new FutureCallback<>();
+            setInitialConnectorOffsets(connName, config, initialOffsets, offsetsCallback);
+            Message offsetsMessage;
+            try {
+                offsetsMessage = offsetsCallback.get();
+            } catch (ExecutionException e) {
+                callback.onCompletion(e.getCause(), null);
+                return;
+            }
+            writeConfigAndStartConnector(connName, config, targetState, created, offsetsMessage.message(), callback);
         } catch (Throwable t) {
             callback.onCompletion(t, null);
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectWorkerIntegrationTest.java
@@ -753,6 +753,95 @@ public class ConnectWorkerIntegrationTest {
     }
 
     @Test
+    public void testCreateSourceConnectorWithInitialOffsets() throws Exception {
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
+        Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
+        // Configure the connector to produce a maximum of 10 messages
+        props.put("max.messages", "10");
+        props.put(TASKS_MAX_CONFIG, "1");
+
+        // Create the connector already positioned at offset 5. The TestableSourceConnector produces messages with
+        // sequence numbers starting after the supplied offset, so it should produce only the last 5 of its 10 messages.
+        CreateConnectorRequest createConnectorRequest = new CreateConnectorRequest(
+            CONNECTOR_NAME,
+            props,
+            null,
+            List.of(new ConnectorOffset(Map.of("task.id", CONNECTOR_NAME + "-0"), Map.of("saved", 5L)))
+        );
+        String response = connect.configureConnector(createConnectorRequest);
+        // The creation response must carry offsets_status because initial_offsets was supplied
+        assertTrue(response.contains("offsets_status"),
+            "Create response should include offsets_status when initial_offsets is supplied: " + response);
+
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+            CONNECTOR_NAME,
+            1,
+            "Connector or tasks did not start running healthily in time"
+        );
+
+        // Verify that only 5 messages were produced, i.e. the connector started from the supplied initial offset
+        // rather than from the beginning. We consume 5 first to ensure at least 5 are available before counting all.
+        long timeoutMs = TimeUnit.SECONDS.toMillis(10);
+        connect.kafka().consume(5, timeoutMs, TOPIC_NAME);
+        assertEquals(5, connect.kafka().consumeAll(timeoutMs, TOPIC_NAME).count());
+    }
+
+    @Test
+    public void testCreateSinkConnectorWithInitialOffsets() throws Exception {
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
+        // Create topic and produce 10 messages
+        connect.kafka().createTopic(TOPIC_NAME);
+        for (int i = 0; i < 10; i++) {
+            connect.kafka().produce(TOPIC_NAME, "Message " + i);
+        }
+
+        Map<String, String> props = defaultSinkConnectorProps(TOPIC_NAME);
+        props.put(TASKS_MAX_CONFIG, "1");
+
+        // This will cause the connector task to fail if it encounters a record with offset < 5
+        TaskHandle taskHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME).taskHandle(CONNECTOR_NAME + "-0",
+            sinkRecord -> {
+                if (sinkRecord.kafkaOffset() < 5L) {
+                    throw new ConnectException("Unexpected record encountered: " + sinkRecord);
+                }
+            });
+        // We produced 10 records and create the connector already positioned at offset 5, so we expect only the last 5 to be consumed
+        taskHandle.expectedRecords(5);
+
+        Map<String, Object> partition = new HashMap<>();
+        partition.put(SinkUtils.KAFKA_TOPIC_KEY, TOPIC_NAME);
+        partition.put(SinkUtils.KAFKA_PARTITION_KEY, 0);
+        CreateConnectorRequest createConnectorRequest = new CreateConnectorRequest(
+            CONNECTOR_NAME,
+            props,
+            null,
+            List.of(new ConnectorOffset(partition, Map.of(SinkUtils.KAFKA_OFFSET_KEY, 5)))
+        );
+        connect.configureConnector(createConnectorRequest);
+
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+            CONNECTOR_NAME,
+            1,
+            "Connector or tasks did not start running healthily in time"
+        );
+
+        taskHandle.awaitRecords(TimeUnit.SECONDS.toMillis(10));
+
+        // Confirm that the task is still running (i.e. it didn't fail due to encountering any records with offset < 5)
+        connect.assertions().assertConnectorAndExactlyNumTasksAreRunning(
+            CONNECTOR_NAME,
+            1,
+            "Connector or tasks did not start running healthily in time"
+        );
+    }
+
+    @Test
     public void testPatchConnectorConfig() throws Exception {
         connect = connectBuilder.build();
         // start the clusters

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RestForwardingIntegrationTest.java
@@ -195,7 +195,7 @@ public class RestForwardingIntegrationTest {
             followerCallbackCaptor.getValue().onCompletion(forwardException, null);
             return null;
         }).when(followerHerder)
-                .putConnectorConfig(any(), any(), isNull(), anyBoolean(), followerCallbackCaptor.capture());
+                .putConnectorConfig(any(), any(), isNull(), isNull(), anyBoolean(), followerCallbackCaptor.capture());
 
         // Leader will reply
         ConnectorInfo connectorInfo = new ConnectorInfo("blah", Map.of(), List.of(), ConnectorType.SOURCE);
@@ -205,7 +205,7 @@ public class RestForwardingIntegrationTest {
             leaderCallbackCaptor.getValue().onCompletion(null, leaderAnswer);
             return null;
         }).when(leaderHerder)
-                .putConnectorConfig(any(), any(), isNull(), anyBoolean(), leaderCallbackCaptor.capture());
+                .putConnectorConfig(any(), any(), isNull(), isNull(), anyBoolean(), leaderCallbackCaptor.capture());
 
         // Client makes request to the follower
         URI followerUrl = followerServer.advertisedUrl();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -68,6 +68,7 @@ import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorOffsets;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.Message;
+import org.apache.kafka.connect.runtime.rest.errors.BadRequestException;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -2630,6 +2631,276 @@ public class WorkerTest {
         assertEquals(ConnectException.class, e.getCause().getClass());
 
         verify(admin, timeout(1000)).close();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SuppressWarnings("unchecked")
+    public void testReplaceOffsetsSourceConnectorWipesStalePartitions(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        mockInternalConverters();
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newSingleThreadExecutor(),
+                allConnectorClientConfigOverridePolicy, null);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+        when(sourceConnector.alterOffsets(eq(connectorProps), anyMap())).thenReturn(true);
+        ConnectorOffsetBackingStore offsetStore = mock(ConnectorOffsetBackingStore.class);
+        KafkaProducer<byte[], byte[]> producer = mock(KafkaProducer.class);
+        OffsetStorageWriter offsetWriter = mock(OffsetStorageWriter.class);
+
+        Map<String, Object> p1 = Map.of("partitionKey", "p1");
+        Map<String, Object> p2 = Map.of("partitionKey", "p2");
+        Map<String, Object> p3 = Map.of("partitionKey", "p3");
+        Set<Map<String, Object>> existingPartitions = new HashSet<>();
+        existingPartitions.add(p1);
+        existingPartitions.add(p2);
+        when(offsetStore.connectorPartitions(eq(CONNECTOR_ID))).thenReturn(existingPartitions);
+
+        // p2 already existed and is being re-requested with a new value; p3 is brand new; p1 existed but isn't
+        // requested, so it should be wiped rather than left behind
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = new HashMap<>();
+        requestedOffsets.put(p2, Map.of("offsetKey", "newP2"));
+        requestedOffsets.put(p3, Map.of("offsetKey", "p3"));
+
+        when(offsetWriter.doFlush(any())).thenAnswer(invocation -> {
+            invocation.getArgument(0, Callback.class).onCompletion(null, null);
+            return null;
+        });
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySourceConnectorOffsets(CONNECTOR_ID, sourceConnector, connectorProps, requestedOffsets, true, offsetStore, producer,
+                offsetWriter, Thread.currentThread().getContextClassLoader(), cb);
+        assertEquals("The offsets for this connector have been set successfully", cb.get(1000, TimeUnit.MILLISECONDS).message());
+
+        verify(offsetWriter).offset(p1, null);
+        verify(offsetWriter).offset(p2, Map.of("offsetKey", "newP2"));
+        verify(offsetWriter).offset(p3, Map.of("offsetKey", "p3"));
+        verify(offsetWriter, times(3)).offset(any(), any());
+        verify(offsetWriter).beginFlush();
+        verify(offsetStore, timeout(1000)).stop();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SuppressWarnings("unchecked")
+    public void testReplaceOffsetsSourceConnectorNoPreexistingOffsets(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        mockInternalConverters();
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newSingleThreadExecutor(),
+                allConnectorClientConfigOverridePolicy, null);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+        when(sourceConnector.alterOffsets(eq(connectorProps), anyMap())).thenReturn(true);
+        ConnectorOffsetBackingStore offsetStore = mock(ConnectorOffsetBackingStore.class);
+        KafkaProducer<byte[], byte[]> producer = mock(KafkaProducer.class);
+        OffsetStorageWriter offsetWriter = mock(OffsetStorageWriter.class);
+
+        // No pre-existing offsets for this connector -- there's nothing to wipe, only something to write
+        when(offsetStore.connectorPartitions(eq(CONNECTOR_ID))).thenReturn(Set.of());
+
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = Map.of(
+                Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+
+        when(offsetWriter.doFlush(any())).thenAnswer(invocation -> {
+            invocation.getArgument(0, Callback.class).onCompletion(null, null);
+            return null;
+        });
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySourceConnectorOffsets(CONNECTOR_ID, sourceConnector, connectorProps, requestedOffsets, true, offsetStore, producer,
+                offsetWriter, Thread.currentThread().getContextClassLoader(), cb);
+        assertEquals("The offsets for this connector have been set successfully", cb.get(1000, TimeUnit.MILLISECONDS).message());
+
+        // The write must still happen even though there was nothing to wipe -- guards against the "no offsets to
+        // write" shortcut (meant for a reset of a connector with no committed offsets) swallowing a genuine write.
+        verify(offsetWriter).offset(Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+        verify(offsetWriter).beginFlush();
+        verify(offsetWriter).doFlush(any());
+        verify(offsetStore, timeout(1000)).stop();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testReplaceOffsetsSinkConnectorWipesStalePartitions(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        String connectorClass = SampleSinkConnector.class.getName();
+        connectorProps.put(CONNECTOR_CLASS_CONFIG, connectorClass);
+
+        Admin admin = mock(Admin.class);
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newCachedThreadPool(),
+                allConnectorClientConfigOverridePolicy, config -> admin);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+        when(sinkConnector.alterOffsets(eq(connectorProps), anyMap())).thenReturn(true);
+
+        TopicPartition p1 = new TopicPartition("test_topic", 1);
+        TopicPartition p2 = new TopicPartition("test_topic", 2);
+        TopicPartition p3 = new TopicPartition("test_topic", 3);
+        mockAdminListConsumerGroupOffsets(admin, Map.of(p1, new OffsetAndMetadata(10L), p2, new OffsetAndMetadata(20L)), null);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> alterOffsetsMapCapture = ArgumentCaptor.forClass(Map.class);
+        AlterConsumerGroupOffsetsResult alterConsumerGroupOffsetsResult = mock(AlterConsumerGroupOffsetsResult.class);
+        when(admin.alterConsumerGroupOffsets(anyString(), alterOffsetsMapCapture.capture(), any(AlterConsumerGroupOffsetsOptions.class)))
+                .thenReturn(alterConsumerGroupOffsetsResult);
+        when(alterConsumerGroupOffsetsResult.all()).thenReturn(KafkaFuture.completedFuture(null));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<TopicPartition>> deleteOffsetsSetCapture = ArgumentCaptor.forClass(Set.class);
+        DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = mock(DeleteConsumerGroupOffsetsResult.class);
+        when(admin.deleteConsumerGroupOffsets(anyString(), deleteOffsetsSetCapture.capture(), any(DeleteConsumerGroupOffsetsOptions.class)))
+                .thenReturn(deleteConsumerGroupOffsetsResult);
+        when(deleteConsumerGroupOffsetsResult.all()).thenReturn(KafkaFuture.completedFuture(null));
+
+        // p2 already existed and is being re-requested with a new value; p3 is brand new; p1 existed but isn't
+        // requested, so it should be wiped rather than left behind
+        Map<String, String> partitionMap2 = new HashMap<>();
+        partitionMap2.put(SinkUtils.KAFKA_TOPIC_KEY, "test_topic");
+        partitionMap2.put(SinkUtils.KAFKA_PARTITION_KEY, "2");
+        Map<String, String> partitionMap3 = new HashMap<>();
+        partitionMap3.put(SinkUtils.KAFKA_TOPIC_KEY, "test_topic");
+        partitionMap3.put(SinkUtils.KAFKA_PARTITION_KEY, "3");
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = new HashMap<>();
+        requestedOffsets.put(partitionMap2, Map.of(SinkUtils.KAFKA_OFFSET_KEY, 99));
+        requestedOffsets.put(partitionMap3, Map.of(SinkUtils.KAFKA_OFFSET_KEY, 5));
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySinkConnectorOffsets(CONNECTOR_ID, sinkConnector, connectorProps, requestedOffsets, true,
+                Thread.currentThread().getContextClassLoader(), cb);
+        assertEquals("The offsets for this connector have been set successfully", cb.get(1000, TimeUnit.MILLISECONDS).message());
+
+        assertEquals(Set.of(p1), deleteOffsetsSetCapture.getValue());
+        assertEquals(2, alterOffsetsMapCapture.getValue().size());
+        assertEquals(99, alterOffsetsMapCapture.getValue().get(p2).offset());
+        assertEquals(5, alterOffsetsMapCapture.getValue().get(p3).offset());
+
+        verify(admin, timeout(1000)).close();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testReplaceOffsetsSinkConnectorNoPreexistingOffsets(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        String connectorClass = SampleSinkConnector.class.getName();
+        connectorProps.put(CONNECTOR_CLASS_CONFIG, connectorClass);
+
+        Admin admin = mock(Admin.class);
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newCachedThreadPool(),
+                allConnectorClientConfigOverridePolicy, config -> admin);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+        when(sinkConnector.alterOffsets(eq(connectorProps), anyMap())).thenReturn(true);
+
+        // No pre-existing offsets for this consumer group -- there's nothing to wipe, only something to write
+        mockAdminListConsumerGroupOffsets(admin, Map.of(), null);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> alterOffsetsMapCapture = ArgumentCaptor.forClass(Map.class);
+        AlterConsumerGroupOffsetsResult alterConsumerGroupOffsetsResult = mock(AlterConsumerGroupOffsetsResult.class);
+        when(admin.alterConsumerGroupOffsets(anyString(), alterOffsetsMapCapture.capture(), any(AlterConsumerGroupOffsetsOptions.class)))
+                .thenReturn(alterConsumerGroupOffsetsResult);
+        when(alterConsumerGroupOffsetsResult.all()).thenReturn(KafkaFuture.completedFuture(null));
+
+        TopicPartition p1 = new TopicPartition("test_topic", 1);
+        Map<String, String> partitionMap1 = new HashMap<>();
+        partitionMap1.put(SinkUtils.KAFKA_TOPIC_KEY, "test_topic");
+        partitionMap1.put(SinkUtils.KAFKA_PARTITION_KEY, "1");
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = Map.of(partitionMap1, Map.of(SinkUtils.KAFKA_OFFSET_KEY, 7));
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySinkConnectorOffsets(CONNECTOR_ID, sinkConnector, connectorProps, requestedOffsets, true,
+                Thread.currentThread().getContextClassLoader(), cb);
+        assertEquals("The offsets for this connector have been set successfully", cb.get(1000, TimeUnit.MILLISECONDS).message());
+
+        assertEquals(1, alterOffsetsMapCapture.getValue().size());
+        assertEquals(7, alterOffsetsMapCapture.getValue().get(p1).offset());
+        verify(admin, times(0)).deleteConsumerGroupOffsets(anyString(), anySet(), any(DeleteConsumerGroupOffsetsOptions.class));
+
+        verify(admin, timeout(1000)).close();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SuppressWarnings("unchecked")
+    public void testReplaceOffsetsSourceConnectorFrameworkManagedMessage(boolean enableTopicCreation) throws Exception {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        mockInternalConverters();
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newSingleThreadExecutor(),
+                allConnectorClientConfigOverridePolicy, null);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+        // A connector that does not override alterOffsets returns false, so the framework-managed message is reported
+        when(sourceConnector.alterOffsets(eq(connectorProps), anyMap())).thenReturn(false);
+        ConnectorOffsetBackingStore offsetStore = mock(ConnectorOffsetBackingStore.class);
+        KafkaProducer<byte[], byte[]> producer = mock(KafkaProducer.class);
+        OffsetStorageWriter offsetWriter = mock(OffsetStorageWriter.class);
+        when(offsetStore.connectorPartitions(eq(CONNECTOR_ID))).thenReturn(Set.of());
+
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = Map.of(
+                Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+        when(offsetWriter.doFlush(any())).thenAnswer(invocation -> {
+            invocation.getArgument(0, Callback.class).onCompletion(null, null);
+            return null;
+        });
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySourceConnectorOffsets(CONNECTOR_ID, sourceConnector, connectorProps, requestedOffsets, true, offsetStore, producer,
+                offsetWriter, Thread.currentThread().getContextClassLoader(), cb);
+        assertEquals("The Connect framework-managed offsets for this connector have been set successfully. However, if this "
+                + "connector manages offsets externally, they will need to be manually set in the system that the connector uses.",
+                cb.get(1000, TimeUnit.MILLISECONDS).message());
+
+        verify(offsetStore, timeout(1000)).stop();
+        verifyKafkaClusterId();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testReplaceOffsetsSinkConnectorInvalidOffsetFailsBeforeAnyAdminWrite(boolean enableTopicCreation) {
+        setup(enableTopicCreation);
+        mockKafkaClusterId();
+        String connectorClass = SampleSinkConnector.class.getName();
+        connectorProps.put(CONNECTOR_CLASS_CONFIG, connectorClass);
+
+        Admin admin = mock(Admin.class);
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, Executors.newCachedThreadPool(),
+                allConnectorClientConfigOverridePolicy, config -> admin);
+        worker.start();
+
+        when(plugins.withClassLoader(any(ClassLoader.class), any(Runnable.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+
+        // A malformed sink offset (partition missing the required kafka_partition key) must be rejected before the wipe
+        Map<String, String> badPartition = new HashMap<>();
+        badPartition.put(SinkUtils.KAFKA_TOPIC_KEY, "test_topic");
+        Map<Map<String, ?>, Map<String, ?>> requestedOffsets = Map.of(badPartition, Map.of(SinkUtils.KAFKA_OFFSET_KEY, 5));
+
+        FutureCallback<Message> cb = new FutureCallback<>();
+        worker.modifySinkConnectorOffsets(CONNECTOR_ID, sinkConnector, connectorProps, requestedOffsets, true,
+                Thread.currentThread().getContextClassLoader(), cb);
+
+        ExecutionException e = assertThrows(ExecutionException.class, () -> cb.get(1000, TimeUnit.MILLISECONDS));
+        assertInstanceOf(BadRequestException.class, e.getCause());
+
+        // No existing offsets may be listed/wiped and no offsets may be written when validation fails
+        verify(admin, times(0)).listConsumerGroupOffsets(anyString(), any(ListConsumerGroupOffsetsOptions.class));
+        verify(admin, times(0)).alterConsumerGroupOffsets(anyString(), anyMap(), any(AlterConsumerGroupOffsetsOptions.class));
+        verify(admin, times(0)).deleteConsumerGroupOffsets(anyString(), anySet(), any(DeleteConsumerGroupOffsetsOptions.class));
+        verify(sinkConnector, times(0)).alterOffsets(anyMap(), anyMap());
         verifyKafkaClusterId();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -80,6 +80,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -134,8 +135,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -143,6 +146,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -806,6 +810,171 @@ public class DistributedHerderTest {
                 ),
                 stages
         );
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsets() {
+        when(member.memberId()).thenReturn("leader");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        when(herder.connectorType(anyMap())).thenReturn(ConnectorType.SOURCE);
+        expectRebalance(1, List.of(), List.of(), true);
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        when(statusBackingStore.connectors()).thenReturn(Set.of());
+        expectMemberPoll();
+
+        // Initial rebalance where this member becomes the leader
+        herder.tick();
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN2_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN2_CONFIG), validateCallback.capture());
+
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets =
+                Map.of(Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+        String offsetsStatus = "The offsets for this connector have been set successfully";
+
+        // The worker writes the offsets asynchronously and completes the callback once they're durable
+        ArgumentCaptor<Callback<Message>> offsetsCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            offsetsCallback.getValue().onCompletion(null, new Message(offsetsStatus));
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), offsetsCallback.capture());
+
+        doNothing().when(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
+
+        expectMemberEnsureActive();
+        List<String> stages = expectRecordStages(putConnectorCallback);
+
+        herder.putConnectorConfig(CONN2, CONN2_CONFIG, null, initialOffsets, false, putConnectorCallback);
+        // Runs the initial herder request, which issues an asynchronous request for connector validation
+        herder.tick();
+        // Validation is complete; this tick performs the precondition checks and the offsets write, which in turn
+        // queues a third request for the config write
+        herder.tick();
+        // ...and this tick is that third request
+        herder.tick();
+
+        // The whole point of the feature: offsets must be durable before the config record makes the connector
+        // startable, otherwise it could begin running from the wrong position
+        InOrder inOrder = inOrder(worker, configBackingStore);
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), any());
+        inOrder.verify(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
+
+        ConnectorInfo info = new ConnectorInfo(CONN2, CONN2_CONFIG, List.of(), ConnectorType.SOURCE)
+                .withOffsetsStatus(offsetsStatus);
+        verify(putConnectorCallback).onCompletion(isNull(), eq(new Herder.Created<>(true, info)));
+
+        // Distinct because the mocked worker completes the offsets callback synchronously, while the "setting initial
+        // offsets" stage is still open, so that stage is reported both to the in-progress request and to the config
+        // write request queued from within it. The real worker completes on another thread once the stage has closed.
+        assertEquals(
+                List.of(
+                        "ensuring membership in the cluster",
+                        "setting initial offsets for connector " + CONN2,
+                        "writing a config for connector " + CONN2 + " to the config topic"
+                ),
+                stages.stream().distinct().toList()
+        );
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsetsNullOffsetValue() {
+        when(member.memberId()).thenReturn("leader");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        expectRebalance(1, List.of(), List.of(), true);
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        when(statusBackingStore.connectors()).thenReturn(Set.of());
+        expectMemberPoll();
+
+        herder.tick();
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN2_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN2_CONFIG), validateCallback.capture());
+
+        expectMemberEnsureActive();
+        expectRecordStages(putConnectorCallback);
+
+        // A null offset means "delete this partition's offset" when altering, but is meaningless on create: the wipe
+        // has already removed every partition. Rejected up front so that nothing destructive has happened yet.
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets = new HashMap<>();
+        initialOffsets.put(Map.of("partitionKey", "partitionValue"), null);
+
+        herder.putConnectorConfig(CONN2, CONN2_CONFIG, null, initialOffsets, false, putConnectorCallback);
+        herder.tick();
+        herder.tick();
+
+        ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+        verify(putConnectorCallback).onCompletion(error.capture(), isNull());
+        assertInstanceOf(BadRequestException.class, error.getValue());
+
+        // Neither the offsets nor the config may be touched by a request that failed validation
+        verify(worker, never()).modifyConnectorOffsets(anyString(), anyMap(), anyMap(), anyBoolean(), any());
+        verify(configBackingStore, never()).putConnectorConfig(anyString(), anyMap(), any());
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsetsConfigWriteFails() {
+        when(member.memberId()).thenReturn("leader");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        expectRebalance(1, List.of(), List.of(), true);
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        when(statusBackingStore.connectors()).thenReturn(Set.of());
+        expectMemberPoll();
+
+        herder.tick();
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN2_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN2_CONFIG), validateCallback.capture());
+
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets =
+                Map.of(Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+
+        ArgumentCaptor<Callback<Message>> offsetsCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            offsetsCallback.getValue().onCompletion(null, new Message("The offsets for this connector have been set successfully"));
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), offsetsCallback.capture());
+
+        // The offsets land, but the config write then fails
+        doThrow(new ConnectException("Test exception")).when(configBackingStore)
+                .putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
+
+        // If the config write fails, the offsets written in the previous step are wiped as cleanup
+        ArgumentCaptor<Callback<Message>> wipeCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            wipeCallback.getValue().onCompletion(null, new Message("The offsets for this connector have been reset successfully"));
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), isNull(), wipeCallback.capture());
+
+        expectMemberEnsureActive();
+        expectRecordStages(putConnectorCallback);
+
+        herder.putConnectorConfig(CONN2, CONN2_CONFIG, null, initialOffsets, false, putConnectorCallback);
+        herder.tick();
+        herder.tick();
+        herder.tick();
+
+        // The offsets that were just written must be wiped back out, so a failed create leaves nothing behind
+        InOrder inOrder = inOrder(worker, configBackingStore);
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), any());
+        inOrder.verify(configBackingStore).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), isNull());
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), isNull(), any());
+
+        // The caller sees the original config-write failure, not the outcome of the cleanup
+        ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+        verify(putConnectorCallback).onCompletion(error.capture(), isNull());
+        assertInstanceOf(ConnectException.class, error.getValue());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -107,6 +107,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -975,6 +976,66 @@ public class DistributedHerderTest {
         ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
         verify(putConnectorCallback).onCompletion(error.capture(), isNull());
         assertInstanceOf(ConnectException.class, error.getValue());
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsetsPreconditionRecheckFails() {
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        expectRebalance(1, List.of(), List.of(), true);
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        when(statusBackingStore.connectors()).thenReturn(Set.of());
+        expectMemberPoll();
+
+        // Leadership is held when the request starts but is lost after the offsets are written (below), so the
+        // precondition re-check before the config write fails
+        AtomicBoolean leader = new AtomicBoolean(true);
+        doAnswer(invocation -> leader.get()).when(herder).isLeader();
+
+        herder.tick();
+
+        ArgumentCaptor<Callback<ConfigInfos>> validateCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            validateCallback.getValue().onCompletion(null, CONN2_CONFIG_INFOS);
+            return null;
+        }).when(herder).validateConnectorConfig(eq(CONN2_CONFIG), validateCallback.capture());
+
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets =
+                Map.of(Map.of("partitionKey", "partitionValue"), Map.of("offsetKey", "offsetValue"));
+
+        ArgumentCaptor<Callback<Message>> offsetsCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            offsetsCallback.getValue().onCompletion(null, new Message("The offsets for this connector have been set successfully"));
+            leader.set(false);
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), offsetsCallback.capture());
+
+        // The offsets written in the previous step are wiped once the re-check fails
+        ArgumentCaptor<Callback<Message>> wipeCallback = ArgumentCaptor.forClass(Callback.class);
+        doAnswer(invocation -> {
+            wipeCallback.getValue().onCompletion(null, new Message("The offsets for this connector have been reset successfully"));
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), isNull(), wipeCallback.capture());
+
+        expectMemberEnsureActive();
+        expectRecordStages(putConnectorCallback);
+
+        herder.putConnectorConfig(CONN2, CONN2_CONFIG, null, initialOffsets, false, putConnectorCallback);
+        herder.tick();
+        herder.tick();
+        herder.tick();
+
+        // The offsets were written, the config was never written because the re-check failed, and the offsets
+        // were wiped back out
+        InOrder inOrder = inOrder(worker, configBackingStore);
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), eq(initialOffsets), eq(true), any());
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONN2), eq(CONN2_CONFIG), isNull(), any());
+        verify(configBackingStore, never()).putConnectorConfig(eq(CONN2), eq(CONN2_CONFIG), any());
+
+        // The caller sees the precondition failure that stopped the create
+        ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+        verify(putConnectorCallback).onCompletion(error.capture(), isNull());
+        assertInstanceOf(NotLeaderException.class, error.getValue());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorInfoTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/ConnectorInfoTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.rest.entities;
+
+import org.apache.kafka.connect.util.ConnectorTaskId;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConnectorInfoTest {
+
+    // A bare ObjectMapper, matching what RestClient and the EmbeddedConnect test fixture use, so these tests exercise
+    // the same (de)serialization behaviour as the follower -> leader forwarding path.
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String NAME = "source-1";
+    private static final Map<String, String> CONFIG = Map.of("connector.class", "FileStreamSource");
+    private static final List<ConnectorTaskId> TASKS = List.of(new ConnectorTaskId(NAME, 0));
+
+    @Test
+    public void testConvenienceConstructorLeavesOffsetsStatusNull() {
+        ConnectorInfo info = new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE);
+        assertNull(info.offsetsStatus());
+    }
+
+    @Test
+    public void testOffsetsStatusOmittedWhenNull() throws Exception {
+        // Endpoints other than POST /connectors never set an offsets status, so their response bodies must be
+        // byte-for-byte unchanged by the addition of this field.
+        String serialized = OBJECT_MAPPER.writeValueAsString(new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE));
+
+        assertFalse(serialized.contains("offsets_status"),
+            "offsets_status must be omitted when null: " + serialized);
+        assertTrue(serialized.contains("\"name\""));
+        assertTrue(serialized.contains("\"config\""));
+        assertTrue(serialized.contains("\"tasks\""));
+        assertTrue(serialized.contains("\"type\""));
+    }
+
+    @Test
+    public void testOffsetsStatusPresentWhenSet() throws Exception {
+        String status = "The offsets for this connector have been set successfully";
+        String serialized = OBJECT_MAPPER.writeValueAsString(
+            new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE, status));
+
+        assertTrue(serialized.contains("\"offsets_status\""), serialized);
+        assertTrue(serialized.contains(status), serialized);
+    }
+
+    @Test
+    public void testRoundTripWithOffsetsStatus() throws Exception {
+        // Deserialization matters because a worker that is not the leader forwards POST /connectors and parses the
+        // leader's response body into this type with a bare ObjectMapper.
+        ConnectorInfo original = new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE, "offsets set");
+
+        String serialized = OBJECT_MAPPER.writeValueAsString(original);
+        ConnectorInfo roundTripped = OBJECT_MAPPER.readValue(serialized, ConnectorInfo.class);
+
+        assertEquals(original, roundTripped);
+        assertEquals("offsets set", roundTripped.offsetsStatus());
+    }
+
+    @Test
+    public void testRoundTripWithoutOffsetsStatus() throws Exception {
+        ConnectorInfo original = new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE);
+
+        String serialized = OBJECT_MAPPER.writeValueAsString(original);
+        ConnectorInfo roundTripped = OBJECT_MAPPER.readValue(serialized, ConnectorInfo.class);
+
+        assertEquals(original, roundTripped);
+        assertNull(roundTripped.offsetsStatus());
+    }
+
+    @Test
+    public void testDeserializeLegacyBodyWithoutOffsetsStatus() throws Exception {
+        // A response produced by an older worker has no offsets_status field at all. Parsing it must succeed, since a
+        // new follower may forward a request to an old leader during a rolling upgrade.
+        String json = "{\"name\": \"source-1\", \"config\": {\"connector.class\": \"FileStreamSource\"},"
+            + " \"tasks\": [{\"connector\": \"source-1\", \"task\": 0}], \"type\": \"source\"}";
+
+        ConnectorInfo info = OBJECT_MAPPER.readValue(json, ConnectorInfo.class);
+
+        assertEquals(NAME, info.name());
+        assertEquals(TASKS, info.tasks());
+        assertNull(info.offsetsStatus());
+    }
+
+    @Test
+    public void testWithOffsetsStatus() {
+        ConnectorInfo info = new ConnectorInfo(NAME, CONFIG, TASKS, ConnectorType.SOURCE);
+        ConnectorInfo withStatus = info.withOffsetsStatus("offsets set");
+
+        assertNull(info.offsetsStatus(), "withOffsetsStatus must not mutate the original");
+        assertEquals("offsets set", withStatus.offsetsStatus());
+        assertEquals(info.name(), withStatus.name());
+        assertEquals(info.config(), withStatus.config());
+        assertEquals(info.tasks(), withStatus.tasks());
+        assertEquals(info.type(), withStatus.type());
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequestTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/entities/CreateConnectorRequestTest.java
@@ -18,14 +18,25 @@ package org.apache.kafka.connect.runtime.rest.entities;
 
 import org.apache.kafka.connect.runtime.TargetState;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CreateConnectorRequestTest {
+
+    // A bare ObjectMapper, matching what RestClient and ConnectStandalone use, so that these tests exercise the same
+    // (de)serialization behaviour as the follower -> leader forwarding path and the standalone CLI.
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     public void testToTargetState() {
@@ -50,5 +61,114 @@ public class CreateConnectorRequestTest {
         assertEquals(CreateConnectorRequest.InitialState.STOPPED, CreateConnectorRequest.InitialState.forValue("stopped"));
         assertEquals(CreateConnectorRequest.InitialState.STOPPED, CreateConnectorRequest.InitialState.forValue("Stopped"));
         assertEquals(CreateConnectorRequest.InitialState.STOPPED, CreateConnectorRequest.InitialState.forValue("STOPPED"));
+    }
+
+    @Test
+    public void testThreeArgConstructorLeavesInitialOffsetsNull() {
+        CreateConnectorRequest request = new CreateConnectorRequest("test-name", Map.of(), null);
+        assertNull(request.initialOffsets());
+        assertNull(request.initialOffsetsMap());
+    }
+
+    @Test
+    public void testDeserializeSourceInitialOffsets() throws Exception {
+        String json = "{"
+            + "\"name\": \"source-1\","
+            + "\"config\": {\"connector.class\": \"FileStreamSource\"},"
+            + "\"initial_offsets\": [{\"partition\": {\"filename\": \"test.txt\"}, \"offset\": {\"position\": 4096}}]"
+            + "}";
+
+        CreateConnectorRequest request = OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class);
+
+        assertEquals("source-1", request.name());
+        assertNull(request.initialState());
+        assertEquals(1, request.initialOffsets().size());
+        assertEquals(Map.of("filename", "test.txt"), request.initialOffsets().get(0).partition());
+        assertEquals(Map.of("position", 4096), request.initialOffsets().get(0).offset());
+        assertEquals(Map.of(Map.of("filename", "test.txt"), Map.of("position", 4096)), request.initialOffsetsMap());
+    }
+
+    @Test
+    public void testDeserializeSinkInitialOffsets() throws Exception {
+        String json = "{"
+            + "\"name\": \"sink-1\","
+            + "\"config\": {\"connector.class\": \"FileStreamSink\"},"
+            + "\"initial_offsets\": [{\"partition\": {\"kafka_topic\": \"t\", \"kafka_partition\": 0},"
+            + " \"offset\": {\"kafka_offset\": 100}}]"
+            + "}";
+
+        CreateConnectorRequest request = OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class);
+
+        assertEquals(Map.of(Map.of("kafka_topic", "t", "kafka_partition", 0), Map.of("kafka_offset", 100)),
+            request.initialOffsetsMap());
+    }
+
+    @Test
+    public void testInitialOffsetsRoundTrip() throws Exception {
+        // Serialize then deserialize. This pins Jackson's choice of creator: CreateConnectorRequest declares both a
+        // canonical (4-arg) and a convenience (3-arg) constructor, and only the canonical one is annotated.
+        CreateConnectorRequest original = new CreateConnectorRequest(
+            "source-1",
+            Map.of("connector.class", "FileStreamSource"),
+            CreateConnectorRequest.InitialState.STOPPED,
+            List.of(new ConnectorOffset(Map.of("filename", "test.txt"), Map.of("position", 4096)))
+        );
+
+        String serialized = OBJECT_MAPPER.writeValueAsString(original);
+        assertTrue(serialized.contains("\"initial_offsets\""),
+            "Serialized form should use the initial_offsets JSON property name: " + serialized);
+
+        CreateConnectorRequest roundTripped = OBJECT_MAPPER.readValue(serialized, CreateConnectorRequest.class);
+        assertEquals(original, roundTripped);
+        assertEquals(original.initialOffsetsMap(), roundTripped.initialOffsetsMap());
+    }
+
+    @Test
+    public void testInitialOffsetsAbsentIsNull() throws Exception {
+        // Absence must be distinguishable from an empty list: absent means "leave offsets alone and omit
+        // offsets_status from the response", whereas an empty list is an invalid request.
+        String json = "{\"name\": \"source-1\", \"config\": {\"connector.class\": \"FileStreamSource\"}}";
+
+        CreateConnectorRequest request = OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class);
+
+        assertNull(request.initialOffsets());
+        assertNull(request.initialOffsetsMap());
+    }
+
+    @Test
+    public void testInitialOffsetsEmptyListIsEmptyMap() throws Exception {
+        String json = "{\"name\": \"source-1\", \"config\": {}, \"initial_offsets\": []}";
+
+        CreateConnectorRequest request = OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class);
+
+        assertNotNull(request.initialOffsets());
+        assertTrue(request.initialOffsets().isEmpty());
+        assertNotNull(request.initialOffsetsMap());
+        assertTrue(request.initialOffsetsMap().isEmpty());
+    }
+
+    @Test
+    public void testDeserializeNullOffsetValue() throws Exception {
+        // A null offset value is accepted by the wire format (it means "reset this partition" on
+        // PATCH /connectors/{connector}/offsets). Whether it is legal in initial_offsets is a separate
+        // validation concern; this test only pins that parsing does not fail.
+        String json = "{\"name\": \"sink-1\", \"config\": {},"
+            + " \"initial_offsets\": [{\"partition\": {\"kafka_topic\": \"t\", \"kafka_partition\": 0}, \"offset\": null}]}";
+
+        CreateConnectorRequest request = OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class);
+
+        assertEquals(1, request.initialOffsets().size());
+        assertNull(request.initialOffsets().get(0).offset());
+        assertNull(request.initialOffsetsMap().get(Map.of("kafka_topic", "t", "kafka_partition", 0)));
+    }
+
+    @Test
+    public void testUnknownFieldRejected() {
+        // Pins the strictness that the follower -> leader forwarding path relies on: an old worker receiving a
+        // forwarded request with initial_offsets must fail loudly rather than silently drop the field.
+        String json = "{\"name\": \"source-1\", \"config\": {}, \"not_a_real_field\": 1}";
+
+        assertThrows(UnrecognizedPropertyException.class,
+            () -> OBJECT_MAPPER.readValue(json, CreateConnectorRequest.class));
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -294,7 +294,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
     }
@@ -307,7 +307,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.PAUSED), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.PAUSED), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
     }
@@ -320,7 +320,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.STOPPED), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.STOPPED), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
     }
@@ -333,7 +333,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.STARTED), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), eq(TargetState.STARTED), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
     }
@@ -345,7 +345,7 @@ public class ConnectorsResourceTest {
 
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackNotLeaderException(cb).when(herder)
-            .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), eq(false), cb.capture());
+            .putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
 
         when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), isNull(), eq(body), any()))
                 .thenReturn(new RestClient.HttpResponse<>(201, new HashMap<>(), new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE)));
@@ -359,7 +359,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         HttpHeaders httpHeaders = mock(HttpHeaders.class);
         expectAndCallbackNotLeaderException(cb)
-            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), eq(false), cb.capture());
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
 
         when(restClient.httpRequest(eq(LEADER_URL + "connectors?forward=false"), eq("POST"), eq(httpHeaders), any(), any()))
                 .thenReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
@@ -373,7 +373,7 @@ public class ConnectorsResourceTest {
 
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackException(cb, new AlreadyExistsException("already exists"))
-            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), eq(false), cb.capture());
+            .when(herder).putConnectorConfig(eq(CONNECTOR_NAME), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
         assertThrows(AlreadyExistsException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body));
     }
 
@@ -388,7 +388,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
     }
@@ -404,7 +404,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
     }
@@ -420,7 +420,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(bodyOut.name(), bodyOut.config(),
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(bodyOut.name()), eq(bodyOut.config()), isNull(), isNull(), eq(false), cb.capture());
 
         connectorsResource.createConnector(FORWARD, NULL_HEADERS, bodyIn);
     }
@@ -532,7 +532,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_SPECIAL_CHARS, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(body.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_SPECIAL_CHARS), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
 
         String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();
@@ -547,7 +547,7 @@ public class ConnectorsResourceTest {
         final ArgumentCaptor<Callback<Herder.Created<ConnectorInfo>>> cb = ArgumentCaptor.forClass(Callback.class);
         expectAndCallbackResult(cb, new Herder.Created<>(true, new ConnectorInfo(CONNECTOR_NAME_CONTROL_SEQUENCES1, CONNECTOR_CONFIG,
             CONNECTOR_TASK_NAMES, ConnectorType.SOURCE))
-        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(body.config()), isNull(), eq(false), cb.capture());
+        ).when(herder).putConnectorConfig(eq(CONNECTOR_NAME_CONTROL_SEQUENCES1), eq(body.config()), isNull(), isNull(), eq(false), cb.capture());
 
         String rspLocation = connectorsResource.createConnector(FORWARD, NULL_HEADERS, body).getLocation().toString();
         String decoded = new URI(rspLocation).getPath();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -68,6 +68,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -94,12 +95,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -264,6 +268,56 @@ public class StandaloneHerderTest {
             connectorInfo.result()
         );
         verify(loaderSwap).close();
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsets() throws Exception {
+        initialize(true);
+        Map<String, String> config = connectorConfig(SourceSink.SOURCE);
+        expectConfigValidation(SourceSink.SOURCE, config);
+        expectAdd(SourceSink.SOURCE);
+
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets =
+            Map.of(Map.of("filename", "test.txt"), Map.of("position", 4096L));
+        String offsetsStatus = "The offsets for this connector have been set successfully";
+
+        // The worker writes the offsets asynchronously and completes the callback once they're durable
+        doAnswer(invocation -> {
+            invocation.getArgument(4, Callback.class).onCompletion(null, new Message(offsetsStatus));
+            return null;
+        }).when(worker).modifyConnectorOffsets(eq(CONNECTOR_NAME), eq(config), eq(initialOffsets), eq(true), any());
+
+        herder.putConnectorConfig(CONNECTOR_NAME, config, null, initialOffsets, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+
+        // The offsets must be written before the connector is started, otherwise a running connector could read from
+        // the wrong position before its initial offsets land
+        InOrder inOrder = inOrder(worker);
+        inOrder.verify(worker).modifyConnectorOffsets(eq(CONNECTOR_NAME), eq(config), eq(initialOffsets), eq(true), any());
+        inOrder.verify(worker).startConnector(eq(CONNECTOR_NAME), eq(config), any(), eq(herder), eq(TargetState.STARTED), any());
+
+        assertEquals(createdInfo(SourceSink.SOURCE).withOffsetsStatus(offsetsStatus), connectorInfo.result());
+    }
+
+    @Test
+    public void testCreateConnectorWithInitialOffsetsNullOffsetValue() {
+        initialize(false);
+        Map<String, String> config = connectorConfig(SourceSink.SOURCE);
+        expectConfigValidation(SourceSink.SOURCE, config);
+
+        // A null offset value is meaningless on create (the wipe has already removed every partition) and is rejected
+        // before anything destructive happens
+        Map<Map<String, ?>, Map<String, ?>> initialOffsets = new HashMap<>();
+        initialOffsets.put(Map.of("filename", "test.txt"), null);
+
+        herder.putConnectorConfig(CONNECTOR_NAME, config, null, initialOffsets, false, createCallback);
+
+        ExecutionException e = assertThrows(ExecutionException.class,
+            () -> createCallback.get(WAIT_TIME_MS, TimeUnit.MILLISECONDS));
+        assertInstanceOf(BadRequestException.class, e.getCause());
+
+        // Neither the offsets nor the config may be touched by a request that failed validation
+        verify(worker, never()).modifyConnectorOffsets(anyString(), anyMap(), anyMap(), anyBoolean(), any());
     }
 
     @Test

--- a/docs/kafka-connect/user-guide.md
+++ b/docs/kafka-connect/user-guide.md
@@ -293,7 +293,7 @@ The REST API is used not only by users to monitor / manage Kafka Connect. In dis
 The following are the currently supported REST API endpoints:
 
   * `GET /connectors` \- return a list of active connectors
-  * `POST /connectors` \- create a new connector; the request body should be a JSON object containing a string `name` field and an object `config` field with the connector configuration parameters. The JSON object may also optionally contain a string `initial_state` field which can take the following values - `STOPPED`, `PAUSED` or `RUNNING` (the default value)
+  * `POST /connectors` \- create a new connector; the request body should be a JSON object containing a string `name` field and an object `config` field with the connector configuration parameters. The JSON object may also optionally contain a string `initial_state` field which can take the following values - `STOPPED`, `PAUSED` or `RUNNING` (the default value). The JSON object may also optionally contain a JSON array `initial_offsets` field, in the same format as the `PATCH /connectors/{name}/offsets` request body; these replace (not merge with) any existing offsets for the connector name, and an invalid payload fails the request without creating the connector (see [KIP-995](https://cwiki.apache.org/confluence/display/KAFKA/KIP-995%3A+Allow+users+to+specify+initial+offsets+while+creating+connectors))
   * `GET /connectors/{name}` \- get information about a specific connector
   * `GET /connectors/{name}/config` \- get the configuration parameters for a specific connector
   * `PUT /connectors/{name}/config` \- update the configuration parameters for a specific connector


### PR DESCRIPTION
- https://cwiki.apache.org/confluence/display/KAFKA/KIP-995%3A+Allow+users+to+specify+initial+offsets+while+creating+connectors
- https://issues.apache.org/jira/browse/KAFKA-15976

Today, creating a connector that starts from a specific position takes three
REST calls — create it stopped, `PATCH` its offsets, then resume it — and any
one of them can fail partway. This also closes a gap in Connect's state model:
offsets are keyed by connector name and outlive the connector, so deleting a
connector and recreating it with the same name silently resumes from the old
position. This KIP makes the safe path a single call.

### Changes in this PR

- Add an optional `initial_offsets` field to the `POST /connectors` request
  body, in the same format as the `PATCH /connectors/{connector}/offsets` body
  (KIP-875). When supplied, all existing offsets for the connector name are
  wiped and replaced with the requested offsets before the connector is created.
- Add an optional `offsets_status` field to the creation response
  (`@JsonInclude(NON_NULL)`), populated only when `initial_offsets` was supplied
  so every other endpoint returning `ConnectorInfo` is unchanged.
- Support the new field in both distributed and standalone modes, and in the
  standalone CLI's JSON connector configuration files.
- Unit and integration tests for both modes, and documentation.

### Sequence

Following the sequence agreed on the discussion thread:

1. Validate the connector config and the initial offsets.
2. Write the offsets (wiping any existing offsets for the name first).
3. Write the connector config **last**.

Writing the config record is what makes a connector startable, so the offsets
are always correct before it can run. Every failure before the config write
leaves only orphaned offsets — the ordinary state of any connector that has been
deleted — and if the config write itself fails, the just-written offsets are
wiped back out, per the KIP.

### Notable decisions

- **Offsets before config.** The config write is done last, on the tick thread,
  and the offsets are written first off it; the connector is never rebalanced
  in the middle of the request.
- **Replace, not merge.** Existing offsets for the name are wiped before the new
  ones are written, so the connector starts from exactly the requested offsets.
- **Null offset values are rejected with a 400.** On create the wipe has already
  removed every partition, so a null offset has nothing to delete; issuing the
  delete anyway targets the consumer group the wipe just removed, which the alter
  path does not tolerate. This is deliberately stricter than
  `PATCH /{connector}/offsets`, which allows nulls.
- **Response wording** reuses the existing KIP-875 message template, so the
  framework-managed variant reads "The Connect framework-managed offsets ...".
- Because the wipe and write happen in a single `Worker` call, a connector's
  `alterOffsets()` hook may receive a map mixing tombstones (reset) and values
  (alter). This is permitted by the `alterOffsets()` contract, which documents
  that a single map may contain `null` values for reset alongside non-null
  values for alter; `POST /connectors` with `initial_offsets` is simply the
  first path to produce this at scale.

### Testing

- `WorkerTest`: replacing offsets for source and sink connectors (with and
  without pre-existing offsets), the exact framework-managed response wording,
  and that a malformed offset is rejected before anything is wiped.
- `DistributedHerderTest` / `StandaloneHerderTest`: the offsets-before-config
  ordering (via `InOrder`), null-value rejection, and — distributed — the
  cleanup that wipes the offsets when the config write fails.
- `ConnectWorkerIntegrationTest`: end-to-end for both offset mechanisms — a
  source connector created at offset 5 produces only its last 5 messages (and
  the response carries `offsets_status`), and a sink connector created at offset
  5 never sees a record below offset 5.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Reviewers: ashwinpankaj <apankaj@confluent.io>
