### PR TITLE
KAFKA-21002: Remove hamcrest from org.apache.kafka.streams package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -107,14 +107,9 @@ import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -521,7 +516,7 @@ public class KafkaStreamsTest {
                 () -> streams.state() == KafkaStreams.State.NOT_RUNNING,
                 "Streams never stopped.");
 
-            assertThat(appender.getMessages(), not(hasItem(containsString("ERROR"))));
+            assertFalse(appender.getMessages().stream().anyMatch(message -> message.contains("ERROR")));
         }
 
         assertTrue(supplier.consumer.closed());
@@ -608,9 +603,9 @@ public class KafkaStreamsTest {
 
             streams.close();
             assertEquals(KafkaStreams.State.ERROR, streams.state(), "KafkaStreams should remain in ERROR state after close.");
-            assertThat(appender.getMessages(), hasItem(containsString("State transition from RUNNING to PENDING_ERROR")));
-            assertThat(appender.getMessages(), hasItem(containsString("State transition from PENDING_ERROR to ERROR")));
-            assertThat(appender.getMessages(), hasItem(containsString("Streams client is already in the terminal ERROR state")));
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("State transition from RUNNING to PENDING_ERROR")));
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("State transition from PENDING_ERROR to ERROR")));
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("Streams client is already in the terminal ERROR state")));
         }
     }
 
@@ -716,8 +711,8 @@ public class KafkaStreamsTest {
             streams.start();
             final int oldSize = streams.threads.size();
             waitForCondition(() -> streams.state() == KafkaStreams.State.RUNNING, 15L, "wait until running");
-            assertThat(streams.addStreamThread(), equalTo(Optional.of("processId-StreamThread-" + 2)));
-            assertThat(streams.threads.size(), equalTo(oldSize + 1));
+            assertEquals(Optional.of("processId-StreamThread-" + 2), streams.addStreamThread());
+            assertEquals(oldSize + 1, streams.threads.size());
         }
     }
 
@@ -728,8 +723,8 @@ public class KafkaStreamsTest {
         prepareStreamThread(streamThreadTwo, 2);
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
             final int oldSize = streams.threads.size();
-            assertThat(streams.addStreamThread(), equalTo(Optional.empty()));
-            assertThat(streams.threads.size(), equalTo(oldSize));
+            assertEquals(Optional.empty(), streams.addStreamThread());
+            assertEquals(oldSize, streams.threads.size());
         }
     }
 
@@ -741,8 +736,8 @@ public class KafkaStreamsTest {
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
             final int oldSize = streams.threads.size();
             streams.close();
-            assertThat(streams.addStreamThread(), equalTo(Optional.empty()));
-            assertThat(streams.threads.size(), equalTo(oldSize));
+            assertEquals(Optional.empty(), streams.addStreamThread());
+            assertEquals(oldSize, streams.threads.size());
         }
     }
 
@@ -760,8 +755,8 @@ public class KafkaStreamsTest {
             final int oldSize = streams.threads.size();
             streams.start();
             streams.globalStreamThread.shutdown();
-            assertThat(streams.addStreamThread(), equalTo(Optional.empty()));
-            assertThat(streams.threads.size(), equalTo(oldSize));
+            assertEquals(Optional.empty(), streams.addStreamThread());
+            assertEquals(oldSize, streams.threads.size());
         }
     }
 
@@ -778,8 +773,8 @@ public class KafkaStreamsTest {
             streams.start();
             streamThreadOne.shutdown(CloseOptions.GroupMembershipOperation.LEAVE_GROUP);
             final Set<ThreadMetadata> threads = streams.metadataForLocalThreads();
-            assertThat(threads.size(), equalTo(1));
-            assertThat(threads, hasItem(streamThreadTwo.threadMetadata()));
+            assertEquals(1, threads.size());
+            assertTrue(threads.contains(streamThreadTwo.threadMetadata()));
         }
     }
 
@@ -799,8 +794,8 @@ public class KafkaStreamsTest {
             final int oldSize = streams.threads.size();
             waitForCondition(() -> streams.state() == KafkaStreams.State.RUNNING, 15L,
                 "Kafka Streams client did not reach state RUNNING");
-            assertThat(streams.removeStreamThread(), equalTo(Optional.of("processId-StreamThread-" + 1)));
-            assertThat(streams.threads.size(), equalTo(oldSize - 1));
+            assertEquals(Optional.of("processId-StreamThread-" + 1), streams.removeStreamThread());
+            assertEquals(oldSize - 1, streams.threads.size());
         }
     }
 
@@ -811,8 +806,8 @@ public class KafkaStreamsTest {
         props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
         try (final KafkaStreams streams =
                      new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
-            assertThat(streams.removeStreamThread(), equalTo(Optional.empty()));
-            assertThat(streams.threads.size(), equalTo(1));
+            assertEquals(Optional.empty(), streams.removeStreamThread());
+            assertEquals(1, streams.threads.size());
         }
     }
 
@@ -978,9 +973,9 @@ public class KafkaStreamsTest {
                 "Streams never started.");
 
             streams.close(Duration.ZERO);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
             assertThrows(IllegalStateException.class, streams::cleanUp);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
         }
     }
 
@@ -1006,9 +1001,9 @@ public class KafkaStreamsTest {
                     .withGroupMembershipOperation(CloseOptions.GroupMembershipOperation.LEAVE_GROUP);
 
             streams.close(closeOptions);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
             assertThrows(IllegalStateException.class, streams::cleanUp);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
         }
     }
 
@@ -1029,9 +1024,9 @@ public class KafkaStreamsTest {
             final CloseOptions closeOptions = CloseOptions.timeout(Duration.ZERO);
 
             streams.close(closeOptions);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
             assertThrows(IllegalStateException.class, streams::cleanUp);
-            assertThat(streams.state() == State.PENDING_SHUTDOWN, equalTo(true));
+            assertEquals(State.PENDING_SHUTDOWN, streams.state());
         }
     }
 
@@ -1571,10 +1566,11 @@ public class KafkaStreamsTest {
         try (final KafkaStreams ignored = new KafkaStreams(new StreamsBuilder().build(), props, supplier, time)) {
             fail("Should have thrown TopologyException");
         } catch (final TopologyException e) {
-            assertThat(
-                e.getMessage(),
-                equalTo("Invalid topology: Topology has no stream threads and no global threads, " +
-                            "must subscribe to at least one source topic or global table."));
+            assertEquals(
+                "Invalid topology: Topology has no stream threads and no global threads, " +
+                    "must subscribe to at least one source topic or global table.",
+                e.getMessage()
+            );
         }
     }
 
@@ -1584,7 +1580,7 @@ public class KafkaStreamsTest {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.globalTable("anyTopic");
         try (final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time)) {
-            assertThat(streams.threads.size(), equalTo(0));
+            assertEquals(0, streams.threads.size());
         }
     }
 
@@ -1595,7 +1591,7 @@ public class KafkaStreamsTest {
         builder.globalTable("anyTopic");
         try (final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time)) {
 
-            assertThat(streams.threads.size(), equalTo(0));
+            assertEquals(0, streams.threads.size());
             assertEquals(KafkaStreams.State.CREATED, streams.state());
 
             streams.start();
@@ -1622,10 +1618,7 @@ public class KafkaStreamsTest {
                 IllegalArgumentException.class,
                 () -> streams.clientInstanceIds(Duration.ofMillis(-1L))
             );
-            assertThat(
-                error.getMessage(),
-                equalTo("The timeout cannot be negative.")
-            );
+            assertEquals("The timeout cannot be negative.", error.getMessage());
         }
     }
 
@@ -1640,10 +1633,7 @@ public class KafkaStreamsTest {
                 IllegalStateException.class,
                 () -> streams.clientInstanceIds(Duration.ZERO)
             );
-            assertThat(
-                error.getMessage(),
-                equalTo("KafkaStreams has not been started, you can retry after calling start().")
-            );
+            assertEquals("KafkaStreams has not been started, you can retry after calling start().", error.getMessage());
         }
     }
 
@@ -1660,10 +1650,7 @@ public class KafkaStreamsTest {
                 IllegalStateException.class,
                 () -> streams.clientInstanceIds(Duration.ZERO)
             );
-            assertThat(
-                error.getMessage(),
-                equalTo("KafkaStreams has been stopped (NOT_RUNNING).")
-            );
+            assertEquals("KafkaStreams has been stopped (NOT_RUNNING).", error.getMessage());
         }
     }
 
@@ -1680,17 +1667,11 @@ public class KafkaStreamsTest {
                 StreamsException.class,
                 () -> streams.clientInstanceIds(Duration.ZERO)
             );
-            assertThat(
-                error.getMessage(),
-                equalTo("Could not retrieve admin client instance id.")
-            );
+            assertEquals("Could not retrieve admin client instance id.", error.getMessage());
 
             final Throwable cause = error.getCause();
-            assertThat(cause, instanceOf(UnsupportedOperationException.class));
-            assertThat(
-                cause.getMessage(),
-                equalTo("clientInstanceId not set")
-            );
+            assertInstanceOf(UnsupportedOperationException.class, cause);
+            assertEquals("clientInstanceId not set", cause.getMessage());
         }
     }
 
@@ -1710,9 +1691,9 @@ public class KafkaStreamsTest {
                 IllegalStateException.class,
                 clientInstanceIds::adminInstanceId
             );
-            assertThat(
-                error.getMessage(),
-                equalTo("Telemetry is not enabled on the admin client. Set config `enable.metrics.push` to `true`.")
+            assertEquals(
+                "Telemetry is not enabled on the admin client. Set config `enable.metrics.push` to `true`.",
+                error.getMessage()
             );
         }
     }
@@ -1747,10 +1728,7 @@ public class KafkaStreamsTest {
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
             streams.start();
 
-            assertThat(
-                streams.clientInstanceIds(Duration.ZERO).adminInstanceId(),
-                equalTo(instanceId)
-            );
+            assertEquals(instanceId, streams.clientInstanceIds(Duration.ZERO).adminInstanceId());
         }
     }
 
@@ -1774,11 +1752,11 @@ public class KafkaStreamsTest {
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
             streams.start();
             final ClientInstanceIds clientInstanceIds = streams.clientInstanceIds(Duration.ZERO);
-            assertThat(clientInstanceIds.consumerInstanceIds().size(), equalTo(1));
-            assertThat(clientInstanceIds.consumerInstanceIds().get("main-consumer"), equalTo(mainConsumerInstanceId));
-            assertThat(clientInstanceIds.producerInstanceIds().size(),  equalTo(1));
-            assertThat(clientInstanceIds.producerInstanceIds().get("some-thread-producer"), equalTo(producerInstanceId));
-            assertThat(clientInstanceIds.adminInstanceId(), equalTo(adminInstanceId));
+            assertEquals(1, clientInstanceIds.consumerInstanceIds().size());
+            assertEquals(mainConsumerInstanceId, clientInstanceIds.consumerInstanceIds().get("main-consumer"));
+            assertEquals(1, clientInstanceIds.producerInstanceIds().size());
+            assertEquals(producerInstanceId, clientInstanceIds.producerInstanceIds().get("some-thread-producer"));
+            assertEquals(adminInstanceId, clientInstanceIds.adminInstanceId());
         }
     }
 
@@ -1798,8 +1776,8 @@ public class KafkaStreamsTest {
                 TimeoutException.class,
                 () -> streams.clientInstanceIds(Duration.ZERO)
             );
-            assertThat(timeoutException.getMessage(), equalTo("Could not retrieve consumer/producer instance id for some-client."));
-            assertThat(timeoutException.getCause(), instanceOf(java.util.concurrent.TimeoutException.class));
+            assertEquals("Could not retrieve consumer/producer instance id for some-client.", timeoutException.getMessage());
+            assertInstanceOf(java.util.concurrent.TimeoutException.class, timeoutException.getCause());
         }
     }
 
@@ -1823,8 +1801,8 @@ public class KafkaStreamsTest {
                 TimeoutException.class,
                 () -> streams.clientInstanceIds(Duration.ZERO)
             );
-            assertThat(timeoutException.getMessage(), equalTo("Could not retrieve global consumer client instance id."));
-            assertThat(timeoutException.getCause(), instanceOf(java.util.concurrent.TimeoutException.class));
+            assertEquals("Could not retrieve global consumer client instance id.", timeoutException.getMessage());
+            assertInstanceOf(java.util.concurrent.TimeoutException.class, timeoutException.getCause());
         }
     }
 
@@ -1848,7 +1826,7 @@ public class KafkaStreamsTest {
                 @Override
                 public Uuid get(final long timeout, final TimeUnit timeUnit) {
                     didAssertThreadOne.set(true);
-                    assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-10L)));
+                    assertEquals(expectedTimeout.getAndAdd(-10L), timeout);
                     mockTime.sleep(10L);
                     return null;
                 }
@@ -1858,7 +1836,7 @@ public class KafkaStreamsTest {
                 @Override
                 public Uuid get(final long timeout, final TimeUnit timeUnit) {
                     didAssertThreadTwo.set(true);
-                    assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-5L)));
+                    assertEquals(expectedTimeout.getAndAdd(-5L), timeout);
                     mockTime.sleep(5L);
                     return null;
                 }
@@ -1875,7 +1853,7 @@ public class KafkaStreamsTest {
                     @Override
                     public Uuid get(final long timeout, final TimeUnit timeUnit) {
                         didAssertGlobalThread.set(true);
-                        assertThat(timeout, equalTo(expectedTimeout.getAndAdd(-8L)));
+                        assertEquals(expectedTimeout.getAndAdd(-8L), timeout);
                         mockTime.sleep(8L);
                         return null;
                     }
@@ -1884,9 +1862,9 @@ public class KafkaStreamsTest {
             streams.clientInstanceIds(Duration.ofMillis(60L));
         }
 
-        assertThat(didAssertThreadOne.get(), equalTo(true));
-        assertThat(didAssertThreadTwo.get(), equalTo(true));
-        assertThat(didAssertGlobalThread.get(), equalTo(true));
+        assertTrue(didAssertThreadOne.get());
+        assertTrue(didAssertThreadTwo.get());
+        assertTrue(didAssertGlobalThread.get());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -75,8 +75,6 @@ import org.apache.kafka.test.MockPredicate;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -104,12 +102,9 @@ import static org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore;
 import static org.apache.kafka.streams.state.Stores.timestampedKeyValueStoreBuilder;
 import static org.apache.kafka.streams.utils.TestUtils.PROCESSOR_WRAPPER_COUNTER_CONFIG;
 import static org.apache.kafka.streams.utils.TestUtils.dummyStreamsConfigMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -165,7 +160,7 @@ public class StreamsBuilderTest {
             inputTopic.pipeInput("hey", "there");
             final KeyValueStore<String, String> store = driver.getKeyValueStore("store");
             final String hey = store.get("hey");
-            assertThat(hey, is("there"));
+            assertEquals("there", hey);
         }
     }
 
@@ -190,12 +185,10 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(1));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"),
-            equalTo(Collections.singleton(topology.stateStores().get(0).name())));
+        assertEquals(1, topology.stateStores().size());
+        assertEquals(
+            Set.of(topology.stateStores().get(0).name()),
+            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
         assertTrue(
             topology.processorConnectedStateStores("KTABLE-FILTER-0000000003").isEmpty());
     }
@@ -213,15 +206,9 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(1));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"),
-            equalTo(Collections.singleton("store")));
-        assertThat(
-            topology.processorConnectedStateStores("KTABLE-FILTER-0000000003"),
-            equalTo(Collections.singleton("store")));
+        assertEquals(1, topology.stateStores().size());
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KTABLE-FILTER-0000000003"));
     }
 
     @Test
@@ -237,12 +224,10 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(1));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"),
-            equalTo(Collections.singleton(topology.stateStores().get(0).name())));
+        assertEquals(1, topology.stateStores().size());
+        assertEquals(
+            Set.of(topology.stateStores().get(0).name()),
+            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
         assertTrue(
             topology.processorConnectedStateStores("KTABLE-MAPVALUES-0000000003").isEmpty());
     }
@@ -260,15 +245,9 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(1));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"),
-            equalTo(Collections.singleton("store")));
-        assertThat(
-            topology.processorConnectedStateStores("KTABLE-MAPVALUES-0000000003"),
-            equalTo(Collections.singleton("store")));
+        assertEquals(1, topology.stateStores().size());
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KTABLE-MAPVALUES-0000000003"));
     }
 
     @Test
@@ -283,12 +262,10 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(2));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000010"),
-            equalTo(Set.of(topology.stateStores().get(0).name(), topology.stateStores().get(1).name())));
+        assertEquals(2, topology.stateStores().size());
+        assertEquals(
+            Set.of(topology.stateStores().get(0).name(), topology.stateStores().get(1).name()),
+            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000010"));
         assertTrue(
             topology.processorConnectedStateStores("KTABLE-MERGE-0000000007").isEmpty());
     }
@@ -307,15 +284,9 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(3));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000010"),
-            equalTo(Collections.singleton("store")));
-        assertThat(
-            topology.processorConnectedStateStores("KTABLE-MERGE-0000000007"),
-            equalTo(Collections.singleton("store")));
+        assertEquals(3, topology.stateStores().size());
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KSTREAM-JOIN-0000000010"));
+        assertEquals(Set.of("store"), topology.processorConnectedStateStores("KTABLE-MERGE-0000000007"));
     }
 
     @Test
@@ -327,15 +298,13 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(
-            topology.stateStores().size(),
-            equalTo(1));
-        assertThat(
-            topology.processorConnectedStateStores("KTABLE-SOURCE-0000000002"),
-            equalTo(Collections.singleton(topology.stateStores().get(0).name())));
-        assertThat(
-            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000004"),
-            equalTo(Collections.singleton(topology.stateStores().get(0).name())));
+        assertEquals(1, topology.stateStores().size());
+        assertEquals(
+            Set.of(topology.stateStores().get(0).name()),
+            topology.processorConnectedStateStores("KTABLE-SOURCE-0000000002"));
+        assertEquals(
+            Set.of(topology.stateStores().get(0).name()),
+            topology.processorConnectedStateStores("KSTREAM-JOIN-0000000004"));
     }
 
     @Test
@@ -637,10 +606,10 @@ public class StreamsBuilderTest {
             inputTopic.pipeInput(2L, "value2");
 
             final KeyValueStore<Long, String> store = driver.getKeyValueStore("store");
-            assertThat(store.get(1L), equalTo("value1"));
-            assertThat(store.get(2L), equalTo("value2"));
-            assertThat(results.get(1L), equalTo("value1"));
-            assertThat(results.get(2L), equalTo("value2"));
+            assertEquals("value1", store.get(1L));
+            assertEquals("value2", store.get(2L));
+            assertEquals("value1", results.get(1L));
+            assertEquals("value2", results.get(2L));
         }
     }
 
@@ -658,8 +627,8 @@ public class StreamsBuilderTest {
             inputTopic.pipeInput(2L, "value2");
             final KeyValueStore<Long, String> store = driver.getKeyValueStore("store");
 
-            assertThat(store.get(1L), equalTo("value1"));
-            assertThat(store.get(2L), equalTo("value2"));
+            assertEquals("value1", store.get(1L));
+            assertEquals("value2", store.get(2L));
         }
     }
 
@@ -686,7 +655,7 @@ public class StreamsBuilderTest {
         final ProcessorTopology topology =
             builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
 
-        assertThat(topology.stateStores().size(), equalTo(0));
+        assertEquals(0, topology.stateStores().size());
     }
 
     @Test
@@ -700,18 +669,10 @@ public class StreamsBuilderTest {
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
         internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
 
-        assertThat(
-            internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
-            equalTo(Collections.singletonMap("store", "topic")));
-        assertThat(
-            internalTopologyBuilder.stateStores().keySet(),
-            equalTo(Collections.singleton("store")));
-        assertThat(
-            internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
-            equalTo(false));
-        assertThat(
-            internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).nonSourceChangelogTopics().isEmpty(),
-            equalTo(true));
+        assertEquals(Map.of("store", "topic"), internalTopologyBuilder.buildTopology().storeToChangelogTopic());
+        assertEquals(Set.of("store"), internalTopologyBuilder.stateStores().keySet());
+        assertFalse(internalTopologyBuilder.stateStores().get("store").loggingEnabled());
+        assertTrue(internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).nonSourceChangelogTopics().isEmpty());
     }
 
     @Test
@@ -725,22 +686,14 @@ public class StreamsBuilderTest {
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
         internalTopologyBuilder.rewriteTopology(new StreamsConfig(props));
 
-        assertThat(
-            internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
-            equalTo(Collections.singletonMap("store", "appId-store-changelog"))
-        );
-        assertThat(
-            internalTopologyBuilder.stateStores().keySet(),
-            equalTo(Collections.singleton("store"))
-        );
-        assertThat(
-            internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
-            equalTo(true)
-        );
-        assertThat(
-            internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_1).stateChangelogTopics.keySet(),
-            equalTo(Collections.singleton("appId-store-changelog"))
-        );
+        assertEquals(
+            Map.of("store", "appId-store-changelog"),
+            internalTopologyBuilder.buildTopology().storeToChangelogTopic());
+        assertEquals(Set.of("store"), internalTopologyBuilder.stateStores().keySet());
+        assertTrue(internalTopologyBuilder.stateStores().get("store").loggingEnabled());
+        assertEquals(
+            Set.of("appId-store-changelog"),
+            internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_1).stateChangelogTopics.keySet());
     }
 
     @Test
@@ -751,18 +704,14 @@ public class StreamsBuilderTest {
         final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(builder.build());
         internalTopologyBuilder.setApplicationId("appId");
 
-        assertThat(
-            internalTopologyBuilder.buildTopology().storeToChangelogTopic(),
-            equalTo(Collections.singletonMap("store", "appId-store-changelog")));
-        assertThat(
-            internalTopologyBuilder.stateStores().keySet(),
-            equalTo(Collections.singleton("store")));
-        assertThat(
-            internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
-            equalTo(true));
-        assertThat(
-            internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).stateChangelogTopics.keySet(),
-            equalTo(Collections.singleton("appId-store-changelog")));
+        assertEquals(
+            Map.of("store", "appId-store-changelog"),
+            internalTopologyBuilder.buildTopology().storeToChangelogTopic());
+        assertEquals(Set.of("store"), internalTopologyBuilder.stateStores().keySet());
+        assertTrue(internalTopologyBuilder.stateStores().get("store").loggingEnabled());
+        assertEquals(
+            Set.of("appId-store-changelog"),
+            internalTopologyBuilder.subtopologyToTopicsInfo().get(SUBTOPOLOGY_0).stateChangelogTopics.keySet());
     }
 
     @Test
@@ -1471,11 +1420,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(3));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "stateful-process-1", "stateful-process-2", "stateless-processValues"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(3, counter.numWrappedProcessors());
+        assertEquals(Set.of("stateful-process-1", "stateful-process-2", "stateless-processValues"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1495,11 +1443,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "groupBy", "groupBy-repartition-filter", "reduce", "toStream"));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(4));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(Set.of("groupBy", "groupBy-repartition-filter", "reduce", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(4, counter.numWrappedProcessors());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1519,10 +1466,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("count", "toStream"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("count", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1543,10 +1490,10 @@ public class StreamsBuilderTest {
                 .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(3));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("count", "toStream", "suppressed"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(3, counter.numWrappedProcessors());
+        assertEquals(Set.of("count", "toStream", "suppressed"), counter.wrappedProcessorNames());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1567,10 +1514,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("count", "toStream"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("count", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1591,10 +1538,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("count", "toStream"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("count", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1615,10 +1562,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("count", "toStream"));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("count", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1646,12 +1593,12 @@ public class StreamsBuilderTest {
 
         builder.build();
 
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "aggregate-cogroup-agg-0", "aggregate-cogroup-agg-1", "aggregate-cogroup-merge", "toStream"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(4));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        ), counter.wrappedProcessorNames());
+        assertEquals(4, counter.numWrappedProcessors());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1668,10 +1615,9 @@ public class StreamsBuilderTest {
             .to("output-topic", Produced.as("sink"));
         builder.build();
 
-        assertThat(counter.wrappedProcessorNames(),
-            Matchers.containsInAnyOrder("source-table", "map-values", "to-stream"));
-        assertThat(counter.numUniqueStateStores(), is(1));
-        assertThat(counter.numConnectedStateStores(), is(1));
+        assertEquals(Set.of("source-table", "map-values", "to-stream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1688,10 +1634,9 @@ public class StreamsBuilderTest {
             .to("output-topic", Produced.as("sink"));
         builder.build();
 
-        assertThat(counter.wrappedProcessorNames(),
-            Matchers.containsInAnyOrder("source-table", "filter", "to-stream"));
-        assertThat(counter.numUniqueStateStores(), is(1));
-        assertThat(counter.numConnectedStateStores(), is(1));
+        assertEquals(Set.of("source-table", "filter", "to-stream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1711,12 +1656,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "source-table", "groupBy", "count", "toStream"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(4));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(Set.of("source-table", "groupBy", "count", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(4, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1736,12 +1679,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "source-table", "groupBy", "reduce", "toStream"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(4));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(Set.of("source-table", "groupBy", "reduce", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(4, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1763,12 +1704,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "filter-stream", "map", "selectKey", "peek", "flatMap"
-        ));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(0));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(0));
+        assertEquals(5, counter.numWrappedProcessors());
+        assertEquals(Set.of("filter-stream", "map", "selectKey", "peek", "flatMap"), counter.wrappedProcessorNames());
+        assertEquals(0, counter.numUniqueStateStores());
+        assertEquals(0, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1791,13 +1730,13 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(6));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(6, counter.numWrappedProcessors());
+        assertEquals(Set.of(
             "to-table", "map-values", "map-values-stateful",
             "filter-table", "filter-table-stateful", "to-stream"
-        ));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        ), counter.wrappedProcessorNames());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1815,12 +1754,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "source", "toStream"
-        ));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(0));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(0));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("source", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(0, counter.numUniqueStateStores());
+        assertEquals(0, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1838,12 +1775,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "source", "toStream"
-        ));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(Set.of("source", "toStream"), counter.wrappedProcessorNames());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1869,14 +1804,14 @@ public class StreamsBuilderTest {
         builder.build();
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-JOINTHIS-0000000004", "KSTREAM-JOINOTHER-0000000005",
             "KSTREAM-WINDOWED-0000000003", "KSTREAM-WINDOWED-0000000002",
             "KSTREAM-MERGE-0000000006"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(4));
+        ), counter.wrappedProcessorNames());
+        assertEquals(5, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(4, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1902,16 +1837,16 @@ public class StreamsBuilderTest {
         builder.build();
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-JOINTHIS-0000000004", "KSTREAM-OUTEROTHER-0000000005",
             "KSTREAM-WINDOWED-0000000003", "KSTREAM-WINDOWED-0000000002",
             "KSTREAM-MERGE-0000000006"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
+        ), counter.wrappedProcessorNames());
+        assertEquals(5, counter.numWrappedProcessors());
 
         // 1 additional store due to spurious results fix for left/outer joins
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(3));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(6));
+        assertEquals(3, counter.numUniqueStateStores());
+        assertEquals(6, counter.numConnectedStateStores());
     }
 
     @Test
@@ -1937,16 +1872,16 @@ public class StreamsBuilderTest {
         builder.build();
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-OUTERTHIS-0000000004", "KSTREAM-OUTEROTHER-0000000005",
             "KSTREAM-WINDOWED-0000000003", "KSTREAM-WINDOWED-0000000002",
             "KSTREAM-MERGE-0000000006"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
+        ), counter.wrappedProcessorNames());
+        assertEquals(5, counter.numWrappedProcessors());
 
         // 1 additional store due to spurious results fix for left/outer joins
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(3));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(6));
+        assertEquals(3, counter.numUniqueStateStores());
+        assertEquals(6, counter.numConnectedStateStores());
     }
 
     @SuppressWarnings("deprecation")
@@ -1973,14 +1908,14 @@ public class StreamsBuilderTest {
         builder.build();
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-OUTERTHIS-0000000004", "KSTREAM-OUTEROTHER-0000000005",
             "KSTREAM-WINDOWED-0000000003", "KSTREAM-WINDOWED-0000000002",
             "KSTREAM-MERGE-0000000006"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(4));
+        ), counter.wrappedProcessorNames());
+        assertEquals(5, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(4, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2005,14 +1940,14 @@ public class StreamsBuilderTest {
         builder.build();
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-JOINTHIS-0000000003", "KSTREAM-JOINOTHER-0000000004",
             "KSTREAM-WINDOWED-0000000001", "KSTREAM-WINDOWED-0000000002",
             "KSTREAM-MERGE-0000000005"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(5));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(4));
+        ), counter.wrappedProcessorNames());
+        assertEquals(5, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(4, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2040,13 +1975,13 @@ public class StreamsBuilderTest {
         builder.build(properties);
 
         // TODO: fix these names once we address https://issues.apache.org/jira/browse/KAFKA-18191
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(Set.of(
             "KSTREAM-WINDOWED-0000000001", "KSTREAM-MERGE-0000000005"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
+        ), counter.wrappedProcessorNames());
+        assertEquals(2, counter.numWrappedProcessors());
         // only 1 store when topology optimizations enabled due to sharing self-join store
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2070,12 +2005,10 @@ public class StreamsBuilderTest {
 
         builder.build();
 
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "source-table", "st-join"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(1));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(1));
+        assertEquals(Set.of("source-table", "st-join"), counter.wrappedProcessorNames());
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(1, counter.numUniqueStateStores());
+        assertEquals(1, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2102,12 +2035,10 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
-            "versioned-source-table", "st-join"
-        ));
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(2));
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(2));
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(2));
+        assertEquals(Set.of("versioned-source-table", "st-join"), counter.wrappedProcessorNames());
+        assertEquals(2, counter.numWrappedProcessors());
+        assertEquals(2, counter.numUniqueStateStores());
+        assertEquals(2, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2128,18 +2059,18 @@ public class StreamsBuilderTest {
                 .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(6));
-        assertThat(counter.wrappedProcessorNames().toString(), counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(6, counter.numWrappedProcessors());
+        assertEquals(Set.of(
                 "input1",
                 "input2",
                 "join-processor-join-this",
                 "join-processor-join-other",
                 "join-processor",
                 "toStream"
-        ));
+        ), counter.wrappedProcessorNames(), counter.wrappedProcessorNames().toString());
 
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(3)); // one for join this, one for join that
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(3));
+        assertEquals(3, counter.numUniqueStateStores()); // one for join this, one for join that
+        assertEquals(3, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2160,18 +2091,18 @@ public class StreamsBuilderTest {
                 .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(6));
-        assertThat(counter.wrappedProcessorNames().toString(), counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(6, counter.numWrappedProcessors());
+        assertEquals(Set.of(
                 "input1",
                 "input2",
                 "join-processor-join-this",
                 "join-processor-join-other",
                 "join-processor",
                 "toStream"
-        ));
+        ), counter.wrappedProcessorNames(), counter.wrappedProcessorNames().toString());
 
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(3)); // table1, table2, join materialized
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(3));
+        assertEquals(3, counter.numUniqueStateStores()); // table1, table2, join materialized
+        assertEquals(3, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2192,18 +2123,18 @@ public class StreamsBuilderTest {
                 .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(6));
-        assertThat(counter.wrappedProcessorNames().toString(), counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(6, counter.numWrappedProcessors());
+        assertEquals(Set.of(
                 "input1",
                 "input2",
                 "join-processor-join-this",
                 "join-processor-join-other",
                 "join-processor",
                 "toStream"
-        ));
+        ), counter.wrappedProcessorNames(), counter.wrappedProcessorNames().toString());
 
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(3)); // table1, table2, join materialized
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(3));
+        assertEquals(3, counter.numUniqueStateStores()); // table1, table2, join materialized
+        assertEquals(3, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2228,8 +2159,8 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(9));
-        assertThat(counter.wrappedProcessorNames().toString(), counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(9, counter.numWrappedProcessors());
+        assertEquals(Set.of(
             "input1",
             "input2",
             "join-foreign-join-subscription",
@@ -2239,10 +2170,10 @@ public class StreamsBuilderTest {
             "join-result",
             "join-subscription-response-resolver",
             "toStream"
-        ));
+        ), counter.wrappedProcessorNames(), counter.wrappedProcessorNames().toString());
 
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(4)); // table1, table2, subscription store, and join materialized
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(5));
+        assertEquals(4, counter.numUniqueStateStores()); // table1, table2, subscription store, and join materialized
+        assertEquals(5, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2267,8 +2198,8 @@ public class StreamsBuilderTest {
             .to("output", Produced.as("sink"));
 
         builder.build();
-        assertThat(counter.numWrappedProcessors(), CoreMatchers.is(9));
-        assertThat(counter.wrappedProcessorNames().toString(), counter.wrappedProcessorNames(), Matchers.containsInAnyOrder(
+        assertEquals(9, counter.numWrappedProcessors());
+        assertEquals(Set.of(
             "input1",
             "input2",
             "l-join-foreign-join-subscription",
@@ -2278,10 +2209,10 @@ public class StreamsBuilderTest {
             "l-join-result",
             "l-join-subscription-response-resolver",
             "toStream"
-        ));
+        ), counter.wrappedProcessorNames(), counter.wrappedProcessorNames().toString());
 
-        assertThat(counter.numUniqueStateStores(), CoreMatchers.is(4)); // table1, table2, subscription store, and join materialized
-        assertThat(counter.numConnectedStateStores(), CoreMatchers.is(5));
+        assertEquals(4, counter.numUniqueStateStores()); // table1, table2, subscription store, and join materialized
+        assertEquals(5, counter.numConnectedStateStores());
     }
 
     @Test
@@ -2937,7 +2868,7 @@ public class StreamsBuilderTest {
             while (store instanceof WrappedStateStore && !(expected[i].isInstance(store))) {
                 store = ((WrappedStateStore<?, ?, ?>) store).wrapped();
             }
-            assertThat(store, instanceOf(expected[i]));
+            assertInstanceOf(expected[i], store);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -189,8 +189,7 @@ public class StreamsBuilderTest {
         assertEquals(
             Set.of(topology.stateStores().get(0).name()),
             topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
-        assertTrue(
-            topology.processorConnectedStateStores("KTABLE-FILTER-0000000003").isEmpty());
+        assertTrue(topology.processorConnectedStateStores("KTABLE-FILTER-0000000003").isEmpty());
     }
 
     @Test
@@ -228,8 +227,7 @@ public class StreamsBuilderTest {
         assertEquals(
             Set.of(topology.stateStores().get(0).name()),
             topology.processorConnectedStateStores("KSTREAM-JOIN-0000000005"));
-        assertTrue(
-            topology.processorConnectedStateStores("KTABLE-MAPVALUES-0000000003").isEmpty());
+        assertTrue(topology.processorConnectedStateStores("KTABLE-MAPVALUES-0000000003").isEmpty());
     }
 
     @Test
@@ -266,8 +264,7 @@ public class StreamsBuilderTest {
         assertEquals(
             Set.of(topology.stateStores().get(0).name(), topology.stateStores().get(1).name()),
             topology.processorConnectedStateStores("KSTREAM-JOIN-0000000010"));
-        assertTrue(
-            topology.processorConnectedStateStores("KTABLE-MERGE-0000000007").isEmpty());
+        assertTrue(topology.processorConnectedStateStores("KTABLE-MERGE-0000000007").isEmpty());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -89,11 +89,6 @@ import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
 import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.totalCacheSize;
 import static org.apache.kafka.test.StreamsTestUtils.getStreamsConfig;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -209,16 +204,16 @@ public class StreamsConfigTest {
     @Test
     public void testGetProducerConfigs() {
         final Map<String, Object> returnedProps = streamsConfig.getProducerConfigs(clientId);
-        assertThat(returnedProps.get(ProducerConfig.CLIENT_ID_CONFIG), equalTo(clientId));
-        assertThat(returnedProps.get(ProducerConfig.LINGER_MS_CONFIG), equalTo("100"));
+        assertEquals(clientId, returnedProps.get(ProducerConfig.CLIENT_ID_CONFIG));
+        assertEquals("100", returnedProps.get(ProducerConfig.LINGER_MS_CONFIG));
     }
 
     @Test
     public void testGetConsumerConfigs() {
         final Map<String, Object> returnedProps = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(returnedProps.get(ConsumerConfig.CLIENT_ID_CONFIG), equalTo(clientId));
-        assertThat(returnedProps.get(ConsumerConfig.GROUP_ID_CONFIG), equalTo(groupId));
-        assertThat(returnedProps.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), equalTo("1000"));
+        assertEquals(clientId, returnedProps.get(ConsumerConfig.CLIENT_ID_CONFIG));
+        assertEquals(groupId, returnedProps.get(ConsumerConfig.GROUP_ID_CONFIG));
+        assertEquals("1000", returnedProps.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
         assertNull(returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
     }
 
@@ -231,9 +226,9 @@ public class StreamsConfigTest {
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
         Map<String, Object> returnedProps = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(
-            returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG),
-            equalTo("group-instance-id-1-" + threadIdx)
+        assertEquals(
+            "group-instance-id-1-" + threadIdx,
+            returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG)
         );
 
         returnedProps = streamsConfig.getRestoreConsumerConfigs(clientId);
@@ -253,9 +248,9 @@ public class StreamsConfigTest {
         final Map<String, Object> mainConsumerConfigs =
             streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
 
-        assertThat(
-            mainConsumerConfigs.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG),
-            equalTo("static-member-1-" + threadIdx)
+        assertEquals(
+            "static-member-1-" + threadIdx,
+            mainConsumerConfigs.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG)
         );
     }
 
@@ -691,7 +686,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldNotSetInternalThrowOnFetchStableOffsetUnsupportedConfigToFalseInConsumerForEosDisabled() {
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(consumerConfigs.get("internal.throw.on.fetch.stable.offset.unsupported"), is(nullValue()));
+        assertNull(consumerConfigs.get("internal.throw.on.fetch.stable.offset.unsupported"));
     }
 
     @Test
@@ -699,7 +694,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(consumerConfigs.get("internal.throw.on.fetch.stable.offset.unsupported"), is(true));
+        assertEquals(Boolean.TRUE, consumerConfigs.get("internal.throw.on.fetch.stable.offset.unsupported"));
     }
 
     @Test
@@ -707,7 +702,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
-        assertThat(producerConfigs.get("internal.auto.downgrade.txn.commit"), is(nullValue()));
+        assertNull(producerConfigs.get("internal.auto.downgrade.txn.commit"));
     }
 
     @Test
@@ -733,7 +728,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldSetDefaultBuiltInMetricsVersionIfNoneIsSpecified() {
         final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG), is(StreamsConfig.METRICS_LATEST));
+        assertEquals(StreamsConfig.METRICS_LATEST, config.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG));
     }
 
     @Test
@@ -741,10 +736,9 @@ public class StreamsConfigTest {
         final String invalidVersion = "0.0.1";
         props.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, invalidVersion);
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
-        assertThat(
-            exception.getMessage(),
-            containsString("Invalid value " + invalidVersion + " for configuration built.in.metrics.version")
-        );
+        assertTrue(exception.getMessage().contains(
+            "Invalid value " + invalidVersion + " for configuration built.in.metrics.version"
+        ));
     }
 
     @Test
@@ -753,10 +747,7 @@ public class StreamsConfigTest {
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "anyValue");
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(
-            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
-            equalTo(READ_COMMITTED.toString())
-        );
+        assertEquals(READ_COMMITTED.toString(), consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG));
     }
 
     @Test
@@ -764,10 +755,7 @@ public class StreamsConfigTest {
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, READ_UNCOMMITTED.toString());
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-        assertThat(
-            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
-            equalTo(READ_UNCOMMITTED.toString())
-        );
+        assertEquals(READ_UNCOMMITTED.toString(), consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG));
     }
 
     @Test
@@ -784,7 +772,7 @@ public class StreamsConfigTest {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
-        assertThat(producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG), equalTo(false));
+        assertEquals(Boolean.FALSE, producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
     }
 
     @Test
@@ -795,14 +783,11 @@ public class StreamsConfigTest {
         final Map<String, Object> consumerConfigs = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
-        assertThat(
-            consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG),
-            equalTo(READ_COMMITTED.toString())
-        );
+        assertEquals(READ_COMMITTED.toString(), consumerConfigs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG));
         assertTrue((Boolean) producerConfigs.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
-        assertThat(producerConfigs.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG), equalTo(Integer.MAX_VALUE));
-        assertThat(producerConfigs.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), equalTo(10000));
-        assertThat(streamsConfig.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), equalTo(100L));
+        assertEquals(Integer.MAX_VALUE, producerConfigs.get(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG));
+        assertEquals(10000, producerConfigs.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG));
+        assertEquals(100L, streamsConfig.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG));
     }
 
     @Test
@@ -813,7 +798,7 @@ public class StreamsConfigTest {
 
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
-        assertThat(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG), is(nullValue()));
+        assertNull(producerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
     }
 
     @Test
@@ -825,7 +810,7 @@ public class StreamsConfigTest {
 
         final Map<String, Object> producerConfigs = streamsConfig.getProducerConfigs(clientId);
 
-        assertThat(producerConfigs.get(ProducerConfig.RETRIES_CONFIG), equalTo(numberOfRetries));
+        assertEquals(numberOfRetries, producerConfigs.get(ProducerConfig.RETRIES_CONFIG));
     }
 
     @Test
@@ -835,7 +820,7 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, commitIntervalMs);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
 
-        assertThat(streamsConfig.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), equalTo(commitIntervalMs));
+        assertEquals(commitIntervalMs, streamsConfig.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG));
     }
 
     @Test
@@ -1117,7 +1102,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldSetDefaultAcceptableRecoveryLag() {
         final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG), is(10000L));
+        assertEquals(10000L, config.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG));
     }
 
     @Test
@@ -1129,7 +1114,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldSetDefaultNumStandbyReplicas() {
         final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG), is(0));
+        assertEquals(0, config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG));
     }
 
     @Test
@@ -1141,7 +1126,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldSetDefaultMaxWarmupReplicas() {
         final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG), is(2));
+        assertEquals(2, config.getInt(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG));
     }
 
     @Test
@@ -1153,7 +1138,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldSetDefaultProbingRebalanceInterval() {
         final StreamsConfig config = new StreamsConfig(props);
-        assertThat(config.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG), is(10 * 60 * 1000L));
+        assertEquals(10 * 60 * 1000L, config.getLong(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG));
     }
 
     @Test
@@ -1508,7 +1493,7 @@ public class StreamsConfigTest {
     @Test
     public void shouldReturnDefaultProcessorWrapperClass() {
         final String defaultWrapperClassName = streamsConfig.getClass(PROCESSOR_WRAPPER_CLASS_CONFIG).getName();
-        assertThat(defaultWrapperClassName, equalTo(NoOpProcessorWrapper.class.getName()));
+        assertEquals(NoOpProcessorWrapper.class.getName(), defaultWrapperClassName);
     }
 
     @Test
@@ -1615,10 +1600,7 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("main.consumer metrics push is disabled")
-        );
+        assertTrue(exception.getMessage().contains("main.consumer metrics push is disabled"));
     }
 
     @Test
@@ -1627,10 +1609,9 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("Kafka Streams metrics push enabled but consumer.enable.metrics is false, the setting needs to be consistent between the two")
-        );
+        assertTrue(exception.getMessage().contains(
+            "Kafka Streams metrics push enabled but consumer.enable.metrics is false, the setting needs to be consistent between the two"
+        ));
     }
 
     @Test
@@ -1641,10 +1622,9 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("Kafka Streams metrics push and consumer.enable.metrics are enabled, but main.consumer and admin.client metrics push are disabled")
-        );
+        assertTrue(exception.getMessage().contains(
+            "Kafka Streams metrics push and consumer.enable.metrics are enabled, but main.consumer and admin.client metrics push are disabled"
+        ));
     }
 
     @Test
@@ -1654,10 +1634,7 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("main.consumer metrics push is disabled")
-        );
+        assertTrue(exception.getMessage().contains("main.consumer metrics push is disabled"));
     }
 
     @Test
@@ -1667,10 +1644,7 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("admin.client metrics push is disabled")
-        );
+        assertTrue(exception.getMessage().contains("admin.client metrics push is disabled"));
     }
 
     @Test
@@ -1703,10 +1677,7 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("admin.client metrics push is disabled")
-        );
+        assertTrue(exception.getMessage().contains("admin.client metrics push is disabled"));
     }
 
     @Test
@@ -1716,10 +1687,7 @@ public class StreamsConfigTest {
 
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("main.consumer and admin.client metrics push are disabled")
-        );
+        assertTrue(exception.getMessage().contains("main.consumer and admin.client metrics push are disabled"));
     }
 
     @Test
@@ -1742,11 +1710,10 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG, "org.apache.kafka.streams.errors.InvalidProcessingExceptionHandler");
         final Exception exception = assertThrows(ConfigException.class, () -> new StreamsConfig(props));
 
-        assertThat(
-                exception.getMessage(),
-                containsString("Invalid value org.apache.kafka.streams.errors.InvalidProcessingExceptionHandler " +
-                        "for configuration processing.exception.handler: Class org.apache.kafka.streams.errors.InvalidProcessingExceptionHandler could not be found.")
-        );
+        assertTrue(exception.getMessage().contains(
+            "Invalid value org.apache.kafka.streams.errors.InvalidProcessingExceptionHandler " +
+                "for configuration processing.exception.handler: Class org.apache.kafka.streams.errors.InvalidProcessingExceptionHandler could not be found."
+        ));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -54,7 +54,6 @@ import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -81,11 +80,11 @@ import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG;
 import static org.apache.kafka.streams.utils.TestUtils.PROCESSOR_WRAPPER_COUNTER_CONFIG;
 import static org.apache.kafka.streams.utils.TestUtils.dummyStreamsConfigMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -397,15 +396,12 @@ public class TopologyTest {
         final Properties config = new Properties();
         config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);
         config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArraySerde.class);
-        try {
-            new TopologyTestDriverBuilder(topology).withConfig(config).build();
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException e) {
-            final String error = e.toString();
-            final String expectedMessage = "org.apache.kafka.streams.errors.StreamsException: failed to initialize processor " + badNodeName;
-
-            assertThat(error, equalTo(expectedMessage));
-        }
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            () -> new TopologyTestDriverBuilder(topology).withConfig(config).build()
+        );
+        final String expectedMessage = "org.apache.kafka.streams.errors.StreamsException: failed to initialize processor " + badNodeName;
+        assertEquals(expectedMessage, exception.toString());
     }
 
     private static class LocalMockProcessorSupplier implements ProcessorSupplier<Object, Object, Object, Object> {
@@ -439,7 +435,7 @@ public class TopologyTest {
 
     @Test
     public void shouldDescribeEmptyTopology() {
-        assertThat(topology.describe(), equalTo(expectedDescription));
+        assertEquals(expectedDescription, topology.describe());
     }
 
     @Test
@@ -447,7 +443,7 @@ public class TopologyTest {
         final TopologyDescription.Sink expectedSinkNode =
             new InternalTopologyBuilder.Sink<>("sink", (key, value, record) -> record.topic() + "-" + key);
 
-        assertThat(expectedSinkNode.topic(), equalTo(null));
+        assertNull(expectedSinkNode.topic());
     }
 
     @Test
@@ -456,7 +452,7 @@ public class TopologyTest {
         final TopologyDescription.Sink expectedSinkNode =
             new InternalTopologyBuilder.Sink<>("sink", topicNameExtractor);
 
-        assertThat(expectedSinkNode.topicNameExtractor(), equalTo(topicNameExtractor));
+        assertEquals(topicNameExtractor, expectedSinkNode.topicNameExtractor());
     }
 
     @Test
@@ -467,8 +463,8 @@ public class TopologyTest {
             new SubtopologyDescription(0,
                                        Collections.singleton(expectedSourceNode)));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -479,8 +475,8 @@ public class TopologyTest {
             new SubtopologyDescription(0,
                                        Collections.singleton(expectedSourceNode)));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -491,8 +487,8 @@ public class TopologyTest {
             new SubtopologyDescription(0,
                                        Collections.singleton(expectedSourceNode)));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -512,8 +508,8 @@ public class TopologyTest {
             new SubtopologyDescription(2,
                                        Collections.singleton(expectedSourceNode3)));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -526,8 +522,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -542,8 +538,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
 
@@ -559,8 +555,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -575,8 +571,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode2);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -591,8 +587,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -621,8 +617,8 @@ public class TopologyTest {
         allNodes3.add(expectedProcessorNode3);
         expectedDescription.addSubtopology(new SubtopologyDescription(2, allNodes3));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -651,8 +647,8 @@ public class TopologyTest {
         allNodes3.add(expectedSinkNode3);
         expectedDescription.addSubtopology(new SubtopologyDescription(2, allNodes3));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -683,8 +679,8 @@ public class TopologyTest {
         allNodes.add(expectedSinkNode);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -714,23 +710,23 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode3);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
     public void shouldDescribeGlobalStoreTopology() {
         addGlobalStoreToTopologyAndExpectedDescription("globalStore", "source", "globalTopic", "processor", 0);
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
     public void shouldDescribeMultipleGlobalStoreTopology() {
         addGlobalStoreToTopologyAndExpectedDescription("globalStore1", "source1", "globalTopic1", "processor1", 0);
         addGlobalStoreToTopologyAndExpectedDescription("globalStore2", "source2", "globalTopic2", "processor2", 1);
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @SuppressWarnings("deprecation")
@@ -1202,7 +1198,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1227,7 +1223,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1252,7 +1248,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1276,7 +1272,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1302,7 +1298,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1326,7 +1322,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1351,7 +1347,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1377,7 +1373,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1402,7 +1398,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1428,7 +1424,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1452,7 +1448,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1477,7 +1473,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1503,7 +1499,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1532,7 +1528,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1563,7 +1559,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1594,7 +1590,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1623,7 +1619,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1654,7 +1650,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1684,7 +1680,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1713,7 +1709,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1744,7 +1740,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1774,7 +1770,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1798,7 +1794,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(true));
+        assertTrue(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1824,7 +1820,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1850,7 +1846,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @ParameterizedTest
@@ -1875,7 +1871,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @SuppressWarnings("deprecation")
@@ -1901,7 +1897,7 @@ public class TopologyTest {
         );
 
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
-        assertThat(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore(), is(false));
+        assertFalse(topology.internalTopologyBuilder.setApplicationId("test").buildTopology().hasPersistentLocalStore());
     }
 
     @Test
@@ -1939,11 +1935,11 @@ public class TopologyTest {
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
         final ProcessorTopology processorTopology = topology.internalTopologyBuilder.setApplicationId("test").buildTopology();
         // one for ktable, and one for count operation
-        assertThat(processorTopology.stateStores().size(), is(2));
+        assertEquals(2, processorTopology.stateStores().size());
         // ktable store is rocksDB (default)
-        assertThat(processorTopology.stateStores().get(0).persistent(), is(true));
+        assertTrue(processorTopology.stateStores().get(0).persistent());
         // count store is rocksDB (default)
-        assertThat(processorTopology.stateStores().get(1).persistent(), is(true));
+        assertTrue(processorTopology.stateStores().get(1).persistent());
     }
 
     @ParameterizedTest
@@ -1983,11 +1979,11 @@ public class TopologyTest {
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
         final ProcessorTopology processorTopology = topology.internalTopologyBuilder.setApplicationId("test").buildTopology();
         // one for ktable, and one for count operation
-        assertThat(processorTopology.stateStores().size(), is(2));
+        assertEquals(2, processorTopology.stateStores().size());
         // ktable store is rocksDB (default)
-        assertThat(processorTopology.stateStores().get(0).persistent(), is(true));
+        assertTrue(processorTopology.stateStores().get(0).persistent());
         // count store is storeType
-        assertThat(processorTopology.stateStores().get(1).persistent(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, processorTopology.stateStores().get(1).persistent());
     }
 
     @SuppressWarnings("deprecation")
@@ -2029,11 +2025,11 @@ public class TopologyTest {
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
         final ProcessorTopology processorTopology = topology.internalTopologyBuilder.setApplicationId("test").buildTopology();
         // one for ktable, and one for count operation
-        assertThat(processorTopology.stateStores().size(), is(2));
+        assertEquals(2, processorTopology.stateStores().size());
         // ktable store is in-memory (default is in-memory)
-        assertThat(processorTopology.stateStores().get(0).persistent(), is(false));
+        assertFalse(processorTopology.stateStores().get(0).persistent());
         // count store is storeType
-        assertThat(processorTopology.stateStores().get(1).persistent(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, processorTopology.stateStores().get(1).persistent());
     }
 
     @ParameterizedTest
@@ -2073,11 +2069,11 @@ public class TopologyTest {
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
         final ProcessorTopology processorTopology = topology.internalTopologyBuilder.setApplicationId("test").buildTopology();
         // one for ktable, and one for count operation
-        assertThat(processorTopology.stateStores().size(), is(2));
+        assertEquals(2, processorTopology.stateStores().size());
         // ktable store is rocksDB (default)
-        assertThat(processorTopology.stateStores().get(0).persistent(), is(true));
+        assertTrue(processorTopology.stateStores().get(0).persistent());
         // count store is storeType
-        assertThat(processorTopology.stateStores().get(1).persistent(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, processorTopology.stateStores().get(1).persistent());
     }
 
     @ParameterizedTest
@@ -2116,11 +2112,11 @@ public class TopologyTest {
         topology.internalTopologyBuilder.setStreamsConfig(streamsConfig);
         final ProcessorTopology processorTopology = topology.internalTopologyBuilder.setApplicationId("test").buildTopology();
         // one for ktable, and one for count operation
-        assertThat(processorTopology.stateStores().size(), is(2));
+        assertEquals(2, processorTopology.stateStores().size());
         // ktable store is rocksDB (default)
-        assertThat(processorTopology.stateStores().get(0).persistent(), is(true));
+        assertTrue(processorTopology.stateStores().get(0).persistent());
         // count store is storeType
-        assertThat(processorTopology.stateStores().get(1).persistent(), is(storeType == StoreType.ROCKS_DB));
+        assertEquals(storeType == StoreType.ROCKS_DB, processorTopology.stateStores().get(1).persistent());
     }
 
     @Test
@@ -2261,8 +2257,8 @@ public class TopologyTest {
     public void topologyWithStaticTopicNameExtractorShouldRespectEqualHashcodeContract() {
         final Topology topologyA = topologyWithStaticTopicName();
         final Topology topologyB = topologyWithStaticTopicName();
-        assertThat(topologyA.describe(), equalTo(topologyB.describe()));
-        assertThat(topologyA.describe().hashCode(), equalTo(topologyB.describe().hashCode()));
+        assertEquals(topologyB.describe(), topologyA.describe());
+        assertEquals(topologyB.describe().hashCode(), topologyA.describe().hashCode());
     }
 
     private Topology topologyWithStaticTopicName() {
@@ -2411,8 +2407,8 @@ public class TopologyTest {
         allNodes.add(expectedProcessor);
         expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
-        assertThat(topology.describe(), equalTo(expectedDescription));
-        assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
+        assertEquals(expectedDescription, topology.describe());
+        assertEquals(expectedDescription.hashCode(), topology.describe().hashCode());
     }
 
     @Test
@@ -2435,7 +2431,7 @@ public class TopologyTest {
                 new MockProcessorSupplier<>());
 
         final StoreFactory stateStoreFactory = topology.internalTopologyBuilder.stateStores().get(storeName);
-        assertThat(stateStoreFactory.loggingEnabled(), equalTo(false));
+        assertFalse(stateStoreFactory.loggingEnabled());
     }
 
     @Test
@@ -2469,8 +2465,8 @@ public class TopologyTest {
             () -> record -> System.out.println("Processing: " + random.nextInt()),
             "p2"
         );
-        assertThat(counter.numWrappedProcessors(), is(3));
-        assertThat(counter.wrappedProcessorNames(), Matchers.containsInAnyOrder("p1", "p2", "p3"));
+        assertEquals(3, counter.numWrappedProcessors());
+        assertEquals(Set.of("p1", "p2", "p3"), counter.wrappedProcessorNames());
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Remove hamcrest from `StreamsBuilderTest` by migrating its assertions to
JUnit.

Reviewers: Ken Huang <s7133700@gmail.com>
