### PR TITLE
KAFKA-19028: Make incremental config deletion consistent for policies

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/AlterConfigPolicy.java
@@ -56,7 +56,8 @@ public interface AlterConfigPolicy extends Configurable, AutoCloseable {
         }
 
         /**
-         * Return the configs in the request.
+         * Return the configs in the request. For incremental alter configs requests, entries explicitly deleted by
+         * the request are mapped to {@code null}, even if the resource has no existing value for the configuration.
          */
         public Map<String, String> configs() {
             return configs;

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -294,6 +294,7 @@ public class ConfigurationControlManager {
         boolean forwarded
     ) {
         List<ApiMessageAndVersion> newRecords = new ArrayList<>();
+        List<String> explicitlyDeletedConfigs = new ArrayList<>();
         for (Entry<String, Entry<OpType, String>> keysToOpsEntry : keysToOps.entrySet()) {
             String key = keysToOpsEntry.getKey();
             String currentValue = null;
@@ -311,6 +312,7 @@ public class ConfigurationControlManager {
                     break;
                 case DELETE:
                     newValue = null;
+                    explicitlyDeletedConfigs.add(key);
                     break;
                 case APPEND:
                 case SUBTRACT:
@@ -343,7 +345,8 @@ public class ConfigurationControlManager {
                     setValue(newValue), (short) 0));
             }
         }
-        ApiError error = validateAlterConfig(configResource, newRecords, List.of(), newlyCreatedResource, forwarded);
+        ApiError error = validateAlterConfig(configResource, newRecords, List.of(), explicitlyDeletedConfigs,
+            newlyCreatedResource, forwarded);
         if (error.isFailure()) {
             return error;
         }
@@ -355,6 +358,7 @@ public class ConfigurationControlManager {
         ConfigResource configResource,
         List<ApiMessageAndVersion> recordsExplicitlyAltered,
         List<ApiMessageAndVersion> recordsImplicitlyDeleted,
+        List<String> explicitlyDeletedConfigs,
         boolean newlyCreatedResource,
         boolean forwarded
     ) {
@@ -387,6 +391,7 @@ public class ConfigurationControlManager {
             }
             alteredConfigsForAlterConfigPolicyCheck.put(configRecord.name(), configRecord.value());
         }
+        explicitlyDeletedConfigs.forEach(config -> alteredConfigsForAlterConfigPolicyCheck.put(config, null));
         for (ApiMessageAndVersion recordImplicitlyDeleted : recordsImplicitlyDeleted) {
             ConfigRecord configRecord = (ConfigRecord) recordImplicitlyDeleted.message();
             if (isDisallowedBrokerMinIsrTransition(configRecord)) {
@@ -563,7 +568,8 @@ public class ConfigurationControlManager {
                     setValue(null), (short) 0));
             }
         }
-        ApiError error = validateAlterConfig(configResource, recordsExplicitlyAltered, recordsImplicitlyDeleted, newlyCreatedResource, forwarded);
+        ApiError error = validateAlterConfig(configResource, recordsExplicitlyAltered, recordsImplicitlyDeleted, List.of(),
+            newlyCreatedResource, forwarded);
         if (error.isFailure()) {
             outputResults.put(configResource, error);
             return;

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -398,6 +398,24 @@ public class ConfigurationControlManagerTest {
                 false));
     }
 
+    @Test
+    public void testIncrementalDeletePolicyIncludesUnsetConfigs() {
+        MockAlterConfigsPolicy policy = new MockAlterConfigsPolicy(List.of(
+            new RequestMetadata(MYTOPIC, toMap(entry("abc", null))),
+            new RequestMetadata(BROKER0, toMap(entry("foo.bar", null)))));
+        ConfigurationControlManager manager = new ConfigurationControlManager.Builder().
+            setFeatureControl(createFeatureControlManager()).
+            setKafkaConfigSchema(SCHEMA).
+            setMaxRecordsPerBatch(KRaftConfigs.CONTROLLER_MAX_RECORDS_PER_BATCH_DEFAULT).
+            setAlterConfigPolicy(Optional.of(policy)).
+            build();
+
+        assertEquals(ApiError.NONE, manager.incrementalAlterConfig(
+            MYTOPIC, toMap(entry("abc", entry(DELETE, null))), false, false).response());
+        assertEquals(ApiError.NONE, manager.incrementalAlterConfig(
+            BROKER0, toMap(entry("foo.bar", entry(DELETE, null))), false, false).response());
+    }
+
     private static class CheckForNullValuesPolicy implements AlterConfigPolicy {
         @Override
         public void validate(RequestMetadata actual) throws PolicyViolationException {


### PR DESCRIPTION
## Summary

KAFKA-19028 identifies inconsistent `AlterConfigPolicy` behavior for
incremental DELETE operations. Deleting an unset topic configuration
produced no `ConfigRecord`, causing the configuration to be omitted from
`RequestMetadata.configs()`. Broker deletions were instead represented
as a key mapped to `null`.

This change ensures every explicit incremental DELETE operation is
passed to `AlterConfigPolicy` as a configuration key mapped to `null`,
even when the resource has no existing override and no metadata record
is generated.

The existing behavior for SET, APPEND, SUBTRACT, and the legacy
AlterConfigs API remains unchanged.

The `AlterConfigPolicy.RequestMetadata.configs()` Javadoc now documents
how incremental DELETE operations are represented.

## Testing

Added a focused unit test covering explicit deletion of unset topic and
broker configurations. The test verifies that both resource types
produce consistent policy metadata containing the deleted key mapped to
`null`.

```text
./gradlew :metadata:test --tests
org.apache.kafka.controller.ConfigurationControlManagerTest
./gradlew :clients:test --tests
org.apache.kafka.server.policy.AlterConfigPolicyTest
./gradlew spotlessCheck
```

Reviewers: Edoardo Comar @edoardocomar, Edoardo Comar
 <edocomar@gmail.com>
