### PR TITLE
KAFKA-21000: Ensure FileRecords trim is fsynced when shutting down

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
@@ -215,8 +215,10 @@ public class FileRecords extends AbstractRecords implements Closeable {
             return;
         }
 
-        flush();
         trim();
+        // flush() must run after trim() so the truncated file length is included in the fsync.
+        // A flush before trim only persists message data, not the smaller size set by truncate().
+        flush();
         channel.close();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
@@ -217,7 +217,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
 
         trim();
         // flush() must run after trim() so the truncated file length is included in the fsync.
-        // A flush before trim only persists message data, not the smaller size set by truncate().
+        // A flush before trim only persists message data, not the smaller size set by trim().
         flush();
         channel.close();
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -59,6 +60,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -403,8 +405,9 @@ public class FileRecordsTest {
         FileRecords records = new FileRecords(tempFile(), channelMock, 100);
         records.close();
 
-        verify(channelMock, times(1)).force(true);
-        verify(channelMock).truncate(100L);
+        InOrder inOrder = inOrder(channelMock);
+        inOrder.verify(channelMock).truncate(100L);
+        inOrder.verify(channelMock).force(true);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
@@ -389,6 +389,25 @@ public class FileRecordsTest {
     }
 
     /**
+     * Closing a preallocated file must fsync after trimming so the truncated length is durable.
+     */
+    @Test
+    public void testCloseFlushesAfterTrim() throws IOException {
+        FileChannel channelMock = mock(FileChannel.class);
+
+        when(channelMock.size()).thenReturn(1024L);
+        when(channelMock.isOpen()).thenReturn(true);
+        when(channelMock.truncate(anyLong())).thenReturn(channelMock);
+        when(channelMock.position(anyLong())).thenReturn(channelMock);
+
+        FileRecords records = new FileRecords(tempFile(), channelMock, 100);
+        records.close();
+
+        verify(channelMock, times(1)).force(true);
+        verify(channelMock).truncate(100L);
+    }
+
+    /**
      * Test the new FileRecords with pre allocate as true and file has been clearly shut down, the file will be truncate to end of valid data.
      */
     @Test


### PR DESCRIPTION
## Summary

Fixes https://issues.apache.org/jira/browse/KAFKA-21000

Related: https://issues.apache.org/jira/browse/KAFKA-20979

## Motivation

When `log.preallocate=true`, a new log segment is created at the configured
initial file size. The physical file is larger than the logical data until
`FileRecords.trim()` truncates it to `sizeInBytes()` on segment roll or close.

`FileRecords.close()` previously called `flush()` before `trim()`. The fsync
persisted message data but not the smaller file length set by `truncate()`,
because truncation happened after the fsync. If the broker shut down cleanly
and the process crashed before the OS flushed file metadata, the on-disk
`.log` file could still report the preallocated length.

On restart, recovery is skipped for a clean shutdown, so `readNextOffset()` can
scan past valid records into uninitialized or zero-filled bytes and fail.

This is the same class of issue as KAFKA-20979, which fixed index resize
durability on shutdown in `AbstractIndex.close()`.

## Change

Reorder `FileRecords.close()`
 from:
flush() → trim() → close()

to:
trim() → flush() → close()


so `channel.force(true)` runs after truncation and the trimmed file length is
durable. Preallocation timing and trim-on-roll behavior are unchanged.

## Testing
- Added `FileRecordsTest.testCloseFlushesAfterTrim` to verify that `close()`
  truncates the channel and calls `force(true)` after trimming.
- Existing `testPreallocateClearShutdown` verifies that a preallocated file is
  truncated to the size of valid data after close and reopen.
  
```bash
./gradlew clients:test --tests org.apache.kafka.common.record.internal.FileRecordsTest

Reviewers: Jun Rao <junrao@gmail.com>
