### PR TITLE
KAFKA-20991 Remove hamcrest from org.apache.kafka.streams.tests package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTestTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTestTest.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.Timeout;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 public class RelationalSmokeTestTest extends SmokeTestUtil {
@@ -95,16 +95,15 @@ public class RelationalSmokeTestTest extends SmokeTestUtil {
             final Map<Integer, RelationalSmokeTest.AugmentedComment> augmentedCommentResults =
                 augmentedComments.readKeyValuesToMap();
 
-            assertThat(augmentedArticleResults.size(), is(dataSet.getArticles().length));
-            assertThat(augmentedCommentResults.size(), is(dataSet.getComments().length));
+            assertEquals(dataSet.getArticles().length, augmentedArticleResults.size());
+            assertEquals(dataSet.getComments().length, augmentedCommentResults.size());
 
-            assertThat(
+            assertTrue(
                 RelationalSmokeTest.App.verifySync(true,
                                                    articleMap,
                                                    commentMap,
                                                    augmentedArticleResults,
-                                                   augmentedCommentResults),
-                is(true));
+                                                   augmentedCommentResults));
         }
     }
 }


### PR DESCRIPTION
Migrate the Hamcrest assertions in the `org.apache.kafka.streams.tests`                           
package to JUnit 5 assertions.

Testing:                                                                                                       
                                                                                                                 
```                                                                                                   
./gradlew :streams:test --tests org.apache.kafka.streams.tests.RelationalSmokeTestTest                                                      
```

Reviewers: Ken Huang <s7133700@gmail.com>
