### PR TITLE
KAFKA-21118: Replace temp file handler with JUnit 5 @TempDir in connect tests

### DIFF
--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -20,15 +20,16 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,8 @@ public class FileStreamSourceTaskTest {
 
     private static final String TOPIC = "test";
 
+    @TempDir
+    private Path tempDir;
     private File tempFile;
     private Map<String, String> config;
     private OffsetStorageReader offsetStorageReader;
@@ -53,7 +56,7 @@ public class FileStreamSourceTaskTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        tempFile = File.createTempFile("file-stream-source-task-test", null);
+        tempFile = Files.createFile(tempDir.resolve("file-stream-source-task-test.tmp")).toFile();
         config = new HashMap<>();
         config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsolutePath());
         config.put(FileStreamSourceConnector.TOPIC_CONFIG, TOPIC);
@@ -62,11 +65,6 @@ public class FileStreamSourceTaskTest {
         offsetStorageReader = mock(OffsetStorageReader.class);
         context = mock(SourceTaskContext.class);
         task.initialize(context);
-    }
-
-    @AfterEach
-    public void teardown() throws IOException {
-        Files.deleteIfExists(tempFile.toPath());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -23,18 +23,18 @@ import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.util.Callback;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +60,8 @@ public class FileOffsetBackingStoreTest {
 
     private FileOffsetBackingStore store;
     private StandaloneConfig config;
+    @TempDir
+    private Path tempDir;
     private File tempFile;
     private Converter converter;
 
@@ -80,7 +82,7 @@ public class FileOffsetBackingStoreTest {
         when(converter.toConnectData(anyString(), any(byte[].class))).thenReturn(new SchemaAndValue(null,
                 List.of("connector", Map.of("partitionKey", "dummy"))));
         store = new FileOffsetBackingStore(converter);
-        tempFile = assertDoesNotThrow(() -> File.createTempFile("fileoffsetbackingstore", null));
+        tempFile = assertDoesNotThrow(() -> Files.createFile(tempDir.resolve("fileoffsetbackingstore.tmp")).toFile());
         Map<String, String> props = new HashMap<>();
         props.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, tempFile.getAbsolutePath());
         props.put(StandaloneConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
@@ -91,11 +93,6 @@ public class FileOffsetBackingStoreTest {
         store.start();
         assertTrue(((ThreadPoolExecutor) store.executor).getThreadFactory()
                 .newThread(EMPTY_RUNNABLE).getName().startsWith(FileOffsetBackingStore.class.getSimpleName()));
-    }
-
-    @AfterEach
-    public void teardown() throws IOException {
-        Files.deleteIfExists(tempFile.toPath());
     }
 
     @Test


### PR DESCRIPTION
Main Jira -
[KAFKA-14218](https://issues.apache.org/jira/browse/KAFKA-14218)
Sub Task -
[KAFKA-21118](https://issues.apache.org/jira/browse/KAFKA-21118)
## Summary
Replace `File.createTempFile()` with JUnit 5 `@TempDir` annotation in
two Connect test files:
- `FileStreamSourceTaskTest.java` (connect/file module)
- `FileOffsetBackingStoreTest.java` (connect/runtime module)

This removes the need for manual `@AfterEach` cleanup methods as JUnit 5
handles temporary directory lifecycle automatically.

## Changes

- Added `@TempDir private Path tempDir` field to both test classes
- Replaced `File.createTempFile(...)` with
`Files.createFile(tempDir.resolve(...)).toFile()`
- Removed `@AfterEach teardown()` methods that manually deleted temp
files

## Scope

This is a scoped PR covering 2 files as suggested in the JIRA ticket
comments. Additional files can be migrated in follow-up PRs.

## Test plan

- [x] `FileStreamSourceTaskTest` - all tests pass
- [x] `FileOffsetBackingStoreTest` - all tests pass
- [x] Verified locally with `./gradlew connect:file:test --tests
FileStreamSourceTaskTest`
- [x] Verified locally with `./gradlew connect:runtime:test --tests
FileOffsetBackingStoreTest`

Reviewers: Uros (github:uros-b)
