### PR TITLE
MINOR: Fix race condition in verify_running

### DIFF
--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -14,8 +14,8 @@ import re
 
 def verify_running(processor, message):
     node = processor.node
+    processor.start_node(node)
     with node.account.monitor_log(processor.STDOUT_FILE) as monitor:
-        processor.start()
         monitor.wait_until(message,
                            timeout_sec=60,
                            err_msg="Never saw '%s' message " % message + str(processor.node.account))


### PR DESCRIPTION
## Problem

`verify_running()` opens a log monitor before calling `processor.start()`. The startup path can open another monitor on the same log file while waiting for a different startup message.

When the Streams client reaches `RUNNING` quickly, the expected message can be missed between the two monitors, resulting in intermittent system test failures.

## Fix

Call `processor.start_node(node)` before opening the log monitor.

This avoids the nested monitor race and ensures the monitor is established only after node startup has completed.

## Testing

The affected test was run repeatedly:

`StreamsStaticMembershipTest.test_fencing_static_streams_member`

Before the fix:

* 1/5 isolated runs failed.

After the fix:

* 5/5 isolated runs passed.

The change is limited to `tests/kafkatest/tests/streams/utils/util.py`.
