### PR TITLE
MINOR: Avoid O(n) List.contains() in AbstractStickyAssignor isBalanced

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -1204,8 +1204,8 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                     int partitionCount = partitionsPerTopic.get(topic).size();
                     for (int i = 0; i < partitionCount; i++) {
                         TopicPartition topicPartition = new TopicPartition(topic, i);
-                        if (!currentAssignment.get(consumer).contains(topicPartition)) {
-                            String otherConsumer = allPartitions.get(topicPartition);
+                        String otherConsumer = allPartitions.get(topicPartition);
+                        if (!consumer.equals(otherConsumer)) {
                             int otherConsumerPartitionCount = currentAssignment.get(otherConsumer).size();
                             if (consumerPartitionCount + 1 < otherConsumerPartitionCount) {
                                 log.debug("{} can be moved from consumer {} to consumer {} for a more balanced assignment.",


### PR DESCRIPTION
### Summary

`AbstractStickyAssignor isBalanced` already builds a `Map<TopicPartition, String> allPartitions` mapping each partition to its currently assigned consumer, specifically so that lookups can be done in O(1). A few lines later, however, it ignores that map for the actual check and instead calls `currentAssignment.get(consumer).contains(topicPartition)`, an O(n) scan over a
`List<TopicPartition>`, to answer the exact same question.

The extra linear factor is paid on every consumer group rebalance, and compounds with group/partition count.

This PR replaces the `List.contains()` scan with a lookup against the map that already exists, which is semantically equivalent (including null-handling behavior for unassigned partitions) but O(1) instead of O(n).

### Changes

- `AbstractStickyAssignor#isBalanced`: reuse `allPartitions.get(topicPartition)` instead of
  `currentAssignment.get(consumer).contains(topicPartition)`.

Reviewers: Maros Orsak <maros.orsak159@gmail.com>
