### PR TITLE
MINOR: Lower log level for non-fatal metadata update failures in AdminMetadataManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -334,7 +334,7 @@ public class AdminMetadataManager {
                 }
             }
         } else {
-            log.info("Metadata update failed", exception);
+            log.debug("Metadata update failed", exception);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -324,8 +324,6 @@ public class AdminMetadataManager {
                 this.fatalException = (ApiException) exception;
             }
 
-            // Log the fatal error once. For UnsupportedVersionException, use the more specific message
-            // that explains which api the remote node does not support instead of the generic one.
             if (exception instanceof UnsupportedVersionException) {
                 if (usingBootstrapControllers) {
                     log.warn("The remote node is not a CONTROLLER that supports the KIP-919 " +

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -319,12 +319,13 @@ public class AdminMetadataManager {
         this.state = State.QUIESCENT;
 
         if (RequestUtils.isFatalException(exception)) {
-            log.warn("Fatal error during metadata update", exception);
             // avoid unchecked/unconfirmed cast to ApiException
             if (exception instanceof  ApiException) {
                 this.fatalException = (ApiException) exception;
             }
 
+            // Log the fatal error once. For UnsupportedVersionException, use the more specific message
+            // that explains which api the remote node does not support instead of the generic one.
             if (exception instanceof UnsupportedVersionException) {
                 if (usingBootstrapControllers) {
                     log.warn("The remote node is not a CONTROLLER that supports the KIP-919 " +
@@ -332,6 +333,8 @@ public class AdminMetadataManager {
                 } else {
                     log.warn("The remote node is not a BROKER that supports the METADATA api.", exception);
                 }
+            } else {
+                log.warn("Fatal error during metadata update", exception);
             }
         } else {
             log.debug("Metadata update failed", exception);


### PR DESCRIPTION
AdminMetadataManager.updateFailed() logged every non-fatal metadata
update failure at INFO. These are transient, retriable errors
(disconnects, timeouts, etc.) that the admin client recovers from
automatically on the next metadata attempt — pending calls trigger the
retry. Logging them at INFO adds noise on the default logs and causes
false alarms, since a failure that immediately self-heals still prints
"Metadata update failed".

This changes the log to debug. Fatal errors continue to be logged at
warn, but an UnsupportedVersionException was previously logged twice at
WARN (the generic "Fatal error during metadata update" plus the
BROKER/CONTROLLER-specific message); now only the specific message is
logged.

Reviewers: Andrew Schofield <aschofield@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
