### PR TITLE
KAFKA-20665: Add refiner building blocks

### DIFF
--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefiner.java
@@ -25,15 +25,15 @@ import java.util.SortedMap;
 /**
  * Refines the task assignor's target assignment into the <em>intermediate</em> assignment that the reconciler
  * ({@link CurrentAssignmentBuilder}) converges the members toward.
- * <p>
- * The assignor decides <em>where</em> a task belongs; the refiner decides <em>how</em> the group gets there. When a
+ *
+ * <p>The assignor decides <em>where</em> a task belongs; the refiner decides <em>how</em> the group gets there. When a
  * stateful task has to move to a member that does not hold its state yet, handing it over right away would stall
  * processing while the new owner restores the state from the changelog. Instead, the refiner leaves the task with its
  * current owner and hands the new owner a warm-up task, so it can restore the state in the background. Once the warm-up
  * task has caught up -- its lag is within {@code acceptable.recovery.lag} -- a later refinement step moves the task
  * over. {@code num.warmup.replicas} bounds how many such warm-up tasks the group runs at a time.
- * <p>
- * Properties of the intermediate assignment that callers rely on:
+ *
+ * <p>Properties of the intermediate assignment that callers rely on:
  * <ul>
  *     <li>It is <b>derived for the whole group at once</b>, because both the warm-up budget and the rule that a
  *     process must not hold a task twice are group-wide. Callers take the individual member's slice out of the
@@ -60,20 +60,25 @@ public interface AssignmentRefiner {
     /**
      * Derives the intermediate assignment for all members of the group.
      *
-     * @param members               All members of the group, with their current assignments, the tasks they are still
-     *                              to revoke, and their process IDs.
-     * @param targetAssignment      All members' target assignments, as computed by the task assignor.
-     * @param taskOffsets           The latest changelog offsets/end-offsets reported by the members via heartbeats,
-     *                              from which the lag of a warm-up task is derived. Not populated for a member that
-     *                              has not reported any offsets yet, for example right after a coordinator failover.
-     * @param subtopologies         The group's resolved subtopologies, keyed by subtopology ID, which tell whether a
-     *                              subtopology is stateful. Only stateful tasks are warmed up; a stateless task has no
-     *                              state to restore. The coordinator resolves the topology and never invokes a refiner
-     *                              until it is ready, so an implementation does not deal with topology readiness.
-     * @param numWarmupReplicas     The maximum number of warm-up tasks the group may run at a time. Never zero: with
-     *                              warm-up tasks disabled, the intermediate assignment is the target assignment and
-     *                              the refiner is not called at all.
-     * @param acceptableRecoveryLag The lag at or below which a warm-up task is considered caught up.
+     * @param members
+     *        All members of the group, with their current assignments, the tasks they are still to revoke, and
+     *        their process IDs.
+     * @param targetAssignment
+     *        All members' target assignments, as computed by the task assignor.
+     * @param taskOffsets
+     *        The latest changelog offsets/end-offsets reported by the members via heartbeats, from which the lag
+     *        of a warm-up task is derived. Not populated for a member that has not reported any offsets yet, for
+     *        example right after a coordinator failover.
+     * @param subtopologies
+     *        The group's resolved subtopologies, keyed by subtopology ID, which tell whether a subtopology is
+     *        stateful. Only stateful tasks are warmed up; a stateless task has no state to restore. The coordinator
+     *        resolves the topology and never invokes a refiner until it is ready, so an implementation does not deal
+     *        with topology readiness.
+     * @param numWarmupReplicas
+     *        The maximum number of warm-up tasks the group may run at a time. Never zero: with warm-up tasks
+     *        disabled, the intermediate assignment is the target assignment and the refiner is not called at all.
+     * @param acceptableRecoveryLag
+     *        The lag at or below which a warm-up task is considered caught up.
      *
      * @return The intermediate assignment, keyed by member ID. It must hand out the same active tasks as the target
      *         assignment, only possibly to different members; an implementation that drops or duplicates one is

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+/**
+ * The {@link AssignmentRefiner} being built out to replace {@link NoOpAssignmentRefiner} as the broker's default
+ * once the derivation is complete.
+ *
+ * <p>{@link #refine} is still a stub -- it returns the target assignment unchanged, exactly like
+ * {@link NoOpAssignmentRefiner} -- while the derivation is built out incrementally across several changes. The
+ * methods below are its building blocks: indexing the current assignment, and deciding which migrations can
+ * complete immediately versus which have to stage behind a warm-up task. None of them are called from
+ * {@link #refine} yet.
+ */
+public class AssignmentRefinerImpl implements AssignmentRefiner {
+
+    @Override
+    public Map<String, TasksTuple> refine(
+        Map<String, StreamsGroupMember> members,
+        Map<String, TasksTuple> targetAssignment,
+        Map<String, MemberTaskOffsets> taskOffsets,
+        SortedMap<String, ConfiguredSubtopology> subtopologies,
+        int numWarmupReplicas,
+        long acceptableRecoveryLag
+    ) {
+        return targetAssignment;
+    }
+
+    /**
+     * Indexes the members' current assignment by task, so that the case analysis can look up what a task's situation is
+     * without scanning the group again for every task. This is a single pass over the members' task entries.
+     *
+     * <p>Only stateful tasks are indexed. A stateless task has no state to restore, so it is never staged and never
+     * consulted here; it simply flows through from the target assignment.
+     *
+     * @param members
+     *        All members of the group.
+     * @param taskOffsets
+     *        The latest changelog offsets/end-offsets reported by the members.
+     * @param subtopologies
+     *        The resolved subtopologies, which tell whether a subtopology is stateful.
+     * @param acceptableRecoveryLag
+     *        The lag at or below which a replica counts as caught up.
+     *
+     * @return The current assignment, indexed by task.
+     */
+    static CurrentAssignmentIndex indexCurrentAssignment(
+        final Map<String, StreamsGroupMember> members,
+        final Map<String, MemberTaskOffsets> taskOffsets,
+        final SortedMap<String, ConfiguredSubtopology> subtopologies,
+        final long acceptableRecoveryLag
+    ) {
+        final Map<TaskId, String> activeOwner = new HashMap<>();
+        final Map<TaskId, Set<String>> processesRevoking = new HashMap<>();
+        final Map<TaskId, List<TaskCopy>> taskCopies = new HashMap<>();
+
+        for (final StreamsGroupMember member : members.values()) {
+            final MemberTaskOffsets offsets = taskOffsets.getOrDefault(member.memberId(), MemberTaskOffsets.EMPTY);
+
+            forEachStatefulActiveTask(
+                member.assignedTasks().activeTasksWithEpochs(),
+                subtopologies,
+                task -> activeOwner.put(task, member.memberId())
+            );
+
+            // The member has been told to give this task up and has stopped running it, so the member is
+            // deliberately not recorded as the task's active owner. Recording the member as the owner would make the
+            // case analysis try to keep the task there, undoing a hand-over that is already under way.
+            //
+            // The task does still occupy the member's process until the revocation completes, and that is what stops
+            // a standby of the same task being placed there. The block applies to the whole process, not just this
+            // one member, so the process is what gets recorded.
+            forEachStatefulActiveTask(
+                member.tasksPendingRevocation().activeTasksWithEpochs(),
+                subtopologies,
+                task -> processesRevoking.computeIfAbsent(task, __ -> new HashSet<>()).add(member.processId())
+            );
+
+            forEachStatefulTask(
+                member.assignedTasks().standbyTasks(),
+                subtopologies,
+                task -> addTaskCopy(taskCopies, task, member, TaskRole.STANDBY, offsets, acceptableRecoveryLag)
+            );
+
+            forEachStatefulTask(
+                member.assignedTasks().warmupTasks(),
+                subtopologies,
+                task -> addTaskCopy(taskCopies, task, member, TaskRole.WARMUP, offsets, acceptableRecoveryLag)
+            );
+        }
+
+        return new CurrentAssignmentIndex(activeOwner, processesRevoking, taskCopies);
+    }
+
+    /**
+     * Decides, for every stateful task whose active role is not already where the target assignment wants it, whether
+     * the migration has to be staged behind a warm-up task or can be completed in this step.
+     *
+     * <p>A task is <b>staged</b> only when all of the following hold: somebody runs it today, the target owner is
+     * somebody else, and there is a warming improvement left to achieve. Everything else completes right away, which
+     * needs no patch at all -- the target assignment already places the task on its target owner, and the previous
+     * owner's slice already omits it. That is why the two outcomes are so lopsided: staging is the exception, and the
+     * result is proportional to how far the current assignment has diverged from the target rather than to the group's
+     * size.
+     *
+     * @param currentAssignment
+     *        The indexed current assignment, from {@link #indexCurrentAssignment}.
+     * @param targetAssignment
+     *        All members' target assignments, as computed by the task assignor.
+     * @param members
+     *        All members of the group, used to resolve which process a member runs in.
+     * @param subtopologies
+     *        The resolved subtopologies, which tell whether a subtopology is stateful.
+     *
+     * @return What was decided for the tasks that are not already in place.
+     */
+    static TaskDecisions analyzeTasks(
+        final CurrentAssignmentIndex currentAssignment,
+        final Map<String, TasksTuple> targetAssignment,
+        final Map<String, StreamsGroupMember> members,
+        final SortedMap<String, ConfiguredSubtopology> subtopologies
+    ) {
+        // Only a task the target assignment still contains needs a decision, so its owners alone drive the loop. A
+        // task the target assignment dropped -- after a topology change, say -- belongs in nobody's slice, and its
+        // current holders revoke it the ordinary way, so walking the current assignment's tasks too would only turn
+        // up tasks to skip.
+        //
+        // The map is sorted, which gives the canonical task order that makes a derivation reproducible and leaves the
+        // budget pass that follows a deterministic tie-break to fall back on.
+        final SortedMap<TaskId, String> targetOwners = statefulActiveOwners(targetAssignment, subtopologies);
+
+        final List<StagedMigration> stagedMigrations = new ArrayList<>();
+        final List<TaskGrant> grantedTasks = new ArrayList<>();
+
+        for (final Map.Entry<TaskId, String> targetOwnerByTask : targetOwners.entrySet()) {
+            final TaskId task = targetOwnerByTask.getKey();
+            final String targetOwner = targetOwnerByTask.getValue();
+
+            final String currentOwner = currentAssignment.activeOwner().get(task);
+            if (targetOwner.equals(currentOwner)) {
+                // The task already runs where it belongs.
+                continue;
+            }
+
+            // The target assignment can still name a member the group has already removed: it is only recomputed when
+            // the assignor runs again, which the assignment interval can defer, and a member can be fenced in the
+            // meantime. Such a member cannot restore anything, so nothing may be staged into it.
+            final StreamsGroupMember targetMember = members.get(targetOwner);
+            if (targetMember == null) {
+                if (currentOwner != null) {
+                    // Keep the task where it runs until the assignor names a member that still exists. Leaving it out
+                    // instead would make its current owner revoke it, so it would stop being processed for no gain.
+                    stagedMigrations.add(new StagedMigration(
+                        task,
+                        currentOwner,
+                        targetOwner,
+                        Optional.empty(),
+                        Optional.empty()
+                    ));
+                }
+                // A task that nobody runs and whose target owner is gone is left to the next assignor run: granting it
+                // to a member that is no longer in the group would achieve nothing.
+                continue;
+            }
+
+            final String targetProcessId = targetMember.processId();
+
+            // The task moves now, for either of two reasons. Nobody runs it -- it is new, its owner left, or a
+            // hand-over is in flight and the previous owner has already released it -- so there is no running task to
+            // protect and the target owner takes it even cold; preferring a warmer owner would be a placement
+            // decision, and placement is the assignor's job. Or somebody runs it but no achievable warming improvement
+            // remains. The current owner, when there is one, is necessarily a member of the group, because the index it
+            // comes from was built from the members themselves.
+            if (currentOwner == null
+                || isReady(currentAssignment, task, members.get(currentOwner).processId(), targetProcessId)) {
+                grantedTasks.add(new TaskGrant(task, targetOwner));
+                continue;
+            }
+
+            stagedMigrations.add(new StagedMigration(
+                task,
+                currentOwner,
+                targetOwner,
+                Optional.of(targetProcessId),
+                findCopyOnProcess(currentAssignment, task, targetProcessId)
+            ));
+        }
+
+        return new TaskDecisions(List.copyOf(stagedMigrations), List.copyOf(grantedTasks));
+    }
+
+    /**
+     * Whether no achievable warming improvement remains for handing the task over to its target owner.
+     *
+     * <p>This is deliberately weaker than "the target owner has caught up". Warming up is only worth staging when it
+     * can actually shorten the hand-over, and there are two situations where it cannot -- one per clause of the
+     * predicate:
+     * <ul>
+     *     <li><b>The task is moving between two members of one process.</b> A process must not hold the same task
+     *     twice, so there is no way to warm the target owner up while the current owner still runs it. No condition
+     *     on the state applies here: staging such a move would park it forever, so it has to count as ready.</li>
+     *     <li><b>The target owner's process already holds a caught-up copy of the task.</b> Here <em>caught up</em>
+     *     carries the weight: a copy that is still catching up leaves a genuine improvement to wait for, so the task
+     *     stays staged, that copy keeps consuming, and a later step grants the task once the copy is hot. Planting a
+     *     warm-up task on the target owner is no help either way, because its process would then hold the task
+     *     twice. The copy sits either on the target owner itself, which promotes it in place, or on a sibling
+     *     member, which has to release the task first so that the target owner can reopen it from the state
+     *     directory.</li>
+     * </ul>
+     *
+     * <p>The two are not variants of one another, even though both turn on members sharing a process. The first is
+     * about the <em>current owner</em> sharing one with the target owner; the second about some <em>copy holder</em>
+     * doing so. They also cannot both apply: if the current owner is on the target owner's process then that process
+     * runs the task, so by one-task-per-process it holds no copy of the task for the second clause to find. The
+     * second therefore only ever decides a move that crosses process boundaries, and the order the two are tested in
+     * makes no difference to the outcome.
+     *
+     * <p>Only the in-place promotion is warm for every store type. The other two paths -- the move within one
+     * process, and the sibling releasing the task -- are warm only for a store that persists to disk, where the
+     * releasing member's clean close leaves a checkpoint behind for the incoming member to reopen from. <b>An
+     * in-memory store is rebuilt from the changelog in full:</b> its state lives on the releasing member's heap and
+     * is dropped when the task closes, and no hand-over of a running task between threads of one process exists to
+     * carry it across. Worse, the lag that made the task look ready was measured on the member that is about to
+     * close, so for an in-memory store it says nothing about what the incoming member then has to restore. This
+     * predicate cannot fix that; it would take a client-side cross-thread task hand-over. The broker cannot even see
+     * the difference, because the topology metadata carries changelog topics but not how a store is backed.
+     *
+     * <p>What bounds the damage is that a warm-up task the refiner plants always targets the target owner itself, so
+     * every migration the refiner stages resolves through the in-place promotion. The other paths arise only out of a
+     * layout the refiner inherited.
+     */
+    private static boolean isReady(
+        final CurrentAssignmentIndex currentAssignment,
+        final TaskId task,
+        final String currentProcessId,
+        final String targetProcessId
+    ) {
+        if (targetProcessId.equals(currentProcessId)) {
+            return true;
+        }
+        return currentAssignment.taskCopies().getOrDefault(task, List.of()).stream()
+            .anyMatch(holder -> holder.processId().equals(targetProcessId) && holder.caughtUp());
+    }
+
+    /**
+     * Whether the member has restored the task closely enough to take it over as an active task. Mirrors the client's
+     * own predicate, so that both ends agree on when a warm-up task is caught up.
+     *
+     * <p>The lag is the distance between the reported end offset and the reported offset, and a lag that is not known
+     * is never within the threshold: an offset missing on either side, or capped at {@link Long#MAX_VALUE} to say that
+     * the restore has not started, counts as not caught up. A slightly negative lag does count, because the offset is a
+     * position while the end offset is the last offset, so a fully restored task reports a lag of -1.
+     *
+     * @param memberTaskOffsets
+     *        The offsets the member reported, {@link MemberTaskOffsets#EMPTY} if it reported none.
+     * @param task
+     *        The task to check.
+     * @param acceptableRecoveryLag
+     *        The lag at or below which the task counts as caught up.
+     */
+    static boolean isCaughtUp(
+        final MemberTaskOffsets memberTaskOffsets,
+        final TaskId task,
+        final long acceptableRecoveryLag
+    ) {
+        final Long offset = offsetOf(memberTaskOffsets.taskOffsets(), task);
+        final Long endOffset = offsetOf(memberTaskOffsets.taskEndOffsets(), task);
+        if (offset == null || endOffset == null || offset == Long.MAX_VALUE || endOffset == Long.MAX_VALUE) {
+            return false;
+        }
+        return endOffset - offset <= acceptableRecoveryLag;
+    }
+
+    private static Long offsetOf(final Map<String, Map<Integer, Long>> offsets, final TaskId task) {
+        final Map<Integer, Long> byPartition = offsets.get(task.subtopologyId());
+        return byPartition == null ? null : byPartition.get(task.partition());
+    }
+
+    /**
+     * The replica of the task that the given process already holds, if any.
+     *
+     * <p>There is at most one, so no tie-break between roles is needed: a process holds a given task in at most one
+     * role, on at most one of its members. The reconciler enforces that -- {@code isUnreleasedActiveTask},
+     * {@code isUnreleasedStandbyTask} and {@code isUnreleasedWarmupTask} in {@link CurrentAssignmentBuilder} each
+     * block a role for as long as the process holds the task in any role.
+     */
+    private static Optional<TaskCopy> findCopyOnProcess(
+        final CurrentAssignmentIndex currentAssignment,
+        final TaskId task,
+        final String processId
+    ) {
+        return currentAssignment.taskCopies().getOrDefault(task, List.of()).stream()
+            .filter(holder -> holder.processId().equals(processId))
+            .findFirst();
+    }
+
+    /**
+     * Inverts the target assignment into a lookup from stateful task to the member that is to run it as an active task.
+     */
+    private static SortedMap<TaskId, String> statefulActiveOwners(
+        final Map<String, TasksTuple> targetAssignment,
+        final SortedMap<String, ConfiguredSubtopology> subtopologies
+    ) {
+        final SortedMap<TaskId, String> owners = new TreeMap<>();
+        targetAssignment.forEach((memberId, tasks) ->
+            forEachStatefulTask(tasks.activeTasks(), subtopologies, task -> owners.put(task, memberId)));
+        return owners;
+    }
+
+    private static void addTaskCopy(
+        final Map<TaskId, List<TaskCopy>> taskCopies,
+        final TaskId task,
+        final StreamsGroupMember member,
+        final TaskRole role,
+        final MemberTaskOffsets offsets,
+        final long acceptableRecoveryLag
+    ) {
+        taskCopies.computeIfAbsent(task, __ -> new ArrayList<>()).add(new TaskCopy(
+            member.memberId(),
+            member.processId(),
+            role,
+            isCaughtUp(offsets, task, acceptableRecoveryLag)
+        ));
+    }
+
+    private static void forEachStatefulActiveTask(
+        final Map<String, Map<Integer, Integer>> activeTasksWithEpochs,
+        final SortedMap<String, ConfiguredSubtopology> subtopologies,
+        final Consumer<TaskId> action
+    ) {
+        activeTasksWithEpochs.forEach((subtopologyId, partitionsWithEpochs) -> {
+            if (isStateful(subtopologies, subtopologyId)) {
+                partitionsWithEpochs.keySet()
+                    .forEach(partitionId -> action.accept(new TaskId(subtopologyId, partitionId)));
+            }
+        });
+    }
+
+    private static void forEachStatefulTask(
+        final Map<String, Set<Integer>> tasks,
+        final SortedMap<String, ConfiguredSubtopology> subtopologies,
+        final Consumer<TaskId> action
+    ) {
+        tasks.forEach((subtopologyId, partitionIds) -> {
+            if (isStateful(subtopologies, subtopologyId)) {
+                partitionIds.forEach(partitionId -> action.accept(new TaskId(subtopologyId, partitionId)));
+            }
+        });
+    }
+
+    private static boolean isStateful(
+        final SortedMap<String, ConfiguredSubtopology> subtopologies,
+        final String subtopologyId
+    ) {
+        final ConfiguredSubtopology subtopology = subtopologies.get(subtopologyId);
+        return subtopology != null && !subtopology.stateChangelogTopics().isEmpty();
+    }
+
+    /**
+     * The members' current assignment, indexed by task. Only stateful tasks appear.
+     *
+     * @param activeOwner
+     *        The member running each task as an active task. A task that only sits in some member's pending revocation
+     *        has no entry here, because an in-flight removal is a decision that has already been taken rather than a
+     *        placement to preserve.
+     * @param processesRevoking
+     *        The processes that were told to revoke each task's active role. Recorded per process rather than per
+     *        member because what matters about it is physical ownership: it blocks a standby task of the same task
+     *        anywhere on that process.
+     * @param taskCopies
+     *        The standby and warm-up holders of each task.
+     */
+    record CurrentAssignmentIndex(
+        Map<TaskId, String> activeOwner,
+        Map<TaskId, Set<String>> processesRevoking,
+        Map<TaskId, List<TaskCopy>> taskCopies
+    ) {
+    }
+
+    /**
+     * A copy of a task that exists on some member: which member holds it, in which role, and whether that member has
+     * restored it far enough to take the task over as an active task.
+     *
+     * <p>Only the {@link TaskRole#STANDBY} and {@link TaskRole#WARMUP} copies are recorded. The active copy is tracked
+     * separately, as {@link CurrentAssignmentIndex#activeOwner()}.
+     *
+     * @param memberId
+     *        The member the copy is on.
+     * @param processId
+     *        The process that member runs in.
+     * @param role
+     *        The role the member holds the task in.
+     * @param caughtUp
+     *        Whether the member's reported lag for the task is within the acceptable recovery lag.
+     */
+    record TaskCopy(String memberId, String processId, TaskRole role, boolean caughtUp) {
+    }
+
+    /**
+     * A migration that this refinement step holds back: the task keeps running on its current owner instead of moving
+     * to the member the target assignment wants it on.
+     *
+     * <p>Whether the target owner <em>also</em> gets a warm-up task, so that it restores the state in the background,
+     * is a separate and later decision. The warm-up budget is finite, and a migration that cannot be funded is still
+     * held back here -- the task simply waits on its current owner with nothing warming up, until a slot frees up.
+     *
+     * @param task
+     *        The task being migrated.
+     * @param currentOwner
+     *        The member the task keeps running on for now.
+     * @param targetOwner
+     *        The member the target assignment moves the task to.
+     * @param targetProcessId
+     *        The process the target owner runs in, or empty if the target assignment names a member the group no longer
+     *        has. Empty means the migration can never be warmed up and must not be given a warm-up task or a budget
+     *        slot; the task just stays with its current owner until the assignor names a member that still exists.
+     * @param copyOnTargetProcess
+     *        The replica of the task that the target owner's process already holds, if any. When there is none, the
+     *        migration is a candidate for a fresh warm-up task. When there is one, the process is already restoring the
+     *        task and must not be handed a second copy of it.
+     */
+    record StagedMigration(
+        TaskId task,
+        String currentOwner,
+        String targetOwner,
+        Optional<String> targetProcessId,
+        Optional<TaskCopy> copyOnTargetProcess
+    ) {
+    }
+
+    /**
+     * A task that is granted to its target owner in this refinement step, rather than held back: the intermediate
+     * assignment says what the target assignment says for it.
+     *
+     * <p>That happens either because no achievable warming improvement remains -- the target owner's process already
+     * holds the task's state, or the move is within a single process, where warming up is impossible -- or because
+     * nobody runs the task at all, which covers a brand-new task as much as one whose owner departed. It notably does
+     * <b>not</b> happen because the warm-up budget ran out: a migration that cannot be funded stays a
+     * {@link StagedMigration} and its task keeps running on its current owner.
+     *
+     * <p>Granting is the refiner's decision that the hand-over may proceed, not the hand-over itself. The reconciler
+     * still serializes it, so a task granted here can still spend a step in {@code UNRELEASED_TASKS} while its
+     * previous owner revokes it.
+     *
+     * <p>The member that ran the task before, if any, is deliberately not recorded here: it is
+     * {@link CurrentAssignmentIndex#activeOwner()} for the task, so repeating it would only be a second copy that
+     * could disagree.
+     *
+     * @param task
+     *        The task moving.
+     * @param targetOwner
+     *        The member the task moves to.
+     */
+    record TaskGrant(
+        TaskId task,
+        String targetOwner
+    ) {
+    }
+
+    /**
+     * What the case analysis decided for the tasks whose active role is not already where the target assignment wants
+     * it.
+     *
+     * <p>Tasks that need no decision are deliberately not listed: neither the ones already in place, nor the ones the
+     * target assignment no longer contains. That keeps the result proportional to how far the current assignment has
+     * diverged from the target rather than to the group's task count.
+     *
+     * @param stagedMigrations
+     *        The migrations held back behind a warm-up task, in canonical task order.
+     * @param grantedTasks
+     *        The tasks whose active role moves in this step, in canonical task order.
+     */
+    record TaskDecisions(
+        List<StagedMigration> stagedMigrations,
+        List<TaskGrant> grantedTasks
+    ) {
+    }
+}

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
@@ -21,7 +21,6 @@ import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,11 +54,16 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
     }
 
     /**
-     * Indexes the members' current assignment by task, so that the case analysis can look up what a task's situation is
+     * Indexes the members' current ownership by task, so that the case analysis can look up what a task's situation is
      * without scanning the group again for every task. This is a single pass over the members' task entries.
      *
      * <p>Only stateful tasks are indexed. A stateless task has no state to restore, so it is never staged and never
      * consulted here; it simply flows through from the target assignment.
+     *
+     * <p>A task a member has been told to give up is deliberately not indexed at all. Recording that member as the
+     * task's holder would make the case analysis try to keep the task there, undoing a hand-over that is already under
+     * way; and the process it occupies until the revocation completes needs no tracking here either, because the
+     * reconciler already refuses to grant a role for a task the process still holds.
      *
      * @param members
      *        All members of the group.
@@ -70,7 +74,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * @param acceptableRecoveryLag
      *        The lag at or below which a replica counts as caught up.
      *
-     * @return The current assignment, indexed by task.
+     * @return The current ownership, indexed by task.
      */
     static CurrentAssignmentIndex indexCurrentAssignment(
         final Map<String, StreamsGroupMember> members,
@@ -78,8 +82,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
         final SortedMap<String, ConfiguredSubtopology> subtopologies,
         final long acceptableRecoveryLag
     ) {
-        final Map<TaskId, String> activeOwner = new HashMap<>();
-        final Map<TaskId, Set<String>> processesRevoking = new HashMap<>();
+        final Map<TaskId, ActiveHolder> activeHolder = new HashMap<>();
         final Map<TaskId, List<TaskCopy>> taskCopies = new HashMap<>();
 
         for (final StreamsGroupMember member : members.values()) {
@@ -88,20 +91,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
             forEachStatefulActiveTask(
                 member.assignedTasks().activeTasksWithEpochs(),
                 subtopologies,
-                task -> activeOwner.put(task, member.memberId())
-            );
-
-            // The member has been told to give this task up and has stopped running it, so the member is
-            // deliberately not recorded as the task's active owner. Recording the member as the owner would make the
-            // case analysis try to keep the task there, undoing a hand-over that is already under way.
-            //
-            // The task does still occupy the member's process until the revocation completes, and that is what stops
-            // a standby of the same task being placed there. The block applies to the whole process, not just this
-            // one member, so the process is what gets recorded.
-            forEachStatefulActiveTask(
-                member.tasksPendingRevocation().activeTasksWithEpochs(),
-                subtopologies,
-                task -> processesRevoking.computeIfAbsent(task, __ -> new HashSet<>()).add(member.processId())
+                task -> activeHolder.put(task, new ActiveHolder(member.memberId(), !isRestoring(offsets, task)))
             );
 
             forEachStatefulTask(
@@ -117,22 +107,46 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
             );
         }
 
-        return new CurrentAssignmentIndex(activeOwner, processesRevoking, taskCopies);
+        return new CurrentAssignmentIndex(activeHolder, taskCopies);
+    }
+
+    /**
+     * Whether the member is still restoring the task it holds as an active task, rather than processing it.
+     *
+     * <p>A client reports changelog offsets for every task it is restoring and stops reporting them once the task is
+     * running, so a reported offset for an active task means the restore is still under way. The value does not matter,
+     * only that something was reported: the {@link Long#MAX_VALUE} "restore not started" cap counts as restoring too.
+     *
+     * <p><b>A member the coordinator has not heard from reports nothing, so its active tasks all read as running.</b>
+     * That is every member right after a coordinator failover -- the reported offsets are in-memory state that does not
+     * survive one -- and a newly joined member until its first report. It is the safe direction: the task is treated as
+     * something to protect, so at worst a migration is staged that could have been granted outright, and the next
+     * report corrects it. Reading the absence the other way would strip ownership from a whole group at once after a
+     * failover.
+     */
+    private static boolean isRestoring(final MemberTaskOffsets memberTaskOffsets, final TaskId task) {
+        return offsetOf(memberTaskOffsets.taskOffsets(), task) != null;
     }
 
     /**
      * Decides, for every stateful task whose active role is not already where the target assignment wants it, whether
      * the migration has to be staged behind a warm-up task or can be completed in this step.
      *
-     * <p>A task is <b>staged</b> only when all of the following hold: somebody runs it today, the target owner is
-     * somebody else, and there is a warming improvement left to achieve. Everything else completes right away, which
-     * needs no patch at all -- the target assignment already places the task on its target owner, and the previous
-     * owner's slice already omits it. That is why the two outcomes are so lopsided: staging is the exception, and the
-     * result is proportional to how far the current assignment has diverged from the target rather than to the group's
-     * size.
+     * <p>A task is <b>staged</b> only when all of the following hold: somebody is <em>processing</em> it today, the
+     * target owner is somebody else, and there is a warming improvement left to achieve. Everything else completes
+     * right away, which needs no patch at all -- the target assignment already places the task on its target owner, and
+     * the previous owner's slice already omits it. That is why the two outcomes are so lopsided: staging is the
+     * exception, and the result is proportional to how far the current ownership has diverged from the target rather
+     * than to the group's size.
+     *
+     * <p>Note it takes <em>processing</em>, not merely holding the active task. A member that has been granted an
+     * active task but is still restoring it processes nothing, so staging a migration away from it would protect
+     * nothing while wasting the restore work and possibly a warm-up slot; such a task is granted to its target
+     * straight away. What this deliberately does not do is compare how far along the two members are -- picking the
+     * better-placed of two candidates is a placement decision, and placement is the assignor's job.
      *
      * @param currentAssignment
-     *        The indexed current assignment, from {@link #indexCurrentAssignment}.
+     *        The indexed current ownership, from {@link #indexCurrentAssignment}.
      * @param targetAssignment
      *        All members' target assignments, as computed by the task assignor.
      * @param members
@@ -164,9 +178,9 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
             final TaskId task = targetOwnerByTask.getKey();
             final String targetOwner = targetOwnerByTask.getValue();
 
-            final String currentOwner = currentAssignment.activeOwner().get(task);
-            if (targetOwner.equals(currentOwner)) {
-                // The task already runs where it belongs.
+            final ActiveHolder holder = currentAssignment.activeHolder().get(task);
+            if (holder != null && targetOwner.equals(holder.memberId())) {
+                // The task is already where it belongs, whether it is processing yet or still restoring.
                 continue;
             }
 
@@ -175,39 +189,42 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
             // meantime. Such a member cannot restore anything, so nothing may be staged into it.
             final StreamsGroupMember targetMember = members.get(targetOwner);
             if (targetMember == null) {
-                if (currentOwner != null) {
-                    // Keep the task where it runs until the assignor names a member that still exists. Leaving it out
-                    // instead would make its current owner revoke it, so it would stop being processed for no gain.
+                if (holder != null) {
+                    // Keep the task with whoever holds it until the assignor names a member that still exists. Leaving
+                    // it out instead would make that member revoke it -- discarding a restore part-way through, or
+                    // stopping processing outright -- for no gain, since the task has nowhere else to go.
                     stagedMigrations.add(new StagedMigration(
                         task,
-                        currentOwner,
+                        holder.memberId(),
                         targetOwner,
                         Optional.empty(),
                         Optional.empty()
                     ));
                 }
-                // A task that nobody runs and whose target owner is gone is left to the next assignor run: granting it
-                // to a member that is no longer in the group would achieve nothing.
+                // A task nobody holds and whose target owner is gone is left to the next assignor run: granting it to
+                // a member that is no longer in the group would achieve nothing.
                 continue;
             }
 
             final String targetProcessId = targetMember.processId();
 
-            // The task moves now, for either of two reasons. Nobody runs it -- it is new, its owner left, or a
-            // hand-over is in flight and the previous owner has already released it -- so there is no running task to
-            // protect and the target owner takes it even cold; preferring a warmer owner would be a placement
-            // decision, and placement is the assignor's job. Or somebody runs it but no achievable warming improvement
-            // remains. The current owner, when there is one, is necessarily a member of the group, because the index it
-            // comes from was built from the members themselves.
-            if (currentOwner == null
-                || isReady(currentAssignment, task, members.get(currentOwner).processId(), targetProcessId)) {
+            // The task moves now, for any of three reasons. Nobody holds it -- it is new, its owner left, or a
+            // hand-over is in flight and the previous owner has already released it -- so there is nothing to protect
+            // and the target owner takes it even cold; preferring a warmer owner would be a placement decision, and
+            // placement is the assignor's job. Or somebody holds it but is still restoring it, so nothing is being
+            // processed and staging would protect nothing. Or somebody is processing it but no achievable warming
+            // improvement remains. The holder, when there is one, is necessarily a member of the group, because the
+            // index it comes from was built from the members themselves.
+            if (holder == null
+                || !holder.processing()
+                || isReady(currentAssignment, task, members.get(holder.memberId()).processId(), targetProcessId)) {
                 grantedTasks.add(new TaskGrant(task, targetOwner));
                 continue;
             }
 
             stagedMigrations.add(new StagedMigration(
                 task,
-                currentOwner,
+                holder.memberId(),
                 targetOwner,
                 Optional.of(targetProcessId),
                 findCopyOnProcess(currentAssignment, task, targetProcessId)
@@ -376,6 +393,16 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
         });
     }
 
+    /**
+     * Whether the subtopology has state the coordinator can reason about, which here means state with a changelog.
+     *
+     * <p>A changelog is the <em>only</em> signal of state that reaches the coordinator -- the topology metadata carries
+     * changelog topics and nothing about stores -- so the two are not merely equal in effect, the broker has no way to
+     * tell them apart. A store configured without logging is therefore invisible here, and that is also the right
+     * outcome: without a changelog there is nothing to restore, so such a task can never be warmed up and is treated
+     * exactly like a stateless one. Note this is narrower than what "stateful" means client-side, where a task can
+     * have state and no changelog.
+     */
     private static boolean isStateful(
         final SortedMap<String, ConfiguredSubtopology> subtopologies,
         final String subtopologyId
@@ -385,32 +412,45 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
     }
 
     /**
-     * The members' current assignment, indexed by task. Only stateful tasks appear.
+     * The members' current ownership, indexed by task. Only stateful tasks appear.
      *
-     * @param activeOwner
-     *        The member running each task as an active task. A task that only sits in some member's pending revocation
+     * @param activeHolder
+     *        The member holding each task as an active task. A task that only sits in some member's pending revocation
      *        has no entry here, because an in-flight removal is a decision that has already been taken rather than a
      *        placement to preserve.
-     * @param processesRevoking
-     *        The processes that were told to revoke each task's active role. Recorded per process rather than per
-     *        member because what matters about it is physical ownership: it blocks a standby task of the same task
-     *        anywhere on that process.
      * @param taskCopies
      *        The standby and warm-up holders of each task.
      */
     record CurrentAssignmentIndex(
-        Map<TaskId, String> activeOwner,
-        Map<TaskId, Set<String>> processesRevoking,
+        Map<TaskId, ActiveHolder> activeHolder,
         Map<TaskId, List<TaskCopy>> taskCopies
     ) {
+    }
+
+    /**
+     * The member holding a task as an active task, and whether it is processing the task or still restoring it.
+     *
+     * <p>Only a member that is <em>processing</em> a task has something a staged migration could protect, so the two
+     * are kept apart rather than collapsed into a plain member ID. The identity is still needed for a member that is
+     * only restoring, though: it is what tells the case analysis the task is already in the right place, and what lets
+     * a task be kept where it is when the target assignment names a member the group no longer has.
+     *
+     * @param memberId
+     *        The member holding the task.
+     * @param processing
+     *        Whether the member is processing the task, as opposed to still restoring it. See {@link #isRestoring}
+     *        for how this is determined, and for why a member the coordinator has not heard from reads as processing.
+     */
+    record ActiveHolder(String memberId, boolean processing) {
     }
 
     /**
      * A copy of a task that exists on some member: which member holds it, in which role, and whether that member has
      * restored it far enough to take the task over as an active task.
      *
-     * <p>Only the {@link TaskRole#STANDBY} and {@link TaskRole#WARMUP} copies are recorded. The active copy is tracked
-     * separately, as {@link CurrentAssignmentIndex#activeOwner()}.
+     * <p>Only the {@link TaskRole#STANDBY} and {@link TaskRole#WARMUP} copies are recorded. A member holding the task
+     * as an active task is tracked separately, as {@link CurrentAssignmentIndex#activeHolder()}, whether it is
+     * processing the task or still restoring it.
      *
      * @param memberId
      *        The member the copy is on.
@@ -435,7 +475,8 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * @param task
      *        The task being migrated.
      * @param currentOwner
-     *        The member the task keeps running on for now.
+     *        The member the task stays with for now. Normally the member processing it; when the target assignment
+     *        names a member the group no longer has, it can also be one that is still restoring the task.
      * @param targetOwner
      *        The member the target assignment moves the task to.
      * @param targetProcessId
@@ -460,9 +501,10 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * A task that is granted to its target owner in this refinement step, rather than held back: the intermediate
      * assignment says what the target assignment says for it.
      *
-     * <p>That happens either because no achievable warming improvement remains -- the target owner's process already
-     * holds the task's state, or the move is within a single process, where warming up is impossible -- or because
-     * nobody runs the task at all, which covers a brand-new task as much as one whose owner departed. It notably does
+     * <p>That happens for any of three reasons: no achievable warming improvement remains -- the target owner's process
+     * already holds the task's state, or the move is within a single process, where warming up is impossible; or nobody
+     * holds the task at all, which covers a brand-new task as much as one whose owner departed; or the member holding
+     * it is still restoring it, so nothing is being processed and staging would protect nothing. It notably does
      * <b>not</b> happen because the warm-up budget ran out: a migration that cannot be funded stays a
      * {@link StagedMigration} and its task keeps running on its current owner.
      *
@@ -470,9 +512,10 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * still serializes it, so a task granted here can still spend a step in {@code UNRELEASED_TASKS} while its
      * previous owner revokes it.
      *
-     * <p>The member that ran the task before, if any, is deliberately not recorded here: it is
-     * {@link CurrentAssignmentIndex#activeOwner()} for the task, so repeating it would only be a second copy that
-     * could disagree.
+     * <p>The member that held the task before is deliberately not recorded here, because applying a grant needs no
+     * patch at all: the intermediate assignment is the target assignment plus patches, and the target assignment
+     * already both places the task on its new owner and omits it from the old one. Only a migration that is
+     * <em>delayed</em> has to patch the target assignment.
      *
      * @param task
      *        The task moving.

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerImpl.java
@@ -54,16 +54,17 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
     }
 
     /**
-     * Indexes the members' current ownership by task, so that the case analysis can look up what a task's situation is
+     * Indexes the members' current assignment by task, so that the case analysis can look up what a task's situation is
      * without scanning the group again for every task. This is a single pass over the members' task entries.
      *
      * <p>Only stateful tasks are indexed. A stateless task has no state to restore, so it is never staged and never
      * consulted here; it simply flows through from the target assignment.
      *
-     * <p>A task a member has been told to give up is deliberately not indexed at all. Recording that member as the
-     * task's holder would make the case analysis try to keep the task there, undoing a hand-over that is already under
-     * way; and the process it occupies until the revocation completes needs no tracking here either, because the
-     * reconciler already refuses to grant a role for a task the process still holds.
+     * <p>A task a member has been told to give up is deliberately not indexed at all, even though the member may still
+     * be physically running it until the revocation is acknowledged. Recording that member as the task's holder would
+     * make the case analysis try to keep the task there, undoing a hand-over that is already under way; and the
+     * process it occupies until the revocation completes needs no tracking here either, because the reconciler already
+     * refuses to grant a role for a task the process still holds.
      *
      * @param members
      *        All members of the group.
@@ -74,7 +75,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * @param acceptableRecoveryLag
      *        The lag at or below which a replica counts as caught up.
      *
-     * @return The current ownership, indexed by task.
+     * @return The current assignment, indexed by task.
      */
     static CurrentAssignmentIndex indexCurrentAssignment(
         final Map<String, StreamsGroupMember> members,
@@ -121,8 +122,8 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * That is every member right after a coordinator failover -- the reported offsets are in-memory state that does not
      * survive one -- and a newly joined member until its first report. It is the safe direction: the task is treated as
      * something to protect, so at worst a migration is staged that could have been granted outright, and the next
-     * report corrects it. Reading the absence the other way would strip ownership from a whole group at once after a
-     * failover.
+     * report corrects it. Reading the absence the other way would leave every active task in the group unprotected at
+     * once after a failover.
      */
     private static boolean isRestoring(final MemberTaskOffsets memberTaskOffsets, final TaskId task) {
         return offsetOf(memberTaskOffsets.taskOffsets(), task) != null;
@@ -136,7 +137,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * target owner is somebody else, and there is a warming improvement left to achieve. Everything else completes
      * right away, which needs no patch at all -- the target assignment already places the task on its target owner, and
      * the previous owner's slice already omits it. That is why the two outcomes are so lopsided: staging is the
-     * exception, and the result is proportional to how far the current ownership has diverged from the target rather
+     * exception, and the result is proportional to how far the current assignment has diverged from the target rather
      * than to the group's size.
      *
      * <p>Note it takes <em>processing</em>, not merely holding the active task. A member that has been granted an
@@ -146,7 +147,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
      * better-placed of two candidates is a placement decision, and placement is the assignor's job.
      *
      * @param currentAssignment
-     *        The indexed current ownership, from {@link #indexCurrentAssignment}.
+     *        The indexed current assignment, from {@link #indexCurrentAssignment}.
      * @param targetAssignment
      *        All members' target assignments, as computed by the task assignor.
      * @param members
@@ -412,7 +413,7 @@ public class AssignmentRefinerImpl implements AssignmentRefiner {
     }
 
     /**
-     * The members' current ownership, indexed by task. Only stateful tasks appear.
+     * The members' current assignment, indexed by task. Only stateful tasks appear.
      *
      * @param activeHolder
      *        The member holding each task as an active task. A task that only sits in some member's pending revocation

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TaskRole.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/TaskRole.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+/**
+ * The role a member holds a task in. The three roles of a task are the three task sets of a {@link TasksTuple}, and a
+ * process holds a given task in at most one of them, on at most one of its members.
+ */
+public enum TaskRole {
+
+    /**
+     * The member runs the task: it reads the task's input topics and produces its output.
+     */
+    ACTIVE,
+
+    /**
+     * The member keeps the task's state up to date from the changelog without running the task, so that it can take
+     * the task over quickly. How many of these a task has is bounded by {@code num.standby.replicas}.
+     */
+    STANDBY,
+
+    /**
+     * The member is restoring the task's state because the task is moving to it, and will run the task once the state
+     * has caught up. Like a standby task in everything but its purpose and its accounting: how many of these the group
+     * runs at a time is bounded by {@code num.warmup.replicas} rather than by {@code num.standby.replicas}.
+     */
+    WARMUP
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -156,7 +156,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
+import org.apache.kafka.coordinator.group.streams.TaskRole;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.AssignmentConfigsImpl;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupMixedGroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupMixedGroupMetadataManagerTest.java
@@ -33,7 +33,7 @@ import org.apache.kafka.coordinator.group.streams.StreamsGroupBuilder;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupHeartbeatResult;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.StreamsTopology;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
+import org.apache.kafka.coordinator.group.streams.TaskRole;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 
@@ -54,7 +54,6 @@ import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.staticHear
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.staticJoinHeartbeat;
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.streamsGroupMemberBuilderWithDefaults;
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.streamsTopicFixture;
-import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTupleWithEpochs;
 import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksWithEpochs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -600,7 +599,7 @@ class StreamsGroupMixedGroupMetadataManagerTest {
             .setMemberEpoch(bumpedGroupEpoch)
             .setPreviousMemberEpoch(0)
             .setAssignedTasks(mkTasksTupleWithEpochs(
-                TaskAssignmentTestUtil.TaskRole.ACTIVE,
+                TaskRole.ACTIVE,
                 mkTasksWithEpochs(subtopologyId, Map.of(0, groupEpoch))
             ))
             .build();
@@ -674,7 +673,7 @@ class StreamsGroupMixedGroupMetadataManagerTest {
             .setMemberEpoch(bumpedGroupEpoch)
             .setPreviousMemberEpoch(groupEpoch)
             .setAssignedTasks(mkTasksTupleWithEpochs(
-                TaskAssignmentTestUtil.TaskRole.ACTIVE,
+                TaskRole.ACTIVE,
                 mkTasksWithEpochs(subtopologyId, Map.of(
                     1, bumpedGroupEpoch,
                     2, groupEpoch,

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/StreamsGroupTestUtil.java
@@ -25,6 +25,7 @@ import org.apache.kafka.coordinator.common.runtime.MetadataImageBuilder;
 import org.apache.kafka.coordinator.group.streams.MemberState;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil;
+import org.apache.kafka.coordinator.group.streams.TaskRole;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
 import org.apache.kafka.coordinator.group.streams.TasksTupleWithEpochs;
 import org.apache.kafka.coordinator.group.streams.assignor.AssignmentConfigsImpl;
@@ -150,7 +151,7 @@ class StreamsGroupTestUtil {
 
         public TasksTuple targetAssignment(Integer... partitions) {
             return TaskAssignmentTestUtil.mkTasksTuple(
-                TaskAssignmentTestUtil.TaskRole.ACTIVE,
+                TaskRole.ACTIVE,
                 tasks(partitions)
             );
         }
@@ -160,7 +161,7 @@ class StreamsGroupTestUtil {
             Integer... partitions
         ) {
             return mkTasksTupleWithCommonEpoch(
-                TaskAssignmentTestUtil.TaskRole.ACTIVE,
+                TaskRole.ACTIVE,
                 epoch,
                 tasks(partitions)
             );

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
@@ -242,7 +242,8 @@ public class AssignmentRefinerTest {
     // ---------------------------------------------------------------------------------------------------------------
 
     @Test
-    public void shouldIndexTheMemberRunningATaskAsItsActiveOwner() {
+    public void shouldIndexTheMemberProcessingATaskAsItsActiveHolder() {
+        // No offsets reported for an active task means the restore has finished and the member is processing it.
         final Map<String, StreamsGroupMember> members = Map.of(
             "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)))
         );
@@ -251,19 +252,49 @@ public class AssignmentRefinerTest {
 
         assertEquals(
             Map.of(
-                STATEFUL_0, "memberA",
-                new TaskId(STATEFUL, 1), "memberA"
+                STATEFUL_0, new AssignmentRefinerImpl.ActiveHolder("memberA", true),
+                new TaskId(STATEFUL, 1), new AssignmentRefinerImpl.ActiveHolder("memberA", true)
             ),
-            index.activeOwner()
+            index.activeHolder()
         );
-        assertEquals(Map.of(), index.processesRevoking());
         assertEquals(Map.of(), index.taskCopies());
     }
 
     @Test
-    public void shouldNotIndexAnActiveOwnerForATaskThatIsPendingRevocation() {
-        // The member was told to give the task up, so it is not ownership to preserve. The process still holds it, and
-        // that is what gets recorded.
+    public void shouldIndexAnActiveHolderThatIsStillRestoringAsNotProcessing() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index =
+            index(members, Map.of("memberA", offsets(500L, 10_000L)));
+
+        assertEquals(
+            Map.of(STATEFUL_0, new AssignmentRefinerImpl.ActiveHolder("memberA", false)),
+            index.activeHolder()
+        );
+    }
+
+    @Test
+    public void shouldIndexAnActiveHolderWhoseRestoreHasNotStartedAsNotProcessing() {
+        // Long.MAX_VALUE is the "restore not started" cap; it is still a report, so the task is still restoring.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index =
+            index(members, Map.of("memberA", offsets(Long.MAX_VALUE, Long.MAX_VALUE)));
+
+        assertEquals(
+            Map.of(STATEFUL_0, new AssignmentRefinerImpl.ActiveHolder("memberA", false)),
+            index.activeHolder()
+        );
+    }
+
+    @Test
+    public void shouldNotIndexAnActiveHolderForATaskThatIsPendingRevocation() {
+        // The member was told to give the task up, so it is not ownership to preserve. The process it still occupies
+        // needs no tracking either: the reconciler blocks a colliding placement until the revocation lands.
         final Map<String, StreamsGroupMember> members = Map.of(
             "memberA", member(
                 "memberA",
@@ -275,8 +306,8 @@ public class AssignmentRefinerTest {
 
         final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, Map.of());
 
-        assertEquals(Map.of(), index.activeOwner());
-        assertEquals(Map.of(STATEFUL_0, Set.of("processA")), index.processesRevoking());
+        assertEquals(Map.of(), index.activeHolder());
+        assertEquals(Map.of(), index.taskCopies());
     }
 
     @Test
@@ -292,7 +323,7 @@ public class AssignmentRefinerTest {
 
         final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, taskOffsets);
 
-        assertEquals(Map.of(), index.activeOwner());
+        assertEquals(Map.of(), index.activeHolder());
         assertEquals(
             Set.of(
                 new AssignmentRefinerImpl.TaskCopy("memberA", "processA", TaskRole.STANDBY, true),
@@ -311,7 +342,7 @@ public class AssignmentRefinerTest {
 
         final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, Map.of());
 
-        assertEquals(Map.of(), index.activeOwner());
+        assertEquals(Map.of(), index.activeHolder());
         assertEquals(Map.of(), index.taskCopies());
     }
 
@@ -340,6 +371,122 @@ public class AssignmentRefinerTest {
     public void shouldStageAMigrationToAMemberThatHoldsNoState() {
         // The headline case: a scale-out moves a stateful task to a cold member, so the task keeps running where it is
         // while the new owner restores it.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "memberB",
+                Optional.of("processB"),
+                Optional.empty()
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldGrantATaskWhoseHolderIsStillRestoringItRatherThanStageIt() {
+        // Nothing is being processed, so staging would protect nothing: it would keep the task on a member that cannot
+        // run it, throw that restore away when the migration completes, and possibly spend a warm-up slot on the way.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+        // memberA reports restore progress for the active task, so it is not processing it; memberB's standby is a
+        // long way behind, so without the restoring check this would stage and wait for it.
+        final Map<String, MemberTaskOffsets> taskOffsets = Map.of(
+            "memberA", offsets(500L, 10_000L),
+            "memberB", offsets(0L, 10_000L)
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, taskOffsets);
+
+        assertEquals(List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")), decisions.grantedTasks());
+        assertEquals(List.of(), decisions.stagedMigrations());
+    }
+
+    @Test
+    public void shouldGrantATaskWhoseHolderIsStillRestoringItEvenToAColdMember() {
+        // The refiner does not weigh how far along the two members are: choosing the better-placed candidate is a
+        // placement decision, so the assignor's choice stands even though it holds no state at all.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions =
+            analyze(members, targetAssignment, Map.of("memberA", offsets(9_999L, 10_000L)));
+
+        assertEquals(List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")), decisions.grantedTasks());
+        assertEquals(List.of(), decisions.stagedMigrations());
+    }
+
+    @Test
+    public void shouldDecideNothingWhenTheTaskIsAlreadyWithItsTargetOwnerButStillRestoring() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions =
+            analyze(members, targetAssignment, Map.of("memberA", offsets(500L, 10_000L)));
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(List.of(), decisions.stagedMigrations());
+    }
+
+    @Test
+    public void shouldHoldATaskWithAHolderThatIsStillRestoringItWhenItsTargetOwnerIsGone() {
+        // Leaving it out would make the holder revoke it and discard a restore that is part-way through, for no gain:
+        // the task has nowhere else to go until the assignor names a member that still exists.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "departedMember", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions =
+            analyze(members, targetAssignment, Map.of("memberA", offsets(500L, 10_000L)));
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "departedMember",
+                Optional.empty(),
+                Optional.empty()
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldStageAMigrationWhenTheHolderHasNotReportedAnyOffsetsYet() {
+        // A member the coordinator has not heard from -- every member right after a failover -- reports nothing, so its
+        // active tasks read as processing. That is the safe direction: we stage rather than hand the task over.
         final Map<String, StreamsGroupMember> members = Map.of(
             "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
             "memberB", member("memberB", "processB", TasksTuple.EMPTY)

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
@@ -16,15 +16,32 @@
  */
 package org.apache.kafka.coordinator.group.streams;
 
+import org.apache.kafka.coordinator.group.streams.assignor.TaskId;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredInternalTopic;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AssignmentRefinerTest {
+
+    private static final String STATEFUL = "stateful-subtopology";
+    private static final String STATELESS = "stateless-subtopology";
+    private static final long ACCEPTABLE_RECOVERY_LAG = 100L;
+    private static final TaskId STATEFUL_0 = new TaskId(STATEFUL, 0);
 
     private static TasksTuple active(final Map<String, Set<Integer>> activeTasks) {
         return new TasksTuple(activeTasks, Map.of(), Map.of());
@@ -150,5 +167,598 @@ public class AssignmentRefinerTest {
         );
 
         assertTrue(AssignmentRefiner.preservesActiveTaskCount(targetAssignment, targetAssignment));
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // isCaughtUp
+    // ---------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldBeCaughtUpWhenTheLagIsWithinTheAcceptableRecoveryLag() {
+        assertTrue(AssignmentRefinerImpl.isCaughtUp(offsets(1000L, 1050L), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldBeCaughtUpWhenTheLagIsExactlyTheAcceptableRecoveryLag() {
+        assertTrue(AssignmentRefinerImpl.isCaughtUp(offsets(1000L, 1100L), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenTheLagExceedsTheAcceptableRecoveryLag() {
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(offsets(1000L, 1101L), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldBeCaughtUpWhenTheLagIsNegative() {
+        // The offset is a position while the end offset is the last offset, so a fully restored task reports -1. That
+        // is more than caught up, not a malformed report.
+        assertTrue(AssignmentRefinerImpl.isCaughtUp(offsets(1000L, 999L), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenNothingWasReported() {
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(MemberTaskOffsets.EMPTY, STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenOnlyTheEndOffsetWasReported() {
+        final MemberTaskOffsets memberTaskOffsets = new MemberTaskOffsets(
+            Map.of(),
+            Map.of(STATEFUL, Map.of(0, 1000L))
+        );
+
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(memberTaskOffsets, STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenOnlyTheOffsetWasReported() {
+        final MemberTaskOffsets memberTaskOffsets = new MemberTaskOffsets(
+            Map.of(STATEFUL, Map.of(0, 1000L)),
+            Map.of()
+        );
+
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(memberTaskOffsets, STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenTheRestoreHasNotStarted() {
+        // Long.MAX_VALUE is the client's way of saying that it has not started restoring the task, so no lag can be
+        // computed from it.
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(offsets(Long.MAX_VALUE, 1000L), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(offsets(1000L, Long.MAX_VALUE), STATEFUL_0, ACCEPTABLE_RECOVERY_LAG));
+    }
+
+    @Test
+    public void shouldNotBeCaughtUpWhenAnotherTaskWasReported() {
+        assertFalse(AssignmentRefinerImpl.isCaughtUp(
+            offsets(1000L, 1000L),
+            new TaskId(STATEFUL, 1),
+            ACCEPTABLE_RECOVERY_LAG
+        ));
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // indexCurrentAssignment
+    // ---------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldIndexTheMemberRunningATaskAsItsActiveOwner() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)))
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, Map.of());
+
+        assertEquals(
+            Map.of(
+                STATEFUL_0, "memberA",
+                new TaskId(STATEFUL, 1), "memberA"
+            ),
+            index.activeOwner()
+        );
+        assertEquals(Map.of(), index.processesRevoking());
+        assertEquals(Map.of(), index.taskCopies());
+    }
+
+    @Test
+    public void shouldNotIndexAnActiveOwnerForATaskThatIsPendingRevocation() {
+        // The member was told to give the task up, so it is not ownership to preserve. The process still holds it, and
+        // that is what gets recorded.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member(
+                "memberA",
+                "processA",
+                TasksTuple.EMPTY,
+                mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+            )
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, Map.of());
+
+        assertEquals(Map.of(), index.activeOwner());
+        assertEquals(Map.of(STATEFUL_0, Set.of("processA")), index.processesRevoking());
+    }
+
+    @Test
+    public void shouldIndexStandbyAndWarmupHoldersWithWhetherTheyAreCaughtUp() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, MemberTaskOffsets> taskOffsets = Map.of(
+            "memberA", offsets(1000L, 1000L),
+            "memberB", offsets(0L, 10_000L)
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, taskOffsets);
+
+        assertEquals(Map.of(), index.activeOwner());
+        assertEquals(
+            Set.of(
+                new AssignmentRefinerImpl.TaskCopy("memberA", "processA", TaskRole.STANDBY, true),
+                new AssignmentRefinerImpl.TaskCopy("memberB", "processB", TaskRole.WARMUP, false)
+            ),
+            Set.copyOf(index.taskCopies().get(STATEFUL_0))
+        );
+    }
+
+    @Test
+    public void shouldNotIndexStatelessTasks() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATELESS, 0)))
+        );
+
+        final AssignmentRefinerImpl.CurrentAssignmentIndex index = index(members, Map.of());
+
+        assertEquals(Map.of(), index.activeOwner());
+        assertEquals(Map.of(), index.taskCopies());
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // analyzeTasks
+    // ---------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldDecideNothingWhenEveryTaskAlreadyRunsWhereItBelongs() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(List.of(), decisions.grantedTasks());
+    }
+
+    @Test
+    public void shouldStageAMigrationToAMemberThatHoldsNoState() {
+        // The headline case: a scale-out moves a stateful task to a cold member, so the task keeps running where it is
+        // while the new owner restores it.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "memberB",
+                Optional.of("processB"),
+                Optional.empty()
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldGrantTheTaskWhenTheTargetOwnerAlreadyHoldsACaughtUpReplica() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(
+            members,
+            targetAssignment,
+            Map.of("memberB", offsets(1000L, 1000L))
+        );
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")),
+            decisions.grantedTasks()
+        );
+    }
+
+    @Test
+    public void shouldStageWhenTheReplicaOnTheTargetProcessIsNotCaughtUpYet() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(
+            members,
+            targetAssignment,
+            Map.of("memberB", offsets(0L, 10_000L))
+        );
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "memberB",
+                Optional.of("processB"),
+                Optional.of(new AssignmentRefinerImpl.TaskCopy("memberB", "processB", TaskRole.STANDBY, false))
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldGrantTheTaskWhenASiblingOnTheTargetProcessHoldsACaughtUpReplica() {
+        // The sibling has to close the task before the target owner can open it, so the hand-over goes through the
+        // checkpointed state directory rather than a network restore. Planting a warm-up task on the target owner is
+        // not possible anyway, because its process already holds the task.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY),
+            "memberC", member("memberC", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberC", TasksTuple.EMPTY
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(
+            members,
+            targetAssignment,
+            Map.of("memberC", offsets(1000L, 1000L))
+        );
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")),
+            decisions.grantedTasks()
+        );
+    }
+
+    @Test
+    public void shouldGrantTheTaskWhenItMovesBetweenTwoMembersOfOneProcess() {
+        // A process must not hold the same task twice, so there is no way to warm the new owner up first. Staging such
+        // a move would park it forever.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processA", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")),
+            decisions.grantedTasks()
+        );
+    }
+
+    @Test
+    public void shouldGrantATaskNobodyRunsEvenToAColdMember() {
+        // There is no running task to protect, and choosing a warmer owner instead would be a placement decision,
+        // which belongs to the assignor.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberA")),
+            decisions.grantedTasks()
+        );
+    }
+
+    @Test
+    public void shouldGrantATaskWhosePreviousOwnerWasAlreadyToldToRevokeIt() {
+        // The hand-over is in flight: holding the task back now would take it away from a member that has already
+        // stopped running it.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member(
+                "memberA",
+                "processA",
+                TasksTuple.EMPTY,
+                mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+            ),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.TaskGrant(STATEFUL_0, "memberB")),
+            decisions.grantedTasks()
+        );
+    }
+
+    @Test
+    public void shouldDecideNothingForATaskTheTargetAssignmentNoLongerContains() {
+        // A topology change removed the task. It belongs in nobody's slice, and its current holder revokes it the
+        // ordinary way.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of("memberA", TasksTuple.EMPTY);
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(List.of(), decisions.grantedTasks());
+    }
+
+    @Test
+    public void shouldNotStageStatelessTasks() {
+        // A stateless task has nothing to restore, so the reconciler's ordinary revoke-and-grant is all its move needs.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 0))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(List.of(), decisions.grantedTasks());
+    }
+
+    @Test
+    public void shouldReportAnInFlightWarmupOnTheTargetProcess() {
+        // The migration is already under way from an earlier step: the target owner holds a warm-up task that has not
+        // caught up yet. It stays staged, and the warm-up task is reported so that the budget pass keeps it rather than
+        // planting a second one.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "memberB",
+                Optional.of("processB"),
+                Optional.of(new AssignmentRefinerImpl.TaskCopy("memberB", "processB", TaskRole.WARMUP, false))
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldHoldATaskWhereItRunsWhenItsTargetOwnerIsGone() {
+        // The target assignment still names a member the group has removed, because the assignor has not run again
+        // yet. Nothing can be staged into that member, so the task stays where it is -- and the empty target process
+        // tells the budget pass not to spend a slot on it.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "goneMember", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.grantedTasks());
+        assertEquals(
+            List.of(new AssignmentRefinerImpl.StagedMigration(
+                STATEFUL_0,
+                "memberA",
+                "goneMember",
+                Optional.empty(),
+                Optional.empty()
+            )),
+            decisions.stagedMigrations()
+        );
+    }
+
+    @Test
+    public void shouldDecideNothingForAnUnownedTaskWhoseTargetOwnerIsGone() {
+        // Granting it to a member that is no longer in the group would achieve nothing; the next assignor run places
+        // the task somewhere real.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "goneMember", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(List.of(), decisions.stagedMigrations());
+        assertEquals(List.of(), decisions.grantedTasks());
+    }
+
+    @Test
+    public void shouldReturnDecisionsInCanonicalTaskOrder() {
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 2, 0, 1))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 2, 0, 1))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(members, targetAssignment, Map.of());
+
+        assertEquals(
+            List.of(STATEFUL_0, new TaskId(STATEFUL, 1), new TaskId(STATEFUL, 2)),
+            decisions.stagedMigrations().stream().map(AssignmentRefinerImpl.StagedMigration::task).toList()
+        );
+    }
+
+    @Test
+    public void shouldDecideEachDivergingTaskExactlyOnce() {
+        // The completeness invariant: every stateful task that is not already in place is either staged or granted,
+        // never both and never neither.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            // 0 stays put, 1 migrates to a cold member, 2 migrates to a caught-up member, 3 is unowned.
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.STANDBY, mkTasks(STATEFUL, 2)))
+        );
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1, 2, 3))
+        );
+
+        final AssignmentRefinerImpl.TaskDecisions decisions = analyze(
+            members,
+            targetAssignment,
+            Map.of("memberB", offsets(2, 1000L, 1000L))
+        );
+
+        assertEquals(
+            List.of(new TaskId(STATEFUL, 1)),
+            decisions.stagedMigrations().stream().map(AssignmentRefinerImpl.StagedMigration::task).toList()
+        );
+        assertEquals(
+            List.of(new TaskId(STATEFUL, 2), new TaskId(STATEFUL, 3)),
+            decisions.grantedTasks().stream().map(AssignmentRefinerImpl.TaskGrant::task).toList()
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // Fixtures
+    // ---------------------------------------------------------------------------------------------------------------
+
+    private static AssignmentRefinerImpl.CurrentAssignmentIndex index(
+        final Map<String, StreamsGroupMember> members,
+        final Map<String, MemberTaskOffsets> taskOffsets
+    ) {
+        return AssignmentRefinerImpl.indexCurrentAssignment(
+            members,
+            taskOffsets,
+            subtopologies(),
+            ACCEPTABLE_RECOVERY_LAG
+        );
+    }
+
+    private static AssignmentRefinerImpl.TaskDecisions analyze(
+        final Map<String, StreamsGroupMember> members,
+        final Map<String, TasksTuple> targetAssignment,
+        final Map<String, MemberTaskOffsets> taskOffsets
+    ) {
+        return AssignmentRefinerImpl.analyzeTasks(
+            index(members, taskOffsets),
+            targetAssignment,
+            members,
+            subtopologies()
+        );
+    }
+
+    private static SortedMap<String, ConfiguredSubtopology> subtopologies() {
+        final SortedMap<String, ConfiguredSubtopology> subtopologies = new TreeMap<>();
+        subtopologies.put(STATEFUL, new ConfiguredSubtopology(
+            4,
+            Set.of("input"),
+            Map.of(),
+            Set.of(),
+            Map.of("changelog", new ConfiguredInternalTopic("changelog", 4, Optional.empty(), Map.of()))
+        ));
+        subtopologies.put(STATELESS, new ConfiguredSubtopology(4, Set.of("input"), Map.of(), Set.of(), Map.of()));
+        return subtopologies;
+    }
+
+    private static StreamsGroupMember member(
+        final String memberId,
+        final String processId,
+        final TasksTuple assignedTasks
+    ) {
+        return member(memberId, processId, assignedTasks, TasksTuple.EMPTY);
+    }
+
+    private static StreamsGroupMember member(
+        final String memberId,
+        final String processId,
+        final TasksTuple assignedTasks,
+        final TasksTuple tasksPendingRevocation
+    ) {
+        return new StreamsGroupMember.Builder(memberId)
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(1)
+            .setState(MemberState.STABLE)
+            .setProcessId(processId)
+            .setRebalanceTimeoutMs(1500)
+            .setTopologyEpoch(0)
+            .setClientTags(Map.of())
+            .setAssignedTasks(withEpochs(assignedTasks))
+            .setTasksPendingRevocation(withEpochs(tasksPendingRevocation))
+            .build();
+    }
+
+    private static TasksTupleWithEpochs withEpochs(final TasksTuple tasks) {
+        final Map<String, Map<Integer, Integer>> activeWithEpochs = new HashMap<>();
+        tasks.activeTasks().forEach((subtopologyId, partitionIds) -> {
+            final Map<Integer, Integer> byPartition = new HashMap<>();
+            partitionIds.forEach(partitionId -> byPartition.put(partitionId, 1));
+            activeWithEpochs.put(subtopologyId, byPartition);
+        });
+        return new TasksTupleWithEpochs(activeWithEpochs, tasks.standbyTasks(), tasks.warmupTasks());
+    }
+
+    private static MemberTaskOffsets offsets(final long offset, final long endOffset) {
+        return offsets(0, offset, endOffset);
+    }
+
+    private static MemberTaskOffsets offsets(final int partitionId, final long offset, final long endOffset) {
+        return new MemberTaskOffsets(
+            Map.of(STATEFUL, Map.of(partitionId, offset)),
+            Map.of(STATEFUL, Map.of(partitionId, endOffset))
+        );
     }
 }

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/AssignmentRefinerTest.java
@@ -293,8 +293,9 @@ public class AssignmentRefinerTest {
 
     @Test
     public void shouldNotIndexAnActiveHolderForATaskThatIsPendingRevocation() {
-        // The member was told to give the task up, so it is not ownership to preserve. The process it still occupies
-        // needs no tracking either: the reconciler blocks a colliding placement until the revocation lands.
+        // The member was told to give the task up, so it is not part of the current assignment to preserve, even
+        // though it may still be running physically. The process it still occupies needs no tracking either: the
+        // reconciler blocks a colliding placement until the revocation lands.
         final Map<String, StreamsGroupMember> members = Map.of(
             "memberA", member(
                 "memberA",

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/CurrentAssignmentBuilderTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.coordinator.group.streams;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.FencedMemberEpochException;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsCoordinatorRecordHelpersTest.java
@@ -32,7 +32,6 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignmentMetadataValue;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
 import org.junit.jupiter.api.Test;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/StreamsGroupTest.java
@@ -47,7 +47,6 @@ import org.apache.kafka.coordinator.group.generated.StreamsGroupTargetAssignment
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyKey;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupTopologyValue;
 import org.apache.kafka.coordinator.group.streams.StreamsGroup.StreamsGroupState;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredTopology;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.timeline.SnapshotRegistry;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TargetAssignmentBuilderTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.coordinator.group.api.streams.assignor.GroupAssignment;
 import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
 import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
 import org.apache.kafka.coordinator.group.generated.StreamsGroupMemberMetadataValue;
-import org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
 import org.apache.kafka.coordinator.group.streams.assignor.AssignmentConfigsImpl;
 import org.apache.kafka.coordinator.group.streams.assignor.GroupSpecImpl;
 import org.apache.kafka.coordinator.group.streams.assignor.MemberMetadataAndStateImpl;

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/TaskAssignmentTestUtil.java
@@ -25,12 +25,6 @@ import java.util.Set;
 
 public class TaskAssignmentTestUtil {
 
-    public enum TaskRole {
-        ACTIVE,
-        STANDBY,
-        WARMUP
-    }
-
     @SafeVarargs
     public static TasksTuple mkTasksTuple(TaskRole taskRole, Map.Entry<String, Set<Integer>>... entries) {
         return switch (taskRole) {


### PR DESCRIPTION
Add building block code for the "streams" assignment refiner, that will
later be used in the overall refinement algorithm.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
