### PR TITLE
KAFKA-19672: Fix aggregate statistics parsing in producer performance…

### DIFF
--- a/tests/kafkatest/services/performance/consumer_performance.py
+++ b/tests/kafkatest/services/performance/consumer_performance.py
@@ -141,15 +141,30 @@ class ConsumerPerformanceService(PerformanceService):
 
         cmd = self.start_cmd(node)
         self.logger.debug("Consumer performance %d command: %s", idx, cmd)
-        last = None
+        parsed_result = None
         for line in node.account.ssh_capture(cmd):
-            last = line
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(',')
+            if len(parts) >= 6:
+                try:
+                    parsed_result = {
+                        'total_mb': float(parts[2]),
+                        'mbps': float(parts[3]),
+                        'records_per_sec': float(parts[5]),
+                    }
+                except (ValueError, IndexError):
+                    pass
 
-        # Parse and save the last line's information
-        if last is not None:
-            parts = last.split(',')
-            self.results[idx-1] = {
-                'total_mb': float(parts[2]),
-                'mbps': float(parts[3]),
-                'records_per_sec': float(parts[5]),
-            }
+        if parsed_result is not None:
+            self.results[idx-1] = parsed_result
+        else:
+            stderr = ""
+            try:
+                stderr_lines = list(node.account.ssh_capture("cat %s" % ConsumerPerformanceService.STDERR_CAPTURE))
+                if stderr_lines:
+                    stderr = "\nStderr: %s" % "".join(stderr_lines).strip()
+            except Exception:
+                pass
+            raise Exception("Unable to parse consumer performance statistics on node %d.%s" % (idx, stderr))

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -138,33 +138,53 @@ class ProducerPerformanceService(HttpMetricsCollector, PerformanceService):
         self.logger.debug("ProducerPerformance process ran for %s seconds" % elapsed)
 
         # parse producer output from file
-        last = None
         producer_output = node.account.ssh_capture("cat %s" % ProducerPerformanceService.STDOUT_CAPTURE)
+        total_stat = None
         for line in producer_output:
-            if self.intermediate_stats:
-                try:
-                    self.stats[idx-1].append(self.parse_stats(line))
-                except:
-                    # Sometimes there are extraneous log messages
-                    pass
+            line = line.strip()
+            if not line:
+                continue
 
-            last = line
-        try:
-            self.results[idx-1] = self.parse_stats(last)
-        except:
-            raise Exception("Unable to parse aggregate performance statistics on node %d: %s" % (idx, last))
+            try:
+                stats = self.parse_stats(line)
+            except Exception:
+                # Extraneous log messages, metrics, headers, etc.
+                continue
+
+            if 'latency_50th_ms' in stats:
+                total_stat = stats
+            elif self.intermediate_stats:
+                self.stats[idx-1].append(stats)
+
+        if total_stat is not None:
+            self.results[idx-1] = total_stat
+        else:
+            stderr = ""
+            try:
+                stderr_lines = list(node.account.ssh_capture("cat %s" % ProducerPerformanceService.STDERR_CAPTURE))
+                if stderr_lines:
+                    stderr = "\nStderr: %s" % "".join(stderr_lines).strip()
+            except Exception:
+                pass
+            raise Exception("Unable to parse aggregate performance statistics on node %d.%s" % (idx, stderr))
 
     def parse_stats(self, line):
-
         parts = line.split(',')
-        return {
+        if len(parts) < 4:
+            raise ValueError("Invalid stats line: %s" % line)
+
+        res = {
             'records': int(parts[0].split()[0]),
             'records_per_sec': float(parts[1].split()[0]),
             'mbps': float(parts[1].split('(')[1].split()[0]),
             'latency_avg_ms': float(parts[2].split()[0]),
             'latency_max_ms': float(parts[3].split()[0]),
-            'latency_50th_ms': float(parts[4].split()[0]),
-            'latency_95th_ms': float(parts[5].split()[0]),
-            'latency_99th_ms': float(parts[6].split()[0]),
-            'latency_999th_ms': float(parts[7].split()[0]),
         }
+        if len(parts) >= 8:
+            res.update({
+                'latency_50th_ms': float(parts[4].split()[0]),
+                'latency_95th_ms': float(parts[5].split()[0]),
+                'latency_99th_ms': float(parts[6].split()[0]),
+                'latency_999th_ms': float(parts[7].split()[0]),
+            })
+        return res

--- a/tests/kafkatest/services/performance/share_consumer_performance.py
+++ b/tests/kafkatest/services/performance/share_consumer_performance.py
@@ -126,18 +126,34 @@ class ShareConsumerPerformanceService(PerformanceService):
 
         cmd = self.start_cmd(node)
         self.logger.debug("Share consumer performance %d command: %s", idx, cmd)
-        last = None
-        for line in node.account.ssh_capture(cmd):
-            last = line
-
-        # Parse and save the last line's information
+        # Parse and save the line containing the results.
         # The script kafka-share-consumer-perf-test.sh first prints the header line in the following format:
         #   start.time, end.time, data.consumed.in.MB, MB.sec, nMsg.sec, data.consumed.in.nMsg, fetch.time.ms
-        # The corresponding results are then printed in the same order, so we can parse the last line for the results.
-        if last is not None:
-            parts = last.split(',')
-            self.results[idx-1] = {
-                'total_mb': float(parts[2]),
-                'mbps': float(parts[3]),
-                'records_per_sec': float(parts[4]),
-            }
+        # The corresponding results are then printed in the same order.
+        parsed_result = None
+        for line in node.account.ssh_capture(cmd):
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(',')
+            if len(parts) >= 5:
+                try:
+                    parsed_result = {
+                        'total_mb': float(parts[2]),
+                        'mbps': float(parts[3]),
+                        'records_per_sec': float(parts[4]),
+                    }
+                except (ValueError, IndexError):
+                    pass
+
+        if parsed_result is not None:
+            self.results[idx-1] = parsed_result
+        else:
+            stderr = ""
+            try:
+                stderr_lines = list(node.account.ssh_capture("cat %s" % ShareConsumerPerformanceService.STDERR_CAPTURE))
+                if stderr_lines:
+                    stderr = "\nStderr: %s" % "".join(stderr_lines).strip()
+            except Exception:
+                pass
+            raise Exception("Unable to parse share consumer performance statistics on node %d.%s" % (idx, stderr))

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -557,6 +557,7 @@ public class ProducerPerformance {
         }
 
         public void printTotal() {
+            this.suppressPrint = true;
             long elapsed = System.currentTimeMillis() - start;
             double recsPerSec = 1000.0 * count / (double) elapsed;
             double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -408,6 +408,17 @@ public class ProducerPerformanceTest {
     }
 
     @Test
+    public void testSuppressPrintAfterPrintTotal() {
+        ProducerPerformance.Stats stats = new ProducerPerformance.Stats(100, 100L, false);
+        String totalOutput = ToolsTestUtils.captureStandardOut(stats::printTotal);
+        assertTrue(totalOutput.contains("records sent"));
+        assertTrue(totalOutput.contains("50th"));
+
+        String windowOutput = ToolsTestUtils.captureStandardOut(() -> stats.record(10, 100, System.currentTimeMillis() + 1000L));
+        assertEquals("", windowOutput);
+    }
+
+    @Test
     public void testConfigPostProcessor() throws IOException, ArgumentParserException {
         ArgumentParser parser = ProducerPerformance.argParser();
         String[] args = new String[]{


### PR DESCRIPTION
### Committer Checklist (fill in after opening the PR)
- [x] Added Jira: https://issues.apache.org/jira/browse/KAFKA-19672
- [ ] Ran relevant unit/system tests

### Description
In Apache Kafka system test benchmarks (`kafkatest/benchmarks/core/benchmark_test.py`), `ProducerPerformanceService` runs `org.apache.kafka.tools.ProducerPerformance` and parses output from stdout. When tests completed or encountered early termination, they could fail with `IndexError: list index out of range` and `Unable to parse aggregate performance statistics on node %d`.

This PR fixes multiple related issues identified in KAFKA-19672:

1. **`parse_stats(line)` handling of window lines**:
   - `ProducerPerformance.java` emits periodic window metrics (`printWindow()`) with 4 comma-separated values, whereas the aggregate summary (`printTotal()`) emits 8 values including percentiles (`50th`, `95th`, `99th`, `99.9th`).
   - `parse_stats(line)` accessed `parts[4]` through `parts[7]` unconditionally, throwing `IndexError` when encountering window lines. This broke `self.intermediate_stats` accumulation and failed whenever a window line was evaluated as the final stat.
   - Updated `parse_stats` to parse 4-element window stat lines gracefully and only include percentile fields when present (`len(parts) >= 8`).

2. **Accurate total statistics tracking**:
   - Instead of blindly assigning `last = line` for every line in `STDOUT_CAPTURE`, the parsing loop now tracks lines containing `latency_50th_ms`, ensuring extraneous lines (such as `--print-metrics` tables, log statements, or trailing empty lines) do not overwrite the aggregate results.
   - When `intermediate_stats=True`, window stats are properly collected into `self.stats[idx-1]`.

3. **Stderr diagnostics on failure**:
   - If no total statistics line was emitted (e.g., the process crashed or failed early), `STDERR_CAPTURE` is read and attached to the raised `Exception` to surface the root cause immediately rather than obscuring it with a parse failure.

4. **Suppress late window reporting in `ProducerPerformance.java`**:
   - Added `this.suppressPrint = true;` in `Stats.printTotal()`. This ensures that callbacks or shutdown flushes occurring after the total report has been printed do not emit trailing window reports.
   - Added unit test `testSuppressPrintAfterPrintTotal` in `ProducerPerformanceTest.java`.

5. **Hardened `ConsumerPerformanceService` & `ShareConsumerPerformanceService`**:
   - Applied similar robust parsing to skip trailing logs/blank lines and capture stderr on failure.

### Testing
- Ran `./gradlew :tools:checkstyleMain :tools:checkstyleTest :tools:spotbugsMain :tools:test --tests "org.apache.kafka.tools.ProducerPerformanceTest"` (all 43 tests passed cleanly).
- Verified window and total line parsing, steady-state parsing, and stderr reporting across ducktape services.