### PR TITLE
KAFKA-20097: Return topic ID when a topic already exists

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -701,10 +701,17 @@ public class ReplicationControlManager {
         for (CreatableTopic topic : request.topics()) {
             ApiError error = topicErrors.get(topic.name());
             if (error != null) {
-                data.topics().add(new CreatableTopicResult().
+                CreatableTopicResult errorResult = new CreatableTopicResult().
                     setName(topic.name()).
                     setErrorCode(error.error().code()).
-                    setErrorMessage(error.message()));
+                    setErrorMessage(error.message());
+                if (error.error() == Errors.TOPIC_ALREADY_EXISTS) {
+                    Uuid topicId = topicsByName.get(topic.name());
+                    if (topicId != null) {
+                        errorResult.setTopicId(topicId);
+                    }
+                }
+                data.topics().add(errorResult);
                 resultsBuilder.append(resultsPrefix).append(topic).append(": ").
                     append(error.error()).append(" (").append(error.message()).append(")");
                 resultsPrefix = ", ";

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -721,6 +721,7 @@ public class ReplicationControlManagerTest {
                 replicationControl.createTopics(requestContext, request, Set.of("foo"), false);
         CreateTopicsResponseData expectedResponse4 = new CreateTopicsResponseData();
         expectedResponse4.topics().add(new CreatableTopicResult().setName("foo").
+                setTopicId(result3.response().topics().find("foo").topicId()).
                 setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code()).
                 setErrorMessage("Topic 'foo' already exists."));
         assertEquals(expectedResponse4, result4.response());


### PR DESCRIPTION
This change includes the existing topic ID in `CreateTopicsResponse`
when topic  creation fails with `TOPIC_ALREADY_EXISTS`.

The existing test now verifies that retrying creation of an existing
topic  returns the same topic ID.

Co-Authored-By: Codex
