### PR TITLE
KAFKA-21020: Upgrade jline from 3.30.16 to 4.2.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -307,9 +307,9 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-native-3.30.16, see: licenses/jline-BSD-3-clause
-- jline-reader-3.30.16, see: licenses/jline-BSD-3-clause
-- jline-terminal-3.30.16, see: licenses/jline-BSD-3-clause
+- jline-native-4.2.1, see: licenses/jline-BSD-3-clause
+- jline-reader-4.2.1, see: licenses/jline-BSD-3-clause
+- jline-terminal-4.2.1, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ versions += [
   jetty: "12.0.37",
   jersey: "3.1.10",
   jgit: "7.7.1.202607240634-r",
-  jline: "3.30.16",
+  jline: "4.2.1",
   jmh: "1.37",
   hamcrest: "3.0",
   scalaLogging: "3.9.6",

--- a/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/InteractiveShell.java
@@ -122,7 +122,7 @@ public final class InteractiveShell implements AutoCloseable {
     }
 
     public int screenWidth() {
-        return terminal.getWidth();
+        return terminal.getSize().getColumns();
     }
 
     public Iterator<Entry<Integer, String>> history(int numEntriesToShow) {


### PR DESCRIPTION
**CVE-2026-56740 (High)** affects `org.jline:jline-remote-telnet` in versions
prior to **4.2.1**. The vulnerable jar is included in the Kafka release
tarball under /opt/kafka/libs/ via the shell module's runtimeClasspath.

Reviewers: Gergely Harmadas (github:harmadasg), Chia-Ping Tsai <chia7712@gmail.com>
