### PR TITLE
KAFKA-20989: Add Notification Cleaners to Migrating Controller Servers

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
 import kafka.migration.MigrationPropagator
 import kafka.network.{DataPlaneAcceptor, SocketServer}
 import kafka.raft.KafkaRaftManager
@@ -25,7 +26,7 @@ import kafka.server.QuotaFactory.QuotaManagers
 import scala.collection.immutable
 import kafka.server.metadata.{AclPublisher, ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, KRaftMetadataCache, KRaftMetadataCachePublisher, ScramPublisher}
 import kafka.utils.{CoreUtils, Logging}
-import kafka.zk.{KafkaZkClient, ZkMigrationClient}
+import kafka.zk.{ConfigEntityChangeNotificationSequenceZNode, ConfigEntityChangeNotificationZNode, KafkaZkClient, ZkAclChangeStore, ZkMigrationClient}
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
@@ -64,9 +65,11 @@ import scala.jdk.CollectionConverters._
 case class ControllerMigrationSupport(
   zkClient: KafkaZkClient,
   migrationDriver: KRaftMigrationDriver,
-  brokersRpcClient: LegacyPropagator
+  brokersRpcClient: LegacyPropagator,
+  notificationCleaners: Seq[ZkNodeChangeNotificationListener]
 ) {
   def shutdown(logging: Logging): Unit = {
+    notificationCleaners.foreach(cleaner => CoreUtils.swallow(cleaner.close(), logging))
     if (zkClient != null) {
       CoreUtils.swallow(zkClient.close(), logging)
     }
@@ -75,6 +78,21 @@ case class ControllerMigrationSupport(
     }
     if (migrationDriver != null) {
       CoreUtils.swallow(migrationDriver.close(), logging)
+    }
+  }
+}
+
+object ControllerMigrationSupport {
+  private[server] val NoOpNotificationHandler: NotificationHandler = _ => ()
+
+  private[server] def notificationCleaners(
+    zkClient: KafkaZkClient,
+    handler: NotificationHandler = NoOpNotificationHandler
+  ): Seq[ZkNodeChangeNotificationListener] = {
+    val paths = (ConfigEntityChangeNotificationZNode.path -> ConfigEntityChangeNotificationSequenceZNode.SequenceNumberPrefix) +:
+      ZkAclChangeStore.stores.map(_.aclChangePath -> ZkAclChangeStore.SequenceNumberPrefix).toSeq
+    paths.map { case (root, prefix) =>
+      new ZkNodeChangeNotificationListener(zkClient, root, prefix, handler)
     }
   }
 }
@@ -310,8 +328,10 @@ class ControllerServer(
           .setMinMigrationBatchSize(config.migrationMetadataMinBatchSize)
           .setTime(time)
           .build()
+        val notificationCleaners = ControllerMigrationSupport.notificationCleaners(zkClient)
+        migrationSupport = Some(ControllerMigrationSupport(zkClient, migrationDriver, propagator, notificationCleaners))
+        notificationCleaners.foreach(_.init())
         migrationDriver.start()
-        migrationSupport = Some(ControllerMigrationSupport(zkClient, migrationDriver, propagator))
       }
 
       quotaManagers = QuotaFactory.instantiate(config,

--- a/core/src/test/scala/unit/kafka/server/ControllerMigrationSupportTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMigrationSupportTest.scala
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
+import kafka.utils.TestUtils
+import kafka.zk.{ConfigEntityChangeNotificationZNode, ConfigEntityZNode, ZkAclChangeStore}
+import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
+import org.apache.kafka.common.resource.ResourcePattern
+import org.apache.kafka.common.resource.ResourceType.TOPIC
+import org.apache.kafka.server.config.ConfigType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo}
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.Seq
+
+class ControllerMigrationSupportTest extends QuorumTestHarness {
+
+  private var notificationHandler: TestNotificationHandler = _
+  private var cleaners: Seq[ZkNodeChangeNotificationListener] = Seq.empty
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    super.setUp(testInfo)
+    zkClient.createAclPaths()
+    zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
+    notificationHandler = new TestNotificationHandler()
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    cleaners.foreach(_.close())
+    super.tearDown()
+  }
+
+  @Test
+  def testNotificationCleanersProcessConfigAndAclChanges(): Unit = {
+    cleaners = ControllerMigrationSupport.notificationCleaners(zkClient, notificationHandler)
+
+    // 1 + the number of ACL change stores, since there's one for config changes too
+    assertEquals(1 + ZkAclChangeStore.stores.size, cleaners.size)
+
+    cleaners.foreach(_.init())
+    zkClient.createConfigChangeNotification(ConfigEntityZNode.path(ConfigType.TOPIC, "test-topic"))
+    zkClient.createAclChangeNotification(new ResourcePattern(TOPIC, "test-topic", LITERAL))
+    zkClient.createAclChangeNotification(new ResourcePattern(TOPIC, "test-topic", PREFIXED))
+
+    TestUtils.waitUntilTrue(() => notificationHandler.receivedCount == 3,
+      s"Expected 3 invocations of processNotification, but there were ${notificationHandler.receivedCount}")
+  }
+
+  private class TestNotificationHandler extends NotificationHandler {
+    private val count = new AtomicInteger
+
+    override def processNotification(notificationMessage: Array[Byte]): Unit =
+      count.incrementAndGet()
+
+    def receivedCount: Int = count.get()
+  }
+}


### PR DESCRIPTION
## Summary
As reported in KAFKA-20989, the KRaft controller creates persistent sequential notifications for config changes and ACL changes when in migration mode.

These nodes are normally deleted after 15 minutes by [ZkNodeChangeNotificationListener](https://github.com/apache/kafka/blob/3.9.1/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala#L125-L140), which is started by [ZooKeeper-mode brokers](https://github.com/apache/kafka/blob/3.9.1/core/src/main/scala/kafka/server/KafkaServer.scala#L631-L633).

However if brokers enter KRaft mode in dual-write phase, no cleanup listener remains while the [migration controller continues dual-writing](https://github.com/apache/kafka/blob/3.9.1/core/src/main/scala/kafka/server/ControllerServer.scala#L284-L314). 

While clusters remain in this mode, /config/changes, /kafka-acl-changes, and /kafka-acl-extended-changes keep growing without deletion.

To solve this, we run the same listeners that the brokers used to purge old notifications but on controllers that are in migration mode.


## Test Plan

- [x] Changes are covered by tests
