### PR TITLE
KAFKA-21025: StreamsGroupHeartbeatRequest must drop warmup tasks for v0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 
+import java.util.List;
+
 public class StreamsGroupHeartbeatRequest extends AbstractRequest {
 
     /**
@@ -49,6 +51,16 @@ public class StreamsGroupHeartbeatRequest extends AbstractRequest {
                 // TaskOffsets/TaskEndOffsets are only supported by brokers supporting v1+ request versions
                 data.setTaskOffsets(null);
                 data.setTaskEndOffsets(null);
+                // A v0 coordinator rejects a heartbeat that reports an owned warm-up task, so a member that
+                // holds one after downgrading to v0 must report none. Unlike the two fields above, null is
+                // not a safe unconditional value here: it means "unchanged", but a v0 coordinator separately
+                // requires the three owned-task lists to be all null or all non-null, and active/standby tasks stay
+                // null on the very same heartbeats where warmup tasks would. So this only clears the list when it is
+                // non-null, i.e. only on a heartbeat that is (re-)sending the assignment this round -- the same
+                // heartbeats where active/standby tasks are non-null too.
+                if (data.warmupTasks() != null) {
+                    data.setWarmupTasks(List.of());
+                }
             }
             return new StreamsGroupHeartbeatRequest(data, version);
         }

--- a/clients/src/test/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StreamsGroupHeartbeatRequestTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StreamsGroupHeartbeatRequestTest {
 
@@ -39,6 +40,17 @@ public class StreamsGroupHeartbeatRequestTest {
                 .setSubtopologyId("sub")
                 .setPartition(0)
                 .setOffset(100L)));
+    }
+
+    private static StreamsGroupHeartbeatRequestData dataWithOwnedWarmupTask() {
+        return new StreamsGroupHeartbeatRequestData()
+            .setGroupId("group")
+            .setMemberId("member")
+            .setActiveTasks(List.of())
+            .setStandbyTasks(List.of())
+            .setWarmupTasks(List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
+                .setSubtopologyId("sub")
+                .setPartitions(List.of(0))));
     }
 
     @Test
@@ -61,5 +73,42 @@ public class StreamsGroupHeartbeatRequestTest {
         assertEquals(42L, request.data().taskOffsets().get(0).offset());
         assertEquals(1, request.data().taskEndOffsets().size());
         assertEquals(100L, request.data().taskEndOffsets().get(0).offset());
+    }
+
+    @Test
+    public void testBuildClearsOwnedWarmupTasksForVersion0() {
+        StreamsGroupHeartbeatRequest request = new StreamsGroupHeartbeatRequest.Builder(dataWithOwnedWarmupTask())
+            .build((short) 0);
+
+        // Empty, not null: a v0 coordinator separately requires the three owned-task lists to be either all
+        // null or all non-null, and this fixture reports active/standby tasks alongside the warm-up task.
+        assertTrue(request.data().warmupTasks().isEmpty());
+    }
+
+    @Test
+    public void testBuildKeepsOwnedWarmupTasksForVersion1() {
+        StreamsGroupHeartbeatRequest request = new StreamsGroupHeartbeatRequest.Builder(dataWithOwnedWarmupTask())
+            .build((short) 1);
+
+        assertEquals(1, request.data().warmupTasks().size());
+        assertEquals("sub", request.data().warmupTasks().get(0).subtopologyId());
+    }
+
+    @Test
+    public void testBuildDoesNotReportOwnedWarmupTasksWhenAssignmentIsNotBeingReported() {
+        // On the common steady-state heartbeat, active/standby/warmup tasks are all left null to mean
+        // "unchanged since the last heartbeat" -- including when a warm-up task is running, since nothing
+        // about it changed either. Forcing warmupTasks non-null here, while active/standby stay null, is
+        // exactly what a v0 coordinator rejects ("if one task-type is non-null, all must be non-null"), so
+        // it must be left alone rather than cleared to an empty list.
+        StreamsGroupHeartbeatRequest request = new StreamsGroupHeartbeatRequest.Builder(
+            new StreamsGroupHeartbeatRequestData()
+                .setGroupId("group")
+                .setMemberId("member")
+        ).build((short) 0);
+
+        assertNull(request.data().activeTasks());
+        assertNull(request.data().standbyTasks());
+        assertNull(request.data().warmupTasks());
     }
 }


### PR DESCRIPTION
Older brokers (4.2/4.3) except the warmup-task field to be null or
empty. If a client connects to a newer broker which support warmup
tasks, and got warmup tasks assigned, and the broker is downgraded
afterwards, the client must not report its assigned warmup tasks on the
v0 request to the older brokers.

Reviewers: Lucas Brutschy <lbrutschy@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
