### PR TITLE
MINOR: Remove stale flaky annotation for resolved KAFKA-15914

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/OffsetsApiIntegrationTest.java
@@ -330,7 +330,6 @@ public class OffsetsApiIntegrationTest {
         alterAndVerifySinkConnectorOffsets(baseSinkConnectorConfigs(), connect.kafka());
     }
 
-    @Flaky("KAFKA-15914")
     @Test
     public void testAlterSinkConnectorOffsetsOverriddenConsumerGroupId() throws Exception {
         Map<String, String> connectorConfigs = baseSinkConnectorConfigs();


### PR DESCRIPTION
[KAFKA-15914](https://issues.apache.org/jira/browse/KAFKA-15914) was resolved as Fixed on 2025-12-10, after `testAlterSinkConnectorOffsetsOverriddenConsumerGroupId` had been passing consistently on trunk for 90 days, but its `Flaky` annotation was never removed.

`Flaky` is meta-annotated with JUnit's `Tag("flaky")`, and `KafkaPostDiscoveryFilter` deselects tagged tests unless `kafka.test.run.flaky` is set. The test is therefore excluded from the default test run and only executes in the separate `(flaky)` CI job, which runs with 3 retries. Removing the annotation puts it back under the regular test run.

Testing:

- With the annotation in place, the default build fails with `No tests found for given includes` for this test, confirming the annotation is what keeps it out of the default run.
- With it removed, the test is selected and passed 5 consecutive local runs of `:connect:runtime:test` (about 14s each, `tests="1" skipped="0" failures="0"`).

Reviewers: Ken Huang <s7133700@gmail.com>
