### PR TITLE
MINOR: Speed up store upgrade integration tests

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -181,6 +183,16 @@ public class HeadersStoreUpgradeIntegrationTest {
         }
     }
 
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+    }
+
+    private void closeAndLeaveGroupBeforeRestart(final Duration timeout) {
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP).withTimeout(timeout));
+    }
+
     @Test
     public void shouldMigrateInMemoryTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi() throws Exception {
         shouldMigrateTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi(false);
@@ -205,7 +217,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyTimestampedValue("key2", "value2", 22L);
         processKeyValueAndVerifyTimestampedValue("key3", "value3", 33L);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -245,7 +257,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyTimestampedValue("key2", "value2", 22L);
         processKeyValueAndVerifyTimestampedValue("key3", "value3", 33L);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -300,7 +312,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyValue("key3", "value3");
         final long lastUpdateKeyThree = persistentStore ? -1L : CLUSTER.time.milliseconds() - 1L;
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -340,7 +352,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyValue("key2", "value2");
         processKeyValueAndVerifyValue("key3", "value3");
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -638,7 +650,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processPlainWindowedKeyValueAndVerify("key2", "value2", baseTime + 200);
         processPlainWindowedKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with TimestampedWindowStoreWithHeaders
@@ -681,7 +693,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processPlainWindowedKeyValueAndVerify("key2", "value2", baseTime + 200);
         processPlainWindowedKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -741,7 +753,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processWindowedKeyValueAndVerifyTimestamped("key2", "value2", baseTime + 200);
         processWindowedKeyValueAndVerifyTimestamped("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -783,7 +795,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processWindowedKeyValueAndVerifyTimestamped("key2", "value2", baseTime + 200);
         processWindowedKeyValueAndVerifyTimestamped("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -1387,7 +1399,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueWithTimestampAndHeadersAndVerify("key1", "value1", 11L, headers, headers);
         processKeyValueWithTimestampAndHeadersAndVerify("key2", "value2", 22L, headers, headers);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     // ==================== Session Store Tests ====================
@@ -1423,7 +1435,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processSessionKeyValueAndVerify("key2", "value2", baseTime + 200);
         processSessionKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close(Duration.ofSeconds(5L));
+        closeAndLeaveGroupBeforeRestart(Duration.ofSeconds(5L));
         kafkaStreams = null;
 
         // Phase 2: Restart with SessionStoreWithHeaders (headers-aware supplier)
@@ -1476,7 +1488,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processSessionKeyValueAndVerify("key2", "value2", baseTime + 200);
         processSessionKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Phase 2: Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -1759,7 +1771,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             "Store was not populated with expected data"
         );
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     // ==================== Session Store Processors ====================


### PR DESCRIPTION
## Summary

Speed up `HeadersStoreUpgradeIntegrationTest` by leaving the group
before immediate restarts with the same `application.id`.

## Testing

Ran affected `HeadersStoreUpgradeIntegrationTest` methods.

```text
Task :streams:integration-tests:integrationTest

Gradle Test Run :streams:integration-tests:integrationTest > Gradle Test
Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldProxyTimestampedWindowStoreToTimestampedWindowStoreWithHeaders()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigratePersistentSessionStoreToSessionStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigratePersistentTimestampedWindowStoreToTimestampedWindowStoreWithHeaders()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigratePersistentPlainKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldProxyPlainKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigrateInMemoryTimestampedWindowStoreToTimestampedWindowStoreWithHeaders()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldProxyTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigrateInMemoryPlainWindowStoreToTimestampedWindowStoreWithHeaders()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldProxySessionStoreToSessionStoreWithHeaders() PASSED  Gradle Test
Run :streams:integration-tests:integrationTest > Gradle Test Executor 2
> HeadersStoreUpgradeIntegrationTest >
shouldMigratePersistentPlainWindowStoreToTimestampedWindowStoreWithHeaders()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigratePersistentTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigrateInMemorySessionStoreToSessionStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigrateInMemoryPlainKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED  Gradle Test Run :streams:integration-tests:integrationTest >
Gradle Test Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldProxyPlainWindowStoreToTimestampedWindowStoreWithHeaders() PASSED
Gradle Test Run :streams:integration-tests:integrationTest > Gradle Test
Executor 2 > HeadersStoreUpgradeIntegrationTest >
shouldMigrateInMemoryTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi()
PASSED

BUILD SUCCESSFUL in 35s
104 actionable tasks: 24 executed, 80 up-to-date

real    0m35.554s
user    0m0.829s
sys     0m0.240s
```
