### PR TITLE
KAFKA-21016: Add client quota-utilization metrics (KIP-1373)

### DIFF
--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -975,6 +975,9 @@ class DynamicBrokerReconfigurationTest extends QuorumTestHarness with SaslSetup 
     val mbeanServer = ManagementFactory.getPlatformMBeanServer
     val byteRate = mbeanServer.getAttribute(new ObjectName(s"kafka.server:type=Produce,client-id=$clientId"), "byte-rate")
     assertTrue(byteRate.asInstanceOf[Double] > 0, "JMX attribute not updated")
+    val quotaUtilization = mbeanServer.getAttribute(
+      new ObjectName(s"kafka.server:type=Produce,client-id=$clientId"), "quota-utilization")
+    assertTrue(quotaUtilization.asInstanceOf[Double] > 0, "Quota utilization JMX attribute not updated")
 
     // Property not related to the metrics reporter config should not reconfigure reporter
     newProps.setProperty("some.prop", "some.value")

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -829,7 +829,7 @@ kafka.server:type={Produce|Fetch},user=([-.\w]+),client-id=([-.\w]+)
 </td>  
 <td>
 
-Two attributes. throttle-time indicates the amount of time in ms the client was throttled. Ideally = 0. byte-rate indicates the data produce/consume rate of the client in bytes/sec. For (user, client-id) quotas, both user and client-id are specified. If per-client-id quota is applied to the client, user is not specified. If per-user quota is applied, client-id is not specified.
+Three attributes. throttle-time indicates the amount of time in ms the client was throttled. Ideally = 0. byte-rate indicates the data produce/consume rate of the client in bytes/sec. quota-utilization is byte-rate as a percentage of the effective quota applied on this broker. It is not capped at 100, and is NaN when there is no finite positive quota. For (user, client-id) quotas, both user and client-id are specified. If per-client-id quota is applied to the client, user is not specified. If per-user quota is applied, client-id is not specified.
 </td> </tr>  
 <tr>  
 <td>
@@ -842,7 +842,7 @@ kafka.server:type=Request,user=([-.\w]+),client-id=([-.\w]+)
 </td>  
 <td>
 
-Two attributes. throttle-time indicates the amount of time in ms the client was throttled. Ideally = 0. request-time indicates the percentage of time spent in broker network and I/O threads to process requests from client group. For (user, client-id) quotas, both user and client-id are specified. If per-client-id quota is applied to the client, user is not specified. If per-user quota is applied, client-id is not specified.
+Three attributes. throttle-time indicates the amount of time in ms the client was throttled. Ideally = 0. request-time indicates the percentage of time spent in broker network and I/O threads to process requests from client group. quota-utilization is request-time as a percentage of the effective request quota applied on this broker. It is not capped at 100, and is NaN when there is no finite positive quota. For (user, client-id) quotas, both user and client-id are specified. If per-client-id quota is applied to the client, user is not specified. If per-user quota is applied, client-id is not specified.
 </td> </tr>  
 <tr>  
 <td>

--- a/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
+++ b/server/src/main/java/org/apache/kafka/server/quota/ClientQuotaManager.java
@@ -18,6 +18,8 @@ package org.apache.kafka.server.quota;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.internals.Plugin;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Quota;
@@ -469,10 +471,15 @@ public class ClientQuotaManager {
     }
 
     protected void registerQuotaMetrics(Map<String, String> metricTags, Sensor sensor) {
+        MetricName quotaMetricName = clientQuotaMetricName(metricTags);
         sensor.add(
-                clientQuotaMetricName(metricTags),
+                quotaMetricName,
                 new Rate(),
                 getQuotaMetricConfig(metricTags)
+        );
+        sensor.add(
+                quotaUtilizationMetricName(metricTags),
+                new QuotaUtilization(metrics.metric(quotaMetricName))
         );
     }
 
@@ -687,11 +694,40 @@ public class ClientQuotaManager {
                 quotaMetricTags);
     }
 
+    private MetricName quotaUtilizationMetricName(Map<String, String> quotaMetricTags) {
+        return metrics.metricName("quota-utilization", quotaType.toString(),
+                "Tracking quota utilization percentage per user/client-id",
+                quotaMetricTags);
+    }
+
     private MetricName throttleMetricName(Map<String, String> quotaMetricTags) {
         return metrics.metricName("throttle-time",
                 quotaType.toString(),
                 "Tracking average throttle-time per user/client-id",
                 quotaMetricTags);
+    }
+
+    private static class QuotaUtilization implements MeasurableStat {
+        private final KafkaMetric quotaMetric;
+
+        private QuotaUtilization(KafkaMetric quotaMetric) {
+            this.quotaMetric = quotaMetric;
+        }
+
+        @Override
+        public void record(MetricConfig config, double value, long timeMs) {
+            // The quota rate metric on the same sensor records the value.
+        }
+
+        @Override
+        public double measure(MetricConfig config, long now) {
+            MetricConfig quotaMetricConfig = quotaMetric.config();
+            Quota quota = quotaMetricConfig.quota();
+            if (quota == null || quota.bound() <= 0 || quota.bound() >= Long.MAX_VALUE) {
+                return Double.NaN;
+            }
+            return quotaMetric.measurable().measure(quotaMetricConfig, now) / quota.bound() * 100;
+        }
     }
 
     public void initiateShutdown() {

--- a/server/src/test/java/org/apache/kafka/server/quota/BaseClientQuotaManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/quota/BaseClientQuotaManagerTest.java
@@ -80,6 +80,10 @@ public class BaseClientQuotaManagerTest {
         return quotaManager.maybeRecordAndGetThrottleTimeMs(buildSession(user), clientId, value, time.milliseconds());
     }
 
+    protected void unrecord(ClientQuotaManager quotaManager, String user, String clientId, double value) {
+        quotaManager.unrecordQuotaSensor(buildSession(user), clientId, value, time.milliseconds());
+    }
+
     protected void throttle(ClientQuotaManager quotaManager, int throttleTimeMs, ThrottleCallback channelThrottlingCallback) {
         AbstractRequest.Builder<FetchRequest> builder = FetchRequest.Builder.forConsumer(ApiKeys.FETCH.latestVersion(), 0, 1000, Map.of());
         FetchRequest fetchRequest = builder.build();

--- a/server/src/test/java/org/apache/kafka/server/quota/ClientQuotaManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/quota/ClientQuotaManagerTest.java
@@ -17,7 +17,10 @@
 package org.apache.kafka.server.quota;
 
 import org.apache.kafka.common.internals.Plugin;
+import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Quota;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -26,11 +29,18 @@ import org.apache.kafka.server.config.ClientQuotaManagerConfig;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -609,6 +619,266 @@ public class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
         } finally {
             clientQuotaManager.shutdown();
         }
+    }
+
+    @Test
+    public void testQuotaUtilization() {
+        for (QuotaType quotaType : List.of(QuotaType.PRODUCE, QuotaType.FETCH)) {
+            withQuotaManager(quotaType, clientQuotaManager -> {
+                String user = "userA";
+                String clientId = "client1";
+                Map<String, String> metricTags = Map.of("user", user, "client-id", clientId);
+                // Default quota window is 11 samples of 1s; Rate pads to n-1 windows, so 800 recorded once is 80/s.
+                clientQuotaManager.updateQuota(
+                        Optional.of(new ClientQuotaManager.UserEntity(user)),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                        Optional.of(Quota.upperBound(100))
+                );
+
+                maybeRecord(clientQuotaManager, user, clientId, 800);
+                KafkaMetric utilizationMetric = metrics.metric(metrics.metricName("quota-utilization", quotaType.toString(), metricTags));
+                assertNotNull(utilizationMetric);
+                assertEquals(80, (Double) utilizationMetric.metricValue(), 0.001);
+
+                clientQuotaManager.updateQuota(
+                        Optional.of(new ClientQuotaManager.UserEntity(user)),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                        Optional.of(Quota.upperBound(50))
+                );
+                assertEquals(160, (Double) utilizationMetric.metricValue(), 0.001);
+
+                clientQuotaManager.updateQuota(
+                        Optional.of(new ClientQuotaManager.UserEntity(user)),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                        Optional.empty()
+                );
+                assertTrue(Double.isNaN((Double) utilizationMetric.metricValue()));
+            });
+        }
+    }
+
+    @Test
+    public void testMeasuringQuotaUtilizationDoesNotResolveQuotaAgain() {
+        AtomicInteger quotaLimitCalls = new AtomicInteger();
+        ClientQuotaCallback customQuotaCallback = new ClientQuotaCallback() {
+            @Override
+            public void configure(Map<String, ?> configs) {}
+
+            @Override
+            public Map<String, String> quotaMetricTags(ClientQuotaType quotaType, KafkaPrincipal principal, String clientId) {
+                return Map.of("custom-tag", "custom-value");
+            }
+
+            @Override
+            public Double quotaLimit(ClientQuotaType quotaType, Map<String, String> metricTags) {
+                quotaLimitCalls.incrementAndGet();
+                return 100.0;
+            }
+
+            @Override
+            public void updateQuota(ClientQuotaType quotaType, ClientQuotaEntity entity, double newValue) {}
+
+            @Override
+            public void removeQuota(ClientQuotaType quotaType, ClientQuotaEntity entity) {}
+
+            @Override
+            public boolean quotaResetRequired(ClientQuotaType quotaType) {
+                return false;
+            }
+
+            @Override
+            public void close() {}
+        };
+        ClientQuotaManager clientQuotaManager = new ClientQuotaManager(
+                config,
+                metrics,
+                QuotaType.PRODUCE,
+                time,
+                "",
+                Optional.of(Plugin.wrapInstance(customQuotaCallback, metrics, ""))
+        );
+
+        try {
+            maybeRecord(clientQuotaManager, "userA", "client1", 800);
+            int callsBeforeMeasurement = quotaLimitCalls.get();
+            KafkaMetric utilizationMetric = metrics.metric(metrics.metricName(
+                    "quota-utilization",
+                    QuotaType.PRODUCE.toString(),
+                    Map.of("custom-tag", "custom-value")
+            ));
+            assertNotNull(utilizationMetric);
+            assertEquals(80, (Double) utilizationMetric.metricValue(), 0.001);
+            assertEquals(callsBeforeMeasurement, quotaLimitCalls.get());
+        } finally {
+            clientQuotaManager.shutdown();
+        }
+    }
+
+    @Test
+    public void testQuotaUtilizationTagsMatchRateMetric() {
+        record TagCase(Optional<ClientQuotaEntity.ConfigEntity> userEntity,
+                       Optional<ClientQuotaEntity.ConfigEntity> clientEntity,
+                       String user,
+                       String clientId,
+                       Map<String, String> tags) {}
+        List<TagCase> cases = List.of(
+                new TagCase(
+                        Optional.empty(),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity("client1")),
+                        "userA",
+                        "client1",
+                        Map.of("user", "", "client-id", "client1")
+                ),
+                new TagCase(
+                        Optional.of(new ClientQuotaManager.UserEntity("userA")),
+                        Optional.empty(),
+                        "userA",
+                        "client1",
+                        Map.of("user", "userA", "client-id", "")
+                ),
+                new TagCase(
+                        Optional.of(new ClientQuotaManager.UserEntity("userA")),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity("client1")),
+                        "userA",
+                        "client1",
+                        Map.of("user", "userA", "client-id", "client1")
+                ),
+                new TagCase(
+                        Optional.of(ClientQuotaManager.DEFAULT_USER_ENTITY),
+                        Optional.empty(),
+                        "userC",
+                        "client3",
+                        Map.of("user", "userC", "client-id", "")
+                ),
+                new TagCase(
+                        Optional.empty(),
+                        Optional.of(ClientQuotaManager.DEFAULT_USER_CLIENT_ID),
+                        "userB",
+                        "client2",
+                        Map.of("user", "", "client-id", "client2")
+                )
+        );
+
+        for (TagCase tagCase : cases) {
+            Metrics localMetrics = new Metrics(new MetricConfig(), List.of(), time);
+            ClientQuotaManager clientQuotaManager = new ClientQuotaManager(config, localMetrics, QuotaType.PRODUCE, time, "");
+            try {
+                clientQuotaManager.updateQuota(tagCase.userEntity(), tagCase.clientEntity(), Optional.of(Quota.upperBound(100)));
+                maybeRecord(clientQuotaManager, tagCase.user(), tagCase.clientId(), 800);
+                KafkaMetric rateMetric = localMetrics.metric(localMetrics.metricName("byte-rate", QuotaType.PRODUCE.toString(), tagCase.tags()));
+                KafkaMetric utilizationMetric = localMetrics.metric(localMetrics.metricName("quota-utilization", QuotaType.PRODUCE.toString(), tagCase.tags()));
+                assertNotNull(rateMetric, "missing byte-rate for " + tagCase.tags());
+                assertNotNull(utilizationMetric, "missing quota-utilization for " + tagCase.tags());
+                assertEquals(rateMetric.metricName().tags(), utilizationMetric.metricName().tags());
+                assertEquals(80, (Double) utilizationMetric.metricValue(), 0.001);
+            } finally {
+                clientQuotaManager.shutdown();
+                localMetrics.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQuotaUtilizationNanForNonPositiveAndMissingBounds() {
+        withQuotaManager(QuotaType.PRODUCE, clientQuotaManager -> {
+            String user = "userA";
+            String clientId = "client1";
+            Map<String, String> tags = Map.of("user", user, "client-id", clientId);
+
+            clientQuotaManager.updateQuota(
+                    Optional.of(new ClientQuotaManager.UserEntity(user)),
+                    Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                    Optional.of(Quota.upperBound(0))
+            );
+            maybeRecord(clientQuotaManager, user, clientId, 800);
+            assertTrue(Double.isNaN((Double) metric("quota-utilization", QuotaType.PRODUCE.toString()).metricValue()));
+
+            clientQuotaManager.updateQuota(
+                    Optional.of(new ClientQuotaManager.UserEntity(user)),
+                    Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                    Optional.of(Quota.upperBound(-10))
+            );
+            assertTrue(Double.isNaN((Double) metric("quota-utilization", QuotaType.PRODUCE.toString()).metricValue()));
+
+            KafkaMetric rateMetric = metrics.metric(metrics.metricName("byte-rate", QuotaType.PRODUCE.toString(), tags));
+            rateMetric.config(new MetricConfig());
+            assertTrue(Double.isNaN((Double) metric("quota-utilization", QuotaType.PRODUCE.toString()).metricValue()));
+        });
+    }
+
+    @Test
+    public void testFetchUnrecordIsReflectedInQuotaUtilization() {
+        withQuotaManager(QuotaType.FETCH, clientQuotaManager -> {
+            String user = "userA";
+            String clientId = "client1";
+            Map<String, String> tags = Map.of("user", user, "client-id", clientId);
+
+            clientQuotaManager.updateQuota(
+                    Optional.of(new ClientQuotaManager.UserEntity(user)),
+                    Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                    Optional.of(Quota.upperBound(100))
+            );
+
+            double recorded = 1500;
+            int throttleTimeMs = maybeRecord(clientQuotaManager, user, clientId, recorded);
+            assertTrue(throttleTimeMs > 0);
+            KafkaMetric utilizationMetric = metrics.metric(metrics.metricName("quota-utilization", QuotaType.FETCH.toString(), tags));
+            assertEquals(150, (Double) utilizationMetric.metricValue(), 0.001);
+
+            unrecord(clientQuotaManager, user, clientId, recorded);
+            double utilizationAfterUnrecord = (Double) utilizationMetric.metricValue();
+            assertEquals(0, utilizationAfterUnrecord, 0.001);
+            assertTrue(utilizationAfterUnrecord < 100);
+        });
+    }
+
+    @Test
+    public void testQuotaUtilizationJmxAttribute() throws Exception {
+        for (QuotaType quotaType : List.of(QuotaType.PRODUCE, QuotaType.FETCH)) {
+            Metrics jmxMetrics = new Metrics(new MetricConfig(), List.of(new JmxReporter()), time);
+            ClientQuotaManager clientQuotaManager = new ClientQuotaManager(config, jmxMetrics, quotaType, time, "");
+            String user = "userA";
+            String clientId = "client1";
+            Map<String, String> tags = Map.of("user", user, "client-id", clientId);
+
+            try {
+                clientQuotaManager.updateQuota(
+                        Optional.of(new ClientQuotaManager.UserEntity(user)),
+                        Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                        Optional.of(Quota.upperBound(100))
+                );
+                maybeRecord(clientQuotaManager, user, clientId, 800);
+
+                KafkaMetric rateMetric = jmxMetrics.metric(jmxMetrics.metricName("byte-rate", quotaType.toString(), tags));
+                assertNotNull(rateMetric);
+                ObjectName objectName = new ObjectName(":type=" + quotaType + ",user=" + user + ",client-id=" + clientId);
+                MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+                assertTrue(Arrays.stream(mbeanServer.getMBeanInfo(objectName).getAttributes())
+                        .anyMatch(attr -> attr.getName().equals("quota-utilization")));
+                assertEquals("double", Arrays.stream(mbeanServer.getMBeanInfo(objectName).getAttributes())
+                        .filter(attr -> attr.getName().equals("quota-utilization"))
+                        .findFirst()
+                        .orElseThrow()
+                        .getType());
+
+                double quota = 100;
+                double byteRate = (Double) mbeanServer.getAttribute(objectName, "byte-rate");
+                double utilization = (Double) mbeanServer.getAttribute(objectName, "quota-utilization");
+                assertEquals(byteRate / quota * 100, utilization, 0.001);
+                assertEquals(80, utilization, 0.001);
+            } finally {
+                clientQuotaManager.shutdown();
+                jmxMetrics.close();
+            }
+        }
+    }
+
+    private KafkaMetric metric(String name, String group) {
+        List<KafkaMetric> found = metrics.metrics().values().stream()
+                .filter(m -> m.metricName().name().equals(name) && m.metricName().group().equals(group))
+                .toList();
+        assertEquals(1, found.size(), "expected one " + name + " metric in " + group + ", found " + found.stream().map(KafkaMetric::metricName).toList());
+        return found.get(0);
     }
 
     record UserClient(

--- a/server/src/test/java/org/apache/kafka/server/quota/ClientRequestQuotaManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/quota/ClientRequestQuotaManagerTest.java
@@ -16,21 +16,103 @@
  */
 package org.apache.kafka.server.quota;
 
+import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Quota;
 import org.apache.kafka.server.config.ClientQuotaManagerConfig;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientRequestQuotaManagerTest extends BaseClientQuotaManagerTest {
     private final ClientQuotaManagerConfig config = new ClientQuotaManagerConfig();
 
     private static double millisToPercent(double millis) {
         return millis * 1000 * 1000 * ClientRequestQuotaManager.NANOS_TO_PERCENTAGE_PER_SECOND;
+    }
+
+    @Test
+    public void testRequestQuotaUtilization() {
+        ClientRequestQuotaManager clientRequestQuotaManager = new ClientRequestQuotaManager(config, metrics, time, "", Optional.empty());
+        String user = "ANONYMOUS";
+        String clientId = "test-client";
+        ClientQuotaEntity.ConfigEntity userEntity = new ClientQuotaManager.UserEntity(user);
+        ClientQuotaEntity.ConfigEntity clientEntity = new ClientQuotaManager.ClientIdEntity(clientId);
+
+        try {
+            clientRequestQuotaManager.updateQuota(
+                    Optional.of(userEntity),
+                    Optional.of(clientEntity),
+                    Optional.of(Quota.upperBound(50))
+            );
+
+            maybeRecord(clientRequestQuotaManager, user, clientId, 400);
+            Map<String, String> tags = Map.of("user", user, "client-id", clientId);
+            KafkaMetric requestTimeMetric = metrics.metric(metrics.metricName("request-time", QuotaType.REQUEST.toString(), tags));
+            KafkaMetric utilizationMetric = metrics.metric(metrics.metricName(
+                    "quota-utilization",
+                    QuotaType.REQUEST.toString(),
+                    tags
+            ));
+            assertNotNull(utilizationMetric);
+            assertEquals(requestTimeMetric.metricName().tags(), utilizationMetric.metricName().tags());
+            double requestTime = (Double) requestTimeMetric.metricValue();
+            assertEquals(requestTime / 50 * 100, (Double) utilizationMetric.metricValue(), 0.001);
+            assertEquals(80, (Double) utilizationMetric.metricValue(), 0.001);
+        } finally {
+            clientRequestQuotaManager.shutdown();
+        }
+    }
+
+    @Test
+    public void testRequestQuotaUtilizationJmxAttribute() throws Exception {
+        Metrics jmxMetrics = new Metrics(new MetricConfig(), List.of(new JmxReporter()), time);
+        ClientRequestQuotaManager clientRequestQuotaManager = new ClientRequestQuotaManager(config, jmxMetrics, time, "", Optional.empty());
+        String user = "ANONYMOUS";
+        String clientId = "test-client";
+        Map<String, String> tags = Map.of("user", user, "client-id", clientId);
+
+        try {
+            clientRequestQuotaManager.updateQuota(
+                    Optional.of(new ClientQuotaManager.UserEntity(user)),
+                    Optional.of(new ClientQuotaManager.ClientIdEntity(clientId)),
+                    Optional.of(Quota.upperBound(50))
+            );
+            maybeRecord(clientRequestQuotaManager, user, clientId, 400);
+
+            KafkaMetric rateMetric = jmxMetrics.metric(jmxMetrics.metricName("request-time", QuotaType.REQUEST.toString(), tags));
+            assertNotNull(rateMetric);
+            ObjectName objectName = new ObjectName(":type=Request,user=" + user + ",client-id=" + clientId);
+            MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+            assertTrue(Arrays.stream(mbeanServer.getMBeanInfo(objectName).getAttributes())
+                    .anyMatch(attr -> attr.getName().equals("quota-utilization")));
+            assertEquals("double", Arrays.stream(mbeanServer.getMBeanInfo(objectName).getAttributes())
+                    .filter(attr -> attr.getName().equals("quota-utilization"))
+                    .findFirst()
+                    .orElseThrow()
+                    .getType());
+
+            double requestTime = (Double) mbeanServer.getAttribute(objectName, "request-time");
+            double utilization = (Double) mbeanServer.getAttribute(objectName, "quota-utilization");
+            assertEquals(requestTime / 50 * 100, utilization, 0.001);
+        } finally {
+            clientRequestQuotaManager.shutdown();
+            jmxMetrics.close();
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/kafka/server/quota/ControllerMutationQuotaManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/quota/ControllerMutationQuotaManagerTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.server.config.ClientQuotaManagerConfig;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -197,6 +198,24 @@ public class ControllerMutationQuotaManagerTest extends BaseClientQuotaManagerTe
             // Current tokens in the bucket = 0
             throttleTime = maybeRecord(quotaManager, USER, CLIENT_ID, 110);
             assertEquals(0, throttleTime, "Should not be throttled");
+        });
+    }
+
+    @Test
+    public void testControllerMutationDoesNotExposeQuotaUtilization() {
+        withQuotaManager(quotaManager -> {
+            quotaManager.updateQuota(
+                    Optional.of(new ClientQuotaManager.UserEntity(USER)),
+                    Optional.of(new ClientQuotaManager.ClientIdEntity(CLIENT_ID)),
+                    Optional.of(Quota.upperBound(10))
+            );
+
+            maybeRecord(quotaManager, USER, CLIENT_ID, 10);
+            List<MetricName> utilizationMetrics = metrics.metrics().keySet().stream()
+                    .filter(metricName -> metricName.group().equals(QuotaType.CONTROLLER_MUTATION.toString())
+                            && metricName.name().equals("quota-utilization"))
+                    .toList();
+            assertTrue(utilizationMetrics.isEmpty(), "ControllerMutation should not expose quota-utilization: " + utilizationMetrics);
         });
     }
 


### PR DESCRIPTION
## Summary
- Adds `quota-utilization` on the existing Produce, Fetch, and Request quota MBeans (no new sensor, ObjectName, or quota entity).
- Value is `measured-rate / effective-quota * 100` using the cached `MetricConfig` bound used for enforcement. It is not capped at 100; unlimited, missing, and non-positive bounds return `NaN`.
- ControllerMutation is excluded (token-bucket enforcement does not match this rate-utilization definition).
- Measurement does not call `ClientQuotaCallback.quotaLimit()`.

## Test plan
- Unit tests
- jmx metrics

```
$>domain kafka.server
#domain is set to kafka.server
$>bean kafka.server:type=Produce,client-id=mg-quota-load-test-client
#bean is set to kafka.server:type=Produce,client-id=mg-quota-load-test-client
$>info
#mbean = kafka.server:type=Produce,client-id=mg-quota-load-test-client
#class name = org.apache.kafka.common.metrics.JmxReporter$KafkaMbean
# attributes
  %0   - byte-rate (double, r)
  %1   - quota-utilization (double, r)
  %2   - throttle-time (double, r)
#there's no operations
#there's no notifications
$>get quota-utilization
#mbean = kafka.server:type=Produce,client-id=mg-quota-load-test-client:
quota-utilization = 21.582440162437226;
```

[KIP-1373: Client Quota Utilization Metrics](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/451971254/KIP-1373+Client+Quota+Utilization+Metrics)