### PR TITLE
KAFKA-17777: Flaky KafkaConsumerTest testReturnRecordsDuringRebalance

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2815,7 +2815,14 @@ public class KafkaConsumerTest {
         fetches1.put(t2p0, new FetchInfo(0, 10));
         client.respondFrom(fetchResponse(fetches1), node);
 
-        ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
+        // A background heartbeat can complete the fetch concurrently, so a single poll may return
+        // no records; poll until the buffered records are returned.
+        AtomicReference<ConsumerRecords<String, String>> polled = new AtomicReference<>(ConsumerRecords.empty());
+        TestUtils.waitForCondition(() -> {
+            polled.set(consumer.poll(Duration.ZERO));
+            return polled.get().count() == 11;
+        }, "Consumer did not return the fetched records in time");
+        ConsumerRecords<String, String> records = polled.get();
 
         // verify that the fetch occurred as expected
         assertEquals(11, records.count());
@@ -2844,7 +2851,11 @@ public class KafkaConsumerTest {
         AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, partitionOffsets1);
 
         // poll once which would not complete the rebalance
-        records = consumer.poll(Duration.ZERO);
+        TestUtils.waitForCondition(() -> {
+            polled.set(consumer.poll(Duration.ZERO));
+            return polled.get().count() == 1;
+        }, "Consumer did not return the fetched records in time");
+        records = polled.get();
 
         // clear out the prefetch so it doesn't interfere with the rest of the test
         fetches1.clear();
@@ -2867,7 +2878,11 @@ public class KafkaConsumerTest {
 
         // we need to poll 1) for getting the join response, and then send the sync request;
         //                 2) for getting the sync response
-        records = consumer.poll(Duration.ZERO);
+        TestUtils.waitForCondition(() -> {
+            polled.set(consumer.poll(Duration.ZERO));
+            return polled.get().count() == 1;
+        }, "Consumer did not return the fetched records in time");
+        records = polled.get();
 
         // should not finish the response yet
         assertEquals(Set.of(topic, topic3), consumer.subscription());
@@ -2885,11 +2900,15 @@ public class KafkaConsumerTest {
         client.respondFrom(syncGroupResponse(Arrays.asList(tp0, t3p0), Errors.NONE), coordinator);
 
         AtomicInteger count = new AtomicInteger(0);
-        AtomicReference<ConsumerRecords<String, String>> recs1 = new AtomicReference<>();
+        AtomicReference<ConsumerRecords<String, String>> recs1 = new AtomicReference<>(ConsumerRecords.empty());
         TestUtils.waitForCondition(() -> {
-            recs1.set(consumer.poll(Duration.ofMillis(100L)));
-            return consumer.assignment().equals(Set.of(tp0, t3p0)) && count.addAndGet(recs1.get().count()) == 1;
-
+            ConsumerRecords<String, String> p = consumer.poll(Duration.ofMillis(100L));
+            // The record can be returned before the rebalance assignment is reconciled, so count on
+            // every poll; gating the count on the assignment would drop an early record.
+            if (p.count() > 0)
+                recs1.set(p);
+            count.addAndGet(p.count());
+            return consumer.assignment().equals(Set.of(tp0, t3p0)) && count.get() == 1;
         }, "Does not complete rebalance in time");
 
         // should have t3 but not sent yet the t3 records

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2815,8 +2815,10 @@ public class KafkaConsumerTest {
         fetches1.put(t2p0, new FetchInfo(0, 10));
         client.respondFrom(fetchResponse(fetches1), node);
 
-        // A background heartbeat can complete the fetch concurrently, so a single poll may return
-        // no records; poll until the buffered records are returned.
+        // A background heartbeat poll can retrieve a completed fetch, then trigger its completion
+        // logic in a separate step to put the data in the buffer. If the app thread poll runs in
+        // between, it finds no completed request or buffered data, so it may return empty on a
+        // first poll attempt.
         AtomicReference<ConsumerRecords<String, String>> polled = new AtomicReference<>(ConsumerRecords.empty());
         TestUtils.waitForCondition(() -> {
             polled.set(consumer.poll(Duration.ZERO));


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-17777

testReturnRecordsDuringRebalance is flaky for the classic consumer due
to the  same heartbeat-vs-application-thread race addressed in
KAFKA-16630: a poll() can  momentarily return no records, or return a
buffered record before the rebalance  assignment has reconciled. As a
result the test's single poll(Duration.ZERO)  calls occasionally
returned zero records, and the step that only counted a record  once the
assignment had settled dropped a record that arrived early and then
timed  out waiting for it.

The affected steps now poll until the expected records are returned
using  TestUtils.waitForCondition, and count each polled record
independently of the  assignment check so an early record is no longer
lost. This is a test-only change.

The flakiness was reproduced locally at a high rate under a tight repeat
loop;  after the fix the test passed 2000 stress iterations and 300
consecutive full  test-task runs with no failures.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
