### PR TITLE
KAFKA-20964: Do not echo salt or saltedPassword in ScramParser errors

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/metadata/storage/ScramParser.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/storage/ScramParser.java
@@ -116,7 +116,7 @@ public class ScramParser {
                 try {
                     this.configuredSalt = Optional.of(Base64.getDecoder().decode(saltString));
                 } catch (IllegalArgumentException e) {
-                    throw new FormatterException("Failed to decode given salt: " + saltString, e);
+                    throw new FormatterException("Failed to decode given salt", e);
                 }
             }
             String iterationsString = components.remove("iterations");
@@ -142,8 +142,7 @@ public class ScramParser {
                     this.configuredPasswordString = Optional.empty();
                     this.configuredSaltedPassword = Optional.of(Base64.getDecoder().decode(saltedPasswordString));
                 } catch (IllegalArgumentException e) {
-                    throw new FormatterException("Failed to decode given saltedPassword: " +
-                            saltedPasswordString, e);
+                    throw new FormatterException("Failed to decode given saltedPassword", e);
                 }
             } else {
                 this.configuredPasswordString = Optional.of(passwordString);

--- a/metadata/src/test/java/org/apache/kafka/metadata/storage/ScramParserTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/storage/ScramParserTest.java
@@ -259,6 +259,25 @@ public class ScramParserTest {
     }
 
     @Test
+    public void testParsePerMechanismDataFailsWithInvalidSaltedPasswordBase64() {
+        assertEquals("Failed to decode given saltedPassword",
+            assertThrows(FormatterException.class,
+                () -> new PerMechanismData(ScramMechanism.SCRAM_SHA_256,
+                    "name=alice,salt=\"MWx2NHBkbnc0ZndxN25vdGN4bTB5eTFrN3E=\"," +
+                        "saltedpassword=\"not-valid-base64!!!\"")).
+                            getMessage());
+    }
+
+    @Test
+    public void testParsePerMechanismDataFailsWithInvalidSaltBase64() {
+        assertEquals("Failed to decode given salt",
+            assertThrows(FormatterException.class,
+                () -> new PerMechanismData(ScramMechanism.SCRAM_SHA_256,
+                    "name=alice,password=mypass,salt=\"%%%\"")).
+                        getMessage());
+    }
+
+    @Test
     public void testPerMechanismDataToRecord() throws Exception {
         ScramFormatter formatter = new ScramFormatter(ScramMechanism.SCRAM_SHA_512);
         assertEquals(new UserScramCredentialRecord().


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/KAFKA-20964

`kafka-storage format --add-scram` parses SCRAM credentials in `ScramParser`. On Base64 decode failure, `PerMechanismData` built a `FormatterException` whose message included the user-supplied `saltedpassword` (and the same for `salt`). `StorageTool` prints `getMessage()` to stderr, so credential-adjacent input was echoed in the CLI error.

### Fix
Use a generic decode-failure message and keep the `IllegalArgumentException` as the cause. Do not concatenate the user-supplied value.

```
Failed to decode given saltedPassword
Failed to decode given salt
```

This matches the existing request-side practice of not printing salt or salted password (`AlterUserScramCredentialsRequest`). Decode details remain on the cause if it is logged.

### Why existing tests missed this
`ScramParserTest` covered valid Base64 `saltedpassword`/`salt` and missing-field errors (`name`, `password`, `salt` required with `saltedpassword`, extra keys). None of those paths throw on Base64 failure, so the decode-error message was never asserted.

### Tests
These failed on trunk (message included the raw input) and pass after this change:

- `testParsePerMechanismDataFailsWithInvalidSaltedPasswordBase64` — valid salt so construction reaches the salted-password decoder; `saltedpassword="not-valid-base64!!!"`. Trunk: `Failed to decode given saltedPassword: not-valid-base64!!!`. After: `Failed to decode given saltedPassword`.
- `testParsePerMechanismDataFailsWithInvalidSaltBase64` — `salt="%%%"`. Trunk: `Failed to decode given salt: %%%`. After: `Failed to decode given salt`.

Related existing tests still pass: full `ScramParserTest` (including valid `saltedpassword` parse and `toRecord()`).

```
./gradlew :metadata:test --tests org.apache.kafka.metadata.storage.ScramParserTest :metadata:checkstyleMain :metadata:checkstyleTest :metadata:spotlessCheck
```
BUILD SUCCESSFUL.