### PR TITLE
MINOR: Add explicit timestamps to WallclockTimestampExtractorTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
@@ -33,12 +33,15 @@ public class WallclockTimestampExtractorTest {
         final TimestampExtractor extractor = new WallclockTimestampExtractor();
 
         final long before = System.currentTimeMillis();
+        final long recordTimestamp = 41;
+        final long partitionTime = 42;
+        // The extractor should ignore the input timestamps and return the current wall-clock time.
         final long timestamp = extractor.extract(
             new ConsumerRecord<>(
                 "anyTopic",
                 0,
                 0,
-                41,
+                recordTimestamp,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -46,7 +49,7 @@ public class WallclockTimestampExtractorTest {
                 null,
                 new RecordHeaders(),
                 Optional.empty()),
-            42);
+            partitionTime);
         final long after = System.currentTimeMillis();
 
         assertTrue(before <= timestamp);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/WallclockTimestampExtractorTest.java
@@ -17,8 +17,12 @@
 package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,7 +33,20 @@ public class WallclockTimestampExtractorTest {
         final TimestampExtractor extractor = new WallclockTimestampExtractor();
 
         final long before = System.currentTimeMillis();
-        final long timestamp = extractor.extract(new ConsumerRecord<>("anyTopic", 0, 0, null, null), 42);
+        final long timestamp = extractor.extract(
+            new ConsumerRecord<>(
+                "anyTopic",
+                0,
+                0,
+                41,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                null,
+                null,
+                new RecordHeaders(),
+                Optional.empty()),
+            42);
         final long after = System.currentTimeMillis();
 
         assertTrue(before <= timestamp);


### PR DESCRIPTION
Add an explicit record timestamp and partition time
to`WallclockTimestampExtractorTest`.  Ensure that
`WallclockTimestampExtractor` returns the wall-clock time instead of
either input timestamp.

### Tests
`./gradlew streams:test --tests
org.apache.kafka.streams.processor.WallclockTimestampExtractorTest`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
