### PR TITLE
MINOR: Validation to check socket.request.max.bytes >= message.max.bytes

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -588,6 +588,9 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _], enforceProv
     require(queuedMaxBytes <= 0 || queuedMaxBytes >= socketRequestMaxBytes,
       s"${SocketServerConfigs.QUEUED_MAX_BYTES_CONFIG} must be larger or equal to ${SocketServerConfigs.SOCKET_REQUEST_MAX_BYTES_CONFIG}")
 
+   require(socketRequestMaxBytes >= messageMaxBytes, 
+      s"${SocketServerConfigs.SOCKET_REQUEST_MAX_BYTES_CONFIG} must be larger or equal to ${ServerConfigs.MESSAGE_MAX_BYTES_CONFIG}")
+
     if (maxConnectionsPerIp == 0)
       require(!maxConnectionsPerIpOverrides.isEmpty, s"${SocketServerConfigs.MAX_CONNECTIONS_PER_IP_CONFIG} can be set to zero only if" +
         s" ${SocketServerConfigs.MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG} property is set.")


### PR DESCRIPTION
Currently, there's no guardrail in case the socket.request.max.size < message.max.bytes. This leads to an odd situation where there's a node disconnection and the error doesn't bubble up properly.
Adding this change ensures that the inequality: socket.request.max.size >= message.max.bytes >= message size is respected in all cases.