### PR TITLE
MINOR: Add deprecation to listConsumerGroups in MockAdminClient

### DIFF
--- a/clients/src/testFixtures/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/testFixtures/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -739,6 +739,7 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    @Deprecated(since = "4.1", forRemoval = true)
     @SuppressWarnings("removal")
     public synchronized ListConsumerGroupsResult listConsumerGroups(ListConsumerGroupsOptions options) {
         KafkaFutureImpl<Collection<Object>> future = new KafkaFutureImpl<>();

--- a/clients/src/testFixtures/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/testFixtures/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1442,7 +1442,8 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
-    @SuppressWarnings({"deprecation", "removal"})
+    @Deprecated(since = "4.1", forRemoval = true)
+    @SuppressWarnings({"removal"})
     public ListClientMetricsResourcesResult listClientMetricsResources(ListClientMetricsResourcesOptions options) {
         KafkaFutureImpl<Collection<ClientMetricsResourceListing>> future = new KafkaFutureImpl<>();
         future.complete(clientMetricsConfigs.keySet().stream().map(ClientMetricsResourceListing::new).collect(Collectors.toList()));


### PR DESCRIPTION
`MockAdminClient#listConsumerGroups` overrides a deprecated API in 4.1. 
Added the missing `@Deprecated` to fix compiler warnings in `:clients:compileTestFixturesJava`.

Reviewers: Andrew Schofield <aschofield@confluent.io>
