### PR TITLE
KAFKA-20416: Source changelog committed offset retry 

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -250,6 +250,11 @@ public class StoreChangelogReader implements ChangelogReader {
     // task keeps counting down its retry deadline instead of resetting it every iteration. See KAFKA-20416.
     private final Map<TopicPartition, Long> committedOffsetMissingSinceMs = new HashMap<>();
 
+    // Changelog partitions that have begun restoring in this process. Outlives unregister so a corrupted-and-wiped
+    // task is still remembered as having had state. A missing committed offset is retried for these (it may be a
+    // transient -1 from a resigning coordinator) but taken as authoritative 0 for a fresh changelog. See KAFKA-20416.
+    private final Set<TopicPartition> everStartedRestoringChangelogs = new HashSet<>();
+
     private final Time time;
     private final Logger log;
     private final Duration pollTime;
@@ -868,15 +873,10 @@ public class StoreChangelogReader implements ChangelogReader {
         }
     }
 
-    // Resolves the committed-offset operand of the restore ceiling (min(endOffset, committedOffset)) for one
-    // changelog. A dedicated changelog is not bounded by any committed offset, so it uses Long.MAX_VALUE. A
-    // source-topic changelog whose group has no committed offset (NO_COMMITTED_OFFSET) is ambiguous: it can be
-    // transient (the coordinator is momentarily unavailable/resigning during a broker restart and reports
-    // -1/NONE for a group whose offset is durable) or authoritative (a brand-new group that has never committed,
-    // for which 0 is correct). We cannot distinguish the two from a single response, so we retry (returning null
-    // to leave the changelog uninitialized this pass) for up to task.timeout.ms before falling back to 0, rather
-    // than truncating restore to 0 immediately, which silently empties the store (KAFKA-20416). The fallback is
-    // only attempted once the end offset is known, so a ceiling is never resolved from a half-fetched pair.
+    // The committed-offset operand of the restore ceiling min(endOffset, committedOffset). A dedicated changelog
+    // is unbounded (Long.MAX_VALUE); a source changelog gates a missing committed offset on whether it has
+    // restored before (see everStartedRestoringChangelogs). Fallback runs only once the end offset is known, so
+    // a ceiling is never resolved from a half-fetched pair.
     private Long resolveRestoreCeilingCommittedOffset(final TopicPartition partition,
                                                       final boolean changelogAsSource,
                                                       final Long endOffset,
@@ -886,16 +886,18 @@ public class StoreChangelogReader implements ChangelogReader {
         }
         final Long committedOffset = committedOffsets.get(partition);
         if (committedOffset != null && committedOffset == NO_COMMITTED_OFFSET) {
+            if (!everStartedRestoringChangelogs.contains(partition)) {
+                // fresh changelog: 0 is authoritative, restore starts now
+                return 0L;
+            }
+            // wiped changelog: a missing committed offset may be a transient coordinator answer, retry it
             return endOffset == null ? null : maybeFallBackToZeroCommittedOffset(partition);
         }
         return committedOffset;
     }
 
-    // Retry budget for a source-topic changelog whose committed offset came back missing. Returns 0L once the
-    // offset has been missing for at least task.timeout.ms — at that point the group most likely genuinely has
-    // no committed offset (e.g. a brand-new group) and 0 is the correct restore ceiling — or null while the
-    // budget remains, to keep retrying. Retrying (rather than defaulting to 0 immediately) is what prevents a
-    // transiently missing committed offset from silently truncating an active source-topic store. See KAFKA-20416.
+    // Bounded retry for a wiped source changelog's missing committed offset: return 0L once it has been missing
+    // for task.timeout.ms (the offset is probably genuinely absent), else null to keep retrying.
     private Long maybeFallBackToZeroCommittedOffset(final TopicPartition partition) {
         final long now = time.milliseconds();
         final long missingSince = committedOffsetMissingSinceMs.computeIfAbsent(partition, p -> now);
@@ -948,9 +950,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 metadata.stateManager.changelogAsSource(partition) &&
                 committedOffsets.containsKey(partition)) {
 
-                // A standby that reads a source topic as its changelog stops applying at the committed offset;
-                // if the group has no committed offset yet (NO_COMMITTED_OFFSET), the limit is 0 (apply nothing),
-                // which is the behavior before committedOffsetForChangelogs began surfacing the missing marker.
+                // no committed offset (NO_COMMITTED_OFFSET) means a standby limit of 0, i.e. apply nothing yet
                 final Long newLimit = Math.max(committedOffsets.get(partition), 0L);
                 final Long previousLimit = metadata.restoreEndOffset;
 
@@ -1041,7 +1041,13 @@ public class StoreChangelogReader implements ChangelogReader {
         addChangelogsToRestoreConsumer(newPartitionsToRestore.stream().map(metadata -> metadata.storeMetadata.changelogPartition())
             .collect(Collectors.toSet()));
 
-        newPartitionsToRestore.forEach(metadata -> metadata.transitTo(ChangelogState.RESTORING));
+        newPartitionsToRestore.forEach(metadata -> {
+            final TopicPartition partition = metadata.storeMetadata.changelogPartition();
+            metadata.transitTo(ChangelogState.RESTORING);
+            // remember that this changelog has begun restoring, so that if its task is later corrupted and its
+            // store wiped, a subsequently missing committed offset is retried rather than truncating restore to 0
+            everStartedRestoringChangelogs.add(partition);
+        });
 
         // if it is in the active restoring mode, we immediately pause those standby changelogs
         // here we just blindly pause all (including the existing and newly added)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -233,16 +233,28 @@ public class StoreChangelogReader implements ChangelogReader {
     // The 8x is a conservative margin over the probe's cost as measured in load testing.
     private static final long PROBE_MIN_OFFSET_GAP = 8 * PROBE_WINDOWS[PROBE_WINDOWS.length - 1];
 
+    // Value used by committedOffsetForChangelogs to mark a source-topic changelog whose group has no
+    // committed offset. The coordinator reports "no committed offset" as INVALID_OFFSET (-1), and a real
+    // committed offset is never negative, so -1 unambiguously distinguishes "missing" from a genuine 0.
+    private static final long NO_COMMITTED_OFFSET = -1L;
+
     private ChangelogReaderState state;
 
     // deliberately outlives unregister: a changelog that is corrupted and re-registered in a loop
     // must not forget that probing it has just failed
     private final Map<TopicPartition, Long> probeFailedAtMs = new HashMap<>();
 
+    // When a source-topic changelog's committed offset comes back missing we retry it (rather than
+    // truncating restore to 0) for up to taskTimeoutMs; this records when the miss was first observed.
+    // Deliberately outlives unregister, mirroring probeFailedAtMs, so a corrupted-wiped-re-registered
+    // task keeps counting down its retry deadline instead of resetting it every iteration. See KAFKA-20416.
+    private final Map<TopicPartition, Long> committedOffsetMissingSinceMs = new HashMap<>();
+
     private final Time time;
     private final Logger log;
     private final Duration pollTime;
     private final long updateOffsetIntervalMs;
+    private final long taskTimeoutMs;
 
     // 1) we keep adding partitions to restore consumer whenever new tasks are registered with the state manager;
     // 2) we do not unassign partitions when we switch between standbys and actives, we just pause / resume them;
@@ -283,6 +295,7 @@ public class StoreChangelogReader implements ChangelogReader {
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
         this.updateOffsetIntervalMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) == Long.MAX_VALUE ?
             DEFAULT_OFFSET_UPDATE_MS : config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
+        this.taskTimeoutMs = config.getLong(StreamsConfig.TASK_TIMEOUT_MS_CONFIG);
         this.lastUpdateOffsetTime = 0L;
 
         this.changelogs = new HashMap<>();
@@ -825,7 +838,11 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         try {
-            // those which do not have a committed offset would default to 0
+            // partitions with no committed offset are mapped to NO_COMMITTED_OFFSET (-1) rather than 0, so
+            // callers can tell "the group has not committed here" apart from a genuine committed offset of 0.
+            // Coercing a missing offset straight to 0 here would let a transiently missing committed offset
+            // (e.g. the group coordinator is momentarily unavailable/resigning during a broker restart)
+            // truncate an active source-topic changelog's restore to 0 — see initializeChangelogs / KAFKA-20416.
             final ListConsumerGroupOffsetsOptions options = new ListConsumerGroupOffsetsOptions()
                 .requireStable(true);
             final ListConsumerGroupOffsetsSpec spec = new ListConsumerGroupOffsetsSpec()
@@ -837,7 +854,7 @@ public class StoreChangelogReader implements ChangelogReader {
                     )
                     .partitionsToOffsetAndMetadata(groupId).get().entrySet()
                     .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? 0L : e.getValue().offset()));
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() == null ? NO_COMMITTED_OFFSET : e.getValue().offset()));
 
             clearTaskTimeout(getTasksFromPartitions(tasks, partitions));
             return committedOffsets;
@@ -849,6 +866,47 @@ public class StoreChangelogReader implements ChangelogReader {
         } catch (final KafkaException e) {
             throw new StreamsException(String.format("Failed to retrieve committed offsets for %s", partitions), e);
         }
+    }
+
+    // Resolves the committed-offset operand of the restore ceiling (min(endOffset, committedOffset)) for one
+    // changelog. A dedicated changelog is not bounded by any committed offset, so it uses Long.MAX_VALUE. A
+    // source-topic changelog whose group has no committed offset (NO_COMMITTED_OFFSET) is ambiguous: it can be
+    // transient (the coordinator is momentarily unavailable/resigning during a broker restart and reports
+    // -1/NONE for a group whose offset is durable) or authoritative (a brand-new group that has never committed,
+    // for which 0 is correct). We cannot distinguish the two from a single response, so we retry (returning null
+    // to leave the changelog uninitialized this pass) for up to task.timeout.ms before falling back to 0, rather
+    // than truncating restore to 0 immediately, which silently empties the store (KAFKA-20416). The fallback is
+    // only attempted once the end offset is known, so a ceiling is never resolved from a half-fetched pair.
+    private Long resolveRestoreCeilingCommittedOffset(final TopicPartition partition,
+                                                      final boolean changelogAsSource,
+                                                      final Long endOffset,
+                                                      final Map<TopicPartition, Long> committedOffsets) {
+        if (!changelogAsSource) {
+            return Long.MAX_VALUE;
+        }
+        final Long committedOffset = committedOffsets.get(partition);
+        if (committedOffset != null && committedOffset == NO_COMMITTED_OFFSET) {
+            return endOffset == null ? null : maybeFallBackToZeroCommittedOffset(partition);
+        }
+        return committedOffset;
+    }
+
+    // Retry budget for a source-topic changelog whose committed offset came back missing. Returns 0L once the
+    // offset has been missing for at least task.timeout.ms — at that point the group most likely genuinely has
+    // no committed offset (e.g. a brand-new group) and 0 is the correct restore ceiling — or null while the
+    // budget remains, to keep retrying. Retrying (rather than defaulting to 0 immediately) is what prevents a
+    // transiently missing committed offset from silently truncating an active source-topic store. See KAFKA-20416.
+    private Long maybeFallBackToZeroCommittedOffset(final TopicPartition partition) {
+        final long now = time.milliseconds();
+        final long missingSince = committedOffsetMissingSinceMs.computeIfAbsent(partition, p -> now);
+        if (now - missingSince >= taskTimeoutMs) {
+            log.warn("Committed offset for source-topic changelog {} was still unavailable {} ms after it was " +
+                "first missing; restoring with a committed offset of 0. If the group did have a committed offset " +
+                "this can leave the restored state incomplete (see KAFKA-20416).", partition, taskTimeoutMs);
+            committedOffsetMissingSinceMs.remove(partition);
+            return 0L;
+        }
+        return null;
     }
 
     private void filterNewPartitionsToRestore(final Map<TaskId, Task> tasks, final Set<ChangelogMetadata> newPartitionsToRestore) {
@@ -890,7 +948,10 @@ public class StoreChangelogReader implements ChangelogReader {
                 metadata.stateManager.changelogAsSource(partition) &&
                 committedOffsets.containsKey(partition)) {
 
-                final Long newLimit = committedOffsets.get(partition);
+                // A standby that reads a source topic as its changelog stops applying at the committed offset;
+                // if the group has no committed offset yet (NO_COMMITTED_OFFSET), the limit is 0 (apply nothing),
+                // which is the behavior before committedOffsetForChangelogs began surfacing the missing marker.
+                final Long newLimit = Math.max(committedOffsets.get(partition), 0L);
                 final Long previousLimit = metadata.restoreEndOffset;
 
                 if (previousLimit != null && previousLimit > newLimit) {
@@ -947,8 +1008,8 @@ public class StoreChangelogReader implements ChangelogReader {
         for (final TopicPartition partition : newPartitionsToFindEndOffset) {
             final ChangelogMetadata changelogMetadata = changelogs.get(partition);
             final Long endOffset = endOffsets.get(partition);
-            final Long committedOffset = newPartitionsToFindCommittedOffset.contains(partition) ?
-                committedOffsets.get(partition) : Long.valueOf(Long.MAX_VALUE);
+            final boolean changelogAsSource = newPartitionsToFindCommittedOffset.contains(partition);
+            final Long committedOffset = resolveRestoreCeilingCommittedOffset(partition, changelogAsSource, endOffset, committedOffsets);
 
             if (endOffset != null && committedOffset != null) {
                 if (changelogMetadata.restoreEndOffset != null) {
@@ -957,6 +1018,7 @@ public class StoreChangelogReader implements ChangelogReader {
                         ", new value: (" + endOffset + ", " + committedOffset + ")");
                 }
 
+                committedOffsetMissingSinceMs.remove(partition);
                 changelogMetadata.restoreEndOffset = Math.min(endOffset, committedOffset);
 
                 log.info("End offset for changelog {} initialized as {}.", partition, changelogMetadata.restoreEndOffset);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -973,6 +973,101 @@ public class StoreChangelogReaderTest {
         }
     }
 
+    @Test
+    public void shouldRetryMissingCommittedOffsetForSourceChangelogThenFallBackToZero() {
+        // KAFKA-20416: a source-topic changelog whose group has no committed offset must NOT immediately
+        // restore to 0 (which, after an EOS state wipe, silently empties the store). The missing offset is
+        // retried for up to task.timeout.ms so a transiently-missing offset can recover, and only then falls
+        // back to 0 for the legitimate brand-new-group case.
+        setupStateManagerMock(ACTIVE);
+        setupStoreMetadata();
+        setupStore();
+
+        final TaskId taskId = new TaskId(0, 0);
+        final Task mockTask = mock(Task.class);
+
+        when(stateManager.changelogAsSource(tp)).thenReturn(true);
+        when(storeMetadata.offset()).thenReturn(5L);
+        when(stateManager.taskId()).thenReturn(taskId);
+
+        final String groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+        // coordinator reports no committed offset (-1) for this partition, i.e. a null OffsetAndMetadata value
+        final Map<TopicPartition, OffsetAndMetadata> missingCommitted = new HashMap<>();
+        missingCommitted.put(tp, null);
+        final MockAdminClient adminClient = new MockAdminClient() {
+            @Override
+            public synchronized ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final Map<String, ListConsumerGroupOffsetsSpec> groupSpecs, final ListConsumerGroupOffsetsOptions options) {
+                return AdminClientTestUtils.listConsumerGroupOffsetsResult(Collections.singletonMap(groupId, missingCommitted));
+            }
+        };
+        adminClient.updateEndOffsets(Collections.singletonMap(tp, 20L));
+
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+
+        changelogReader.register(tp, stateManager);
+
+        // first pass: the missing committed offset is retried rather than coerced to 0, so the changelog is
+        // left uninitialized instead of being declared restored at offset 0
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(StoreChangelogReader.ChangelogState.REGISTERED, changelogReader.changelogMetadata(tp).state());
+        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+
+        // once the retry budget (task.timeout.ms) is exhausted the group most likely genuinely has no committed
+        // offset (e.g. a brand-new group), so fall back to 0
+        time.sleep(config.getLong(StreamsConfig.TASK_TIMEOUT_MS_CONFIG) + 1);
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(0L, (long) changelogReader.changelogMetadata(tp).endOffset());
+    }
+
+    @Test
+    public void shouldRecoverToRealCommittedOffsetWhenTransientlyMissingBeforeTimeout() {
+        // KAFKA-20416: the case the fix exists for — a source-topic changelog's committed offset is missing on
+        // the first pass (transient coordinator unavailability) and the real offset appears on the next pass,
+        // before task.timeout.ms elapses. The ceiling must resolve to min(endOffset, committedOffset), not 0.
+        setupStateManagerMock(ACTIVE);
+        setupStoreMetadata();
+        setupStore();
+
+        final TaskId taskId = new TaskId(0, 0);
+        final Task mockTask = mock(Task.class);
+
+        when(stateManager.changelogAsSource(tp)).thenReturn(true);
+        when(storeMetadata.offset()).thenReturn(5L);
+        when(stateManager.taskId()).thenReturn(taskId);
+
+        final String groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+        final Map<TopicPartition, OffsetAndMetadata> missingCommitted = new HashMap<>();
+        missingCommitted.put(tp, null);
+        final AtomicBoolean firstCall = new AtomicBoolean(true);
+        final MockAdminClient adminClient = new MockAdminClient() {
+            @Override
+            public synchronized ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final Map<String, ListConsumerGroupOffsetsSpec> groupSpecs, final ListConsumerGroupOffsetsOptions options) {
+                // first pass: no committed offset (transiently missing); later passes: the real committed offset
+                final Map<TopicPartition, OffsetAndMetadata> offsets = firstCall.compareAndSet(true, false)
+                    ? missingCommitted
+                    : Collections.singletonMap(tp, new OffsetAndMetadata(10L));
+                return AdminClientTestUtils.listConsumerGroupOffsetsResult(Collections.singletonMap(groupId, offsets));
+            }
+        };
+        adminClient.updateEndOffsets(Collections.singletonMap(tp, 20L));
+
+        final StoreChangelogReader changelogReader =
+            new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
+
+        changelogReader.register(tp, stateManager);
+
+        // first pass: missing → retried, left uninitialized (not truncated to 0)
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(StoreChangelogReader.ChangelogState.REGISTERED, changelogReader.changelogMetadata(tp).state());
+        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+
+        // second pass, still well within task.timeout.ms: the real committed offset recovers the ceiling to
+        // min(endOffset=20, committedOffset=10) rather than falling back to 0
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(10L, (long) changelogReader.changelogMetadata(tp).endOffset());
+    }
+
     @ParameterizedTest
     @EnumSource(Task.TaskType.class)
     public void shouldThrowIfCommittedOffsetsFail(final Task.TaskType type) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -974,11 +975,10 @@ public class StoreChangelogReaderTest {
     }
 
     @Test
-    public void shouldRetryMissingCommittedOffsetForSourceChangelogThenFallBackToZero() {
-        // KAFKA-20416: a source-topic changelog whose group has no committed offset must NOT immediately
-        // restore to 0 (which, after an EOS state wipe, silently empties the store). The missing offset is
-        // retried for up to task.timeout.ms so a transiently-missing offset can recover, and only then falls
-        // back to 0 for the legitimate brand-new-group case.
+    public void shouldRestoreFreshSourceChangelogWithMissingCommittedOffsetImmediatelyAtZero() {
+        // KAFKA-20416: for a brand-new group the coordinator legitimately reports no committed offset, and 0 is
+        // the correct restore ceiling. A first-time (never-before-restored) source changelog must take this fast
+        // path immediately and NOT retry — otherwise every fresh source-table app stalls waiting on task.timeout.ms.
         setupStateManagerMock(ACTIVE);
         setupStoreMetadata();
         setupStore();
@@ -987,11 +987,10 @@ public class StoreChangelogReaderTest {
         final Task mockTask = mock(Task.class);
 
         when(stateManager.changelogAsSource(tp)).thenReturn(true);
-        when(storeMetadata.offset()).thenReturn(5L);
+        when(storeMetadata.offset()).thenReturn(null);
         when(stateManager.taskId()).thenReturn(taskId);
 
         final String groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-        // coordinator reports no committed offset (-1) for this partition, i.e. a null OffsetAndMetadata value
         final Map<TopicPartition, OffsetAndMetadata> missingCommitted = new HashMap<>();
         missingCommitted.put(tp, null);
         final MockAdminClient adminClient = new MockAdminClient() {
@@ -1001,53 +1000,91 @@ public class StoreChangelogReaderTest {
             }
         };
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 20L));
+        // fresh store (no restored offset) seeks to the beginning of the changelog
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
 
         final StoreChangelogReader changelogReader =
             new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
         changelogReader.register(tp, stateManager);
 
-        // first pass: the missing committed offset is retried rather than coerced to 0, so the changelog is
-        // left uninitialized instead of being declared restored at offset 0
+        // fresh changelog, missing committed offset → initialize immediately at 0 (no retry, no stall); with a
+        // ceiling of 0 there is nothing to restore, so it completes at once and the store starts empty
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(StoreChangelogReader.ChangelogState.COMPLETED, changelogReader.changelogMetadata(tp).state());
+        assertEquals(0L, (long) changelogReader.changelogMetadata(tp).endOffset());
+    }
+
+    @Test
+    public void shouldRetryMissingCommittedOffsetForWipedSourceChangelogThenFallBackToZero() {
+        // KAFKA-20416: a source changelog that has restored before (its task was corrupted and its store wiped)
+        // must NOT be truncated to 0 on a missing committed offset — that would silently empty the store. The
+        // missing offset is retried for up to task.timeout.ms, and only then falls back to 0.
+        final AtomicReference<Map<TopicPartition, OffsetAndMetadata>> committed = new AtomicReference<>();
+        final TaskId taskId = new TaskId(0, 0);
+        final Task mockTask = mock(Task.class);
+        final StoreChangelogReader changelogReader = setupWipedSourceChangelog(committed, taskId, mockTask);
+
+        // after the wipe the committed offset is (transiently) missing → retried, changelog left uninitialized
+        committed.set(committedOf(null));
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
         assertEquals(StoreChangelogReader.ChangelogState.REGISTERED, changelogReader.changelogMetadata(tp).state());
         assertNull(changelogReader.changelogMetadata(tp).endOffset());
 
-        // once the retry budget (task.timeout.ms) is exhausted the group most likely genuinely has no committed
-        // offset (e.g. a brand-new group), so fall back to 0
+        // once the retry budget (task.timeout.ms) is exhausted, fall back to 0
         time.sleep(config.getLong(StreamsConfig.TASK_TIMEOUT_MS_CONFIG) + 1);
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
         assertEquals(0L, (long) changelogReader.changelogMetadata(tp).endOffset());
     }
 
     @Test
-    public void shouldRecoverToRealCommittedOffsetWhenTransientlyMissingBeforeTimeout() {
-        // KAFKA-20416: the case the fix exists for — a source-topic changelog's committed offset is missing on
-        // the first pass (transient coordinator unavailability) and the real offset appears on the next pass,
-        // before task.timeout.ms elapses. The ceiling must resolve to min(endOffset, committedOffset), not 0.
+    public void shouldRecoverWipedSourceChangelogToRealCommittedOffsetWhenTransientlyMissingBeforeTimeout() {
+        // KAFKA-20416: the case the fix exists for — after a wipe the committed offset is missing on the first
+        // pass (transient coordinator unavailability) and the real offset appears before task.timeout.ms elapses.
+        // The ceiling must recover to min(endOffset, committedOffset), not fall to 0.
+        final AtomicReference<Map<TopicPartition, OffsetAndMetadata>> committed = new AtomicReference<>();
+        final TaskId taskId = new TaskId(0, 0);
+        final Task mockTask = mock(Task.class);
+        final StoreChangelogReader changelogReader = setupWipedSourceChangelog(committed, taskId, mockTask);
+
+        // first pass after the wipe: missing → retried, left uninitialized (not truncated to 0)
+        committed.set(committedOf(null));
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(StoreChangelogReader.ChangelogState.REGISTERED, changelogReader.changelogMetadata(tp).state());
+        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+
+        // second pass, still within task.timeout.ms: the real committed offset recovers the ceiling to
+        // min(endOffset=20, committedOffset=10) rather than falling back to 0
+        committed.set(committedOf(10L));
+        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
+        assertEquals(10L, (long) changelogReader.changelogMetadata(tp).endOffset());
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> committedOf(final Long offset) {
+        final Map<TopicPartition, OffsetAndMetadata> map = new HashMap<>();
+        map.put(tp, offset == null ? null : new OffsetAndMetadata(offset));
+        return map;
+    }
+
+    // Drives a source changelog through an initial restore (so it is remembered as "previously restored"), then
+    // simulates an EOS corruption wipe by unregistering and re-registering it. The returned reader is positioned
+    // so the next restore() exercises the wiped-store missing-committed-offset path; the caller controls the
+    // committed-offset response via the supplied holder.
+    private StoreChangelogReader setupWipedSourceChangelog(final AtomicReference<Map<TopicPartition, OffsetAndMetadata>> committed,
+                                                           final TaskId taskId,
+                                                           final Task mockTask) {
         setupStateManagerMock(ACTIVE);
         setupStoreMetadata();
         setupStore();
-
-        final TaskId taskId = new TaskId(0, 0);
-        final Task mockTask = mock(Task.class);
-
         when(stateManager.changelogAsSource(tp)).thenReturn(true);
         when(storeMetadata.offset()).thenReturn(5L);
         when(stateManager.taskId()).thenReturn(taskId);
 
         final String groupId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-        final Map<TopicPartition, OffsetAndMetadata> missingCommitted = new HashMap<>();
-        missingCommitted.put(tp, null);
-        final AtomicBoolean firstCall = new AtomicBoolean(true);
         final MockAdminClient adminClient = new MockAdminClient() {
             @Override
             public synchronized ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final Map<String, ListConsumerGroupOffsetsSpec> groupSpecs, final ListConsumerGroupOffsetsOptions options) {
-                // first pass: no committed offset (transiently missing); later passes: the real committed offset
-                final Map<TopicPartition, OffsetAndMetadata> offsets = firstCall.compareAndSet(true, false)
-                    ? missingCommitted
-                    : Collections.singletonMap(tp, new OffsetAndMetadata(10L));
-                return AdminClientTestUtils.listConsumerGroupOffsetsResult(Collections.singletonMap(groupId, offsets));
+                return AdminClientTestUtils.listConsumerGroupOffsetsResult(Collections.singletonMap(groupId, committed.get()));
             }
         };
         adminClient.updateEndOffsets(Collections.singletonMap(tp, 20L));
@@ -1055,17 +1092,16 @@ public class StoreChangelogReaderTest {
         final StoreChangelogReader changelogReader =
             new StoreChangelogReader(time, config, logContext, adminClient, consumer, callback, standbyListener);
 
+        // initial restore with a real committed offset → changelog begins restoring and is remembered
+        committed.set(committedOf(10L));
         changelogReader.register(tp, stateManager);
-
-        // first pass: missing → retried, left uninitialized (not truncated to 0)
         changelogReader.restore(Collections.singletonMap(taskId, mockTask));
-        assertEquals(StoreChangelogReader.ChangelogState.REGISTERED, changelogReader.changelogMetadata(tp).state());
-        assertNull(changelogReader.changelogMetadata(tp).endOffset());
+        assertEquals(StoreChangelogReader.ChangelogState.RESTORING, changelogReader.changelogMetadata(tp).state());
 
-        // second pass, still well within task.timeout.ms: the real committed offset recovers the ceiling to
-        // min(endOffset=20, committedOffset=10) rather than falling back to 0
-        changelogReader.restore(Collections.singletonMap(taskId, mockTask));
-        assertEquals(10L, (long) changelogReader.changelogMetadata(tp).endOffset());
+        // simulate the corruption wipe: the store is discarded and the changelog re-registered fresh
+        changelogReader.unregister(Collections.singleton(tp));
+        changelogReader.register(tp, stateManager);
+        return changelogReader;
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Under EOS, a source-topic-backed KTable store can be silently emptied by
a double race during a broker rolling restart:

1. An `AddOffsetsToTxn` timeout raises `TaskCorruptedException`, so the
task is closed dirty and its state store is wiped.
2. On the re-restore, `StoreChangelogReader` fetches the group's
committed offset to compute the restore ceiling min(endOffset,
committedOffset). A resigning/unavailable coordinator can transiently
answer -1/NONE ("no committed offset"), which was coerced to 0 → ceiling
0 → the wiped store is declared fully restored while empty, returning
null for keys that exist in the topic.

The trouble is that -1 is also the legitimate answer for a brand-new
group, where 0 is correct — so we can't just retry every missing offset
(that would stall every fresh source-table startup).

The fix is to distinguish the two cases by whether the changelog has
restored before in this process. Fresh changelog → take 0 immediately
(unchanged fast path); a previously-restored (i.e. wiped) changelog →
treat a missing committed offset as possibly-transient and retry it,
bounded by task.timeout.ms, before falling back to 0.

[System test run
passes](https://confluent-open-source-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/trunk/2026-09-02--001.d1cffc46-a556-4b57-b41b-31207080c13f--1788381749--bbejeck--KAFKA-20416-source-changelog-committed-offset-retry--a890bc62ad/report.html)

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>
