### PR TITLE
MINOR: Remove ThreadMetadataImpl null check and test-only ClientState constructors

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -851,12 +851,15 @@ public class StateDirectory implements AutoCloseable {
         final List<TaskDirectory> taskDirectories = new ArrayList<>();
         if (hasPersistentStores && stateDir.exists()) {
             if (hasNamedTopologies) {
-                for (final File namedTopologyDir : listNamedTopologyDirs()) {
-                    final String namedTopology = parseNamedTopologyFromDirectory(namedTopologyDir.getName());
-                    final File[] taskDirs = namedTopologyDir.listFiles(filter);
-                    if (taskDirs != null) {
-                        taskDirectories.addAll(Arrays.stream(taskDirs)
-                            .map(f -> new TaskDirectory(f, namedTopology)).collect(Collectors.toList()));
+                final File[] namedTopologyDirs = stateDir.listFiles(f -> f.getName().startsWith("__") && f.getName().endsWith("__"));
+                if (namedTopologyDirs != null) {
+                    for (final File namedTopologyDir : namedTopologyDirs) {
+                        final String namedTopology = parseNamedTopologyFromDirectory(namedTopologyDir.getName());
+                        final File[] taskDirs = namedTopologyDir.listFiles(filter);
+                        if (taskDirs != null) {
+                            taskDirectories.addAll(Arrays.stream(taskDirs)
+                                .map(f -> new TaskDirectory(f, namedTopology)).collect(Collectors.toList()));
+                        }
                     }
                 }
             } else {
@@ -870,11 +873,6 @@ public class StateDirectory implements AutoCloseable {
         }
 
         return taskDirectories;
-    }
-
-    private List<File> listNamedTopologyDirs() {
-        final File[] namedTopologyDirectories = stateDir.listFiles(f -> f.getName().startsWith("__") &&  f.getName().endsWith("__"));
-        return namedTopologyDirectories != null ? Arrays.asList(namedTopologyDirectories) : List.of();
     }
 
     private String parseNamedTopologyFromDirectory(final String dirName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
@@ -57,7 +57,7 @@ public class ThreadMetadataImpl implements ThreadMetadata {
                               final Set<TaskMetadata> standbyTasks) {
         this.mainConsumerClientId = mainConsumerClientId;
         this.restoreConsumerClientId = restoreConsumerClientId;
-        this.producerClientIds = producerClientIds != null ? Set.of(producerClientIds) : Set.of();
+        this.producerClientIds = Set.of(producerClientIds);
         this.adminClientId = adminClientId;
         this.threadName = threadName;
         this.threadState = threadState;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -38,6 +38,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingLong;
@@ -89,7 +90,7 @@ public class ClientState {
         taskLagTotals = new TreeMap<>();
         this.capacity = capacity;
         this.processId = processId;
-        this.clientTags = new TreeMap<>(clientTags);
+        this.clientTags = unmodifiableMap(clientTags);
     }
 
     public int capacity() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -92,43 +92,6 @@ public class ClientState {
         this.clientTags = new TreeMap<>(clientTags);
     }
 
-    // For testing only
-    public ClientState(final Set<TaskId> previousActiveTasks,
-                       final Set<TaskId> previousStandbyTasks,
-                       final Map<TaskId, Long> taskLagTotals,
-                       final Map<String, String> clientTags,
-                       final int capacity) {
-        this(previousActiveTasks, previousStandbyTasks, taskLagTotals, clientTags, capacity, null);
-    }
-
-    // For testing only
-    public ClientState(final Set<TaskId> previousActiveTasks,
-                       final Set<TaskId> previousStandbyTasks,
-                       final Map<TaskId, Long> taskLagTotals,
-                       final Map<String, String> clientTags,
-                       final int capacity,
-                       final ProcessId processId) {
-        this.previousStandbyTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousStandbyTasks)));
-        this.previousActiveTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousActiveTasks)));
-        taskOffsetSums = Map.of();
-        this.taskLagTotals = new TreeMap<>(taskLagTotals);
-        this.capacity = capacity;
-        this.clientTags = new TreeMap<>(clientTags);
-        this.processId = processId;
-    }
-
-    // For testing only
-    public ClientState(final ClientState clientState) {
-        this(
-            new HashSet<>(clientState.previousActiveTasks.taskIds()),
-            new HashSet<>(clientState.previousStandbyTasks.taskIds()),
-            clientState.taskLagTotals,
-            clientState.clientTags,
-            clientState.capacity,
-            clientState.processId
-        );
-    }
-
     public int capacity() {
         return capacity;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -38,7 +38,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingLong;
@@ -90,7 +89,7 @@ public class ClientState {
         taskLagTotals = new TreeMap<>();
         this.capacity = capacity;
         this.processId = processId;
-        this.clientTags = unmodifiableMap(clientTags);
+        this.clientTags = new TreeMap<>(clientTags);
     }
 
     // For testing only
@@ -112,9 +111,9 @@ public class ClientState {
         this.previousStandbyTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousStandbyTasks)));
         this.previousActiveTasks.setTaskIds(unmodifiableSet(new TreeSet<>(previousActiveTasks)));
         taskOffsetSums = Map.of();
-        this.taskLagTotals = unmodifiableMap(taskLagTotals);
+        this.taskLagTotals = new TreeMap<>(taskLagTotals);
         this.capacity = capacity;
-        this.clientTags = unmodifiableMap(clientTags);
+        this.clientTags = new TreeMap<>(clientTags);
         this.processId = processId;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -438,6 +438,10 @@ public class ClientState {
         return taskLagTotals;
     }
 
+    void addTaskLagTotals(final Map<TaskId, Long> taskLagTotals) {
+        this.taskLagTotals.putAll(taskLagTotals);
+    }
+
     public SortedSet<TaskId> previousActiveTasks() {
         return new TreeSet<>(previousActiveTasks.taskIds());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -690,7 +690,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = Mockito.mock(TaskManager.class);
+        final TaskManager taskManager = mock(TaskManager.class);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -711,7 +711,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = Mockito.mock(TaskManager.class);
+        final TaskManager taskManager = mock(TaskManager.class);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -734,7 +734,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = Mockito.mock(TaskManager.class);
+        final TaskManager taskManager = mock(TaskManager.class);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -756,7 +756,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = Mockito.mock(TaskManager.class);
+        final TaskManager taskManager = mock(TaskManager.class);
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -4662,7 +4662,7 @@ public class StreamThreadTest {
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         when(mainConsumer.poll(Mockito.any(Duration.class))).thenReturn(new ConsumerRecords<>(Map.of(), Map.of()));
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
-        final TaskManager taskManager = Mockito.mock(TaskManager.class);
+        final TaskManager taskManager = mock(TaskManager.class);
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         return new StreamThread(
@@ -4706,6 +4706,14 @@ public class StreamThreadTest {
     private TaskManager mockTaskManagerPurge() {
         final Task runningTask = mock(Task.class);
         return mockTaskManager(runningTask);
+    }
+
+    private <T> T mock(final Class<T> classToMock) {
+        final T mock = Mockito.mock(classToMock);
+        if (classToMock == TaskManager.class) {
+            lenient().when(((TaskManager) mock).producerClientIds()).thenReturn(CLIENT_ID + "-producer");
+        }
+        return mock;
     }
 
     private TaskManager mockTaskManagerCommit(final Task runningTask, final int commits) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -592,7 +592,7 @@ public class StreamThreadTest {
         final TaskId taskId = new TaskId(0, 0);
         final Task runningTask = statelessTask(taskId)
             .inState(Task.State.RUNNING).build();
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         when(taskManager.allRunningTasks()).thenReturn(Collections.singletonMap(taskId, runningTask));
         when(taskManager.commit(Collections.singleton(runningTask))).thenReturn(0);
 
@@ -622,7 +622,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -647,7 +647,7 @@ public class StreamThreadTest {
         // iteration, including the ones that return early because the group is not ready -- which is exactly when a
         // task may still be restoring.
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         when(mainConsumer.poll(Mockito.any())).thenReturn(ConsumerRecords.empty());
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -690,7 +690,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -711,7 +711,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -734,7 +734,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -756,7 +756,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = Mockito.mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
@@ -1586,7 +1586,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
@@ -1607,7 +1607,7 @@ public class StreamThreadTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void shouldNotReturnDataAfterTaskMigrated(final boolean processingThreadsEnabled) {
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final InternalTopologyBuilder internalTopologyBuilder = mock(InternalTopologyBuilder.class);
         when(internalTopologyBuilder.fullSourceTopicNames()).thenReturn(Collections.singletonList(topic1));
 
@@ -1678,7 +1678,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
@@ -1696,7 +1696,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
@@ -1713,7 +1713,7 @@ public class StreamThreadTest {
     @Test
     public void shouldRouteDefaultToRemainInGroupForClassicProtocol() {
         // Classic protocol: DEFAULT should map to consumer REMAIN_IN_GROUP
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final StreamsConfig config = new StreamsConfig(configProps(false, false));
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -1739,7 +1739,7 @@ public class StreamThreadTest {
     @Test
     public void shouldRouteDefaultToConsumerDefaultForStreamsProtocol() {
         // Streams protocol: DEFAULT should map to consumer DEFAULT (dynamic member leaves)
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final StreamsConfig config = new StreamsConfig(configProps(false, false));
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -1772,7 +1772,7 @@ public class StreamThreadTest {
     @Test
     public void shouldRouteRemainInGroupToRemainInGroupForStreamsProtocol() {
         // Streams protocol: explicit REMAIN_IN_GROUP must always map to consumer REMAIN_IN_GROUP
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final StreamsConfig config = new StreamsConfig(configProps(false, false));
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2685,7 +2685,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(AutoOffsetResetStrategy.LATEST.name());
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2713,7 +2713,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(AutoOffsetResetStrategy.LATEST.name());
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2740,7 +2740,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchHandleCorruptionOnTaskCorruptedExceptionPath(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2803,7 +2803,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTimeoutExceptionFromHandleCorruptionAndInvokeExceptionHandler(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2871,7 +2871,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTaskMigratedExceptionOnOnTaskCorruptedExceptionPath(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -2939,7 +2939,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldEnforceRebalanceWhenTaskCorruptedExceptionIsThrownForAnActiveTask(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(true, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -3007,7 +3007,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldNotEnforceRebalanceOnTaskCorruptedExceptionUnderStreamsProtocol(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(true, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         // The Streams group protocol requires the main consumer to be an AsyncKafkaConsumer (see subscribeConsumer).
         final Consumer<byte[], byte[]> consumer = mock(AsyncKafkaConsumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
@@ -3084,7 +3084,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldNotEnforceRebalanceWhenTaskCorruptedExceptionIsThrownForAnInactiveTask(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(true, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
@@ -3148,7 +3148,7 @@ public class StreamThreadTest {
     @ValueSource(booleans = {true, false})
     public void shouldNotCommitNonRunningNonRestoringTasks(final boolean processingThreadsEnabled) {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
@@ -3294,7 +3294,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
         final Metric testMetric = new KafkaMetric(
@@ -3328,7 +3328,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
 
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime);
@@ -3390,7 +3390,7 @@ public class StreamThreadTest {
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         when(consumer.groupMetadata()).thenReturn(consumerGroupMetadata);
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime);
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
@@ -4004,7 +4004,7 @@ public class StreamThreadTest {
             consumer,
             changelogReader,
             null,
-            mock(TaskManager.class),
+            mockTaskManager(),
             null,
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -4066,7 +4066,7 @@ public class StreamThreadTest {
             consumer,
             changelogReader,
             null,
-            mock(TaskManager.class),
+            mockTaskManager(),
             null,
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -4114,7 +4114,7 @@ public class StreamThreadTest {
             consumer,
             changelogReader,
             null,
-            mock(TaskManager.class),
+            mockTaskManager(),
             null,
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -4160,7 +4160,7 @@ public class StreamThreadTest {
             consumer,
             changelogReader,
             null,
-            mock(TaskManager.class),
+            mockTaskManager(),
             null,
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -4224,7 +4224,7 @@ public class StreamThreadTest {
                 consumer,
                 changelogReader,
                 null,
-                mock(TaskManager.class),
+                mockTaskManager(),
                 null,
                 new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
                 new TopologyMetadata(internalTopologyBuilder, config),
@@ -4298,7 +4298,7 @@ public class StreamThreadTest {
                 consumer,
                 changelogReader,
                 null,
-                mock(TaskManager.class),
+                mockTaskManager(),
                 null,
                 new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
                 new TopologyMetadata(internalTopologyBuilder, config),
@@ -4363,7 +4363,7 @@ public class StreamThreadTest {
             consumer,
             changelogReader,
             null,
-            mock(TaskManager.class),
+            mockTaskManager(),
             null,
             new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
             new TopologyMetadata(internalTopologyBuilder, config),
@@ -4428,7 +4428,7 @@ public class StreamThreadTest {
                 consumer,
                 changelogReader,
                 null,
-                mock(TaskManager.class),
+                mockTaskManager(),
                 null,
                 new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
                 new TopologyMetadata(internalTopologyBuilder, config),
@@ -4502,7 +4502,7 @@ public class StreamThreadTest {
                 consumer,
                 changelogReader,
                 null,
-                mock(TaskManager.class),
+                mockTaskManager(),
                 null,
                 new StreamsMetricsImpl(metrics, CLIENT_ID, mockTime),
                 new TopologyMetadata(internalTopologyBuilder, config),
@@ -4662,7 +4662,7 @@ public class StreamThreadTest {
         when(consumerGroupMetadata.groupInstanceId()).thenReturn(Optional.empty());
         when(mainConsumer.poll(Mockito.any(Duration.class))).thenReturn(new ConsumerRecords<>(Map.of(), Map.of()));
         when(mainConsumer.groupMetadata()).thenReturn(consumerGroupMetadata);
-        final TaskManager taskManager = mock(TaskManager.class);
+        final TaskManager taskManager = mockTaskManager();
         final TopologyMetadata topologyMetadata = new TopologyMetadata(internalTopologyBuilder, config);
         topologyMetadata.buildAndRewriteTopology();
         return new StreamThread(
@@ -4694,8 +4694,16 @@ public class StreamThreadTest {
         );
     }
 
-    private TaskManager mockTaskManager(final Task runningTask) {
+    // ThreadMetadataImpl wraps producerClientIds() in Set.of(...), so every TaskManager mock
+    // has to return a non-null value for it.
+    private TaskManager mockTaskManager() {
         final TaskManager taskManager = mock(TaskManager.class);
+        lenient().when(taskManager.producerClientIds()).thenReturn(CLIENT_ID + "-producer");
+        return taskManager;
+    }
+
+    private TaskManager mockTaskManager(final Task runningTask) {
+        final TaskManager taskManager = mockTaskManager();
         final TaskId taskId = new TaskId(0, 0);
 
         when(runningTask.state()).thenReturn(Task.State.RUNNING);
@@ -4706,14 +4714,6 @@ public class StreamThreadTest {
     private TaskManager mockTaskManagerPurge() {
         final Task runningTask = mock(Task.class);
         return mockTaskManager(runningTask);
-    }
-
-    private <T> T mock(final Class<T> classToMock) {
-        final T mock = Mockito.mock(classToMock);
-        if (classToMock == TaskManager.class) {
-            lenient().when(((TaskManager) mock).producerClientIds()).thenReturn(CLIENT_ID + "-producer");
-        }
-        return mock;
     }
 
     private TaskManager mockTaskManagerCommit(final Task runningTask, final int commits) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T0_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NAMED_TASK_T1_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
@@ -47,7 +46,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasActiveTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasStandbyTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientState;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -60,12 +59,11 @@ public class ClientStateTest {
     private final ClientState zeroCapacityClient = new ClientState(0);
 
     @Test
-    public void previousStateConstructorShouldCreateAValidObject() {
-        final ClientState clientState = new ClientState(
+    public void shouldCreateAValidClientStateFromPreviousState() {
+        final ClientState clientState = clientState(
             Set.of(TASK_0_0, TASK_0_1),
             Set.of(TASK_0_2, TASK_0_3),
             mkMap(mkEntry(TASK_0_0, 5L), mkEntry(TASK_0_2, -1L)),
-            EMPTY_CLIENT_TAGS,
             4
         );
 
@@ -546,16 +544,4 @@ public class ClientStateTest {
         assertNull(new ClientState().processId());
     }
 
-    @Test
-    public void shouldCopyState() {
-        final ClientState clientState = new ClientState(Set.of(new TaskId(0, 0)), Set.of(new TaskId(0, 1)), Map.of(), EMPTY_CLIENT_TAGS, 1, processIdForInt(1));
-        final ClientState clientStateCopy = new ClientState(clientState);
-
-        assertEquals(clientStateCopy.processId(), clientState.processId());
-        assertEquals(clientStateCopy.capacity(), clientState.capacity());
-        assertEquals(clientStateCopy.prevActiveTasks(), clientStateCopy.prevActiveTasks());
-        assertEquals(clientStateCopy.prevStandbyTasks(), clientStateCopy.prevStandbyTasks());
-        assertEquals(clientState.prevActiveTasks(), clientStateCopy.prevActiveTasks());
-        assertEquals(clientState.prevStandbyTasks(), clientStateCopy.prevStandbyTasks());
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -37,7 +37,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_0_2;
@@ -46,7 +45,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasActiveTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasStandbyTasks;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientState;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -57,33 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ClientStateTest {
     private final ClientState client = new ClientState(1);
     private final ClientState zeroCapacityClient = new ClientState(0);
-
-    @Test
-    public void shouldCreateAValidClientStateFromPreviousState() {
-        final ClientState clientState = clientState(
-            Set.of(TASK_0_0, TASK_0_1),
-            Set.of(TASK_0_2, TASK_0_3),
-            mkMap(mkEntry(TASK_0_0, 5L), mkEntry(TASK_0_2, -1L)),
-            4
-        );
-
-        // all the "next assignment" fields should be empty
-        assertEquals(0, clientState.activeTaskCount());
-        assertEquals(0.0, clientState.activeTaskLoad());
-        assertTrue(clientState.activeTasks().isEmpty());
-        assertEquals(0, clientState.standbyTaskCount());
-        assertTrue(clientState.standbyTasks().isEmpty());
-        assertEquals(0, clientState.assignedTaskCount());
-        assertTrue(clientState.assignedTasks().isEmpty());
-
-        // and the "previous assignment" fields should match the constructor args
-        assertEquals(Set.of(TASK_0_0, TASK_0_1), clientState.prevActiveTasks());
-        assertEquals(Set.of(TASK_0_2, TASK_0_3), clientState.prevStandbyTasks());
-        assertEquals(Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3), clientState.previousAssignedTasks());
-        assertEquals(4, clientState.capacity());
-        assertEquals(5L, clientState.lagFor(TASK_0_0));
-        assertEquals(-1L, clientState.lagFor(TASK_0_2));
-    }
 
     @Test
     public void shouldHaveNotReachedCapacityWhenAssignedTasksLessThanCapacity() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_RACK_AWARE_ASSIGNMENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.PID_1;
@@ -69,6 +68,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasAssignedTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasStandbyTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertValidAssignment;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientState;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.copyClientStateMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getRackAwareTaskAssignor;
@@ -132,13 +132,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldBeStickyForActiveAndStandbyTasksWhileWarmingUp(final String rackAwareStrategy,
                                                                      final boolean enableRackAwareTaskAssignor) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
-        final ClientState clientState1 = new ClientState(allTaskIds, Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(allTaskIds, Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), allTaskIds, allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), allTaskIds, allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L)), 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), 1,
             PID_3
         );
 
@@ -189,13 +189,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldSkipWarmupsWhenAcceptableLagIsMax(final String rackAwareStrategy,
                                                         final boolean enableRackAwareTaskAssignor) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
-        final ClientState clientState1 = new ClientState(allTaskIds, Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(allTaskIds, Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L)), 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE)), 1,
             PID_3
         );
 
@@ -245,13 +245,13 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                                                    final int maxSkew) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), lags, 1,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
@@ -300,13 +300,13 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                                                    final int maxSkew) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 3,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 3,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 3,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 3,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 3,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), lags, 3,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
@@ -356,10 +356,10 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                                                       final int maxSkew) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 1,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
@@ -404,13 +404,13 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                           final boolean enableRackAwareTaskAssignor) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 2,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 2,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 3,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), lags, 3,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
@@ -462,13 +462,13 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                          final int maxSkew) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), lags, 1,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
@@ -512,13 +512,13 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                                                        final int maxSkew) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 9,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 9,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 9,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 9,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 9,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), lags, 9,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2, clientState3);
@@ -569,13 +569,13 @@ public class HighAvailabilityTaskAssignorTest {
         final Map<TaskId, Long> lagsForCaughtUpClient = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 0L));
         final Map<TaskId, Long> lagsForNotCaughtUpClient =
             allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
-        final ClientState caughtUpClientState = new ClientState(allTaskIds, Set.of(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+        final ClientState caughtUpClientState = clientState(allTaskIds, Set.of(), lagsForCaughtUpClient, 5,
             PID_1
         );
-        final ClientState notCaughtUpClientState1 = new ClientState(Set.of(), Set.of(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+        final ClientState notCaughtUpClientState1 = clientState(Set.of(), Set.of(), lagsForNotCaughtUpClient, 5,
             PID_2
         );
-        final ClientState notCaughtUpClientState2 = new ClientState(Set.of(), Set.of(), lagsForNotCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+        final ClientState notCaughtUpClientState2 = clientState(Set.of(), Set.of(), lagsForNotCaughtUpClient, 5,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates =
@@ -634,13 +634,13 @@ public class HighAvailabilityTaskAssignorTest {
             allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> Long.MAX_VALUE));
         lagsForWarmedUpClient2.put(warmupTaskId2, 0L);
 
-        final ClientState caughtUpClientState = new ClientState(allTaskIds, Set.of(), lagsForCaughtUpClient, EMPTY_CLIENT_TAGS, 5,
+        final ClientState caughtUpClientState = clientState(allTaskIds, Set.of(), lagsForCaughtUpClient, 5,
             PID_1
         );
-        final ClientState warmedUpClientState1 = new ClientState(Set.of(), warmedUpTaskIds1, lagsForWarmedUpClient1, EMPTY_CLIENT_TAGS, 5,
+        final ClientState warmedUpClientState1 = clientState(Set.of(), warmedUpTaskIds1, lagsForWarmedUpClient1, 5,
             PID_2
         );
-        final ClientState warmedUpClientState2 = new ClientState(Set.of(), warmedUpTaskIds2, lagsForWarmedUpClient2, EMPTY_CLIENT_TAGS, 5,
+        final ClientState warmedUpClientState2 = clientState(Set.of(), warmedUpTaskIds2, lagsForWarmedUpClient2, 5,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates =
@@ -685,10 +685,10 @@ public class HighAvailabilityTaskAssignorTest {
                                                                                                final boolean enableRackAwareTaskAssignor) {
         final Set<TaskId> allTaskIds = Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_1_0, TASK_1_1, TASK_1_2, TASK_2_0, TASK_2_1, TASK_2_2);
         final Map<TaskId, Long> lags = allTaskIds.stream().collect(Collectors.toMap(k -> k, k -> 10L));
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 6,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), lags, 6,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), lags, EMPTY_CLIENT_TAGS, 3,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), lags, 3,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(clientState1, clientState2);
@@ -734,7 +734,7 @@ public class HighAvailabilityTaskAssignorTest {
                                                                           final boolean enableRackAwareTaskAssignor,
                                                                           final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0, TASK_0_1);
-        final ClientState client1 = new ClientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 0L), 1,
             PID_1
         );
         final Map<ProcessId, ClientState> clientStates = Map.of(PID_1, client1);
@@ -768,10 +768,10 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfThereAreUnassignedStandbyTasks(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = new ClientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 0L), 1,
             PID_1
         );
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), Map.of(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client2 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 0L), 1,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(mkEntry(PID_1, client1), mkEntry(PID_2, client2));
@@ -803,10 +803,10 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfActiveTasksWasNotOnCaughtUpClient(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = new ClientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 500L), 1,
             PID_1
         );
-        final ClientState client2 = new ClientState(Set.of(TASK_0_1), Set.of(), Map.of(TASK_0_0, 0L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client2 = clientState(singleton(TASK_0_1), Set.of(), singletonMap(TASK_0_0, 0L), 1,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(
@@ -841,13 +841,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignToMostCaughtUpIfActiveTasksWasNotOnCaughtUpClient(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = new ClientState(Set.of(), Set.of(), Map.of(TASK_0_0, Long.MAX_VALUE), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client1 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, Long.MAX_VALUE), 1,
             PID_1
         );
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), Map.of(TASK_0_0, 1000L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client2 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 1000L), 1,
             PID_2
         );
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), Map.of(TASK_0_0, 500L), EMPTY_CLIENT_TAGS, 1,
+        final ClientState client3 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 500L), 1,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(
@@ -1228,9 +1228,9 @@ public class HighAvailabilityTaskAssignorTest {
             Set.of(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3, TASK_2_0); // 9 total
         final Map<TaskId, Long> allTaskLags = allTasks.stream().collect(Collectors.toMap(t -> t, t -> 0L));
         final Set<TaskId> statefulTasks = new HashSet<>(allTasks);
-        final ClientState client1 = new ClientState(Set.of(), Set.of(), allTaskLags, EMPTY_CLIENT_TAGS, 100);
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), allTaskLags, EMPTY_CLIENT_TAGS, 50);
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), allTaskLags, EMPTY_CLIENT_TAGS, 1);
+        final ClientState client1 = clientState(Set.of(), Set.of(), allTaskLags, 100);
+        final ClientState client2 = clientState(Set.of(), Set.of(), allTaskLags, 50);
+        final ClientState client3 = clientState(Set.of(), Set.of(), allTaskLags, 1);
 
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
@@ -1351,9 +1351,9 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statelessTasks = new HashSet<>(allTasks);
 
         final Map<TaskId, Long> taskLags = new HashMap<>();
-        final ClientState client1 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 7);
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 7);
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 7);
+        final ClientState client1 = clientState(Set.of(), Set.of(), taskLags, 7);
+        final ClientState client2 = clientState(Set.of(), Set.of(), taskLags, 7);
+        final ClientState client3 = clientState(Set.of(), Set.of(), taskLags, 7);
 
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
@@ -1403,9 +1403,9 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statelessTasks = new HashSet<>(allTasks);
 
         final Map<TaskId, Long> taskLags = new HashMap<>();
-        final ClientState client1 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 2);
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 2);
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 2);
+        final ClientState client1 = clientState(Set.of(), Set.of(), taskLags, 2);
+        final ClientState client2 = clientState(Set.of(), Set.of(), taskLags, 2);
+        final ClientState client3 = clientState(Set.of(), Set.of(), taskLags, 2);
 
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
@@ -1455,9 +1455,9 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statelessTasks = new HashSet<>(allTasks);
 
         final Map<TaskId, Long> taskLags = new HashMap<>();
-        final ClientState client1 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 1);
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 2);
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 3);
+        final ClientState client1 = clientState(Set.of(), Set.of(), taskLags, 1);
+        final ClientState client2 = clientState(Set.of(), Set.of(), taskLags, 2);
+        final ClientState client3 = clientState(Set.of(), Set.of(), taskLags, 3);
 
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
@@ -1507,9 +1507,9 @@ public class HighAvailabilityTaskAssignorTest {
         final Set<TaskId> statelessTasks = new HashSet<>(allTasks);
 
         final Map<TaskId, Long> taskLags = new HashMap<>();
-        final ClientState client1 = new ClientState(statelessTasks, Set.of(), taskLags, EMPTY_CLIENT_TAGS, 3);
-        final ClientState client2 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 3);
-        final ClientState client3 = new ClientState(Set.of(), Set.of(), taskLags, EMPTY_CLIENT_TAGS, 3);
+        final ClientState client1 = clientState(statelessTasks, Set.of(), taskLags, 3);
+        final ClientState client2 = clientState(Set.of(), Set.of(), taskLags, 3);
+        final ClientState client3 = clientState(Set.of(), Set.of(), taskLags, 3);
 
         final Map<ProcessId, ClientState> clientStates = getClientStatesMap(client1, client2, client3);
 
@@ -1737,7 +1737,7 @@ public class HighAvailabilityTaskAssignorTest {
                 taskLags.put(task, Long.MAX_VALUE);
             }
         }
-        return new ClientState(statefulActiveTasks, Set.of(), taskLags, EMPTY_CLIENT_TAGS, 1, processId);
+        return clientState(statefulActiveTasks, Set.of(), taskLags, 1, processId);
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignorTest.java
@@ -734,7 +734,7 @@ public class HighAvailabilityTaskAssignorTest {
                                                                           final boolean enableRackAwareTaskAssignor,
                                                                           final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0, TASK_0_1);
-        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 0L), 1,
+        final ClientState client1 = clientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 0L), 1,
             PID_1
         );
         final Map<ProcessId, ClientState> clientStates = Map.of(PID_1, client1);
@@ -768,10 +768,10 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfThereAreUnassignedStandbyTasks(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 0L), 1,
+        final ClientState client1 = clientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 0L), 1,
             PID_1
         );
-        final ClientState client2 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 0L), 1,
+        final ClientState client2 = clientState(Set.of(), Set.of(), Map.of(TASK_0_0, 0L), 1,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(mkEntry(PID_1, client1), mkEntry(PID_2, client2));
@@ -803,10 +803,10 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldComputeNewAssignmentIfActiveTasksWasNotOnCaughtUpClient(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0, TASK_0_1);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = clientState(singleton(TASK_0_0), Set.of(), singletonMap(TASK_0_0, 500L), 1,
+        final ClientState client1 = clientState(Set.of(TASK_0_0), Set.of(), Map.of(TASK_0_0, 500L), 1,
             PID_1
         );
-        final ClientState client2 = clientState(singleton(TASK_0_1), Set.of(), singletonMap(TASK_0_0, 0L), 1,
+        final ClientState client2 = clientState(Set.of(TASK_0_1), Set.of(), Map.of(TASK_0_0, 0L), 1,
             PID_2
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(
@@ -841,13 +841,13 @@ public class HighAvailabilityTaskAssignorTest {
     public void shouldAssignToMostCaughtUpIfActiveTasksWasNotOnCaughtUpClient(final String rackAwareStrategy, final boolean enableRackAwareTaskAssignor, final int maxSkew) {
         final Set<TaskId> allTasks = Set.of(TASK_0_0);
         final Set<TaskId> statefulTasks = Set.of(TASK_0_0);
-        final ClientState client1 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, Long.MAX_VALUE), 1,
+        final ClientState client1 = clientState(Set.of(), Set.of(), Map.of(TASK_0_0, Long.MAX_VALUE), 1,
             PID_1
         );
-        final ClientState client2 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 1000L), 1,
+        final ClientState client2 = clientState(Set.of(), Set.of(), Map.of(TASK_0_0, 1000L), 1,
             PID_2
         );
-        final ClientState client3 = clientState(Set.of(), Set.of(), singletonMap(TASK_0_0, 500L), 1,
+        final ClientState client3 = clientState(Set.of(), Set.of(), Map.of(TASK_0_0, 500L), 1,
             PID_3
         );
         final Map<ProcessId, ClientState> clientStates = mkMap(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -56,7 +56,6 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.CHANGELOG_TP_0_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.CHANGELOG_TP_0_NAME;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CLIENT_TAGS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.NODE_2;
@@ -84,6 +83,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TP_1_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertBalancedTasks;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertValidAssignment;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientState;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientTaskCount;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.configProps;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClusterForAllTopics;
@@ -499,7 +499,7 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
 
@@ -537,9 +537,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
         clientState2.assignActive(TASK_1_0);
@@ -679,9 +679,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState2.assignActive(TASK_1_0);
         clientState3.assignActive(TASK_0_0);
@@ -731,9 +731,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState2.assignActiveTasks(Set.of(TASK_0_1, TASK_1_0));
         clientState3.assignActive(TASK_0_0);
@@ -783,8 +783,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -833,8 +833,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -865,8 +865,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
@@ -899,8 +899,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -932,13 +932,13 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_3
         );
 
@@ -976,22 +976,22 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_3
         );
-        final ClientState clientState4 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState4 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_4
         );
-        final ClientState clientState5 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState5 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_6
         );
-        final ClientState clientState6 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState6 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_7
         );
 
@@ -1053,22 +1053,22 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_1
         );
-        final ClientState clientState2 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_2
         );
-        final ClientState clientState3 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_3
         );
-        final ClientState clientState4 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState4 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_4
         );
-        final ClientState clientState5 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState5 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_6
         );
-        final ClientState clientState6 = new ClientState(Set.of(), Set.of(), Map.of(), EMPTY_CLIENT_TAGS, 1,
+        final ClientState clientState6 = clientState(Set.of(), Set.of(), emptyMap(), 1,
             PID_7
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/RackAwareTaskAssignorTest.java
@@ -499,7 +499,7 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
 
@@ -537,9 +537,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
         clientState2.assignActive(TASK_1_0);
@@ -679,9 +679,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState2.assignActive(TASK_1_0);
         clientState3.assignActive(TASK_0_0);
@@ -731,9 +731,9 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState2.assignActiveTasks(Set.of(TASK_0_1, TASK_1_0));
         clientState3.assignActive(TASK_0_0);
@@ -783,8 +783,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -833,8 +833,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -865,8 +865,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActiveTasks(Set.of(TASK_0_1, TASK_1_1));
@@ -899,8 +899,8 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1);
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1);
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1);
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1);
 
         clientState1.assignActiveTasks(Set.of(TASK_0_0, TASK_1_1));
         clientState2.assignActive(TASK_0_1);
@@ -932,13 +932,13 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_1
         );
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_2
         );
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_3
         );
 
@@ -976,22 +976,22 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_1
         );
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_2
         );
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_3
         );
-        final ClientState clientState4 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState4 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_4
         );
-        final ClientState clientState5 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState5 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_6
         );
-        final ClientState clientState6 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState6 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_7
         );
 
@@ -1053,22 +1053,22 @@ public class RackAwareTaskAssignorTest {
             time
         );
 
-        final ClientState clientState1 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState1 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_1
         );
-        final ClientState clientState2 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState2 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_2
         );
-        final ClientState clientState3 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState3 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_3
         );
-        final ClientState clientState4 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState4 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_4
         );
-        final ClientState clientState5 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState5 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_6
         );
-        final ClientState clientState6 = clientState(Set.of(), Set.of(), emptyMap(), 1,
+        final ClientState clientState6 = clientState(Set.of(), Set.of(), Map.of(), 1,
             PID_7
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskMovementTest.java
@@ -45,6 +45,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.assertHasProperty;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.clientState;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getClientStatesMap;
 import static org.apache.kafka.streams.processor.internals.assignment.TaskMovement.assignActiveTaskMovements;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -291,7 +292,7 @@ public class TaskMovementTest {
 
     private static ClientState getClientStateWithLags(final Set<TaskId> activeTasks,
                                                       final Map<TaskId, Long> taskLags) {
-        final ClientState client1 = new ClientState(activeTasks, Set.of(), taskLags, Map.of(), 1);
+        final ClientState client1 = clientState(activeTasks, Set.of(), taskLags, 1);
         client1.assignActiveTasks(activeTasks);
         return client1;
     }

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -732,7 +732,7 @@ public final class AssignmentTestUtils {
         for (int i = 1; i <= clientSize; i++) {
             final int capacity = rand.nextInt(maxCapacity) + 1;
             final ProcessId processId = processIdForInt(i);
-            final ClientState clientState = new ClientState(previousActives.get(i - 1), previousStandbys.get(i - 1), taskLags, EMPTY_CLIENT_TAGS, capacity, processId);
+            final ClientState clientState = clientState(previousActives.get(i - 1), previousStandbys.get(i - 1), taskLags, capacity, processId);
             clientStates.put(processId, clientState);
         }
 
@@ -1002,10 +1002,37 @@ public final class AssignmentTestUtils {
             .collect(
                 Collectors.toMap(
                     Entry::getKey,
-                    entry -> new ClientState(entry.getValue())
+                    entry -> copyClientState(entry.getValue())
                 )
             )
         );
+    }
+
+    static ClientState clientState(final Set<TaskId> previousActiveTasks,
+                                   final Set<TaskId> previousStandbyTasks,
+                                   final Map<TaskId, Long> taskLagTotals,
+                                   final int capacity) {
+        return clientState(previousActiveTasks, previousStandbyTasks, taskLagTotals, capacity, null);
+    }
+
+    static ClientState clientState(final Set<TaskId> previousActiveTasks,
+                                   final Set<TaskId> previousStandbyTasks,
+                                   final Map<TaskId, Long> taskLagTotals,
+                                   final int capacity,
+                                   final ProcessId processId) {
+        final ClientState clientState = new ClientState(processId, capacity);
+        clientState.addPreviousActiveTasks(previousActiveTasks);
+        clientState.addPreviousStandbyTasks(previousStandbyTasks);
+        clientState.taskLagTotals().putAll(taskLagTotals);
+        return clientState;
+    }
+
+    private static ClientState copyClientState(final ClientState clientState) {
+        final ClientState copy = new ClientState(clientState.processId(), clientState.capacity(), clientState.clientTags());
+        copy.addPreviousActiveTasks(clientState.previousActiveTasks());
+        copy.addPreviousStandbyTasks(clientState.previousStandbyTasks());
+        copy.taskLagTotals().putAll(clientState.taskLagTotals());
+        return copy;
     }
 
     static synchronized Random getRandom() {

--- a/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/testFixtures/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -1023,7 +1023,7 @@ public final class AssignmentTestUtils {
         final ClientState clientState = new ClientState(processId, capacity);
         clientState.addPreviousActiveTasks(previousActiveTasks);
         clientState.addPreviousStandbyTasks(previousStandbyTasks);
-        clientState.taskLagTotals().putAll(taskLagTotals);
+        clientState.addTaskLagTotals(taskLagTotals);
         return clientState;
     }
 
@@ -1031,7 +1031,7 @@ public final class AssignmentTestUtils {
         final ClientState copy = new ClientState(clientState.processId(), clientState.capacity(), clientState.clientTags());
         copy.addPreviousActiveTasks(clientState.previousActiveTasks());
         copy.addPreviousStandbyTasks(clientState.previousStandbyTasks());
-        copy.taskLagTotals().putAll(clientState.taskLagTotals());
+        copy.addTaskLagTotals(clientState.taskLagTotals());
         return copy;
     }
 


### PR DESCRIPTION
Follow-up to #23242.

- ThreadMetadataImpl: drop the null check on producerClientIds. The only
  source of null was the default TaskManager mock in StreamThreadTest,
so
  a mockTaskManager() helper now stubs producerClientIds() for every
mock
  and the production code uses Set.of(producerClientIds) directly.
- ClientState: remove the three "For testing only" constructors and add
a
  package-private addTaskLagTotals() setter.
- AssignmentTestUtils: add clientState(...) and copyClientState(...)
  helpers to replace the removed constructors. Callers in
  HighAvailabilityTaskAssignorTest, RackAwareTaskAssignorTest and
  TaskMovementTest are updated accordingly.
- ClientStateTest: remove the two tests that only covered the deleted
  constructors.
- StateDirectory: inline listNamedTopologyDirs() so the named topology
  branch follows the same listFiles() null-check pattern as the rest of
  the class.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
