### PR TITLE
MINOR: Replace try/fail/catch with assertThrows in producer tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -48,7 +48,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("removal")
 public class MockProducerTest {
@@ -115,12 +114,10 @@ public class MockProducerTest {
         assertFalse(md2.isDone(), "Second request still incomplete");
         IllegalArgumentException e = new IllegalArgumentException("blah");
         assertTrue(producer.errorNext(e), "Complete the second request with an error");
-        try {
-            md2.get();
-            fail("Expected error to be thrown");
-        } catch (ExecutionException err) {
-            assertEquals(e, err.getCause());
-        }
+
+        ExecutionException err = assertThrows(ExecutionException.class, md2::get);
+        assertEquals(e, err.getCause());
+
         assertFalse(producer.completeNext(), "No more requests to complete");
 
         Future<RecordMetadata> md3 = producer.send(record1);
@@ -732,12 +729,9 @@ public class MockProducerTest {
         });
         IllegalArgumentException e = new IllegalArgumentException("dummy exception");
         assertTrue(producer.errorNext(e), "Complete the second request with an error");
-        try {
-            metadata.get();
-            fail("Something went wrong, expected an error");
-        } catch (ExecutionException err) {
-            assertEquals(e, err.getCause());
-        }
+
+        ExecutionException err = assertThrows(ExecutionException.class, metadata::get);
+        assertEquals(e, err.getCause());
     }
 
     private boolean isError(Future<?> future) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
@@ -53,17 +53,11 @@ public class ProducerRecordTest {
 
     @Test
     public void testInvalidRecords() {
-        assertThrows(IllegalArgumentException.class,
-                () -> new ProducerRecord<>(null, 0, "key", 1),
-                "Expected IllegalArgumentException to be raised because topic is null");
+        assertThrows(IllegalArgumentException.class, () -> new ProducerRecord<>(null, 0, "key", 1));
 
-        assertThrows(IllegalArgumentException.class,
-                () -> new ProducerRecord<>("test", 0, -1L, "key", 1),
-                "Expected IllegalArgumentException to be raised because of negative timestamp");
+        assertThrows(IllegalArgumentException.class, () -> new ProducerRecord<>("test", 0, -1L, "key", 1));
 
-        assertThrows(IllegalArgumentException.class,
-                () -> new ProducerRecord<>("test", -1, "key", 1),
-                "Expected IllegalArgumentException to be raised because of negative partition");
+        assertThrows(IllegalArgumentException.class, () -> new ProducerRecord<>("test", -1, "key", 1));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProducerRecordTest {
 
@@ -53,26 +53,17 @@ public class ProducerRecordTest {
 
     @Test
     public void testInvalidRecords() {
-        try {
-            new ProducerRecord<>(null, 0, "key", 1);
-            fail("Expected IllegalArgumentException to be raised because topic is null");
-        } catch (IllegalArgumentException e) {
-            //expected
-        }
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProducerRecord<>(null, 0, "key", 1),
+                "Expected IllegalArgumentException to be raised because topic is null");
 
-        try {
-            new ProducerRecord<>("test", 0, -1L, "key", 1);
-            fail("Expected IllegalArgumentException to be raised because of negative timestamp");
-        } catch (IllegalArgumentException e) {
-            //expected
-        }
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProducerRecord<>("test", 0, -1L, "key", 1),
+                "Expected IllegalArgumentException to be raised because of negative timestamp");
 
-        try {
-            new ProducerRecord<>("test", -1, "key", 1);
-            fail("Expected IllegalArgumentException to be raised because of negative partition");
-        } catch (IllegalArgumentException e) {
-            //expected
-        }
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProducerRecord<>("test", -1, "key", 1),
+                "Expected IllegalArgumentException to be raised because of negative partition");
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordSendTest {
 
@@ -50,11 +49,9 @@ public class RecordSendTest {
         FutureRecordMetadata future = new FutureRecordMetadata(request, relOffset,
                 RecordBatch.NO_TIMESTAMP, 0, 0, Time.SYSTEM);
         assertFalse(future.isDone(), "Request is not completed");
-        try {
-            future.get(5, TimeUnit.MILLISECONDS);
-            fail("Should have thrown exception.");
-        } catch (TimeoutException e) { /* this is good */
-        }
+
+        assertThrows(TimeoutException.class,
+                () -> future.get(5, TimeUnit.MILLISECONDS));
 
         request.set(baseOffset, RecordBatch.NO_TIMESTAMP, null);
         request.done();


### PR DESCRIPTION
Modernize six exception assertions in `ProducerRecordTest`,
`RecordSendTest` and `MockProducerTest` from the old try/call/fail/catch
idiom to `assertThrows`.

`assertThrows` fails automatically when no exception is thrown, so a
missing fail() can no longer let a test pass silently, and it verifies
the expected exception type. Where the original catch block asserted on
the wrapped cause, the `assertThrows` return value preserves that check:

    ExecutionException err = assertThrows(ExecutionException.class,
md2::get);      assertEquals(e, err.getCause());

Follows the same cleanup as #19975.

Testing: ./gradlew :clients:test for the three test classes plus
checkstyle, all green.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
