### PR TITLE
KAFKA-20953: Remove Hamcrest from Streams internals tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
@@ -24,10 +24,9 @@ import java.time.Instant;
 import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 import static org.apache.kafka.streams.internals.ApiUtils.validateMillisecondDuration;
 import static org.apache.kafka.streams.internals.ApiUtils.validateMillisecondInstant;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApiUtilsTest {
     // This is the maximum limit that Duration accepts but fails when it converts to milliseconds.
@@ -39,12 +38,11 @@ public class ApiUtilsTest {
     public void shouldThrowNullPointerExceptionForNullDuration() {
         final String nullDurationPrefix = prepareMillisCheckFailMsgPrefix(null, "nullDuration");
 
-        try {
-            validateMillisecondDuration(null, nullDurationPrefix);
-            fail("Expected exception when null passed to duration.");
-        } catch (final IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString(nullDurationPrefix));
-        }
+        final IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateMillisecondDuration(null, nullDurationPrefix)
+        );
+        assertTrue(e.getMessage().contains(nullDurationPrefix));
     }
 
     @Test
@@ -52,36 +50,33 @@ public class ApiUtilsTest {
         final Duration maxDurationInDays = Duration.ofDays(MAX_ACCEPTABLE_DAYS_FOR_DURATION);
         final String maxDurationPrefix = prepareMillisCheckFailMsgPrefix(maxDurationInDays, "maxDuration");
 
-        try {
-            validateMillisecondDuration(maxDurationInDays, maxDurationPrefix);
-            fail("Expected exception when maximum days passed for duration, because of long overflow");
-        } catch (final IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString(maxDurationPrefix));
-        }
+        final IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateMillisecondDuration(maxDurationInDays, maxDurationPrefix)
+        );
+        assertTrue(e.getMessage().contains(maxDurationPrefix));
     }
 
     @Test
     public void shouldThrowNullPointerExceptionForNullInstant() {
         final String nullInstantPrefix = prepareMillisCheckFailMsgPrefix(null, "nullInstant");
 
-        try {
-            validateMillisecondInstant(null, nullInstantPrefix);
-            fail("Expected exception when null value passed for instant.");
-        } catch (final IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString(nullInstantPrefix));
-        }
+        final IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateMillisecondInstant(null, nullInstantPrefix)
+        );
+        assertTrue(e.getMessage().contains(nullInstantPrefix));
     }
 
     @Test
     public void shouldThrowArithmeticExceptionForMaxInstant() {
         final String maxInstantPrefix = prepareMillisCheckFailMsgPrefix(Instant.MAX, "maxInstant");
 
-        try {
-            validateMillisecondInstant(Instant.MAX, maxInstantPrefix);
-            fail("Expected exception when maximum value passed for instant, because of long overflow.");
-        } catch (final IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString(maxInstantPrefix));
-        }
+        final IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateMillisecondInstant(Instant.MAX, maxInstantPrefix)
+        );
+        assertTrue(e.getMessage().contains(maxInstantPrefix));
     }
 
     @Test
@@ -102,7 +97,7 @@ public class ApiUtilsTest {
     public void shouldContainsNameAndValueInFailMsgPrefix() {
         final String failMsgPrefix = prepareMillisCheckFailMsgPrefix("someValue", "variableName");
 
-        assertThat(failMsgPrefix, containsString("variableName"));
-        assertThat(failMsgPrefix, containsString("someValue"));
+        assertTrue(failMsgPrefix.contains("variableName"));
+        assertTrue(failMsgPrefix.contains("someValue"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
@@ -46,7 +46,7 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void shouldThrowArithmeticExceptionForMaxDuration() {
+    public void shouldThrowIllegalArgumentExceptionForMaxDuration() {
         final Duration maxDurationInDays = Duration.ofDays(MAX_ACCEPTABLE_DAYS_FOR_DURATION);
         final String maxDurationPrefix = prepareMillisCheckFailMsgPrefix(maxDurationInDays, "maxDuration");
 
@@ -69,7 +69,7 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void shouldThrowArithmeticExceptionForMaxInstant() {
+    public void shouldThrowIllegalArgumentExceptionForMaxInstant() {
         final String maxInstantPrefix = prepareMillisCheckFailMsgPrefix(Instant.MAX, "maxInstant");
 
         final IllegalArgumentException e = assertThrows(

--- a/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
@@ -35,7 +35,7 @@ public class ApiUtilsTest {
     private static final long MAX_ACCEPTABLE_DAYS_FOR_DURATION_TO_MILLIS = 106751991167L;
 
     @Test
-    public void shouldThrowNullPointerExceptionForNullDuration() {
+    public void shouldThrowIllegalArgumentExceptionForNullDuration() {
         final String nullDurationPrefix = prepareMillisCheckFailMsgPrefix(null, "nullDuration");
 
         final IllegalArgumentException e = assertThrows(
@@ -58,7 +58,7 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionForNullInstant() {
+    public void shouldThrowIllegalArgumentExceptionForNullInstant() {
         final String nullInstantPrefix = prepareMillisCheckFailMsgPrefix(null, "nullInstant");
 
         final IllegalArgumentException e = assertThrows(

--- a/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
@@ -40,7 +40,8 @@ public class ApiUtilsTest {
 
         final IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> validateMillisecondDuration(null, nullDurationPrefix)
+            () -> validateMillisecondDuration(null, nullDurationPrefix),
+            "Expected exception when null passed to duration."
         );
         assertTrue(e.getMessage().contains(nullDurationPrefix));
     }
@@ -52,7 +53,8 @@ public class ApiUtilsTest {
 
         final IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> validateMillisecondDuration(maxDurationInDays, maxDurationPrefix)
+            () -> validateMillisecondDuration(maxDurationInDays, maxDurationPrefix),
+            "Expected exception when maximum days passed for duration, because of long overflow"
         );
         assertTrue(e.getMessage().contains(maxDurationPrefix));
     }
@@ -63,7 +65,8 @@ public class ApiUtilsTest {
 
         final IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> validateMillisecondInstant(null, nullInstantPrefix)
+            () -> validateMillisecondInstant(null, nullInstantPrefix),
+            "Expected exception when null value passed for instant."
         );
         assertTrue(e.getMessage().contains(nullInstantPrefix));
     }
@@ -74,7 +77,8 @@ public class ApiUtilsTest {
 
         final IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
-            () -> validateMillisecondInstant(Instant.MAX, maxInstantPrefix)
+            () -> validateMillisecondInstant(Instant.MAX, maxInstantPrefix),
+            "Expected exception when maximum value passed for instant, because of long overflow."
         );
         assertTrue(e.getMessage().contains(maxInstantPrefix));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -29,8 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CLIENT_LEVEL_GROUP;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -168,7 +167,7 @@ public class ClientMetricsTest {
         );
 
         final Sensor sensor = ClientMetrics.failedStreamThreadSensor(streamsMetrics);
-        assertThat(sensor, is(expectedSensor));
+        assertEquals(expectedSensor, sensor);
     }
 
     private <K> void setUpAndVerifyMutableMetric(final String name,


### PR DESCRIPTION
## Description

Remove Hamcrest usage from `ApiUtilsTest` and `ClientMetricsTest` as
part of KAFKA-20953.

The assertions now use their JUnit 5 equivalents:

- `assertThrows` and `assertTrue` for exception and message validation.
- `assertEquals` for sensor comparison.

This is a test-only migration and does not change production behavior.

## Testing

```bash
./gradlew :streams:test \
  --tests org.apache.kafka.streams.internals.ApiUtilsTest \
  --tests org.apache.kafka.streams.internals.metrics.ClientMetricsTest
```

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>, majialong <majialoong@gmail.com>
