### PR TITLE
MINOR: Speed up more streams restart tests

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
@@ -114,6 +116,12 @@ public class SelfJoinUpgradeIntegrationTest {
         }
     }
 
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+    }
+
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -156,7 +164,7 @@ public class SelfJoinUpgradeIntegrationTest {
         );
 
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
@@ -223,7 +231,7 @@ public class SelfJoinUpgradeIntegrationTest {
             )
         );
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SessionsStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SessionsStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -119,6 +121,12 @@ public class SessionsStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -241,7 +249,7 @@ public class SessionsStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -320,7 +328,7 @@ public class SessionsStoreWithHeadersTest {
 
         receivedRecords.forEach(receivedRecord -> assertEquals(0, receivedRecord.value));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -117,6 +119,12 @@ public class TimestampedKeyValueStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -256,7 +264,7 @@ public class TimestampedKeyValueStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -346,7 +354,7 @@ public class TimestampedKeyValueStoreWithHeadersTest {
         }
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedWindowStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedWindowStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -119,6 +121,12 @@ public class TimestampedWindowStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -241,7 +249,7 @@ public class TimestampedWindowStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -320,7 +328,7 @@ public class TimestampedWindowStoreWithHeadersTest {
 
         receivedRecords.forEach(receivedRecord -> assertEquals(0, receivedRecord.value));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -125,6 +127,12 @@ public class VersionedKeyValueStoreIntegrationTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @ParameterizedTest
@@ -253,7 +261,7 @@ public class VersionedKeyValueStoreIntegrationTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app and pass expected store contents to processor
@@ -392,7 +400,7 @@ public class VersionedKeyValueStoreIntegrationTest {
         }
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with versioned store, and pass expected store contents to processor


### PR DESCRIPTION
## Summary

Speed up several Streams restart-based integration tests by leaving the
group before immediate restarts with the same `application.id`.

## Testing

Ran affected integration test methods:

```bash
./gradlew :streams:integration-tests:integrationTest \
  --tests
org.apache.kafka.streams.integration.SelfJoinUpgradeIntegrationTest.shouldUpgradeWithTopologyOptimizationOff
\
  --tests
org.apache.kafka.streams.integration.SelfJoinUpgradeIntegrationTest.shouldRestartWithTopologyOptimizationOn
\
  --tests
org.apache.kafka.streams.integration.SessionsStoreWithHeadersTest.shouldRestore
\
  --tests
org.apache.kafka.streams.integration.SessionsStoreWithHeadersTest.shouldManualUpgradeFromTimestampedToHeaders
\
  --tests
org.apache.kafka.streams.integration.TimestampedKeyValueStoreWithHeadersTest.shouldRestore
\
  --tests
org.apache.kafka.streams.integration.TimestampedKeyValueStoreWithHeadersTest.shouldManualUpgradeFromTimestampedToHeaders
\
  --tests
org.apache.kafka.streams.integration.TimestampedWindowStoreWithHeadersTest.shouldRestore
\
  --tests
org.apache.kafka.streams.integration.TimestampedWindowStoreWithHeadersTest.shouldManualUpgradeFromTimestampedToHeaders
\
  --tests
org.apache.kafka.streams.integration.VersionedKeyValueStoreIntegrationTest.shouldRestore
\
  --tests
org.apache.kafka.streams.integration.VersionedKeyValueStoreIntegrationTest.shouldManualUpgradeFromNonVersionedTimestampedToVersioned
\
  --tests
org.apache.kafka.streams.integration.VersionedKeyValueStoreIntegrationTest.shouldManualUpgradeFromNonVersionedNonTimestampedToVersioned
 ```
## Runtime comparison
Before this change: `3m 16s`
After this change: `35s`

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>
