### PR TITLE
KAFKA-19657: Updated RebalanceProtocolMigrationIntegrationTest 

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceProtocolMigrationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceProtocolMigrationIntegrationTest.java
@@ -17,13 +17,12 @@
 
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.streams.CloseOptions;
 import org.apache.kafka.streams.GroupProtocol;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
@@ -45,11 +44,9 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import static java.util.Collections.singletonList;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -128,11 +125,6 @@ public class RebalanceProtocolMigrationIntegrationTest {
         props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.CLASSIC.name());
         processExactlyOneRecord(streamsBuilder, props, "1", "A");
 
-        // Wait for session to time out
-        try (final Admin adminClient = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers()))) {
-            waitForEmptyConsumerGroup(adminClient, props.getProperty(StreamsConfig.APPLICATION_ID_CONFIG), 1000);
-        }
-
         props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.name());
         processExactlyOneRecord(streamsBuilder, props, "2", "B");
 
@@ -153,11 +145,6 @@ public class RebalanceProtocolMigrationIntegrationTest {
 
         props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.CLASSIC.name());
         processExactlyOneRecord(streamsBuilder, props, "2", "B");
-
-        // Wait for session to time out
-        try (final Admin adminClient = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers()))) {
-            waitForEmptyConsumerGroup(adminClient, props.getProperty(StreamsConfig.APPLICATION_ID_CONFIG), 1000);
-        }
 
         props.put(StreamsConfig.GROUP_PROTOCOL_CONFIG, GroupProtocol.STREAMS.name());
         processExactlyOneRecord(streamsBuilder, props, "3", "C");
@@ -183,7 +170,7 @@ public class RebalanceProtocolMigrationIntegrationTest {
             )
         );
 
-        kafkaStreams.close();
+        kafkaStreams.close(CloseOptions.groupMembershipOperation(CloseOptions.GroupMembershipOperation.LEAVE_GROUP));
         kafkaStreams = null;
     }
 


### PR DESCRIPTION
Changed to `kafka.Streams#CloseOptions` api on the RebalanceProtocolMigrationIntegrationTest. 

This was added as part of the KIP-1153 under #19955 & #22792