### PR TITLE
KAFKA-21003: Verify replica assignments in CreateTopicsRequestTest

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/CreateTopicsRequestTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/CreateTopicsRequestTest.java
@@ -288,7 +288,7 @@ public class CreateTopicsRequestTest {
             .filter(t -> topic.name().equals(t.topic())).findFirst().orElse(null);
 
         int partitions = !topic.assignments().isEmpty() ? topic.assignments().size() : topic.numPartitions();
-        int replication = !topic.assignments().isEmpty() ? topic.assignments().iterator().next().brokerIds().size() : topic.replicationFactor();
+        int replication = topic.replicationFactor();
 
         if (validateOnly) {
             assertNotNull(metadataForTopic);
@@ -305,7 +305,18 @@ public class CreateTopicsRequestTest {
                     "The topic should have the correct number of partitions");
             }
 
-            if (replication == -1) {
+            if (!topic.assignments().isEmpty()) {
+                for (CreatableReplicaAssignment assignment : topic.assignments()) {
+                    MetadataResponse.PartitionMetadata partitionMetadata = metadataForTopic.partitionMetadata().stream()
+                        .filter(metadata -> metadata.partition() == assignment.partitionIndex())
+                        .findFirst()
+                        .orElse(null);
+                    assertNotNull(partitionMetadata,
+                        "The topic should contain partition " + assignment.partitionIndex());
+                    assertEquals(assignment.brokerIds(), partitionMetadata.replicaIds,
+                        "The replica assignment should match for partition " + assignment.partitionIndex());
+                }
+            } else if (replication == -1) {
                 assertEquals(defaultReplicationFactor(cluster), metadataForTopic.partitionMetadata().get(0).replicaIds.size(),
                     "The topic should have the default replication factor");
             } else {


### PR DESCRIPTION
`testValidCreateTopicsRequests` creates topics with manual replica
assignments, but the existing metadata verification only checks the
replica count of the first partition.

This change verifies that every manually assigned partition exists and
that its replica IDs and ordering match the requested assignment.
Generated and default replica assignments continue to use the existing
replication-factor checks.

Co-Authored-By: Codex (GPT-5)

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
