### PR TITLE
KAFKA-20952: Remove Hamcrest from kstream package tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -25,8 +25,6 @@ import static java.time.Duration.ofSeconds;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.apache.kafka.streams.kstream.Windows.DEPRECATED_DEFAULT_24_HR_GRACE_PERIOD;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -57,7 +55,7 @@ public class JoinWindowsTest {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_OTHER_SIZE))
             .before(ofSeconds(ANY_SIZE));
 
-        assertThat(joinWindows.gracePeriodMs(), equalTo(ANY_OTHER_SIZE));
+        assertEquals(ANY_OTHER_SIZE, joinWindows.gracePeriodMs());
     }
 
     @Test
@@ -65,7 +63,7 @@ public class JoinWindowsTest {
         final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(ANY_SIZE), ofMillis(ANY_OTHER_SIZE))
             .after(ofSeconds(ANY_SIZE));
 
-        assertThat(joinWindows.gracePeriodMs(), equalTo(ANY_OTHER_SIZE));
+        assertEquals(ANY_OTHER_SIZE, joinWindows.gracePeriodMs());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/PrintedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/PrintedTest.java
@@ -36,8 +36,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -70,7 +68,7 @@ public class PrintedTest {
         try (final InputStream stream = Files.newInputStream(file.toPath())) {
             final byte[] data = new byte[stream.available()];
             stream.read(data);
-            assertThat(new String(data, StandardCharsets.UTF_8), equalTo("[processor]: hi, 1\n"));
+            assertEquals("[processor]: hi, 1\n", new String(data, StandardCharsets.UTF_8));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/RepartitionTopicNamingTest.java
@@ -36,8 +36,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,15 +62,15 @@ public class RepartitionTopicNamingTest {
         final String optimizedTopology = buildTopology(StreamsConfig.OPTIMIZE).describe().toString();
         final String unOptimizedTopology = buildTopology(StreamsConfig.NO_OPTIMIZATION).describe().toString();
 
-        assertThat(optimizedTopology, is(EXPECTED_OPTIMIZED_TOPOLOGY));
+        assertEquals(EXPECTED_OPTIMIZED_TOPOLOGY, optimizedTopology);
         // only one repartition topic
-        assertThat(1, is(getCountOfRepartitionTopicsFound(optimizedTopology, repartitionTopicPattern)));
+        assertEquals(1, getCountOfRepartitionTopicsFound(optimizedTopology, repartitionTopicPattern));
         // the first named repartition topic
         assertTrue(optimizedTopology.contains(firstRepartitionTopicName + "-repartition"));
 
-        assertThat(unOptimizedTopology, is(EXPECTED_UNOPTIMIZED_TOPOLOGY));
+        assertEquals(EXPECTED_UNOPTIMIZED_TOPOLOGY, unOptimizedTopology);
         // now 4 repartition topic
-        assertThat(4, is(getCountOfRepartitionTopicsFound(unOptimizedTopology, repartitionTopicPattern)));
+        assertEquals(4, getCountOfRepartitionTopicsFound(unOptimizedTopology, repartitionTopicPattern));
         // all 4 named repartition topics present
         assertTrue(unOptimizedTopology.contains(firstRepartitionTopicName + "-repartition"));
         assertTrue(unOptimizedTopology.contains(secondRepartitionTopicName + "-repartition"));
@@ -106,7 +105,7 @@ public class RepartitionTopicNamingTest {
         kGroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(30L))).count().toStream().to("output-two");
 
         final String topologyString = builder.build().describe().toString();
-        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(1, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
         assertTrue(topologyString.contains("grouping-repartition"));
     }
 
@@ -124,7 +123,7 @@ public class RepartitionTopicNamingTest {
         kGroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(30L))).count().toStream().to("output-two");
 
         final String topologyString = builder.build().describe().toString();
-        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(1, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
         assertTrue(topologyString.contains("grouping-repartition"));
     }
 
@@ -142,7 +141,7 @@ public class RepartitionTopicNamingTest {
         kGroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(30L))).count().toStream().to("output-two");
 
         final String topologyString = builder.build().describe().toString();
-        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(1, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
         assertTrue(topologyString.contains("grouping-repartition"));
     }
 
@@ -154,7 +153,7 @@ public class RepartitionTopicNamingTest {
         kGroupedTable.count().toStream().to("output-count");
         kGroupedTable.reduce((v, v2) -> v2, (v, v2) -> v2).toStream().to("output-reduce");
         final String topologyString = builder.build().describe().toString();
-        assertThat(1, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(1, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
         assertTrue(topologyString.contains("grouping-repartition"));
     }
 
@@ -167,7 +166,7 @@ public class RepartitionTopicNamingTest {
         kGroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(10L))).count().toStream().to("output-one");
         kGroupedStream.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(30L))).count().toStream().to("output-two");
         final String topologyString = builder.build().describe().toString();
-        assertThat(2, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(2, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
     }
 
     @Test
@@ -177,7 +176,7 @@ public class RepartitionTopicNamingTest {
         kGroupedTable.count().toStream().to("output-count");
         kGroupedTable.reduce((v, v2) -> v2, (v, v2) -> v2).toStream().to("output-reduce");
         final String topologyString = builder.build().describe().toString();
-        assertThat(2, is(getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern)));
+        assertEquals(2, getCountOfRepartitionTopicsFound(topologyString, repartitionTopicPattern));
     }
 
     @Test
@@ -191,7 +190,7 @@ public class RepartitionTopicNamingTest {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         final Topology topology = builder.build(properties);
-        assertThat(getCountOfRepartitionTopicsFound(topology.describe().toString(), repartitionTopicPattern), is(1));
+        assertEquals(1, getCountOfRepartitionTopicsFound(topology.describe().toString(), repartitionTopicPattern));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
@@ -33,124 +33,119 @@ import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.unbounded
 import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
 import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
 import static org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.SHUT_DOWN;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SuppressedTest {
 
     @Test
     public void bufferBuilderShouldBeConsistent() {
-        assertThat(
-            "noBound should remove bounds",
+        assertEquals(
+            unbounded(),
             maxBytes(2L).withMaxRecords(4L).withNoBound(),
-            is(unbounded())
+            "noBound should remove bounds"
         );
 
-        assertThat(
-            "keys alone should be set",
+        assertEquals(
+            new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.emptyMap()),
             maxRecords(2L),
-            is(new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.emptyMap()))
+            "keys alone should be set"
         );
 
-        assertThat(
-            "size alone should be set",
+        assertEquals(
+            new EagerBufferConfigImpl(MAX_VALUE, 2L, Collections.emptyMap()),
             maxBytes(2L),
-            is(new EagerBufferConfigImpl(MAX_VALUE, 2L, Collections.emptyMap()))
+            "size alone should be set"
         );
 
-        assertThat(
-            "config should be set even after max records",
+        assertEquals(
+            new EagerBufferConfigImpl(2L, 4L, Collections.singletonMap("myConfigKey", "myConfigValue")),
             maxRecords(2L).withMaxBytes(4L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")),
-            is(new EagerBufferConfigImpl(2L, 4L, Collections.singletonMap("myConfigKey", "myConfigValue")))
+            "config should be set even after max records"
         );
     }
 
     @Test
     public void intermediateEventsShouldAcceptAnyBufferAndSetBounds() {
-        assertThat(
-            "name should be set",
+        assertEquals(
+            new SuppressedInternal<>("myname", ofMillis(2), unbounded(), null, false),
             untilTimeLimit(ofMillis(2), unbounded()).withName("myname"),
-            is(new SuppressedInternal<>("myname", ofMillis(2), unbounded(), null, false))
+            "name should be set"
         );
 
-        assertThat(
-            "time alone should be set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false),
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
+            "time alone should be set"
         );
 
-        assertThat(
-            "time and unbounded buffer should be set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false),
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
+            "time and unbounded buffer should be set"
         );
 
-        assertThat(
-            "time and keys buffer should be set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), maxRecords(2), null, false),
             untilTimeLimit(ofMillis(2), maxRecords(2)),
-            is(new SuppressedInternal<>(null, ofMillis(2), maxRecords(2), null, false))
+            "time and keys buffer should be set"
         );
 
-        assertThat(
-            "time and size buffer should be set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), maxBytes(2), null, false),
             untilTimeLimit(ofMillis(2), maxBytes(2)),
-            is(new SuppressedInternal<>(null, ofMillis(2), maxBytes(2), null, false))
+            "time and size buffer should be set"
         );
 
-        assertThat(
-            "all constraints should be set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L, Collections.emptyMap()), null, false),
             untilTimeLimit(ofMillis(2L), maxRecords(3L).withMaxBytes(2L)),
-            is(new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L, Collections.emptyMap()), null, false))
+            "all constraints should be set"
         );
 
-        assertThat(
-            "config is not lost early emit is set",
+        assertEquals(
+            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.singletonMap("myConfigKey", "myConfigValue")), null, false),
             untilTimeLimit(ofMillis(2), maxRecords(2L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")).emitEarlyWhenFull()),
-            is(new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.singletonMap("myConfigKey", "myConfigValue")), null, false))
+            "config is not lost early emit is set"
         );
     }
 
     @Test
     public void finalEventsShouldAcceptStrictBuffersAndSetBounds() {
 
-        assertThat(
-            untilWindowCloses(unbounded()),
-            is(new FinalResultsSuppressionBuilder<>(null, unbounded()))
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>(null, unbounded()),
+            untilWindowCloses(unbounded())
         );
 
-        assertThat(
-            untilWindowCloses(maxRecords(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap()))
-            )
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap())),
+            untilWindowCloses(maxRecords(2L).shutDownWhenFull())
         );
 
-        assertThat(
-            untilWindowCloses(maxBytes(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap()))
-            )
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap())),
+            untilWindowCloses(maxBytes(2L).shutDownWhenFull())
         );
 
-        assertThat(
-            untilWindowCloses(unbounded()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", unbounded()))
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>("name", unbounded()),
+            untilWindowCloses(unbounded()).withName("name")
         );
 
-        assertThat(
-            untilWindowCloses(maxRecords(2L).shutDownWhenFull()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap()))
-            )
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap())),
+            untilWindowCloses(maxRecords(2L).shutDownWhenFull()).withName("name")
         );
 
-        assertThat(
-            untilWindowCloses(maxBytes(2L).shutDownWhenFull()).withName("name"),
-            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap()))
-            )
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap())),
+            untilWindowCloses(maxBytes(2L).shutDownWhenFull()).withName("name")
         );
 
-        assertThat(
-            "config is not lost when shutdown when full is set",
+        assertEquals(
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue"))),
             untilWindowCloses(maxBytes(2L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue"))))
+            "config is not lost when shutdown when full is set"
         );
     }
 
@@ -163,15 +158,15 @@ public class SuppressedTest {
             .withMaxRecords(5L)
             .withMaxBytes(6L);
 
-        assertThat(
-            "long chain of eager buffer config sets attributes properly",
+        assertEquals(
+            new EagerBufferConfigImpl(5L, 6L, Collections.emptyMap()),
             bufferConfig,
-            is(new EagerBufferConfigImpl(5L, 6L, Collections.emptyMap()))
+            "long chain of eager buffer config sets attributes properly"
         );
-        assertThat(
-            "long chain of strict buffer config sets attributes properly",
+        assertEquals(
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.emptyMap()),
             bufferConfig.shutDownWhenFull(),
-            is(new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.emptyMap()))
+            "long chain of strict buffer config sets attributes properly"
         );
 
         final Suppressed.BufferConfig<Suppressed.EagerBufferConfig> bufferConfigWithLogging = unbounded()
@@ -182,15 +177,15 @@ public class SuppressedTest {
             .withMaxRecords(5L)
             .withMaxBytes(6L);
 
-        assertThat(
-            "long chain of eager buffer config sets attributes properly with logging enabled",
+        assertEquals(
+            new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")),
             bufferConfigWithLogging,
-            is(new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")))
+            "long chain of eager buffer config sets attributes properly with logging enabled"
         );
-        assertThat(
-            "long chain of strict buffer config sets attributes properly with logging enabled",
+        assertEquals(
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")),
             bufferConfigWithLogging.shutDownWhenFull(),
-            is(new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")))
+            "long chain of strict buffer config sets attributes properly with logging enabled"
         );
 
         final Suppressed.BufferConfig<Suppressed.EagerBufferConfig> bufferConfigWithLoggingCalledAtTheEnd = unbounded()
@@ -201,15 +196,15 @@ public class SuppressedTest {
             .withMaxBytes(6L)
             .withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue"));
 
-        assertThat(
-            "long chain of eager buffer config sets logging even after other setters",
-                bufferConfigWithLoggingCalledAtTheEnd,
-            is(new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")))
+        assertEquals(
+            new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            bufferConfigWithLoggingCalledAtTheEnd,
+            "long chain of eager buffer config sets logging even after other setters"
         );
-        assertThat(
-            "long chain of strict buffer config sets logging even after other setters",
-                bufferConfigWithLoggingCalledAtTheEnd.shutDownWhenFull(),
-            is(new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")))
+        assertEquals(
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            bufferConfigWithLoggingCalledAtTheEnd.shutDownWhenFull(),
+            "long chain of strict buffer config sets logging even after other setters"
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.streams.kstream.internals.suppress.SuppressedInternal;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Map;
 
 import static java.lang.Long.MAX_VALUE;
 import static java.time.Duration.ofMillis;
@@ -46,20 +46,20 @@ public class SuppressedTest {
         );
 
         assertEquals(
-            new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.emptyMap()),
+            new EagerBufferConfigImpl(2L, MAX_VALUE, Map.of()),
             maxRecords(2L),
             "keys alone should be set"
         );
 
         assertEquals(
-            new EagerBufferConfigImpl(MAX_VALUE, 2L, Collections.emptyMap()),
+            new EagerBufferConfigImpl(MAX_VALUE, 2L, Map.of()),
             maxBytes(2L),
             "size alone should be set"
         );
 
         assertEquals(
-            new EagerBufferConfigImpl(2L, 4L, Collections.singletonMap("myConfigKey", "myConfigValue")),
-            maxRecords(2L).withMaxBytes(4L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")),
+            new EagerBufferConfigImpl(2L, 4L, Map.of("myConfigKey", "myConfigValue")),
+            maxRecords(2L).withMaxBytes(4L).withLoggingEnabled(Map.of("myConfigKey", "myConfigValue")),
             "config should be set even after max records"
         );
     }
@@ -97,14 +97,14 @@ public class SuppressedTest {
         );
 
         assertEquals(
-            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L, Collections.emptyMap()), null, false),
+            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L, Map.of()), null, false),
             untilTimeLimit(ofMillis(2L), maxRecords(3L).withMaxBytes(2L)),
             "all constraints should be set"
         );
 
         assertEquals(
-            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(2L, MAX_VALUE, Collections.singletonMap("myConfigKey", "myConfigValue")), null, false),
-            untilTimeLimit(ofMillis(2), maxRecords(2L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")).emitEarlyWhenFull()),
+            new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(2L, MAX_VALUE, Map.of("myConfigKey", "myConfigValue")), null, false),
+            untilTimeLimit(ofMillis(2), maxRecords(2L).withLoggingEnabled(Map.of("myConfigKey", "myConfigValue")).emitEarlyWhenFull()),
             "config is not lost early emit is set"
         );
     }
@@ -118,12 +118,12 @@ public class SuppressedTest {
         );
 
         assertEquals(
-            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap())),
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Map.of())),
             untilWindowCloses(maxRecords(2L).shutDownWhenFull())
         );
 
         assertEquals(
-            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap())),
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Map.of())),
             untilWindowCloses(maxBytes(2L).shutDownWhenFull())
         );
 
@@ -133,18 +133,18 @@ public class SuppressedTest {
         );
 
         assertEquals(
-            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Collections.emptyMap())),
+            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN, Map.of())),
             untilWindowCloses(maxRecords(2L).shutDownWhenFull()).withName("name")
         );
 
         assertEquals(
-            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.emptyMap())),
+            new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Map.of())),
             untilWindowCloses(maxBytes(2L).shutDownWhenFull()).withName("name")
         );
 
         assertEquals(
-            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue"))),
-            untilWindowCloses(maxBytes(2L).withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue")).shutDownWhenFull()),
+            new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN, Map.of("myConfigKey", "myConfigValue"))),
+            untilWindowCloses(maxBytes(2L).withLoggingEnabled(Map.of("myConfigKey", "myConfigValue")).shutDownWhenFull()),
             "config is not lost when shutdown when full is set"
         );
     }
@@ -159,18 +159,18 @@ public class SuppressedTest {
             .withMaxBytes(6L);
 
         assertEquals(
-            new EagerBufferConfigImpl(5L, 6L, Collections.emptyMap()),
+            new EagerBufferConfigImpl(5L, 6L, Map.of()),
             bufferConfig,
             "long chain of eager buffer config sets attributes properly"
         );
         assertEquals(
-            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.emptyMap()),
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Map.of()),
             bufferConfig.shutDownWhenFull(),
             "long chain of strict buffer config sets attributes properly"
         );
 
         final Suppressed.BufferConfig<Suppressed.EagerBufferConfig> bufferConfigWithLogging = unbounded()
-            .withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue"))
+            .withLoggingEnabled(Map.of("myConfigKey", "myConfigValue"))
             .emitEarlyWhenFull()
             .withMaxRecords(3L)
             .withMaxBytes(4L)
@@ -178,12 +178,12 @@ public class SuppressedTest {
             .withMaxBytes(6L);
 
         assertEquals(
-            new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            new EagerBufferConfigImpl(5L, 6L, Map.of("myConfigKey", "myConfigValue")),
             bufferConfigWithLogging,
             "long chain of eager buffer config sets attributes properly with logging enabled"
         );
         assertEquals(
-            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Map.of("myConfigKey", "myConfigValue")),
             bufferConfigWithLogging.shutDownWhenFull(),
             "long chain of strict buffer config sets attributes properly with logging enabled"
         );
@@ -194,15 +194,15 @@ public class SuppressedTest {
             .withMaxBytes(4L)
             .withMaxRecords(5L)
             .withMaxBytes(6L)
-            .withLoggingEnabled(Collections.singletonMap("myConfigKey", "myConfigValue"));
+            .withLoggingEnabled(Map.of("myConfigKey", "myConfigValue"));
 
         assertEquals(
-            new EagerBufferConfigImpl(5L, 6L, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            new EagerBufferConfigImpl(5L, 6L, Map.of("myConfigKey", "myConfigValue")),
             bufferConfigWithLoggingCalledAtTheEnd,
             "long chain of eager buffer config sets logging even after other setters"
         );
         assertEquals(
-            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Collections.singletonMap("myConfigKey", "myConfigValue")),
+            new StrictBufferConfigImpl(5L, 6L, SHUT_DOWN, Map.of("myConfigKey", "myConfigValue")),
             bufferConfigWithLoggingCalledAtTheEnd.shutDownWhenFull(),
             "long chain of strict buffer config sets logging even after other setters"
         );

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,7 +54,7 @@ public class TimeWindowedDeserializerTest {
         final Deserializer<?> inner = timeWindowedDeserializer.innerDeserializer();
         assertNotNull(inner, "Inner deserializer should be not null");
         assertInstanceOf(StringDeserializer.class, inner, "Inner deserializer type should be StringDeserializer");
-        assertThat(timeWindowedDeserializer.getWindowSize(), is(5000000L));
+        assertEquals(5000000L, timeWindowedDeserializer.getWindowSize());
     }
 
     @Deprecated
@@ -66,7 +64,7 @@ public class TimeWindowedDeserializerTest {
         props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
         try (final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>()) {
             deserializer.configure(props, false);
-            assertThat(deserializer.getWindowSize(), is(500L));
+            assertEquals(500L, deserializer.getWindowSize());
             assertInstanceOf(ByteArrayDeserializer.class, deserializer.innerDeserializer());
         }
     }
@@ -77,7 +75,7 @@ public class TimeWindowedDeserializerTest {
         props.put(TimeWindowedDeserializer.WINDOWED_INNER_DESERIALIZER_CLASS, Serdes.ByteArraySerde.class.getName());
         try (final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>()) {
             deserializer.configure(props, false);
-            assertThat(deserializer.getWindowSize(), is(500L));
+            assertEquals(500L, deserializer.getWindowSize());
             assertInstanceOf(ByteArrayDeserializer.class, deserializer.innerDeserializer());
         }
     }
@@ -96,7 +94,7 @@ public class TimeWindowedDeserializerTest {
         props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, "some.non.existent.class");
         try (final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>()) {
             deserializer.configure(props, false);
-            assertThat(deserializer.getWindowSize(), is(500L));
+            assertEquals(500L, deserializer.getWindowSize());
             assertInstanceOf(ByteArrayDeserializer.class, deserializer.innerDeserializer());
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowedSerdesTest.java
@@ -25,8 +25,6 @@ import org.apache.kafka.streams.kstream.internals.TimeWindow;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -77,10 +75,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> serializer.serialize("topic", new Windowed<>(new byte[0], new TimeWindow(0, 1))));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner serializer is `null`. User code must use constructor " +
-                "`TimeWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner serializer is `null`. User code must use constructor " +
+                "`TimeWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test
@@ -89,10 +87,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new TimeWindow(0, 1))));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner serializer is `null`. User code must use constructor " +
-                "`TimeWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner serializer is `null`. User code must use constructor " +
+                "`TimeWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test
@@ -101,10 +99,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> deserializer.deserialize("topic", new byte[0]));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner deserializer is `null`. User code must use constructor " +
-                "`TimeWindowedDeserializer(final Deserializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner deserializer is `null`. User code must use constructor " +
+                "`TimeWindowedDeserializer(final Deserializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test
@@ -113,10 +111,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> serializer.serialize("topic", new Windowed<>(new byte[0], new SessionWindow(0, 0))));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner serializer is `null`. User code must use constructor " +
-                "`SessionWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner serializer is `null`. User code must use constructor " +
+                "`SessionWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test
@@ -125,10 +123,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> serializer.serializeBaseKey("topic", new RecordHeaders(), new Windowed<>(new byte[0], new SessionWindow(0, 0))));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner serializer is `null`. User code must use constructor " +
-                "`SessionWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner serializer is `null`. User code must use constructor " +
+                "`SessionWindowedSerializer(final Serializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test
@@ -137,10 +135,10 @@ public class WindowedSerdesTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> deserializer.deserialize("topic", new byte[0]));
-        assertThat(
-            exception.getMessage(),
-            equalTo("Inner deserializer is `null`. User code must use constructor " +
-                "`SessionWindowedDeserializer(final Deserializer<T> inner)` instead of the no-arg constructor."));
+        assertEquals(
+            "Inner deserializer is `null`. User code must use constructor " +
+                "`SessionWindowedDeserializer(final Deserializer<T> inner)` instead of the no-arg constructor.",
+            exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Description

Replace Hamcrest assertions with equivalent JUnit 5 assertions in the `org.apache.kafka.streams.kstream` test package as part of KAFKA-20952.

The following tests were migrated:

- `JoinWindowsTest`
- `PrintedTest`
- `RepartitionTopicNamingTest`
- `SuppressedTest`
- `TimeWindowedDeserializerTest`
- `WindowedSerdesTest`

Assertion messages and expected-versus-actual semantics are preserved. This is a test-only dependency cleanup with no production behavior changes.

## Testing Strategy

```bash
./gradlew streams:test \
  --tests 'org.apache.kafka.streams.kstream.JoinWindowsTest' \
  --tests 'org.apache.kafka.streams.kstream.PrintedTest' \
  --tests 'org.apache.kafka.streams.kstream.RepartitionTopicNamingTest' \
  --tests 'org.apache.kafka.streams.kstream.SuppressedTest' \
  --tests 'org.apache.kafka.streams.kstream.TimeWindowedDeserializerTest' \
  --tests 'org.apache.kafka.streams.kstream.WindowedSerdesTest'
```

Reviewers: Chia-Ping Tsai (chia7712@gmail.com) @chia7712, Uros (github:uros-b), Ken Huang <s7133700@gmail.com>, Parker Chang <parkerhiphop027@gmail.com>
