### PR TITLE
MINOR: Fix flaky testDescribeQuorumRequestToControllers and testCannotResignIfObserver

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -876,7 +876,7 @@ class KafkaRaftClientTest {
     @ValueSource(booleans = { true, false })
     public void testCannotResignIfObserver(boolean withKip853Rpc) throws Exception {
         int leaderId = randomReplicaId();
-        int otherNodeId = randomReplicaId() + 1;
+        int otherNodeId = leaderId + 1;
         int epoch = 5;
         Set<Integer> voters = Set.of(leaderId, otherNodeId);
 

--- a/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
+++ b/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
@@ -1198,23 +1198,37 @@ public class KRaftClusterTest {
                 assertTrue(controllerIds.contains(quorumInfo.leaderId()),
                     "Leader ID " + quorumInfo.leaderId() + " was not a controller ID.");
 
-                // Try to bring down the raft client in the active controller node to force the leader election.
-                // Stop raft client but not the controller, because we would like to get NOT_LEADER_OR_FOLLOWER error first.
-                // If the controller is shutdown, the client can't send request to the original leader.
-                cluster.controllers().get(quorumInfo.leaderId()).sharedServer().raftManager().client().shutdown(1000);
-                // Send another describe metadata quorum request, it'll get NOT_LEADER_OR_FOLLOWER error first and then re-retrieve the metadata update
-                // and send to the correct active controller.
-                KafkaFuture<QuorumInfo> quorumInfo2Future = admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions()).quorumInfo();
-                // If raft client finishes shutdown before returning NOT_LEADER_OR_FOLLOWER error, the request will not be handled.
-                // This makes test fail. Shutdown the controller to make sure the request is handled by another controller.
-                cluster.controllers().get(quorumInfo.leaderId()).shutdown();
-                QuorumInfo quorumInfo2 = quorumInfo2Future.get();
-                // Make sure the leader has changed
-                assertTrue(quorumInfo.leaderId() != quorumInfo2.leaderId());
+                // Force a leader election by shutting down the current leader. Resign its raft client
+                // first so the remaining controllers hold a prompt election, then fully shut the
+                // controller down so the admin client is forced to re-route DescribeQuorum requests to
+                // a surviving controller.
+                int oldLeaderId = quorumInfo.leaderId();
+                cluster.controllers().get(oldLeaderId).sharedServer().raftManager().client().shutdown(1000);
+                cluster.controllers().get(oldLeaderId).shutdown();
 
-                assertEquals(controllerIds, voterIds);
-                assertTrue(controllerIds.contains(quorumInfo.leaderId()),
-                    "Leader ID " + quorumInfo.leaderId() + " was not a controller ID.");
+                // Poll until the admin client observes the new leader. describeMetadataQuorum retries
+                // through the NOT_LEADER_OR_FOLLOWER errors and re-resolves the active controller while
+                // the election completes. Polling (rather than relying on a single in-flight request)
+                // avoids racing the request against the leadership transition: previously the old leader
+                // could answer before it had resigned, reporting itself as the leader and failing the
+                // "leader has changed" assertion.
+                AtomicReference<QuorumInfo> quorumInfo2Ref = new AtomicReference<>();
+                TestUtils.waitForCondition(() -> {
+                    QuorumInfo qi = admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions()).quorumInfo().get();
+                    quorumInfo2Ref.set(qi);
+                    return qi.leaderId() != oldLeaderId && controllerIds.contains(qi.leaderId());
+                }, "Timed out waiting for a new metadata quorum leader after shutting down node " + oldLeaderId);
+                QuorumInfo quorumInfo2 = quorumInfo2Ref.get();
+
+                // The leader must have moved to a different controller. The voter set is unchanged by an
+                // election, since voters are only removed via RemoveVoter.
+                assertNotEquals(oldLeaderId, quorumInfo2.leaderId());
+                Set<Integer> voterIds2 = quorumInfo2.voters().stream()
+                    .map(QuorumInfo.ReplicaState::replicaId)
+                    .collect(Collectors.toSet());
+                assertEquals(controllerIds, voterIds2);
+                assertTrue(controllerIds.contains(quorumInfo2.leaderId()),
+                    "Leader ID " + quorumInfo2.leaderId() + " was not a controller ID.");
             }
         }
     }

--- a/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
+++ b/server/src/test/java/org/apache/kafka/server/KRaftClusterTest.java
@@ -1198,20 +1198,13 @@ public class KRaftClusterTest {
                 assertTrue(controllerIds.contains(quorumInfo.leaderId()),
                     "Leader ID " + quorumInfo.leaderId() + " was not a controller ID.");
 
-                // Force a leader election by shutting down the current leader. Resign its raft client
-                // first so the remaining controllers hold a prompt election, then fully shut the
-                // controller down so the admin client is forced to re-route DescribeQuorum requests to
-                // a surviving controller.
+                // Force a leader election by shutting down the current leader.
                 int oldLeaderId = quorumInfo.leaderId();
-                cluster.controllers().get(oldLeaderId).sharedServer().raftManager().client().shutdown(1000);
                 cluster.controllers().get(oldLeaderId).shutdown();
 
                 // Poll until the admin client observes the new leader. describeMetadataQuorum retries
                 // through the NOT_LEADER_OR_FOLLOWER errors and re-resolves the active controller while
-                // the election completes. Polling (rather than relying on a single in-flight request)
-                // avoids racing the request against the leadership transition: previously the old leader
-                // could answer before it had resigned, reporting itself as the leader and failing the
-                // "leader has changed" assertion.
+                // the election completes.
                 AtomicReference<QuorumInfo> quorumInfo2Ref = new AtomicReference<>();
                 TestUtils.waitForCondition(() -> {
                     QuorumInfo qi = admin.describeMetadataQuorum(new DescribeMetadataQuorumOptions()).quorumInfo().get();
@@ -1220,8 +1213,6 @@ public class KRaftClusterTest {
                 }, "Timed out waiting for a new metadata quorum leader after shutting down node " + oldLeaderId);
                 QuorumInfo quorumInfo2 = quorumInfo2Ref.get();
 
-                // The leader must have moved to a different controller. The voter set is unchanged by an
-                // election, since voters are only removed via RemoveVoter.
                 assertNotEquals(oldLeaderId, quorumInfo2.leaderId());
                 Set<Integer> voterIds2 = quorumInfo2.voters().stream()
                     .map(QuorumInfo.ReplicaState::replicaId)


### PR DESCRIPTION
## What Changed

### KRaftClusterTest#testDescribeQuorumRequestToControllers:

the test forces a leader change and asserts the new leader differs, but
it observed the change with a single in-flight `DescribeQuorum` request
that races with the old leader's resignation.

Shut the old leader down fully first, then poll `describeMetadataQuorum`
until a surviving controller reports itself as the new leader. Because
the old leader is gone, no successful response can name it, so the
assertion is now deterministic; polling also lets the admin client retry
through the `NOT_LEADER_OR_FOLLOWER` errors and re-resolve the active
controller.

### KafkaRaftClientTest#testCannotResignIfObserver:

`leaderId` and `otherNodeId` were drawn from two `randomReplicaId()`
calls, so the test's voter ids can collide and throw a
`IllegalArgumentException`. Other unit tests in the `raft` module only
call `randomReplicaId()` once so do not run into this.

Reviewers: Manikumar Reddy <manikumar.reddy@gmail.com>
