### PR TITLE
KAFKA-20665: Make the assignment refiner injectable

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -435,13 +435,13 @@ public class GroupCoordinatorConfig {
     public static final Class<?> STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DEFAULT = null;
     public static final String STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DOC = "The fully qualified class name of a StreamsGroupTopologyDescriptionPlugin implementation. When not set, the feature is disabled.";
 
-    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG = "group.streams.assignment.refiner.class";
-    public static final Class<?> STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DEFAULT = null;
-    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DOC = "The fully qualified class name of an AssignmentRefiner implementation, which derives the intermediate assignment (with warm-up tasks) that the members of a streams group are reconciled towards. When not set, no warm-up tasks are handed out and a task that has to move does so right away. This should be used for testing only.";
-
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG = "group.streams.acceptable.recovery.lag";
     public static final long STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT = 10000L;
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC = "The maximum acceptable lag (number of offsets to catch up) for a client to be considered caught-up enough to receive an active task assignment.";
+
+    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG = "group.streams.assignment.refiner.class";
+    public static final Class<?> STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DEFAULT = NoOpAssignmentRefiner.class;
+    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DOC = "The fully qualified class name of an AssignmentRefiner implementation, which derives the intermediate assignment (with warm-up tasks) that the members of a streams group are reconciled towards. When not set, no warm-up tasks are handed out and a task that has to move does so right away. This should be used for testing only.";
 
     public static final Set<String> RECONFIGURABLE_CONFIGS = Set.of(
         CACHED_BUFFER_MAX_BYTES_CONFIG,
@@ -1073,21 +1073,6 @@ public class GroupCoordinatorConfig {
     }
 
     /**
-     * The assignment refiner to derive the intermediate assignment of a streams group with, or {@code null} if none is
-     * configured, in which case the caller falls back to {@link NoOpAssignmentRefiner}.
-     * <p>
-     * Instantiated on demand rather than held in a field, because a {@code GroupCoordinatorConfig} is constructed
-     * whenever any dynamic broker config changes ({@code DynamicBrokerConfig.processReconfiguration} builds a whole
-     * {@code KafkaConfig}), and we do not want to construct a refiner for each of those. A shard asks for one when it
-     * is loaded, so every shard gets its own instance.
-     */
-    public AssignmentRefiner streamsGroupAssignmentRefiner() {
-        return config.getConfiguredInstance(
-            STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
-            AssignmentRefiner.class);
-    }
-
-    /**
      * The number of threads or event loops running.
      */
     public int numThreads() {
@@ -1576,6 +1561,16 @@ public class GroupCoordinatorConfig {
      */
     public long streamsGroupAcceptableRecoveryLag() {
         return streamsGroupAcceptableRecoveryLag;
+    }
+
+    /**
+     * A newly constructed {@link AssignmentRefiner}, defaulting to {@link NoOpAssignmentRefiner}. A fresh instance is
+     * returned on each call, as a refiner is not thread-safe.
+     */
+    public AssignmentRefiner streamsGroupAssignmentRefiner() {
+        return config.getConfiguredInstance(
+            STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
+            AssignmentRefiner.class);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -31,6 +31,8 @@ import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.assignor.RangeAssignor;
 import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
+import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
+import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 
 import org.slf4j.Logger;
@@ -433,6 +435,10 @@ public class GroupCoordinatorConfig {
     public static final Class<?> STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DEFAULT = null;
     public static final String STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DOC = "The fully qualified class name of a StreamsGroupTopologyDescriptionPlugin implementation. When not set, the feature is disabled.";
 
+    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG = "group.streams.assignment.refiner.class";
+    public static final Class<?> STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DEFAULT = null;
+    public static final String STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DOC = "The fully qualified class name of an AssignmentRefiner implementation, which derives the intermediate assignment (with warm-up tasks) that the members of a streams group are reconciled towards. When not set, no warm-up tasks are handed out and a task that has to move does so right away. This should be used for testing only.";
+
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG = "group.streams.acceptable.recovery.lag";
     public static final long STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT = 10000L;
     public static final String STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC = "The maximum acceptable lag (number of offsets to catch up) for a client to be considered caught-up enough to receive an active task assignment.";
@@ -535,7 +541,8 @@ public class GroupCoordinatorConfig {
         .define(STREAMS_GROUP_MAX_WARMUP_REPLICAS_CONFIG, INT, STREAMS_GROUP_MAX_WARMUP_REPLICAS_DEFAULT, atLeast(0), MEDIUM, STREAMS_GROUP_MAX_WARMUP_REPLICAS_DOC)
         .define(STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, LIST, STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_DEFAULT, ConfigDef.ValidList.anyNonDuplicateValues(true, false), LOW, STREAMS_GROUP_RACK_AWARE_ASSIGNMENT_TAGS_DOC)
         .define(STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG, CLASS, STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DEFAULT, MEDIUM, STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_DOC)
-        .define(STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG, LONG, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT, atLeast(0L), MEDIUM, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC);
+        .define(STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_CONFIG, LONG, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DEFAULT, atLeast(0L), MEDIUM, STREAMS_GROUP_ACCEPTABLE_RECOVERY_LAG_DOC)
+        .defineInternal(STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG, CLASS, STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DEFAULT, null, LOW, STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_DOC);
 
 
     /**
@@ -1063,6 +1070,21 @@ public class GroupCoordinatorConfig {
      */
     public boolean isStreamsGroupTopologyDescriptionPluginConfigured() {
         return config.getClass(STREAMS_GROUP_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS_CONFIG) != null;
+    }
+
+    /**
+     * The assignment refiner to derive the intermediate assignment of a streams group with, or {@code null} if none is
+     * configured, in which case the caller falls back to {@link NoOpAssignmentRefiner}.
+     * <p>
+     * Instantiated on demand rather than held in a field, because a {@code GroupCoordinatorConfig} is constructed
+     * whenever any dynamic broker config changes ({@code DynamicBrokerConfig.processReconfiguration} builds a whole
+     * {@code KafkaConfig}), and we do not want to construct a refiner for each of those. A shard asks for one when it
+     * is loaded, so every shard gets its own instance.
+     */
+    public AssignmentRefiner streamsGroupAssignmentRefiner() {
+        return config.getConfiguredInstance(
+            STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
+            AssignmentRefiner.class);
     }
 
     /**

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -275,7 +275,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 .withGroupCoordinatorMetricsShard(metricsShard)
                 .withShareGroupAssignor(config.shareGroupAssignors().get(0))
                 .withStreamsGroupAssignors(config.streamsGroupAssignors())
-                .withAssignmentRefiner(config.streamsGroupAssignmentRefiner())
+                .withStreamsGroupAssignmentRefiner(config.streamsGroupAssignmentRefiner())
                 .withAuthorizerPlugin(authorizerPlugin)
                 .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorShard.java
@@ -275,6 +275,7 @@ public class GroupCoordinatorShard implements CoordinatorShard<CoordinatorRecord
                 .withGroupCoordinatorMetricsShard(metricsShard)
                 .withShareGroupAssignor(config.shareGroupAssignors().get(0))
                 .withStreamsGroupAssignors(config.streamsGroupAssignors())
+                .withAssignmentRefiner(config.streamsGroupAssignmentRefiner())
                 .withAuthorizerPlugin(authorizerPlugin)
                 .build();
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -155,6 +155,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup.ShareGroupStat
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupAssignmentBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
+import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupDescribeResult;
@@ -329,6 +330,7 @@ public class GroupMetadataManager {
         private GroupCoordinatorMetricsShard metrics;
         private Optional<Plugin<Authorizer>> authorizerPlugin = null;
         private List<TaskAssignor> streamsGroupAssignors = null;
+        private AssignmentRefiner assignmentRefiner = null;
 
         Builder withLogContext(LogContext logContext) {
             this.logContext = logContext;
@@ -367,6 +369,11 @@ public class GroupMetadataManager {
 
         Builder withStreamsGroupAssignors(List<TaskAssignor> streamsGroupAssignors) {
             this.streamsGroupAssignors = streamsGroupAssignors;
+            return this;
+        }
+
+        Builder withAssignmentRefiner(AssignmentRefiner assignmentRefiner) {
+            this.assignmentRefiner = assignmentRefiner;
             return this;
         }
 
@@ -411,6 +418,8 @@ public class GroupMetadataManager {
                 throw new IllegalArgumentException("GroupConfigManager must be set.");
             if (streamsGroupAssignors == null)
                 streamsGroupAssignors = List.of(new StickyTaskAssignor());
+            if (assignmentRefiner == null)
+                assignmentRefiner = new NoOpAssignmentRefiner();
 
             return new GroupMetadataManager(
                 snapshotRegistry,
@@ -424,7 +433,8 @@ public class GroupMetadataManager {
                 groupConfigManager,
                 shareGroupAssignor,
                 authorizerPlugin,
-                streamsGroupAssignors
+                streamsGroupAssignors,
+                assignmentRefiner
             );
         }
     }
@@ -518,6 +528,11 @@ public class GroupMetadataManager {
     private final TaskAssignor defaultStreamsGroupAssignor;
 
     /**
+     * Derives the intermediate assignment that the members of a streams group are reconciled towards.
+     */
+    private final AssignmentRefiner assignmentRefiner;
+
+    /**
      * The metadata image.
      */
     private CoordinatorMetadataImage metadataImage;
@@ -566,7 +581,8 @@ public class GroupMetadataManager {
         GroupConfigManager groupConfigManager,
         ShareGroupPartitionAssignor shareGroupAssignor,
         Optional<Plugin<Authorizer>> authorizerPlugin,
-        List<TaskAssignor> streamsGroupAssignors
+        List<TaskAssignor> streamsGroupAssignors,
+        AssignmentRefiner assignmentRefiner
     ) {
         this.logContext = logContext;
         this.log = logContext.logger(GroupMetadataManager.class);
@@ -589,6 +605,7 @@ public class GroupMetadataManager {
         this.shareGroupAssignor = shareGroupAssignor;
         this.defaultStreamsGroupAssignor = streamsGroupAssignors.get(0);
         this.streamsGroupAssignors = streamsGroupAssignors.stream().collect(Collectors.toMap(TaskAssignor::name, Function.identity()));
+        this.assignmentRefiner = assignmentRefiner;
         this.topicRegexResolver = new TopicRegexResolver(() -> authorizerPlugin, this.time);
         this.topicHashCache = new HashMap<>();
     }
@@ -4537,11 +4554,21 @@ public class GroupMetadataManager {
             // Warm-up tasks are disabled, so there is nothing to refine and no state to keep for the group.
             return targetAssignment;
         }
-        final Map<String, TasksTuple> refinedAssignment = AssignmentRefiner.refine(
+        if (!configuredTopology.isReady()) {
+            // A refiner is handed the resolved subtopologies, never an unresolved topology, so it does not have to
+            // reason about readiness; the topology must be ready to allow the refiner to identify stateless vs
+            // stateful tasks.
+            // If the topology is not ready, the assignor computes an empty assignment, which we can just fall back to.
+            // Even if the assignor fall-back would be a non-empty assignment, it's still reasonable to not refine and
+            // just apply the target assignment directly. It's a robust fall back, ensuring that we converge to the new
+            // target assignment, trading off availability.
+            return targetAssignment;
+        }
+        final Map<String, TasksTuple> refinedAssignment = assignmentRefiner.refine(
             group.members(),
             targetAssignment,
             group.taskOffsets(),
-            configuredTopology,
+            Collections.unmodifiableSortedMap(configuredTopology.subtopologies().get()),
             numWarmupReplicas,
             streamsGroupAcceptableRecoveryLag(group.groupId())
         );

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupMetadataManager.java
@@ -330,7 +330,7 @@ public class GroupMetadataManager {
         private GroupCoordinatorMetricsShard metrics;
         private Optional<Plugin<Authorizer>> authorizerPlugin = null;
         private List<TaskAssignor> streamsGroupAssignors = null;
-        private AssignmentRefiner assignmentRefiner = null;
+        private AssignmentRefiner streamsGroupAssignmentRefiner = null;
 
         Builder withLogContext(LogContext logContext) {
             this.logContext = logContext;
@@ -372,8 +372,8 @@ public class GroupMetadataManager {
             return this;
         }
 
-        Builder withAssignmentRefiner(AssignmentRefiner assignmentRefiner) {
-            this.assignmentRefiner = assignmentRefiner;
+        Builder withStreamsGroupAssignmentRefiner(AssignmentRefiner streamsGroupAssignmentRefiner) {
+            this.streamsGroupAssignmentRefiner = streamsGroupAssignmentRefiner;
             return this;
         }
 
@@ -418,8 +418,8 @@ public class GroupMetadataManager {
                 throw new IllegalArgumentException("GroupConfigManager must be set.");
             if (streamsGroupAssignors == null)
                 streamsGroupAssignors = List.of(new StickyTaskAssignor());
-            if (assignmentRefiner == null)
-                assignmentRefiner = new NoOpAssignmentRefiner();
+            if (streamsGroupAssignmentRefiner == null)
+                streamsGroupAssignmentRefiner = new NoOpAssignmentRefiner();
 
             return new GroupMetadataManager(
                 snapshotRegistry,
@@ -434,7 +434,7 @@ public class GroupMetadataManager {
                 shareGroupAssignor,
                 authorizerPlugin,
                 streamsGroupAssignors,
-                assignmentRefiner
+                streamsGroupAssignmentRefiner
             );
         }
     }
@@ -530,7 +530,7 @@ public class GroupMetadataManager {
     /**
      * Derives the intermediate assignment that the members of a streams group are reconciled towards.
      */
-    private final AssignmentRefiner assignmentRefiner;
+    private final AssignmentRefiner streamsGroupAssignmentRefiner;
 
     /**
      * The metadata image.
@@ -582,7 +582,7 @@ public class GroupMetadataManager {
         ShareGroupPartitionAssignor shareGroupAssignor,
         Optional<Plugin<Authorizer>> authorizerPlugin,
         List<TaskAssignor> streamsGroupAssignors,
-        AssignmentRefiner assignmentRefiner
+        AssignmentRefiner streamsGroupAssignmentRefiner
     ) {
         this.logContext = logContext;
         this.log = logContext.logger(GroupMetadataManager.class);
@@ -605,7 +605,7 @@ public class GroupMetadataManager {
         this.shareGroupAssignor = shareGroupAssignor;
         this.defaultStreamsGroupAssignor = streamsGroupAssignors.get(0);
         this.streamsGroupAssignors = streamsGroupAssignors.stream().collect(Collectors.toMap(TaskAssignor::name, Function.identity()));
-        this.assignmentRefiner = assignmentRefiner;
+        this.streamsGroupAssignmentRefiner = streamsGroupAssignmentRefiner;
         this.topicRegexResolver = new TopicRegexResolver(() -> authorizerPlugin, this.time);
         this.topicHashCache = new HashMap<>();
     }
@@ -4564,7 +4564,7 @@ public class GroupMetadataManager {
             // target assignment, trading off availability.
             return targetAssignment;
         }
-        final Map<String, TasksTuple> refinedAssignment = assignmentRefiner.refine(
+        final Map<String, TasksTuple> refinedAssignment = streamsGroupAssignmentRefiner.refine(
             group.members(),
             targetAssignment,
             group.taskOffsets(),

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
@@ -16,10 +16,11 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
-import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 
 /**
  * Refines the task assignor's target assignment into the <em>intermediate</em> assignment that the reconciler
@@ -44,11 +45,20 @@ import java.util.Set;
  *     the decisions of a step are taken once, when the epoch is minted, and do not change while the members reconcile
  *     towards it. See {@link StreamsGroup#refinedAssignment(int)}.</li>
  * </ul>
+ * <p>
+ * One instance is created per coordinator shard, and serves every streams group on that shard: the two configurations
+ * a refinement depends on are per-group overridable and are therefore passed in on every call rather than held as
+ * instance state. Since a shard is single-threaded, an implementation does not have to be thread-safe unless it shares
+ * state across shards.
+ * <p>
+ * The default is {@link NoOpAssignmentRefiner}. Which implementation is used is not a public extension point; it is
+ * selected by an internal broker configuration
+ * ({@code GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG}) that exists so that tests can put a
+ * warm-up assignment in front of a real client while the derivation itself is still being built. An implementation
+ * that also implements {@link org.apache.kafka.common.Configurable} is handed the broker configuration, so a test
+ * implementation can be steered through broker properties.
  */
-public class AssignmentRefiner {
-
-    private AssignmentRefiner() {
-    }
+public interface AssignmentRefiner {
 
     /**
      * Derives the intermediate assignment for all members of the group.
@@ -59,28 +69,29 @@ public class AssignmentRefiner {
      * @param taskOffsets           The latest changelog offsets/end-offsets reported by the members via heartbeats,
      *                              from which the lag of a warm-up task is derived. Not populated for a member that
      *                              has not reported any offsets yet, for example right after a coordinator failover.
-     * @param configuredTopology    The configured topology, which tells whether a subtopology is stateful. Only
-     *                              stateful tasks are warmed up; a stateless task has no state to restore.
-     * @param numWarmupReplicas     The maximum number of warm-up tasks the group may run at a time. Zero disables
-     *                              warm-up tasks altogether, in which case the intermediate assignment is the target
-     *                              assignment.
+     * @param subtopologies         The group's resolved subtopologies, keyed by subtopology ID, which tell whether a
+     *                              subtopology is stateful. Only stateful tasks are warmed up; a stateless task has no
+     *                              state to restore. The coordinator resolves the topology and never invokes a refiner
+     *                              until it is ready, so an implementation does not deal with topology readiness.
+     * @param numWarmupReplicas     The maximum number of warm-up tasks the group may run at a time. Never zero: with
+     *                              warm-up tasks disabled, the intermediate assignment is the target assignment and
+     *                              the refiner is not called at all.
      * @param acceptableRecoveryLag The lag at or below which a warm-up task is considered caught up.
      *
-     * @return The intermediate assignment, keyed by member ID.
+     * @return The intermediate assignment, keyed by member ID. It must hand out the same active tasks as the target
+     *         assignment, only possibly to different members; an implementation that drops or duplicates one is
+     *         ignored in favour of the target assignment (see {@link #preservesActiveTaskCount}).
      */
-    public static Map<String, TasksTuple> refine(
+    Map<String, TasksTuple> refine(
         Map<String, StreamsGroupMember> members,
         Map<String, TasksTuple> targetAssignment,
         Map<String, MemberTaskOffsets> taskOffsets,
-        ConfiguredTopology configuredTopology,
+        SortedMap<String, ConfiguredSubtopology> subtopologies,
         int numWarmupReplicas,
         long acceptableRecoveryLag
-    ) {
-        // No warm-up tasks are inserted yet, so the intermediate assignment is the target assignment.
-        return targetAssignment;
-    }
+    );
 
-    public static boolean preservesActiveTaskCount(
+    static boolean preservesActiveTaskCount(
         Map<String, TasksTuple> targetAssignment,
         Map<String, TasksTuple> refinedAssignment
     ) {

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
@@ -46,17 +46,14 @@ import java.util.SortedMap;
  *     towards it. See {@link StreamsGroup#refinedAssignment(int)}.</li>
  * </ul>
  * <p>
- * One instance is created per coordinator shard, and serves every streams group on that shard: the two configurations
- * a refinement depends on are per-group overridable and are therefore passed in on every call rather than held as
- * instance state. Since a shard is single-threaded, an implementation does not have to be thread-safe unless it shares
- * state across shards.
+ * An implementation need not be thread-safe, and holds no per-group state: the two per-group configurations a
+ * refinement depends on are passed on every call.
  * <p>
- * The default is {@link NoOpAssignmentRefiner}. Which implementation is used is not a public extension point; it is
- * selected by an internal broker configuration
- * ({@code GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG}) that exists so that tests can put a
- * warm-up assignment in front of a real client while the derivation itself is still being built. An implementation
- * that also implements {@link org.apache.kafka.common.Configurable} is handed the broker configuration, so a test
- * implementation can be steered through broker properties.
+ * An internal broker configuration ({@code GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG})
+ * selects the implementation, defaulting to {@link NoOpAssignmentRefiner}. It exists so that tests can put a warm-up
+ * assignment in front of a real client while the derivation itself is still being built, and is not a public extension
+ * point. An implementation that also implements {@link org.apache.kafka.common.Configurable} is handed the broker
+ * configuration, so a test implementation can be steered through broker properties.
  */
 public interface AssignmentRefiner {
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/NoOpAssignmentRefiner.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/NoOpAssignmentRefiner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import java.util.Map;
+import java.util.SortedMap;
+
+/**
+ * The {@link AssignmentRefiner} the broker uses unless an implementation is configured: it hands the target assignment
+ * back unchanged, so no warm-up tasks are inserted and a task that has to move does so right away. This is the
+ * behaviour of the group coordinator before warm-up derivation exists.
+ */
+public class NoOpAssignmentRefiner implements AssignmentRefiner {
+
+    @Override
+    public Map<String, TasksTuple> refine(
+        Map<String, StreamsGroupMember> members,
+        Map<String, TasksTuple> targetAssignment,
+        Map<String, MemberTaskOffsets> taskOffsets,
+        SortedMap<String, ConfiguredSubtopology> subtopologies,
+        int numWarmupReplicas,
+        long acceptableRecoveryLag
+    ) {
+        return targetAssignment;
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.coordinator.group;
 
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.record.internal.CompressionType;
@@ -33,7 +34,12 @@ import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber
 import org.apache.kafka.coordinator.group.assignor.RangeAssignor;
 import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
+import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
+import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
+import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.SortedMap;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1231,6 +1238,78 @@ public class GroupCoordinatorConfigTest {
         StreamsGroupTopologyDescriptionPlugin second =
             config.streamsGroupTopologyDescriptionPlugin(Map.of());
         assertNotSame(first, second);
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentRefinerDefaultIsNull() {
+        GroupCoordinatorConfig config = createConfig(new HashMap<>());
+        assertNull(config.streamsGroupAssignmentRefiner());
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentRefinerLoadedAndConfigured() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
+            TestAssignmentRefiner.class.getName());
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        AssignmentRefiner refiner = config.streamsGroupAssignmentRefiner();
+        assertInstanceOf(TestAssignmentRefiner.class, refiner);
+        // A refiner is handed the broker configuration, so a test implementation can be steered through broker
+        // properties rather than static state.
+        assertEquals(TestAssignmentRefiner.class.getName(),
+            ((TestAssignmentRefiner) refiner).configs.get(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG));
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentRefinerReturnsFreshInstancePerCall() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
+            TestAssignmentRefiner.class);
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        // Every coordinator shard asks for its own refiner, so they must not share one instance.
+        assertNotSame(config.streamsGroupAssignmentRefiner(), config.streamsGroupAssignmentRefiner());
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentRefinerRejectsUnknownClassAtStartup() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG, "not.a.Class");
+        // The class is resolved while the configuration is parsed, so a typo fails the broker rather than the
+        // coordinator shard that first tries to use it.
+        assertThrows(ConfigException.class, () -> createConfig(configs));
+    }
+
+    @Test
+    public void testStreamsGroupAssignmentRefinerRejectsClassOfWrongType() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNMENT_REFINER_CLASS_CONFIG,
+            TestTopologyDescriptionPlugin.class);
+        GroupCoordinatorConfig config = createConfig(configs);
+
+        assertThrows(KafkaException.class, config::streamsGroupAssignmentRefiner);
+    }
+
+    public static class TestAssignmentRefiner implements AssignmentRefiner, Configurable {
+        public Map<String, ?> configs;
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            this.configs = configs;
+        }
+
+        @Override
+        public Map<String, TasksTuple> refine(
+            Map<String, StreamsGroupMember> members,
+            Map<String, TasksTuple> targetAssignment,
+            Map<String, MemberTaskOffsets> taskOffsets,
+            SortedMap<String, ConfiguredSubtopology> subtopologies,
+            int numWarmupReplicas,
+            long acceptableRecoveryLag
+        ) {
+            return targetAssignment;
+        }
     }
 
     public static class TestTopologyDescriptionPlugin implements StreamsGroupTopologyDescriptionPlugin {

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
 import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
+import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
@@ -1241,9 +1242,9 @@ public class GroupCoordinatorConfigTest {
     }
 
     @Test
-    public void testStreamsGroupAssignmentRefinerDefaultIsNull() {
+    public void testStreamsGroupAssignmentRefinerDefaultsToNoOp() {
         GroupCoordinatorConfig config = createConfig(new HashMap<>());
-        assertNull(config.streamsGroupAssignmentRefiner());
+        assertInstanceOf(NoOpAssignmentRefiner.class, config.streamsGroupAssignmentRefiner());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -98,6 +98,7 @@ import org.apache.kafka.coordinator.common.runtime.MockCoordinatorExecutor;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer.ExpiredTimeout;
 import org.apache.kafka.coordinator.common.runtime.MockCoordinatorTimer.ScheduledTimeout;
+import org.apache.kafka.coordinator.group.StreamsGroupTestUtil.StreamsTopicFixture;
 import org.apache.kafka.coordinator.group.api.assignor.ConsumerGroupPartitionAssignor;
 import org.apache.kafka.coordinator.group.api.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.assignor.GroupSpec;
@@ -144,6 +145,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroupBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
 import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
+import org.apache.kafka.coordinator.group.streams.MockAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.MockTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.StreamsCoordinatorRecordHelpers;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
@@ -232,6 +234,7 @@ import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext
 import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_CLIENT_ID;
 import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_PROCESS_ID;
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.getDefaultAssignmentConfigs;
+import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.streamsTopicFixture;
 import static org.apache.kafka.coordinator.group.Utils.computeGroupHash;
 import static org.apache.kafka.coordinator.group.Utils.computeTopicHash;
 import static org.apache.kafka.coordinator.group.Utils.toAssignmentWithEpochs;
@@ -245,6 +248,7 @@ import static org.apache.kafka.coordinator.group.classic.ClassicGroupState.STABL
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CLASSIC_GROUP_COMPLETED_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.CONSUMER_GROUP_REBALANCES_SENSOR_NAME;
 import static org.apache.kafka.coordinator.group.metrics.GroupCoordinatorMetrics.SHARE_GROUP_REBALANCES_SENSOR_NAME;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithCommonEpoch;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithEpochs;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochs;
@@ -19243,6 +19247,233 @@ public class GroupMetadataManagerTest {
         // anyway, so nothing is frozen for the group -- the group keeps no per-epoch state it would never read.
         StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
         assertNull(group.refinedAssignment(group.assignmentEpoch()));
+    }
+
+    @Test
+    public void testStreamsGroupRefinerIsPassedTheGroupContextAndTheGroupsConfigs() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        StreamsTopicFixture topic = streamsTopicFixture("subtopology1", "foo", 3);
+        TasksTuple targetAssignment = topic.targetAssignment(0, 1, 2);
+
+        MockAssignmentRefiner refiner = new MockAssignmentRefiner();
+        GroupMetadataManagerTestContext context = streamsGroupContextForRefinement(
+            groupId, refiner, topic, Map.of(memberId, List.of(0, 1, 2)), Map.of(memberId, DEFAULT_PROCESS_ID));
+
+        Properties groupConfig = new Properties();
+        groupConfig.setProperty(GroupConfig.STREAMS_NUM_WARMUP_REPLICAS_CONFIG, "3");
+        groupConfig.setProperty(GroupConfig.STREAMS_ACCEPTABLE_RECOVERY_LAG_CONFIG, "17");
+        context.updateGroupConfig(groupId, groupConfig);
+
+        context.streamsGroupHeartbeat(
+            streamsGroupRefinementHeartbeat(groupId, memberId, DEFAULT_PROCESS_ID, topic, List.of(0, 1, 2))
+                .setTaskOffsets(List.of(new StreamsGroupHeartbeatRequestData.TaskOffset()
+                    .setSubtopologyId("subtopology1")
+                    .setPartition(0)
+                    .setOffset(42L))));
+
+        // The refiner derives the intermediate assignment for the whole group, so it is handed the group's members and
+        // their target assignments rather than a single member's slice, plus the reported offsets it derives lag from.
+        assertEquals(1, refiner.numRefinements());
+        assertEquals(Set.of(memberId), refiner.lastPassedMembers().keySet());
+        assertEquals(Map.of(memberId, targetAssignment), refiner.lastPassedTargetAssignment());
+        assertEquals(
+            Map.of("subtopology1", Map.of(0, 42L)),
+            refiner.lastPassedTaskOffsets().get(memberId).taskOffsets());
+        assertEquals(Set.of("subtopology1"), refiner.lastPassedSubtopologies().keySet());
+        // Both configurations are overridable per group, so the group's values have to arrive, not the broker defaults.
+        assertEquals(3, refiner.lastPassedNumWarmupReplicas());
+        assertEquals(17L, refiner.lastPassedAcceptableRecoveryLag());
+    }
+
+    @Test
+    public void testStreamsGroupReconcilesTowardsTheRefinedAssignment() {
+        String groupId = "fooup";
+        String memberA = Uuid.randomUuid().toString();
+        String memberB = Uuid.randomUuid().toString();
+        StreamsTopicFixture topic = streamsTopicFixture("subtopology1", "foo", 3);
+
+        MockAssignmentRefiner refiner = new MockAssignmentRefiner();
+        GroupMetadataManagerTestContext context = streamsGroupContextForRefinement(
+            groupId,
+            refiner,
+            topic,
+            Map.of(memberA, List.of(0, 1, 2), memberB, List.of()),
+            Map.of(memberA, DEFAULT_PROCESS_ID, memberB, "process-b")
+        );
+
+        // What a refinement step does to stage a migration: memberA keeps 0_2 active while memberB warms it up.
+        refiner.prepareRefinedAssignment(Map.of(
+            memberA, topic.targetAssignment(0, 1, 2),
+            memberB, mkTasksTuple(TaskRole.WARMUP, topic.tasks(2))
+        ));
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            streamsGroupRefinementHeartbeat(groupId, memberB, "process-b", topic, List.of()));
+
+        // The refined assignment differs from what memberB holds, so this is a refinement step of its own: the epoch is
+        // bumped for it and memberB is reconciled towards the warm-up task, which no target assignment ever held.
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+        assertEquals(11, group.groupEpoch());
+        assertEquals(topic.responseTasks(2), result.response().data().warmupTasks());
+        assertEquals(List.of(), result.response().data().activeTasks());
+        assertEquals(
+            mkTasksTuple(TaskRole.WARMUP, topic.tasks(2)),
+            group.refinedAssignment(group.assignmentEpoch()).get(memberB)
+        );
+    }
+
+    @Test
+    public void testStreamsGroupDoesNotRefineWhenWarmupsAreDisabled() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        StreamsTopicFixture topic = streamsTopicFixture("subtopology1", "foo", 3);
+
+        MockAssignmentRefiner refiner = new MockAssignmentRefiner();
+        GroupMetadataManagerTestContext context = streamsGroupContextForRefinement(
+            groupId, refiner, topic, Map.of(memberId, List.of(0, 1, 2)),
+            Map.of(memberId, DEFAULT_PROCESS_ID));
+
+        Properties groupConfig = new Properties();
+        groupConfig.setProperty(GroupConfig.STREAMS_NUM_WARMUP_REPLICAS_CONFIG, "0");
+        context.updateGroupConfig(groupId, groupConfig);
+
+        context.streamsGroupHeartbeat(
+            streamsGroupRefinementHeartbeat(groupId, memberId, DEFAULT_PROCESS_ID, topic, List.of(0, 1, 2)));
+
+        // A group with no warm-up budget reconciles towards the target assignment directly, so there is nothing to
+        // refine and the refiner is not consulted at all.
+        assertEquals(0, refiner.numRefinements());
+    }
+
+    @Test
+    public void testStreamsGroupDoesNotRefineWhileTheTopologyIsNotReady() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        // A source topic that does not exist in the metadata image leaves the topology unconfigurable, so we cannot
+        // tell which subtopologies are stateful yet.
+        StreamsTopicFixture topic = streamsTopicFixture("subtopology1", "foo", 3);
+        StreamsGroupHeartbeatRequestData.Topology unresolvableTopology = new StreamsGroupHeartbeatRequestData.Topology()
+            .setSubtopologies(List.of(new StreamsGroupHeartbeatRequestData.Subtopology()
+                .setSubtopologyId("subtopology1")
+                .setSourceTopics(List.of("does-not-exist"))));
+
+        MockAssignmentRefiner refiner = new MockAssignmentRefiner();
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(new MockTaskAssignor("sticky")))
+            .withAssignmentRefiner(refiner)
+            .withMetadataImage(topic.metadataImage())
+            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10)
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .build())
+                .withTopology(StreamsTopology.fromHeartbeatRequest(unresolvableTopology))
+                .withTargetAssignment(memberId, TasksTuple.EMPTY)
+                .withTargetAssignmentEpoch(10)
+                .withMetadataHash(topic.metadataHash())
+                .withLastAssignmentConfigs(getDefaultAssignmentConfigs()))
+            .build();
+
+        context.streamsGroupHeartbeat(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId(groupId)
+                .setMemberId(memberId)
+                .setMemberEpoch(10)
+                .setProcessId(DEFAULT_PROCESS_ID)
+                .setRebalanceTimeoutMs(1500)
+                .setTopology(unresolvableTopology)
+                .setActiveTasks(List.of())
+                .setStandbyTasks(List.of())
+                .setWarmupTasks(List.of()));
+
+        // Every refiner has to read the subtopologies to tell a stateful task from a stateless one, so it must not be
+        // called before they are known.
+        assertEquals(0, refiner.numRefinements());
+    }
+
+    @Test
+    public void testStreamsGroupFallsBackToTargetAssignmentWhenRefinementLosesAnActiveTask() {
+        String groupId = "fooup";
+        String memberId = Uuid.randomUuid().toString();
+        StreamsTopicFixture topic = streamsTopicFixture("subtopology1", "foo", 3);
+        TasksTuple targetAssignment = topic.targetAssignment(0, 1, 2);
+
+        MockAssignmentRefiner refiner = new MockAssignmentRefiner();
+        GroupMetadataManagerTestContext context = streamsGroupContextForRefinement(
+            groupId, refiner, topic, Map.of(memberId, List.of(0, 1, 2)), Map.of(memberId, DEFAULT_PROCESS_ID));
+
+        refiner.prepareRefinedAssignment(Map.of(memberId, topic.targetAssignment(0, 1)));
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> result = context.streamsGroupHeartbeat(
+            streamsGroupRefinementHeartbeat(groupId, memberId, DEFAULT_PROCESS_ID, topic, List.of(0, 1, 2)));
+
+        // Reconciling towards an intermediate assignment that dropped an active task would leave input partitions
+        // unprocessed, so the target assignment is used instead: the member keeps all three tasks, which leaves nothing
+        // to reconcile and hence no epoch to bump and no assignment to return.
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+        assertEquals(10, group.groupEpoch());
+        assertNull(result.response().data().activeTasks());
+        assertEquals(
+            mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10, topic.tasks(0, 1, 2)),
+            group.getMemberOrThrow(memberId).assignedTasks()
+        );
+        assertEquals(Map.of(memberId, targetAssignment), group.refinedAssignment(group.assignmentEpoch()));
+    }
+
+    /**
+     * A streams group that is settled at epoch 10 -- every member reconciled to its target assignment -- which is the
+     * state a refinement step is derived from.
+     */
+    private GroupMetadataManagerTestContext streamsGroupContextForRefinement(
+        String groupId,
+        MockAssignmentRefiner refiner,
+        StreamsTopicFixture topic,
+        Map<String, List<Integer>> activeTasksByMemberId,
+        Map<String, String> processIdByMemberId
+    ) {
+        StreamsGroupBuilder groupBuilder = new StreamsGroupBuilder(groupId, 10)
+            .withTopology(StreamsTopology.fromHeartbeatRequest(topic.topology()))
+            .withTargetAssignmentEpoch(10)
+            .withMetadataHash(topic.metadataHash())
+            .withValidatedTopologyEpoch(0)
+            .withLastAssignmentConfigs(getDefaultAssignmentConfigs());
+        activeTasksByMemberId.forEach((memberId, partitions) -> {
+            Integer[] activeTasks = partitions.toArray(Integer[]::new);
+            groupBuilder
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .setProcessId(processIdByMemberId.get(memberId))
+                    .setAssignedTasks(topic.assignedTasks(10, activeTasks))
+                    .build())
+                .withTargetAssignment(memberId, topic.targetAssignment(activeTasks));
+        });
+
+        return new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(new MockTaskAssignor("sticky")))
+            .withAssignmentRefiner(refiner)
+            .withMetadataImage(topic.metadataImage())
+            .withStreamsGroup(groupBuilder)
+            .build();
+    }
+
+    private StreamsGroupHeartbeatRequestData streamsGroupRefinementHeartbeat(
+        String groupId,
+        String memberId,
+        String processId,
+        StreamsTopicFixture topic,
+        List<Integer> ownedActiveTasks
+    ) {
+        return new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId)
+            .setMemberEpoch(10)
+            .setProcessId(processId)
+            .setRebalanceTimeoutMs(1500)
+            .setActiveTasks(ownedActiveTasks.isEmpty() ? List.of() : topic.requestTasks(ownedActiveTasks))
+            .setStandbyTasks(List.of())
+            .setWarmupTasks(List.of());
     }
 
     @Test

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -19361,7 +19361,7 @@ public class GroupMetadataManagerTest {
         MockAssignmentRefiner refiner = new MockAssignmentRefiner();
         GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
             .withStreamsGroupTaskAssignors(List.of(new MockTaskAssignor("sticky")))
-            .withAssignmentRefiner(refiner)
+            .withStreamsGroupAssignmentRefiner(refiner)
             .withMetadataImage(topic.metadataImage())
             .withStreamsGroup(new StreamsGroupBuilder(groupId, 10)
                 .withMember(streamsGroupMemberBuilderWithDefaults(memberId)
@@ -19452,7 +19452,7 @@ public class GroupMetadataManagerTest {
 
         return new GroupMetadataManagerTestContext.Builder()
             .withStreamsGroupTaskAssignors(List.of(new MockTaskAssignor("sticky")))
-            .withAssignmentRefiner(refiner)
+            .withStreamsGroupAssignmentRefiner(refiner)
             .withMetadataImage(topic.metadataImage())
             .withStreamsGroup(groupBuilder)
             .build();

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -109,7 +109,9 @@ import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroup;
 import org.apache.kafka.coordinator.group.modern.consumer.ConsumerGroupBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroup;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupBuilder;
+import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.MockTaskAssignor;
+import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
@@ -475,6 +477,7 @@ public class GroupMetadataManagerTestContext {
         private final Map<String, Object> config = new HashMap<>();
         private Optional<Plugin<Authorizer>> authorizerPlugin = Optional.empty();
         private List<TaskAssignor> streamsGroupAssignors = Collections.singletonList(new MockTaskAssignor("mock"));
+        private AssignmentRefiner assignmentRefiner = new NoOpAssignmentRefiner();
 
         public Builder withConfig(String key, Object value) {
             config.put(key, value);
@@ -516,6 +519,11 @@ public class GroupMetadataManagerTestContext {
             return this;
         }
 
+        public Builder withAssignmentRefiner(AssignmentRefiner assignmentRefiner) {
+            this.assignmentRefiner = assignmentRefiner;
+            return this;
+        }
+
         public Builder withTime(MockTime time) {
             this.time = time;
             return this;
@@ -552,6 +560,7 @@ public class GroupMetadataManagerTestContext {
                     .withGroupConfigManager(groupConfigManager)
                     .withAuthorizerPlugin(authorizerPlugin)
                     .withStreamsGroupAssignors(streamsGroupAssignors)
+                    .withAssignmentRefiner(assignmentRefiner)
                     .build(),
                 groupConfigManager
             );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTestContext.java
@@ -477,7 +477,7 @@ public class GroupMetadataManagerTestContext {
         private final Map<String, Object> config = new HashMap<>();
         private Optional<Plugin<Authorizer>> authorizerPlugin = Optional.empty();
         private List<TaskAssignor> streamsGroupAssignors = Collections.singletonList(new MockTaskAssignor("mock"));
-        private AssignmentRefiner assignmentRefiner = new NoOpAssignmentRefiner();
+        private AssignmentRefiner streamsGroupAssignmentRefiner = new NoOpAssignmentRefiner();
 
         public Builder withConfig(String key, Object value) {
             config.put(key, value);
@@ -519,8 +519,8 @@ public class GroupMetadataManagerTestContext {
             return this;
         }
 
-        public Builder withAssignmentRefiner(AssignmentRefiner assignmentRefiner) {
-            this.assignmentRefiner = assignmentRefiner;
+        public Builder withStreamsGroupAssignmentRefiner(AssignmentRefiner streamsGroupAssignmentRefiner) {
+            this.streamsGroupAssignmentRefiner = streamsGroupAssignmentRefiner;
             return this;
         }
 
@@ -560,7 +560,7 @@ public class GroupMetadataManagerTestContext {
                     .withGroupConfigManager(groupConfigManager)
                     .withAuthorizerPlugin(authorizerPlugin)
                     .withStreamsGroupAssignors(streamsGroupAssignors)
-                    .withAssignmentRefiner(assignmentRefiner)
+                    .withStreamsGroupAssignmentRefiner(streamsGroupAssignmentRefiner)
                     .build(),
                 groupConfigManager
             );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/MockAssignmentRefiner.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/MockAssignmentRefiner.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import java.util.Map;
+import java.util.SortedMap;
+
+/**
+ * An {@link AssignmentRefiner} that hands out a prepared intermediate assignment and records what it was called with,
+ * so that a test can drive the group towards an assignment with warm-up tasks and check that the group context reaches
+ * the refiner. Returns the target assignment unchanged until an assignment is prepared.
+ */
+public class MockAssignmentRefiner implements AssignmentRefiner {
+
+    private Map<String, TasksTuple> preparedRefinedAssignment = null;
+    private int numRefinements = 0;
+    private Map<String, StreamsGroupMember> lastPassedMembers = Map.of();
+    private Map<String, TasksTuple> lastPassedTargetAssignment = Map.of();
+    private Map<String, MemberTaskOffsets> lastPassedTaskOffsets = Map.of();
+    private SortedMap<String, ConfiguredSubtopology> lastPassedSubtopologies = null;
+    private int lastPassedNumWarmupReplicas = -1;
+    private long lastPassedAcceptableRecoveryLag = -1L;
+
+    public void prepareRefinedAssignment(Map<String, TasksTuple> refinedAssignment) {
+        this.preparedRefinedAssignment = refinedAssignment;
+    }
+
+    public int numRefinements() {
+        return numRefinements;
+    }
+
+    public Map<String, StreamsGroupMember> lastPassedMembers() {
+        return lastPassedMembers;
+    }
+
+    public Map<String, TasksTuple> lastPassedTargetAssignment() {
+        return lastPassedTargetAssignment;
+    }
+
+    public Map<String, MemberTaskOffsets> lastPassedTaskOffsets() {
+        return lastPassedTaskOffsets;
+    }
+
+    public SortedMap<String, ConfiguredSubtopology> lastPassedSubtopologies() {
+        return lastPassedSubtopologies;
+    }
+
+    public int lastPassedNumWarmupReplicas() {
+        return lastPassedNumWarmupReplicas;
+    }
+
+    public long lastPassedAcceptableRecoveryLag() {
+        return lastPassedAcceptableRecoveryLag;
+    }
+
+    @Override
+    public Map<String, TasksTuple> refine(
+        Map<String, StreamsGroupMember> members,
+        Map<String, TasksTuple> targetAssignment,
+        Map<String, MemberTaskOffsets> taskOffsets,
+        SortedMap<String, ConfiguredSubtopology> subtopologies,
+        int numWarmupReplicas,
+        long acceptableRecoveryLag
+    ) {
+        numRefinements++;
+        lastPassedMembers = members;
+        lastPassedTargetAssignment = targetAssignment;
+        lastPassedTaskOffsets = taskOffsets;
+        lastPassedSubtopologies = subtopologies;
+        lastPassedNumWarmupReplicas = numWarmupReplicas;
+        lastPassedAcceptableRecoveryLag = acceptableRecoveryLag;
+        return preparedRefinedAssignment == null ? targetAssignment : preparedRefinedAssignment;
+    }
+}


### PR DESCRIPTION
The refiner is a static no-op today, so no broker ever hands out a
warm-up task and the client-side warm-up handling has no end-to-end
coverage. Turn AssignmentRefiner into an interface with a NoOp default
and let an internal, undocumented broker config
(group.streams.assignment.refiner.class) select an implementation, so a
test can put a real warm-up assignment in front of a real client. With
the config unset, behavior is unchanged.

The refiner is also no longer called with a topology that is not
configured yet: the isReady() check in the heartbeat path guards only
the task-ID validation, so any refiner that reads subtopologies() to
tell a stateful task from a stateless one would have thrown. The
identity refiner masked this.

Reviewers: Sean Quah <squah@confluent.io>, Lucas Brutschy
 <lbrutschy@confluent.io>
