### PR TITLE
KAFKA-18477 Remove usage of OffsetForLeaderEpochRequest in AbstractFetcherThread

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -114,17 +114,6 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
     }
   }
 
-  // This method is only needed by ReplicaAlterDirManager
-  def markPartitionsForTruncation(brokerId: Int, topicPartition: TopicPartition, truncationOffset: Long): Unit = {
-    lock synchronized {
-      val fetcherId = getFetcherId(topicPartition)
-      val brokerIdAndFetcherId = BrokerIdAndFetcherId(brokerId, fetcherId)
-      fetcherThreadMap.get(brokerIdAndFetcherId).foreach { thread =>
-        thread.markPartitionsForTruncation(topicPartition, truncationOffset)
-      }
-    }
-  }
-
   // to be defined in subclass to create a specific fetcher
   def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): T
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -23,7 +23,7 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.PartitionStates
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.message.FetchResponseData.PartitionData
-import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
+import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.internal.{FileRecords, MemoryRecords, Records}
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
@@ -65,7 +65,6 @@ abstract class AbstractFetcherThread(name: String,
   this.logIdent = this.logPrefix
 
   type FetchData = FetchResponseData.PartitionData
-  type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
 
   private val partitionStates = new PartitionStates[PartitionFetchState]
   protected val partitionMapLock = new ReentrantLock
@@ -144,38 +143,22 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   /**
-   * Builds offset for leader epoch requests for partitions that are in the truncating phase based
-   * on latest epochs of the future replicas (the one that is fetching)
+   * Truncate partitions that are in the truncating phase to their local high watermark. A partition
+   * only enters the truncating phase when the replica has no leader epoch information (e.g. it only
+   * contains messages with the old format); replicas with leader epochs rely on the diverging epoch
+   * returned in fetch responses for truncation.
    */
-  private def fetchTruncatingPartitions(): (Map[TopicPartition, EpochData], Set[TopicPartition]) =
-    LockUtils.inLock(partitionMapLock, () => {
-    val partitionsWithEpochs = mutable.Map.empty[TopicPartition, EpochData]
-    val partitionsWithoutEpochs = mutable.Set.empty[TopicPartition]
-
-    partitionStates.partitionStateMap.forEach { (tp, state) =>
-      if (state.isTruncating) {
-        latestEpoch(tp).toScala match {
-          case Some(epoch) =>
-            partitionsWithEpochs += tp -> new EpochData()
-              .setPartition(tp.partition)
-              .setCurrentLeaderEpoch(state.currentLeaderEpoch)
-              .setLeaderEpoch(epoch)
-          case _ =>
-            partitionsWithoutEpochs += tp
-        }
-      }
-    }
-
-    (partitionsWithEpochs, partitionsWithoutEpochs)
-  })
-
   private def maybeTruncate(): Unit = {
-    val (partitionsWithEpochs, partitionsWithoutEpochs) = fetchTruncatingPartitions()
-    if (partitionsWithEpochs.nonEmpty) {
-      truncateToEpochEndOffsets(partitionsWithEpochs)
-    }
-    if (partitionsWithoutEpochs.nonEmpty) {
-      truncateToHighWatermark(partitionsWithoutEpochs)
+    val truncatingPartitions = LockUtils.inLock(partitionMapLock, () => {
+      val partitions = mutable.Set.empty[TopicPartition]
+      partitionStates.partitionStateMap.forEach { (tp, state) =>
+        if (state.isTruncating)
+          partitions += tp
+      }
+      partitions
+    })
+    if (truncatingPartitions.nonEmpty) {
+      truncateToHighWatermark(truncatingPartitions)
     }
   }
 
@@ -197,42 +180,10 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * - Build a leader epoch fetch based on partitions that are in the Truncating phase
-   * - Send OffsetsForLeaderEpochRequest, retrieving the latest offset for each partition's
-   * leader epoch. This is the offset the follower should truncate to ensure
-   * accurate log replication.
-   * - Finally truncate the logs for partitions in the truncating phase and mark the
-   * truncation complete. Do this within a lock to ensure no leadership changes can
-   * occur during truncation.
-   */
-  private def truncateToEpochEndOffsets(latestEpochsForPartitions: Map[TopicPartition, EpochData]): Unit = {
-    val endOffsets = leader.fetchEpochEndOffsets(latestEpochsForPartitions.asJava)
-    // Ensure we hold a lock during truncation
-
-    LockUtils.inLock[Exception](partitionMapLock, () => {
-      //Check no leadership and no leader epoch changes happened whilst we were unlocked, fetching epochs
-
-      val epochEndOffsets = endOffsets.asScala.filter { case (tp, _) =>
-        val curPartitionState = partitionStates.stateValue(tp)
-        val partitionEpochRequest = latestEpochsForPartitions.getOrElse(tp, {
-          throw new IllegalStateException(
-            s"Leader replied with partition $tp not requested in OffsetsForLeaderEpoch request")
-        })
-        val leaderEpochInRequest = partitionEpochRequest.currentLeaderEpoch
-        curPartitionState != null && leaderEpochInRequest == curPartitionState.currentLeaderEpoch
-      }
-
-      val result = maybeTruncateToEpochEndOffsets(epochEndOffsets, latestEpochsForPartitions)
-      handlePartitionsWithErrors(result.partitionsWithError.asScala, "truncateToEpochEndOffsets")
-      updateFetchOffsetAndMaybeMarkTruncationComplete(result.result)
-    })
-  }
-
   // Visibility for unit tests
   protected[server] def truncateOnFetchResponse(epochEndOffsets: Map[TopicPartition, EpochEndOffset]): Unit = {
     LockUtils.inLock[Exception](partitionMapLock, () => {
-      val result = maybeTruncateToEpochEndOffsets(epochEndOffsets, Map.empty)
+      val result = maybeTruncateToEpochEndOffsets(epochEndOffsets)
       handlePartitionsWithErrors(result.partitionsWithError.asScala, "truncateOnFetchResponse")
       updateFetchOffsetAndMaybeMarkTruncationComplete(result.result)
     })
@@ -258,8 +209,7 @@ abstract class AbstractFetcherThread(name: String,
     updateFetchOffsetAndMaybeMarkTruncationComplete(fetchOffsets)
   })
 
-  private def maybeTruncateToEpochEndOffsets(fetchedEpochs: Map[TopicPartition, EpochEndOffset],
-                                             latestEpochsForPartitions: Map[TopicPartition, EpochData]): ResultWithPartitions[Map[TopicPartition, OffsetTruncationState]] = {
+  private def maybeTruncateToEpochEndOffsets(fetchedEpochs: Map[TopicPartition, EpochEndOffset]): ResultWithPartitions[Map[TopicPartition, OffsetTruncationState]] = {
     val fetchOffsets = mutable.HashMap.empty[TopicPartition, OffsetTruncationState]
     val partitionsWithError = mutable.HashSet.empty[TopicPartition]
 
@@ -273,9 +223,7 @@ abstract class AbstractFetcherThread(name: String,
               fetchOffsets.put(tp, offsetTruncationState)
 
           case Errors.FENCED_LEADER_EPOCH =>
-            val currentLeaderEpoch = latestEpochsForPartitions.get(tp)
-              .map(epochEndOffset => Int.box(epochEndOffset.currentLeaderEpoch)).toJava
-            if (onPartitionFenced(tp, currentLeaderEpoch))
+            if (onPartitionFenced(tp, Optional.empty()))
               partitionsWithError += tp
 
           case error =>
@@ -353,7 +301,7 @@ abstract class AbstractFetcherThread(name: String,
               Errors.forCode(partitionData.errorCode) match {
                 case Errors.NONE =>
                   try {
-                    if (leader.isTruncationOnFetchSupported && FetchResponse.isDivergingEpoch(partitionData)) {
+                    if (FetchResponse.isDivergingEpoch(partitionData)) {
                       // If a diverging epoch is present, we truncate the log of the replica
                       // but we don't process the partition data in order to not update the
                       // low/high watermarks until the truncation is actually done. Those will
@@ -474,23 +422,6 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * This is used to mark partitions for truncation in ReplicaAlterLogDirsThread after leader
-   * offsets are known.
-   */
-  def markPartitionsForTruncation(topicPartition: TopicPartition, truncationOffset: Long): Unit = {
-    partitionMapLock.lockInterruptibly()
-    try {
-      Option(partitionStates.stateValue(topicPartition)).foreach { state =>
-        val newState = new PartitionFetchState(state.topicId, math.min(truncationOffset, state.fetchOffset),
-          state.lag, state.currentLeaderEpoch, state.delay, ReplicaState.TRUNCATING,
-          Optional.empty())
-        partitionStates.updateAndMoveToEnd(topicPartition, newState)
-        partitionMapCond.signalAll()
-      }
-    } finally partitionMapLock.unlock()
-  }
-
   private def markPartitionFailed(topicPartition: TopicPartition): Unit = {
     partitionMapLock.lock()
     try {
@@ -502,24 +433,20 @@ abstract class AbstractFetcherThread(name: String,
 
   /**
    * Returns initial partition fetch state based on current state and the provided `initialFetchState`.
-   * From IBP 2.7 onwards, we can rely on truncation based on diverging data returned in fetch responses.
-   * For older versions, we can skip the truncation step iff the leader epoch matches the existing epoch.
+   * We rely on truncation based on diverging data returned in fetch responses.
    */
   private def partitionFetchState(tp: TopicPartition, initialFetchState: InitialFetchState, currentState: PartitionFetchState): PartitionFetchState = {
     if (currentState != null && currentState.currentLeaderEpoch == initialFetchState.currentLeaderEpoch) {
       currentState
     } else if (initialFetchState.initOffset < 0) {
       fetchOffsetAndTruncate(tp, initialFetchState.topicId, initialFetchState.currentLeaderEpoch)
-    } else if (leader.isTruncationOnFetchSupported) {
+    } else {
       // With old message format, `latestEpoch` will be empty and we use Truncating state
       // to truncate to high watermark.
       val lastFetchedEpoch = latestEpoch(tp)
       val state = if (lastFetchedEpoch.isPresent) ReplicaState.FETCHING else ReplicaState.TRUNCATING
       new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
         state, lastFetchedEpoch)
-    } else {
-      new PartitionFetchState(initialFetchState.topicId.toJava, initialFetchState.initOffset, Optional.empty(), initialFetchState.currentLeaderEpoch,
-        ReplicaState.TRUNCATING, Optional.empty())
     }
   }
 
@@ -565,12 +492,8 @@ abstract class AbstractFetcherThread(name: String,
         val maybeTruncationComplete = fetchOffsets.get(topicPartition) match {
           case Some(offsetTruncationState) =>
             val lastFetchedEpoch = latestEpoch(topicPartition)
-            val state = if (leader.isTruncationOnFetchSupported || offsetTruncationState.truncationCompleted)
-              ReplicaState.FETCHING
-            else
-              ReplicaState.TRUNCATING
             new PartitionFetchState(currentFetchState.topicId, offsetTruncationState.offset, currentFetchState.lag,
-              currentFetchState.currentLeaderEpoch, currentFetchState.delay, state, lastFetchedEpoch)
+              currentFetchState.currentLeaderEpoch, currentFetchState.delay, ReplicaState.FETCHING, lastFetchedEpoch)
           case None => currentFetchState
         }
         (topicPartition, maybeTruncationComplete)
@@ -579,22 +502,20 @@ abstract class AbstractFetcherThread(name: String,
   }
 
   /**
-   * Called from ReplicaFetcherThread and ReplicaAlterLogDirsThread maybeTruncate for each topic
-   * partition. Returns truncation offset and whether this is the final offset to truncate to
+   * Called when the leader returns a diverging epoch in the fetch response. Returns the truncation
+   * offset and whether this is the final offset to truncate to.
    *
    * For each topic partition, the offset to truncate to is calculated based on leader's returned
    * epoch and offset:
    *  -- If the leader replied with undefined epoch offset, we must use the high watermark. This can
-   *  happen if 1) the leader is still using message format older than IBP_0_11_0; 2) the follower
-   *  requested leader epoch < the first leader epoch known to the leader.
+   *  happen if the follower requested leader epoch < the first leader epoch known to the leader.
    *  -- If the leader replied with the valid offset but undefined leader epoch, we truncate to
-   *  leader's offset if it is lower than follower's Log End Offset. This may happen if the
-   *  leader is on the inter-broker protocol version < IBP_2_0_IV0
+   *  leader's offset if it is lower than follower's Log End Offset.
    *  -- If the leader replied with leader epoch not known to the follower, we truncate to the
-   *  end offset of the largest epoch that is smaller than the epoch the leader replied with, and
-   *  send OffsetsForLeaderEpochRequest with that leader epoch. In a more rare case, where the
-   *  follower was not tracking epochs smaller than the epoch the leader replied with, we
-   *  truncate the leader's offset (and do not send any more leader epoch requests).
+   *  end offset of the largest epoch that is smaller than the epoch the leader replied with; the
+   *  next fetch request then carries that epoch as the last fetched epoch and the leader may reply
+   *  with another diverging epoch. In a more rare case, where the follower was not tracking epochs
+   *  smaller than the epoch the leader replied with, we truncate to the leader's offset.
    *  -- Otherwise, truncate to min(leader's offset, end offset on the follower for epoch that
    *  leader replied with, follower's Log End Offset).
    *
@@ -604,10 +525,7 @@ abstract class AbstractFetcherThread(name: String,
   private def getOffsetTruncationState(tp: TopicPartition, leaderEpochOffset: EpochEndOffset): OffsetTruncationState =
     LockUtils.inLock(partitionMapLock , () => {
     if (leaderEpochOffset.endOffset == UNDEFINED_EPOCH_OFFSET) {
-      // truncate to initial offset which is the high watermark for follower replica. For
-      // future replica, it is either high watermark of the future replica or current
-      // replica's truncation offset (when the current replica truncates, it forces future
-      // replica's partition state to 'truncating' and sets initial offset to its truncation offset)
+      // truncate to initial offset which is the high watermark of the replica
       warn(s"Based on replica's leader epoch, leader replied with an unknown offset in $tp. " +
         s"The initial fetch offset ${partitionStates.stateValue(tp).fetchOffset} will be used for truncation.")
       OffsetTruncationState(partitionStates.stateValue(tp).fetchOffset, truncationCompleted = true)
@@ -630,11 +548,12 @@ abstract class AbstractFetcherThread(name: String,
         if (followerEpoch != leaderEpochOffset.leaderEpoch) {
           // the follower does not know about the epoch that leader replied with
           // we truncate to the end offset of the largest epoch that is smaller than the
-          // epoch the leader replied with, and send another offset for leader epoch request
+          // epoch the leader replied with; the next fetch request carries that epoch as
+          // the last fetched epoch and the leader may reply with another diverging epoch
           val intermediateOffsetToTruncateTo = min(followerEndOffset, replicaEndOffset)
           info(s"Based on replica's leader epoch, leader replied with epoch ${leaderEpochOffset.leaderEpoch} " +
             s"unknown to the replica for $tp. " +
-            s"Will truncate to $intermediateOffsetToTruncateTo and send another leader epoch request to the leader.")
+            s"Will truncate to $intermediateOffsetToTruncateTo and continue fetching with the last known epoch.")
           OffsetTruncationState(intermediateOffsetToTruncateTo, truncationCompleted = false)
         } else {
           val offsetToTruncateTo = min(followerEndOffset, leaderEpochOffset.endOffset)

--- a/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/LocalLeaderEndPoint.scala
@@ -56,8 +56,6 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
   private val fetchSize = brokerConfig.replicaFetchMaxBytes
   private var inProgressPartition: Option[TopicPartition] = None
 
-  override val isTruncationOnFetchSupported: Boolean = false
-
   override def initiateClose(): Unit = {} // do nothing
 
   override def close(): Unit = {} // do nothing
@@ -79,7 +77,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
       partitionData = responsePartitionData.map { case (tp, data) =>
         val abortedTransactions =  data.abortedTransactions.orElse(null)
         val lastStableOffset: Long = data.lastStableOffset.orElse(FetchResponse.INVALID_LAST_STABLE_OFFSET)
-        tp.topicPartition -> new FetchResponseData.PartitionData()
+        val partitionData = new FetchResponseData.PartitionData()
           .setPartitionIndex(tp.topicPartition.partition)
           .setErrorCode(data.error.code)
           .setHighWatermark(data.highWatermark)
@@ -87,6 +85,8 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
           .setLogStartOffset(data.logStartOffset)
           .setAbortedTransactions(abortedTransactions)
           .setRecords(data.records)
+        data.divergingEpoch.ifPresent(partitionData.setDivergingEpoch)
+        tp.topicPartition -> partitionData
       }
     }
 
@@ -237,10 +237,7 @@ class LocalLeaderEndPoint(sourceBroker: BrokerEndPoint,
 
     try {
       val logStartOffset = replicaManager.futureLocalLogOrException(topicPartition).logStartOffset
-      val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-        fetchState.lastFetchedEpoch
-      else
-        Optional.empty[Integer]
+      val lastFetchedEpoch = fetchState.lastFetchedEpoch
       val topicId = fetchState.topicId.orElse(Uuid.ZERO_UUID)
       requestMap.put(topicPartition, new FetchRequest.PartitionData(topicId, fetchState.fetchOffset, logStartOffset,
         fetchSize, Optional.of(fetchState.currentLeaderEpoch), lastFetchedEpoch))

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -65,8 +65,6 @@ class RemoteLeaderEndPoint(logPrefix: String,
   private val maxBytes = brokerConfig.replicaFetchResponseMaxBytes
   private val fetchSize = brokerConfig.replicaFetchMaxBytes
 
-  override def isTruncationOnFetchSupported: Boolean = true
-
   override def initiateClose(): Unit = blockingSender.initiateClose()
 
   override def close(): Unit = blockingSender.close()
@@ -184,10 +182,7 @@ class RemoteLeaderEndPoint(logPrefix: String,
       if (fetchState.isReadyForFetch && !shouldFollowerThrottle(quota, fetchState, topicPartition)) {
         try {
           val logStartOffset = replicaManager.localLogOrException(topicPartition).logStartOffset
-          val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-            fetchState.lastFetchedEpoch()
-          else
-            Optional.empty[Integer]
+          val lastFetchedEpoch = fetchState.lastFetchedEpoch()
           builder.add(topicPartition, new FetchRequest.PartitionData(
             fetchState.topicId().orElse(Uuid.ZERO_UUID),
             fetchState.fetchOffset(),

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -179,18 +179,15 @@ class ReplicaAlterLogDirsThread(name: String,
   }
 
   /**
-   * Truncate the log for each partition based on current replica's returned epoch and offset.
+   * Truncate the future replica's log for each partition based on the diverging epoch and offset
+   * returned by the current replica in the fetch response.
    *
-   * The logic for finding the truncation offset is the same as in ReplicaFetcherThread
-   * and mainly implemented in AbstractFetcherThread.getOffsetTruncationState. One difference is
-   * that the initial fetch offset for topic partition could be set to the truncation offset of
-   * the current replica if that replica truncates. Otherwise, it is high watermark as in ReplicaFetcherThread.
-   *
-   * The reason we have to follow the leader epoch approach for truncating a future replica is to
-   * cover the case where a future replica is offline when the current replica truncates and
-   * re-replicates offsets that may have already been copied to the future replica. In that case,
-   * the future replica may miss "mark for truncation" event and must use the offset for leader epoch
-   * exchange with the current replica to truncate to the largest common log prefix for the topic partition
+   * The logic for finding the truncation offset is the same as in ReplicaFetcherThread and mainly
+   * implemented in AbstractFetcherThread.getOffsetTruncationState. The local fetch carries the
+   * future replica's latest epoch as the last fetched epoch, so if the current replica truncates
+   * (e.g. while the future replica is offline), the divergence is detected on the next fetch and
+   * the future replica truncates to the largest common log prefix for the topic partition. A future
+   * replica without any leader epoch truncates to its initial fetch offset via the high watermark path.
    */
   override def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit = {
     val partition = replicaMgr.getPartitionOrException(topicPartition)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -176,13 +176,7 @@ class ReplicaFetcherThread(name: String,
    */
   override def truncate(tp: TopicPartition, offsetTruncationState: OffsetTruncationState): Unit = {
     val partition = replicaMgr.getPartitionOrException(tp)
-
     partition.truncateTo(offsetTruncationState.offset, isFuture = false)
-
-    // mark the future replica for truncation only when we do last truncation
-    if (offsetTruncationState.truncationCompleted)
-      replicaMgr.replicaAlterLogDirsManager.markPartitionsForTruncation(brokerConfig.brokerId, tp,
-        offsetTruncationState.offset)
   }
 
   override protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -58,7 +58,6 @@ import org.apache.kafka.raft.MetadataLogConfig
 import org.apache.kafka.security.JaasTestUtils
 import org.apache.kafka.server.config.{ReplicationConfigs, ServerConfigs, ServerLogConfigs, ServerTopicConfigSynonyms}
 import org.apache.kafka.server.metrics.{KafkaYammerMetrics, MetricConfigs}
-import org.apache.kafka.server.ReplicaState
 import org.apache.kafka.server.record.BrokerCompressionType
 import org.apache.kafka.server.util.ShutdownableThread
 import org.apache.kafka.server.quota.{ClientQuotaEntity, ClientQuotaManager}
@@ -879,7 +878,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     verifyThreads("data-plane-kafka-socket-acceptor-", config.listeners.size, 1)
 
     verifyProcessorMetrics()
-    verifyMarkPartitionsForTruncation()
   }
 
   private def isProcessorMetric(metricName: MetricName): Boolean = {
@@ -911,33 +909,6 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
       .filter(isProcessorMetric)
       .groupBy(_.getName)
       .foreach { case (name, set) => assertEquals(numProcessors, set.size, s"Metrics not deleted $name") }
-  }
-
-  // Verify that replicaFetcherManager.markPartitionsForTruncation uses the current fetcher thread size
-  // to obtain partition assignment
-  private def verifyMarkPartitionsForTruncation(): Unit = {
-    val leaderId = 0
-    val topicDescription = adminClients.head.
-      describeTopics(java.util.List.of(topic)).
-      allTopicNames().
-      get(3, TimeUnit.MINUTES).get(topic)
-    val partitions = topicDescription.partitions().asScala.
-      filter(p => p.leader().id() == leaderId).
-      map(p => new TopicPartition(topic, p.partition()))
-    assertTrue(partitions.nonEmpty, s"Partitions not found with leader $leaderId")
-    partitions.foreach { tp =>
-      (1 to 2).foreach { i =>
-        val replicaFetcherManager = servers(i).replicaManager.replicaFetcherManager
-        val truncationOffset = tp.partition
-        replicaFetcherManager.markPartitionsForTruncation(leaderId, tp, truncationOffset)
-        val fetcherThreads = replicaFetcherManager.fetcherThreadMap.filter(_._2.fetchState(tp).isDefined)
-        assertEquals(1, fetcherThreads.size)
-        assertEquals(replicaFetcherManager.getFetcherId(tp), fetcherThreads.head._1.fetcherId)
-        val thread = fetcherThreads.head._2
-        assertEquals(Some(truncationOffset), thread.fetchState(tp).map(_.fetchOffset))
-        assertEquals(Some(ReplicaState.TRUNCATING), thread.fetchState(tp).map(_.state))
-      }
-    }
   }
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherManagerTest.scala
@@ -315,8 +315,6 @@ class AbstractFetcherManagerTest {
 
     override def buildFetch(partitions: java.util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[java.util.Optional[ReplicaFetch]] = new ResultWithPartitions(java.util.Optional.empty[ReplicaFetch](), java.util.Set.of())
 
-    override val isTruncationOnFetchSupported: Boolean = false
-
     override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = new OffsetAndEpoch(1L, 0)
 
     override def fetchEarliestPendingUploadOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = new OffsetAndEpoch(-1L, -1)

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -34,12 +34,9 @@ import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochR
 import org.apache.kafka.server.log.remote.storage.RetriableRemoteStorageException
 import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
 import org.apache.kafka.server.util.ServerTestUtils
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicInteger
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Set}
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -304,9 +301,9 @@ class AbstractFetcherThreadTest {
 
     fetcher.doWork()
 
-    // Not data has been fetched and the follower is still truncating
+    // No data has been fetched since the leader replied with an unknown leader epoch
     assertEquals(0, replicaState.logEndOffset)
-    assertEquals(Some(ReplicaState.TRUNCATING), fetcher.fetchState(partition).map(_.state))
+    assertEquals(Some(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
 
     // Bump the epoch on the leader
     fetcher.mockLeader.leaderPartitionState(partition).leaderEpoch += 1
@@ -802,149 +799,6 @@ class AbstractFetcherThreadTest {
 
     val replicaState = fetcher.replicaPartitionState(partition)
     assertEquals(2L, replicaState.logEndOffset)
-  }
-
-  @ParameterizedTest
-  @ValueSource(ints = Array(0, 1))
-  def testParameterizedLeaderEpochChangeDuringFetchEpochsFromLeader(leaderEpochOnLeader: Int): Unit = {
-    // When leaderEpochOnLeader = 1:
-    // The leader is on the new epoch when the OffsetsForLeaderEpoch with old epoch is sent, so it
-    // returns the fence error. Validate that response is ignored if the leader epoch changes on
-    // the follower while OffsetsForLeaderEpoch request is in flight, but able to truncate and fetch
-    // in the next of round of "doWork"
-
-    // When leaderEpochOnLeader = 0:
-    // The leader is on the old epoch when the OffsetsForLeaderEpoch with old epoch is sent
-    // and returns the valid response. Validate that response is ignored if the leader epoch changes
-    // on the follower while OffsetsForLeaderEpoch request is in flight, but able to truncate and
-    // fetch once the leader is on the newer epoch (same as follower)
-
-    val partition = new TopicPartition("topic", 1)
-    val initialLeaderEpochOnFollower = 0
-    val nextLeaderEpochOnFollower = initialLeaderEpochOnFollower + 1
-
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version) {
-      var fetchEpochsFromLeaderOnce = false
-
-      override def fetchEpochEndOffsets(partitions: java.util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): java.util.Map[TopicPartition, EpochEndOffset] = {
-        val fetchedEpochs = super.fetchEpochEndOffsets(partitions)
-        if (!fetchEpochsFromLeaderOnce) {
-          responseCallback.apply()
-          fetchEpochsFromLeaderOnce = true
-        }
-        fetchedEpochs
-      }
-    }
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine)
-
-    def changeLeaderEpochWhileFetchEpoch(): Unit = {
-      fetcher.removePartitions(Set(partition))
-      fetcher.setReplicaState(partition, PartitionState(leaderEpoch = nextLeaderEpochOnFollower))
-      fetcher.addPartitions(Map(partition -> initialFetchState(topicIds.get(partition.topic), 0L, leaderEpoch = nextLeaderEpochOnFollower)), forceTruncation = true)
-    }
-
-    fetcher.setReplicaState(partition, PartitionState(leaderEpoch = initialLeaderEpochOnFollower))
-    fetcher.addPartitions(Map(partition -> initialFetchState(topicIds.get(partition.topic), 0L, leaderEpoch = initialLeaderEpochOnFollower)), forceTruncation = true)
-
-    val leaderLog = Seq(
-      mkBatch(baseOffset = 0, leaderEpoch = initialLeaderEpochOnFollower, new SimpleRecord("c".getBytes)))
-    val leaderState = PartitionState(leaderLog, leaderEpochOnLeader, highWatermark = 0L)
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setResponseCallback(changeLeaderEpochWhileFetchEpoch)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    // first round of truncation
-    fetcher.doWork()
-
-    // Since leader epoch changed, fetch epochs response is ignored due to partition being in
-    // truncating state with the updated leader epoch
-    assertEquals(Option(ReplicaState.TRUNCATING), fetcher.fetchState(partition).map(_.state))
-    assertEquals(Option(nextLeaderEpochOnFollower), fetcher.fetchState(partition).map(_.currentLeaderEpoch))
-
-    if (leaderEpochOnLeader < nextLeaderEpochOnFollower) {
-      fetcher.mockLeader.setLeaderState(
-        partition, PartitionState(leaderLog, nextLeaderEpochOnFollower, highWatermark = 0L))
-    }
-
-    // make sure the fetcher is now able to truncate and fetch
-    fetcher.doWork()
-    assertEquals(fetcher.mockLeader.leaderPartitionState(partition).log, fetcher.replicaPartitionState(partition).log)
-  }
-
-  @Test
-  def testTruncateToEpochEndOffsetsDuringRemovePartitions(): Unit = {
-    val partition = new TopicPartition("topic", 0)
-    val leaderEpochOnLeader = 0
-    val initialLeaderEpochOnFollower = 0
-    val nextLeaderEpochOnFollower = initialLeaderEpochOnFollower + 1
-
-    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version) {
-      override def fetchEpochEndOffsets(partitions: java.util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): java.util.Map[TopicPartition, EpochEndOffset]= {
-        val fetchedEpochs = super.fetchEpochEndOffsets(partitions)
-        responseCallback.apply()
-        fetchedEpochs
-      }
-    }
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine)
-
-    def changeLeaderEpochDuringFetchEpoch(): Unit = {
-      // leader epoch changes while fetching epochs from leader
-      // at the same time, the replica fetcher manager removes the partition
-      fetcher.removePartitions(Set(partition))
-      fetcher.setReplicaState(partition, PartitionState(leaderEpoch = nextLeaderEpochOnFollower))
-    }
-
-    fetcher.setReplicaState(partition, PartitionState(leaderEpoch = initialLeaderEpochOnFollower))
-    fetcher.addPartitions(Map(partition -> initialFetchState(topicIds.get(partition.topic), 0L, leaderEpoch = initialLeaderEpochOnFollower)))
-
-    val leaderLog = Seq(
-      mkBatch(baseOffset = 0, leaderEpoch = initialLeaderEpochOnFollower, new SimpleRecord("c".getBytes)))
-    val leaderState = PartitionState(leaderLog, leaderEpochOnLeader, highWatermark = 0L)
-    fetcher.mockLeader.setLeaderState(partition, leaderState)
-    fetcher.mockLeader.setResponseCallback(changeLeaderEpochDuringFetchEpoch)
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    // first round of work
-    fetcher.doWork()
-
-    // since the partition was removed before the fetched endOffsets were filtered against the leader epoch,
-    // we do not expect the partition to be in Truncating state
-    assertEquals(None, fetcher.fetchState(partition).map(_.state))
-    assertEquals(None, fetcher.fetchState(partition).map(_.currentLeaderEpoch))
-
-    fetcher.mockLeader.setLeaderState(
-      partition, PartitionState(leaderLog, nextLeaderEpochOnFollower, highWatermark = 0L))
-
-    // make sure the fetcher is able to continue work
-    fetcher.doWork()
-    assertEquals(ArrayBuffer.empty, fetcher.replicaPartitionState(partition).log)
-  }
-
-  @Test
-  def testTruncationThrowsExceptionIfLeaderReturnsPartitionsNotRequestedInFetchEpochs(): Unit = {
-    val partition = new TopicPartition("topic", 0)
-    val mockLeaderEndPoint = new MockLeaderEndPoint(version = version) {
-      override def fetchEpochEndOffsets(partitions: java.util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): java.util.Map[TopicPartition, EpochEndOffset] = {
-        val unrequestedTp = new TopicPartition("topic2", 0)
-        super.fetchEpochEndOffsets(partitions).asScala + (unrequestedTp -> new EpochEndOffset()
-          .setPartition(unrequestedTp.partition)
-          .setErrorCode(Errors.NONE.code)
-          .setLeaderEpoch(0)
-          .setEndOffset(0))
-      }.asJava
-    }
-    val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndPoint)
-    val fetcher = new MockFetcherThread(mockLeaderEndPoint, mockTierStateMachine)
-
-    fetcher.setReplicaState(partition, PartitionState(leaderEpoch = 0))
-    fetcher.addPartitions(Map(partition -> initialFetchState(topicIds.get(partition.topic), 0L, leaderEpoch = 0)), forceTruncation = true)
-    fetcher.mockLeader.setLeaderState(partition, PartitionState(leaderEpoch = 0))
-    fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
-
-    // first round of truncation should throw an exception
-    assertThrows(classOf[IllegalStateException], () => fetcher.doWork())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
+++ b/core/src/test/scala/unit/kafka/server/MockFetcherThread.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData
 import org.apache.kafka.common.record.internal._
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET
 import org.apache.kafka.common.requests.FetchResponse
@@ -77,7 +78,7 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
   ): Option[LogAppendInfo] = {
     val state = replicaPartitionState(topicPartition)
 
-    if (leader.isTruncationOnFetchSupported && FetchResponse.isDivergingEpoch(partitionData)) {
+    if (FetchResponse.isDivergingEpoch(partitionData)) {
       throw new IllegalStateException("processPartitionData should not be called for a partition with " +
         "a diverging epoch.")
     }
@@ -168,7 +169,7 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
   override def logEndOffset(topicPartition: TopicPartition): Long = replicaPartitionState(topicPartition).logEndOffset
 
   override def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = {
-    val epochData = new EpochData()
+    val epochData = new OffsetForLeaderEpochRequestData.OffsetForLeaderPartition()
       .setPartition(topicPartition.partition)
       .setLeaderEpoch(epoch)
     val result = mockLeader.lookupEndOffsetForEpoch(topicPartition, epochData, replicaPartitionState(topicPartition))
@@ -179,10 +180,8 @@ class MockFetcherThread(val mockLeader: MockLeaderEndPoint,
   }
 
   def verifyLastFetchedEpoch(partition: TopicPartition, expectedEpoch: Option[Int]): Unit = {
-    if (leader.isTruncationOnFetchSupported) {
-      assertEquals(Some(ReplicaState.FETCHING), fetchState(partition).map(_.state))
-      assertEquals(expectedEpoch, fetchState(partition).map(_.lastFetchedEpoch.get()))
-    }
+    assertEquals(Some(ReplicaState.FETCHING), fetchState(partition).map(_.state))
+    assertEquals(expectedEpoch, fetchState(partition).map(_.lastFetchedEpoch.get()))
   }
 
   override def shouldFetchFromLastTieredOffset(topicPartition: TopicPartition, leaderEndOffset: Long, replicaEndOffset: Long): Boolean = fetchFromLastTieredOffset

--- a/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
+++ b/core/src/test/scala/unit/kafka/server/MockLeaderEndPoint.scala
@@ -36,7 +36,6 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.util.Random
 
 class MockLeaderEndPoint(sourceBroker: BrokerEndPoint = new BrokerEndPoint(1, "localhost", Random.nextInt()),
-                         truncateOnFetch: Boolean = true,
                          version: Short = ApiKeys.FETCH.latestVersion())
   extends LeaderEndPoint {
 
@@ -45,8 +44,6 @@ class MockLeaderEndPoint(sourceBroker: BrokerEndPoint = new BrokerEndPoint(1, "l
 
   var replicaPartitionStateCallback: TopicPartition => Option[PartitionState] = { _ => Option.empty }
   var replicaId: Int = 0
-
-  override val isTruncationOnFetchSupported: Boolean = truncateOnFetch
 
   def leaderPartitionState(topicPartition: TopicPartition): PartitionState = {
     leaderPartitionStates.getOrElse(topicPartition,
@@ -163,10 +160,7 @@ class MockLeaderEndPoint(sourceBroker: BrokerEndPoint = new BrokerEndPoint(1, "l
     partitions.forEach { case (partition, state) =>
       if (state.isReadyForFetch) {
         val replicaState = replicaPartitionStateCallback(partition).getOrElse(throw new IllegalArgumentException(s"Unknown partition $partition"))
-        val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-          state.lastFetchedEpoch
-        else
-          Optional.empty[Integer]
+        val lastFetchedEpoch = state.lastFetchedEpoch
         fetchData.put(partition,
           new FetchRequest.PartitionData(state.topicId.orElse(Uuid.ZERO_UUID), state.fetchOffset, replicaState.logStartOffset,
             1024 * 1024, Optional.of[Integer](state.currentLeaderEpoch), lastFetchedEpoch))

--- a/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaAlterLogDirsThreadTest.scala
@@ -21,6 +21,7 @@ import org.apache.kafka.server.quota.QuotaFactory.UNBOUNDED_QUOTA
 import kafka.server.ReplicaAlterLogDirsThread.ReassignmentState
 import kafka.utils.TestUtils
 import org.apache.kafka.common.errors.KafkaStorageException
+import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.Errors
@@ -658,159 +659,55 @@ class ReplicaAlterLogDirsThreadTest {
   }
 
   @Test
-  def shouldTruncateToReplicaOffset(): Unit = {
+  def shouldTruncateToDivergingEpochOffsetFromFetchResponse(): Unit = {
 
     //Create a capture to track what partitions/offsets are truncated
-    val truncateCaptureT1p0: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
-    val truncateCaptureT1p1: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
+    val truncateCapture: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
 
     // Setup all the dependencies
     val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1))
     val quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
     val logManager: LogManager = mock(classOf[LogManager])
-    val logT1p0: UnifiedLog = mock(classOf[UnifiedLog])
-    val logT1p1: UnifiedLog = mock(classOf[UnifiedLog])
-    // one future replica mock because our mocking methods return same values for both future replicas
-    val futureLogT1p0: UnifiedLog = mock(classOf[UnifiedLog])
-    val futureLogT1p1: UnifiedLog = mock(classOf[UnifiedLog])
-    val partitionT1p0: Partition = mock(classOf[Partition])
-    val partitionT1p1: Partition = mock(classOf[Partition])
-    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
-    val responseCallback: ArgumentCaptor[Seq[(TopicIdPartition, FetchPartitionData)] => Unit] = ArgumentCaptor.forClass(classOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit])
-
-    val partitionT1p0Id = 0
-    val partitionT1p1Id = 1
-    val leaderEpoch = 2
-    val futureReplicaLEO = 191
-    val replicaT1p0LEO = 190
-    val replicaT1p1LEO = 192
-
-    //Stubs
-    when(partitionT1p0.partitionId).thenReturn(partitionT1p0Id)
-    when(partitionT1p1.partitionId).thenReturn(partitionT1p1Id)
-
-    when(replicaManager.metadataCache).thenReturn(metadataCache)
-    when(replicaManager.getPartitionOrException(t1p0))
-      .thenReturn(partitionT1p0)
-    when(replicaManager.getPartitionOrException(t1p1))
-      .thenReturn(partitionT1p1)
-    when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLogT1p0)
-    when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
-    when(replicaManager.futureLocalLogOrException(t1p1)).thenReturn(futureLogT1p1)
-    when(replicaManager.futureLogExists(t1p1)).thenReturn(true)
-
-    when(futureLogT1p0.logEndOffset).thenReturn(futureReplicaLEO)
-    when(futureLogT1p1.logEndOffset).thenReturn(futureReplicaLEO)
-
-    when(futureLogT1p0.latestEpoch).thenReturn(Optional.of(leaderEpoch))
-    when(futureLogT1p0.endOffsetForEpoch(leaderEpoch)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch)))
-    when(partitionT1p0.lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch, fetchOnlyFromLeader = false))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionT1p0Id)
-        .setErrorCode(Errors.NONE.code)
-        .setLeaderEpoch(leaderEpoch)
-        .setEndOffset(replicaT1p0LEO))
-
-    when(futureLogT1p1.latestEpoch).thenReturn(Optional.of(leaderEpoch))
-    when(futureLogT1p1.endOffsetForEpoch(leaderEpoch)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch)))
-    when(partitionT1p1.lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch, fetchOnlyFromLeader = false))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionT1p1Id)
-        .setErrorCode(Errors.NONE.code)
-        .setLeaderEpoch(leaderEpoch)
-        .setEndOffset(replicaT1p1LEO))
-    when(partitionT1p0.logDirectoryId()).thenReturn(Some(Uuid.fromString("Jsg8ufNCQYONNquPt7VYpA")))
-    when(partitionT1p1.logDirectoryId()).thenReturn(Some(Uuid.fromString("D2Yf6FtNROGVKoIZadSFIg")))
-
-    when(replicaManager.logManager).thenReturn(logManager)
-    stubWithFetchMessages(logT1p0, logT1p1, futureLogT1p0, partitionT1p0, replicaManager, responseCallback)
-
-    //Create the thread
-    val endPoint = new BrokerEndPoint(0, "localhost", 1000)
-    val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
-    val thread = new ReplicaAlterLogDirsThread(
-      "alter-logs-dirs-thread-test1",
-      leader,
-      failedPartitions,
-      replicaManager,
-      quotaManager,
-      null,
-      config.replicaFetchBackoffMs)
-    thread.addPartitions(Map(t1p0 -> initialFetchState(0L), t1p1 -> initialFetchState(0L)))
-
-    //Run it
-    thread.doWork()
-
-    //We should have truncated to the offsets in the response
-    verify(partitionT1p0).truncateTo(truncateCaptureT1p0.capture(), anyBoolean())
-    verify(partitionT1p1).truncateTo(truncateCaptureT1p1.capture(), anyBoolean())
-    assertEquals(replicaT1p0LEO, truncateCaptureT1p0.getValue)
-    assertEquals(futureReplicaLEO, truncateCaptureT1p1.getValue)
-  }
-
-  @Test
-  def shouldTruncateToEndOffsetOfLargestCommonEpoch(): Unit = {
-
-    //Create a capture to track what partitions/offsets are truncated
-    val truncateToCapture: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
-
-    // Setup all the dependencies
-    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1))
-    val quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
-    val logManager: LogManager = mock(classOf[LogManager])
-    val log: UnifiedLog = mock(classOf[UnifiedLog])
-    // one future replica mock because our mocking methods return same values for both future replicas
     val futureLog: UnifiedLog = mock(classOf[UnifiedLog])
     val partition: Partition = mock(classOf[Partition])
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
-    val responseCallback: ArgumentCaptor[Seq[(TopicIdPartition, FetchPartitionData)] => Unit] = ArgumentCaptor.forClass(classOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit])
 
-    val partitionId = 0
-    val leaderEpoch = 5
-    val futureReplicaLEO = 195
-    val replicaLEO = 200
-    val replicaEpochEndOffset = 190
-    val futureReplicaEpochEndOffset = 191
+    val leaderEpoch = 2
+    val futureReplicaLEO = 191
+    val replicaLEO = 190
 
     //Stubs
-    when(partition.partitionId).thenReturn(partitionId)
+    when(partition.partitionId).thenReturn(0)
+    when(partition.logDirectoryId()).thenReturn(Some(Uuid.fromString("Jsg8ufNCQYONNquPt7VYpA")))
 
     when(replicaManager.metadataCache).thenReturn(metadataCache)
-    when(replicaManager.getPartitionOrException(t1p0))
-      .thenReturn(partition)
+    when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
     when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
     when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
-
-    when(futureLog.logEndOffset).thenReturn(futureReplicaLEO)
-    when(futureLog.latestEpoch)
-      .thenReturn(Optional.of(leaderEpoch))
-      .thenReturn(Optional.of(leaderEpoch - 2))
-
-    // leader replica truncated and fetched new offsets with new leader epoch
-    when(partition.lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch, fetchOnlyFromLeader = false))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.NONE.code)
-        .setLeaderEpoch(leaderEpoch - 1)
-        .setEndOffset(replicaLEO))
-    // but future replica does not know about this leader epoch, so returns a smaller leader epoch
-    when(futureLog.endOffsetForEpoch(leaderEpoch - 1)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch - 2)))
-    // finally, the leader replica knows about the leader epoch and returns end offset
-    when(partition.lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch - 2, fetchOnlyFromLeader = false))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.NONE.code)
-        .setLeaderEpoch(leaderEpoch - 2)
-        .setEndOffset(replicaEpochEndOffset))
-    when(futureLog.endOffsetForEpoch(leaderEpoch - 2)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaEpochEndOffset, leaderEpoch - 2)))
-    when(partition.logDirectoryId()).thenReturn(Some(Uuid.fromString("n6WOe2zPScqZLIreCWN6Ug")))
-
+    when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
     when(replicaManager.logManager).thenReturn(logManager)
-    stubWithFetchMessages(log, null, futureLog, partition, replicaManager, responseCallback)
+
+    when(futureLog.logStartOffset).thenReturn(0L)
+    when(futureLog.logEndOffset).thenReturn(futureReplicaLEO)
+    when(futureLog.latestEpoch).thenReturn(Optional.of(leaderEpoch))
+    when(futureLog.endOffsetForEpoch(leaderEpoch)).thenReturn(
+      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch)))
+
+    // The fetch request must carry the future log's latest epoch as the last fetched epoch,
+    // and the current replica replies with a diverging epoch instead of the partition data.
+    val requestData = new FetchRequest.PartitionData(topicId, 0L, 0L,
+      config.replicaFetchMaxBytes, Optional.of(1), Optional.of(leaderEpoch))
+    val responseData = new FetchPartitionData(
+      Errors.NONE,
+      0L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.of(new FetchResponseData.EpochEndOffset().setEpoch(leaderEpoch).setEndOffset(replicaLEO)),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false)
+    mockFetchFromCurrentLog(tid1p0, requestData, config, replicaManager, responseData)
 
     //Create the thread
     val endPoint = new BrokerEndPoint(0, "localhost", 1000)
@@ -825,19 +722,119 @@ class ReplicaAlterLogDirsThreadTest {
       config.replicaFetchBackoffMs)
     thread.addPartitions(Map(t1p0 -> initialFetchState(0L)))
 
-    // First run will result in another offset for leader epoch request
-    thread.doWork()
-    // Second run should actually truncate
+    //Run it
     thread.doWork()
 
-    //We should have truncated to the offsets in the response
-    verify(partition, times(2)).truncateTo(truncateToCapture.capture(), ArgumentMatchers.eq(true))
-    assertTrue(truncateToCapture.getAllValues.asScala.contains(replicaEpochEndOffset),
-               "Expected offset " + replicaEpochEndOffset + " in captured truncation offsets " + truncateToCapture.getAllValues)
+    //We should have truncated to the diverging epoch end offset from the fetch response
+    verify(partition).truncateTo(truncateCapture.capture(), ArgumentMatchers.eq(true))
+    verify(partition, never()).lastOffsetForLeaderEpoch(any(), ArgumentMatchers.anyInt(), anyBoolean())
+    assertEquals(replicaLEO, truncateCapture.getValue)
   }
 
   @Test
-  def shouldTruncateToInitialFetchOffsetIfReplicaReturnsUndefinedOffset(): Unit = {
+  def shouldTruncateToEndOffsetOfLargestCommonEpoch(): Unit = {
+
+    //Create a capture to track what partitions/offsets are truncated
+    val truncateToCapture: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
+
+    // Setup all the dependencies
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1))
+    val quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
+    val logManager: LogManager = mock(classOf[LogManager])
+    val futureLog: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition: Partition = mock(classOf[Partition])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+
+    val partitionId = 0
+    val leaderEpoch = 5
+    val futureReplicaLEO = 195
+    val replicaLEO = 200
+    val replicaEpochEndOffset = 190
+    val futureReplicaEpochEndOffset = 191
+
+    //Stubs
+    when(partition.partitionId).thenReturn(partitionId)
+    when(partition.logDirectoryId()).thenReturn(Some(Uuid.fromString("n6WOe2zPScqZLIreCWN6Ug")))
+
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
+    when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+    when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
+    when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
+    when(replicaManager.onlinePartition(t1p0)).thenReturn(Some(partition))
+    when(replicaManager.logManager).thenReturn(logManager)
+
+    when(futureLog.logStartOffset).thenReturn(0L)
+    when(futureLog.logEndOffset).thenReturn(futureReplicaLEO)
+    when(futureLog.latestEpoch)
+      .thenReturn(Optional.of(leaderEpoch))
+      .thenReturn(Optional.of(leaderEpoch - 2))
+
+    // the current replica truncated to an epoch unknown to the future replica, so the future
+    // replica's end offset for that epoch corresponds to a smaller leader epoch
+    when(futureLog.endOffsetForEpoch(leaderEpoch - 1)).thenReturn(
+      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch - 2)))
+    when(futureLog.endOffsetForEpoch(leaderEpoch - 2)).thenReturn(
+      Optional.of(new OffsetAndEpoch(futureReplicaEpochEndOffset, leaderEpoch - 2)))
+
+    // First fetch carries the future log's latest epoch; the current replica replies with a
+    // diverging epoch unknown to the future replica
+    val firstRequestData = new FetchRequest.PartitionData(topicId, 0L, 0L,
+      config.replicaFetchMaxBytes, Optional.of(1), Optional.of(leaderEpoch))
+    val firstResponseData = new FetchPartitionData(
+      Errors.NONE,
+      0L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.of(new FetchResponseData.EpochEndOffset().setEpoch(leaderEpoch - 1).setEndOffset(replicaLEO)),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false)
+    mockFetchFromCurrentLog(tid1p0, firstRequestData, config, replicaManager, firstResponseData)
+
+    // After the intermediate truncation, the second fetch carries the older epoch and the current
+    // replica replies with the end offset of the largest common epoch
+    val secondRequestData = new FetchRequest.PartitionData(topicId, futureReplicaLEO, 0L,
+      config.replicaFetchMaxBytes, Optional.of(1), Optional.of(leaderEpoch - 2))
+    val secondResponseData = new FetchPartitionData(
+      Errors.NONE,
+      0L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.of(new FetchResponseData.EpochEndOffset().setEpoch(leaderEpoch - 2).setEndOffset(replicaEpochEndOffset)),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false)
+    mockFetchFromCurrentLog(tid1p0, secondRequestData, config, replicaManager, secondResponseData)
+
+    //Create the thread
+    val endPoint = new BrokerEndPoint(0, "localhost", 1000)
+    val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
+    val thread = new ReplicaAlterLogDirsThread(
+      "alter-logs-dirs-thread-test1",
+      leader,
+      failedPartitions,
+      replicaManager,
+      quotaManager,
+      null,
+      config.replicaFetchBackoffMs)
+    thread.addPartitions(Map(t1p0 -> initialFetchState(0L)))
+
+    // First run results in an intermediate truncation and a fetch with the older epoch
+    thread.doWork()
+    // Second run truncates to the end offset of the largest common epoch
+    thread.doWork()
+
+    //We should have truncated to the offsets in the diverging epoch responses
+    verify(partition, times(2)).truncateTo(truncateToCapture.capture(), ArgumentMatchers.eq(true))
+    assertTrue(truncateToCapture.getAllValues.asScala.contains(replicaEpochEndOffset),
+               "Expected offset " + replicaEpochEndOffset + " in captured truncation offsets " + truncateToCapture.getAllValues)
+    verify(partition, never()).lastOffsetForLeaderEpoch(any(), ArgumentMatchers.anyInt(), anyBoolean())
+  }
+
+  @Test
+  def shouldTruncateToInitialFetchOffsetIfFutureLogHasNoEpochs(): Unit = {
 
     //Create a capture to track what partitions/offsets are truncated
     val truncated: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
@@ -888,103 +885,11 @@ class ReplicaAlterLogDirsThreadTest {
     //We should have truncated to initial fetch offset
     verify(partition).truncateTo(truncated.capture(), isFuture = ArgumentMatchers.eq(true))
     assertEquals(initialFetchOffset,
-                 truncated.getValue, "Expected future replica to truncate to initial fetch offset if replica returns UNDEFINED_EPOCH_OFFSET")
+                 truncated.getValue, "Expected future replica to truncate to initial fetch offset if the future log has no epochs")
   }
 
   @Test
-  def shouldPollIndefinitelyIfReplicaNotAvailable(): Unit = {
-
-    //Create a capture to track what partitions/offsets are truncated
-    val truncated: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
-
-    // Setup all the dependencies
-    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1))
-    val quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
-    val logManager: LogManager = mock(classOf[LogManager])
-    val log: UnifiedLog = mock(classOf[UnifiedLog])
-    val futureLog: UnifiedLog = mock(classOf[UnifiedLog])
-    val partition: Partition = mock(classOf[Partition])
-    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
-    val responseCallback: ArgumentCaptor[Seq[(TopicIdPartition, FetchPartitionData)] => Unit] = ArgumentCaptor.forClass(classOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit])
-
-    val partitionId = 0
-    val futureReplicaLeaderEpoch = 1
-    val futureReplicaLEO = 290
-    val replicaLEO = 300
-
-    //Stubs
-    when(partition.partitionId).thenReturn(partitionId)
-    when(partition.logDirectoryId()).thenReturn(Some(Uuid.fromString("wO7bUpvcSZC0QKEK6P6AiA")))
-
-    when(replicaManager.metadataCache).thenReturn(metadataCache)
-    when(replicaManager.getPartitionOrException(t1p0))
-      .thenReturn(partition)
-
-    when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
-    when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
-    when(futureLog.logEndOffset).thenReturn(futureReplicaLEO)
-    when(futureLog.latestEpoch).thenReturn(Optional.of(futureReplicaLeaderEpoch))
-    when(futureLog.endOffsetForEpoch(futureReplicaLeaderEpoch)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaLEO, futureReplicaLeaderEpoch)))
-    when(replicaManager.localLog(t1p0)).thenReturn(Some(log))
-
-    // this will cause fetchEpochsFromLeader return an error with undefined offset
-    when(partition.lastOffsetForLeaderEpoch(Optional.of(1), futureReplicaLeaderEpoch, fetchOnlyFromLeader = false))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.REPLICA_NOT_AVAILABLE.code))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.REPLICA_NOT_AVAILABLE.code))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.REPLICA_NOT_AVAILABLE.code))
-      .thenReturn(new EpochEndOffset()
-        .setPartition(partitionId)
-        .setErrorCode(Errors.NONE.code)
-        .setLeaderEpoch(futureReplicaLeaderEpoch)
-        .setEndOffset(replicaLEO))
-
-    when(replicaManager.logManager).thenReturn(logManager)
-    when(replicaManager.fetchMessages(
-      any[FetchParams],
-      any[Seq[(TopicIdPartition, FetchRequest.PartitionData)]],
-      any[ReplicaQuota],
-      responseCallback.capture(),
-    )).thenAnswer(_ => responseCallback.getValue.apply(Seq.empty[(TopicIdPartition, FetchPartitionData)]))
-
-    //Create the thread
-    val endPoint = new BrokerEndPoint(0, "localhost", 1000)
-    val leader = new LocalLeaderEndPoint(endPoint, config, replicaManager, quotaManager)
-    val thread = new ReplicaAlterLogDirsThread(
-      "alter-logs-dirs-thread-test1",
-      leader,
-      failedPartitions,
-      replicaManager,
-      quotaManager,
-      null,
-      config.replicaFetchBackoffMs)
-    thread.addPartitions(Map(t1p0 -> initialFetchState(0L)))
-
-    // Run thread 3 times (exactly number of times we mock exception for getReplicaOrException)
-    (0 to 2).foreach { _ =>
-      thread.doWork()
-    }
-
-    // Nothing happened since the replica was not available
-    verify(partition, never()).truncateTo(truncated.capture(), isFuture = ArgumentMatchers.eq(true))
-    assertEquals(0, truncated.getAllValues.size())
-
-    // Next time we loop, getReplicaOrException will return replica
-    thread.doWork()
-
-    // Now the final call should have actually done a truncation (to offset futureReplicaLEO)
-    verify(partition).truncateTo(truncated.capture(), isFuture = ArgumentMatchers.eq(true))
-    assertEquals(futureReplicaLEO, truncated.getValue)
-  }
-
-  @Test
-  def shouldFetchLeaderEpochOnFirstFetchOnly(): Unit = {
+  def shouldNotIssueLeaderEpochRequests(): Unit = {
 
     //Setup all dependencies
     val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(1))
@@ -996,30 +901,20 @@ class ReplicaAlterLogDirsThreadTest {
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
     val responseCallback: ArgumentCaptor[Seq[(TopicIdPartition, FetchPartitionData)] => Unit] = ArgumentCaptor.forClass(classOf[Seq[(TopicIdPartition, FetchPartitionData)] => Unit])
 
-    val partitionId = 0
     val leaderEpoch = 5
     val futureReplicaLEO = 190
-    val replicaLEO = 213
 
-    when(partition.partitionId).thenReturn(partitionId)
+    when(partition.partitionId).thenReturn(0)
     when(partition.logDirectoryId()).thenReturn(Some(Uuid.fromString("dybMM9CpRP2s6HSslW4NHg")))
 
     when(replicaManager.metadataCache).thenReturn(metadataCache)
     when(replicaManager.getPartitionOrException(t1p0))
         .thenReturn(partition)
-    when(partition.lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch, fetchOnlyFromLeader = false))
-        .thenReturn(new EpochEndOffset()
-          .setPartition(partitionId)
-          .setErrorCode(Errors.NONE.code)
-          .setLeaderEpoch(leaderEpoch)
-          .setEndOffset(replicaLEO))
 
     when(replicaManager.futureLocalLogOrException(t1p0)).thenReturn(futureLog)
     when(replicaManager.futureLogExists(t1p0)).thenReturn(true)
     when(futureLog.latestEpoch).thenReturn(Optional.of(leaderEpoch))
     when(futureLog.logEndOffset).thenReturn(futureReplicaLEO)
-    when(futureLog.endOffsetForEpoch(leaderEpoch)).thenReturn(
-      Optional.of(new OffsetAndEpoch(futureReplicaLEO, leaderEpoch)))
     when(replicaManager.logManager).thenReturn(logManager)
     stubWithFetchMessages(log, null, futureLog, partition, replicaManager, responseCallback)
 
@@ -1041,9 +936,8 @@ class ReplicaAlterLogDirsThreadTest {
       thread.doWork()
     }
 
-    //Assert that truncate to is called exactly once (despite more loops)
-    verify(partition).lastOffsetForLeaderEpoch(Optional.of(1), leaderEpoch, fetchOnlyFromLeader = false)
-    verify(partition).truncateTo(futureReplicaLEO, isFuture = true)
+    verify(partition, never()).lastOffsetForLeaderEpoch(any(), ArgumentMatchers.anyInt(), anyBoolean())
+    verify(partition, never()).truncateTo(ArgumentMatchers.anyLong(), anyBoolean())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -186,11 +186,7 @@ class ReplicaFetcherThreadTest {
   }
 
   @Test
-  def shouldNotFetchLeaderEpochOnFirstFetchWithTruncateOnFetch(): Unit = {
-    verifyFetchLeaderEpochOnFirstFetch(MetadataVersion.latestTesting, epochFetchCount = 0)
-  }
-
-  private def verifyFetchLeaderEpochOnFirstFetch(metadataVersion: MetadataVersion, epochFetchCount: Int): Unit = {
+  def shouldNotFetchLeaderEpochOnFirstFetch(): Unit = {
     val props = TestUtils.createBrokerConfig(1)
     val config = KafkaConfig.fromProps(props)
 
@@ -230,23 +226,23 @@ class ReplicaFetcherThreadTest {
       replicaManager,
       UNBOUNDED_QUOTA,
       mockNetwork,
-      metadataVersion
+      MetadataVersion.latestTesting
     )
     thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 0L), t1p1 -> initialFetchState(Some(topicId1), 0L)))
 
     //Loop 1
     thread.doWork()
-    assertEquals(epochFetchCount, mockNetwork.epochFetchCount)
+    assertEquals(0, mockNetwork.epochFetchCount)
     assertEquals(1, mockNetwork.fetchCount)
 
     //Loop 2 we should not fetch epochs
     thread.doWork()
-    assertEquals(epochFetchCount, mockNetwork.epochFetchCount)
+    assertEquals(0, mockNetwork.epochFetchCount)
     assertEquals(2, mockNetwork.fetchCount)
 
     //Loop 3 we should not fetch epochs
     thread.doWork()
-    assertEquals(epochFetchCount, mockNetwork.epochFetchCount)
+    assertEquals(0, mockNetwork.epochFetchCount)
     assertEquals(3, mockNetwork.fetchCount)
   }
 

--- a/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TierStateMachineTest.scala
@@ -25,8 +25,7 @@ import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
 import org.junit.jupiter.api.Assertions._
 import kafka.server.FetcherThreadTestUtils.{initialFetchState, mkBatch}
 import org.apache.kafka.server.common.OffsetAndEpoch
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.Test
 
 import java.util.Optional
 import scala.collection.Map
@@ -37,9 +36,8 @@ class TierStateMachineTest {
   val version = ApiKeys.FETCH.latestVersion()
   private val failedPartitions = new FailedPartitions
 
-  @ParameterizedTest
-  @ValueSource(booleans = Array(true, false))
-  def testFollowerFetchMovedToTieredStore(truncateOnFetch: Boolean): Unit = {
+  @Test
+  def testFollowerFetchMovedToTieredStore(): Unit = {
     val partition = new TopicPartition("topic", 0)
 
     val replicaLog = Seq(
@@ -49,7 +47,7 @@ class TierStateMachineTest {
 
     val replicaState = PartitionState(replicaLog, leaderEpoch = 5, highWatermark = 0L, rlmEnabled = true)
 
-    val mockLeaderEndpoint = new MockLeaderEndPoint(truncateOnFetch = truncateOnFetch, version = version)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
     val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine)
 
@@ -69,8 +67,7 @@ class TierStateMachineTest {
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
 
     assertEquals(3L, replicaState.logEndOffset)
-    val expectedState = if (truncateOnFetch) Option(ReplicaState.FETCHING) else Option(ReplicaState.TRUNCATING)
-    assertEquals(expectedState, fetcher.fetchState(partition).map(_.state))
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
 
     fetcher.doWork()
     // verify that the offset moved to tiered store error triggered and respective states are truncated to expected.
@@ -97,9 +94,8 @@ class TierStateMachineTest {
    *    tiered storage as well. Hence, `X < globalLogStartOffset`.
    * 4. Follower comes online and tries to fetch X from leader.
    */
-  @ParameterizedTest
-  @ValueSource(booleans = Array(true, false))
-  def testFollowerFetchOffsetOutOfRangeWithTieredStore(truncateOnFetch: Boolean): Unit = {
+  @Test
+  def testFollowerFetchOffsetOutOfRangeWithTieredStore(): Unit = {
     val partition = new TopicPartition("topic", 0)
 
     val replicaLog = Seq(
@@ -109,7 +105,7 @@ class TierStateMachineTest {
 
     val replicaState = PartitionState(replicaLog, leaderEpoch = 7, highWatermark = 0L, rlmEnabled = true)
 
-    val mockLeaderEndpoint = new MockLeaderEndPoint(truncateOnFetch = truncateOnFetch, version = version)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint)
     val fetcher = new MockFetcherThread(mockLeaderEndpoint, mockTierStateMachine)
 
@@ -130,8 +126,7 @@ class TierStateMachineTest {
     fetcher.mockLeader.setReplicaPartitionStateCallback(fetcher.replicaPartitionState)
 
     assertEquals(3L, replicaState.logEndOffset)
-    val expectedState = if (truncateOnFetch) Option(ReplicaState.FETCHING) else Option(ReplicaState.TRUNCATING)
-    assertEquals(expectedState, fetcher.fetchState(partition).map(_.state))
+    assertEquals(Option(ReplicaState.FETCHING), fetcher.fetchState(partition).map(_.state))
 
     fetcher.doWork()
     // Verify that the out of range error is triggered and the fetch offset is reset to the global log start offset.
@@ -157,12 +152,11 @@ class TierStateMachineTest {
     assertEquals(11L, replicaState.logEndOffset)
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = Array(true, false))
-  def testFencedOffsetResetAfterMovedToRemoteTier(truncateOnFetch: Boolean): Unit = {
+  @Test
+  def testFencedOffsetResetAfterMovedToRemoteTier(): Unit = {
     val partition = new TopicPartition("topic", 0)
     var isErrorHandled = false
-    val mockLeaderEndpoint = new MockLeaderEndPoint(truncateOnFetch = truncateOnFetch, version = version)
+    val mockLeaderEndpoint = new MockLeaderEndPoint(version = version)
     val mockTierStateMachine = new MockTierStateMachine(mockLeaderEndpoint) {
       override def start(topicPartition: TopicPartition,
                          topicId: Optional[Uuid],

--- a/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
+++ b/server/src/main/java/org/apache/kafka/server/LeaderEndPoint.java
@@ -34,11 +34,6 @@ import java.util.Optional;
 public interface LeaderEndPoint {
 
     /**
-     * A boolean specifying if truncation when fetching from the leader is supported
-     */
-    boolean isTruncationOnFetchSupported();
-
-    /**
      * Initiate closing access to fetches from leader.
      */
     void initiateClose();
@@ -85,7 +80,10 @@ public interface LeaderEndPoint {
     OffsetAndEpoch fetchLatestOffset(TopicPartition topicPartition, int currentLeaderEpoch);
 
     /**
-     * Fetches offset for leader epoch from the leader for each given topic partition
+     * Fetches offset for leader epoch from the leader for each given topic partition.
+     * This is only used by {@code TierStateMachine} to build the auxiliary state of a
+     * partition with tiered storage; the fetcher threads truncate via the diverging
+     * epoch in the fetch response instead.
      *
      * @param partitions A map of topic partition -> leader epoch of the replica
      *


### PR DESCRIPTION
Since the 4.0 baseline `MetadataVersion` is 3.0, all brokers support
truncation on fetch (`Fetch` v12+ with `LastFetchedEpoch` and
`DivergingEpoch`). Fetcher threads can therefore skip the separate
`OffsetsForLeaderEpochRequest` and detect divergence directly from fetch
responses.
