### PR TITLE
KAFKA-1983: Remove redundant offset commits from EndToEndLatency

### DIFF
--- a/api-checker/maven-plugin/bin/main/META-INF/maven/plugin.xml
+++ b/api-checker/maven-plugin/bin/main/META-INF/maven/plugin.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<plugin>
+  <name>Apache Kafka Internal API Checker Maven Plugin</name>
+  <description>Maven plugin to check that external projects don't use internal Kafka APIs</description>
+  <groupId>org.apache.kafka</groupId>
+  <artifactId>kafka-internal-api-checker-maven-plugin</artifactId>
+  <version>@version@</version>
+  <goalPrefix>kafka-internal-api-checker</goalPrefix>
+  <isolatedRealm>false</isolatedRealm>
+  <inheritedByDefault>true</inheritedByDefault>
+
+  <mojos>
+    <mojo>
+      <goal>verify</goal>
+      <description>Checks source code for usage of internal Kafka APIs</description>
+      <requiresDirectInvocation>false</requiresDirectInvocation>
+      <requiresProject>true</requiresProject>
+      <requiresReports>false</requiresReports>
+      <aggregator>false</aggregator>
+      <requiresOnline>false</requiresOnline>
+      <inheritedByDefault>true</inheritedByDefault>
+      <phase>verify</phase>
+      <implementation>org.apache.kafka.maven.KafkaInternalApiCheckerMojo</implementation>
+      <language>java</language>
+      <instantiationStrategy>per-lookup</instantiationStrategy>
+      <executionStrategy>once-per-session</executionStrategy>
+      <threadSafe>true</threadSafe>
+      <requiresDependencyResolution>compile+runtime</requiresDependencyResolution>
+
+      <parameters>
+        <parameter>
+          <name>project</name>
+          <type>org.apache.maven.project.MavenProject</type>
+          <required>true</required>
+          <editable>false</editable>
+          <description>The Maven project</description>
+        </parameter>
+
+        <parameter>
+          <name>enabled</name>
+          <type>boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Enable/disable the internal API checker</description>
+        </parameter>
+
+        <parameter>
+          <name>failOnViolation</name>
+          <type>boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Fail build on violations</description>
+        </parameter>
+
+        <parameter>
+          <name>failOnNoKafkaDependency</name>
+          <type>boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Fail the build when no org.apache.kafka:* dependency is found on the classpath (default: false, which warns and skips)</description>
+        </parameter>
+
+        <parameter>
+          <name>classesDirectories</name>
+          <type>java.util.List</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Compiled-class directories or jars to scan for internal API usage</description>
+        </parameter>
+
+        <parameter>
+          <name>reportFile</name>
+          <type>java.io.File</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Report file location</description>
+        </parameter>
+      </parameters>
+
+      <configuration>
+        <project implementation="org.apache.maven.project.MavenProject" default-value="${project}" />
+        <enabled implementation="boolean" default-value="true">${kafka.internal-api-checker.enabled}</enabled>
+        <failOnViolation implementation="boolean" default-value="true">${kafka.internal-api-checker.failOnViolation}</failOnViolation>
+        <failOnNoKafkaDependency implementation="boolean" default-value="false">${kafka.internal-api-checker.failOnNoKafkaDependency}</failOnNoKafkaDependency>
+        <classesDirectories implementation="java.util.List" />
+        <reportFile implementation="java.io.File" default-value="${project.build.directory}/reports/kafka-internal-api-usage.txt" />
+      </configuration>
+    </mojo>
+  </mojos>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <type>jar</type>
+      <version>@mavenApiVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <type>jar</type>
+      <version>@mavenApiVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <type>jar</type>
+      <version>@mavenApiVersion@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <type>jar</type>
+      <version>@mavenPluginAnnotationsVersion@</version>
+    </dependency>
+  </dependencies>
+</plugin>

--- a/clients/clients-integration-tests/bin/test/log4j2.yaml
+++ b/clients/clients-integration-tests/bin/test/log4j2.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: org.apache.kafka
+        level: WARN

--- a/connect/file/bin/main/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/file/bin/main/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.file.FileStreamSinkConnector

--- a/connect/file/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/file/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.file.FileStreamSourceConnector

--- a/connect/file/bin/test/log4j2.yaml
+++ b/connect/file/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %X{connector.context}%m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN

--- a/connect/mirror/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/mirror/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,18 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.mirror.MirrorCheckpointConnector
+org.apache.kafka.connect.mirror.MirrorHeartbeatConnector
+org.apache.kafka.connect.mirror.MirrorSourceConnector

--- a/connect/mirror/bin/test/log4j2.yaml
+++ b/connect/mirror/bin/test/log4j2.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %X{connector.context}%m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: state.change.logger
+        level: "OFF"
+
+      - name: org.apache.kafka.connect
+        level: DEBUG

--- a/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
+++ b/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
@@ -1,0 +1,19 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy
+org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy
+org.apache.kafka.connect.connector.policy.NoneConnectorClientConfigOverridePolicy
+org.apache.kafka.connect.connector.policy.AllowlistConnectorClientConfigOverridePolicy

--- a/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.converters.ByteArrayConverter
+org.apache.kafka.connect.converters.DoubleConverter
+org.apache.kafka.connect.converters.FloatConverter
+org.apache.kafka.connect.converters.IntegerConverter
+org.apache.kafka.connect.converters.LongConverter
+org.apache.kafka.connect.converters.ShortConverter
+org.apache.kafka.connect.converters.BooleanConverter

--- a/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
+++ b/connect/runtime/bin/main/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.converters.ByteArrayConverter
+org.apache.kafka.connect.converters.DoubleConverter
+org.apache.kafka.connect.converters.FloatConverter
+org.apache.kafka.connect.converters.IntegerConverter
+org.apache.kafka.connect.converters.LongConverter
+org.apache.kafka.connect.converters.ShortConverter
+org.apache.kafka.connect.converters.BooleanConverter

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.rest.ConnectRestExtension
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.rest.ConnectRestExtension
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.runtime.isolation.PluginsTest$TestConnectRestExtension

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.integration.BlockingConnectorTest$BlockingSinkConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$TaskInitializeBlockingSinkConnector
+org.apache.kafka.connect.integration.ErrantRecordSinkConnector
+org.apache.kafka.connect.integration.MonitorableSinkConnector
+org.apache.kafka.connect.integration.TestableSinkConnector
+org.apache.kafka.connect.runtime.SampleSinkConnector
+org.apache.kafka.connect.integration.ConnectWorkerIntegrationTest$EmptyTaskConfigsConnector

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,27 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.integration.BlockingConnectorTest$BlockingConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$InitializeBlockingConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$ConfigBlockingConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$ValidateBlockingConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$BlockingSourceConnector
+org.apache.kafka.connect.integration.BlockingConnectorTest$TaskInitializeBlockingSourceConnector
+org.apache.kafka.connect.integration.ExactlyOnceSourceIntegrationTest$NaughtyConnector
+org.apache.kafka.connect.integration.MonitorableSourceConnector
+org.apache.kafka.connect.integration.TestableSourceConnector
+org.apache.kafka.connect.runtime.SamplePartiallyValidatingConnector
+org.apache.kafka.connect.runtime.SampleSourceConnector
+org.apache.kafka.connect.runtime.rest.resources.ConnectorPluginsResourceTest$ConnectorPluginsResourceTestConnector

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.runtime.SampleConverterWithHeaders
+org.apache.kafka.connect.runtime.ErrorHandlingTaskTest$FaultyConverter
+org.apache.kafka.connect.runtime.isolation.PluginsTest$TestConverter
+org.apache.kafka.connect.runtime.isolation.PluginsTest$TestInternalConverter
+org.apache.kafka.connect.runtime.isolation.PluginUtilsTest$CollidingConverter
+org.apache.kafka.connect.integration.ConnectorValidationIntegrationTest$TestConverterWithSinglePropertyConfigDef
+org.apache.kafka.connect.integration.ConnectorValidationIntegrationTest$TestConverterWithNoConfigDef

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.runtime.SampleHeaderConverter
+org.apache.kafka.connect.runtime.ErrorHandlingTaskTest$FaultyConverter
+org.apache.kafka.connect.runtime.isolation.PluginsTest$TestHeaderConverter
+org.apache.kafka.connect.runtime.isolation.PluginsTest$TestInternalConverter
+org.apache.kafka.connect.runtime.isolation.PluginUtilsTest$CollidingHeaderConverter
+org.apache.kafka.connect.integration.ConnectorValidationIntegrationTest$TestConverterWithSinglePropertyConfigDef
+org.apache.kafka.connect.integration.ConnectorValidationIntegrationTest$TestConverterWithNoConfigDef

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,23 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.integration.ErrorHandlingIntegrationTest$FaultyPassthrough
+org.apache.kafka.connect.runtime.ErrorHandlingTaskTest$FaultyPassthrough
+org.apache.kafka.connect.runtime.ConnectorConfigTest$SimpleTransformation
+org.apache.kafka.connect.runtime.ConnectorConfigTest$HasDuplicateConfigTransformation
+org.apache.kafka.connect.runtime.ConnectorConfigTest$AbstractKeyValueTransformation$Key
+org.apache.kafka.connect.runtime.ConnectorConfigTest$AbstractKeyValueTransformation$Value
+org.apache.kafka.connect.runtime.SampleTransformation
+org.apache.kafka.connect.runtime.isolation.PluginUtilsTest$Colliding

--- a/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
+++ b/connect/runtime/bin/test/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.runtime.ConnectorConfigTest$TestPredicate
+org.apache.kafka.connect.runtime.SamplePredicate

--- a/connect/runtime/bin/test/log4j2.yaml
+++ b/connect/runtime/bin/test/log4j2.yaml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %X{connector.context}%m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: state.change.logger
+        level: "OFF"
+
+      - name: org.apache.kafka.connect
+        level: DEBUG
+
+      # Troubleshooting KAFKA-17493.
+      - name: org.apache.kafka.consumer
+        level: DEBUG
+
+      - name: org.apache.kafka.coordinator.group
+        level: DEBUG

--- a/connect/runtime/bin/testFixtures/test-plugins/aliased-static-field/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/aliased-static-field/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.AliasedStaticField

--- a/connect/runtime/bin/testFixtures/test-plugins/always-throw-exception/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/always-throw-exception/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.AlwaysThrowException

--- a/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
+++ b/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.NoDefaultConstructorOverridePolicy

--- a/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.rest.ConnectRestExtension
+++ b/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.rest.ConnectRestExtension
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.StaticInitializerThrowsRestExtension

--- a/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,22 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.DefaultConstructorPrivateConnector
+test.plugins.DefaultConstructorThrowsConnector
+test.plugins.InnocuousSinkConnector
+test.plugins.NoDefaultConstructorConnector
+test.plugins.StaticInitializerThrowsConnector
+test.plugins.OuterClass$InnerClass
+test.plugins.VersionMethodThrowsConnector

--- a/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,20 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.CoLocatedPlugin
+test.plugins.DefaultConstructorThrowsConverter
+test.plugins.MissingSuperclassConverter
+test.plugins.NoDefaultConstructorConverter
+

--- a/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
+++ b/connect/runtime/bin/testFixtures/test-plugins/bad-packaging/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.DefaultConstructorThrowsConverter
+test.plugins.NoDefaultConstructorConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/classpath-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/classpath-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.converters.ByteArrayConverter
+

--- a/connect/runtime/bin/testFixtures/test-plugins/multiple-plugins-in-jar/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/multiple-plugins-in-jar/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.ThingOne
+test.plugins.ThingTwo

--- a/connect/runtime/bin/testFixtures/test-plugins/non-migrated/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
+++ b/connect/runtime/bin/testFixtures/test-plugins/non-migrated/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.NonMigratedMultiPlugin

--- a/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v1/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v1/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.ReadVersionFromResource

--- a/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v1/version
+++ b/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v1/version
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+1.0.0

--- a/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v2/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v2/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.ReadVersionFromResource

--- a/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v2/version
+++ b/connect/runtime/bin/testFixtures/test-plugins/read-version-from-resource-v2/version
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+2.0.0

--- a/connect/runtime/bin/testFixtures/test-plugins/sampling-config-provider/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/connect/runtime/bin/testFixtures/test-plugins/sampling-config-provider/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SamplingConfigProvider

--- a/connect/runtime/bin/testFixtures/test-plugins/sampling-configurable/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/sampling-configurable/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SamplingConfigurable

--- a/connect/runtime/bin/testFixtures/test-plugins/sampling-connector/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/bin/testFixtures/test-plugins/sampling-connector/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SamplingConnector

--- a/connect/runtime/bin/testFixtures/test-plugins/sampling-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/sampling-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SamplingConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/sampling-header-converter/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
+++ b/connect/runtime/bin/testFixtures/test-plugins/sampling-header-converter/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SamplingHeaderConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/service-loader/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/service-loader/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.ServiceLoaderPlugin

--- a/connect/runtime/bin/testFixtures/test-plugins/service-loader/META-INF/services/test.plugins.ServiceLoadedClass
+++ b/connect/runtime/bin/testFixtures/test-plugins/service-loader/META-INF/services/test.plugins.ServiceLoadedClass
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.ServiceLoadedSubclass

--- a/connect/runtime/bin/testFixtures/test-plugins/subclass-of-classpath/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
+++ b/connect/runtime/bin/testFixtures/test-plugins/subclass-of-classpath/META-INF/services/org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SubclassOfClasspathOverridePolicy

--- a/connect/runtime/bin/testFixtures/test-plugins/subclass-of-classpath/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/subclass-of-classpath/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.SubclassOfClasspathConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-converter/META-INF/services/org.apache.kafka.connect.storage.Converter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-header-converter/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-header-converter/META-INF/services/org.apache.kafka.connect.storage.HeaderConverter
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedHeaderConverter

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-predicate/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-predicate/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedPredicate

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-sink-connector/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-sink-connector/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedSinkConnector

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-source-connector/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-source-connector/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedSourceConnector

--- a/connect/runtime/bin/testFixtures/test-plugins/versioned-transformation/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/connect/runtime/bin/testFixtures/test-plugins/versioned-transformation/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,16 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+test.plugins.VersionedTransformation

--- a/connect/test-plugins/bin/main/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/connect/test-plugins/bin/main/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,17 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.tools.MockSinkConnector
+org.apache.kafka.connect.tools.VerifiableSinkConnector

--- a/connect/test-plugins/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/connect/test-plugins/bin/main/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,18 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.tools.MockSourceConnector
+org.apache.kafka.connect.tools.SchemaSourceConnector
+org.apache.kafka.connect.tools.VerifiableSourceConnector

--- a/connect/transforms/bin/main/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/connect/transforms/bin/main/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,41 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.transforms.Cast$Key
+org.apache.kafka.connect.transforms.Cast$Value
+org.apache.kafka.connect.transforms.DropHeaders
+org.apache.kafka.connect.transforms.ExtractField$Key
+org.apache.kafka.connect.transforms.ExtractField$Value
+org.apache.kafka.connect.transforms.Filter
+org.apache.kafka.connect.transforms.Flatten$Key
+org.apache.kafka.connect.transforms.Flatten$Value
+org.apache.kafka.connect.transforms.HeaderFrom$Key
+org.apache.kafka.connect.transforms.HeaderFrom$Value
+org.apache.kafka.connect.transforms.HoistField$Key
+org.apache.kafka.connect.transforms.HoistField$Value
+org.apache.kafka.connect.transforms.InsertField$Key
+org.apache.kafka.connect.transforms.InsertField$Value
+org.apache.kafka.connect.transforms.InsertHeader
+org.apache.kafka.connect.transforms.MaskField$Key
+org.apache.kafka.connect.transforms.MaskField$Value
+org.apache.kafka.connect.transforms.RegexRouter
+org.apache.kafka.connect.transforms.ReplaceField$Key
+org.apache.kafka.connect.transforms.ReplaceField$Value
+org.apache.kafka.connect.transforms.SetSchemaMetadata$Key
+org.apache.kafka.connect.transforms.SetSchemaMetadata$Value
+org.apache.kafka.connect.transforms.TimestampConverter$Key
+org.apache.kafka.connect.transforms.TimestampConverter$Value
+org.apache.kafka.connect.transforms.TimestampRouter
+org.apache.kafka.connect.transforms.ValueToKey

--- a/connect/transforms/bin/main/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
+++ b/connect/transforms/bin/main/META-INF/services/org.apache.kafka.connect.transforms.predicates.Predicate
@@ -1,0 +1,18 @@
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements. See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+org.apache.kafka.connect.transforms.predicates.HasHeaderKey
+org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
+org.apache.kafka.connect.transforms.predicates.TopicNameMatches

--- a/coordinator-common/bin/test/log4j2.yaml
+++ b/coordinator-common/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: WARN
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: WARN

--- a/server-common/bin/test/log4j2.yaml
+++ b/server-common/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: INFO

--- a/server/bin/test/log4j2.yaml
+++ b/server/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: WARN
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: WARN

--- a/server/bin/testFixtures/minikdc-krb5.conf
+++ b/server/bin/testFixtures/minikdc-krb5.conf
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[libdefaults]
+default_realm = {0}
+udp_preference_limit = 1
+default_tkt_enctypes=aes128-cts-hmac-sha1-96
+default_tgs_enctypes=aes128-cts-hmac-sha1-96
+
+[realms]
+{0} = '{'
+  kdc = {1}:{2}
+'}'

--- a/server/bin/testFixtures/minikdc.ldiff
+++ b/server/bin/testFixtures/minikdc.ldiff
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+dn: ou=users,dc=${0},dc=${1}
+objectClass: organizationalUnit
+objectClass: top
+ou: users
+
+dn: uid=krbtgt,ou=users,dc=${0},dc=${1}
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: KDC Service
+sn: Service
+uid: krbtgt
+userPassword: secret
+krb5PrincipalName: krbtgt/${2}.${3}@${2}.${3}
+krb5KeyVersionNumber: 0
+
+dn: uid=ldap,ou=users,dc=${0},dc=${1}
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: LDAP
+sn: Service
+uid: ldap
+userPassword: secret
+krb5PrincipalName: ldap/${4}@${2}.${3}
+krb5KeyVersionNumber: 0

--- a/share-coordinator/bin/main/common/message/ShareSnapshotKey.json
+++ b/share-coordinator/bin/main/common/message/ShareSnapshotKey.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "coordinator-key",
+  "name": "ShareSnapshotKey",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "0",
+      "about": "The group id." },
+    { "name": "TopicId", "type": "uuid", "versions": "0",
+      "about": "The topic id." },
+    { "name": "Partition", "type": "int32", "versions": "0",
+      "about": "The partition index." }
+  ]
+}
+

--- a/share-coordinator/bin/main/common/message/ShareSnapshotValue.json
+++ b/share-coordinator/bin/main/common/message/ShareSnapshotValue.json
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "coordinator-value",
+  "name": "ShareSnapshotValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "SnapshotEpoch", "type": "int32", "versions": "0+",
+      "about": "The snapshot epoch." },
+    { "name": "StateEpoch", "type": "int32", "versions": "0+",
+      "about": "The state epoch for this share-partition." },
+    { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+      "about": "The leader epoch of the share-partition." },
+    { "name": "StartOffset", "type": "int64", "versions": "0+",
+      "about": "The share-partition start offset." },
+    // DeliveryCompleteCount was added in Apache Kafka 4.2 (KIP-1226).
+    { "name": "DeliveryCompleteCount", "type": "int32", "versions": "0+", "taggedVersions": "0+", "tag": 0, "default": "-1",
+      "about": "The number of offsets greater than or equal to share-partition start offset for which delivery has been completed." },
+    { "name": "CreateTimestamp", "type": "int64", "versions": "0+",
+      "about": "The time at which the state was created." },
+    { "name": "WriteTimestamp", "type": "int64", "versions": "0+",
+      "about": "The time at which the state was written or rewritten." },
+    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+",
+      "about": "The state batches.", "fields": [
+      { "name": "FirstOffset", "type": "int64", "versions": "0+",
+        "about": "The first offset of this state batch." },
+      { "name": "LastOffset", "type": "int64", "versions": "0+",
+        "about": "The last offset of this state batch." },
+      { "name": "DeliveryState", "type": "int8", "versions": "0+",
+        "about": "The delivery state - 0:Available,2:Acked,4:Archived." },
+      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
+        "about": "The delivery count." }
+    ]}
+  ]
+}
+

--- a/share-coordinator/bin/main/common/message/ShareUpdateKey.json
+++ b/share-coordinator/bin/main/common/message/ShareUpdateKey.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "coordinator-key",
+  "name": "ShareUpdateKey",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "GroupId", "type": "string", "versions": "0",
+      "about": "The group id." },
+    { "name": "TopicId", "type": "uuid", "versions": "0",
+      "about": "The topic id." },
+    { "name": "Partition", "type": "int32", "versions": "0",
+      "about": "The partition index." }
+  ]
+}
+

--- a/share-coordinator/bin/main/common/message/ShareUpdateValue.json
+++ b/share-coordinator/bin/main/common/message/ShareUpdateValue.json
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "coordinator-value",
+  "name": "ShareUpdateValue",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "SnapshotEpoch", "type": "int32", "versions": "0+",
+      "about": "The snapshot epoch." },
+    { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+      "about": "The leader epoch of the share-partition." },
+    { "name": "StartOffset", "type": "int64", "versions": "0+",
+      "about": "The share-partition start offset, or -1 if the start offset is not being updated." },
+    // DeliveryCompleteCount was added in Apache Kafka 4.2 (KIP-1226).
+    { "name": "DeliveryCompleteCount", "type": "int32", "versions": "0+", "taggedVersions": "0+", "tag": 0, "default": "-1",
+      "about": "The number of offsets greater than or equal to share-partition start offset for which delivery has been completed." },
+    { "name": "StateBatches", "type": "[]StateBatch", "versions": "0+",
+      "about": "The state batches that have been updated.", "fields": [
+      { "name": "FirstOffset", "type": "int64", "versions": "0+",
+        "about": "The first offset of this state batch." },
+      { "name": "LastOffset", "type": "int64", "versions": "0+",
+        "about": "The last offset of this state batch." },
+      { "name": "DeliveryState", "type": "int8", "versions": "0+",
+        "about": "The delivery state - 0:Available,2:Acked,4:Archived." },
+      { "name": "DeliveryCount", "type": "int16", "versions": "0+",
+        "about": "The delivery count." }
+    ]}
+  ]
+}
+

--- a/share-coordinator/bin/test/log4j2.yaml
+++ b/share-coordinator/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: WARN
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: WARN

--- a/shell/bin/test/log4j2.yaml
+++ b/shell/bin/test/log4j2.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: DEBUG
+      AppenderRef:
+        - ref: STDOUT

--- a/storage/api/bin/test/log4j2.yaml
+++ b/storage/api/bin/test/log4j2.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: org.apache.kafka
+        level: WARN

--- a/storage/bin/main/message/ProducerSnapshot.json
+++ b/storage/bin/main/message/ProducerSnapshot.json
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "ProducerSnapshot",
+  "validVersions": "1",
+  "flexibleVersions":  "none",
+  "fields": [
+    {
+      "name": "Crc",
+      "type": "uint32",
+      "versions": "1",
+      "about": "CRC of the snapshot data"
+    },
+    {
+      "name": "ProducerEntries",
+      "type": "[]ProducerEntry",
+      "versions": "1",
+      "about": "The entries in the producer table",
+      "fields": [
+        {
+          "name": "ProducerId",
+          "type": "int64",
+          "versions": "1",
+          "about": "The producer ID"
+        },
+        {
+          "name": "Epoch",
+          "type": "int16",
+          "versions": "1",
+          "about": "Current epoch of the producer"
+        },
+        {
+          "name": "LastSequence",
+          "type": "int32",
+          "versions": "1",
+          "about": "Last written sequence of the producer"
+        },
+        {
+          "name": "LastOffset",
+          "type": "int64",
+          "versions": "1",
+          "about": "Last written offset of the producer"
+        },
+        {
+          "name": "OffsetDelta",
+          "type": "int32",
+          "versions": "1",
+          "about": "The difference of the last sequence and first sequence in the last written batch"
+        },
+        {
+          "name": "Timestamp",
+          "type": "int64",
+          "versions": "1",
+          "about": "Max timestamp from the last written entry"
+        },
+        {
+          "name": "CoordinatorEpoch",
+          "type": "int32",
+          "versions": "1",
+          "about": "The epoch of the last transaction coordinator to send an end transaction marker"
+        },
+        {
+          "name": "CurrentTxnFirstOffset",
+          "type": "int64",
+          "versions": "1",
+          "about": "The first offset of the on-going transaction (-1 if there is none)"
+        }
+      ]
+    }
+  ]
+}

--- a/storage/bin/main/message/RemoteLogSegmentMetadataRecord.json
+++ b/storage/bin/main/message/RemoteLogSegmentMetadataRecord.json
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "metadata",
+  "name": "RemoteLogSegmentMetadataRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    {
+      "name": "RemoteLogSegmentId",
+      "type": "RemoteLogSegmentIdEntry",
+      "versions": "0+",
+      "about": "Unique representation of the remote log segment.",
+      "fields": [
+        {
+          "name": "TopicIdPartition",
+          "type": "TopicIdPartitionEntry",
+          "versions": "0+",
+          "about": "Represents unique topic partition.",
+          "fields": [
+            {
+              "name": "Name",
+              "type": "string",
+              "versions": "0+",
+              "about": "Topic name."
+            },
+            {
+              "name": "Id",
+              "type": "uuid",
+              "versions": "0+",
+              "about": "Unique identifier of the topic."
+            },
+            {
+              "name": "Partition",
+              "type": "int32",
+              "versions": "0+",
+              "about": "Partition number."
+            }
+          ]
+        },
+        {
+          "name": "Id",
+          "type": "uuid",
+          "versions": "0+",
+          "about": "Unique identifier of the remote log segment."
+        }
+      ]
+    },
+    {
+      "name": "StartOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Start offset  of the segment."
+    },
+    {
+      "name": "EndOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "End offset  of the segment."
+    },
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker id from which this event is generated."
+    },
+    {
+      "name": "MaxTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Maximum timestamp in milliseconds with in this segment."
+    },
+    {
+      "name": "EventTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Epoch time in milliseconds at which this event is generated."
+    },
+    {
+      "name": "SegmentLeaderEpochs",
+      "type": "[]SegmentLeaderEpochEntry",
+      "versions": "0+",
+      "about": "Leader epoch to start-offset mappings for the records with in this segment.",
+      "fields": [
+        {
+          "name": "LeaderEpoch",
+          "type": "int32",
+          "versions": "0+",
+          "about": "Leader epoch"
+        },
+        {
+          "name": "Offset",
+          "type": "int64",
+          "versions": "0+",
+          "about": "Start offset for the leader epoch."
+        }
+      ]
+    },
+    {
+      "name": "SegmentSizeInBytes",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Segment size in bytes."
+    },
+    {
+      "name": "CustomMetadata",
+      "type": "bytes",
+      "default": "null",
+      "versions": "0+",
+      "nullableVersions": "0+",
+      "about": "Custom metadata."
+    },
+    {
+      "name": "RemoteLogSegmentState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "State identifier of the remote log segment, which is RemoteLogSegmentState.id()."
+    },
+    {
+      "name": "TxnIndexEmpty",
+      "type": "bool",
+      "versions": "0+",
+      "about": "Flag to indicate if the transaction index is empty.",
+      "taggedVersions": "0+",
+      "tag": 0
+    }
+  ]
+}

--- a/storage/bin/main/message/RemoteLogSegmentMetadataSnapshotRecord.json
+++ b/storage/bin/main/message/RemoteLogSegmentMetadataSnapshotRecord.json
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 3,
+  "type": "metadata",
+  "name": "RemoteLogSegmentMetadataSnapshotRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    {
+      "name": "SegmentId",
+      "type": "uuid",
+      "versions": "0+",
+      "about": "Unique identifier of the log segment"
+    },
+    {
+      "name": "StartOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Start offset  of the segment."
+    },
+    {
+      "name": "EndOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "End offset  of the segment."
+    },
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker (controller or leader) id from which this event is created or updated."
+    },
+    {
+      "name": "MaxTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Maximum timestamp with in this segment."
+    },
+    {
+      "name": "EventTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Event timestamp of this segment."
+    },
+    {
+      "name": "SegmentLeaderEpochs",
+      "type": "[]SegmentLeaderEpochEntry",
+      "versions": "0+",
+      "about": "Leader epochs of this segment.",
+      "fields": [
+        {
+          "name": "LeaderEpoch",
+          "type": "int32",
+          "versions": "0+",
+          "about": "Leader epoch"
+        },
+        {
+          "name": "Offset",
+          "type": "int64",
+          "versions": "0+",
+          "about": "Start offset for the leader epoch"
+        }
+      ]
+    },
+    {
+      "name": "SegmentSizeInBytes",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Segment size in bytes"
+    },
+    {
+      "name": "CustomMetadata",
+      "type": "bytes",
+      "default": "null",
+      "versions": "0+",
+      "nullableVersions": "0+",
+      "about": "Custom metadata."
+    },
+    {
+      "name": "RemoteLogSegmentState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "State of the remote log segment"
+    },
+    {
+      "name": "TxnIndexEmpty",
+      "type": "bool",
+      "versions": "0+",
+      "about": "Flag to indicate if the transaction index is empty.",
+      "taggedVersions": "0+",
+      "tag": 0
+    }
+  ]
+}

--- a/storage/bin/main/message/RemoteLogSegmentMetadataUpdateRecord.json
+++ b/storage/bin/main/message/RemoteLogSegmentMetadataUpdateRecord.json
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "metadata",
+  "name": "RemoteLogSegmentMetadataUpdateRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    {
+      "name": "RemoteLogSegmentId",
+      "type": "RemoteLogSegmentIdEntry",
+      "versions": "0+",
+      "about": "Unique representation of the remote log segment.",
+      "fields": [
+        {
+          "name": "TopicIdPartition",
+          "type": "TopicIdPartitionEntry",
+          "versions": "0+",
+          "about": "Represents unique topic partition.",
+          "fields": [
+            {
+              "name": "Name",
+              "type": "string",
+              "versions": "0+",
+              "about": "Topic name."
+            },
+            {
+              "name": "Id",
+              "type": "uuid",
+              "versions": "0+",
+              "about": "Unique identifier of the topic."
+            },
+            {
+              "name": "Partition",
+              "type": "int32",
+              "versions": "0+",
+              "about": "Partition number."
+            }
+          ]
+        },
+        {
+          "name": "Id",
+          "type": "uuid",
+          "versions": "0+",
+          "about": "Unique identifier of the remote log segment."
+        }
+      ]
+    },
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker id from which this event is generated."
+    },
+    {
+      "name": "EventTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Epoch time in milliseconds at which this event is generated."
+    },
+    {
+      "name": "CustomMetadata",
+      "type": "bytes",
+      "default": "null",
+      "versions": "0+",
+      "nullableVersions": "0+",
+      "about": "Custom metadata."
+    },
+    {
+      "name": "RemoteLogSegmentState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "State identifier of the remote log segment, which is RemoteLogSegmentState.id()."
+    }
+  ]
+}

--- a/storage/bin/main/message/RemotePartitionDeleteMetadataRecord.json
+++ b/storage/bin/main/message/RemotePartitionDeleteMetadataRecord.json
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 2,
+  "type": "metadata",
+  "name": "RemotePartitionDeleteMetadataRecord",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    {
+      "name": "TopicIdPartition",
+      "type": "TopicIdPartitionEntry",
+      "versions": "0+",
+      "about": "Represents unique topic partition.",
+      "fields": [
+        {
+          "name": "Name",
+          "type": "string",
+          "versions": "0+",
+          "about": "Topic name."
+        },
+        {
+          "name": "Id",
+          "type": "uuid",
+          "versions": "0+",
+          "about": "Unique identifier of the topic."
+        },
+        {
+          "name": "Partition",
+          "type": "int32",
+          "versions": "0+",
+          "about": "Partition number."
+        }
+      ]
+    },
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker (controller or leader) id from which this event is created. DELETE_PARTITION_MARKED is sent by the controller. DELETE_PARTITION_STARTED and DELETE_PARTITION_FINISHED are sent by remote log metadata topic partition leader."
+    },
+    {
+      "name": "EventTimestampMs",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Epoch time in milliseconds at which this event is generated."
+    },
+    {
+      "name": "RemotePartitionDeleteState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "Deletion state identifier of the remote partition, which is RemotePartitionDeleteState.id()."
+    }
+  ]
+}

--- a/storage/bin/test/log4j2.yaml
+++ b/storage/bin/test/log4j2.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+      - name: "fileLogPattern"
+        value: "%d [%t] %-5p %c %x - %m%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+    RollingFile:
+      - name: FileAppender
+        fileName: build/kafka-storage-test/storage.log
+        filePattern: "build/kafka-storage-test/storage-%d{yyyy-MM-dd}.log"
+        PatternLayout:
+          pattern: "${fileLogPattern}"
+        TimeBasedTriggeringPolicy:
+          interval: 1
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka.server.log.remote.storage
+        level: INFO
+        AppenderRef:
+          - ref: FileAppender
+
+      - name: org.apache.kafka.server.log.remote.metadata.storage
+        level: INFO
+        AppenderRef:
+          - ref: FileAppender
+
+      - name: kafka.log.remote
+        level: INFO
+        AppenderRef:
+          - ref: FileAppender

--- a/storage/bin/test/org/apache/kafka/tiered/storage/README.md
+++ b/storage/bin/test/org/apache/kafka/tiered/storage/README.md
@@ -1,0 +1,11 @@
+# The Test Flow
+
+Step 1: Each test is a standalone class. It declares a `clusterConfig()` method that returns a `List<ClusterConfig>` with tiered storage enabled (via `TieredStorageTestUtils.createServerPropsForRemoteStorage`), and test methods annotated with `@ClusterTemplate("clusterConfig")` that receive a `ClusterInstance` provided by the test framework.
+
+Step 2: The test is written as a specification consisting of sequential actions and assertions. The spec for the complete test is built first using `TieredStorageTestBuilder`, which creates the "actions" to be executed.
+
+Step 3: A `TieredStorageTestContext` is created from the `ClusterInstance` (plus any extra consumer config). The test is then executed by running each action of the spec sequentially against the context.
+
+Step 4: The test execution stops when any of the actions throws an exception (or an assertion error).
+
+Step 5: Clean-up for the test is performed on test exit — the `TieredStorageTestContext` is closed (it is `AutoCloseable`, typically via try-with-resources) and the test report is printed.

--- a/streams/integration-tests/bin/test/log4j2.yaml
+++ b/streams/integration-tests/bin/test/log4j2.yaml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: ERROR
+
+      - name: state.change.logger
+        level: ERROR
+
+      - name: org.apache.kafka
+        level: ERROR
+
+      - name: org.apache.kafka.clients
+        level: ERROR
+
+      - name: org.apache.kafka.clients.consumer
+        level: INFO
+
+      - name: org.apache.kafka.clients.producer
+        level: INFO
+
+      - name: org.apache.kafka.streams
+        level: INFO
+
+      - name: org.apache.kafka.coordinator.group
+        level: INFO
+
+      - name: org.apache.kafka.clients.producer.ProducerConfig
+        level: ERROR
+
+      - name: org.apache.kafka.clients.consumer.ConsumerConfig
+        level: ERROR
+
+      - name: org.apache.kafka.clients.admin.AdminClientConfig
+        level: ERROR
+
+      - name: org.apache.kafka.streams.StreamsConfig
+        level: ERROR

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/FunctionsCompatConversions.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/FunctionsCompatConversions.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.kstream._
+import scala.jdk.CollectionConverters._
+import java.lang.{Iterable => JIterable}
+
+import org.apache.kafka.streams.processor.ProcessorContext
+
+/**
+ * Implicit classes that offer conversions of Scala function literals to SAM (Single Abstract Method) objects in Java.
+ * These make the Scala APIs much more expressive, with less boilerplate and more succinct.
+ */
+private[scala] object FunctionsCompatConversions {
+
+  implicit class ForeachActionFromFunction[K, V](val p: (K, V) => Unit) extends AnyVal {
+    def asForeachAction: ForeachAction[K, V] = (key: K, value: V) => p(key, value)
+  }
+
+  implicit class PredicateFromFunction[K, V](val p: (K, V) => Boolean) extends AnyVal {
+    def asPredicate: Predicate[K, V] = (key: K, value: V) => p(key, value)
+  }
+
+  implicit class MapperFromFunction[T, U, VR](val f: (T, U) => VR) extends AnyVal {
+    def asKeyValueMapper: KeyValueMapper[T, U, VR] = (key: T, value: U) => f(key, value)
+    def asValueJoiner: ValueJoiner[T, U, VR] = (value1: T, value2: U) => f(value1, value2)
+  }
+
+  implicit class KeyValueMapperFromFunction[K, V, KR, VR](val f: (K, V) => (KR, VR)) extends AnyVal {
+    def asKeyValueMapper: KeyValueMapper[K, V, KeyValue[KR, VR]] = (key: K, value: V) => {
+      val (kr, vr) = f(key, value)
+      KeyValue.pair(kr, vr)
+    }
+  }
+
+  implicit class FunctionFromFunction[V, VR](val f: V => VR) extends AnyVal {
+    def asJavaFunction: java.util.function.Function[V, VR] = (value: V) => f(value)
+  }
+
+  implicit class ValueMapperFromFunction[V, VR](val f: V => VR) extends AnyVal {
+    def asValueMapper: ValueMapper[V, VR] = (value: V) => f(value)
+  }
+
+  implicit class FlatValueMapperFromFunction[V, VR](val f: V => Iterable[VR]) extends AnyVal {
+    def asValueMapper: ValueMapper[V, JIterable[VR]] = (value: V) => f(value).asJava
+  }
+
+  implicit class ValueMapperWithKeyFromFunction[K, V, VR](val f: (K, V) => VR) extends AnyVal {
+    def asValueMapperWithKey: ValueMapperWithKey[K, V, VR] = (readOnlyKey: K, value: V) => f(readOnlyKey, value)
+  }
+
+  implicit class FlatValueMapperWithKeyFromFunction[K, V, VR](val f: (K, V) => Iterable[VR]) extends AnyVal {
+    def asValueMapperWithKey: ValueMapperWithKey[K, V, JIterable[VR]] =
+      (readOnlyKey: K, value: V) => f(readOnlyKey, value).asJava
+  }
+
+  implicit class AggregatorFromFunction[K, V, VA](val f: (K, V, VA) => VA) extends AnyVal {
+    def asAggregator: Aggregator[K, V, VA] = (key: K, value: V, aggregate: VA) => f(key, value, aggregate)
+  }
+
+  implicit class MergerFromFunction[K, VR](val f: (K, VR, VR) => VR) extends AnyVal {
+    def asMerger: Merger[K, VR] = (aggKey: K, aggOne: VR, aggTwo: VR) => f(aggKey, aggOne, aggTwo)
+  }
+
+  implicit class ReducerFromFunction[V](val f: (V, V) => V) extends AnyVal {
+    def asReducer: Reducer[V] = (value1: V, value2: V) => f(value1, value2)
+  }
+
+  implicit class InitializerFromFunction[VA](val f: () => VA) extends AnyVal {
+    def asInitializer: Initializer[VA] = () => f()
+  }
+
+  @deprecated(
+    since = "4.0.0"
+  )
+  implicit class TransformerSupplierFromFunction[K, V, VO](val f: () => Transformer[K, V, VO]) extends AnyVal {
+    def asTransformerSupplier: TransformerSupplier[K, V, VO] = () => f()
+  }
+
+  @deprecated(
+    since = "4.0.0"
+  )
+  implicit class TransformerSupplierAsJava[K, V, VO](val supplier: TransformerSupplier[K, V, Iterable[VO]])
+      extends AnyVal {
+    def asJava: TransformerSupplier[K, V, JIterable[VO]] = () => {
+      val innerTransformer = supplier.get()
+      new Transformer[K, V, JIterable[VO]] {
+        override def transform(key: K, value: V): JIterable[VO] = innerTransformer.transform(key, value).asJava
+        override def init(context: ProcessorContext): Unit = innerTransformer.init(context)
+        override def close(): Unit = innerTransformer.close()
+      }
+    }
+  }
+
+  @deprecated(
+    since = "4.0.0"
+  )
+  implicit class ValueTransformerSupplierAsJava[V, VO](val supplier: ValueTransformerSupplier[V, Iterable[VO]])
+      extends AnyVal {
+    def asJava: ValueTransformerSupplier[V, JIterable[VO]] = () => {
+      val innerTransformer = supplier.get()
+      new ValueTransformer[V, JIterable[VO]] {
+        override def transform(value: V): JIterable[VO] = innerTransformer.transform(value).asJava
+        override def init(context: ProcessorContext): Unit = innerTransformer.init(context)
+        override def close(): Unit = innerTransformer.close()
+      }
+    }
+  }
+
+  @deprecated(
+    since = "4.0.0"
+  )
+  implicit class ValueTransformerSupplierWithKeyAsJava[K, V, VO](
+    val supplier: ValueTransformerWithKeySupplier[K, V, Iterable[VO]]
+  ) extends AnyVal {
+    def asJava: ValueTransformerWithKeySupplier[K, V, JIterable[VO]] = () => {
+      val innerTransformer = supplier.get()
+      new ValueTransformerWithKey[K, V, JIterable[VO]] {
+        override def transform(key: K, value: V): JIterable[VO] = innerTransformer.transform(key, value).asJava
+        override def init(context: ProcessorContext): Unit = innerTransformer.init(context)
+        override def close(): Unit = innerTransformer.close()
+      }
+    }
+  }
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/ImplicitConversions.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/ImplicitConversions.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.kstream.{
+  CogroupedKStream => CogroupedKStreamJ,
+  KGroupedStream => KGroupedStreamJ,
+  KGroupedTable => KGroupedTableJ,
+  KStream => KStreamJ,
+  KTable => KTableJ,
+  SessionWindowedCogroupedKStream => SessionWindowedCogroupedKStreamJ,
+  SessionWindowedKStream => SessionWindowedKStreamJ,
+  TimeWindowedCogroupedKStream => TimeWindowedCogroupedKStreamJ,
+  TimeWindowedKStream => TimeWindowedKStreamJ
+}
+import org.apache.kafka.streams.processor.StateStore
+import org.apache.kafka.streams.scala.kstream._
+
+/**
+ * Implicit conversions between the Scala wrapper objects and the underlying Java objects.
+ */
+object ImplicitConversions {
+
+  implicit def wrapKStream[K, V](inner: KStreamJ[K, V]): KStream[K, V] =
+    new KStream[K, V](inner)
+
+  implicit def wrapKGroupedStream[K, V](inner: KGroupedStreamJ[K, V]): KGroupedStream[K, V] =
+    new KGroupedStream[K, V](inner)
+
+  implicit def wrapTimeWindowedKStream[K, V](inner: TimeWindowedKStreamJ[K, V]): TimeWindowedKStream[K, V] =
+    new TimeWindowedKStream[K, V](inner)
+
+  implicit def wrapSessionWindowedKStream[K, V](inner: SessionWindowedKStreamJ[K, V]): SessionWindowedKStream[K, V] =
+    new SessionWindowedKStream[K, V](inner)
+
+  implicit def wrapCogroupedKStream[K, V](inner: CogroupedKStreamJ[K, V]): CogroupedKStream[K, V] =
+    new CogroupedKStream[K, V](inner)
+
+  implicit def wrapTimeWindowedCogroupedKStream[K, V](
+    inner: TimeWindowedCogroupedKStreamJ[K, V]
+  ): TimeWindowedCogroupedKStream[K, V] =
+    new TimeWindowedCogroupedKStream[K, V](inner)
+
+  implicit def wrapSessionWindowedCogroupedKStream[K, V](
+    inner: SessionWindowedCogroupedKStreamJ[K, V]
+  ): SessionWindowedCogroupedKStream[K, V] =
+    new SessionWindowedCogroupedKStream[K, V](inner)
+
+  implicit def wrapKTable[K, V](inner: KTableJ[K, V]): KTable[K, V] =
+    new KTable[K, V](inner)
+
+  implicit def wrapKGroupedTable[K, V](inner: KGroupedTableJ[K, V]): KGroupedTable[K, V] =
+    new KGroupedTable[K, V](inner)
+
+  implicit def tuple2ToKeyValue[K, V](tuple: (K, V)): KeyValue[K, V] = new KeyValue(tuple._1, tuple._2)
+
+  // we would also like to allow users implicit serdes
+  // and these implicits will convert them to `Grouped`, `Produced` or `Consumed`
+
+  implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] =
+    Consumed.`with`[K, V]
+
+  implicit def groupedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Grouped[K, V] =
+    Grouped.`with`[K, V]
+
+  implicit def joinedFromKeyValueOtherSerde[K, V, VO](implicit
+    keySerde: Serde[K],
+    valueSerde: Serde[V],
+    otherValueSerde: Serde[VO]
+  ): Joined[K, V, VO] =
+    Joined.`with`[K, V, VO]
+
+  implicit def materializedFromSerde[K, V, S <: StateStore](implicit
+    keySerde: Serde[K],
+    valueSerde: Serde[V]
+  ): Materialized[K, V, S] =
+    Materialized.`with`[K, V, S]
+
+  implicit def producedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Produced[K, V] =
+    Produced.`with`[K, V]
+
+  implicit def repartitionedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Repartitioned[K, V] =
+    Repartitioned.`with`[K, V]
+
+  implicit def streamJoinFromKeyValueOtherSerde[K, V, VO](implicit
+    keySerde: Serde[K],
+    valueSerde: Serde[V],
+    otherValueSerde: Serde[VO]
+  ): StreamJoined[K, V, VO] =
+    StreamJoined.`with`[K, V, VO]
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/StreamsBuilder.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/StreamsBuilder.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import java.util.Properties
+import java.util.regex.Pattern
+
+import org.apache.kafka.streams.kstream.GlobalKTable
+import org.apache.kafka.streams.processor.StateStore
+import org.apache.kafka.streams.state.StoreBuilder
+import org.apache.kafka.streams.{StreamsBuilder => StreamsBuilderJ, Topology}
+import org.apache.kafka.streams.scala.kstream.{Consumed, KStream, KTable, Materialized}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Wraps the Java class StreamsBuilder and delegates method calls to the underlying Java object.
+ */
+@deprecated("Use `org.apache.kafka.streams.StreamsBuilder` instead", "4.3.0")
+class StreamsBuilder(inner: StreamsBuilderJ = new StreamsBuilderJ) {
+
+  /**
+   * Create a [[kstream.KStream]] from the specified topic.
+   * <p>
+   * The `implicit Consumed` instance provides the values of `auto.offset.reset` strategy, `TimestampExtractor`,
+   * key and value deserializers etc. If the implicit is not found in scope, compiler error will result.
+   * <p>
+   * A convenient alternative is to have the necessary implicit serdes in scope, which will be implicitly
+   * converted to generate an instance of `Consumed`. @see [[ImplicitConversions]].
+   * {{{
+   * // Brings all implicit conversions in scope
+   * import ImplicitConversions._
+   *
+   * // Bring implicit default serdes in scope
+   * import Serdes._
+   *
+   * val builder = new StreamsBuilder()
+   *
+   * // stream function gets the implicit Consumed which is constructed automatically
+   * // from the serdes through the implicits in ImplicitConversions#consumedFromSerde
+   * val userClicksStream: KStream[String, Long] = builder.stream(userClicksTopic)
+   * }}}
+   *
+   * @param topic the topic name
+   * @return a [[kstream.KStream]] for the specified topic
+   */
+  def stream[K, V](topic: String)(implicit consumed: Consumed[K, V]): KStream[K, V] =
+    new KStream(inner.stream[K, V](topic, consumed))
+
+  /**
+   * Create a [[kstream.KStream]] from the specified topics.
+   *
+   * @param topics the topic names
+   * @return a [[kstream.KStream]] for the specified topics
+   * @see #stream(String)
+   * @see `org.apache.kafka.streams.StreamsBuilder#stream`
+   */
+  def stream[K, V](topics: Set[String])(implicit consumed: Consumed[K, V]): KStream[K, V] =
+    new KStream(inner.stream[K, V](topics.asJava, consumed))
+
+  /**
+   * Create a [[kstream.KStream]] from the specified topic pattern.
+   *
+   * @param topicPattern the topic name pattern
+   * @return a [[kstream.KStream]] for the specified topics
+   * @see #stream(String)
+   * @see `org.apache.kafka.streams.StreamsBuilder#stream`
+   */
+  def stream[K, V](topicPattern: Pattern)(implicit consumed: Consumed[K, V]): KStream[K, V] =
+    new KStream(inner.stream[K, V](topicPattern, consumed))
+
+  /**
+   * Create a [[kstream.KTable]] from the specified topic.
+   * <p>
+   * The `implicit Consumed` instance provides the values of `auto.offset.reset` strategy, `TimestampExtractor`,
+   * key and value deserializers etc. If the implicit is not found in scope, compiler error will result.
+   * <p>
+   * A convenient alternative is to have the necessary implicit serdes in scope, which will be implicitly
+   * converted to generate an instance of `Consumed`. @see [[ImplicitConversions]].
+   * {{{
+   * // Brings all implicit conversions in scope
+   * import ImplicitConversions._
+   *
+   * // Bring implicit default serdes in scope
+   * import Serdes._
+   *
+   * val builder = new StreamsBuilder()
+   *
+   * // stream function gets the implicit Consumed which is constructed automatically
+   * // from the serdes through the implicits in ImplicitConversions#consumedFromSerde
+   * val userClicksStream: KTable[String, Long] = builder.table(userClicksTopic)
+   * }}}
+   *
+   * @param topic the topic name
+   * @return a [[kstream.KTable]] for the specified topic
+   * @see `org.apache.kafka.streams.StreamsBuilder#table`
+   */
+  def table[K, V](topic: String)(implicit consumed: Consumed[K, V]): KTable[K, V] =
+    new KTable(inner.table[K, V](topic, consumed))
+
+  /**
+   * Create a [[kstream.KTable]] from the specified topic.
+   *
+   * @param topic the topic name
+   * @param materialized  the instance of `Materialized` used to materialize a state store
+   * @return a [[kstream.KTable]] for the specified topic
+   * @see #table(String)
+   * @see `org.apache.kafka.streams.StreamsBuilder#table`
+   */
+  def table[K, V](topic: String, materialized: Materialized[K, V, ByteArrayKeyValueStore])(implicit
+    consumed: Consumed[K, V]
+  ): KTable[K, V] =
+    new KTable(inner.table[K, V](topic, consumed, materialized))
+
+  /**
+   * Create a `GlobalKTable` from the specified topic. The serializers from the implicit `Consumed`
+   * instance will be used. Input records with `null` key will be dropped.
+   *
+   * @param topic the topic name
+   * @return a `GlobalKTable` for the specified topic
+   * @see `org.apache.kafka.streams.StreamsBuilder#globalTable`
+   */
+  def globalTable[K, V](topic: String)(implicit consumed: Consumed[K, V]): GlobalKTable[K, V] =
+    inner.globalTable(topic, consumed)
+
+  /**
+   * Create a `GlobalKTable` from the specified topic. The resulting `GlobalKTable` will be materialized
+   * in a local `KeyValueStore` configured with the provided instance of `Materialized`. The serializers
+   * from the implicit `Consumed` instance will be used.
+   *
+   * @param topic the topic name
+   * @param materialized  the instance of `Materialized` used to materialize a state store
+   * @return a `GlobalKTable` for the specified topic
+   * @see `org.apache.kafka.streams.StreamsBuilder#globalTable`
+   */
+  def globalTable[K, V](topic: String, materialized: Materialized[K, V, ByteArrayKeyValueStore])(implicit
+    consumed: Consumed[K, V]
+  ): GlobalKTable[K, V] =
+    inner.globalTable(topic, consumed, materialized)
+
+  /**
+   * Adds a state store to the underlying `Topology`. The store must still be "connected" to a `Processor`,
+   * `Transformer`, or `ValueTransformer` before it can be used.
+   * <p>
+   * It is required to connect state stores to `Processor`, `Transformer`, or `ValueTransformer` before they can be used.
+   *
+   * @param builder the builder used to obtain this state store `StateStore` instance
+   * @return the underlying Java abstraction `StreamsBuilder` after adding the `StateStore`
+   * @throws org.apache.kafka.streams.errors.TopologyException if state store supplier is already added
+   * @see `org.apache.kafka.streams.StreamsBuilder#addStateStore`
+   */
+  def addStateStore(builder: StoreBuilder[_ <: StateStore]): StreamsBuilderJ = inner.addStateStore(builder)
+
+  /**
+   * Adds a global `StateStore` to the topology. Global stores should not be added to `Processor`, `Transformer`,
+   * or `ValueTransformer` (in contrast to regular stores).
+   * <p>
+   * It is not required to connect a global store to `Processor`, `Transformer`, or `ValueTransformer`;
+   * those have read-only access to all global stores by default.
+   *
+   * @see `org.apache.kafka.streams.StreamsBuilder#addGlobalStore`
+   */
+  def addGlobalStore[K, V](
+    storeBuilder: StoreBuilder[_ <: StateStore],
+    topic: String,
+    consumed: Consumed[K, V],
+    stateUpdateSupplier: org.apache.kafka.streams.processor.api.ProcessorSupplier[K, V, Void, Void]
+  ): StreamsBuilderJ =
+    inner.addGlobalStore(storeBuilder, topic, consumed, stateUpdateSupplier)
+
+  def build(): Topology = inner.build()
+
+  /**
+   * Returns the `Topology` that represents the specified processing logic and accepts
+   * a `Properties` instance used to indicate whether to optimize topology or not.
+   *
+   * @param props the `Properties` used for building possibly optimized topology
+   * @return the `Topology` that represents the specified processing logic
+   * @see `org.apache.kafka.streams.StreamsBuilder#build`
+   */
+  def build(props: Properties): Topology = inner.build(props)
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Branched.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Branched.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.{Branched => BranchedJ, KStream => KStreamJ}
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Branched` instead", "4.3.0")
+object Branched {
+
+  /**
+   * Create an instance of `Branched` with provided branch name suffix.
+   *
+   * @param name the branch name suffix to be used (see [[BranchedKStream]] description for details)
+   * @tparam K key type
+   * @tparam V value type
+   * @return a new instance of `Branched`
+   */
+  def as[K, V](name: String): BranchedJ[K, V] =
+    BranchedJ.as[K, V](name)
+
+  /**
+   * Create an instance of `Branched` with provided chain function and branch name suffix.
+   *
+   * @param chain A function that will be applied to the branch. If the provided function returns
+   *              `null`, its result is ignored, otherwise it is added to the Map returned
+   *              by [[BranchedKStream.defaultBranch()*]] or [[BranchedKStream.noDefaultBranch]] (see
+   *              [[BranchedKStream]] description for details).
+   * @param name  the branch name suffix to be used. If `null`, a default branch name suffix will be generated
+   *              (see [[BranchedKStream]] description for details)
+   * @tparam K key type
+   * @tparam V value type
+   * @return a new instance of `Branched`
+   * @see `org.apache.kafka.streams.kstream.Branched#withFunction(java.util.function.Function, java.lang.String)`
+   */
+  def withFunction[K, V](chain: KStream[K, V] => KStream[K, V], name: String = null): BranchedJ[K, V] =
+    BranchedJ.withFunction((f: KStreamJ[K, V]) => chain.apply(new KStream[K, V](f)).inner, name)
+
+  /**
+   * Create an instance of `Branched` with provided chain consumer and branch name suffix.
+   *
+   * @param chain A consumer to which the branch will be sent. If a non-null consumer is provided here,
+   *              the respective branch will not be added to the resulting Map returned
+   *              by [[BranchedKStream.defaultBranch()*]] or [[BranchedKStream.noDefaultBranch]] (see
+   *              [[BranchedKStream]] description for details).
+   * @param name  the branch name suffix to be used. If `null`, a default branch name suffix will be generated
+   *              (see [[BranchedKStream]] description for details)
+   * @tparam K key type
+   * @tparam V value type
+   * @return a new instance of `Branched`
+   * @see `org.apache.kafka.streams.kstream.Branched#withConsumer(java.util.function.Consumer, java.lang.String)`
+   */
+  def withConsumer[K, V](chain: KStream[K, V] => Unit, name: String = null): BranchedJ[K, V] =
+    BranchedJ.withConsumer((c: KStreamJ[K, V]) => chain.apply(new KStream[K, V](c)), name)
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/BranchedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/BranchedKStream.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import java.util
+
+import org.apache.kafka.streams.kstream
+import org.apache.kafka.streams.kstream.{BranchedKStream => BranchedKStreamJ}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.PredicateFromFunction
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Branches the records in the original stream based on the predicates supplied for the branch definitions.
+ * <p>
+ * Branches are defined with [[branch]] or [[defaultBranch()*]]
+ * methods. Each record is evaluated against the predicates
+ * supplied via [[Branched]] parameters, and is routed to the first branch for which its respective predicate
+ * evaluates to `true`. If a record does not match any predicates, it will be routed to the default branch,
+ * or dropped if no default branch is created.
+ * <p>
+ *
+ * Each branch (which is a [[KStream]] instance) then can be processed either by
+ * a function or a consumer provided via a [[Branched]]
+ * parameter. If certain conditions are met, it also can be accessed from the `Map` returned by
+ * an optional [[defaultBranch()*]] or [[noDefaultBranch]] method call.
+ * <p>
+ * The branching happens on a first match basis: A record in the original stream is assigned to the corresponding result
+ * stream for the first predicate that evaluates to true, and is assigned to this stream only. If you need
+ * to route a record to multiple streams, you can apply multiple
+ * [[KStream.filter]] operators to the same [[KStream]]
+ * instance, one for each predicate, instead of branching.
+ * <p>
+ * The process of routing the records to different branches is a stateless record-by-record operation.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.BranchedKStream` instead", "4.3.0")
+class BranchedKStream[K, V](val inner: BranchedKStreamJ[K, V]) {
+
+  /**
+   * Define a branch for records that match the predicate.
+   *
+   * @param predicate A predicate against which each record will be evaluated.
+   *                  If this predicate returns `true` for a given record, the record will be
+   *                  routed to the current branch and will not be evaluated against the predicates
+   *                  for the remaining branches.
+   * @return `this` to facilitate method chaining
+   */
+  def branch(predicate: (K, V) => Boolean): BranchedKStream[K, V] = {
+    inner.branch(predicate.asPredicate)
+    this
+  }
+
+  /**
+   * Define a branch for records that match the predicate.
+   *
+   * @param predicate A predicate against which each record will be evaluated.
+   *                  If this predicate returns `true` for a given record, the record will be
+   *                  routed to the current branch and will not be evaluated against the predicates
+   *                  for the remaining branches.
+   * @param branched  A [[Branched]] parameter, that allows to define a branch name, an in-place
+   *                  branch consumer or branch mapper (see <a href="#examples">code examples</a>
+   *                  for [[BranchedKStream]])
+   * @return `this` to facilitate method chaining
+   */
+  def branch(predicate: (K, V) => Boolean, branched: Branched[K, V]): BranchedKStream[K, V] = {
+    inner.branch(predicate.asPredicate, branched)
+    this
+  }
+
+  /**
+   * Finalize the construction of branches and defines the default branch for the messages not intercepted
+   * by other branches. Calling [[defaultBranch()*]] or [[noDefaultBranch]] is optional.
+   *
+   * @return Map of named branches. For rules of forming the resulting map, see [[BranchedKStream]]
+   *         description.
+   */
+  def defaultBranch(): Map[String, KStream[K, V]] = toScalaMap(inner.defaultBranch())
+
+  /**
+   * Finalize the construction of branches and defines the default branch for the messages not intercepted
+   * by other branches. Calling [[defaultBranch()*]] or [[noDefaultBranch]] is optional.
+   *
+   * @param branched A [[Branched]] parameter, that allows to define a branch name, an in-place
+   *                 branch consumer or branch mapper for [[BranchedKStream]].
+   * @return Map of named branches. For rules of forming the resulting map, see [[BranchedKStream]]
+   *         description.
+   */
+  def defaultBranch(branched: Branched[K, V]): Map[String, KStream[K, V]] = toScalaMap(inner.defaultBranch(branched))
+
+  /**
+   * Finalizes the construction of branches without forming a default branch.
+   *
+   * @return Map of named branches. For rules of forming the resulting map, see [[BranchedKStream]]
+   *         description.
+   */
+  def noDefaultBranch(): Map[String, KStream[K, V]] = toScalaMap(inner.noDefaultBranch())
+
+  private def toScalaMap(m: util.Map[String, kstream.KStream[K, V]]): collection.immutable.Map[String, KStream[K, V]] =
+    m.asScala.map { case (name, kStreamJ) =>
+      (name, new KStream(kStreamJ))
+    }.toMap
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.{
+  CogroupedKStream => CogroupedKStreamJ,
+  SessionWindows,
+  SlidingWindows,
+  Window,
+  Windows
+}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction}
+
+/**
+ * Wraps the Java class CogroupedKStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam KIn  Type of keys
+ * @tparam VOut Type of values
+ * @param inner The underlying Java abstraction for CogroupedKStream
+ * @see `org.apache.kafka.streams.kstream.CogroupedKStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.CogroupedKStream` instead", "4.3.0")
+class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
+
+  /**
+   * Add an already [[KGroupedStream]] to this [[CogroupedKStream]].
+   *
+   * @param groupedStream a group stream
+   * @param aggregator    a function that computes a new aggregate result
+   * @return a [[CogroupedKStream]]
+   */
+  def cogroup[VIn](
+    groupedStream: KGroupedStream[KIn, VIn],
+    aggregator: (KIn, VIn, VOut) => VOut
+  ): CogroupedKStream[KIn, VOut] =
+    new CogroupedKStream(inner.cogroup(groupedStream.inner, aggregator.asAggregator))
+
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result.
+   *                     Cannot be { @code null}.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   *                     Cannot be { @code null}.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => VOut)(implicit
+    materialized: Materialized[KIn, VOut, ByteArrayKeyValueStore]
+  ): KTable[KIn, VOut] = new KTable(inner.aggregate((() => initializer).asInitializer, materialized))
+
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result.
+   *                     Cannot be { @code null}.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   *                     Cannot be { @code null}.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => VOut, named: Named)(implicit
+    materialized: Materialized[KIn, VOut, ByteArrayKeyValueStore]
+  ): KTable[KIn, VOut] = new KTable(inner.aggregate((() => initializer).asInitializer, named, materialized))
+
+  /**
+   * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `Windows`
+   * @return an instance of [[TimeWindowedCogroupedKStream]]
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#windowedBy`
+   */
+  def windowedBy[W <: Window](windows: Windows[W]): TimeWindowedCogroupedKStream[KIn, VOut] =
+    new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform sliding windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SlidingWindows`
+   * @return an instance of [[TimeWindowedCogroupedKStream]]
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#windowedBy`
+   */
+  def windowedBy(windows: SlidingWindows): TimeWindowedCogroupedKStream[KIn, VOut] =
+    new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[SessionWindowedKStream]] instance that can be used to perform session windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SessionWindows`
+   * @return an instance of [[SessionWindowedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
+   */
+  def windowedBy(windows: SessionWindows): SessionWindowedCogroupedKStream[KIn, VOut] =
+    new SessionWindowedCogroupedKStream(inner.windowedBy(windows))
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Consumed.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Consumed.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Consumed => ConsumedJ}
+import org.apache.kafka.streams.{AutoOffsetReset, Topology}
+import org.apache.kafka.streams.processor.TimestampExtractor
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Consumed` instead", "4.3.0")
+object Consumed {
+
+  /**
+   * Create an instance of [[Consumed]] with the supplied arguments. `null` values are acceptable.
+   *
+   * @tparam K                 key type
+   * @tparam V                 value type
+   * @param timestampExtractor the timestamp extractor to used. If `null` the default timestamp extractor from
+   *                           config will be used
+   * @param resetPolicy        the offset reset policy to be used. If `null` the default reset policy from config
+   *                           will be used
+   * @param keySerde           the key serde to use.
+   * @param valueSerde         the value serde to use.
+   * @return a new instance of [[Consumed]]
+   */
+  @deprecated("Use `with` method that accepts `AutoOffsetReset` instead", "4.0.0")
+  def `with`[K, V](
+    timestampExtractor: TimestampExtractor,
+    resetPolicy: Topology.AutoOffsetReset
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(keySerde, valueSerde, timestampExtractor, resetPolicy)
+
+  /**
+   * Create an instance of [[Consumed]] with the supplied arguments. `null` values are acceptable.
+   *
+   * @tparam K                 key type
+   * @tparam V                 value type
+   * @param timestampExtractor the timestamp extractor to used. If `null` the default timestamp extractor from
+   *                           config will be used
+   * @param resetPolicy        the offset reset policy to be used. If `null` the default reset policy from config
+   *                           will be used
+   * @param keySerde           the key serde to use.
+   * @param valueSerde         the value serde to use.
+   * @return a new instance of [[Consumed]]
+   */
+  def `with`[K, V](
+    timestampExtractor: TimestampExtractor,
+    resetPolicy: AutoOffsetReset
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(keySerde, valueSerde, timestampExtractor, resetPolicy)
+
+  /**
+   * Create an instance of [[Consumed]] with key and value Serdes.
+   *
+   * @tparam K         key type
+   * @tparam V         value type
+   * @return a new instance of [[Consumed]]
+   */
+  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(keySerde, valueSerde)
+
+  /**
+   * Create an instance of [[Consumed]] with a `org.apache.kafka.streams.processor.TimestampExtractor`.
+   *
+   * @param timestampExtractor the timestamp extractor to used. If `null` the default timestamp extractor from
+   *                           config will be used
+   * @tparam K                 key type
+   * @tparam V                 value type
+   * @return a new instance of [[Consumed]]
+   */
+  def `with`[K, V](
+    timestampExtractor: TimestampExtractor
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(timestampExtractor).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Create an instance of [[Consumed]] with a `org.apache.kafka.streams.Topology.AutoOffsetReset`.
+   *
+   * @tparam K          key type
+   * @tparam V          value type
+   * @param resetPolicy the offset reset policy to be used. If `null` the default reset policy from config will be used
+   * @return a new instance of [[Consumed]]
+   */
+  @deprecated("Use `with` method that accepts `AutoOffsetReset` instead", "4.0.0")
+  def `with`[K, V](
+    resetPolicy: Topology.AutoOffsetReset
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(resetPolicy).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Create an instance of [[Consumed]] with a `org.apache.kafka.streams.AutoOffsetReset`.
+   *
+   * @tparam K          key type
+   * @tparam V          value type
+   * @param resetPolicy the offset reset policy to be used. If `null` the default reset policy from config will be used
+   * @return a new instance of [[Consumed]]
+   */
+  def `with`[K, V](
+    resetPolicy: AutoOffsetReset
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ConsumedJ[K, V] =
+    ConsumedJ.`with`(resetPolicy).withKeySerde(keySerde).withValueSerde(valueSerde)
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Grouped.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Grouped.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Grouped => GroupedJ}
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Grouped` instead", "4.3.0")
+object Grouped {
+
+  /**
+   * Construct a `Grouped` instance with the provided key and value Serdes.
+   * If the Serde params are `null` the default serdes defined in the configs will be used.
+   *
+   * @tparam K the key type
+   * @tparam V the value type
+   * @param keySerde   keySerde that will be used to materialize a stream
+   * @param valueSerde valueSerde that will be used to materialize a stream
+   * @return a new instance of [[Grouped]] configured with the provided serdes
+   */
+  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): GroupedJ[K, V] =
+    GroupedJ.`with`(keySerde, valueSerde)
+
+  /**
+   * Construct a `Grouped` instance with the provided key and value Serdes.
+   * If the Serde params are `null` the default serdes defined in the configs will be used.
+   *
+   * @tparam K the key type
+   * @tparam V the value type
+   * @param name the name used as part of a potential repartition topic
+   * @param keySerde   keySerde that will be used to materialize a stream
+   * @param valueSerde valueSerde that will be used to materialize a stream
+   * @return a new instance of [[Grouped]] configured with the provided serdes
+   */
+  def `with`[K, V](name: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): GroupedJ[K, V] =
+    GroupedJ.`with`(name, keySerde, valueSerde)
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Joined.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Joined.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Joined => JoinedJ}
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Joined` instead", "4.3.0")
+object Joined {
+
+  /**
+   * Create an instance of `org.apache.kafka.streams.kstream.Joined` with key, value, and otherValue Serde
+   * instances.
+   * `null` values are accepted and will be replaced by the default serdes as defined in config.
+   *
+   * @tparam K              key type
+   * @tparam V              value type
+   * @tparam VO             other value type
+   * @param keySerde        the key serde to use.
+   * @param valueSerde      the value serde to use.
+   * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
+   * @return new `org.apache.kafka.streams.kstream.Joined` instance with the provided serdes
+   */
+  def `with`[K, V, VO](implicit
+    keySerde: Serde[K],
+    valueSerde: Serde[V],
+    otherValueSerde: Serde[VO]
+  ): JoinedJ[K, V, VO] =
+    JoinedJ.`with`(keySerde, valueSerde, otherValueSerde)
+
+  /**
+   * Create an instance of `org.apache.kafka.streams.kstream.Joined` with key, value, and otherValue Serde
+   * instances.
+   * `null` values are accepted and will be replaced by the default serdes as defined in config.
+   *
+   * @tparam K              key type
+   * @tparam V              value type
+   * @tparam VO             other value type
+   * @param name            name of possible repartition topic
+   * @param keySerde        the key serde to use.
+   * @param valueSerde      the value serde to use.
+   * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
+   * @return new `org.apache.kafka.streams.kstream.Joined` instance with the provided serdes
+   */
+  // disable spotless scala, which wants to make a mess of the argument lists
+  // format: off
+  def `with`[K, V, VO](name: String)
+                      (implicit keySerde: Serde[K],
+                       valueSerde: Serde[V],
+                       otherValueSerde: Serde[VO]): JoinedJ[K, V, VO] =
+    JoinedJ.`with`(keySerde, valueSerde, otherValueSerde, name)
+  // format:on
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.internals.KTableImpl
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.kstream.{
+  KGroupedStream => KGroupedStreamJ,
+  KTable => KTableJ,
+  SessionWindows,
+  SlidingWindows,
+  Window,
+  Windows
+}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  AggregatorFromFunction,
+  InitializerFromFunction,
+  ReducerFromFunction,
+  ValueMapperFromFunction
+}
+
+/**
+ * Wraps the Java class KGroupedStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for KGroupedStream
+ * @see `org.apache.kafka.streams.kstream.KGroupedStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.KGroupedStream` instead", "4.3.0")
+class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
+
+  /**
+   * Count the number of records in this stream by the grouped key.
+   * The result is written into a local `KeyValueStore` (which is basically an ever-updating materialized view)
+   * provided by the given `materialized`.
+   *
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#count`
+   */
+  def count()(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
+    val javaCountTable: KTableJ[K, java.lang.Long] =
+      inner.count(materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayKeyValueStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[K, ByteArrayKeyValueStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[K, Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Count the number of records in this stream by the grouped key.
+   * The result is written into a local `KeyValueStore` (which is basically an ever-updating materialized view)
+   * provided by the given `materialized`.
+   *
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#count`
+   */
+  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
+    val javaCountTable: KTableJ[K, java.lang.Long] =
+      inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayKeyValueStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[K, ByteArrayKeyValueStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[K, Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Combine the values of records in this stream by the grouped key.
+   *
+   * @param reducer      a function `(V, V) => V` that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Combine the values of records in this stream by the grouped key.
+   *
+   * @param reducer      a function `(V, V) => V` that computes a new aggregate result.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key.
+   *
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result
+   * @param aggregator   an `Aggregator` that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, materialized))
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key.
+   *
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result
+   * @param aggregator   an `Aggregator` that computes a new aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, named, materialized))
+
+  /**
+   * Create a new [[TimeWindowedKStream]] instance that can be used to perform windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `Windows`
+   * @return an instance of [[TimeWindowedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
+   */
+  def windowedBy[W <: Window](windows: Windows[W]): TimeWindowedKStream[K, V] =
+    new TimeWindowedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[TimeWindowedKStream]] instance that can be used to perform sliding windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SlidingWindows`
+   * @return an instance of [[TimeWindowedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
+   */
+  def windowedBy(windows: SlidingWindows): TimeWindowedKStream[K, V] =
+    new TimeWindowedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[SessionWindowedKStream]] instance that can be used to perform session windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SessionWindows`
+   * @return an instance of [[SessionWindowedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
+   */
+  def windowedBy(windows: SessionWindows): SessionWindowedKStream[K, V] =
+    new SessionWindowedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[CogroupedKStream]] from this grouped KStream to allow cogrouping other [[KGroupedStream]] to it.
+   *
+   * @param aggregator an `Aggregator` that computes a new aggregate result
+   * @return an instance of [[CogroupedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#cogroup`
+   */
+  def cogroup[VR](aggregator: (K, V, VR) => VR): CogroupedKStream[K, VR] =
+    new CogroupedKStream(inner.cogroup(aggregator.asAggregator))
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.{KGroupedTable => KGroupedTableJ}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  AggregatorFromFunction,
+  InitializerFromFunction,
+  ReducerFromFunction
+}
+
+/**
+ * Wraps the Java class KGroupedTable and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for KGroupedTable
+ * @see `org.apache.kafka.streams.kstream.KGroupedTable`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.KGroupedTable` instead", "4.3.0")
+class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
+
+  /**
+   * Count number of records of the original [[KTable]] that got [[KTable#groupBy]] to
+   * the same key into a new instance of [[KTable]].
+   *
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#count`
+   */
+  def count()(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
+    val c: KTable[K, java.lang.Long] =
+      new KTable(inner.count(materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayKeyValueStore]]))
+    c.mapValues[Long](Long2long _)
+  }
+
+  /**
+   * Count number of records of the original [[KTable]] that got [[KTable#groupBy]] to
+   * the same key into a new instance of [[KTable]].
+   *
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#count`
+   */
+  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
+    val c: KTable[K, java.lang.Long] =
+      new KTable(inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayKeyValueStore]]))
+    c.mapValues[Long](Long2long _)
+  }
+
+  /**
+   * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]].
+   *
+   * @param adder        a function that adds a new value to the aggregate result
+   * @param subtractor   a function that removed an old value from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
+   */
+  def reduce(adder: (V, V) => V, subtractor: (V, V) => V)(implicit
+    materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
+    new KTable(inner.reduce(adder.asReducer, subtractor.asReducer, materialized))
+
+  /**
+   * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]].
+   *
+   * @param adder        a function that adds a new value to the aggregate result
+   * @param subtractor   a function that removed an old value from the aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
+   */
+  def reduce(adder: (V, V) => V, subtractor: (V, V) => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
+    new KTable(inner.reduce(adder.asReducer, subtractor.asReducer, named, materialized))
+
+  /**
+   * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]] using default serializers and deserializers.
+   *
+   * @param initializer  a function that provides an initial aggregate result value
+   * @param adder        a function that adds a new record to the aggregate result
+   * @param subtractor   an aggregator function that removed an old record from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#aggregate`
+   */
+  def aggregate[VR](initializer: => VR)(adder: (K, V, VR) => VR, subtractor: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(
+      inner.aggregate((() => initializer).asInitializer, adder.asAggregator, subtractor.asAggregator, materialized)
+    )
+
+  /**
+   * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]] using default serializers and deserializers.
+   *
+   * @param initializer  a function that provides an initial aggregate result value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param adder        a function that adds a new record to the aggregate result
+   * @param subtractor   an aggregator function that removed an old record from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(adder: (K, V, VR) => VR, subtractor: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(
+      inner.aggregate(
+        (() => initializer).asInitializer,
+        adder.asAggregator,
+        subtractor.asAggregator,
+        named,
+        materialized
+      )
+    )
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -1,0 +1,878 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.{GlobalKTable, JoinWindows, KStream => KStreamJ, Printed}
+import org.apache.kafka.streams.processor.TopicNameExtractor
+import org.apache.kafka.streams.processor.api.{FixedKeyProcessorSupplier, ProcessorSupplier}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  FlatValueMapperFromFunction,
+  FlatValueMapperWithKeyFromFunction,
+  ForeachActionFromFunction,
+  KeyValueMapperFromFunction,
+  MapperFromFunction,
+  PredicateFromFunction,
+  ValueMapperFromFunction,
+  ValueMapperWithKeyFromFunction
+}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Wraps the Java class `org.apache.kafka.streams.kstream.KStream` and delegates method calls to the
+ * underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for KStream
+ * @see `org.apache.kafka.streams.kstream.KStream`
+ */
+//noinspection ScalaDeprecation
+@deprecated("Use `org.apache.kafka.streams.kstream.KStream` instead", "4.3.0")
+class KStream[K, V](val inner: KStreamJ[K, V]) {
+
+  /**
+   * Create a new [[KStream]] that consists all records of this stream which satisfies the given predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @return a [[KStream]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filter`
+   */
+  def filter(predicate: (K, V) => Boolean): KStream[K, V] =
+    new KStream(inner.filter(predicate.asPredicate))
+
+  /**
+   * Create a new [[KStream]] that consists all records of this stream which satisfies the given predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named     a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, named: Named): KStream[K, V] =
+    new KStream(inner.filter(predicate.asPredicate, named))
+
+  /**
+   * Create a new [[KStream]] that consists all records of this stream which do <em>not</em> satisfy the given
+   * predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @return a [[KStream]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean): KStream[K, V] =
+    new KStream(inner.filterNot(predicate.asPredicate))
+
+  /**
+   * Create a new [[KStream]] that consists all records of this stream which do <em>not</em> satisfy the given
+   * predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named     a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, named: Named): KStream[K, V] =
+    new KStream(inner.filterNot(predicate.asPredicate, named))
+
+  /**
+   * Set a new key (with possibly new type) for each input record.
+   * <p>
+   * The function `mapper` passed is applied to every record and results in the generation of a new
+   * key `KR`. The function outputs a new [[KStream]] where each record has this new key.
+   *
+   * @param mapper a function `(K, V) => KR` that computes a new key for each record
+   * @return a [[KStream]] that contains records with new key (possibly of different type) and unmodified value
+   * @see `org.apache.kafka.streams.kstream.KStream#selectKey`
+   */
+  def selectKey[KR](mapper: (K, V) => KR): KStream[KR, V] =
+    new KStream(inner.selectKey[KR](mapper.asKeyValueMapper))
+
+  /**
+   * Set a new key (with possibly new type) for each input record.
+   * <p>
+   * The function `mapper` passed is applied to every record and results in the generation of a new
+   * key `KR`. The function outputs a new [[KStream]] where each record has this new key.
+   *
+   * @param mapper a function `(K, V) => KR` that computes a new key for each record
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with new key (possibly of different type) and unmodified value
+   * @see `org.apache.kafka.streams.kstream.KStream#selectKey`
+   */
+  def selectKey[KR](mapper: (K, V) => KR, named: Named): KStream[KR, V] =
+    new KStream(inner.selectKey[KR](mapper.asKeyValueMapper, named))
+
+  /**
+   * Transform each record of the input stream into a new record in the output stream (both key and value type can be
+   * altered arbitrarily).
+   * <p>
+   * The provided `mapper`, a function `(K, V) => (KR, VR)` is applied to each input record and computes a new output record.
+   *
+   * @param mapper a function `(K, V) => (KR, VR)` that computes a new output record
+   * @return a [[KStream]] that contains records with new key and value (possibly both of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#map`
+   */
+  def map[KR, VR](mapper: (K, V) => (KR, VR)): KStream[KR, VR] =
+    new KStream(inner.map[KR, VR](mapper.asKeyValueMapper))
+
+  /**
+   * Transform each record of the input stream into a new record in the output stream (both key and value type can be
+   * altered arbitrarily).
+   * <p>
+   * The provided `mapper`, a function `(K, V) => (KR, VR)` is applied to each input record and computes a new output record.
+   *
+   * @param mapper a function `(K, V) => (KR, VR)` that computes a new output record
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with new key and value (possibly both of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#map`
+   */
+  def map[KR, VR](mapper: (K, V) => (KR, VR), named: Named): KStream[KR, VR] =
+    new KStream(inner.map[KR, VR](mapper.asKeyValueMapper, named))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapper))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, named: Named): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapperWithKey))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, named: Named): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapperWithKey, named))
+
+  /**
+   * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+   * can be altered arbitrarily).
+   * <p>
+   * The provided `mapper`, function `(K, V) => Iterable[(KR, VR)]` is applied to each input record and computes zero or more output records.
+   *
+   * @param mapper function `(K, V) => Iterable[(KR, VR)]` that computes the new output records
+   * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMap`
+   */
+  def flatMap[KR, VR](mapper: (K, V) => Iterable[(KR, VR)]): KStream[KR, VR] = {
+    val kvMapper = mapper.tupled.andThen(_.map(ImplicitConversions.tuple2ToKeyValue).asJava)
+    new KStream(inner.flatMap[KR, VR](((k: K, v: V) => kvMapper(k, v)).asKeyValueMapper))
+  }
+
+  /**
+   * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+   * can be altered arbitrarily).
+   * <p>
+   * The provided `mapper`, function `(K, V) => Iterable[(KR, VR)]` is applied to each input record and computes zero or more output records.
+   *
+   * @param mapper function `(K, V) => Iterable[(KR, VR)]` that computes the new output records
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMap`
+   */
+  def flatMap[KR, VR](mapper: (K, V) => Iterable[(KR, VR)], named: Named): KStream[KR, VR] = {
+    val kvMapper = mapper.tupled.andThen(_.map(ImplicitConversions.tuple2ToKeyValue).asJava)
+    new KStream(inner.flatMap[KR, VR](((k: K, v: V) => kvMapper(k, v)).asKeyValueMapper, named))
+  }
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `V => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `V => Iterable[VR]` that computes the new output values
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: V => Iterable[VR]): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapper))
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `V => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `V => Iterable[VR]` that computes the new output values
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: V => Iterable[VR], named: Named): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `(K, V) => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `(K, V) => Iterable[VR]` that computes the new output values
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: (K, V) => Iterable[VR]): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapperWithKey))
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `(K, V) => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `(K, V) => Iterable[VR]` that computes the new output values
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: (K, V) => Iterable[VR], named: Named): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapperWithKey, named))
+
+  /**
+   * Print the records of this KStream using the options provided by `Printed`
+   *
+   * @param printed options for printing
+   * @see `org.apache.kafka.streams.kstream.KStream#print`
+   */
+  def print(printed: Printed[K, V]): Unit = inner.print(printed)
+
+  /**
+   * Perform an action on each record of `KStream`
+   *
+   * @param action an action to perform on each record
+   * @see `org.apache.kafka.streams.kstream.KStream#foreach`
+   */
+  def foreach(action: (K, V) => Unit): Unit =
+    inner.foreach(action.asForeachAction)
+
+  /**
+   * Perform an action on each record of `KStream`
+   *
+   * @param action an action to perform on each record
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @see `org.apache.kafka.streams.kstream.KStream#foreach`
+   */
+  def foreach(action: (K, V) => Unit, named: Named): Unit =
+    inner.foreach(action.asForeachAction, named)
+
+  /**
+   * Split this stream. [[BranchedKStream]] can be used for routing the records to different branches depending
+   * on evaluation against the supplied predicates.
+   * Stream branching is a stateless record-by-record operation.
+   *
+   * @return [[BranchedKStream]] that provides methods for routing the records to different branches.
+   * @see `org.apache.kafka.streams.kstream.KStream#split`
+   */
+  def split(): BranchedKStream[K, V] =
+    new BranchedKStream(inner.split())
+
+  /**
+   * Split this stream. [[BranchedKStream]] can be used for routing the records to different branches depending
+   * on evaluation against the supplied predicates.
+   * Stream branching is a stateless record-by-record operation.
+   *
+   * @param named a [[Named]] config used to name the processor in the topology and also to set the name prefix
+   *              for the resulting branches (see [[BranchedKStream]])
+   * @return [[BranchedKStream]] that provides methods for routing the records to different branches.
+   * @see `org.apache.kafka.streams.kstream.KStream#split`
+   */
+  def split(named: Named): BranchedKStream[K, V] =
+    new BranchedKStream(inner.split(named))
+
+  /**
+   * Materialize this stream to a topic and creates a new [[KStream]] from the topic using the `Repartitioned` instance
+   * for configuration of the `Serde key serde`, `Serde value serde`, `StreamPartitioner`, number of partitions, and
+   * topic name part.
+   * <p>
+   * The created topic is considered as an internal topic and is meant to be used only by the current Kafka Streams instance.
+   * Similar to auto-repartitioning, the topic will be created with infinite retention time and data will be automatically purged by Kafka Streams.
+   * The topic will be named as "\${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
+   * `StreamsConfig` via parameter `APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG`,
+   * "&lt;name&gt;" is either provided via `Repartitioned#as(String)` or an internally
+   * generated name, and "-repartition" is a fixed suffix.
+   * <p>
+   * The user can either supply the `Repartitioned` instance as an implicit in scope or they can also provide implicit
+   * key and value serdes that will be converted to a `Repartitioned` instance implicitly.
+   * <p>
+   * {{{
+   * Example:
+   *
+   * // brings implicit serdes in scope
+   * import Serdes._
+   *
+   * //..
+   * val clicksPerRegion: KStream[String, Long] = //..
+   *
+   * // Implicit serdes in scope will generate an implicit Produced instance, which
+   * // will be passed automatically to the call of through below
+   * clicksPerRegion.repartition
+   *
+   * // Similarly you can create an implicit Repartitioned and it will be passed implicitly
+   * // to the repartition call
+   * }}}
+   *
+   * @param repartitioned the `Repartitioned` instance used to specify `Serdes`, `StreamPartitioner` which determines
+   *                      how records are distributed among partitions of the topic,
+   *                      part of the topic name, and number of partitions for a repartition topic.
+   * @return a [[KStream]] that contains the exact same repartitioned records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#repartition`
+   */
+  def repartition(implicit repartitioned: Repartitioned[K, V]): KStream[K, V] =
+    new KStream(inner.repartition(repartitioned))
+
+  /**
+   * Materialize this stream to a topic using the `Produced` instance for
+   * configuration of the `Serde key serde`, `Serde value serde`, and `StreamPartitioner`
+   * <p>
+   * The user can either supply the `Produced` instance as an implicit in scope or they can also provide implicit
+   * key and value serdes that will be converted to a `Produced` instance implicitly.
+   * <p>
+   * {{{
+   * Example:
+   *
+   * // brings implicit serdes in scope
+   * import Serdes._
+   *
+   * //..
+   * val clicksPerRegion: KTable[String, Long] = //..
+   *
+   * // Implicit serdes in scope will generate an implicit Produced instance, which
+   * // will be passed automatically to the call of through below
+   * clicksPerRegion.to(topic)
+   *
+   * // Similarly you can create an implicit Produced and it will be passed implicitly
+   * // to the through call
+   * }}}
+   *
+   * @param topic    the topic name
+   * @param produced the instance of Produced that gives the serdes and `StreamPartitioner`
+   * @see `org.apache.kafka.streams.kstream.KStream#to`
+   */
+  def to(topic: String)(implicit produced: Produced[K, V]): Unit =
+    inner.to(topic, produced)
+
+  /**
+   * Dynamically materialize this stream to topics using the `Produced` instance for
+   * configuration of the `Serde key serde`, `Serde value serde`, and `StreamPartitioner`.
+   * The topic names for each record to send to is dynamically determined based on the given mapper.
+   * <p>
+   * The user can either supply the `Produced` instance as an implicit in scope or they can also provide implicit
+   * key and value serdes that will be converted to a `Produced` instance implicitly.
+   * <p>
+   * {{{
+   * Example:
+   *
+   * // brings implicit serdes in scope
+   * import Serdes._
+   *
+   * //..
+   * val clicksPerRegion: KTable[String, Long] = //..
+   *
+   * // Implicit serdes in scope will generate an implicit Produced instance, which
+   * // will be passed automatically to the call of through below
+   * clicksPerRegion.to(topicChooser)
+   *
+   * // Similarly you can create an implicit Produced and it will be passed implicitly
+   * // to the through call
+   * }}}
+   *
+   * @param extractor the extractor to determine the name of the Kafka topic to write to for reach record
+   * @param produced  the instance of Produced that gives the serdes and `StreamPartitioner`
+   * @see `org.apache.kafka.streams.kstream.KStream#to`
+   */
+  def to(extractor: TopicNameExtractor[K, V])(implicit produced: Produced[K, V]): Unit =
+    inner.to(extractor, produced)
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable: KTable[K, V] =
+    new KTable(inner.toTable)
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable(named: Named): KTable[K, V] =
+    new KTable(inner.toTable(named))
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable(materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.toTable(materialized))
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable(named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.toTable(named, materialized))
+
+  /**
+   * Process all records in this stream, one record at a time, by applying a `Processor` (provided by the given
+   * `processorSupplier`).
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `Processor`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * Note that this overload takes a ProcessorSupplier instead of a Function to avoid post-erasure ambiguity with
+   * the older (deprecated) overload.
+   *
+   * @param processorSupplier a supplier for `org.apache.kafka.streams.processor.api.Processor`
+   * @param stateStoreNames   the names of the state store used by the processor
+   * @see `org.apache.kafka.streams.kstream.KStream#process`
+   */
+  def process[KR, VR](processorSupplier: ProcessorSupplier[K, V, KR, VR], stateStoreNames: String*): KStream[KR, VR] =
+    new KStream(inner.process(processorSupplier, stateStoreNames: _*))
+
+  /**
+   * Process all records in this stream, one record at a time, by applying a `Processor` (provided by the given
+   * `processorSupplier`).
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `Processor`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * Note that this overload takes a ProcessorSupplier instead of a Function to avoid post-erasure ambiguity with
+   * the older (deprecated) overload.
+   *
+   * @param processorSupplier a supplier for `org.apache.kafka.streams.processor.api.Processor`
+   * @param named             a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames   the names of the state store used by the processor
+   * @see `org.apache.kafka.streams.kstream.KStream#process`
+   */
+  def process[KR, VR](
+    processorSupplier: ProcessorSupplier[K, V, KR, VR],
+    named: Named,
+    stateStoreNames: String*
+  ): KStream[KR, VR] =
+    new KStream(inner.process(processorSupplier, named, stateStoreNames: _*))
+
+  /**
+   * Process all records in this stream, one record at a time, by applying a `FixedKeyProcessor` (provided by the given
+   * `processorSupplier`).
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `FixedKeyProcessor`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * Note that this overload takes a FixedKeyProcessorSupplier instead of a Function to avoid post-erasure ambiguity with
+   * the older (deprecated) overload.
+   *
+   * @param processorSupplier a supplier for `org.apache.kafka.streams.processor.api.FixedKeyProcessor`
+   * @param stateStoreNames   the names of the state store used by the processor
+   * @see `org.apache.kafka.streams.kstream.KStream#process`
+   */
+  def processValues[VR](
+    processorSupplier: FixedKeyProcessorSupplier[K, V, VR],
+    stateStoreNames: String*
+  ): KStream[K, VR] =
+    new KStream(inner.processValues(processorSupplier, stateStoreNames: _*))
+
+  /**
+   * Process all records in this stream, one record at a time, by applying a `FixedKeyProcessor` (provided by the given
+   * `processorSupplier`).
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `FixedKeyProcessor`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * Note that this overload takes a ProcessorSupplier instead of a Function to avoid post-erasure ambiguity with
+   * the older (deprecated) overload.
+   *
+   * @param processorSupplier a supplier for `org.apache.kafka.streams.processor.api.FixedKeyProcessor`
+   * @param named             a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames   the names of the state store used by the processor
+   * @see `org.apache.kafka.streams.kstream.KStream#process`
+   */
+  def processValues[VR](
+    processorSupplier: FixedKeyProcessorSupplier[K, V, VR],
+    named: Named,
+    stateStoreNames: String*
+  ): KStream[K, VR] =
+    new KStream(inner.processValues(processorSupplier, named, stateStoreNames: _*))
+
+  /**
+   * Group the records by their current key into a [[KGroupedStream]]
+   * <p>
+   * The user can either supply the `Grouped` instance as an implicit in scope or they can also provide an implicit
+   * serdes that will be converted to a `Grouped` instance implicitly.
+   * <p>
+   * {{{
+   * Example:
+   *
+   * // brings implicit serdes in scope
+   * import Serdes._
+   *
+   * val clicksPerRegion: KTable[String, Long] =
+   *   userClicksStream
+   *     .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+   *     .map((_, regionWithClicks) => regionWithClicks)
+   *
+   *     // the groupByKey gets the Grouped instance through an implicit conversion of the
+   *     // serdes brought into scope through the import Serdes._ above
+   *     .groupByKey
+   *     .reduce(_ + _)
+   *
+   * // Similarly you can create an implicit Grouped and it will be passed implicitly
+   * // to the groupByKey call
+   * }}}
+   *
+   * @param grouped the instance of Grouped that gives the serdes
+   * @return a [[KGroupedStream]] that contains the grouped records of the original [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#groupByKey`
+   */
+  def groupByKey(implicit grouped: Grouped[K, V]): KGroupedStream[K, V] =
+    new KGroupedStream(inner.groupByKey(grouped))
+
+  /**
+   * Group the records of this [[KStream]] on a new key that is selected using the provided key transformation function
+   * and the `Grouped` instance.
+   * <p>
+   * The user can either supply the `Grouped` instance as an implicit in scope or they can also provide an implicit
+   * serdes that will be converted to a `Grouped` instance implicitly.
+   * <p>
+   * {{{
+   * Example:
+   *
+   * // brings implicit serdes in scope
+   * import Serdes._
+   *
+   * val textLines = streamBuilder.stream[String, String](inputTopic)
+   *
+   * val pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS)
+   *
+   * val wordCounts: KTable[String, Long] =
+   *   textLines.flatMapValues(v => pattern.split(v.toLowerCase))
+   *
+   *     // the groupBy gets the Grouped instance through an implicit conversion of the
+   *     // serdes brought into scope through the import Serdes._ above
+   *     .groupBy((k, v) => v)
+   *
+   *     .count()
+   * }}}
+   *
+   * @param selector a function that computes a new key for grouping
+   * @return a [[KGroupedStream]] that contains the grouped records of the original [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#groupBy`
+   */
+  def groupBy[KR](selector: (K, V) => KR)(implicit grouped: Grouped[KR, V]): KGroupedStream[KR, V] =
+    new KGroupedStream(inner.groupBy(selector.asKeyValueMapper, grouped))
+
+  /**
+   * Join records of this stream with another [[KStream]]'s records using windowed inner equi join with
+   * serializers and deserializers supplied by the implicit `StreamJoined` instance.
+   *
+   * @param otherStream the [[KStream]] to be joined with this stream
+   * @param joiner      a function that computes the join result for a pair of matching records
+   * @param windows     the specification of the `JoinWindows`
+   * @param streamJoin  an implicit `StreamJoin` instance that defines the serdes to be used to serialize/deserialize
+   *                    inputs and outputs of the joined streams. Instead of `StreamJoin`, the user can also supply
+   *                    key serde, value serde and other value serde in implicit scope and they will be
+   *                    converted to the instance of `Stream` through implicit conversion.  The `StreamJoin` instance can
+   *                    also name the repartition topic (if required), the state stores for the join, and the join
+   *                    processor node.
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one for each matched record-pair with the same key and within the joining window intervals
+   * @see `org.apache.kafka.streams.kstream.KStream#join`
+   */
+  def join[VO, VR](otherStream: KStream[K, VO])(
+    joiner: (V, VO) => VR,
+    windows: JoinWindows
+  )(implicit streamJoin: StreamJoined[K, V, VO]): KStream[K, VR] =
+    new KStream(inner.join[VO, VR](otherStream.inner, joiner.asValueJoiner, windows, streamJoin))
+
+  /**
+   * Join records of this stream with another [[KStream]]'s records using windowed left equi join with
+   * serializers and deserializers supplied by the implicit `StreamJoined` instance.
+   *
+   * @param otherStream the [[KStream]] to be joined with this stream
+   * @param joiner      a function that computes the join result for a pair of matching records
+   * @param windows     the specification of the `JoinWindows`
+   * @param streamJoin  an implicit `StreamJoin` instance that defines the serdes to be used to serialize/deserialize
+   *                    inputs and outputs of the joined streams. Instead of `StreamJoin`, the user can also supply
+   *                    key serde, value serde and other value serde in implicit scope and they will be
+   *                    converted to the instance of `Stream` through implicit conversion.  The `StreamJoin` instance can
+   *                    also name the repartition topic (if required), the state stores for the join, and the join
+   *                    processor node.
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one for each matched record-pair with the same key and within the joining window intervals
+   * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
+   */
+  def leftJoin[VO, VR](otherStream: KStream[K, VO])(
+    joiner: (V, VO) => VR,
+    windows: JoinWindows
+  )(implicit streamJoin: StreamJoined[K, V, VO]): KStream[K, VR] =
+    new KStream(inner.leftJoin[VO, VR](otherStream.inner, joiner.asValueJoiner, windows, streamJoin))
+
+  /**
+   * Join records of this stream with another [[KStream]]'s records using windowed outer equi join with
+   * serializers and deserializers supplied by the implicit `Joined` instance.
+   *
+   * @param otherStream the [[KStream]] to be joined with this stream
+   * @param joiner      a function that computes the join result for a pair of matching records
+   * @param windows     the specification of the `JoinWindows`
+   * @param streamJoin  an implicit `StreamJoin` instance that defines the serdes to be used to serialize/deserialize
+   *                    inputs and outputs of the joined streams. Instead of `StreamJoin`, the user can also supply
+   *                    key serde, value serde and other value serde in implicit scope and they will be
+   *                    converted to the instance of `Stream` through implicit conversion.  The `StreamJoin` instance can
+   *                    also name the repartition topic (if required), the state stores for the join, and the join
+   *                    processor node.
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one for each matched record-pair with the same key and within the joining window intervals
+   * @see `org.apache.kafka.streams.kstream.KStream#outerJoin`
+   */
+  def outerJoin[VO, VR](otherStream: KStream[K, VO])(
+    joiner: (V, VO) => VR,
+    windows: JoinWindows
+  )(implicit streamJoin: StreamJoined[K, V, VO]): KStream[K, VR] =
+    new KStream(inner.outerJoin[VO, VR](otherStream.inner, joiner.asValueJoiner, windows, streamJoin))
+
+  /**
+   * Join records of this stream with another [[KTable]]'s records using inner equi join with
+   * serializers and deserializers supplied by the implicit `Joined` instance.
+   *
+   * @param table  the [[KTable]] to be joined with this stream
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param joined an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
+   *               inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
+   *               key serde, value serde and other value serde in implicit scope and they will be
+   *               converted to the instance of `Joined` through implicit conversion
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KStream#join`
+   */
+  def join[VT, VR](table: KTable[K, VT])(joiner: (V, VT) => VR)(implicit joined: Joined[K, V, VT]): KStream[K, VR] =
+    new KStream(inner.join[VT, VR](table.inner, joiner.asValueJoiner, joined))
+
+  /**
+   * Join records of this stream with another [[KTable]]'s records using left equi join with
+   * serializers and deserializers supplied by the implicit `Joined` instance.
+   *
+   * @param table  the [[KTable]] to be joined with this stream
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param joined an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
+   *               inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
+   *               key serde, value serde and other value serde in implicit scope and they will be
+   *               converted to the instance of `Joined` through implicit conversion
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
+   */
+  def leftJoin[VT, VR](table: KTable[K, VT])(joiner: (V, VT) => VR)(implicit joined: Joined[K, V, VT]): KStream[K, VR] =
+    new KStream(inner.leftJoin[VT, VR](table.inner, joiner.asValueJoiner, joined))
+
+  /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed inner equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#join`
+   */
+  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV
+  ): KStream[K, RV] =
+    new KStream(
+      inner.join[GK, GV, RV](
+        globalKTable,
+        ((k: K, v: V) => keyValueMapper(k, v)).asKeyValueMapper,
+        ((v: V, gv: GV) => joiner(v, gv)).asValueJoiner
+      )
+    )
+
+  /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed inner equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param named          a [[Named]] config used to name the processor in the topology
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#join`
+   */
+  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV], named: Named)(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV
+  ): KStream[K, RV] =
+    new KStream(
+      inner.join[GK, GV, RV](
+        globalKTable,
+        ((k: K, v: V) => keyValueMapper(k, v)).asKeyValueMapper,
+        ((v: V, gv: GV) => joiner(v, gv)).asValueJoiner,
+        named
+      )
+    )
+
+  /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed left equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
+   */
+  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV
+  ): KStream[K, RV] =
+    new KStream(inner.leftJoin[GK, GV, RV](globalKTable, keyValueMapper.asKeyValueMapper, joiner.asValueJoiner))
+
+  /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed left equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param named          a [[Named]] config used to name the processor in the topology
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *         one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
+   */
+  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV], named: Named)(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV
+  ): KStream[K, RV] =
+    new KStream(inner.leftJoin[GK, GV, RV](globalKTable, keyValueMapper.asKeyValueMapper, joiner.asValueJoiner, named))
+
+  /**
+   * Merge this stream and the given stream into one larger stream.
+   * <p>
+   * There is no ordering guarantee between records from this `KStream` and records from the provided `KStream`
+   * in the merged stream. Relative order is preserved within each input stream though (ie, records within
+   * one input stream are processed in order).
+   *
+   * @param stream a stream which is to be merged into this stream
+   * @return a merged stream containing all records from this and the provided [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#merge`
+   */
+  def merge(stream: KStream[K, V]): KStream[K, V] =
+    new KStream(inner.merge(stream.inner))
+
+  /**
+   * Merge this stream and the given stream into one larger stream.
+   * <p>
+   * There is no ordering guarantee between records from this `KStream` and records from the provided `KStream`
+   * in the merged stream. Relative order is preserved within each input stream though (ie, records within
+   * one input stream are processed in order).
+   *
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @param stream a stream which is to be merged into this stream
+   * @return a merged stream containing all records from this and the provided [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#merge`
+   */
+  def merge(stream: KStream[K, V], named: Named): KStream[K, V] =
+    new KStream(inner.merge(stream.inner, named))
+
+  /**
+   * Perform an action on each record of `KStream`.
+   * <p>
+   * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
+   * and returns an unchanged stream.
+   *
+   * @param action an action to perform on each record
+   * @see `org.apache.kafka.streams.kstream.KStream#peek`
+   */
+  def peek(action: (K, V) => Unit): KStream[K, V] =
+    new KStream(inner.peek(action.asForeachAction))
+
+  /**
+   * Perform an action on each record of `KStream`.
+   * <p>
+   * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
+   * and returns an unchanged stream.
+   *
+   * @param action an action to perform on each record
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @see `org.apache.kafka.streams.kstream.KStream#peek`
+   */
+  def peek(action: (K, V) => Unit, named: Named): KStream[K, V] =
+    new KStream(inner.peek(action.asForeachAction, named))
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -1,0 +1,807 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import scala.jdk.FunctionWrappers.AsJavaBiFunction
+import org.apache.kafka.common.utils.Bytes
+import org.apache.kafka.streams.kstream.{KTable => KTableJ, TableJoined, ValueJoiner, ValueTransformerWithKeySupplier}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  FunctionFromFunction,
+  KeyValueMapperFromFunction,
+  MapperFromFunction,
+  PredicateFromFunction,
+  ValueMapperFromFunction,
+  ValueMapperWithKeyFromFunction
+}
+import org.apache.kafka.streams.state.KeyValueStore
+
+/**
+ * Wraps the Java class `org.apache.kafka.streams.kstream.KTable` and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for KTable
+ * @see `org.apache.kafka.streams.kstream.KTable`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.KTable` instead", "4.3.0")
+class KTable[K, V](val inner: KTableJ[K, V]) {
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(predicate: (K, V) => Boolean): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named     a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, named: Named): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate, named))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate    a filter that is applied to each record
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate, materialized))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate    a filter that is applied to each record
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(
+    predicate: (K, V) => Boolean,
+    named: Named,
+    materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate, named, materialized))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named     a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, named: Named): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate, named))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate    a filter that is applied to each record
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate, materialized))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate    a filter that is applied to each record
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(
+    predicate: (K, V) => Boolean,
+    named: Named,
+    materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate, named, materialized))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, named: Named): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper       , a function `V => VR` that computes a new output value
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper, materialized))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper       , a function `V => VR` that computes a new output value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](
+    mapper: V => VR,
+    named: Named,
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper, named, materialized))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, named: Named): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, named))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper       , a function `(K, V) => VR` that computes a new output value
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, materialized))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper       , a function `(K, V) => VR` that computes a new output value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](
+    mapper: (K, V) => VR,
+    named: Named,
+    materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, named, materialized))
+
+  /**
+   * Convert this changelog stream to a [[KStream]].
+   *
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream: KStream[K, V] =
+    new KStream(inner.toStream)
+
+  /**
+   * Convert this changelog stream to a [[KStream]].
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream(named: Named): KStream[K, V] =
+    new KStream(inner.toStream(named))
+
+  /**
+   * Convert this changelog stream to a [[KStream]] using the given key/value mapper to select the new key
+   *
+   * @param mapper a function that computes a new key for each record
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream[KR](mapper: (K, V) => KR): KStream[KR, V] =
+    new KStream(inner.toStream[KR](mapper.asKeyValueMapper))
+
+  /**
+   * Convert this changelog stream to a [[KStream]] using the given key/value mapper to select the new key
+   *
+   * @param mapper a function that computes a new key for each record
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream[KR](mapper: (K, V) => KR, named: Named): KStream[KR, V] =
+    new KStream(inner.toStream[KR](mapper.asKeyValueMapper, named))
+
+  /**
+   * Suppress some updates from this changelog stream, determined by the supplied `org.apache.kafka.streams.kstream.Suppressed` configuration.
+   *
+   * This controls what updates downstream table and stream operations will receive.
+   *
+   * @param suppressed Configuration object determining what, if any, updates to suppress.
+   * @return A new KTable with the desired suppression characteristics.
+   * @see `org.apache.kafka.streams.kstream.KTable#suppress`
+   */
+  def suppress(suppressed: org.apache.kafka.streams.kstream.Suppressed[_ >: K]): KTable[K, V] =
+    new KTable(inner.suppress(suppressed))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * A `ValueTransformerWithKey` (provided by the given `ValueTransformerWithKeySupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing access to additional state-stores,
+   * and to the `ProcessorContext`.
+   * If the downstream topology uses aggregation functions, (e.g. `KGroupedTable#reduce`, `KGroupedTable#aggregate`, etc),
+   * care must be taken when dealing with state, (either held in state-stores or transformer instances), to ensure correct
+   * aggregate results.
+   * In contrast, if the resulting KTable is materialized, (cf. `#transformValues(ValueTransformerWithKeySupplier, Materialized, String...)`),
+   * such concerns are handled for you.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`.
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param stateStoreNames                 the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](
+    valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+    stateStoreNames: String*
+  ): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, stateStoreNames: _*))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * A `ValueTransformerWithKey` (provided by the given `ValueTransformerWithKeySupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing access to additional state-stores,
+   * and to the `ProcessorContext`.
+   * If the downstream topology uses aggregation functions, (e.g. `KGroupedTable#reduce`, `KGroupedTable#aggregate`, etc),
+   * care must be taken when dealing with state, (either held in state-stores or transformer instances), to ensure correct
+   * aggregate results.
+   * In contrast, if the resulting KTable is materialized, (cf. `#transformValues(ValueTransformerWithKeySupplier, Materialized, String...)`),
+   * such concerns are handled for you.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`.
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param named                           a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames                 the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](
+    valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+    named: Named,
+    stateStoreNames: String*
+  ): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, named, stateStoreNames: _*))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing stateful, rather than stateless,
+   * record-by-record operation, access to additional state-stores, and access to the `ProcessorContext`.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   * The resulting `KTable` is materialized into another state store (additional to the provided state store names)
+   * as specified by the user via `Materialized` parameter, and is queryable through its given name.
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param materialized                    an instance of `Materialized` used to describe how the state store of the
+   *                                        resulting table should be materialized.
+   * @param stateStoreNames                 the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](
+    valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]],
+    stateStoreNames: String*
+  ): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, materialized, stateStoreNames: _*))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing stateful, rather than stateless,
+   * record-by-record operation, access to additional state-stores, and access to the `ProcessorContext`.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   * The resulting `KTable` is materialized into another state store (additional to the provided state store names)
+   * as specified by the user via `Materialized` parameter, and is queryable through its given name.
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param materialized                    an instance of `Materialized` used to describe how the state store of the
+   *                                        resulting table should be materialized.
+   * @param named                           a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames                 the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](
+    valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]],
+    named: Named,
+    stateStoreNames: String*
+  ): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, materialized, named, stateStoreNames: _*))
+
+  /**
+   * Re-groups the records of this [[KTable]] using the provided key/value mapper
+   * and `Serde`s as specified by `Grouped`.
+   *
+   * @param selector a function that computes a new grouping key and value to be aggregated
+   * @param grouped  the `Grouped` instance used to specify `Serdes`
+   * @return a [[KGroupedTable]] that contains the re-grouped records of the original [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#groupBy`
+   */
+  def groupBy[KR, VR](selector: (K, V) => (KR, VR))(implicit grouped: Grouped[KR, VR]): KGroupedTable[KR, VR] =
+    new KGroupedTable(inner.groupBy(selector.asKeyValueMapper, grouped))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, named))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, named))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named  a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, named))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def join[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: Function[V, KO],
+    joiner: ValueJoiner[V, VO, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.join(other.inner, keyExtractor.asJavaFunction, joiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's key and value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def join[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: (K, V) => KO,
+    joiner: ValueJoiner[V, VO, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.join(other.inner, AsJavaBiFunction[K, V, KO](keyExtractor), joiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param tableJoined  a `org.apache.kafka.streams.kstream.TableJoined` used to configure
+   *                     partitioners and names of internal topics and stores
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def join[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: Function[V, KO],
+    joiner: ValueJoiner[V, VO, VR],
+    tableJoined: TableJoined[K, KO],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.join(other.inner, keyExtractor.asJavaFunction, joiner, tableJoined, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's key and value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param tableJoined  a `org.apache.kafka.streams.kstream.TableJoined` used to configure
+   *                     partitioners and names of internal topics and stores
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def join[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: (K, V) => KO,
+    joiner: ValueJoiner[V, VO, VR],
+    tableJoined: TableJoined[K, KO],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.join(other.inner, AsJavaBiFunction[K, V, KO](keyExtractor), joiner, tableJoined, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def leftJoin[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: Function[V, KO],
+    joiner: ValueJoiner[V, VO, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin(other.inner, keyExtractor.asJavaFunction, joiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's key and value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def leftJoin[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: (K, V) => KO,
+    joiner: ValueJoiner[V, VO, VR],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin(other.inner, AsJavaBiFunction[K, V, KO](keyExtractor), joiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param tableJoined  a `org.apache.kafka.streams.kstream.TableJoined` used to configure
+   *                     partitioners and names of internal topics and stores
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def leftJoin[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: Function[V, KO],
+    joiner: ValueJoiner[V, VO, VR],
+    tableJoined: TableJoined[K, KO],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin(other.inner, keyExtractor.asJavaFunction, joiner, tableJoined, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's key and value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param tableJoined  a `org.apache.kafka.streams.kstream.TableJoined` used to configure
+   *                     partitioners and names of internal topics and stores
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   *         one for each matched record-pair with the same key
+   */
+  def leftJoin[VR, KO, VO](
+    other: KTable[KO, VO],
+    keyExtractor: (K, V) => KO,
+    joiner: ValueJoiner[V, VO, VR],
+    tableJoined: TableJoined[K, KO],
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin(other.inner, AsJavaBiFunction[K, V, KO](keyExtractor), joiner, tableJoined, materialized))
+
+  /**
+   * Get the name of the local state store used that can be used to query this [[KTable]].
+   *
+   * @return the underlying state store name, or `null` if this [[KTable]] cannot be queried.
+   */
+  def queryableStoreName: String =
+    inner.queryableStoreName
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Materialized.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Materialized.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Materialized => MaterializedJ}
+import org.apache.kafka.streams.processor.StateStore
+import org.apache.kafka.streams.scala.{ByteArrayKeyValueStore, ByteArraySessionStore, ByteArrayWindowStore}
+import org.apache.kafka.streams.state.{KeyValueBytesStoreSupplier, SessionBytesStoreSupplier, WindowBytesStoreSupplier}
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Materialized` instead", "4.3.0")
+object Materialized {
+
+  /**
+   * Materialize a `org.apache.kafka.streams.processor.StateStore` with the provided key and value Serdes.
+   * An internal name will be used for the store.
+   *
+   * @tparam K         key type
+   * @tparam V         value type
+   * @tparam S         store type
+   * @param keySerde   the key Serde to use.
+   * @param valueSerde the value Serde to use.
+   * @return a new [[Materialized]] instance with the given key and value serdes
+   */
+  def `with`[K, V, S <: StateStore](implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, S] =
+    MaterializedJ.`with`(keySerde, valueSerde)
+
+  /**
+   * Materialize a `org.apache.kafka.streams.processor.StateStore` with the given name.
+   *
+   * @tparam K         key type of the store
+   * @tparam V         value type of the store
+   * @tparam S         type of the `org.apache.kafka.streams.processor.StateStore`
+   * @param storeName  the name of the underlying [[org.apache.kafka.streams.scala.kstream.KTable]] state store;
+   *                   valid characters are ASCII alphanumerics, '.', '_' and '-'.
+   * @param keySerde   the key serde to use.
+   * @param valueSerde the value serde to use.
+   * @return a new [[Materialized]] instance with the given storeName
+   */
+  def as[K, V, S <: StateStore](
+    storeName: String
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, S] =
+    MaterializedJ.as(storeName).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Materialize a `org.apache.kafka.streams.state.WindowStore` using the provided
+   * `org.apache.kafka.streams.state.WindowBytesStoreSupplier`.
+   *
+   * Important: Custom subclasses are allowed here, but they should respect the retention contract:
+   * Window stores are required to retain windows at least as long as (window size + window grace period).
+   * Stores constructed via `org.apache.kafka.streams.state.Stores` already satisfy this contract.
+   *
+   * @tparam K         key type of the store
+   * @tparam V         value type of the store
+   * @param supplier   the `org.apache.kafka.streams.state.WindowBytesStoreSupplier` used to materialize the store
+   * @param keySerde   the key serde to use.
+   * @param valueSerde the value serde to use.
+   * @return a new [[Materialized]] instance with the given supplier
+   */
+  def as[K, V](
+    supplier: WindowBytesStoreSupplier
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, ByteArrayWindowStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Materialize a `org.apache.kafka.streams.state.SessionStore` using the provided
+   * `org.apache.kafka.streams.state.SessionBytesStoreSupplier`.
+   *
+   * Important: Custom subclasses are allowed here, but they should respect the retention contract:
+   * Session stores are required to retain windows at least as long as (session inactivity gap + session grace period).
+   * Stores constructed via `org.apache.kafka.streams.state.Stores` already satisfy this contract.
+   *
+   * @tparam K         key type of the store
+   * @tparam V         value type of the store
+   * @param supplier   the `org.apache.kafka.streams.state.SessionBytesStoreSupplier` used to materialize the store
+   * @param keySerde   the key serde to use.
+   * @param valueSerde the value serde to use.
+   * @return a new [[Materialized]] instance with the given supplier
+   */
+  def as[K, V](
+    supplier: SessionBytesStoreSupplier
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, ByteArraySessionStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Materialize a `org.apache.kafka.streams.state.KeyValueStore` using the provided
+   * `org.apache.kafka.streams.state.KeyValueBytesStoreSupplier`.
+   *
+   * @tparam K         key type of the store
+   * @tparam V         value type of the store
+   * @param supplier   the `org.apache.kafka.streams.state.KeyValueBytesStoreSupplier` used to
+   *                   materialize the store
+   * @param keySerde   the key serde to use.
+   * @param valueSerde the value serde to use.
+   * @return a new [[Materialized]] instance with the given supplier
+   */
+  def as[K, V](
+    supplier: KeyValueBytesStoreSupplier
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): MaterializedJ[K, V, ByteArrayKeyValueStore] =
+    MaterializedJ.as(supplier).withKeySerde(keySerde).withValueSerde(valueSerde)
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Produced.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Produced.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Produced => ProducedJ}
+import org.apache.kafka.streams.processor.StreamPartitioner
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Produced` instead", "4.3.0")
+object Produced {
+
+  /**
+   * Create a Produced instance with provided keySerde and valueSerde.
+   *
+   * @tparam K         key type
+   * @tparam V         value type
+   * @param keySerde   Serde to use for serializing the key
+   * @param valueSerde Serde to use for serializing the value
+   * @return A new [[Produced]] instance configured with keySerde and valueSerde
+   * @see KStream#through(String, Produced)
+   * @see KStream#to(String, Produced)
+   */
+  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): ProducedJ[K, V] =
+    ProducedJ.`with`(keySerde, valueSerde)
+
+  /**
+   * Create a Produced instance with provided keySerde, valueSerde, and partitioner.
+   *
+   * @tparam K          key type
+   * @tparam V          value type
+   * @param partitioner the function used to determine how records are distributed among partitions of the topic,
+   *                    if not specified and `keySerde` provides a
+   *                    `org.apache.kafka.streams.kstream.internals.WindowedSerializer` for the key
+   *                    `org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner` will be
+   *                    used&mdash;otherwise `org.apache.kafka.clients.producer.internals.DefaultPartitioner`
+   *                    will be used
+   * @param keySerde    Serde to use for serializing the key
+   * @param valueSerde  Serde to use for serializing the value
+   * @return A new [[Produced]] instance configured with keySerde, valueSerde, and partitioner
+   * @see KStream#through(String, Produced)
+   * @see KStream#to(String, Produced)
+   */
+  def `with`[K, V](
+    partitioner: StreamPartitioner[K, V]
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): ProducedJ[K, V] =
+    ProducedJ.`with`(keySerde, valueSerde, partitioner)
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Repartitioned.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/Repartitioned.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Repartitioned => RepartitionedJ}
+import org.apache.kafka.streams.processor.StreamPartitioner
+
+@deprecated("Use `org.apache.kafka.streams.kstream.Repartitioned` instead", "4.3.0")
+object Repartitioned {
+
+  /**
+   * Create a Repartitioned instance with provided keySerde and valueSerde.
+   *
+   * @tparam K         key type
+   * @tparam V         value type
+   * @param keySerde    Serde to use for serializing the key
+   * @param valueSerde  Serde to use for serializing the value
+   * @return A new [[Repartitioned]] instance configured with keySerde and valueSerde
+   * @see KStream#repartition(Repartitioned)
+   */
+  def `with`[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): RepartitionedJ[K, V] =
+    RepartitionedJ.`with`(keySerde, valueSerde)
+
+  /**
+   * Create a Repartitioned instance with provided keySerde, valueSerde, and name used as part of the repartition topic.
+   *
+   * @tparam K         key type
+   * @tparam V         value type
+   * @param name   the name used as a processor named and part of the repartition topic name.
+   * @param keySerde    Serde to use for serializing the key
+   * @param valueSerde  Serde to use for serializing the value
+   * @return A new [[Repartitioned]] instance configured with keySerde, valueSerde, and processor and repartition topic name
+   * @see KStream#repartition(Repartitioned)
+   */
+  def `with`[K, V](name: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): RepartitionedJ[K, V] =
+    RepartitionedJ.`as`(name).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Create a Repartitioned instance with provided keySerde, valueSerde, and partitioner.
+   *
+   * @tparam K          key type
+   * @tparam V          value type
+   * @param partitioner the function used to determine how records are distributed among partitions of the topic,
+   *                    if not specified and `keySerde` provides a
+   *                    `org.apache.kafka.streams.kstream.internals.WindowedSerializer` for the key
+   *                    `org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner` will be
+   *                    used&mdash;otherwise `org.apache.kafka.clients.producer.internals.DefaultPartitioner`
+   *                    will be used
+   * @param keySerde    Serde to use for serializing the key
+   * @param valueSerde  Serde to use for serializing the value
+   * @return A new [[Repartitioned]] instance configured with keySerde, valueSerde, and partitioner
+   * @see KStream#repartition(Repartitioned)
+   */
+  def `with`[K, V](
+    partitioner: StreamPartitioner[K, V]
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V]): RepartitionedJ[K, V] =
+    RepartitionedJ.`streamPartitioner`(partitioner).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  /**
+   * Create a Repartitioned instance with provided keySerde, valueSerde, and number of partitions for repartition topic.
+   *
+   * @tparam K          key type
+   * @tparam V          value type
+   * @param numberOfPartitions number of partitions used when creating repartition topic
+   * @param keySerde    Serde to use for serializing the key
+   * @param valueSerde  Serde to use for serializing the value
+   * @return A new [[Repartitioned]] instance configured with keySerde, valueSerde, and number of partitions
+   * @see KStream#repartition(Repartitioned)
+   */
+  def `with`[K, V](numberOfPartitions: Int)(implicit keySerde: Serde[K], valueSerde: Serde[V]): RepartitionedJ[K, V] =
+    RepartitionedJ.`numberOfPartitions`(numberOfPartitions).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.{SessionWindowedCogroupedKStream => SessionWindowedCogroupedKStreamJ, Windowed}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{InitializerFromFunction, MergerFromFunction}
+
+/**
+ * Wraps the Java class SessionWindowedCogroupedKStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for SessionWindowedCogroupedKStream
+ * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream` instead", "4.3.0")
+class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedKStreamJ[K, V]) {
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer  the initializer function
+   * @param merger       a function that combines two aggregation results.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V, merger: (K, V, V) => V)(implicit
+    materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, materialized))
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer  the initializer function
+   * @param merger       a function that combines two aggregation results.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V, merger: (K, V, V) => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, named, materialized))
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.internals.KTableImpl
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.kstream.{KTable => KTableJ, SessionWindowedKStream => SessionWindowedKStreamJ, Windowed}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  AggregatorFromFunction,
+  InitializerFromFunction,
+  MergerFromFunction,
+  ReducerFromFunction,
+  ValueMapperFromFunction
+}
+
+/**
+ * Wraps the Java class SessionWindowedKStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for SessionWindowedKStream
+ * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.SessionWindowedKStream` instead", "4.3.0")
+class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer  the initializer function
+   * @param aggregator   the aggregator function
+   * @param merger       the merger function
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR, merger: (K, VR, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArraySessionStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(
+      inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, merger.asMerger, materialized)
+    )
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer  the initializer function
+   * @param aggregator   the aggregator function
+   * @param merger       the merger function
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR, merger: (K, VR, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArraySessionStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(
+      inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, merger.asMerger, named, materialized)
+    )
+
+  /**
+   * Count the number of records in this stream by the grouped key into `SessionWindows`.
+   *
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys and `Long` values
+   *         that represent the latest (rolling) count (i.e., number of records) for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
+   */
+  def count()(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArraySessionStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArraySessionStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Count the number of records in this stream by the grouped key into `SessionWindows`.
+   *
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys and `Long` values
+   *         that represent the latest (rolling) count (i.e., number of records) for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
+   */
+  def count(
+    named: Named
+  )(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArraySessionStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArraySessionStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Combine values of this stream by the grouped key into `SessionWindows`.
+   *
+   * @param reducer      a reducer function that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V)(implicit
+    materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Combine values of this stream by the grouped key into `SessionWindows`.
+   *
+   * @param reducer      a reducer function that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   *         the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, named, materialized))
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/StreamJoined.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/StreamJoined.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{StreamJoined => StreamJoinedJ}
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier
+
+@deprecated("Use `org.apache.kafka.streams.kstream.StreamJoined` instead", "4.3.0")
+object StreamJoined {
+
+  /**
+   * Create an instance of [[StreamJoined]] with key, value, and otherValue
+   * `org.apache.kafka.common.serialization.Serde` instances.
+   * `null` values are accepted and will be replaced by the default serdes as defined in config.
+   *
+   * @tparam K              key type
+   * @tparam V              value type
+   * @tparam VO             other value type
+   * @param keySerde        the key serde to use.
+   * @param valueSerde      the value serde to use.
+   * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
+   * @return new [[StreamJoined]] instance with the provided serdes
+   */
+  def `with`[K, V, VO](implicit
+    keySerde: Serde[K],
+    valueSerde: Serde[V],
+    otherValueSerde: Serde[VO]
+  ): StreamJoinedJ[K, V, VO] =
+    StreamJoinedJ.`with`(keySerde, valueSerde, otherValueSerde)
+
+  /**
+   * Create an instance of [[StreamJoined]] with store suppliers for the calling stream
+   * and the other stream.  Also adds the key, value, and otherValue
+   * `org.apache.kafka.common.serialization.Serde` instances.
+   * `null` values are accepted and will be replaced by the default serdes as defined in config.
+   *
+   * @tparam K key type
+   * @tparam V value type
+   * @tparam VO other value type
+   * @param supplier  store supplier to use
+   * @param otherSupplier other store supplier to use
+   * @param keySerde        the key serde to use.
+   * @param valueSerde      the value serde to use.
+   * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
+   * @return new [[StreamJoined]] instance with the provided store suppliers and serdes
+   */
+  def `with`[K, V, VO](
+    supplier: WindowBytesStoreSupplier,
+    otherSupplier: WindowBytesStoreSupplier
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V], otherValueSerde: Serde[VO]): StreamJoinedJ[K, V, VO] =
+    StreamJoinedJ
+      .`with`(supplier, otherSupplier)
+      .withKeySerde(keySerde)
+      .withValueSerde(valueSerde)
+      .withOtherValueSerde(otherValueSerde)
+
+  /**
+   * Create an instance of [[StreamJoined]] with the name used for naming
+   * the state stores involved in the join.  Also adds the key, value, and otherValue
+   * `org.apache.kafka.common.serialization.Serde` instances.
+   * `null` values are accepted and will be replaced by the default serdes as defined in config.
+   *
+   * @tparam K key type
+   * @tparam V value type
+   * @tparam VO other value type
+   * @param storeName       the name to use as a base name for the state stores of the join
+   * @param keySerde        the key serde to use.
+   * @param valueSerde      the value serde to use.
+   * @param otherValueSerde the otherValue serde to use. If `null` the default value serde from config will be used
+   * @return new [[StreamJoined]] instance with the provided store suppliers and serdes
+   */
+  def as[K, V, VO](
+    storeName: String
+  )(implicit keySerde: Serde[K], valueSerde: Serde[V], otherValueSerde: Serde[VO]): StreamJoinedJ[K, V, VO] =
+    StreamJoinedJ.as(storeName).withKeySerde(keySerde).withValueSerde(valueSerde).withOtherValueSerde(otherValueSerde)
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.{TimeWindowedCogroupedKStream => TimeWindowedCogroupedKStreamJ, Windowed}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.InitializerFromFunction
+
+/**
+ * Wraps the Java class TimeWindowedCogroupedKStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for TimeWindowedCogroupedKStream
+ * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream` instead", "4.3.0")
+class TimeWindowedCogroupedKStream[K, V](val inner: TimeWindowedCogroupedKStreamJ[K, V]) {
+
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V)(implicit
+    materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, materialized))
+
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, named, materialized))
+
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+package kstream
+
+import org.apache.kafka.streams.kstream.internals.KTableImpl
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.kstream.{KTable => KTableJ, TimeWindowedKStream => TimeWindowedKStreamJ, Windowed}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  AggregatorFromFunction,
+  InitializerFromFunction,
+  ReducerFromFunction,
+  ValueMapperFromFunction
+}
+
+/**
+ * Wraps the Java class TimeWindowedKStream and delegates method calls to the underlying Java object.
+ *
+ * @tparam K Type of keys
+ * @tparam V Type of values
+ * @param inner The underlying Java abstraction for TimeWindowedKStream
+ * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream`
+ */
+@deprecated("Use `org.apache.kafka.streams.kstream.TimeWindowedKStream` instead", "4.3.0")
+class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key.
+   *
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param aggregator   an aggregator function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayWindowStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, materialized))
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key.
+   *
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param aggregator   an aggregator function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR)(implicit
+    materialized: Materialized[K, VR, ByteArrayWindowStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, named, materialized))
+
+  /**
+   * Count the number of records in this stream by the grouped key and the defined windows.
+   *
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
+   */
+  def count()(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayWindowStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArrayWindowStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Count the number of records in this stream by the grouped key and the defined windows.
+   *
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   *         represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
+   */
+  def count(
+    named: Named
+  )(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayWindowStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArrayWindowStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Combine the values of records in this stream by the grouped key.
+   *
+   * @param reducer      a function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V)(implicit
+    materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Combine the values of records in this stream by the grouped key.
+   *
+   * @param reducer      a function that computes a new aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   *         latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V, named: Named)(implicit
+    materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/package.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/kstream/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.streams.processor.StateStore
+
+package object kstream {
+  type Materialized[K, V, S <: StateStore] = org.apache.kafka.streams.kstream.Materialized[K, V, S]
+  type Grouped[K, V] = org.apache.kafka.streams.kstream.Grouped[K, V]
+  type Consumed[K, V] = org.apache.kafka.streams.kstream.Consumed[K, V]
+  type Produced[K, V] = org.apache.kafka.streams.kstream.Produced[K, V]
+  type Repartitioned[K, V] = org.apache.kafka.streams.kstream.Repartitioned[K, V]
+  type Joined[K, V, VO] = org.apache.kafka.streams.kstream.Joined[K, V, VO]
+  type StreamJoined[K, V, VO] = org.apache.kafka.streams.kstream.StreamJoined[K, V, VO]
+  type Named = org.apache.kafka.streams.kstream.Named
+  type Branched[K, V] = org.apache.kafka.streams.kstream.Branched[K, V]
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/package.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/package.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams
+
+import org.apache.kafka.streams.state.{KeyValueStore, SessionStore, WindowStore}
+import org.apache.kafka.common.utils.Bytes
+
+package object scala {
+  type ByteArrayKeyValueStore = KeyValueStore[Bytes, Array[Byte]]
+  type ByteArraySessionStore = SessionStore[Bytes, Array[Byte]]
+  type ByteArrayWindowStore = WindowStore[Bytes, Array[Byte]]
+}

--- a/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/serialization/Serdes.scala
+++ b/streams/streams-scala/bin/main/org/apache/kafka/streams/scala/serialization/Serdes.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.serialization
+
+import java.nio.ByteBuffer
+import java.util
+import java.util.UUID
+
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serdes => JSerdes, Serializer}
+import org.apache.kafka.streams.kstream.WindowedSerdes
+
+@deprecated("Use org.apache.kafka.common.serialization.Serdes instead", "4.3.0")
+object Serdes extends LowPrioritySerdes {
+  implicit def stringSerde: Serde[String] = JSerdes.String()
+  implicit def longSerde: Serde[Long] = JSerdes.Long().asInstanceOf[Serde[Long]]
+  implicit def javaLongSerde: Serde[java.lang.Long] = JSerdes.Long()
+  implicit def byteArraySerde: Serde[Array[Byte]] = JSerdes.ByteArray()
+  implicit def bytesSerde: Serde[org.apache.kafka.common.utils.Bytes] = JSerdes.Bytes()
+  implicit def byteBufferSerde: Serde[ByteBuffer] = JSerdes.ByteBuffer()
+  implicit def shortSerde: Serde[Short] = JSerdes.Short().asInstanceOf[Serde[Short]]
+  implicit def javaShortSerde: Serde[java.lang.Short] = JSerdes.Short()
+  implicit def floatSerde: Serde[Float] = JSerdes.Float().asInstanceOf[Serde[Float]]
+  implicit def javaFloatSerde: Serde[java.lang.Float] = JSerdes.Float()
+  implicit def doubleSerde: Serde[Double] = JSerdes.Double().asInstanceOf[Serde[Double]]
+  implicit def javaDoubleSerde: Serde[java.lang.Double] = JSerdes.Double()
+  implicit def intSerde: Serde[Int] = JSerdes.Integer().asInstanceOf[Serde[Int]]
+  implicit def javaIntegerSerde: Serde[java.lang.Integer] = JSerdes.Integer()
+  implicit def uuidSerde: Serde[UUID] = JSerdes.UUID()
+
+  implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T] =
+    new WindowedSerdes.SessionWindowedSerde[T](tSerde)
+
+  def fromFn[T >: Null](serializer: T => Array[Byte], deserializer: Array[Byte] => Option[T]): Serde[T] =
+    JSerdes.serdeFrom(
+      new Serializer[T] {
+        override def serialize(topic: String, data: T): Array[Byte] = serializer(data)
+        override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+        override def close(): Unit = ()
+      },
+      new Deserializer[T] {
+        override def deserialize(topic: String, data: Array[Byte]): T = deserializer(data).orNull
+        override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+        override def close(): Unit = ()
+      }
+    )
+
+  def fromFn[T >: Null](
+    serializer: (String, T) => Array[Byte],
+    deserializer: (String, Array[Byte]) => Option[T]
+  ): Serde[T] =
+    JSerdes.serdeFrom(
+      new Serializer[T] {
+        override def serialize(topic: String, data: T): Array[Byte] = serializer(topic, data)
+        override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+        override def close(): Unit = ()
+      },
+      new Deserializer[T] {
+        override def deserialize(topic: String, data: Array[Byte]): T = deserializer(topic, data).orNull
+        override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+        override def close(): Unit = ()
+      }
+    )
+}
+
+trait LowPrioritySerdes {
+
+  implicit val nullSerde: Serde[Null] =
+    Serdes.fromFn[Null](
+      { _: Null =>
+        null
+      },
+      { _: Array[Byte] =>
+        None
+      }
+    )
+}

--- a/streams/streams-scala/bin/test/log4j2.yaml
+++ b/streams/streams-scala/bin/test/log4j2.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "%-4r [%t] %-5p %c %x - %m%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/StreamToTableJoinTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/StreamToTableJoinTest.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.kstream._
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.scala.utils.TestDriver
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Test suite that demonstrates a stream-table join in Kafka Streams using the Scala API with implicit serdes.
+ */
+class StreamToTableJoinTest extends TestDriver {
+
+  private val userClicksTopic = "user-clicks"
+  private val userRegionsTopic = "user-regions"
+  private val outputTopic = "output-topic"
+
+  // Input 1: Clicks per user (multiple records allowed per user).
+  private val userClicks: Seq[(String, Long)] = Seq(
+    "alice" -> 13L,
+    "bob" -> 4L,
+    "chao" -> 25L,
+    "bob" -> 19L,
+    "dave" -> 56L,
+    "eve" -> 78L,
+    "alice" -> 40L,
+    "fang" -> 99L
+  )
+
+  // Input 2: Region per user (multiple records allowed per user).
+  private val userRegions: Seq[(String, String)] = Seq(
+    "alice" -> "asia",
+    "bob" -> "americas",
+    "chao" -> "asia",
+    "dave" -> "europe",
+    "alice" -> "europe",
+    "eve" -> "americas",
+    "fang" -> "asia"
+  )
+
+  private val expectedClicksPerRegion: Map[String, Long] = Map(
+    "americas" -> 101L,
+    "europe" -> 109L,
+    "asia" -> 124L
+  )
+
+  @Test
+  def testShouldCountClicksPerRegionWithImplicitSerdes(): Unit = {
+    // DefaultSerdes brings into scope implicit serdes (mostly for primitives) that will set up all Grouped, Produced,
+    // Consumed and Joined instances. So all APIs below that accept Grouped, Produced, Consumed or Joined will
+    // get these instances automatically.
+    val builder = new StreamsBuilder()
+
+    val userClicksStream: KStream[String, Long] = builder.stream(userClicksTopic)
+
+    val userRegionsTable: KTable[String, String] = builder.table(userRegionsTopic)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: KTable[String, Long] =
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable)((clicks, region) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val testDriver = createTestDriver(builder)
+    val userRegionsInput = testDriver.createInput[String, String](userRegionsTopic)
+    val userClicksInput = testDriver.createInput[String, Long](userClicksTopic)
+    val output = testDriver.createOutput[String, Long](outputTopic)
+
+    userRegions.foreach { case (user, region) => userRegionsInput.pipeInput(user, region) }
+    userClicks.foreach { case (user, clicks) => userClicksInput.pipeInput(user, clicks) }
+
+    assertEquals(expectedClicksPerRegion.asJava, output.readKeyValuesToMap())
+
+    testDriver.close()
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -1,0 +1,470 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala
+
+import java.time.Duration
+import java.util
+import java.util.{Locale, Properties}
+import java.util.regex.Pattern
+import org.apache.kafka.common.serialization.{Serdes => SerdesJ}
+import org.apache.kafka.streams.kstream.{
+  Aggregator,
+  Initializer,
+  JoinWindows,
+  KGroupedStream => KGroupedStreamJ,
+  KStream => KStreamJ,
+  KTable => KTableJ,
+  KeyValueMapper,
+  Materialized => MaterializedJ,
+  Reducer,
+  StreamJoined => StreamJoinedJ,
+  ValueJoiner,
+  ValueMapper
+}
+import org.apache.kafka.streams.processor.api
+import org.apache.kafka.streams.processor.api.{Processor, ProcessorSupplier}
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.serialization.{Serdes => NewSerdes}
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.scala.kstream._
+import org.apache.kafka.streams.{KeyValue, StreamsBuilder => StreamsBuilderJ, StreamsConfig, TopologyDescription}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api._
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Test suite that verifies that the topology built by the Java and Scala APIs match.
+ */
+//noinspection ScalaDeprecation
+@Timeout(600)
+class TopologyTest {
+  private val inputTopic = "input-topic"
+  private val userClicksTopic = "user-clicks-topic"
+  private val userRegionsTopic = "user-regions-topic"
+
+  private val pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS)
+
+  @Test
+  def shouldBuildIdenticalTopologyInJavaNScalaSimple(): Unit = {
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val streamBuilder = new StreamsBuilder
+      val textLines = streamBuilder.stream[String, String](inputTopic)
+
+      val _: KStream[String, String] = textLines.flatMapValues(v => pattern.split(v.toLowerCase))
+
+      streamBuilder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+      val streamBuilder = new StreamsBuilderJ
+      val textLines = streamBuilder.stream[String, String](inputTopic)
+      val _: KStreamJ[String, String] = textLines.flatMapValues(s => pattern.split(s.toLowerCase).toBuffer.asJava)
+      streamBuilder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test
+  def shouldBuildIdenticalTopologyInJavaNScalaAggregate(): Unit = {
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val streamBuilder = new StreamsBuilder
+      val textLines = streamBuilder.stream[String, String](inputTopic)
+
+      textLines
+        .flatMapValues(v => pattern.split(v.toLowerCase))
+        .groupBy((_, v) => v)
+        .count()
+
+      streamBuilder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+
+      val streamBuilder = new StreamsBuilderJ
+      val textLines: KStreamJ[String, String] = streamBuilder.stream[String, String](inputTopic)
+
+      val splits: KStreamJ[String, String] =
+        textLines.flatMapValues(s => pattern.split(s.toLowerCase).toBuffer.asJava)
+
+      val grouped: KGroupedStreamJ[String, String] = splits.groupBy((_, v) => v)
+
+      grouped.count()
+
+      streamBuilder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test def shouldBuildIdenticalTopologyInJavaNScalaCogroupSimple(): Unit = {
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val streamBuilder = new StreamsBuilder
+      val textLines = streamBuilder.stream[String, String](inputTopic)
+      textLines
+        .mapValues(v => v.length)
+        .groupByKey
+        .cogroup((_, v1, v2: Long) => v1 + v2)
+        .aggregate(0L)
+
+      streamBuilder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+
+      val streamBuilder = new StreamsBuilderJ
+      val textLines: KStreamJ[String, String] = streamBuilder.stream[String, String](inputTopic)
+
+      val splits: KStreamJ[String, Int] = textLines.mapValues(
+        new ValueMapper[String, Int] {
+          def apply(s: String): Int = s.length
+        }
+      )
+
+      splits.groupByKey
+        .cogroup((k: String, v: Int, a: Long) => a + v)
+        .aggregate(() => 0L)
+
+      streamBuilder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test def shouldBuildIdenticalTopologyInJavaNScalaCogroup(): Unit = {
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val streamBuilder = new StreamsBuilder
+      val textLines1 = streamBuilder.stream[String, String](inputTopic)
+      val textLines2 = streamBuilder.stream[String, String]("inputTopic2")
+
+      textLines1
+        .mapValues(v => v.length)
+        .groupByKey
+        .cogroup((_, v1, v2: Long) => v1 + v2)
+        .cogroup(textLines2.groupByKey, (_, v: String, a) => v.length + a)
+        .aggregate(0L)
+
+      streamBuilder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+
+      val streamBuilder = new StreamsBuilderJ
+      val textLines1: KStreamJ[String, String] = streamBuilder.stream[String, String](inputTopic)
+      val textLines2: KStreamJ[String, String] = streamBuilder.stream[String, String]("inputTopic2")
+
+      val splits: KStreamJ[String, Int] = textLines1.mapValues(
+        new ValueMapper[String, Int] {
+          def apply(s: String): Int = s.length
+        }
+      )
+
+      splits.groupByKey
+        .cogroup((k: String, v: Int, a: Long) => a + v)
+        .cogroup(textLines2.groupByKey(), (k: String, v: String, a: Long) => v.length + a)
+        .aggregate(() => 0L)
+
+      streamBuilder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test def shouldBuildIdenticalTopologyInJavaNScalaJoin(): Unit = {
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val builder = new StreamsBuilder()
+
+      val userClicksStream: KStream[String, Long] = builder.stream(userClicksTopic)
+
+      val userRegionsTable: KTable[String, String] = builder.table(userRegionsTopic)
+
+      // clicks per region
+      userClicksStream
+        .leftJoin(userRegionsTable)((clicks, region) => (if (region == null) "UNKNOWN" else region, clicks))
+        .map((_, regionWithClicks) => regionWithClicks)
+        .groupByKey
+        .reduce(_ + _)
+
+      builder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+
+      import java.lang.{Long => JLong}
+
+      val builder: StreamsBuilderJ = new StreamsBuilderJ()
+
+      val userClicksStream: KStreamJ[String, JLong] =
+        builder.stream[String, JLong](userClicksTopic, Consumed.`with`[String, JLong])
+
+      val userRegionsTable: KTableJ[String, String] =
+        builder.table[String, String](userRegionsTopic, Consumed.`with`[String, String])
+
+      // Join the stream against the table.
+      val valueJoinerJ: ValueJoiner[JLong, String, (String, JLong)] =
+        (clicks: JLong, region: String) => (if (region == null) "UNKNOWN" else region, clicks)
+      val userClicksJoinRegion: KStreamJ[String, (String, JLong)] = userClicksStream.leftJoin(
+        userRegionsTable,
+        valueJoinerJ,
+        Joined.`with`[String, JLong, String]
+      )
+
+      // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+      val clicksByRegion: KStreamJ[String, JLong] = userClicksJoinRegion.map { (_, regionWithClicks) =>
+        new KeyValue(regionWithClicks._1, regionWithClicks._2)
+      }
+
+      // Compute the total per region by summing the individual click counts per region.
+      clicksByRegion
+        .groupByKey(Grouped.`with`[String, JLong])
+        .reduce((v1, v2) => v1 + v2)
+
+      builder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test
+  def shouldBuildIdenticalTopologyInJavaNScalaProcess(): Unit = {
+    val processorSupplier = new ProcessorSupplier[String, String, String, String] {
+      override def get(): Processor[String, String, String, String] =
+        new api.Processor[String, String, String, String] {
+          override def process(record: api.Record[String, String]): Unit = {}
+        }
+    }
+
+    // build the Scala topology
+    def getTopologyScala: TopologyDescription = {
+
+      import org.apache.kafka.streams.scala.serialization.Serdes._
+
+      val streamBuilder = new StreamsBuilder
+      val textLines = streamBuilder.stream[String, String](inputTopic)
+
+      val _: KTable[String, Long] = textLines
+        .process(processorSupplier)
+        .groupBy((_, v) => v)
+        .count()
+
+      streamBuilder.build().describe()
+    }
+
+    // build the Java topology
+    def getTopologyJava: TopologyDescription = {
+
+      val streamBuilder = new StreamsBuilderJ
+      val textLines: KStreamJ[String, String] = streamBuilder.stream[String, String](inputTopic)
+
+      val lowered: KStreamJ[String, String] = textLines.process(processorSupplier)
+
+      val grouped: KGroupedStreamJ[String, String] = lowered.groupBy((_, v) => v)
+
+      // word counts
+      grouped.count()
+
+      streamBuilder.build().describe()
+    }
+
+    // should match
+    assertEquals(getTopologyScala, getTopologyJava)
+  }
+
+  @Test
+  def shouldBuildIdenticalTopologyInJavaNScalaProperties(): Unit = {
+
+    val props = new Properties()
+    props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE)
+
+    val propsNoOptimization = new Properties()
+    propsNoOptimization.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.NO_OPTIMIZATION)
+
+    val AGGREGATION_TOPIC = "aggregationTopic"
+    val REDUCE_TOPIC = "reduceTopic"
+    val JOINED_TOPIC = "joinedTopic"
+
+    // build the Scala topology
+    def getTopologyScala: StreamsBuilder = {
+
+      val aggregator = (_: String, v: String, agg: Int) => agg + v.length
+      val reducer = (v1: String, v2: String) => v1 + ":" + v2
+      val processorValueCollector: util.List[String] = new util.ArrayList[String]
+
+      val builder: StreamsBuilder = new StreamsBuilder
+
+      val sourceStream: KStream[String, String] =
+        builder.stream(inputTopic)(Consumed.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+
+      val mappedStream: KStream[String, String] =
+        sourceStream.map((k: String, v: String) => (k.toUpperCase(Locale.getDefault), v))
+      mappedStream
+        .filter((k: String, _: String) => k == "B")
+        .mapValues((v: String) => v.toUpperCase(Locale.getDefault))
+        .process(new SimpleProcessorSupplier(processorValueCollector))
+
+      val stream2 = mappedStream.groupByKey
+        .aggregate(0)(aggregator)(Materialized.`with`(NewSerdes.stringSerde, NewSerdes.intSerde))
+        .toStream
+      stream2.to(AGGREGATION_TOPIC)(Produced.`with`(NewSerdes.stringSerde, NewSerdes.intSerde))
+
+      // adding operators for case where the repartition node is further downstream
+      val stream3 = mappedStream
+        .filter((_: String, _: String) => true)
+        .peek((k: String, v: String) => System.out.println(k + ":" + v))
+        .groupByKey
+        .reduce(reducer)(Materialized.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+        .toStream
+      stream3.to(REDUCE_TOPIC)(Produced.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+
+      mappedStream
+        .filter((k: String, _: String) => k == "A")
+        .join(stream2)(
+          (v1: String, v2: Int) => v1 + ":" + v2.toString,
+          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24))
+        )(
+          StreamJoined.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, NewSerdes.intSerde)
+        )
+        .to(JOINED_TOPIC)
+
+      mappedStream
+        .filter((k: String, _: String) => k == "A")
+        .join(stream3)(
+          (v1: String, v2: String) => v1 + ":" + v2.toString,
+          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24))
+        )(
+          StreamJoined.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, NewSerdes.stringSerde)
+        )
+        .to(JOINED_TOPIC)
+
+      builder
+    }
+
+    // build the Java topology
+    def getTopologyJava: StreamsBuilderJ = {
+
+      val keyValueMapper: KeyValueMapper[String, String, KeyValue[String, String]] =
+        (key, value) => KeyValue.pair(key.toUpperCase(Locale.getDefault), value)
+      val initializer: Initializer[Integer] = () => 0
+      val aggregator: Aggregator[String, String, Integer] = (_, value, aggregate) => aggregate + value.length
+      val reducer: Reducer[String] = (v1, v2) => v1 + ":" + v2
+      val valueMapper: ValueMapper[String, String] = v => v.toUpperCase(Locale.getDefault)
+      val processorValueCollector = new util.ArrayList[String]
+      val processorSupplier = new SimpleProcessorSupplier(processorValueCollector)
+      val valueJoiner2: ValueJoiner[String, Integer, String] = (value1, value2) => value1 + ":" + value2.toString
+      val valueJoiner3: ValueJoiner[String, String, String] = (value1, value2) => value1 + ":" + value2
+
+      val builder = new StreamsBuilderJ
+
+      val sourceStream = builder.stream(inputTopic, Consumed.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+
+      val mappedStream: KStreamJ[String, String] =
+        sourceStream.map(keyValueMapper)
+      mappedStream
+        .filter((key, _) => key == "B")
+        .mapValues[String](valueMapper)
+        .process(processorSupplier)
+
+      val stream2: KStreamJ[String, Integer] = mappedStream.groupByKey
+        .aggregate(initializer, aggregator, MaterializedJ.`with`(NewSerdes.stringSerde, SerdesJ.Integer))
+        .toStream
+      stream2.to(AGGREGATION_TOPIC, Produced.`with`(NewSerdes.stringSerde, SerdesJ.Integer))
+
+      // adding operators for case where the repartition node is further downstream
+      val stream3 = mappedStream
+        .filter((_, _) => true)
+        .peek((k, v) => System.out.println(k + ":" + v))
+        .groupByKey
+        .reduce(reducer, MaterializedJ.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+        .toStream
+      stream3.to(REDUCE_TOPIC, Produced.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde))
+
+      mappedStream
+        .filter((key, _) => key == "A")
+        .join[Integer, String](
+          stream2,
+          valueJoiner2,
+          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)),
+          StreamJoinedJ.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, SerdesJ.Integer)
+        )
+        .to(JOINED_TOPIC)
+
+      mappedStream
+        .filter((key, _) => key == "A")
+        .join(
+          stream3,
+          valueJoiner3,
+          JoinWindows.ofTimeDifferenceAndGrace(Duration.ofMillis(5000), Duration.ofHours(24)),
+          StreamJoinedJ.`with`(NewSerdes.stringSerde, NewSerdes.stringSerde, SerdesJ.String)
+        )
+        .to(JOINED_TOPIC)
+
+      builder
+    }
+
+    assertNotEquals(
+      getTopologyScala.build(props).describe.toString,
+      getTopologyScala.build(propsNoOptimization).describe.toString
+    )
+    assertEquals(
+      getTopologyScala.build(propsNoOptimization).describe.toString,
+      getTopologyJava.build(propsNoOptimization).describe.toString
+    )
+    assertEquals(getTopologyScala.build(props).describe.toString, getTopologyJava.build(props).describe.toString)
+  }
+
+  private class SimpleProcessorSupplier private[TopologyTest] (val valueList: util.List[String])
+      extends ProcessorSupplier[String, String, Void, Void] {
+
+    override def get(): Processor[String, String, Void, Void] =
+      (record: api.Record[String, String]) => valueList.add(record.value())
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/ConsumedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/ConsumedTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy
+import org.apache.kafka.streams.AutoOffsetReset
+import org.apache.kafka.streams.kstream.internals.ConsumedInternal
+import org.apache.kafka.streams.processor.FailOnInvalidTimestamp
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ConsumedTest {
+
+  @Test
+  def testCreateConsumed(): Unit = {
+    val consumed: Consumed[String, Long] = Consumed.`with`[String, Long]
+
+    val internalConsumed = new ConsumedInternal(consumed)
+    assertEquals(Serdes.stringSerde.getClass, internalConsumed.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalConsumed.valueSerde.getClass)
+  }
+
+  @Test
+  def testCreateConsumedWithTimestampExtractorAndResetPolicy(): Unit = {
+    val timestampExtractor = new FailOnInvalidTimestamp()
+    val resetPolicy = AutoOffsetReset.latest()
+    val consumed: Consumed[String, Long] =
+      Consumed.`with`(timestampExtractor, resetPolicy)
+
+    val internalConsumed = new ConsumedInternal(consumed)
+    assertEquals(Serdes.stringSerde.getClass, internalConsumed.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalConsumed.valueSerde.getClass)
+    assertEquals(timestampExtractor, internalConsumed.timestampExtractor)
+    assertEquals(AutoOffsetResetStrategy.StrategyType.LATEST, internalConsumed.offsetResetPolicy.offsetResetStrategy())
+  }
+
+  @Test
+  def testCreateConsumedWithTimestampExtractor(): Unit = {
+    val timestampExtractor = new FailOnInvalidTimestamp()
+    val consumed: Consumed[String, Long] = Consumed.`with`[String, Long](timestampExtractor)
+
+    val internalConsumed = new ConsumedInternal(consumed)
+    assertEquals(Serdes.stringSerde.getClass, internalConsumed.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalConsumed.valueSerde.getClass)
+    assertEquals(timestampExtractor, internalConsumed.timestampExtractor)
+  }
+
+  @Test
+  def testCreateConsumedWithResetPolicy(): Unit = {
+    val resetPolicy = AutoOffsetReset.latest()
+    val consumed: Consumed[String, Long] = Consumed.`with`[String, Long](resetPolicy)
+
+    val internalConsumed = new ConsumedInternal(consumed)
+    assertEquals(Serdes.stringSerde.getClass, internalConsumed.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalConsumed.valueSerde.getClass)
+    assertEquals(AutoOffsetResetStrategy.StrategyType.LATEST, internalConsumed.offsetResetPolicy.offsetResetStrategy())
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/GroupedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/GroupedTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.internals.GroupedInternal
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GroupedTest {
+
+  @Test
+  def testCreateGrouped(): Unit = {
+    val grouped: Grouped[String, Long] = Grouped.`with`[String, Long]
+
+    val internalGrouped = new GroupedInternal[String, Long](grouped)
+    assertEquals(Serdes.stringSerde.getClass, internalGrouped.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalGrouped.valueSerde.getClass)
+  }
+
+  @Test
+  def testCreateGroupedWithRepartitionTopicName(): Unit = {
+    val repartitionTopicName = "repartition-topic"
+    val grouped: Grouped[String, Long] = Grouped.`with`(repartitionTopicName)
+
+    val internalGrouped = new GroupedInternal[String, Long](grouped)
+    assertEquals(Serdes.stringSerde.getClass, internalGrouped.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalGrouped.valueSerde.getClass)
+    assertEquals(repartitionTopicName, internalGrouped.name())
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/JoinedTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JoinedTest {
+
+  @Test
+  def testCreateJoined(): Unit = {
+    val joined: Joined[String, Long, Int] = Joined.`with`[String, Long, Int]
+
+    assertEquals(joined.keySerde.getClass, Serdes.stringSerde.getClass)
+    assertEquals(joined.valueSerde.getClass, Serdes.longSerde.getClass)
+    assertEquals(joined.otherValueSerde.getClass, Serdes.intSerde.getClass)
+  }
+
+  @Test
+  def testCreateJoinedWithSerdesAndRepartitionTopicName(): Unit = {
+    val repartitionTopicName = "repartition-topic"
+    val joined: Joined[String, Long, Int] = Joined.`with`(repartitionTopicName)
+
+    assertEquals(joined.keySerde.getClass, Serdes.stringSerde.getClass)
+    assertEquals(joined.valueSerde.getClass, Serdes.longSerde.getClass)
+    assertEquals(joined.otherValueSerde.getClass, Serdes.intSerde.getClass)
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KStreamSplitTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.Named
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.scala.utils.TestDriver
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class KStreamSplitTest extends TestDriver {
+
+  @Test
+  def testRouteMessagesAccordingToPredicates(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = Array("default", "even", "three");
+
+    val m = builder
+      .stream[Integer, Integer](sourceTopic)
+      .split(Named.as("_"))
+      .branch((_, v) => v % 2 == 0)
+      .branch((_, v) => v % 3 == 0)
+      .defaultBranch()
+
+    m("_0").to(sinkTopic(0))
+    m("_1").to(sinkTopic(1))
+    m("_2").to(sinkTopic(2))
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
+    val testOutput = sinkTopic.map(name => testDriver.createOutput[Integer, Integer](name))
+
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5)
+        .map(Integer.valueOf)
+        .asJava
+    )
+    assertEquals(List(1, 5), testOutput(0).readValuesToList().asScala)
+    assertEquals(List(2, 4), testOutput(1).readValuesToList().asScala)
+    assertEquals(List(3), testOutput(2).readValuesToList().asScala)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testRouteMessagesToConsumers(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+
+    val m = builder
+      .stream[Integer, Integer](sourceTopic)
+      .split(Named.as("_"))
+      .branch((_, v) => v % 2 == 0, Branched.withConsumer(ks => ks.to("even"), "consumedEvens"))
+      .branch((_, v) => v % 3 == 0, Branched.withFunction(ks => ks.mapValues(x => x * x), "mapped"))
+      .noDefaultBranch()
+
+    m("_mapped").to("mapped")
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5, 9)
+        .map(Integer.valueOf)
+        .asJava
+    )
+
+    val even = testDriver.createOutput[Integer, Integer]("even")
+    val mapped = testDriver.createOutput[Integer, Integer]("mapped")
+
+    assertEquals(List(2, 4), even.readValuesToList().asScala)
+    assertEquals(List(9, 81), mapped.readValuesToList().asScala)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testRouteMessagesToAnonymousConsumers(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+
+    val m = builder
+      .stream[Integer, Integer](sourceTopic)
+      .split(Named.as("_"))
+      .branch((_, v) => v % 2 == 0, Branched.withConsumer(ks => ks.to("even")))
+      .branch((_, v) => v % 3 == 0, Branched.withFunction(ks => ks.mapValues(x => x * x)))
+      .noDefaultBranch()
+
+    m("_2").to("mapped")
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[Integer, Integer](sourceTopic)
+    testInput.pipeValueList(
+      List(1, 2, 3, 4, 5, 9)
+        .map(Integer.valueOf)
+        .asJava
+    )
+
+    val even = testDriver.createOutput[Integer, Integer]("even")
+    val mapped = testDriver.createOutput[Integer, Integer]("mapped")
+
+    assertEquals(List(2, 4), even.readValuesToList().asScala)
+    assertEquals(List(9, 81), mapped.readValuesToList().asScala)
+
+    testDriver.close()
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import java.time.Duration.ofSeconds
+import java.time.{Duration, Instant}
+import org.apache.kafka.streams.kstream.{JoinWindows, Named}
+import org.apache.kafka.streams.processor.api
+import org.apache.kafka.streams.processor.api.{FixedKeyRecord, Processor, ProcessorSupplier}
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.utils.TestDriver
+import org.apache.kafka.streams.state.{KeyValueStore, StoreBuilder, Stores}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.util
+import java.util.Collections
+import scala.jdk.CollectionConverters._
+
+class KStreamTest extends TestDriver {
+
+  @Test
+  def testFilterRecordsSatisfyingPredicate(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    builder.stream[String, String](sourceTopic).filter((_, value) => value != "value2").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value1")
+    assertEquals("value1", testOutput.readValue)
+
+    testInput.pipeInput("2", "value2")
+    assertTrue(testOutput.isEmpty)
+
+    testInput.pipeInput("3", "value3")
+    assertEquals("value3", testOutput.readValue)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testFilterRecordsNotSatisfyingPredicate(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    builder.stream[String, String](sourceTopic).filterNot((_, value) => value == "value2").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value1")
+    assertEquals("value1", testOutput.readValue)
+
+    testInput.pipeInput("2", "value2")
+    assertTrue(testOutput.isEmpty)
+
+    testInput.pipeInput("3", "value3")
+    assertEquals("value3", testOutput.readValue)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testForeachActionsOnRecords(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+
+    var acc = ""
+    builder.stream[String, String](sourceTopic).foreach((_, value) => acc += value)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+
+    testInput.pipeInput("1", "value1")
+    assertEquals("value1", acc)
+
+    testInput.pipeInput("2", "value2")
+    assertEquals("value1value2", acc)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testPeekActionsOnRecords(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    var acc = ""
+    builder.stream[String, String](sourceTopic).peek((_, v) => acc += v).to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value1")
+    assertEquals("value1", acc)
+    assertEquals("value1", testOutput.readValue)
+
+    testInput.pipeInput("2", "value2")
+    assertEquals("value1value2", acc)
+    assertEquals("value2", testOutput.readValue)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testSelectNewKey(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    builder.stream[String, String](sourceTopic).selectKey((_, value) => value).to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value1")
+    assertEquals("value1", testOutput.readKeyValue.key)
+
+    testInput.pipeInput("1", "value2")
+    assertEquals("value2", testOutput.readKeyValue.key)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testRepartitionKStream(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val repartitionName = "repartition"
+    val sinkTopic = "sink"
+
+    builder.stream[String, String](sourceTopic).repartition(Repartitioned.`with`(repartitionName)).to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value1")
+    val kv1 = testOutput.readKeyValue
+    assertEquals("1", kv1.key)
+    assertEquals("value1", kv1.value)
+
+    testInput.pipeInput("2", "value2")
+    val kv2 = testOutput.readKeyValue
+    assertEquals("2", kv2.key)
+    assertEquals("value2", kv2.value)
+
+    assertTrue(testOutput.isEmpty)
+
+    // appId == "test"
+    testDriver.producedTopicNames() contains "test-" + repartitionName + "-repartition"
+
+    testDriver.close()
+  }
+
+  // noinspection ScalaDeprecation
+  @Test
+  def testJoinCorrectlyRecords(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val stream1 = builder.stream[String, String](sourceTopic1)
+    val stream2 = builder.stream[String, String](sourceTopic2)
+    stream1
+      .join(stream2)((a, b) => s"$a-$b", JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(1), Duration.ofHours(24)))
+      .to(sinkTopic)
+
+    val now = Instant.now()
+
+    val testDriver = createTestDriver(builder, now)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput1.pipeInput("1", "topic1value1", now)
+    testInput2.pipeInput("1", "topic2value1", now)
+
+    assertEquals("topic1value1-topic2value1", testOutput.readValue)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testProcessCorrectlyRecords(): Unit = {
+    val processorSupplier: ProcessorSupplier[String, String, String, String] =
+      new api.ProcessorSupplier[String, String, String, String] {
+        private val storeName = "store-name"
+
+        override def stores: util.Set[StoreBuilder[_]] = {
+          val keyValueStoreBuilder = Stores.keyValueStoreBuilder(
+            Stores.persistentKeyValueStore(storeName),
+            Serdes.stringSerde,
+            Serdes.stringSerde
+          )
+          Collections.singleton(keyValueStoreBuilder)
+        }
+
+        override def get(): Processor[String, String, String, String] =
+          new api.Processor[String, String, String, String] {
+            private var context: api.ProcessorContext[String, String] = _
+            private var store: KeyValueStore[String, String] = _
+
+            override def init(context: api.ProcessorContext[String, String]): Unit = {
+              this.context = context
+              store = context.getStateStore(storeName)
+            }
+
+            override def process(record: api.Record[String, String]): Unit = {
+              val key = record.key()
+              val value = record.value()
+              val processedKey = s"$key-processed"
+              val processedValue = s"$value-processed"
+              store.put(processedKey, processedValue)
+              context.forward(new api.Record(processedKey, processedValue, record.timestamp()))
+            }
+          }
+      }
+
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val stream = builder.stream[String, String](sourceTopic)
+    stream
+      .process(processorSupplier)
+      .to(sinkTopic)
+
+    val now = Instant.now()
+    val testDriver = createTestDriver(builder, now)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value", now)
+
+    val result = testOutput.readKeyValue()
+    assertEquals("value-processed", result.value)
+    assertEquals("1-processed", result.key)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testProcessValuesCorrectlyRecords(): Unit = {
+    val processorSupplier: api.FixedKeyProcessorSupplier[String, String, String] =
+      () =>
+        new api.FixedKeyProcessor[String, String, String] {
+          private var context: api.FixedKeyProcessorContext[String, String] = _
+
+          override def init(context: api.FixedKeyProcessorContext[String, String]): Unit =
+            this.context = context
+
+          override def process(record: FixedKeyRecord[String, String]): Unit = {
+            val processedValue = s"${record.value()}-processed"
+            context.forward(record.withValue(processedValue))
+          }
+        }
+
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val stream = builder.stream[String, String](sourceTopic)
+    stream
+      .processValues(processorSupplier)
+      .to(sinkTopic)
+
+    val now = Instant.now()
+    val testDriver = createTestDriver(builder, now)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput.pipeInput("1", "value", now)
+
+    val result = testOutput.readKeyValue()
+    assertEquals("value-processed", result.value)
+    assertEquals("1", result.key)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testJoinTwoKStreamToTables(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).toTable
+    val table2 = builder.stream[String, String](sourceTopic2).toTable
+    table1.join(table2)((a, b) => a + b).toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput1.pipeInput("1", "topic1value1")
+    testInput2.pipeInput("1", "topic2value1")
+
+    assertEquals("topic1value1topic2value1", testOutput.readValue)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testSettingNameOnFilter(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    builder
+      .stream[String, String](sourceTopic)
+      .filter((_, value) => value != "value2", Named.as("my-name"))
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val filterNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.toList(1)
+    assertEquals("my-name", filterNode.name())
+  }
+
+  @Test
+  def testSettingNameOnOutputTable(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sinkTopic = "sink"
+
+    builder
+      .stream[String, String](sourceTopic1)
+      .toTable(Named.as("my-name"))
+      .toStream
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val tableNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.toList(1)
+    assertEquals("my-name", tableNode.name())
+  }
+
+  @Test
+  def testSettingNameOnJoin(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source"
+    val sourceGTable = "table"
+    val sinkTopic = "sink"
+
+    val stream = builder.stream[String, String](sourceTopic1)
+    val table = builder.globalTable[String, String](sourceGTable)
+    stream
+      .join(table, Named.as("my-name"))((a, b) => s"$a-$b", (a, b) => a + b)
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val joinNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.toList(1)
+    assertEquals("my-name", joinNode.name())
+  }
+
+  @Test
+  def testSettingNameOnProcess(): Unit = {
+    class TestProcessor extends api.Processor[String, String, String, String] {
+      override def process(record: api.Record[String, String]): Unit = {}
+    }
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val stream = builder.stream[String, String](sourceTopic)
+    stream
+      .process(() => new TestProcessor, Named.as("my-name"))
+      .to(sinkTopic)
+
+    val transformNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.toList(1)
+    assertEquals("my-name", transformNode.name())
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -1,0 +1,617 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.Suppressed.BufferConfig
+import org.apache.kafka.streams.kstream.{
+  Named,
+  SessionWindows,
+  SlidingWindows,
+  Suppressed => JSuppressed,
+  TimeWindows,
+  Windowed
+}
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.scala.utils.TestDriver
+import org.apache.kafka.streams.scala.{ByteArrayKeyValueStore, StreamsBuilder}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertTrue}
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Duration.ofMillis
+
+import scala.jdk.CollectionConverters._
+
+//noinspection ScalaDeprecation
+class KTableTest extends TestDriver {
+
+  @Test
+  def testFilterRecordsSatisfyingPredicate(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count()
+    table.filter((key, value) => key.equals("a") && value == 1).toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      testInput.pipeInput("a", "passes filter : add new row to table")
+      val record = testOutput.readKeyValue
+      assertEquals("a", record.key)
+      assertEquals(1, record.value)
+    }
+    {
+      testInput.pipeInput("a", "fails filter : remove existing row from table")
+      val record = testOutput.readKeyValue
+      assertEquals("a", record.key)
+      assertNull(record.value)
+    }
+    {
+      testInput.pipeInput("b", "fails filter : no output")
+      assertTrue(testOutput.isEmpty)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testFilterRecordsNotSatisfyingPredicate(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count()
+    table.filterNot((_, value) => value > 1).toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      testInput.pipeInput("1", "value1")
+      val record = testOutput.readKeyValue
+      assertEquals("1", record.key)
+      assertEquals(1, record.value)
+    }
+    {
+      testInput.pipeInput("1", "value2")
+      val record = testOutput.readKeyValue
+      assertEquals("1", record.key)
+      assertNull(record.value)
+    }
+    {
+      testInput.pipeInput("2", "value1")
+      val record = testOutput.readKeyValue
+      assertEquals("2", record.key)
+      assertEquals(1, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testJoinCorrectlyRecords(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).groupBy((key, _) => key).count()
+    val table2 = builder.stream[String, String](sourceTopic2).groupBy((key, _) => key).count()
+    table1.join(table2)((a, b) => a + b).toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    testInput1.pipeInput("1", "topic1value1")
+    testInput2.pipeInput("1", "topic2value1")
+    assertEquals(2, testOutput.readValue)
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testJoinCorrectlyRecordsAndStateStore(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+    val stateStore = "store"
+    val materialized = Materialized.as[String, Long, ByteArrayKeyValueStore](stateStore)
+
+    val table1 = builder.stream[String, String](sourceTopic1).groupBy((key, _) => key).count()
+    val table2 = builder.stream[String, String](sourceTopic2).groupBy((key, _) => key).count()
+    table1.join(table2, materialized)((a, b) => a + b).toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    testInput1.pipeInput("1", "topic1value1")
+    testInput2.pipeInput("1", "topic2value1")
+    assertEquals(2, testOutput.readValue)
+    assertEquals(2, testDriver.getKeyValueStore[String, Long](stateStore).get("1"))
+
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlySuppressResultsUsingSuppressedUntilTimeLimit(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    val window = TimeWindows.ofSizeAndGrace(Duration.ofSeconds(1L), Duration.ofHours(24))
+    val suppression = JSuppressed.untilTimeLimit[Windowed[String]](Duration.ofSeconds(2L), BufferConfig.unbounded())
+
+    val table: KTable[Windowed[String], Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .windowedBy(window)
+      .count()
+      .suppress(suppression)
+
+    table.toStream((k, _) => s"${k.window().start()}:${k.window().end()}:${k.key()}").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // publish key=1 @ time 0 => count==1
+      testInput.pipeInput("1", "value1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish key=1 @ time 1 => count==2
+      testInput.pipeInput("1", "value2", 1L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time past the first window, but before the suppression window
+      testInput.pipeInput("2", "value1", 1001L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time riiiight before suppression window ends
+      testInput.pipeInput("2", "value2", 1999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish a late event before suppression window terminates => count==3
+      testInput.pipeInput("1", "value3", 999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right past the suppression window of the first window.
+      testInput.pipeInput("2", "value3", 2001L)
+      val record = testOutput.readKeyValue
+      assertEquals("0:1000:1", record.key)
+      assertEquals(3L, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlyGroupByKeyWindowedBySlidingWindow(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    val window = SlidingWindows.ofTimeDifferenceAndGrace(ofMillis(1000L), ofMillis(1000L))
+    val suppression = JSuppressed.untilWindowCloses(BufferConfig.unbounded())
+
+    val table: KTable[Windowed[String], Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .windowedBy(window)
+      .count()
+      .suppress(suppression)
+
+    table.toStream((k, _) => s"${k.window().start()}:${k.window().end()}:${k.key()}").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // publish key=1 @ time 0 => count==1
+      testInput.pipeInput("1", "value1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right past the grace period of the first window.
+      testInput.pipeInput("2", "value3", 5001L)
+      val record = testOutput.readKeyValue
+      assertEquals("0:1000:1", record.key)
+      assertEquals(1L, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlySuppressResultsUsingSuppressedUntilWindowClosesByWindowed(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    val window = TimeWindows.ofSizeAndGrace(Duration.ofSeconds(1L), Duration.ofSeconds(1L))
+    val suppression = JSuppressed.untilWindowCloses(BufferConfig.unbounded())
+
+    val table: KTable[Windowed[String], Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .windowedBy(window)
+      .count()
+      .suppress(suppression)
+
+    table.toStream((k, _) => s"${k.window().start()}:${k.window().end()}:${k.key()}").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // publish key=1 @ time 0 => count==1
+      testInput.pipeInput("1", "value1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish key=1 @ time 1 => count==2
+      testInput.pipeInput("1", "value2", 1L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time past the window, but before the grace period
+      testInput.pipeInput("2", "value1", 1001L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time riiiight before grace period ends
+      testInput.pipeInput("2", "value2", 1999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish a late event before grace period terminates => count==3
+      testInput.pipeInput("1", "value3", 999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right past the grace period of the first window.
+      testInput.pipeInput("2", "value3", 2001L)
+      val record = testOutput.readKeyValue
+      assertEquals("0:1000:1", record.key)
+      assertEquals(3L, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlySuppressResultsUsingSuppressedUntilWindowClosesBySession(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    // Very similar to SuppressScenarioTest.shouldSupportFinalResultsForSessionWindows
+    val window = SessionWindows.ofInactivityGapAndGrace(Duration.ofMillis(5L), Duration.ofMillis(10L))
+    val suppression = JSuppressed.untilWindowCloses(BufferConfig.unbounded())
+
+    val table: KTable[Windowed[String], Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .windowedBy(window)
+      .count()
+      .suppress(suppression)
+
+    table.toStream((k, _) => s"${k.window().start()}:${k.window().end()}:${k.key()}").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // first window
+      testInput.pipeInput("k1", "v1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // first window
+      testInput.pipeInput("k1", "v1", 1L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // new window, but grace period hasn't ended for first window
+      testInput.pipeInput("k1", "v1", 8L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // out-of-order event for first window, included since grade period hasn't passed
+      testInput.pipeInput("k1", "v1", 2L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // add to second window
+      testInput.pipeInput("k1", "v1", 13L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // add out-of-order to second window
+      testInput.pipeInput("k1", "v1", 10L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // push stream time forward to flush other events through
+      testInput.pipeInput("k1", "v1", 30L)
+      // late event should get dropped from the stream
+      testInput.pipeInput("k1", "v1", 3L)
+      // should now have to results
+      val r1 = testOutput.readRecord
+      assertEquals("0:2:k1", r1.key)
+      assertEquals(3L, r1.value)
+      assertEquals(2L, r1.timestamp)
+      val r2 = testOutput.readRecord
+      assertEquals("8:13:k1", r2.key)
+      assertEquals(3L, r2.value)
+      assertEquals(13L, r2.timestamp)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlySuppressResultsUsingSuppressedUntilTimeLimtByNonWindowed(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    val suppression = JSuppressed.untilTimeLimit[String](Duration.ofSeconds(2L), BufferConfig.unbounded())
+
+    val table: KTable[String, Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .count()
+      .suppress(suppression)
+
+    table.toStream.to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // publish key=1 @ time 0 => count==1
+      testInput.pipeInput("1", "value1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish key=1 @ time 1 => count==2
+      testInput.pipeInput("1", "value2", 1L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time past the window, but before the grace period
+      testInput.pipeInput("2", "value1", 1001L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right before grace period ends
+      testInput.pipeInput("2", "value2", 1999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // publish a late event before grace period terminates => count==3
+      testInput.pipeInput("1", "value3", 999L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right past the grace period of the first window.
+      testInput.pipeInput("2", "value3", 2001L)
+      val record = testOutput.readKeyValue
+      assertEquals("1", record.key)
+      assertEquals(3L, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testSettingNameOnFilterProcessor(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count()
+    table
+      .filter((key, value) => key.equals("a") && value == 1, Named.as("my-name"))
+      .toStream
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val filterNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(3)
+    assertEquals("my-name", filterNode.name())
+  }
+
+  @Test
+  def testSettingNameOnCountProcessor(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count(Named.as("my-name"))
+    table.toStream.to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val countNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(1)
+    assertEquals("my-name", countNode.name())
+  }
+
+  @Test
+  def testSettingNameOnJoinProcessor(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).groupBy((key, _) => key).count()
+    val table2 = builder.stream[String, String](sourceTopic2).groupBy((key, _) => key).count()
+    table1
+      .join(table2, Named.as("my-name"))((a, b) => a + b)
+      .toStream
+      .to(sinkTopic)
+
+    val joinNodeLeft = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(6)
+    val joinNodeRight = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(7)
+    assertTrue(joinNodeLeft.name().contains("my-name"))
+    assertTrue(joinNodeRight.name().contains("my-name"))
+  }
+
+  @Test
+  def testMapValuesWithValueMapperWithMaterialized(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val stateStore = "store"
+    val materialized = Materialized.as[String, Long, ByteArrayKeyValueStore](stateStore)
+
+    val table = builder.stream[String, String](sourceTopic).toTable
+    table.mapValues(value => value.length.toLong, materialized)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+
+    testInput.pipeInput("1", "topic1value1")
+    assertEquals(12, testDriver.getKeyValueStore[String, Long](stateStore).get("1"))
+
+    testDriver.close()
+  }
+
+  @Test
+  def testMapValuesWithValueMapperWithKeyAndWithMaterialized(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val stateStore = "store"
+    val materialized = Materialized.as[String, Long, ByteArrayKeyValueStore](stateStore)
+
+    val table = builder.stream[String, String](sourceTopic).toTable
+    table.mapValues((key, value) => key.length + value.length.toLong, materialized)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+
+    testInput.pipeInput("1", "topic1value1")
+    assertEquals(13, testDriver.getKeyValueStore[String, Long](stateStore).get("1"))
+
+    testDriver.close()
+  }
+
+  @Test
+  def testJoinWithBiFunctionKeyExtractor(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).toTable
+    val table2 = builder.stream[String, String](sourceTopic2).toTable
+
+    table1
+      .join[String, String, String](
+        table2,
+        (key: String, value: String) => s"$key-$value",
+        joiner = (v1: String, v2: String) => s"$v1+$v2",
+        materialized = Materialized.`with`[String, String, ByteArrayKeyValueStore]
+      )
+      .toStream
+      .to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    testInput1.pipeInput("k1", "v1")
+    testInput2.pipeInput("k1-v1", "v2")
+
+    val record = testOutput.readKeyValue
+    assertEquals("k1", record.key)
+    assertEquals("v1+v2", record.value)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testLeftJoinWithBiFunctionKeyExtractor(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).toTable
+    val table2 = builder.stream[String, String](sourceTopic2).toTable
+
+    table1
+      .leftJoin[String, String, String](
+        table2,
+        (key: String, value: String) => s"$key-$value",
+        joiner = (v1: String, v2: String) => s"${v1}+${Option(v2).getOrElse("null")}",
+        materialized = Materialized.`with`[String, String, ByteArrayKeyValueStore]
+      )
+      .toStream
+      .to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput1 = testDriver.createInput[String, String](sourceTopic1)
+    val testInput2 = testDriver.createInput[String, String](sourceTopic2)
+    val testOutput = testDriver.createOutput[String, String](sinkTopic)
+
+    // First insert into the foreign key table (table2)
+    testInput2.pipeInput("k1-v1", "v2")
+
+    // Then insert into the primary table (table1)
+    testInput1.pipeInput("k1", "v1")
+
+    val record1 = testOutput.readKeyValue
+    assertEquals("k1", record1.key)
+    assertEquals("v1+v2", record1.value)
+
+    // Test with non-matching foreign key (should still output due to left join)
+    testInput1.pipeInput("k2", "v3")
+
+    val record2 = testOutput.readKeyValue
+    assertEquals("k2", record2.key)
+    assertEquals("v3+null", record2.value)
+
+    testDriver.close()
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/MaterializedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/MaterializedTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.internals.MaterializedInternal
+import org.apache.kafka.streams.scala._
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.state.Stores
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.time.Duration
+
+class MaterializedTest {
+
+  @Test
+  def testCreateMaterializedWithSerdes(): Unit = {
+    val materialized: Materialized[String, Long, ByteArrayKeyValueStore] =
+      Materialized.`with`[String, Long, ByteArrayKeyValueStore]
+
+    val internalMaterialized = new MaterializedInternal(materialized)
+    assertEquals(Serdes.stringSerde.getClass, internalMaterialized.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalMaterialized.valueSerde.getClass)
+  }
+
+  @Test
+  def testCreateMaterializedWithSerdesAndStoreName(): Unit = {
+    val storeName = "store"
+    val materialized: Materialized[String, Long, ByteArrayKeyValueStore] =
+      Materialized.as[String, Long, ByteArrayKeyValueStore](storeName)
+
+    val internalMaterialized = new MaterializedInternal(materialized)
+    assertEquals(Serdes.stringSerde.getClass, internalMaterialized.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalMaterialized.valueSerde.getClass)
+    assertEquals(storeName, internalMaterialized.storeName)
+  }
+
+  @Test
+  def testCreateMaterializedWithSerdesAndWindowStoreSupplier(): Unit = {
+    val storeSupplier = Stores.persistentWindowStore("store", Duration.ofMillis(1), Duration.ofMillis(1), true)
+    val materialized: Materialized[String, Long, ByteArrayWindowStore] =
+      Materialized.as[String, Long](storeSupplier)
+
+    val internalMaterialized = new MaterializedInternal(materialized)
+    assertEquals(Serdes.stringSerde.getClass, internalMaterialized.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalMaterialized.valueSerde.getClass)
+    assertEquals(storeSupplier, internalMaterialized.storeSupplier)
+  }
+
+  @Test
+  def testCreateMaterializedWithSerdesAndKeyValueStoreSupplier(): Unit = {
+    val storeSupplier = Stores.persistentKeyValueStore("store")
+    val materialized: Materialized[String, Long, ByteArrayKeyValueStore] =
+      Materialized.as[String, Long](storeSupplier)
+
+    val internalMaterialized = new MaterializedInternal(materialized)
+    assertEquals(Serdes.stringSerde.getClass, internalMaterialized.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalMaterialized.valueSerde.getClass)
+    assertEquals(storeSupplier, internalMaterialized.storeSupplier)
+  }
+
+  @Test
+  def testCreateMaterializedWithSerdesAndSessionStoreSupplier(): Unit = {
+    val storeSupplier = Stores.persistentSessionStore("store", Duration.ofMillis(1))
+    val materialized: Materialized[String, Long, ByteArraySessionStore] =
+      Materialized.as[String, Long](storeSupplier)
+
+    val internalMaterialized = new MaterializedInternal(materialized)
+    assertEquals(Serdes.stringSerde.getClass, internalMaterialized.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalMaterialized.valueSerde.getClass)
+    assertEquals(storeSupplier, internalMaterialized.storeSupplier)
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.internals.ProducedInternal
+import org.apache.kafka.streams.processor.StreamPartitioner
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.util
+import java.util.Optional
+
+class ProducedTest {
+
+  @Test
+  def testCreateProducedWithSerdes(): Unit = {
+    val produced: Produced[String, Long] = Produced.`with`[String, Long]
+
+    val internalProduced = new ProducedInternal(produced)
+    assertEquals(Serdes.stringSerde.getClass, internalProduced.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalProduced.valueSerde.getClass)
+  }
+
+  @Test
+  def testCreateProducedWithSerdesAndStreamPartitioner(): Unit = {
+    val partitioner = new StreamPartitioner[String, Long] {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
+    }
+    val produced: Produced[String, Long] = Produced.`with`(partitioner)
+
+    val internalProduced = new ProducedInternal(produced)
+    assertEquals(Serdes.stringSerde.getClass, internalProduced.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalProduced.valueSerde.getClass)
+    assertEquals(partitioner, internalProduced.streamPartitioner)
+  }
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/RepartitionedTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.internals.RepartitionedInternal
+import org.apache.kafka.streams.processor.StreamPartitioner
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.util
+import java.util.Optional
+
+class RepartitionedTest {
+
+  @Test
+  def testCreateRepartitionedWithSerdes(): Unit = {
+    val repartitioned: Repartitioned[String, Long] = Repartitioned.`with`[String, Long]
+
+    val internalRepartitioned = new RepartitionedInternal(repartitioned)
+    assertEquals(Serdes.stringSerde.getClass, internalRepartitioned.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalRepartitioned.valueSerde.getClass)
+  }
+
+  @Test
+  def testCreateRepartitionedWithSerdesAndNumPartitions(): Unit = {
+    val repartitioned: Repartitioned[String, Long] = Repartitioned.`with`[String, Long](5)
+
+    val internalRepartitioned = new RepartitionedInternal(repartitioned)
+    assertEquals(Serdes.stringSerde.getClass, internalRepartitioned.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalRepartitioned.valueSerde.getClass)
+    assertEquals(5, internalRepartitioned.numberOfPartitions)
+
+  }
+
+  @Test
+  def testCreateRepartitionedWithSerdesAndTopicName(): Unit = {
+    val repartitioned: Repartitioned[String, Long] = Repartitioned.`with`[String, Long]("repartitionTopic")
+
+    val internalRepartitioned = new RepartitionedInternal(repartitioned)
+    assertEquals(Serdes.stringSerde.getClass, internalRepartitioned.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalRepartitioned.valueSerde.getClass)
+    assertEquals("repartitionTopic", internalRepartitioned.name)
+  }
+
+  @Test
+  def testCreateRepartitionedWithSerdesAndTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
+    val partitioner = new StreamPartitioner[String, Long] {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
+    }
+    val repartitioned: Repartitioned[String, Long] = Repartitioned.`with`[String, Long](partitioner)
+
+    val internalRepartitioned = new RepartitionedInternal(repartitioned)
+    assertEquals(Serdes.stringSerde.getClass, internalRepartitioned.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalRepartitioned.valueSerde.getClass)
+    assertEquals(partitioner, internalRepartitioned.streamPartitioner)
+  }
+
+  @Test
+  def testCreateRepartitionedWithTopicNameAndNumPartitionsAndStreamPartitioner(): Unit = {
+    val partitioner = new StreamPartitioner[String, Long] {
+      override def partitions(
+        topic: String,
+        key: String,
+        value: Long,
+        numPartitions: Int
+      ): Optional[util.Set[Integer]] = {
+        val partitions = new util.HashSet[Integer]()
+        partitions.add(Int.box(0))
+        Optional.of(partitions)
+      }
+    }
+    val repartitioned: Repartitioned[String, Long] =
+      Repartitioned
+        .`with`[String, Long](5)
+        .withName("repartitionTopic")
+        .withStreamPartitioner(partitioner)
+
+    val internalRepartitioned = new RepartitionedInternal(repartitioned)
+    assertEquals(Serdes.stringSerde.getClass, internalRepartitioned.keySerde.getClass)
+    assertEquals(Serdes.longSerde.getClass, internalRepartitioned.valueSerde.getClass)
+    assertEquals(5, internalRepartitioned.numberOfPartitions)
+    assertEquals("repartitionTopic", internalRepartitioned.name)
+    assertEquals(partitioner, internalRepartitioned.streamPartitioner)
+  }
+
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/kstream/StreamJoinedTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.kstream
+
+import org.apache.kafka.streams.kstream.internals.{InternalStreamsBuilder, StreamJoinedInternal}
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder
+import org.apache.kafka.streams.scala.serialization.Serdes
+import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.streams.state.Stores
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
+import org.mockito.junit.jupiter.{MockitoExtension, MockitoSettings}
+import org.mockito.quality.Strictness
+
+import java.time.Duration
+
+@ExtendWith(Array(classOf[MockitoExtension]))
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class StreamJoinedTest {
+
+  val builder: InternalStreamsBuilder = mock(classOf[InternalStreamsBuilder])
+  val topoBuilder: InternalTopologyBuilder = mock(classOf[InternalTopologyBuilder])
+
+  @BeforeEach
+  def before(): Unit = {
+    when(builder.internalTopologyBuilder()).thenReturn(topoBuilder)
+    when(topoBuilder.topologyConfigs()).thenReturn(null)
+  }
+
+  @Test
+  def testCreateStreamJoinedWithSerdes(): Unit = {
+    val streamJoined: StreamJoined[String, String, Long] = StreamJoined.`with`[String, String, Long]
+
+    val streamJoinedInternal = new StreamJoinedInternal[String, String, Long](streamJoined, builder)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.keySerde().getClass)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.valueSerde().getClass)
+    assertEquals(Serdes.longSerde.getClass, streamJoinedInternal.otherValueSerde().getClass)
+  }
+
+  @Test
+  def testCreateStreamJoinedWithSerdesAndStoreSuppliers(): Unit = {
+    val storeSupplier = Stores.inMemoryWindowStore("myStore", Duration.ofMillis(500), Duration.ofMillis(250), false)
+
+    val otherStoreSupplier =
+      Stores.inMemoryWindowStore("otherStore", Duration.ofMillis(500), Duration.ofMillis(250), false)
+
+    val streamJoined: StreamJoined[String, String, Long] =
+      StreamJoined.`with`[String, String, Long](storeSupplier, otherStoreSupplier)
+
+    val streamJoinedInternal = new StreamJoinedInternal[String, String, Long](streamJoined, builder)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.keySerde().getClass)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.valueSerde().getClass)
+    assertEquals(Serdes.longSerde.getClass, streamJoinedInternal.otherValueSerde().getClass)
+    assertEquals(otherStoreSupplier, streamJoinedInternal.otherStoreSupplier())
+    assertEquals(storeSupplier, streamJoinedInternal.thisStoreSupplier())
+  }
+
+  @Test
+  def testCreateStreamJoinedWithSerdesAndStateStoreName(): Unit = {
+    val streamJoined: StreamJoined[String, String, Long] = StreamJoined.as[String, String, Long]("myStoreName")
+
+    val streamJoinedInternal = new StreamJoinedInternal[String, String, Long](streamJoined, builder)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.keySerde().getClass)
+    assertEquals(Serdes.stringSerde.getClass, streamJoinedInternal.valueSerde().getClass)
+    assertEquals(Serdes.longSerde.getClass, streamJoinedInternal.otherValueSerde().getClass)
+    assertEquals("myStoreName", streamJoinedInternal.storeName())
+  }
+
+}

--- a/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/utils/TestDriver.scala
+++ b/streams/streams-scala/bin/test/org/apache/kafka/streams/scala/utils/TestDriver.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.scala.utils
+
+import java.time.Instant
+import java.util.Properties
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.{StreamsConfig, TestInputTopic, TestOutputTopic, TopologyTestDriver}
+import org.apache.kafka.test.TestUtils
+
+trait TestDriver {
+  def createTestDriver(builder: StreamsBuilder, initialWallClockTime: Instant = Instant.now()): TopologyTestDriver = {
+    val config = new Properties()
+    config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath)
+    new TopologyTestDriver(builder.build(), config, initialWallClockTime)
+  }
+
+  implicit class TopologyTestDriverOps(inner: TopologyTestDriver) {
+    def createInput[K, V](topic: String)(implicit serdeKey: Serde[K], serdeValue: Serde[V]): TestInputTopic[K, V] =
+      inner.createInputTopic(topic, serdeKey.serializer, serdeValue.serializer)
+
+    def createOutput[K, V](topic: String)(implicit serdeKey: Serde[K], serdeValue: Serde[V]): TestOutputTopic[K, V] =
+      inner.createOutputTopic(topic, serdeKey.deserializer, serdeValue.deserializer)
+  }
+}

--- a/streams/test-utils/bin/test/log4j2.yaml
+++ b/streams/test-utils/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: INFO

--- a/test-common/test-common-internal-api/bin/main/org/apache/kafka/common/test/api/README.md
+++ b/test-common/test-common-internal-api/bin/main/org/apache/kafka/common/test/api/README.md
@@ -1,0 +1,192 @@
+This document describes a custom JUnit extension which allows for running the same JUnit tests against multiple Kafka 
+cluster configurations.
+
+# Annotations
+
+Three annotations are provided for defining a template of a Kafka cluster.
+
+* `@ClusterTest`: declarative style cluster definition
+* `@ClusterTests`: wrapper around multiple `@ClusterTest`-s
+* `@ClusterTemplate`: points to a function for imperative cluster definition
+
+Another helper annotation `@ClusterTestDefaults` allows overriding the defaults for 
+all `@ClusterTest` in a single test class.
+
+# Usage
+
+The simplest usage is `@ClusterTest` by itself which will use some reasonable defaults.
+
+```java
+public class SampleTest {
+    @ClusterTest
+    void testSomething() { ... }
+}
+```
+
+The defaults can be modified by setting specific parameters on the annotation. 
+
+```java
+public class SampleTest {
+    @ClusterTest(brokers = 3, metadataVersion = MetadataVersion.IBP_4_0_IV3)
+    void testSomething() { ... }
+}
+```
+
+It is also possible to modify the defaults for a whole class using `@ClusterTestDefaults`.
+
+```java
+@ClusterTestDefaults(brokers = 3, metadataVersion = MetadataVersion.IBP_4_0_IV3)
+public class SampleTest {
+    @ClusterTest
+    void testSomething() { ... }
+}
+```
+
+To set some specific config, an array of `@ClusterProperty` annotations can be
+given.
+
+```java
+public class SampleTest {
+    @ClusterTest(
+      types = {Type.KRAFT},
+      brokerSecurityProtocol = SecurityProtocol.PLAINTEXT,
+      properties = {
+          @ClusterProperty(key = "inter.broker.protocol.version", value = "2.7-IV2"),
+          @ClusterProperty(key = "socket.send.buffer.bytes", value = "10240"),
+    })
+    void testSomething() { ... }
+}
+```
+
+Using the `@ClusterTests` annotation, multiple declarative cluster templates can
+be given.
+
+```java
+public class SampleTest {
+    @ClusterTests({
+        @ClusterTest(brokerSecurityProtocol = SecurityProtocol.PLAINTEXT),
+        @ClusterTest(brokerSecurityProtocol = SecurityProtocol.SASL_PLAINTEXT)
+    })
+    void testSomething() { ... }
+}
+```
+
+# Dynamic Configuration
+
+In order to allow for more flexible cluster configuration, a `@ClusterTemplate` 
+annotation is also introduced. This annotation takes a single string value which 
+references a static method on the test class. This method is used to produce any 
+number of test configurations using a fluent builder style API.
+
+```java
+import java.util.List;
+
+@ClusterTemplate("generateConfigs")
+void testSomething() { ... }
+
+static List<ClusterConfig> generateConfigs() {
+  ClusterConfig config1 = ClusterConfig.defaultClusterBuilder()
+          .name("Generated Test 1")
+          .serverProperties(props1)
+          .setMetadataVersion(MetadataVersion.IBP_2_7_IV1)
+          .build();
+  ClusterConfig config2 = ClusterConfig.defaultClusterBuilder()
+          .name("Generated Test 2")
+          .serverProperties(props2)
+          .setMetadataVersion(MetadataVersion.IBP_2_7_IV2)
+          .build();
+  ClusterConfig config3 = ClusterConfig.defaultClusterBuilder()
+          .name("Generated Test 3")
+          .serverProperties(props3)
+          .build();
+  return List.of(config1, config2, config3);
+}
+```
+
+This alternate configuration style makes it easy to create any number of complex 
+configurations. Each returned ClusterConfig by a template method will result in
+an additional variation of the run.
+
+
+# JUnit Extension
+
+The core logic of our test framework lies in `ClusterTestExtensions` which is a
+JUnit extension. It is automatically registered using SPI and will look for test
+methods that include one of the three annotations mentioned above. 
+
+This way of dynamically generating tests uses the JUnit concept of test templates.
+
+# JUnit Lifecycle
+
+JUnit discovers test template methods that are annotated with `@ClusterTest`, 
+`@ClusterTests`, or `@ClusterTemplate`. These annotations are processed and some
+number of test invocations are created.
+
+For each generated test invocation we have the following lifecycle:
+
+* Static `@BeforeAll` methods are called
+* Test class is instantiated
+* Kafka Cluster is started (if autoStart=true)
+* Non-static `@BeforeEach` methods are called
+* Test method is invoked
+* Kafka Cluster is stopped
+* Non-static `@AfterEach` methods are called
+* Static `@AfterAll` methods are called
+
+`@BeforeEach` methods give an opportunity to set up additional test dependencies 
+after the cluster has started but before the test method is run.
+
+# Dependency Injection
+
+A ClusterInstance object can be injected into the test method or the test class constructor.
+This object is a shim to the underlying test framework and provides access to things like 
+SocketServers and has convenience factory methods for getting a client.
+
+The class is introduced to provide context to the underlying cluster and to provide reusable 
+functionality that was previously garnered from the test hierarchy.
+
+Common usage is to inject this class into a test method
+
+```java
+class SampleTest {
+    @ClusterTest
+    public void testOne(ClusterInstance cluster) {
+        this.cluster.admin().createTopics(...);
+        // Test code
+    }
+}
+```
+
+For cases where there is common setup code that involves the cluster (such as 
+creating topics), it is possible to access the ClusterInstance from a `@BeforeEach` 
+method. This requires injecting the object in the constructor. For example, 
+
+```java
+class SampleTest {
+    private final ClusterInstance cluster;
+
+    SampleTest(ClusterInstance cluster) {
+        this.cluster = cluster;
+    }
+    
+    @BeforeEach
+    public void setup() {
+      // Common setup code with started ClusterInstance
+      this.cluster.admin().createTopics(...); 
+    }
+
+    @ClusterTest
+    public void testOne() {
+        // Test code
+    }
+}
+```
+
+It is okay to inject the ClusterInstance in both ways. The same object will be
+provided in either case.
+
+# Gotchas
+* Cluster tests are not compatible with other test templates like `@ParameterizedTest`
+* Test methods annotated with JUnit's `@Test` will still be run, but no cluster will be started and no dependency 
+  injection will happen. This is generally not what you want.
+* Even though ClusterConfig is accessible, it is immutable inside the test method.

--- a/test-common/test-common-internal-api/bin/test/log4j2.yaml
+++ b/test-common/test-common-internal-api/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: INFO

--- a/test-common/test-common-runtime/bin/main/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test-common/test-common-runtime/bin/main/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.kafka.common.test.junit.ClusterTestExtensions

--- a/test-common/test-common-runtime/bin/main/log4j2.yaml
+++ b/test-common/test-common-runtime/bin/main/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: INFO

--- a/test-common/test-common-runtime/bin/test/log4j2.yaml
+++ b/test-common/test-common-runtime/bin/test/log4j2.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: org.apache.kafka
+        level: WARN

--- a/test-common/test-common-util/bin/main/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
+++ b/test-common/test-common-util/bin/main/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.kafka.common.test.junit.KafkaPostDiscoveryFilter

--- a/test-common/test-common-util/bin/main/junit-platform.properties
+++ b/test-common/test-common-util/bin/main/junit-platform.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+junit.jupiter.params.displayname.default = "{displayName}.{argumentsWithNames}"
+junit.jupiter.extensions.autodetection.enabled = true

--- a/test-common/test-common-util/bin/test/log4j2.yaml
+++ b/test-common/test-common-util/bin/test/log4j2.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: org.apache.kafka
+        level: WARN

--- a/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
+++ b/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
@@ -136,7 +136,6 @@ public class EndToEndLatency {
             }
 
             printResults(numRecords, totalTime, latencies);
-            consumer.commitSync();
         }
     }
 
@@ -177,7 +176,6 @@ public class EndToEndLatency {
     }
 
     private static void commitAndThrow(KafkaConsumer<byte[], byte[]> consumer, String message) {
-        consumer.commitSync();
         throw new RuntimeException(message);
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
+++ b/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
@@ -142,7 +142,7 @@ public class EndToEndLatency {
     // Visible for testing
     static void validate(KafkaConsumer<byte[], byte[]> consumer, byte[] sentRecordValue, ConsumerRecords<byte[], byte[]> records, byte[] sentRecordKey, Iterable<Header> sentHeaders) {
         if (records.isEmpty()) {
-            commitAndThrow(consumer, "poll() timed out before finding a result (timeout:[" + POLL_TIMEOUT_MS + "ms])");
+            throw new RuntimeException("poll() timed out before finding a result (timeout:[" + POLL_TIMEOUT_MS + "ms])");
         }
 
         ConsumerRecord<byte[], byte[]> record = records.iterator().next();
@@ -150,20 +150,20 @@ public class EndToEndLatency {
         String read = new String(record.value(), StandardCharsets.UTF_8);
 
         if (!read.equals(sent)) {
-            commitAndThrow(consumer, "The message value read [" + read + "] did not match the message value sent [" + sent + "]");
+            throw new RuntimeException("The message value read [" + read + "] did not match the message value sent [" + sent + "]");
         }
 
         if (sentRecordKey != null) {
             if (record.key() == null) {
-                commitAndThrow(consumer, "Expected message key but received null");
+                throw new RuntimeException("Expected message key but received null");
             }
             String sentKey = new String(sentRecordKey, StandardCharsets.UTF_8);
             String readKey = new String(record.key(), StandardCharsets.UTF_8);
             if (!readKey.equals(sentKey)) {
-                commitAndThrow(consumer, "The message key read [" + readKey + "] did not match the message key sent [" + sentKey + "]");
+                throw new RuntimeException("The message key read [" + readKey + "] did not match the message key sent [" + sentKey + "]");
             }
         } else if (record.key() != null) {
-            commitAndThrow(consumer, "Expected null message key but received [" + new String(record.key(), StandardCharsets.UTF_8) + "]");
+            throw new RuntimeException("Expected null message key but received [" + new String(record.key(), StandardCharsets.UTF_8) + "]");
         }
 
         validateHeaders(consumer, sentHeaders, record);
@@ -171,36 +171,32 @@ public class EndToEndLatency {
         //Check we only got the one message
         if (records.count() != 1) {
             int count = records.count();
-            commitAndThrow(consumer, "Only one result was expected during this test. We found [" + count + "]");
+            throw new RuntimeException("Only one result was expected during this test. We found [" + count + "]");
         }
-    }
-
-    private static void commitAndThrow(KafkaConsumer<byte[], byte[]> consumer, String message) {
-        throw new RuntimeException(message);
     }
 
     private static void validateHeaders(KafkaConsumer<byte[], byte[]> consumer, Iterable<Header> sentHeaders, ConsumerRecord<byte[], byte[]> record) {
         if (sentHeaders != null && sentHeaders.iterator().hasNext()) {
             if (!record.headers().iterator().hasNext()) {
-                commitAndThrow(consumer, "Expected message headers but received none");
+                throw new RuntimeException("Expected message headers but received none");
             }
-            
+
             Iterator<Header> sentIterator = sentHeaders.iterator();
             Iterator<Header> receivedIterator = record.headers().iterator();
-            
+
             while (sentIterator.hasNext() && receivedIterator.hasNext()) {
                 Header sentHeader = sentIterator.next();
                 Header receivedHeader = receivedIterator.next();
                 if (!receivedHeader.key().equals(sentHeader.key()) || !Arrays.equals(receivedHeader.value(), sentHeader.value())) {
                     String receivedValueStr = receivedHeader.value() == null ? "null" : Arrays.toString(receivedHeader.value());
                     String sentValueStr = sentHeader.value() == null ? "null" : Arrays.toString(sentHeader.value());
-                    commitAndThrow(consumer, "The message header read [" + receivedHeader.key() + ":" + receivedValueStr +
+                    throw new RuntimeException("The message header read [" + receivedHeader.key() + ":" + receivedValueStr +
                             "] did not match the message header sent [" + sentHeader.key() + ":" + sentValueStr + "]");
                 }
             }
-            
+
             if (sentIterator.hasNext() || receivedIterator.hasNext()) {
-                commitAndThrow(consumer, "Header count mismatch between sent and received messages");
+                throw new RuntimeException("Header count mismatch between sent and received messages");
             }
         }
     }
@@ -312,11 +308,11 @@ public class EndToEndLatency {
             return args;
         }
 
-        boolean hasRequiredNamedArgs = Arrays.stream(args).anyMatch(arg -> 
-            arg.equals("--bootstrap-server") || 
-            arg.equals("--topic") || 
-            arg.equals("--num-records") || 
-            arg.equals("--producer-acks") || 
+        boolean hasRequiredNamedArgs = Arrays.stream(args).anyMatch(arg ->
+            arg.equals("--bootstrap-server") ||
+            arg.equals("--topic") ||
+            arg.equals("--num-records") ||
+            arg.equals("--producer-acks") ||
             arg.equals("--record-size"));
         if (hasRequiredNamedArgs) {
             return args;

--- a/tools/tools-api/bin/test/log4j2.yaml
+++ b/tools/tools-api/bin/test/log4j2.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: "OFF"
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: kafka
+        level: WARN
+
+      - name: org.apache.kafka
+        level: WARN

--- a/transaction-coordinator/bin/main/common/message/TransactionLogKey.json
+++ b/transaction-coordinator/bin/main/common/message/TransactionLogKey.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "coordinator-key",
+  "name": "TransactionLogKey",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "TransactionalId", "type": "string", "versions": "0",
+      "about": "The transactional id of the transaction."}
+  ]
+}

--- a/transaction-coordinator/bin/main/common/message/TransactionLogValue.json
+++ b/transaction-coordinator/bin/main/common/message/TransactionLogValue.json
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "coordinator-value",
+  "name": "TransactionLogValue",
+  // Version 1 is the first flexible version.
+  // KIP-915: bumping the version will no longer make this record backward compatible.
+  // We suggest to add/remove only tagged fields to maintain backward compatibility.
+  "validVersions": "0-1",
+  "flexibleVersions": "1+",
+  "fields": [
+    { "name": "ProducerId", "type": "int64", "versions": "0+",
+      "about": "Producer id in use by the transactional id."},
+    { "name": "PreviousProducerId", "type": "int64", "taggedVersions": "1+", "tag": 0, "default": -1,
+      "about": "Producer id used by the last committed transaction."},
+    { "name": "NextProducerId", "type": "int64", "taggedVersions": "1+", "tag": 1, "default": -1,
+      "about": "Latest producer ID sent to the producer for the given transactional id."},
+    { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
+      "about": "Epoch associated with the producer id."},
+    { "name": "NextProducerEpoch", "type": "int16", "default": -1, "taggedVersions": "1+", "tag": 3,
+      "about": "Producer epoch associated with the NextProducerId"},
+    { "name": "TransactionTimeoutMs", "type": "int32", "versions": "0+",
+      "about": "Transaction timeout in milliseconds."},
+    { "name": "TransactionStatus", "type": "int8", "versions": "0+",
+      "about": "TransactionState the transaction is in."},
+    { "name": "TransactionPartitions", "type": "[]PartitionsSchema", "versions": "0+", "nullableVersions": "0+",
+      "about": "Partitions involved in the transaction.", "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+",
+        "about": "Topic involved in the transaction."},
+      { "name": "PartitionIds", "type": "[]int32", "versions": "0+",
+        "about": "Partition ids involved in the transaction."}]},
+    { "name": "TransactionLastUpdateTimestampMs", "type": "int64", "versions": "0+",
+      "about": "Time the transaction was last updated."},
+    { "name": "TransactionStartTimestampMs", "type": "int64", "versions": "0+",
+      "about": "Time the transaction was started."},
+    { "name": "ClientTransactionVersion", "type": "int16", "default": 0, "taggedVersions": "1+", "tag": 2,
+      "about": "The transaction version used by the client."}
+  ]
+}

--- a/transaction-coordinator/bin/test/log4j2.yaml
+++ b/transaction-coordinator/bin/test/log4j2.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Configuration:
+  Properties:
+    Property:
+      - name: "logPattern"
+        value: "[%d] %p %m (%c:%L)%n"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      PatternLayout:
+        pattern: "${logPattern}"
+
+  Loggers:
+    Root:
+      level: WARN
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: org.apache.kafka
+        level: WARN


### PR DESCRIPTION
### **PR Description**

#### **Summary**
This PR removes redundant offset commits from `EndToEndLatency.java` to
make the benchmarking tool completely stateless. This ensures that if
the process is abruptly terminated (hard-killed), it does not leave
behind stale checkpoints on the broker that could skew latency metrics
upon restart.

#### **The Problem**
If `EndToEndLatency` is hard-killed, the consumer group might have
uncommitted messages. Upon restart, the consumer resumes from the last
committed checkpoint rather than the tail of the log. Because it
immediately processes the backlog already sitting on the broker, it
erroneously reports near-zero "ghost" latency.

#### **The Solution**
Since the tool is stateless and only measures live end-to-end
performance, we do not need to save the consumer's progress.
* Removed `consumer.commitSync()` from the success path in `execute()`.
* Removed `consumer.commitSync()` from the failure path in
`commitAndThrow()`.

By avoiding offset commits entirely, the consumer group has no recorded
state on the broker. Upon restart, it is forced to obey
`auto.offset.reset = latest` (and the programmatic `seekToEnd` on
startup), jumping directly to the log end to await newly produced
messages.

---

### **How to Test**

1. **Start a local Kafka broker** and create a test topic.
2. **Run the benchmark**, then abruptly terminate it mid-run (`Ctrl +
C`):
   ```bash
   ./bin/kafka-run-class.sh org.apache.kafka.tools.EndToEndLatency
--bootstrap-server localhost:9092 --topic test-topic --num-records 50000
--producer-acks all --record-size 100
   ```
3. **Restart the benchmark immediately.**
   * **Verification:** The initial print (at index `0`) will report
realistic startup latency (e.g., `~30-40ms` for metadata and handshake
bootstrap overhead) instead of an immediate near-zero reading. This
proves the consumer is correctly ignoring any backlog and waiting for
new messages.

Conclusion: The latency recorded on the first loop (0 36.269337 ms)
indicates real client connection handshakes, JIT compilation, and
metadata initializatoin overhead.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>
