### PR TITLE
KAFKA-20960 - Block ZK-to-KRaft migration finalization until brokers re-register

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -27,6 +27,8 @@ import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 public class ActivationRecordsGenerator {
@@ -120,6 +122,7 @@ public class ActivationRecordsGenerator {
         Consumer<String> activationMessageConsumer,
         long transactionStartOffset,
         boolean zkMigrationEnabled,
+        Set<Integer> stillZkRegisteredBrokerIds,
         FeatureControlManager featureControl,
         MetadataVersion metadataVersion
     ) {
@@ -182,10 +185,17 @@ public class ActivationRecordsGenerator {
                         // This can happen if controller leadership transfers to a controller with migrations enabled
                         // after another controller had finalized the migration. For example, during a rolling restart
                         // of the controller quorum during which the migration config is being set to false.
-                        logMessageBuilder
-                            .append("Completing the ZK migration since this controller was configured with ")
-                            .append("'zookeeper.metadata.migration.enable' set to 'false'. ");
-                        records.add(ZkMigrationState.POST_MIGRATION.toRecord());
+                        if (!stillZkRegisteredBrokerIds.isEmpty()) {
+                            logMessageBuilder
+                                .append("Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: ")
+                                .append(new TreeSet<>(stillZkRegisteredBrokerIds))
+                                .append(". Restart these brokers in KRaft mode before finalizing the migration. ");
+                        } else {
+                            logMessageBuilder
+                                .append("Completing the ZK migration since this controller was configured with ")
+                                .append("'zookeeper.metadata.migration.enable' set to 'false'. ");
+                            records.add(ZkMigrationState.POST_MIGRATION.toRecord());
+                        }
                     } else {
                         // This log message is used in zookeeper_migration_test.py
                         logMessageBuilder
@@ -224,6 +234,7 @@ public class ActivationRecordsGenerator {
         boolean isEmpty,
         long transactionStartOffset,
         boolean zkMigrationEnabled,
+        Set<Integer> stillZkRegisteredBrokerIds,
         BootstrapMetadata bootstrapMetadata,
         FeatureControlManager featureControl
     ) {
@@ -232,7 +243,7 @@ public class ActivationRecordsGenerator {
                 bootstrapMetadata, bootstrapMetadata.metadataVersion());
         } else {
             return recordsForNonEmptyLog(activationMessageConsumer, transactionStartOffset, zkMigrationEnabled,
-                featureControl, featureControl.metadataVersion());
+                stillZkRegisteredBrokerIds, featureControl, featureControl.metadataVersion());
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -186,9 +186,9 @@ public class ActivationRecordsGenerator {
                         // of the controller quorum during which the migration config is being set to false.
                         if (!stillZkRegisteredBrokerIds.isEmpty()) {
                             logMessageBuilder
-                                .append("Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: ")
+                                .append("Staying in ZK migration mode even though 'zookeeper.metadata.migration.enable' set to 'false' because the following broker(s) are still registered as ZK brokers: ")
                                 .append(stillZkRegisteredBrokerIds)
-                                .append(". Restart these brokers in KRaft mode before restarting the controllers to finalize the migration. ");
+                                .append(". These brokers must be migrated to KRaft before the controller can finalize the migration.");
                         } else {
                             logMessageBuilder
                                 .append("Completing the ZK migration since this controller was configured with ")

--- a/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ActivationRecordsGenerator.java
@@ -28,7 +28,6 @@ import org.apache.kafka.server.common.MetadataVersion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 
 public class ActivationRecordsGenerator {
@@ -188,8 +187,8 @@ public class ActivationRecordsGenerator {
                         if (!stillZkRegisteredBrokerIds.isEmpty()) {
                             logMessageBuilder
                                 .append("Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: ")
-                                .append(new TreeSet<>(stillZkRegisteredBrokerIds))
-                                .append(". Restart these brokers in KRaft mode before finalizing the migration. ");
+                                .append(stillZkRegisteredBrokerIds)
+                                .append(". Restart these brokers in KRaft mode before restarting the controllers to finalize the migration. ");
                         } else {
                             logMessageBuilder
                                 .append("Completing the ZK migration since this controller was configured with ")

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -98,6 +98,7 @@ import org.apache.kafka.controller.metrics.QuorumControllerMetrics;
 import org.apache.kafka.deferred.DeferredEvent;
 import org.apache.kafka.deferred.DeferredEventQueue;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
+import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metadata.FinalizedControllerFeatures;
 import org.apache.kafka.metadata.KafkaConfigSchema;
@@ -145,11 +146,13 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -1240,11 +1243,16 @@ public final class QuorumController implements Controller {
         @Override
         public ControllerResult<Void> generateRecordsAndResult() {
             try {
+                Set<Integer> stillZkRegisteredBrokerIds = clusterControl.brokerRegistrations().values().stream()
+                    .filter(BrokerRegistration::isMigratingZkBroker)
+                    .map(BrokerRegistration::id)
+                    .collect(Collectors.toCollection(TreeSet::new));
                 return ActivationRecordsGenerator.generate(
                     log::warn,
                     logReplayTracker.empty(),
                     offsetControl.transactionStartOffset(),
                     zkMigrationEnabled,
+                    stillZkRegisteredBrokerIds,
                     bootstrapMetadata,
                     featureControl);
             } catch (Throwable t) {

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1243,7 +1243,7 @@ public final class QuorumController implements Controller {
         @Override
         public ControllerResult<Void> generateRecordsAndResult() {
             try {
-                Set<Integer> stillZkRegisteredBrokerIds = clusterControl.brokerRegistrations().values().stream()
+                Set<Integer> sortedStillZkRegisteredBrokerIds = clusterControl.brokerRegistrations().values().stream()
                     .filter(BrokerRegistration::isMigratingZkBroker)
                     .map(BrokerRegistration::id)
                     .collect(Collectors.toCollection(TreeSet::new));
@@ -1252,7 +1252,7 @@ public final class QuorumController implements Controller {
                     logReplayTracker.empty(),
                     offsetControl.transactionStartOffset(),
                     zkMigrationEnabled,
-                    stillZkRegisteredBrokerIds,
+                    sortedStillZkRegisteredBrokerIds,
                     bootstrapMetadata,
                     featureControl);
             } catch (Throwable t) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -24,7 +24,10 @@ import org.apache.kafka.server.common.MetadataVersion;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,6 +176,7 @@ public class ActivationRecordsGeneratorTest {
                 "record was found in the log. Treating the log as version 3.0-IV1.", logMsg),
             -1L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.MINIMUM_KRAFT_VERSION, Optional.empty()),
             MetadataVersion.MINIMUM_KRAFT_VERSION
         );
@@ -183,6 +187,7 @@ public class ActivationRecordsGeneratorTest {
             logMsg -> assertEquals("Performing controller activation.", logMsg),
             -1L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_3_IV0, Optional.empty()),
             MetadataVersion.IBP_3_3_IV0
         );
@@ -194,6 +199,7 @@ public class ActivationRecordsGeneratorTest {
                                    + "This is expected because this is a de-novo KRaft cluster.", logMsg),
             -1L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
             MetadataVersion.IBP_3_4_IV0
         );
@@ -206,6 +212,7 @@ public class ActivationRecordsGeneratorTest {
                                    "This is expected because this is a de-novo KRaft cluster.", logMsg),
             42L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),
             MetadataVersion.IBP_3_6_IV1
         );
@@ -220,6 +227,7 @@ public class ActivationRecordsGeneratorTest {
                     logMsg -> fail(),
                     42L,
                     false,
+                    Collections.emptySet(),
                     buildFeatureControl(MetadataVersion.IBP_3_6_IV0, Optional.empty()),
                     MetadataVersion.IBP_3_6_IV0
                 )).getMessage()
@@ -237,6 +245,7 @@ public class ActivationRecordsGeneratorTest {
                     logMsg -> fail(),
                     -1L,
                     true,
+                    Collections.emptySet(),
                     buildFeatureControl(MetadataVersion.IBP_3_3_IV0, Optional.empty()),
                     MetadataVersion.IBP_3_3_IV0
                 )).getMessage()
@@ -249,6 +258,7 @@ public class ActivationRecordsGeneratorTest {
                     logMsg -> fail(),
                     -1L,
                     true,
+                    Collections.emptySet(),
                     buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.empty()),
                     MetadataVersion.IBP_3_4_IV0
                 )).getMessage()
@@ -261,6 +271,7 @@ public class ActivationRecordsGeneratorTest {
                     logMsg -> fail(),
                     -1L,
                     true,
+                    Collections.emptySet(),
                     buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.empty()),
                     MetadataVersion.IBP_3_6_IV1
                 )
@@ -272,6 +283,7 @@ public class ActivationRecordsGeneratorTest {
                 "PRE_MIGRATION.", logMsg),
             -1L,
             true,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.PRE_MIGRATION)),
             MetadataVersion.IBP_3_6_IV1
         );
@@ -283,6 +295,7 @@ public class ActivationRecordsGeneratorTest {
                 "Staying in ZK migration mode since 'zookeeper.metadata.migration.enable' is still 'true'.", logMsg),
             -1L,
             true,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.MIGRATION)),
             MetadataVersion.IBP_3_6_IV1
         );
@@ -295,6 +308,7 @@ public class ActivationRecordsGeneratorTest {
                 "'zookeeper.metadata.migration.enable' set to 'false'.", logMsg),
             -1L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.MIGRATION)),
             MetadataVersion.IBP_3_4_IV0
         );
@@ -307,6 +321,7 @@ public class ActivationRecordsGeneratorTest {
                 "since this controller was configured with 'zookeeper.metadata.migration.enable' set to 'false'.", logMsg),
             42L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.MIGRATION)),
             MetadataVersion.IBP_3_6_IV1
         );
@@ -318,6 +333,7 @@ public class ActivationRecordsGeneratorTest {
                 "POST_MIGRATION.", logMsg),
             -1L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.POST_MIGRATION)),
             MetadataVersion.IBP_3_4_IV0
         );
@@ -329,6 +345,7 @@ public class ActivationRecordsGeneratorTest {
                 "transaction at offset 42. Loaded ZK migration state of POST_MIGRATION.", logMsg),
             42L,
             false,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.POST_MIGRATION)),
             MetadataVersion.IBP_3_6_IV1
         );
@@ -341,6 +358,7 @@ public class ActivationRecordsGeneratorTest {
                 "ZK migration has been completed.", logMsg),
             -1L,
             true,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_4_IV0, Optional.of(ZkMigrationState.POST_MIGRATION)),
             MetadataVersion.IBP_3_4_IV0
         );
@@ -353,10 +371,31 @@ public class ActivationRecordsGeneratorTest {
                 "'zookeeper.metadata.migration.enable' value of 'true' since the ZK migration has been completed.", logMsg),
             42L,
             true,
+            Collections.emptySet(),
             buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.POST_MIGRATION)),
             MetadataVersion.IBP_3_6_IV1
         );
         assertTrue(result.isAtomic());
         assertEquals(1, result.records().size());
+    }
+
+    @Test
+    public void testMigrationNotFinalizedWhileBrokersStillRegisteredAsZk() {
+        Set<Integer> stillZkRegistered = new TreeSet<>();
+        stillZkRegistered.add(1);
+        stillZkRegistered.add(3);
+
+        ControllerResult<Void> result = ActivationRecordsGenerator.recordsForNonEmptyLog(
+            logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of MIGRATION. " +
+                "Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: [1, 3]" +
+                ". Restart these brokers in KRaft mode before finalizing the migration.", logMsg),
+            -1L,
+            false,
+            stillZkRegistered,
+            buildFeatureControl(MetadataVersion.IBP_3_6_IV1, Optional.of(ZkMigrationState.MIGRATION)),
+            MetadataVersion.IBP_3_6_IV1
+        );
+        assertTrue(result.isAtomic());
+        assertEquals(0, result.records().size());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -387,8 +387,8 @@ public class ActivationRecordsGeneratorTest {
 
         ControllerResult<Void> result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of MIGRATION. " +
-                "Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: [1, 3]" +
-                ". Restart these brokers in KRaft mode before restarting the controllers to finalize the migration.", logMsg),
+                "Staying in ZK migration mode even though 'zookeeper.metadata.migration.enable' set to 'false' because the following broker(s) are still registered as ZK brokers: [1, 3]" +
+                ". These brokers must be migrated to KRaft before the controller can finalize the migration.", logMsg),
             -1L,
             false,
             stillZkRegistered,

--- a/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ActivationRecordsGeneratorTest.java
@@ -388,7 +388,7 @@ public class ActivationRecordsGeneratorTest {
         ControllerResult<Void> result = ActivationRecordsGenerator.recordsForNonEmptyLog(
             logMsg -> assertEquals("Performing controller activation. Loaded ZK migration state of MIGRATION. " +
                 "Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers: [1, 3]" +
-                ". Restart these brokers in KRaft mode before finalizing the migration.", logMsg),
+                ". Restart these brokers in KRaft mode before restarting the controllers to finalize the migration.", logMsg),
             -1L,
             false,
             stillZkRegistered,

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -1466,6 +1466,7 @@ public class QuorumControllerTest {
             !stateInLog.isPresent(),
             -1L,
             zkMigrationEnabled,
+            Collections.emptySet(),
             BootstrapMetadata.fromVersion(metadataVersion, "test"),
             featureControlManager);
         RecordTestUtils.replayAll(featureControlManager, result.records());
@@ -1559,6 +1560,7 @@ public class QuorumControllerTest {
             true,
             0L,
             zkMigrationEnabled,
+            Collections.emptySet(),
             BootstrapMetadata.fromVersion(MetadataVersion.IBP_3_6_IV1, "test"),
             featureControlManager);
         assertFalse(result.isAtomic());
@@ -1635,6 +1637,7 @@ public class QuorumControllerTest {
             false,
             offsetControlManager.transactionStartOffset(),
             false,
+            Collections.emptySet(),
             BootstrapMetadata.fromVersion(MetadataVersion.IBP_3_6_IV1, "test"),
             featureControlManager);
 
@@ -1665,6 +1668,7 @@ public class QuorumControllerTest {
                 false,
                 offsetControlManager.transactionStartOffset(),
                 false,
+                Collections.emptySet(),
                 BootstrapMetadata.fromVersion(MetadataVersion.IBP_3_6_IV0, "test"),
                 featureControlManager)
         );

--- a/tests/kafkatest/tests/core/zookeeper_migration_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_migration_test.py
@@ -207,6 +207,112 @@ class TestMigration(ProduceConsumeValidateTest):
         assert saw_expected_error, "Did not see expected ERROR log in the controller logs"
 
     @cluster(num_nodes=5)
+    def test_finalize_blocked_until_brokers_reregister_in_kraft(self):
+        """
+        Regression test for KAFKA-20960. The KRaft controller must not finalize a
+        ZK-to-KRaft migration while any broker is still registered as a ZK broker in the KRaft metadata.
+        Instead it should log a warning naming the offending broker(s) and stay in
+        MIGRATION. Once those brokers have re-registered in KRaft mode, a
+        subsequent activation with 'zookeeper.metadata.migration.enable=false'
+        should finalize the migration.
+        """
+        zk_quorum = partial(ServiceQuorumInfo, zk)
+        self.zk = ZookeeperService(self.test_context, num_nodes=1, version=DEV_BRANCH)
+        self.kafka = KafkaService(self.test_context,
+                                  num_nodes=3,
+                                  zk=self.zk,
+                                  version=DEV_BRANCH,
+                                  quorum_info_provider=zk_quorum,
+                                  allow_zk_with_kraft=True,
+                                  server_prop_overrides=[
+                                      ["zookeeper.metadata.migration.enable", "false"]])
+
+        remote_quorum = partial(ServiceQuorumInfo, isolated_kraft)
+        controller = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=DEV_BRANCH,
+                                  allow_zk_with_kraft=True,
+                                  isolated_kafka=self.kafka,
+                                  server_prop_overrides=[["zookeeper.connect", self.zk.connect_setting()],
+                                                         ["zookeeper.metadata.migration.enable", "true"]],
+                                  quorum_info_provider=remote_quorum)
+
+        self.kafka.security_protocol = "PLAINTEXT"
+        self.kafka.interbroker_security_protocol = "PLAINTEXT"
+        self.zk.start()
+        self.logger.info("Pre-generating clusterId for ZK.")
+        cluster_id_json = """{"version": "1", "id": "%s"}""" % CLUSTER_ID
+        self.zk.create(path="/cluster")
+        self.zk.create(path="/cluster/id", value=cluster_id_json)
+        self.kafka.start()
+
+        self.kafka.create_topic({
+            "topic": self.topic,
+            "partitions": self.partitions,
+            "replication-factor": self.replication_factor,
+            "configs": {"min.insync.replicas": 2}
+        })
+
+        controller.start()
+        self.logger.info("Restarting ZK brokers in migration mode")
+        self.kafka.reconfigure_zk_for_migration(controller)
+        for node in self.kafka.nodes:
+            self.kafka.stop_node(node)
+            self.kafka.start_node(node)
+            self.wait_until_rejoin()
+
+        controller_node = controller.nodes[0]
+        with controller_node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+            monitor.offset = 0
+            monitor.wait_until(
+                "Finished initial migration of ZK metadata to KRaft",
+                timeout_sec=60.0, backoff_sec=.25,
+                err_msg="Did not see expected INFO log after initial migration")
+
+        self.logger.info("Restart controller with migration disabled while brokers are still ZK-registered")
+        controller.server_prop_overrides = [
+            ["zookeeper.connect", self.zk.connect_setting()],
+            ["zookeeper.metadata.migration.enable", "false"],
+        ]
+        with controller_node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+            controller.stop_node(controller_node)
+            controller.start_node(controller_node)
+            monitor.wait_until(
+                "Cannot complete ZK migration because the following broker(s) are still registered as ZK brokers",
+                timeout_sec=60.0, backoff_sec=.25,
+                err_msg="Controller did not log the expected 'Cannot complete ZK migration' warning")
+
+        self.logger.info("Restart controller with migration re-enabled so brokers can migrate to KRaft")
+        controller.server_prop_overrides = [
+            ["zookeeper.connect", self.zk.connect_setting()],
+            ["zookeeper.metadata.migration.enable", "true"],
+        ]
+        controller.stop_node(controller_node)
+        controller.start_node(controller_node)
+
+        self.logger.info("Restarting ZK brokers as KRaft brokers")
+        self.kafka.reconfigure_zk_as_kraft(controller)
+        for node in self.kafka.nodes:
+            self.kafka.stop_node(node)
+            self.kafka.start_node(node)
+            self.wait_until_rejoin()
+
+        self.logger.info("Restart controller with migration disabled; migration should finalize")
+        controller.server_prop_overrides = [
+            ["zookeeper.connect", self.zk.connect_setting()],
+            ["zookeeper.metadata.migration.enable", "false"],
+        ]
+        with controller_node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+            controller.stop_node(controller_node)
+            controller.start_node(controller_node)
+            monitor.wait_until(
+                "Completing the ZK migration since this controller was configured with",
+                timeout_sec=60.0, backoff_sec=.25,
+                err_msg="Controller did not finalize the ZK migration once brokers re-registered as KRaft")
+
+        self.kafka.stop()
+        controller.stop()
+        self.zk.stop()
+
+    @cluster(num_nodes=5)
     def test_reconcile_kraft_to_zk(self):
         """
         Perform a migration and delete a topic directly from ZK. Ensure that the topic is added back


### PR DESCRIPTION

Added a controller-side check to confirm that brokers have re-registered with KRaft before finalizing ZK migration. If brokers have not re-registered, then the migration is blocked and the offending brokers are listed.

Also added `testMigrationNotFinalizedWhileBrokersStillRegisteredAsZk()`, which tests and confirms that migration is blocked when brokers have failed to re-register with KRaft
