### PR TITLE
MINOR: Speed up Streams restart integration tests

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -184,13 +184,15 @@ public class HeadersStoreUpgradeIntegrationTest {
     }
 
     private void closeAndLeaveGroupBeforeRestart() {
-        // Leave the group so the immediate restart with the same application id
-        // does not wait for the previous member's session timeout.
-        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+        closeAndLeaveGroupBeforeRestart(null);
     }
 
     private void closeAndLeaveGroupBeforeRestart(final Duration timeout) {
-        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP).withTimeout(timeout));
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(
+            CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP)
+                .withTimeout(timeout));
     }
 
     @Test
@@ -1355,7 +1357,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             "Store was not populated with expected data"
         );
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     private long setupWindowStoreWithHeaders(final Properties props) throws Exception {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HeadersStoreUpgradeIntegrationTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -181,6 +183,16 @@ public class HeadersStoreUpgradeIntegrationTest {
         }
     }
 
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+    }
+
+    private void closeAndLeaveGroupBeforeRestart(final Duration timeout) {
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP).withTimeout(timeout));
+    }
+
     @Test
     public void shouldMigrateInMemoryTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi() throws Exception {
         shouldMigrateTimestampedKeyValueStoreToTimestampedKeyValueStoreWithHeadersUsingPapi(false);
@@ -205,7 +217,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyTimestampedValue("key2", "value2", 22L);
         processKeyValueAndVerifyTimestampedValue("key3", "value3", 33L);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -245,7 +257,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyTimestampedValue("key2", "value2", 22L);
         processKeyValueAndVerifyTimestampedValue("key3", "value3", 33L);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -300,7 +312,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyValue("key3", "value3");
         final long lastUpdateKeyThree = persistentStore ? -1L : CLUSTER.time.milliseconds() - 1L;
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -340,7 +352,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueAndVerifyValue("key2", "value2");
         processKeyValueAndVerifyValue("key3", "value3");
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -638,7 +650,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processPlainWindowedKeyValueAndVerify("key2", "value2", baseTime + 200);
         processPlainWindowedKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with TimestampedWindowStoreWithHeaders
@@ -681,7 +693,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processPlainWindowedKeyValueAndVerify("key2", "value2", baseTime + 200);
         processPlainWindowedKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -741,7 +753,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processWindowedKeyValueAndVerifyTimestamped("key2", "value2", baseTime + 200);
         processWindowedKeyValueAndVerifyTimestamped("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         buildAndStart(
@@ -783,7 +795,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processWindowedKeyValueAndVerifyTimestamped("key2", "value2", baseTime + 200);
         processWindowedKeyValueAndVerifyTimestamped("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -1387,7 +1399,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processKeyValueWithTimestampAndHeadersAndVerify("key1", "value1", 11L, headers, headers);
         processKeyValueWithTimestampAndHeadersAndVerify("key2", "value2", 22L, headers, headers);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     // ==================== Session Store Tests ====================
@@ -1423,7 +1435,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processSessionKeyValueAndVerify("key2", "value2", baseTime + 200);
         processSessionKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close(Duration.ofSeconds(5L));
+        closeAndLeaveGroupBeforeRestart(Duration.ofSeconds(5L));
         kafkaStreams = null;
 
         // Phase 2: Restart with SessionStoreWithHeaders (headers-aware supplier)
@@ -1476,7 +1488,7 @@ public class HeadersStoreUpgradeIntegrationTest {
         processSessionKeyValueAndVerify("key2", "value2", baseTime + 200);
         processSessionKeyValueAndVerify("key3", "value3", baseTime + 300);
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         // Phase 2: Restart with headers-aware builder but non-headers supplier (proxy/adapter mode)
@@ -1759,7 +1771,7 @@ public class HeadersStoreUpgradeIntegrationTest {
             "Store was not populated with expected data"
         );
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     // ==================== Session Store Processors ====================

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
@@ -114,6 +116,12 @@ public class SelfJoinUpgradeIntegrationTest {
         }
     }
 
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+    }
+
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
@@ -156,7 +164,7 @@ public class SelfJoinUpgradeIntegrationTest {
         );
 
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
@@ -223,7 +231,7 @@ public class SelfJoinUpgradeIntegrationTest {
             )
         );
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SessionsStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SessionsStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -119,6 +121,12 @@ public class SessionsStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -241,7 +249,7 @@ public class SessionsStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -320,7 +328,7 @@ public class SessionsStoreWithHeadersTest {
 
         receivedRecords.forEach(receivedRecord -> assertEquals(0, receivedRecord.value));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -117,6 +119,12 @@ public class TimestampedKeyValueStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -256,7 +264,7 @@ public class TimestampedKeyValueStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -346,7 +354,7 @@ public class TimestampedKeyValueStoreWithHeadersTest {
         }
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedStoreUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedStoreUpgradeIntegrationTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.integration;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -110,6 +112,12 @@ public class TimestampedStoreUpgradeIntegrationTest {
         }
     }
 
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
+    }
+
     @Test
     public void shouldMigrateInMemoryKeyValueStoreToTimestampedKeyValueStoreUsingPapi() throws Exception {
         shouldMigrateKeyValueStoreToTimestampedKeyValueStoreUsingPapi(false);
@@ -170,7 +178,7 @@ public class TimestampedStoreUpgradeIntegrationTest {
             KeyValue.pair(4, 3L)));
         final long lastUpdateKeyFour = persistentStore ? -1L : CLUSTER.time.milliseconds() - 1L;
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
 
@@ -276,7 +284,7 @@ public class TimestampedStoreUpgradeIntegrationTest {
             KeyValue.pair(3, 1L),
             KeyValue.pair(4, 3L)));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
 
@@ -616,7 +624,7 @@ public class TimestampedStoreUpgradeIntegrationTest {
             KeyValue.pair(new Windowed<>(4, new TimeWindow(0L, 1000L)), 3L)));
         final long lastUpdateKeyFour = persistentStore ? -1L : CLUSTER.time.milliseconds() - 1L;
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
 
@@ -763,7 +771,7 @@ public class TimestampedStoreUpgradeIntegrationTest {
             KeyValue.pair(new Windowed<>(3, new TimeWindow(0L, 1000L)), 1L),
             KeyValue.pair(new Windowed<>(4, new TimeWindow(0L, 1000L)), 3L)));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams = null;
 
 
@@ -1054,7 +1062,7 @@ public class TimestampedStoreUpgradeIntegrationTest {
             KeyValue.pair(1, ValueAndTimestamp.make(1L, timestamp1)),
             KeyValue.pair(2, ValueAndTimestamp.make(1L, timestamp2))));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
     }
 
     private static class KeyValueProcessor implements Processor<Integer, Integer, Void, Void> {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedWindowStoreWithHeadersTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimestampedWindowStoreWithHeadersTest.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -119,6 +121,12 @@ public class TimestampedWindowStoreWithHeadersTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @Test
@@ -241,7 +249,7 @@ public class TimestampedWindowStoreWithHeadersTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app - use processor WITHOUT validation of initial data, just write to store
@@ -320,7 +328,7 @@ public class TimestampedWindowStoreWithHeadersTest {
 
         receivedRecords.forEach(receivedRecord -> assertEquals(0, receivedRecord.value));
 
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with headers-aware store to test upgrade path

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.CloseOptions;
+import org.apache.kafka.streams.CloseOptions.GroupMembershipOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -125,6 +127,12 @@ public class VersionedKeyValueStoreIntegrationTest {
             kafkaStreams.close(Duration.ofSeconds(30L));
             kafkaStreams.cleanUp();
         }
+    }
+
+    private void closeAndLeaveGroupBeforeRestart() {
+        // Leave the group so the immediate restart with the same application id
+        // does not wait for the previous member's session timeout.
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(GroupMembershipOperation.LEAVE_GROUP));
     }
 
     @ParameterizedTest
@@ -253,7 +261,7 @@ public class VersionedKeyValueStoreIntegrationTest {
             initialRecordsProduced);
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app and pass expected store contents to processor
@@ -392,7 +400,7 @@ public class VersionedKeyValueStoreIntegrationTest {
         }
 
         // wipe out state store to trigger restore process on restart
-        kafkaStreams.close();
+        closeAndLeaveGroupBeforeRestart();
         kafkaStreams.cleanUp();
 
         // restart app with versioned store, and pass expected store contents to processor


### PR DESCRIPTION
## Summary

Speed up Streams restart-based integration tests by leaving the group
before immediate restarts with the same `application.id`.

## Testing

Ran the 7 affected test classes locally on trunk and with this patch (57 tests, all passed in both runs).

| Test class | trunk | patch | speedup |
|---|---|---|---|
| HeadersStoreUpgradeIntegrationTest | 15m37.6s | 46.1s | 20.3x |
| TimestampedStoreUpgradeIntegrationTest | 5m31.7s | 28.5s | 11.6x |
| VersionedKeyValueStoreIntegrationTest | 3m16.5s | 19.2s | 10.2x |
| SelfJoinUpgradeIntegrationTest | 3m13.9s | 17.3s | 11.2x |
| SessionsStoreWithHeadersTest | 1m41.7s | 12.6s | 8.1x |
| TimestampedWindowStoreWithHeadersTest | 1m41.6s | 12.6s | 8.1x |
| TimestampedKeyValueStoreWithHeadersTest | 1m40.8s | 11.4s | 8.8x |
| **Total** | **15m38s** | **46.8s** | **20x** |

Each restart with the same `application.id` previously waited for the old member's session timeout (~45s, the default `session.timeout.ms`) before rejoining. Closing with `GroupMembershipOperation.LEAVE_GROUP` removes that wait, saving roughly 45s per restart.

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
