### PR TITLE
MINOR: use ConfigDef.parseType for rack aware tag

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -516,7 +516,10 @@ public final class GroupConfig extends AbstractConfig {
         }
         @SuppressWarnings("unchecked")
         List<String> rawTags = (List<String>) ConfigDef.parseType(
-                STREAMS_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rawValue, ConfigDef.Type.LIST);
+            STREAMS_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
+            rawValue,
+            ConfigDef.Type.LIST
+        );
         if (Set.copyOf(rawTags).size() != rawTags.size()) {
             throw new InvalidConfigurationException(
                 STREAMS_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG + " must not contain duplicate tag keys.");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupConfig.java
@@ -514,8 +514,9 @@ public final class GroupConfig extends AbstractConfig {
         if (rawValue == null) {
             return;
         }
-        String trimmed = rawValue.trim();
-        List<String> rawTags = trimmed.isEmpty() ? List.of() : List.of(trimmed.split("\\s*,\\s*", -1));
+        @SuppressWarnings("unchecked")
+        List<String> rawTags = (List<String>) ConfigDef.parseType(
+                STREAMS_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rawValue, ConfigDef.Type.LIST);
         if (Set.copyOf(rawTags).size() != rawTags.size()) {
             throw new InvalidConfigurationException(
                 STREAMS_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG + " must not contain duplicate tag keys.");

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -798,12 +798,14 @@ public class GroupCoordinatorConfig {
      * Returns the rack-aware assignment tags exactly as configured, before {@link ConfigDef} removes duplicates.
      */
     private List<String> rawRackAwareAssignmentTags() {
-        String rawValue = (String) config.originals().get(STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
+        Object rawValue = config.originals().get(STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG);
         if (rawValue == null) {
             return List.of();
         }
-        String trimmed = rawValue.trim();
-        return trimmed.isEmpty() ? List.of() : List.of(trimmed.split("\\s*,\\s*", -1));
+        @SuppressWarnings("unchecked")
+        List<String> rawTags = (List<String>) ConfigDef.parseType(
+                STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rawValue, ConfigDef.Type.LIST);
+        return rawTags;
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -804,7 +804,10 @@ public class GroupCoordinatorConfig {
         }
         @SuppressWarnings("unchecked")
         List<String> rawTags = (List<String>) ConfigDef.parseType(
-                STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rawValue, ConfigDef.Type.LIST);
+            STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG,
+            rawValue,
+            ConfigDef.Type.LIST
+        );
         return rawTags;
     }
 


### PR DESCRIPTION
replace hand wrote  \s*,\s*  with ConfigDef.parseType

Reviewers: Matthias J. Sax <matthias@confluent.io>
