### PR TITLE
MINOR: Enforce non-null groupState in GroupListing constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
@@ -46,7 +46,7 @@ public class GroupListing {
         this.groupId = groupId;
         this.type = Objects.requireNonNull(type);
         this.protocol = protocol;
-        this.groupState = groupState;
+        this.groupState = Objects.requireNonNull(groupState);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/GroupListing.java
@@ -45,7 +45,7 @@ public class GroupListing {
     public GroupListing(String groupId, Optional<GroupType> type, String protocol, Optional<GroupState> groupState) {
         this.groupId = groupId;
         this.type = Objects.requireNonNull(type);
-        this.protocol = protocol;
+        this.protocol = Objects.requireNonNull(protocol);
         this.groupState = Objects.requireNonNull(groupState);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/GroupListingTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/GroupListingTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupListingTest {
@@ -45,5 +46,17 @@ public class GroupListingTest {
 
         gl = new GroupListing(GROUP_ID, Optional.empty(), "", Optional.empty());
         assertFalse(gl.isSimpleConsumerGroup());
+    }
+
+    @Test
+    public void testNullTypeConstructor() {
+        assertThrows(NullPointerException.class,
+                () -> new GroupListing(GROUP_ID, null, "", Optional.of(GroupState.EMPTY)));
+    }
+
+    @Test
+    public void testNullGroupStateConstructor() {
+        assertThrows(NullPointerException.class,
+                () -> new GroupListing(GROUP_ID, Optional.of(GroupType.CLASSIC), "", null));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/GroupListingTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/GroupListingTest.java
@@ -59,4 +59,10 @@ public class GroupListingTest {
         assertThrows(NullPointerException.class,
                 () -> new GroupListing(GROUP_ID, Optional.of(GroupType.CLASSIC), "", null));
     }
+
+    @Test
+    public void testNullProtocolConstructor() {
+        assertThrows(NullPointerException.class,
+                () -> new GroupListing(GROUP_ID, Optional.of(GroupType.CLASSIC), null, Optional.of(GroupState.EMPTY)));
+    }
 }


### PR DESCRIPTION
## Description

`GroupListing`'s constructor validates the `type` parameter with
`Objects.requireNonNull` but not the sibling `groupState` parameter,
even though both are `Optional<T>` fields used identically throughout
the class (`toString()`, `equals()`, `hashCode()`, accessors).

The omission was introduced when `groupState` was added alongside the
pre-existing `type` field in KAFKA-17949 (#17763) — the constructor
pattern was copied but the `requireNonNull` wrapper on the new field
was dropped.

For comparison, the equivalent (deprecated) `ConsumerGroupListing`
class validates both of its analogous `Optional` fields (`groupState`
and `type`) consistently.

This PR adds the missing `Objects.requireNonNull(groupState)` check
and adds unit tests covering the null case for both parameters.

### Validation
- Compiles cleanly
- All `GroupListingTest` tests pass (including the two new ones)
- Verified all existing call sites across `clients`, `tools`, `core`,
  and `connect/mirror` modules always pass `Optional.of(...)` or
  `Optional.empty()`, never a raw `null`, for `groupState` — so this
  change introduces no behavioral regression
- checkstyle passes

Reviewers: Maros Orsak <maros.orsak159@gmail.com>, Andrew Schofield <aschofield@confluent.io>
