### PR TITLE
KAFKA-20988: Remove hamcrest from streams test fixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2881,7 +2881,6 @@ project(':streams') {
     implementation libs.slf4jApi
 
     testFixturesImplementation testFixtures(project(':clients'))
-    testFixturesImplementation libs.hamcrest
     testFixturesImplementation libs.junitJupiter
     testFixturesImplementation libs.mockitoCore
     testFixturesImplementation libs.slf4jApi

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -48,6 +48,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasActiveTasks;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -161,18 +163,18 @@ public class ClientStateTest {
     public void shouldUnassignActiveTask() {
         final ClientState clientState = new ClientState(1);
         clientState.assignActive(TASK_0_0);
-        assertEquals(1, clientState.activeTaskCount());
+        assertHasActiveTasks(clientState, 1);
         clientState.unassignActive(TASK_0_0);
-        assertEquals(0, clientState.activeTaskCount());
+        assertHasActiveTasks(clientState, 0);
     }
 
     @Test
     public void shouldUnassignStandbyTask() {
         final ClientState clientState = new ClientState(1);
         clientState.assignStandby(TASK_0_0);
-        assertEquals(1, clientState.standbyTaskCount());
+        assertHasStandbyTasks(clientState, 1);
         clientState.unassignStandby(TASK_0_0);
-        assertEquals(0, clientState.standbyTaskCount());
+        assertHasStandbyTasks(clientState, 0);
     }
 
     @Test
@@ -180,7 +182,7 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.activeTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertEquals(0, clientState.activeTaskCount());
+        assertHasActiveTasks(clientState, 0);
     }
 
     @Test
@@ -188,7 +190,7 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.standbyTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertEquals(0, clientState.standbyTaskCount());
+        assertHasStandbyTasks(clientState, 0);
     }
 
     @Test
@@ -196,8 +198,8 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.assignedTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertEquals(0, clientState.activeTaskCount());
-        assertEquals(0, clientState.standbyTaskCount());
+        assertHasActiveTasks(clientState, 0);
+        assertHasStandbyTasks(clientState, 0);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -48,8 +48,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasActiveTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -163,18 +161,18 @@ public class ClientStateTest {
     public void shouldUnassignActiveTask() {
         final ClientState clientState = new ClientState(1);
         clientState.assignActive(TASK_0_0);
-        assertThat(clientState, hasActiveTasks(1));
+        assertEquals(1, clientState.activeTaskCount());
         clientState.unassignActive(TASK_0_0);
-        assertThat(clientState, hasActiveTasks(0));
+        assertEquals(0, clientState.activeTaskCount());
     }
 
     @Test
     public void shouldUnassignStandbyTask() {
         final ClientState clientState = new ClientState(1);
         clientState.assignStandby(TASK_0_0);
-        assertThat(clientState, hasStandbyTasks(1));
+        assertEquals(1, clientState.standbyTaskCount());
         clientState.unassignStandby(TASK_0_0);
-        assertThat(clientState, hasStandbyTasks(0));
+        assertEquals(0, clientState.standbyTaskCount());
     }
 
     @Test
@@ -182,7 +180,7 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.activeTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertThat(clientState, hasActiveTasks(0));
+        assertEquals(0, clientState.activeTaskCount());
     }
 
     @Test
@@ -190,7 +188,7 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.standbyTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertThat(clientState, hasStandbyTasks(0));
+        assertEquals(0, clientState.standbyTaskCount());
     }
 
     @Test
@@ -198,8 +196,8 @@ public class ClientStateTest {
         final ClientState clientState = new ClientState(1);
         final Set<TaskId> taskIds = clientState.assignedTasks();
         assertThrows(UnsupportedOperationException.class, () -> taskIds.add(TASK_0_0));
-        assertThat(clientState, hasActiveTasks(0));
-        assertThat(clientState, hasStandbyTasks(0));
+        assertEquals(0, clientState.activeTaskCount());
+        assertEquals(0, clientState.standbyTaskCount());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -69,6 +69,9 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedActiveAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedStatefulAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedTasks;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasActiveTasks;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasAssignedTasks;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertValidAssignment;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.copyClientStateMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
@@ -87,7 +90,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 
@@ -178,11 +180,11 @@ public class HighAvailabilityTaskAssignorTest {
             configs
         );
 
-        assertEquals(allTaskIds.size(), clientState1.assignedTaskCount());
+        assertHasAssignedTasks(clientState1, allTaskIds.size());
 
-        assertEquals(allTaskIds.size(), clientState2.assignedTaskCount());
+        assertHasAssignedTasks(clientState2, allTaskIds.size());
 
-        assertEquals(2, clientState3.assignedTaskCount());
+        assertHasAssignedTasks(clientState3, 2);
 
         assertThat(unstable, is(true));
 
@@ -235,9 +237,9 @@ public class HighAvailabilityTaskAssignorTest {
             configs
         );
 
-        assertEquals(6, clientState1.assignedTaskCount());
-        assertEquals(6, clientState2.assignedTaskCount());
-        assertEquals(6, clientState3.assignedTaskCount());
+        assertHasAssignedTasks(clientState1, 6);
+        assertHasAssignedTasks(clientState2, 6);
+        assertHasAssignedTasks(clientState3, 6);
         assertThat(unstable, is(false));
 
         verifyTaskPlacementWithRackAwareAssignor(rackAwareTaskAssignor, allTaskIds, clientStates, true, enableRackAwareTaskAssignor);
@@ -449,9 +451,9 @@ public class HighAvailabilityTaskAssignorTest {
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
 
-        assertEquals(1, clientState1.activeTaskCount());
-        assertEquals(2, clientState2.activeTaskCount());
-        assertEquals(3, clientState3.activeTaskCount());
+        assertHasActiveTasks(clientState1, 1);
+        assertHasActiveTasks(clientState2, 2);
+        assertHasActiveTasks(clientState3, 3);
         final AssignmentTestUtils.TaskSkewReport taskSkewReport = analyzeTaskAssignmentBalance(clientStates, 1);
         if (taskSkewReport.totalSkewedTasks() == 0) {
             fail("Expected a skewed task assignment, but was: " + taskSkewReport);
@@ -727,8 +729,8 @@ public class HighAvailabilityTaskAssignorTest {
         assertValidAssignment(0, allTaskIds, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
-        assertEquals(6, clientState1.activeTaskCount());
-        assertEquals(3, clientState2.activeTaskCount());
+        assertHasActiveTasks(clientState1, 6);
+        assertHasActiveTasks(clientState2, 3);
 
         verifyTaskPlacementWithRackAwareAssignor(rackAwareTaskAssignor, allTaskIds, clientStates, false, enableRackAwareTaskAssignor);
     }
@@ -757,8 +759,8 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                          configs);
 
         assertThat(probingRebalanceNeeded, is(false));
-        assertEquals(2, client1.activeTaskCount());
-        assertEquals(0, client1.standbyTaskCount());
+        assertHasActiveTasks(client1, 2);
+        assertHasStandbyTasks(client1, 0);
 
         assertValidAssignment(0, allTasks, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
@@ -1724,7 +1726,7 @@ public class HighAvailabilityTaskAssignorTest {
 
     private static void assertHasNoStandbyTasks(final ClientState... clients) {
         for (final ClientState client : clients) {
-            assertEquals(0, client.standbyTaskCount());
+            assertHasStandbyTasks(client, 0);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -79,9 +79,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getRandomSubset;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getTaskTopicPartitionMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getTasksForTopicGroup;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasActiveTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasAssignedTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.mockInternalTopicManagerForRandomChangelog;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.verifyTaskPlacementWithRackAwareAssignor;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -90,6 +87,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 
@@ -180,11 +178,11 @@ public class HighAvailabilityTaskAssignorTest {
             configs
         );
 
-        assertThat(clientState1, hasAssignedTasks(allTaskIds.size()));
+        assertEquals(allTaskIds.size(), clientState1.assignedTaskCount());
 
-        assertThat(clientState2, hasAssignedTasks(allTaskIds.size()));
+        assertEquals(allTaskIds.size(), clientState2.assignedTaskCount());
 
-        assertThat(clientState3, hasAssignedTasks(2));
+        assertEquals(2, clientState3.assignedTaskCount());
 
         assertThat(unstable, is(true));
 
@@ -237,9 +235,9 @@ public class HighAvailabilityTaskAssignorTest {
             configs
         );
 
-        assertThat(clientState1, hasAssignedTasks(6));
-        assertThat(clientState2, hasAssignedTasks(6));
-        assertThat(clientState3, hasAssignedTasks(6));
+        assertEquals(6, clientState1.assignedTaskCount());
+        assertEquals(6, clientState2.assignedTaskCount());
+        assertEquals(6, clientState3.assignedTaskCount());
         assertThat(unstable, is(false));
 
         verifyTaskPlacementWithRackAwareAssignor(rackAwareTaskAssignor, allTaskIds, clientStates, true, enableRackAwareTaskAssignor);
@@ -451,9 +449,9 @@ public class HighAvailabilityTaskAssignorTest {
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
 
-        assertThat(clientState1, hasActiveTasks(1));
-        assertThat(clientState2, hasActiveTasks(2));
-        assertThat(clientState3, hasActiveTasks(3));
+        assertEquals(1, clientState1.activeTaskCount());
+        assertEquals(2, clientState2.activeTaskCount());
+        assertEquals(3, clientState3.activeTaskCount());
         final AssignmentTestUtils.TaskSkewReport taskSkewReport = analyzeTaskAssignmentBalance(clientStates, 1);
         if (taskSkewReport.totalSkewedTasks() == 0) {
             fail("Expected a skewed task assignment, but was: " + taskSkewReport);
@@ -729,8 +727,8 @@ public class HighAvailabilityTaskAssignorTest {
         assertValidAssignment(0, allTaskIds, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
         assertBalancedStatefulAssignment(allTaskIds, clientStates, new StringBuilder());
-        assertThat(clientState1, hasActiveTasks(6));
-        assertThat(clientState2, hasActiveTasks(3));
+        assertEquals(6, clientState1.activeTaskCount());
+        assertEquals(3, clientState2.activeTaskCount());
 
         verifyTaskPlacementWithRackAwareAssignor(rackAwareTaskAssignor, allTaskIds, clientStates, false, enableRackAwareTaskAssignor);
     }
@@ -759,8 +757,8 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                          configs);
 
         assertThat(probingRebalanceNeeded, is(false));
-        assertThat(client1, hasActiveTasks(2));
-        assertThat(client1, hasStandbyTasks(0));
+        assertEquals(2, client1.activeTaskCount());
+        assertEquals(0, client1.standbyTaskCount());
 
         assertValidAssignment(0, allTasks, emptySet(), clientStates, new StringBuilder());
         assertBalancedActiveAssignment(clientStates, new StringBuilder());
@@ -1726,7 +1724,7 @@ public class HighAvailabilityTaskAssignorTest {
 
     private static void assertHasNoStandbyTasks(final ClientState... clients) {
         for (final ClientState client : clients) {
-            assertThat(client, hasStandbyTasks(0));
+            assertEquals(0, client.standbyTaskCount());
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -48,10 +48,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.hasProperty;
 import static org.apache.kafka.streams.processor.internals.assignment.TaskMovement.assignActiveTaskMovements;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TaskMovementTest {
     @Test
@@ -70,15 +68,15 @@ public class TaskMovementTest {
         final ClientState client2 = getClientStateWithActiveAssignment(Set.of(TASK_0_1, TASK_1_1), allTasks, allTasks);
         final ClientState client3 = getClientStateWithActiveAssignment(Set.of(TASK_0_2, TASK_1_2), allTasks, allTasks);
 
-        assertThat(
+        assertEquals(
+            0,
             assignActiveTaskMovements(
                 tasksToCaughtUpClients,
                 tasksToClientByLag,
                 getClientStatesMap(client1, client2, client3),
                 new TreeMap<>(),
                 new AtomicInteger(maxWarmupReplicas)
-            ),
-            is(0)
+            )
         );
     }
 
@@ -107,15 +105,15 @@ public class TaskMovementTest {
             mkEntry(TASK_1_1, mkOrderedSet(PID_1, PID_2, PID_3)),
             mkEntry(TASK_1_2, mkOrderedSet(PID_1, PID_2, PID_3))
         );
-        assertThat(
+        assertEquals(
+            0,
             assignActiveTaskMovements(
                 tasksToCaughtUpClients,
                 tasksToClientByLag,
                 getClientStatesMap(client1, client2, client3),
                 new TreeMap<>(),
                 new AtomicInteger(maxWarmupReplicas)
-            ),
-            is(0)
+            )
         );
     }
 
@@ -139,8 +137,8 @@ public class TaskMovementTest {
             mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
-        assertThat(
-            "should have assigned movements",
+        assertEquals(
+            2,
             assignActiveTaskMovements(
                 tasksToCaughtUpClients,
                 tasksToClientByLag,
@@ -148,17 +146,17 @@ public class TaskMovementTest {
                 new TreeMap<>(),
                 new AtomicInteger(maxWarmupReplicas)
             ),
-            is(2)
+            "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is caught up on
-        assertThat(client1, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_0)));
-        assertThat(client2, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_2)));
-        assertThat(client3, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_1)));
+        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
+        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
+        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
 
         // we assigned warmups to migrate to the input active assignment
-        assertThat(client1, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of()));
-        assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1)));
-        assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_2)));
+        assertEquals(Set.of(), client1.standbyTasks());
+        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
+        assertEquals(Set.of(TASK_0_2), client3.standbyTasks());
     }
 
     @Test
@@ -186,8 +184,8 @@ public class TaskMovementTest {
                 mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_3, PID_1))
         );
 
-        assertThat(
-                "should have assigned movements",
+        assertEquals(
+                2,
                 assignActiveTaskMovements(
                         tasksToCaughtUpClients,
                         tasksToClientByLag,
@@ -195,17 +193,17 @@ public class TaskMovementTest {
                         new TreeMap<>(),
                         new AtomicInteger(maxWarmupReplicas)
                 ),
-                is(2)
+                "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is most caught up on
-        assertThat(client1, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_0)));
-        assertThat(client2, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_2)));
-        assertThat(client3, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_1)));
+        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
+        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
+        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
 
         // we assigned warmups to migrate to the input active assignment
-        assertThat(client1, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of()));
-        assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1)));
-        assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_2)));
+        assertEquals(Set.of(), client1.standbyTasks());
+        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
+        assertEquals(Set.of(TASK_0_2), client3.standbyTasks());
     }
 
     @Test
@@ -228,8 +226,8 @@ public class TaskMovementTest {
             mkEntry(TASK_0_2, mkOrderedSet(PID_2, PID_1, PID_3))
         );
 
-        assertThat(
-            "should have assigned movements",
+        assertEquals(
+            2,
             assignActiveTaskMovements(
                 tasksToCaughtUpClients,
                 tasksToClientByLag,
@@ -237,17 +235,17 @@ public class TaskMovementTest {
                 new TreeMap<>(),
                 new AtomicInteger(maxWarmupReplicas)
             ),
-            is(2)
+            "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is caught up on
-        assertThat(client1, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_0)));
-        assertThat(client2, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_2)));
-        assertThat(client3, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_1)));
+        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
+        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
+        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
 
         // we should only assign one warmup, and the task movement should have the highest priority
-        assertThat(client1, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of()));
-        assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1)));
-        assertThat(client3, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of()));
+        assertEquals(Set.of(), client1.standbyTasks());
+        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
+        assertEquals(Set.of(), client3.standbyTasks());
     }
 
     @Test
@@ -266,8 +264,8 @@ public class TaskMovementTest {
             mkEntry(TASK_0_0, mkOrderedSet(PID_1, PID_2))
         );
 
-        assertThat(
-            "should have assigned movements",
+        assertEquals(
+            1,
             assignActiveTaskMovements(
                 tasksToCaughtUpClients,
                 tasksToClientByLag,
@@ -275,7 +273,7 @@ public class TaskMovementTest {
                 new TreeMap<>(),
                 new AtomicInteger(maxWarmupReplicas)
             ),
-            is(1)
+            "should have assigned movements"
         );
         // Even though we have no warmups allowed, we still let client1 take over active processing while
         // client2 "warms up" because client1 was a caught-up standby, so it can "trade" standby status with
@@ -283,11 +281,11 @@ public class TaskMovementTest {
 
         // I.e., when you have a caught-up standby and a not-caught-up active, you can just swap their roles
         // and not call it a "warmup".
-        assertThat(client1, hasProperty("activeTasks", ClientState::activeTasks, Set.of(TASK_0_0)));
-        assertThat(client2, hasProperty("activeTasks", ClientState::activeTasks, Set.of()));
+        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
+        assertEquals(Set.of(), client2.activeTasks());
 
-        assertThat(client1, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of()));
-        assertThat(client2, hasProperty("standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_0)));
+        assertEquals(Set.of(), client1.standbyTasks());
+        assertEquals(Set.of(TASK_0_0), client2.standbyTasks());
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -47,6 +47,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasProperty;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
 import static org.apache.kafka.streams.processor.internals.assignment.TaskMovement.assignActiveTaskMovements;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -149,14 +150,14 @@ public class TaskMovementTest {
             "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is caught up on
-        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
-        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
-        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
+        assertHasProperty(client1, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_0));
+        assertHasProperty(client2, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_2));
+        assertHasProperty(client3, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_1));
 
         // we assigned warmups to migrate to the input active assignment
-        assertEquals(Set.of(), client1.standbyTasks());
-        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
-        assertEquals(Set.of(TASK_0_2), client3.standbyTasks());
+        assertHasProperty(client1, "standbyTasks", ClientState::standbyTasks, Set.of());
+        assertHasProperty(client2, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1));
+        assertHasProperty(client3, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_2));
     }
 
     @Test
@@ -196,14 +197,14 @@ public class TaskMovementTest {
                 "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is most caught up on
-        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
-        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
-        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
+        assertHasProperty(client1, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_0));
+        assertHasProperty(client2, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_2));
+        assertHasProperty(client3, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_1));
 
         // we assigned warmups to migrate to the input active assignment
-        assertEquals(Set.of(), client1.standbyTasks());
-        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
-        assertEquals(Set.of(TASK_0_2), client3.standbyTasks());
+        assertHasProperty(client1, "standbyTasks", ClientState::standbyTasks, Set.of());
+        assertHasProperty(client2, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1));
+        assertHasProperty(client3, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_2));
     }
 
     @Test
@@ -238,14 +239,14 @@ public class TaskMovementTest {
             "should have assigned movements"
         );
         // The active tasks have changed to the ones that each client is caught up on
-        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
-        assertEquals(Set.of(TASK_0_2), client2.activeTasks());
-        assertEquals(Set.of(TASK_0_1), client3.activeTasks());
+        assertHasProperty(client1, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_0));
+        assertHasProperty(client2, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_2));
+        assertHasProperty(client3, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_1));
 
         // we should only assign one warmup, and the task movement should have the highest priority
-        assertEquals(Set.of(), client1.standbyTasks());
-        assertEquals(Set.of(TASK_0_1), client2.standbyTasks());
-        assertEquals(Set.of(), client3.standbyTasks());
+        assertHasProperty(client1, "standbyTasks", ClientState::standbyTasks, Set.of());
+        assertHasProperty(client2, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_1));
+        assertHasProperty(client3, "standbyTasks", ClientState::standbyTasks, Set.of());
     }
 
     @Test
@@ -281,11 +282,11 @@ public class TaskMovementTest {
 
         // I.e., when you have a caught-up standby and a not-caught-up active, you can just swap their roles
         // and not call it a "warmup".
-        assertEquals(Set.of(TASK_0_0), client1.activeTasks());
-        assertEquals(Set.of(), client2.activeTasks());
+        assertHasProperty(client1, "activeTasks", ClientState::activeTasks, Set.of(TASK_0_0));
+        assertHasProperty(client2, "activeTasks", ClientState::activeTasks, Set.of());
 
-        assertEquals(Set.of(), client1.standbyTasks());
-        assertEquals(Set.of(TASK_0_0), client2.standbyTasks());
+        assertHasProperty(client1, "standbyTasks", ClientState::standbyTasks, Set.of());
+        assertHasProperty(client2, "standbyTasks", ClientState::standbyTasks, Set.of(TASK_0_0));
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockApiFixedKeyProcessor.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockApiFixedKeyProcessor.java
@@ -32,8 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MockApiFixedKeyProcessor<KIn, VIn, VOut> implements FixedKeyProcessor<KIn, VIn, VOut> {
 
@@ -93,13 +92,13 @@ public class MockApiFixedKeyProcessor<KIn, VIn, VOut> implements FixedKeyProcess
     }
 
     public void checkAndClearProcessResult(final KeyValueTimestamp<?, ?>... expected) {
-        assertThat("the number of outputs:" + processed, processed.size(), is(expected.length));
+        assertEquals(expected.length, processed.size(), "the number of outputs:" + processed);
         for (int i = 0; i < expected.length; i++) {
             final FixedKeyRecord<KIn, VIn> record = processed.get(i);
-            assertThat(
-                "output[" + i + "]:",
+            assertEquals(
+                expected[i],
                 new KeyValueTimestamp<>(record.key(), record.value(), record.timestamp()),
-                is(expected[i])
+                "output[" + i + "]:"
             );
         }
 
@@ -107,9 +106,9 @@ public class MockApiFixedKeyProcessor<KIn, VIn, VOut> implements FixedKeyProcess
     }
 
     public void checkAndClearProcessedRecords(final Record<?, ?>... expected) {
-        assertThat("the number of outputs:" + processed, processed.size(), is(expected.length));
+        assertEquals(expected.length, processed.size(), "the number of outputs:" + processed);
         for (int i = 0; i < expected.length; i++) {
-            assertThat("output[" + i + "]:", processed.get(i), is(expected[i]));
+            assertEquals(expected[i], processed.get(i), "output[" + i + "]:");
         }
 
         processed.clear();
@@ -120,16 +119,16 @@ public class MockApiFixedKeyProcessor<KIn, VIn, VOut> implements FixedKeyProcess
     }
 
     public void checkEmptyAndClearProcessResult() {
-        assertThat("the number of outputs:", processed.size(), is(0));
+        assertEquals(0, processed.size(), "the number of outputs:");
         processed.clear();
     }
 
     public void checkAndClearPunctuateResult(final PunctuationType type, final long... expected) {
         final ArrayList<Long> punctuated = type == PunctuationType.STREAM_TIME ? punctuatedStreamTime : punctuatedSystemTime;
-        assertThat("the number of outputs:", punctuated.size(), is(expected.length));
+        assertEquals(expected.length, punctuated.size(), "the number of outputs:");
 
         for (int i = 0; i < expected.length; i++) {
-            assertThat("output[" + i + "]:", punctuated.get(i), is(expected[i]));
+            assertEquals(expected[i], punctuated.get(i), "output[" + i + "]:");
         }
 
         processed.clear();

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -503,6 +503,25 @@ public final class AssignmentTestUtils {
         return new TaskSkewReport(maxTaskSkew, skewedSubtopologies, subtopologyToClientsWithPartition);
     }
 
+    static void assertHasAssignedTasks(final ClientState clientState, final int taskCount) {
+        assertEquals(taskCount, clientState.assignedTaskCount());
+    }
+
+    static void assertHasActiveTasks(final ClientState clientState, final int taskCount) {
+        assertEquals(taskCount, clientState.activeTaskCount());
+    }
+
+    static void assertHasStandbyTasks(final ClientState clientState, final int taskCount) {
+        assertEquals(taskCount, clientState.standbyTaskCount());
+    }
+
+    static <V> void assertHasProperty(final ClientState clientState,
+                                      final String propertyName,
+                                      final Function<ClientState, V> propertyExtractor,
+                                      final V propertyValue) {
+        assertEquals(propertyValue, propertyExtractor.apply(clientState), propertyName);
+    }
+
     static void appendClientStates(final StringBuilder stringBuilder,
                                    final Map<ProcessId, ClientState> clientStates) {
         stringBuilder.append('{').append('\n');

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -37,10 +37,6 @@ import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockInternalTopicManager;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -70,10 +65,6 @@ import static org.apache.kafka.common.utils.Utils.intersection;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -373,9 +364,13 @@ public final class AssignmentTestUtils {
                 .collect(entriesToMap(TreeMap::new));
 
         if (!misassigned.isEmpty()) {
-            assertThat("Found some over- or under-assigned tasks in the final assignment with " + numStandbyReplicas +
+            assertEquals(
+                emptyMap(),
+                misassigned,
+                "Found some over- or under-assigned tasks in the final assignment with " + numStandbyReplicas +
                     " and max warmups " + maxWarmupReplicas + " standby replicas, stateful tasks:" + statefulTasks +
-                    ", and stateless tasks:" + statelessTasks + failureContext, misassigned, is(emptyMap()));
+                    ", and stateless tasks:" + statelessTasks + failureContext
+            );
         }
     }
 
@@ -506,38 +501,6 @@ public final class AssignmentTestUtils {
         }
 
         return new TaskSkewReport(maxTaskSkew, skewedSubtopologies, subtopologyToClientsWithPartition);
-    }
-
-    static Matcher<ClientState> hasAssignedTasks(final int taskCount) {
-        return hasProperty("assignedTasks", ClientState::assignedTaskCount, taskCount);
-    }
-
-    static Matcher<ClientState> hasActiveTasks(final int taskCount) {
-        return hasProperty("activeTasks", ClientState::activeTaskCount, taskCount);
-    }
-
-    static Matcher<ClientState> hasStandbyTasks(final int taskCount) {
-        return hasProperty("standbyTasks", ClientState::standbyTaskCount, taskCount);
-    }
-
-    static <V> Matcher<ClientState> hasProperty(final String propertyName,
-                                                final Function<ClientState, V> propertyExtractor,
-                                                final V propertyValue) {
-        return new BaseMatcher<>() {
-            @Override
-            public void describeTo(final Description description) {
-                description.appendText(propertyName).appendText(":").appendValue(propertyValue);
-            }
-
-            @Override
-            public boolean matches(final Object actual) {
-                if (actual instanceof ClientState) {
-                    return Objects.equals(propertyExtractor.apply((ClientState) actual), propertyValue);
-                } else {
-                    return false;
-                }
-            }
-        };
     }
 
     static void appendClientStates(final StringBuilder stringBuilder,
@@ -938,7 +901,10 @@ public final class AssignmentTestUtils {
 
                 if (!relaxRackCheck && clientState.hasAssignedTask(taskId)) {
                     final String rack = racksForProcess.get(processId);
-                    assertThat("Task " + taskId + " appears in both " + processId + " and " + racks.get(rack), racks.keySet(), not(hasItems(rack)));
+                    assertFalse(
+                        racks.containsKey(rack),
+                        "Task " + taskId + " appears in both " + processId + " and " + racks.get(rack)
+                    );
                     racks.put(rack, processId);
                 }
 

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/utils/TestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/utils/TestUtils.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUtils {
 
@@ -81,7 +81,7 @@ public class TestUtils {
                 timeout.toMillis(),
                 wrongStateMap
             );
-            assertThat(reason, wrongStateMap.isEmpty());
+            assertTrue(wrongStateMap.isEmpty(), reason);
         });
     }
 

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java
@@ -29,8 +29,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UniqueTopicSerdeScope {
     private final Map<String, Class<?>> topicTypeRegistry = new TreeMap<>();
@@ -108,7 +107,11 @@ public class UniqueTopicSerdeScope {
             if (data != null) {
                 final String key = topic + (isKey.get() ? "--key" : "--value");
                 if (topicTypeRegistry.containsKey(key)) {
-                    assertThat(String.format("key[%s] data[%s][%s]", key, data, data.getClass()), topicTypeRegistry.get(key), equalTo(data.getClass()));
+                    assertEquals(
+                        data.getClass(),
+                        topicTypeRegistry.get(key),
+                        String.format("key[%s] data[%s][%s]", key, data, data.getClass())
+                    );
                 } else {
                     topicTypeRegistry.put(key, data.getClass());
                 }

--- a/streams/src/testFixtures/java/org/apache/kafka/test/MockApiProcessor.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/test/MockApiProcessor.java
@@ -33,8 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MockApiProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VIn, KOut, VOut> {
 
@@ -111,13 +110,13 @@ public class MockApiProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VI
     }
 
     public void checkAndClearProcessResult(final KeyValueTimestamp<?, ?>... expected) {
-        assertThat("the number of outputs:" + processed, processed.size(), is(expected.length));
+        assertEquals(expected.length, processed.size(), "the number of outputs:" + processed);
         for (int i = 0; i < expected.length; i++) {
             final Record<KIn, VIn> record = processed.get(i);
-            assertThat(
-                "output[" + i + "]:",
+            assertEquals(
+                expected[i],
                 new KeyValueTimestamp<>(record.key(), record.value(), record.timestamp()),
-                is(expected[i])
+                "output[" + i + "]:"
             );
         }
 
@@ -125,9 +124,9 @@ public class MockApiProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VI
     }
 
     public void checkAndClearProcessedRecords(final Record<?, ?>... expected) {
-        assertThat("the number of outputs:" + processed, processed.size(), is(expected.length));
+        assertEquals(expected.length, processed.size(), "the number of outputs:" + processed);
         for (int i = 0; i < expected.length; i++) {
-            assertThat("output[" + i + "]:", processed.get(i), is(expected[i]));
+            assertEquals(expected[i], processed.get(i), "output[" + i + "]:");
         }
 
         processed.clear();
@@ -138,16 +137,16 @@ public class MockApiProcessor<KIn, VIn, KOut, VOut> implements Processor<KIn, VI
     }
 
     public void checkEmptyAndClearProcessResult() {
-        assertThat("the number of outputs:", processed.size(), is(0));
+        assertEquals(0, processed.size(), "the number of outputs:");
         processed.clear();
     }
 
     public void checkAndClearPunctuateResult(final PunctuationType type, final long... expected) {
         final ArrayList<Long> punctuated = type == PunctuationType.STREAM_TIME ? punctuatedStreamTime : punctuatedSystemTime;
-        assertThat("the number of outputs:", punctuated.size(), is(expected.length));
+        assertEquals(expected.length, punctuated.size(), "the number of outputs:");
 
         for (int i = 0; i < expected.length; i++) {
-            assertThat("output[" + i + "]:", punctuated.get(i), is(expected[i]));
+            assertEquals(expected[i], punctuated.get(i), "output[" + i + "]:");
         }
 
         processed.clear();

--- a/streams/src/testFixtures/java/org/apache/kafka/test/MockClientSupplier.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/test/MockClientSupplier.java
@@ -32,9 +32,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MockClientSupplier implements KafkaClientSupplier {
     private static final ByteArraySerializer BYTE_ARRAY_SERIALIZER = new ByteArraySerializer();
@@ -69,7 +69,9 @@ public class MockClientSupplier implements KafkaClientSupplier {
     @Override
     public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
         if (applicationId != null) {
-            assertThat((String) config.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), startsWith(applicationId + "-"));
+            final String transactionalId = (String) config.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
+            assertNotNull(transactionalId);
+            assertTrue(transactionalId.startsWith(applicationId + "-"));
         } else {
             assertFalse(config.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
         }

--- a/streams/src/testFixtures/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -49,8 +49,8 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.apache.kafka.common.metrics.Sensor.RecordingLevel.DEBUG;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -151,12 +151,12 @@ public final class StreamsTestUtils {
     }
 
     public static <K> void verifyKeyValueList(final List<KeyValue<K, byte[]>> expected, final List<KeyValue<K, byte[]>> actual) {
-        assertThat(actual.size(), equalTo(expected.size()));
+        assertEquals(expected.size(), actual.size());
         for (int i = 0; i < actual.size(); i++) {
             final KeyValue<K, byte[]> expectedKv = expected.get(i);
             final KeyValue<K, byte[]> actualKv = actual.get(i);
-            assertThat(actualKv.key, equalTo(expectedKv.key));
-            assertThat(actualKv.value, equalTo(expectedKv.value));
+            assertEquals(expectedKv.key, actualKv.key);
+            assertArrayEquals(expectedKv.value, actualKv.value);
         }
     }
 
@@ -181,9 +181,9 @@ public final class StreamsTestUtils {
     public static void verifyWindowedKeyValue(final KeyValue<Windowed<Bytes>, byte[]> actual,
                                               final Windowed<Bytes> expectedKey,
                                               final String expectedValue) {
-        assertThat(actual.key.window(), equalTo(expectedKey.window()));
-        assertThat(actual.key.key(), equalTo(expectedKey.key()));
-        assertThat(actual.value, equalTo(expectedValue.getBytes()));
+        assertEquals(expectedKey.window(), actual.key.window());
+        assertEquals(expectedKey.key(), actual.key.key());
+        assertArrayEquals(expectedValue.getBytes(), actual.value);
     }
 
     public static Metric getMetricByName(final Map<MetricName, ? extends Metric> metrics,


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-20988
Parent: https://issues.apache.org/jira/browse/KAFKA-20948

Migrate hamcrest `assertThat` usage in streams test fixtures and `org.apache.kafka.test` mock helpers to JUnit 5.

Files changed:
- `streams/src/testFixtures/java/org/apache/kafka/streams/utils/TestUtils.java`
- `streams/src/testFixtures/java/org/apache/kafka/streams/utils/UniqueTopicSerdeScope.java`
- `streams/src/testFixtures/java/org/apache/kafka/test/MockApiProcessor.java`
- `streams/src/testFixtures/java/org/apache/kafka/test/MockClientSupplier.java`
- `streams/src/testFixtures/java/org/apache/kafka/test/StreamsTestUtils.java`
- `streams/src/test/java/org/apache/kafka/test/MockApiFixedKeyProcessor.java`

`AssignmentTestUtils` is out of scope: it still exposes custom Hamcrest `Matcher`s used by unclaimed `processor.internals.assignment` tests, so `testFixturesImplementation libs.hamcrest` on `:streams` is retained.

No production code changes. This contribution is original work and is licensed to the project under the Apache License, Version 2.0.

### Tests
```
./gradlew :streams:compileTestFixturesJava :streams:compileTestJava \
  :streams:checkstyleTest :streams:spotlessCheck \
  :streams:test --tests org.apache.kafka.streams.kstream.internals.KStreamMapTest
```
BUILD SUCCESSFUL.

Reviewers: Ken Huang <s7133700@gmail.com>
