### PR TITLE
KAFKA-14302: Advance restored offsets after changelog catch-up

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -92,13 +92,15 @@ public class ProcessorStateManager implements StateManager {
         // applied to the store used for both restoration (active and standby tasks restored offset) and
         // normal processing that update stores (written offset); could be null (when initialized)
         //
-        // the offset is updated in three ways:
+        // the offset is updated in four ways:
         //   1. when loading from the checkpoint file, when the corresponding task has acquired the state
         //      directory lock and have registered all the state store; it is only one-time
         //   2. when updating with restore records (by both restoring active and standby),
         //      update to the last restore record's offset
         //   3. when checkpointing with the given written offsets from record collector,
         //      update blindly with the given offset
+        //   4. when restoration reaches a confirmed catch-up boundary with no further records to apply
+        //      (KAFKA-14302), as last-applied = next-fetch - 1, never moving backwards
         private Long offset;
 
         // Will be updated on batch restored
@@ -531,6 +533,31 @@ public class ProcessorStateManager implements StateManager {
 
             stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
         }
+    }
+
+    /**
+     * Records that restoration has conclusively reached {@code nextOffsetToFetch} (Kafka next-offset-to-fetch
+     * semantics: log-end offset / restore boundary), converting to last-applied as
+     * {@code nextOffsetToFetch - 1}. Used when a catch-up boundary is confirmed with no further records
+     * to apply (KAFKA-14302). Does not change {@link #changelogOffsets()} mapping of {@code null -> 0}.
+     */
+    void advanceRestoredOffsetTo(final StateStoreMetadata storeMetadata, final long nextOffsetToFetch) {
+        if (!stores.containsValue(storeMetadata)) {
+            throw new IllegalStateException("Advancing offset for " + storeMetadata + " which is not registered in this state manager, " +
+                "this should not happen.");
+        }
+        if (nextOffsetToFetch <= 0L) {
+            return;
+        }
+        final long lastAppliedOffset = nextOffsetToFetch - 1L;
+        final Long currentOffset = storeMetadata.offset();
+        if (currentOffset != null && currentOffset >= lastAppliedOffset) {
+            return;
+        }
+        storeMetadata.setOffset(lastAppliedOffset);
+        log.debug("State store {} restored offset advanced to {} at changelog {} (next fetch {})",
+            storeMetadata.stateStore.name(), storeMetadata.offset, storeMetadata.changelogPartition, nextOffsetToFetch);
+        stateDirectory.updateTaskOffsets(taskId, persistentChangelogOffsets());
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -99,8 +99,8 @@ public class ProcessorStateManager implements StateManager {
         //      update to the last restore record's offset
         //   3. when checkpointing with the given written offsets from record collector,
         //      update blindly with the given offset
-        //   4. when restoration reaches a confirmed catch-up boundary with no further records to apply
-        //      (KAFKA-14302), as last-applied = next-fetch - 1, never moving backwards
+        // 4. when restoration reaches the end offset (the limit offset for standbys) with no further
+        //    records to apply, update to next offset to fetch minus one (last-applied); never moves backwards
         private Long offset;
 
         // Will be updated on batch restored
@@ -536,10 +536,10 @@ public class ProcessorStateManager implements StateManager {
     }
 
     /**
-     * Records that restoration has conclusively reached {@code nextOffsetToFetch} (Kafka next-offset-to-fetch
-     * semantics: log-end offset / restore boundary), converting to last-applied as
-     * {@code nextOffsetToFetch - 1}. Used when a catch-up boundary is confirmed with no further records
-     * to apply (KAFKA-14302). Does not change {@link #changelogOffsets()} mapping of {@code null -> 0}.
+     * Advances the store's restored offset once restoration has reached the end offset (the limit
+     * offset for standbys): {@code nextOffsetToFetch} is a next offset to fetch (exclusive end),
+     * stored as last-applied {@code nextOffsetToFetch - 1} (KAFKA-14302). Never moves backwards;
+     * a non-positive value is a no-op, so the stored offset stays non-negative.
      */
     void advanceRestoredOffsetTo(final StateStoreMetadata storeMetadata, final long nextOffsetToFetch) {
         if (!stores.containsValue(storeMetadata)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -754,6 +754,10 @@ public class StoreChangelogReader implements ChangelogReader {
             // markers) so the remaining-records metric reaches exactly zero on completion
             recordRestorationProgress(task, changelogMetadata, 0, storeMetadata.offset(), changelogMetadata.restoreEndOffset);
 
+            // Catch-up boundary: advertise restoreEndOffset, not the live consumer position, which may
+            // already be past records that were buffered and never applied (KAFKA-14302).
+            stateManager.advanceRestoredOffsetTo(storeMetadata, changelogMetadata.restoreEndOffset);
+
             changelogMetadata.transitTo(ChangelogState.COMPLETED);
             pauseChangelogsFromRestoreConsumer(Set.of(partition));
             if (storeMetadata.store() instanceof MeteredStateStore) {
@@ -765,6 +769,8 @@ public class StoreChangelogReader implements ChangelogReader {
             } catch (final Exception e) {
                 throw new StreamsException("State restore listener failed on restore completed", e);
             }
+        } else if (changelogMetadata.stateManager.taskType() == TaskType.STANDBY) {
+            maybeAdvanceStandbyRestoredOffset(stateManager, changelogMetadata, storeMetadata, partition);
         }
 
         if (numRecords > 0 || changelogMetadata.state().equals(ChangelogState.COMPLETED)) {
@@ -772,6 +778,41 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         return numRecords;
+    }
+
+    /**
+     * Advance a standby store's restored offset only at a confirmed catch-up boundary (KAFKA-14302).
+     * A zero-record poll is not sufficient: retention seeks, source-changelog buffering, and incomplete
+     * fetches can all leave the consumer at a non-zero position while records remain to apply.
+     */
+    private void maybeAdvanceStandbyRestoredOffset(final ProcessorStateManager stateManager,
+                                                   final ChangelogMetadata changelogMetadata,
+                                                   final StateStoreMetadata storeMetadata,
+                                                   final TopicPartition partition) {
+        if (!changelogMetadata.bufferedRecords().isEmpty()) {
+            return;
+        }
+        try {
+            final Long restoreEndOffset = changelogMetadata.restoreEndOffset;
+            if (restoreEndOffset == null) {
+                // Dedicated changelog: no restoreEndOffset. lag == 0 with an empty buffer means
+                // the restore consumer is at LEO and every fetched record has already been applied.
+                // position() is the next-fetch boundary, not a last-applied offset.
+                final OptionalLong lag = restoreConsumer.currentLag(partition);
+                if (lag.isPresent() && lag.getAsLong() == 0L) {
+                    stateManager.advanceRestoredOffsetTo(storeMetadata, restoreConsumer.position(partition));
+                }
+            } else if (restoreEndOffset > 0L) {
+                // Source changelog: restoreEndOffset is the committed-offset limit. Advertise
+                // only that boundary, never live position past unapplied/uncommitted records.
+                final long position = restoreConsumer.position(partition);
+                if (position >= restoreEndOffset) {
+                    stateManager.advanceRestoredOffsetTo(storeMetadata, restoreEndOffset);
+                }
+            }
+        } catch (final TimeoutException timeoutException) {
+            // Leave the offset unchanged; the next restore loop retries.
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -654,7 +654,7 @@ public class StoreChangelogReader implements ChangelogReader {
             updateOffsetIntervalMs < time.milliseconds() - lastUpdateOffsetTime) {
 
             // when the interval has elapsed we should try to update the limit offset for standbys reading from
-            // a source changelog with the new committed offset, unless there are no buffered records since 
+            // a source changelog with the new committed offset, unless there are no buffered records since
             // we only need the limit when processing new records
             // for other changelog partitions we do not need to update limit offset at all since we never need to
             // check when it completes based on limit offset anyways: the end offset would keep increasing and the
@@ -754,8 +754,8 @@ public class StoreChangelogReader implements ChangelogReader {
             // markers) so the remaining-records metric reaches exactly zero on completion
             recordRestorationProgress(task, changelogMetadata, 0, storeMetadata.offset(), changelogMetadata.restoreEndOffset);
 
-            // Catch-up boundary: advertise restoreEndOffset, not the live consumer position, which may
-            // already be past records that were buffered and never applied (KAFKA-14302).
+            // restoration reached the end offset: advance to restoreEndOffset, not the consumer position,
+            // which may already be past buffered records that were never applied
             stateManager.advanceRestoredOffsetTo(storeMetadata, changelogMetadata.restoreEndOffset);
 
             changelogMetadata.transitTo(ChangelogState.COMPLETED);
@@ -781,9 +781,10 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     /**
-     * Advance a standby store's restored offset only at a confirmed catch-up boundary (KAFKA-14302).
-     * A zero-record poll is not sufficient: retention seeks, source-changelog buffering, and incomplete
-     * fetches can all leave the consumer at a non-zero position while records remain to apply.
+     * Advance a standby store's restored offset only once restoration has actually reached the end
+     * offset — the limit offset for changelogs piggy-backed on a source topic. A zero-record poll is
+     * not sufficient: retention seeks, source buffering, and incomplete fetches can leave the consumer
+     * at a non-zero position while records remain to apply.
      */
     private void maybeAdvanceStandbyRestoredOffset(final ProcessorStateManager stateManager,
                                                    final ChangelogMetadata changelogMetadata,
@@ -795,16 +796,16 @@ public class StoreChangelogReader implements ChangelogReader {
         try {
             final Long restoreEndOffset = changelogMetadata.restoreEndOffset;
             if (restoreEndOffset == null) {
-                // Dedicated changelog: no restoreEndOffset. lag == 0 with an empty buffer means
-                // the restore consumer is at LEO and every fetched record has already been applied.
-                // position() is the next-fetch boundary, not a last-applied offset.
+                // dedicated changelog (no restoreEndOffset): lag == 0 with an empty buffer means the
+                // consumer is at the log-end offset with every fetched record applied; position() is
+                // the next offset to fetch, not last-applied
                 final OptionalLong lag = restoreConsumer.currentLag(partition);
                 if (lag.isPresent() && lag.getAsLong() == 0L) {
                     stateManager.advanceRestoredOffsetTo(storeMetadata, restoreConsumer.position(partition));
                 }
             } else if (restoreEndOffset > 0L) {
-                // Source changelog: restoreEndOffset is the committed-offset limit. Advertise
-                // only that boundary, never live position past unapplied/uncommitted records.
+                // source changelog: restoreEndOffset is the committed-offset limit; advance only up to
+                // that limit, never the live position past unapplied/uncommitted records
                 final long position = restoreConsumer.position(partition);
                 if (position >= restoreEndOffset) {
                     stateManager.advanceRestoredOffsetTo(storeMetadata, restoreEndOffset);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -301,6 +301,66 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
+    public void shouldNoOpAdvanceRestoredOffsetWhenNextFetchIsZero() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
+            final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
+            stateMgr.advanceRestoredOffsetTo(storeMetadata, 0L);
+            assertNull(storeMetadata.offset());
+            assertEquals(singletonMap(persistentStorePartition, 0L), stateMgr.changelogOffsets());
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
+    public void shouldConvertNextFetchToLastAppliedOffsetWhenAdvancingRestoredOffset() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
+            final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
+            stateMgr.advanceRestoredOffsetTo(storeMetadata, 20_000L);
+            assertEquals(19_999L, storeMetadata.offset());
+            assertEquals(singletonMap(persistentStorePartition, 20_000L), stateMgr.changelogOffsets());
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
+    public void shouldNotMoveRestoredOffsetBackwards() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
+            final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
+            stateMgr.advanceRestoredOffsetTo(storeMetadata, 20_000L);
+            stateMgr.advanceRestoredOffsetTo(storeMetadata, 10_000L);
+            assertEquals(19_999L, storeMetadata.offset());
+            assertEquals(singletonMap(persistentStorePartition, 20_000L), stateMgr.changelogOffsets());
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
+    public void shouldNotAdvanceOffsetWhenAlreadyAtRestoreBoundary() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
+            final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
+            stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
+            assertEquals(100L, storeMetadata.offset());
+            assertEquals(singletonMap(persistentStorePartition, 101L), stateMgr.changelogOffsets());
+            stateMgr.advanceRestoredOffsetTo(storeMetadata, 101L);
+            assertEquals(100L, storeMetadata.offset());
+            assertEquals(singletonMap(persistentStorePartition, 101L), stateMgr.changelogOffsets());
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
     public void shouldCloseStateStoresOnStateManagerClose() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
         final StateStore store = mock(StateStore.class);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderCaughtUpOffsetTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderCaughtUpOffsetTest.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.assignment.ClientState;
+import org.apache.kafka.test.MockKeyValueStore;
+import org.apache.kafka.test.MockStandbyUpdateListener;
+import org.apache.kafka.test.MockStateRestoreListener;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.processor.internals.Task.TaskType.ACTIVE;
+import static org.apache.kafka.streams.processor.internals.Task.TaskType.STANDBY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class StoreChangelogReaderCaughtUpOffsetTest {
+
+    private final String storeName = "store";
+    private final String topicName = "topic";
+    private final LogContext logContext = new LogContext("test-reader ");
+    private final TopicPartition tp = new TopicPartition(topicName, 0);
+    private final StreamsConfig config = new StreamsConfig(StreamsTestUtils.getStreamsConfig("test-reader"));
+    private final MockTime time = new MockTime();
+    private final MockStateRestoreListener callback = new MockStateRestoreListener();
+    private final MockStandbyUpdateListener standbyListener = new MockStandbyUpdateListener();
+    private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name());
+    private final MockAdminClient adminClient = new MockAdminClient();
+
+    @Test
+    public void shouldAdvertiseZeroAfterActiveRestoreOfEmptyChangelogWithZeroEndOffset() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 0L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 0L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, reader.changelogMetadata(tp).state());
+            assertNull(stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 0L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldNotAdvanceActiveOffsetOnEmptyPollWhileStillBehindEndOffset() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+            assertNull(stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 0L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldAdvertiseRestoreEndOffsetNotLivePositionWhenActiveCompletesPastEnd() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            // Compacted log start is beyond the restore snapshot; live position is 15_000, restore end is 10_000.
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 15_000L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 15_000L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 10_000L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, reader.changelogMetadata(tp).state());
+            assertEquals(15_000L, consumer.position(tp));
+            assertEquals(Collections.singletonMap(tp, 10_000L), stateManager.changelogOffsets());
+            assertEquals(9_999L, stateManager.storeMetadata(tp).offset());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldNotAdvanceActiveOffsetWhenPositionIsBehindRestoreEndOffset() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 15_000L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+            assertEquals(15_000L, consumer.position(tp));
+            assertNull(stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 0L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldNotAdvanceStandbyOffsetOnEmptyPollWhileLagIsPositive() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(STANDBY, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.transitToUpdateStandby();
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+            assertNull(stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 0L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldNotAdvertiseBufferedSourceChangelogRecordsBeyondCommittedLimit() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(STANDBY, stateDir, true);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 12L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 12L));
+            adminClient.updateConsumerGroupOffsets(Collections.singletonMap(tp, 7L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.transitToUpdateStandby();
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            final byte[] keyBytes = new byte[] {0x0, 0x0, 0x0, 0x1};
+            for (long offset = 5L; offset <= 11L; offset++) {
+                consumer.addRecord(new ConsumerRecord<>(topicName, 0, offset, keyBytes, "value".getBytes()));
+            }
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertTrue(reader.changelogMetadata(tp).bufferedRecords().size() > 0);
+            assertEquals(7L, (long) reader.changelogMetadata(tp).endOffset());
+            // Applied offsets 5 and 6 (strictly below the committed limit); do not advertise buffered 7+.
+            assertEquals(Collections.singletonMap(tp, 7L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldNotAdvanceStandbyOffsetWhenPositionTimesOut() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(STANDBY, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        final MockConsumer<byte[], byte[]> timeoutConsumer = new MockConsumer<>(AutoOffsetResetStrategy.EARLIEST.name()) {
+            @Override
+            public long position(final TopicPartition partition) {
+                throw new TimeoutException("KABOOM!");
+            }
+        };
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            timeoutConsumer.updateBeginningOffsets(Collections.singletonMap(tp, 20_000L));
+            timeoutConsumer.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 20_000L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, timeoutConsumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.transitToUpdateStandby();
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertNull(stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 0L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldReportZeroTaskLagAfterEmptyHighEndOffsetRestore() throws IOException {
+        final long changelogEndOffset = 20_000L;
+        final long acceptableRecoveryLag = 10_000L;
+        final TaskId taskId = new TaskId(0, 0);
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(STANDBY, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.transitToUpdateStandby();
+            reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
+
+            assertEquals(changelogEndOffset - 1L, stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, changelogEndOffset), stateManager.changelogOffsets());
+
+            final long taskOffsetSum = StateDirectory.sumOfChangelogOffsets(taskId, stateManager.changelogOffsets());
+            assertEquals(changelogEndOffset, taskOffsetSum);
+
+            final ClientState restored = new ClientState();
+            restored.addPreviousTasksAndOffsetSums("c1", Collections.singletonMap(taskId, taskOffsetSum));
+            restored.computeTaskLags(null, Collections.singletonMap(taskId, changelogEndOffset));
+            assertEquals(0L, restored.lagFor(taskId));
+            assertTrue(restored.lagFor(taskId) <= acceptableRecoveryLag);
+
+            final ClientState unrestored = new ClientState();
+            unrestored.addPreviousTasksAndOffsetSums("c1", Collections.singletonMap(taskId, 0L));
+            unrestored.computeTaskLags(null, Collections.singletonMap(taskId, changelogEndOffset));
+            assertEquals(changelogEndOffset, unrestored.lagFor(taskId));
+            assertTrue(unrestored.lagFor(taskId) > acceptableRecoveryLag);
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldKeepLastAppliedOffsetAfterNonEmptyActiveRestore() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 8L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 8L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            final byte[] keyBytes = new byte[] {0x0, 0x0, 0x0, 0x1};
+            for (long offset = 0L; offset < 8L; offset++) {
+                consumer.addRecord(new ConsumerRecord<>(topicName, 0, offset, keyBytes, "value".getBytes()));
+            }
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+
+            assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, reader.changelogMetadata(tp).state());
+            assertEquals(7L, stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 8L), stateManager.changelogOffsets());
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldAccountForTrailingOffsetHolesBeforeAdvancingCaughtUpOffset() throws IOException {
+        // end offset is 10 but only records 0..7 are restored; 8 and 9 are trailing holes the restore
+        // consumer never returns. remaining-records must decrement from the pre-advance last-applied
+        // offset (7), then the catch-up helper may set last-applied to 9 so changelogOffsets() == 10.
+        final File stateDir = TestUtils.tempDirectory();
+        final ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+        final Task mockTask = mock(Task.class);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, 10L));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, 10L));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mockTask));
+            assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+
+            final byte[] keyBytes = new byte[] {0x0, 0x0, 0x0, 0x1};
+            for (long offset = 0L; offset < 8L; offset++) {
+                consumer.addRecord(new ConsumerRecord<>(topicName, 0, offset, keyBytes, "value".getBytes()));
+            }
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mockTask));
+            assertEquals(8L, reader.changelogMetadata(tp).totalRestored());
+            assertEquals(7L, stateManager.storeMetadata(tp).offset());
+            assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+
+            consumer.seek(tp, 10L);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mockTask));
+
+            assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, reader.changelogMetadata(tp).state());
+            assertEquals(8L, reader.changelogMetadata(tp).totalRestored());
+            assertEquals(9L, stateManager.storeMetadata(tp).offset());
+            assertEquals(Collections.singletonMap(tp, 10L), stateManager.changelogOffsets());
+
+            final ArgumentCaptor<Long> numRecordsCaptor = ArgumentCaptor.forClass(Long.class);
+            final ArgumentCaptor<Long> numOffsetsCaptor = ArgumentCaptor.forClass(Long.class);
+            final ArgumentCaptor<Boolean> initCaptor = ArgumentCaptor.forClass(Boolean.class);
+            verify(mockTask, atLeastOnce())
+                .recordRestoration(any(), numRecordsCaptor.capture(), numOffsetsCaptor.capture(), initCaptor.capture());
+
+            long initialRemaining = 0L;
+            long decrementedRemaining = 0L;
+            long totalRecords = 0L;
+            for (int i = 0; i < initCaptor.getAllValues().size(); i++) {
+                if (initCaptor.getAllValues().get(i)) {
+                    initialRemaining += numOffsetsCaptor.getAllValues().get(i);
+                } else {
+                    decrementedRemaining += numOffsetsCaptor.getAllValues().get(i);
+                    totalRecords += numRecordsCaptor.getAllValues().get(i);
+                }
+            }
+
+            assertEquals(10L, initialRemaining, "remaining-records metric should be initialized from the offset range");
+            assertEquals(initialRemaining, decrementedRemaining, "remaining-records metric should decrement to exactly zero");
+            assertEquals(8L, totalRecords, "restore-total should count the records actually restored");
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    @Test
+    public void shouldResumeAtLogEndOffsetAfterCheckpointingEmptyHighEndOffsetRestore() throws IOException {
+        final File stateDir = TestUtils.tempDirectory();
+        final long changelogEndOffset = 20_000L;
+        final OffsetTrackingStore kvStore = new OffsetTrackingStore(storeName);
+        ProcessorStateManager stateManager = newRealStateManager(ACTIVE, stateDir, false);
+        try {
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, stateManager);
+            reader.restore(Collections.singletonMap(new TaskId(0, 0), mock(Task.class)));
+            assertEquals(Collections.singletonMap(tp, changelogEndOffset), stateManager.changelogOffsets());
+
+            stateManager.commit();
+            stateManager.close();
+
+            stateManager = newRealStateManager(ACTIVE, stateDir, false);
+            stateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            stateManager.initializeStoreOffsets(true);
+            assertEquals(
+                Collections.singletonMap(tp, changelogEndOffset),
+                stateManager.changelogOffsets(),
+                "re-init from checkpoint must resume at LEO, not 0"
+            );
+        } finally {
+            stateManager.close();
+            Utils.delete(stateDir);
+        }
+    }
+
+    private ProcessorStateManager newRealStateManager(final Task.TaskType type,
+                                                      final File stateDir,
+                                                      final boolean sourceChangelog) {
+        final StateDirectory stateDirectory = new StateDirectory(
+            new StreamsConfig(new Properties() {
+                {
+                    put(StreamsConfig.APPLICATION_ID_CONFIG, "test-reader");
+                    put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                    put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+                }
+            }),
+            time,
+            true,
+            false
+        );
+        return new ProcessorStateManager(
+            new TaskId(0, 0),
+            type,
+            false,
+            false,
+            logContext,
+            stateDirectory,
+            time,
+            mkMap(mkEntry(storeName, topicName)),
+            sourceChangelog ? Set.of(tp) : Collections.emptySet()
+        );
+    }
+
+    private static final class OffsetTrackingStore extends MockKeyValueStore {
+        private final Map<TopicPartition, Long> committed = new HashMap<>();
+
+        OffsetTrackingStore(final String name) {
+            super(name, true);
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public boolean managesOffsets() {
+            return true;
+        }
+
+        @Override
+        public void commit(final Map<TopicPartition, Long> changelogOffsets) {
+            super.commit(changelogOffsets);
+            committed.clear();
+            committed.putAll(changelogOffsets);
+        }
+
+        @Override
+        public Long committedOffset(final TopicPartition partition) {
+            return committed.get(partition);
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.common.utils.internals.LogContext;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -46,9 +47,11 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager.StateStoreMetadata;
 import org.apache.kafka.streams.state.internals.MeteredKeyValueStore;
+import org.apache.kafka.test.MockKeyValueStore;
 import org.apache.kafka.test.MockStandbyUpdateListener;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.StreamsTestUtils;
+import org.apache.kafka.test.TestUtils;
 
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
@@ -62,6 +65,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -668,6 +673,85 @@ public class StoreChangelogReaderTest {
         assertEquals(storeName, callback.storeNameCalledStates.get(RESTORE_START));
         assertEquals(storeName, callback.storeNameCalledStates.get(RESTORE_END));
         assertNull(callback.storeNameCalledStates.get(RESTORE_BATCH));
+    }
+
+    /**
+     * KAFKA-14302: an empty restore of a high-LEO compacted changelog must still advertise the log
+     * end offset (next-fetch), not 0, so taskOffsetSums match the assignor's endOffsetSum.
+     */
+    @ParameterizedTest
+    @EnumSource(value = Task.TaskType.class, names = {"ACTIVE", "STANDBY"})
+    public void shouldReportCaughtUpOffsetAfterRestoringEmptyChangelogWithHighEndOffset(final Task.TaskType type) throws IOException {
+        final long changelogEndOffset = 20_000L;
+        final TaskId taskId = new TaskId(0, 0);
+        final File stateDir = TestUtils.tempDirectory();
+        final StateDirectory stateDirectory = new StateDirectory(
+            new StreamsConfig(new Properties() {
+                {
+                    put(StreamsConfig.APPLICATION_ID_CONFIG, "test-reader");
+                    put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+                    put(StreamsConfig.STATE_DIR_CONFIG, stateDir.getPath());
+                }
+            }),
+            time,
+            true,
+            false
+        );
+        final ProcessorStateManager realStateManager = new ProcessorStateManager(
+            taskId,
+            type,
+            false,
+            false,
+            logContext,
+            stateDirectory,
+            time,
+            mkMap(mkEntry(storeName, topicName)),
+            Collections.emptySet()
+        );
+        final MockKeyValueStore kvStore = new MockKeyValueStore(storeName, true);
+
+        try {
+            realStateManager.registerStore(kvStore, kvStore.stateRestoreCallback, null);
+            // Empty local state directory: no checkpoint, store offset stays null (pod restart without a PV).
+            realStateManager.initializeStoreOffsets(true);
+
+            consumer.updateBeginningOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            consumer.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+            adminClient.updateEndOffsets(Collections.singletonMap(tp, changelogEndOffset));
+
+            final StoreChangelogReader reader =
+                new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+            reader.register(tp, realStateManager);
+            if (type == STANDBY) {
+                reader.transitToUpdateStandby();
+            }
+            reader.restore(Collections.singletonMap(taskId, mock(Task.class)));
+
+            if (type == ACTIVE) {
+                assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, reader.changelogMetadata(tp).state());
+            } else {
+                // Standbys never transit to COMPLETED; they keep updating. The advertised offset
+                // is what TaskManager publishes on the next subscription (no LATEST_OFFSET overlay).
+                assertEquals(StoreChangelogReader.ChangelogState.RESTORING, reader.changelogMetadata(tp).state());
+            }
+            assertEquals(0L, reader.changelogMetadata(tp).totalRestored());
+            assertTrue(kvStore.keys.isEmpty());
+            assertEquals(
+                changelogEndOffset,
+                consumer.position(tp),
+                "restore consumer must sit at the compacted log end"
+            );
+            assertEquals(changelogEndOffset - 1L, realStateManager.storeMetadata(tp).offset());
+            // Next offset to fetch must be the log end offset so taskOffsetSums equal the assignor's endOffsetSum.
+            assertEquals(
+                Collections.singletonMap(tp, changelogEndOffset),
+                realStateManager.changelogOffsets(),
+                "empty restore of a high-end changelog must advertise LEO, not 0"
+            );
+        } finally {
+            realStateManager.close();
+            Utils.delete(stateDir);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the bug?

When restoring an empty changelog with a non-zero end offset,
ProcessorStateManager does not update the restored offset because no
records are applied.

As a result, changelogOffsets() can report 0 even though restoration has
completed at a higher offset. This can cause Kafka Streams to
incorrectly report recovery lag for the task.

## What does this change do?

The fix advances the restored offset once changelog restoration has
actually reached its known boundary.

The implementation preserves the existing offset semantics and ensures
that the restored offset does not move backwards.

## Testing

Added regression coverage for:

* An empty changelog with a high end offset.
* Task lag calculation after changelog restoration.
* Active and standby restore scenarios.

Existing relevant Streams tests also pass.

Reviewers: Alan Lau (github:alanlau28), Bill Bejeck <bbejeck@apache.org>
