### PR TITLE
KAFKA-20913: Snapshot CompletedBatch appendTimestamp before buffer reuse

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -561,6 +561,9 @@ public class BatchAccumulator<T> implements Closeable {
         // Buffer that was allocated by the MemoryPool (pool). This may not be the buffer used in
         // the MemoryRecords (data) object.
         private final ByteBuffer initialBuffer;
+        // Snapshot at construction: MemoryRecords may share the pooled buffer, which can be
+        // overwritten after release().
+        private final long appendTimestamp;
 
         private CompletedBatch(
             long baseOffset,
@@ -577,6 +580,7 @@ public class BatchAccumulator<T> implements Closeable {
             this.initialBuffer = initialBuffer;
 
             validateConstruction();
+            this.appendTimestamp = data.firstBatch().maxTimestamp();
         }
 
         private CompletedBatch(
@@ -594,6 +598,7 @@ public class BatchAccumulator<T> implements Closeable {
             this.initialBuffer = initialBuffer;
 
             validateConstruction();
+            this.appendTimestamp = data.firstBatch().maxTimestamp();
         }
 
         private void validateConstruction() {
@@ -615,10 +620,7 @@ public class BatchAccumulator<T> implements Closeable {
         }
 
         public long appendTimestamp() {
-            // 1. firstBatch is not null because data has one and only one batch
-            // 2. maxTimestamp is the append time of the batch. This needs to be changed
-            //    to return the LastContainedLogTimestamp of the SnapshotHeaderRecord
-            return data.firstBatch().maxTimestamp();
+            return appendTimestamp;
         }
 
         public boolean drainable(long drainOffset) {

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1793,6 +1793,68 @@ class KafkaRaftClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    public void testLeaderHandleCommitAppendTimestampStableWhenPoolReusesBuffer(boolean withKip853Rpc) throws Exception {
+        int localId = randomReplicaId();
+        ReplicaKey otherNodeKey = replicaKey(localId + 1, withKip853Rpc);
+        Set<Integer> voters = Set.of(localId, otherNodeKey.id());
+
+        ByteBuffer buffer = ByteBuffer.allocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES);
+        MemoryPool memoryPool = Mockito.mock(MemoryPool.class);
+        Mockito.when(memoryPool.tryAllocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES))
+            .thenReturn(buffer);
+        Mockito.doAnswer(invocation -> {
+            buffer.clear();
+            return null;
+        }).when(memoryPool).release(Mockito.any(ByteBuffer.class));
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withMemoryPool(memoryPool)
+            .withKip853Rpc(withKip853Rpc)
+            .build();
+
+        context.unattachedToLeader();
+        int epoch = context.currentEpoch();
+        context.poll();
+        assertEquals(1L, context.log.endOffset().offset());
+
+        // Advance HWM through the leader-change batch so later data commits use the
+        // in-memory handleCommit path instead of log replay.
+        context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, 1L, epoch, 0));
+        context.pollUntilResponse();
+        assertEquals(OptionalLong.of(1L), context.client.highWatermark());
+        assertEquals(OptionalLong.of(0L), context.listener.lastCommitOffset());
+
+        long firstAppendTimestamp = context.time.milliseconds();
+        long firstOffset = context.client.prepareAppend(epoch, List.of("a"));
+        context.client.schedulePreparedAppend();
+        context.poll();
+
+        context.time.sleep(5_000L);
+        long secondAppendTimestamp = context.time.milliseconds();
+        long secondOffset = context.client.prepareAppend(epoch, List.of("b"));
+        context.client.schedulePreparedAppend();
+        context.poll();
+        assertNotEquals(firstAppendTimestamp, secondAppendTimestamp);
+
+        context.deliverRequest(context.fetchRequest(epoch, otherNodeKey, context.log.endOffset().offset(), epoch, 0));
+        context.pollUntil(() -> context.listener.commitWithLastOffset(secondOffset) != null);
+
+        Batch<String> firstBatch = context.listener.committedBatches().stream()
+            .filter(batch -> List.of("a").equals(batch.records()))
+            .findFirst()
+            .get();
+        Batch<String> secondBatch = context.listener.committedBatches().stream()
+            .filter(batch -> List.of("b").equals(batch.records()))
+            .findFirst()
+            .get();
+        assertEquals(firstOffset, firstBatch.lastOffset());
+        assertEquals(secondOffset, secondBatch.lastOffset());
+        assertEquals(firstAppendTimestamp, firstBatch.appendTimestamp());
+        assertEquals(secondAppendTimestamp, secondBatch.appendTimestamp());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     public void testLeaderImmediatelySendsDivergingEpoch(boolean withKip853Rpc) throws Exception {
         int localId = randomReplicaId();
         ReplicaKey otherNodeKey = replicaKey(localId + 1, withKip853Rpc);

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -276,6 +276,54 @@ class BatchAccumulatorTest {
     }
 
     @Test
+    public void testAppendTimestampUnchangedAfterBufferReleasedAndReused() {
+        int leaderEpoch = 17;
+        long baseOffset = 157;
+        int lingerMs = 50;
+        int maxBatchSize = 512;
+
+        BatchMemoryPool pool = new BatchMemoryPool(1, maxBatchSize);
+        BatchAccumulator<String> acc = new BatchAccumulator<>(
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize,
+            maxNumberOfBatches,
+            pool,
+            time,
+            Compression.NONE,
+            serde
+        );
+
+        assertEquals(baseOffset, acc.append(leaderEpoch, List.of("a"), false));
+        long firstAppendTimestamp = time.milliseconds();
+        time.sleep(lingerMs);
+        List<BatchAccumulator.CompletedBatch<String>> firstDrain = acc.drain();
+        assertEquals(1, firstDrain.size());
+        BatchAccumulator.CompletedBatch<String> first = firstDrain.get(0);
+        assertEquals(firstAppendTimestamp, first.appendTimestamp());
+        assertEquals(List.of("a"), first.records.get());
+        first.release();
+
+        time.sleep(1000);
+        assertEquals(baseOffset + 1, acc.append(leaderEpoch, List.of("b"), false));
+        long secondAppendTimestamp = time.milliseconds();
+        time.sleep(lingerMs);
+        List<BatchAccumulator.CompletedBatch<String>> secondDrain = acc.drain();
+        assertEquals(1, secondDrain.size());
+        BatchAccumulator.CompletedBatch<String> second = secondDrain.get(0);
+        assertEquals(secondAppendTimestamp, second.appendTimestamp());
+        assertEquals(List.of("b"), second.records.get());
+        assertNotEquals(firstAppendTimestamp, secondAppendTimestamp);
+
+        assertEquals(List.of("a"), first.records.get());
+        assertEquals(firstAppendTimestamp, first.appendTimestamp());
+
+        second.release();
+        acc.close();
+    }
+
+    @Test
     public void testUnflushedBuffersReleasedByClose() {
         int leaderEpoch = 17;
         long baseOffset = 157;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-20913

On the Raft leader, `KafkaRaftClient.appendBatch` writes the batch to the log, registers an async commit callback, then `release()`s the pooled buffer. `CompletedBatch.appendTimestamp()` was reading `MemoryRecords.firstBatch().maxTimestamp()` from a slice of that buffer. Production uses `BatchMemoryPool`, which requeues the buffer; a later batch overwrites the v2 header. When HWM later completes the callback, `handleCommit` can deliver the newer batch's append time.

### Fix
Snapshot `maxTimestamp` when `CompletedBatch` is constructed and return that field from `appendTimestamp()`. The timestamp is fixed at build time (`BatchBuilder` writes `time.milliseconds()` into the header). Record payloads and `sizeInBytes()` are not affected.

### Why existing tests missed this
- `RaftClientTestContext` defaults to `MemoryPool.NONE`, which allocates a new buffer every time and never reuses.
- `BatchAccumulatorTest` called `appendTimestamp()` before `release()`, or verified `release()` without reading the timestamp afterward.
- If the listener is still at the starting offset, commits come from log replay (the log copies records at append time), which hides the in-memory path.

### Tests
These failed on trunk (first batch reported T2) and pass after the snapshot:

- `BatchAccumulatorTest.testAppendTimestampUnchangedAfterBufferReleasedAndReused` — one-buffer `BatchMemoryPool`; drain/release at T1, append at T2; first batch must still report T1.
- `KafkaRaftClientTest.testLeaderHandleCommitAppendTimestampStableWhenPoolReusesBuffer` — two voters so HWM lags; catch the listener up past the leader-change batch; append at T1 then T2 with a single reused buffer; after commit the listener's first data batch must still be T1.

Related existing tests still pass: full `BatchAccumulatorTest`, `testListenerCommitCallbackAfterLeaderWrite`, `testAccumulatorClearedAfterBecomingFollower`.

```
./gradlew :raft:spotlessApply :raft:checkstyleMain :raft:checkstyleTest :raft:spotlessCheck
./gradlew :raft:test --tests org.apache.kafka.raft.internals.BatchAccumulatorTest --tests org.apache.kafka.raft.KafkaRaftClientTest.testLeaderHandleCommitAppendTimestampStableWhenPoolReusesBuffer --tests org.apache.kafka.raft.KafkaRaftClientTest.testListenerCommitCallbackAfterLeaderWrite --tests org.apache.kafka.raft.KafkaRaftClientTest.testAccumulatorClearedAfterBecomingFollower
```
BUILD SUCCESSFUL.