### PR TITLE
KAFKA-20665: Add a lag-driven assignment refiner for testing

### DIFF
--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupMetadataManagerTest.java
@@ -144,6 +144,7 @@ import org.apache.kafka.coordinator.group.modern.share.ShareGroup.InitMapValue;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupBuilder;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupConfig;
 import org.apache.kafka.coordinator.group.modern.share.ShareGroupMember;
+import org.apache.kafka.coordinator.group.streams.LagDrivenAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
 import org.apache.kafka.coordinator.group.streams.MockAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.MockTaskAssignor;
@@ -234,6 +235,7 @@ import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext
 import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_CLIENT_ID;
 import static org.apache.kafka.coordinator.group.GroupMetadataManagerTestContext.DEFAULT_PROCESS_ID;
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.getDefaultAssignmentConfigs;
+import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.mkResponseTasks;
 import static org.apache.kafka.coordinator.group.StreamsGroupTestUtil.streamsTopicFixture;
 import static org.apache.kafka.coordinator.group.Utils.computeGroupHash;
 import static org.apache.kafka.coordinator.group.Utils.computeTopicHash;
@@ -19419,6 +19421,155 @@ public class GroupMetadataManagerTest {
             group.getMemberOrThrow(memberId).assignedTasks()
         );
         assertEquals(Map.of(memberId, targetAssignment), group.refinedAssignment(group.assignmentEpoch()));
+    }
+
+    @Test
+    public void testStreamsGroupWarmsUpAStatefulTaskBeforeHandingItOver() {
+        String groupId = "fooup";
+        String memberA = Uuid.randomUuid().toString();
+        String memberB = Uuid.randomUuid().toString();
+        String subtopology1 = "subtopology1";
+        Uuid fooTopicId = Uuid.randomUuid();
+        Uuid changelogTopicId = Uuid.randomUuid();
+
+        // A stateful subtopology: its tasks have state to restore, so they are the ones that get warmed up.
+        Topology topology = new Topology().setSubtopologies(List.of(
+            new Subtopology()
+                .setSubtopologyId(subtopology1)
+                .setSourceTopics(List.of("foo"))
+                .setStateChangelogTopics(List.of(
+                    new StreamsGroupHeartbeatRequestData.TopicInfo().setName("changelog")))
+        ));
+        CoordinatorMetadataImage metadataImage = new MetadataImageBuilder()
+            .addTopic(fooTopicId, "foo", 2)
+            .addTopic(changelogTopicId, "changelog", 2)
+            .buildCoordinatorMetadataImage();
+        long groupMetadataHash = computeGroupHash(Map.of(
+            "foo", computeTopicHash("foo", metadataImage),
+            "changelog", computeTopicHash("changelog", metadataImage)
+        ));
+
+        // The assignor decides 0_1 belongs on memberB, which holds no state for it.
+        MockTaskAssignor assignor = new MockTaskAssignor("sticky");
+        assignor.prepareGroupAssignment(Map.of(
+            memberA, mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 0)),
+            memberB, mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 1))
+        ));
+
+        GroupMetadataManagerTestContext context = new GroupMetadataManagerTestContext.Builder()
+            .withStreamsGroupTaskAssignors(List.of(assignor))
+            .withStreamsGroupAssignmentRefiner(new LagDrivenAssignmentRefiner())
+            .withMetadataImage(metadataImage)
+            .withStreamsGroup(new StreamsGroupBuilder(groupId, 10)
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberA)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .setProcessId("processA")
+                    .setAssignedTasks(mkTasksTupleWithCommonEpoch(TaskRole.ACTIVE, 10,
+                        TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1)))
+                    .build())
+                .withMember(streamsGroupMemberBuilderWithDefaults(memberB)
+                    .setMemberEpoch(10)
+                    .setPreviousMemberEpoch(10)
+                    .setProcessId("processB")
+                    .build())
+                .withTopology(StreamsTopology.fromHeartbeatRequest(topology))
+                .withTargetAssignment(memberA, mkTasksTuple(TaskRole.ACTIVE,
+                    TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1)))
+                .withTargetAssignment(memberB, TasksTuple.EMPTY)
+                .withTargetAssignmentEpoch(10)
+                .withMetadataHash(groupMetadataHash)
+                .withValidatedTopologyEpoch(0)
+                .withLastAssignmentConfigs(getDefaultAssignmentConfigs()))
+            .build();
+
+        // Changing an assignment configuration is the cheapest way to make the coordinator run the assignor, which
+        // hands back the target assignment prepared above.
+        Properties groupConfig = new Properties();
+        groupConfig.setProperty(GroupConfig.STREAMS_NUM_STANDBY_REPLICAS_CONFIG, "1");
+        context.updateGroupConfig(groupId, groupConfig);
+
+        // Step 1: memberB is told to warm 0_1 up rather than to run it. memberA keeps running it in the meantime.
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> plant =
+            context.streamsGroupHeartbeat(streamsGroupWarmupHeartbeat(groupId, memberB, "processB", 10, List.of(), null));
+        assertEquals(mkResponseTasks(subtopology1, 1), plant.response().data().warmupTasks());
+        assertEquals(List.of(), plant.response().data().activeTasks());
+
+        StreamsGroup group = context.groupMetadataManager.streamsGroup(groupId);
+        assertEquals(11, group.groupEpoch());
+        assertEquals(
+            mkTasksTuple(TaskRole.ACTIVE, TaskAssignmentTestUtil.mkTasks(subtopology1, 0, 1)),
+            group.refinedAssignment(group.assignmentEpoch()).get(memberA)
+        );
+
+        // Step 2: memberA reconciles to the new epoch, keeping both tasks, which settles the group.
+        context.streamsGroupHeartbeat(
+            streamsGroupWarmupHeartbeat(groupId, memberA, "processA", 10, List.of(0, 1), null));
+        assertEquals(StreamsGroupState.STABLE, group.state());
+
+        // Step 3: memberB reports that its warm-up has caught up, so the next refinement step stops withholding 0_1 and
+        // memberA is asked to revoke it. memberB cannot have it yet.
+        context.streamsGroupHeartbeat(
+            streamsGroupWarmupHeartbeat(groupId, memberB, "processB", 11, List.of(), 0L));
+        assertEquals(12, group.groupEpoch());
+        // memberB still cannot run the task: memberA has to release it first. It keeps the warm-up in the meantime
+        // rather than giving it up while it waits, so the restored state is still there to recycle when the active task
+        // is granted.
+        assertEquals(Map.of(), group.getMemberOrThrow(memberB).assignedTasks().activeTasksWithEpochs());
+        assertEquals(
+            Map.of(subtopology1, Set.of(1)),
+            group.getMemberOrThrow(memberB).assignedTasks().warmupTasks()
+        );
+
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> revoke = context.streamsGroupHeartbeat(
+            streamsGroupWarmupHeartbeat(groupId, memberA, "processA", 11, List.of(0, 1), null));
+        assertEquals(mkResponseTasks(subtopology1, 0), revoke.response().data().activeTasks());
+
+        // memberA acknowledges the revocation by reporting that it now only owns 0_0.
+        context.streamsGroupHeartbeat(
+            streamsGroupWarmupHeartbeat(groupId, memberA, "processA", 11, List.of(0), null));
+
+        // Step 4: with 0_1 released, memberB takes it over as an active task and its warm-up is promoted in place --
+        // the warm-up is gone from the assignment rather than revoked and restored a second time.
+        CoordinatorResult<StreamsGroupHeartbeatResult, CoordinatorRecord> promote = context.streamsGroupHeartbeat(
+            streamsGroupWarmupHeartbeat(groupId, memberB, "processB", 12, List.of(), 0L));
+        assertEquals(mkResponseTasks(subtopology1, 1), promote.response().data().activeTasks());
+        assertEquals(
+            Set.of(1),
+            group.getMemberOrThrow(memberB).assignedTasks().activeTasksWithEpochs().get(subtopology1).keySet()
+        );
+        assertEquals(Map.of(), group.getMemberOrThrow(memberB).assignedTasks().warmupTasks());
+    }
+
+    private StreamsGroupHeartbeatRequestData streamsGroupWarmupHeartbeat(
+        String groupId,
+        String memberId,
+        String processId,
+        int memberEpoch,
+        List<Integer> ownedActiveTasks,
+        Long warmupTaskLag
+    ) {
+        StreamsGroupHeartbeatRequestData request = new StreamsGroupHeartbeatRequestData()
+            .setGroupId(groupId)
+            .setMemberId(memberId)
+            .setMemberEpoch(memberEpoch)
+            .setProcessId(processId)
+            .setRebalanceTimeoutMs(1500)
+            .setActiveTasks(ownedActiveTasks.isEmpty()
+                ? List.of()
+                : List.of(new StreamsGroupHeartbeatRequestData.TaskIds()
+                    .setSubtopologyId("subtopology1")
+                    .setPartitions(ownedActiveTasks)))
+            .setStandbyTasks(List.of())
+            .setWarmupTasks(List.of());
+        if (warmupTaskLag != null) {
+            request
+                .setTaskOffsets(List.of(new StreamsGroupHeartbeatRequestData.TaskOffset()
+                    .setSubtopologyId("subtopology1").setPartition(1).setOffset(1000L)))
+                .setTaskEndOffsets(List.of(new StreamsGroupHeartbeatRequestData.TaskOffset()
+                    .setSubtopologyId("subtopology1").setPartition(1).setOffset(1000L + warmupTaskLag)));
+        }
+        return request;
     }
 
     /**

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/LagDrivenAssignmentRefinerTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/LagDrivenAssignmentRefinerTest.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredInternalTopic;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.TaskRole;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasks;
+import static org.apache.kafka.coordinator.group.streams.TaskAssignmentTestUtil.mkTasksTuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LagDrivenAssignmentRefinerTest {
+
+    private static final String STATEFUL = "stateful-subtopology";
+    private static final String STATELESS = "stateless-subtopology";
+    private static final long ACCEPTABLE_RECOVERY_LAG = 100L;
+
+    private final LagDrivenAssignmentRefiner refiner = new LagDrivenAssignmentRefiner();
+
+    private static SortedMap<String, ConfiguredSubtopology> subtopologies() {
+        final SortedMap<String, ConfiguredSubtopology> subtopologies = new TreeMap<>();
+        subtopologies.put(STATEFUL, new ConfiguredSubtopology(
+            4,
+            Set.of("input"),
+            Map.of(),
+            Set.of(),
+            Map.of("changelog", new ConfiguredInternalTopic("changelog", 4, Optional.empty(), Map.of()))
+        ));
+        subtopologies.put(STATELESS, new ConfiguredSubtopology(4, Set.of("input"), Map.of(), Set.of(), Map.of()));
+        return subtopologies;
+    }
+
+    private static StreamsGroupMember member(
+        final String memberId,
+        final String processId,
+        final TasksTuple assignedTasks
+    ) {
+        return member(memberId, processId, assignedTasks, TasksTuple.EMPTY);
+    }
+
+    private static StreamsGroupMember member(
+        final String memberId,
+        final String processId,
+        final TasksTuple assignedTasks,
+        final TasksTuple tasksPendingRevocation
+    ) {
+        return new StreamsGroupMember.Builder(memberId)
+            .setMemberEpoch(1)
+            .setPreviousMemberEpoch(1)
+            .setState(MemberState.STABLE)
+            .setProcessId(processId)
+            .setRebalanceTimeoutMs(1500)
+            .setTopologyEpoch(0)
+            .setClientTags(Map.of())
+            .setAssignedTasks(withEpochs(assignedTasks))
+            .setTasksPendingRevocation(withEpochs(tasksPendingRevocation))
+            .build();
+    }
+
+    private static TasksTupleWithEpochs withEpochs(final TasksTuple tasks) {
+        final Map<String, Map<Integer, Integer>> activeWithEpochs = new HashMap<>();
+        tasks.activeTasks().forEach((subtopologyId, partitionIds) -> {
+            final Map<Integer, Integer> byPartition = new HashMap<>();
+            partitionIds.forEach(partitionId -> byPartition.put(partitionId, 1));
+            activeWithEpochs.put(subtopologyId, byPartition);
+        });
+        return new TasksTupleWithEpochs(activeWithEpochs, tasks.standbyTasks(), tasks.warmupTasks());
+    }
+
+    private static Map<String, MemberTaskOffsets> lag(
+        final String memberId,
+        final String subtopologyId,
+        final int partitionId,
+        final long lag
+    ) {
+        return Map.of(memberId, new MemberTaskOffsets(
+            Map.of(subtopologyId, Map.of(partitionId, 1000L)),
+            Map.of(subtopologyId, Map.of(partitionId, 1000L + lag))
+        ));
+    }
+
+    private Map<String, TasksTuple> refine(
+        final Map<String, StreamsGroupMember> members,
+        final Map<String, TasksTuple> targetAssignment,
+        final Map<String, MemberTaskOffsets> taskOffsets,
+        final int numWarmupReplicas
+    ) {
+        return refiner.refine(
+            members, targetAssignment, taskOffsets, subtopologies(), numWarmupReplicas, ACCEPTABLE_RECOVERY_LAG);
+    }
+
+    @Test
+    public void shouldHandBackTargetAssignmentWhenNoTaskMoves() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 2, 3))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", targetAssignment.get("memberA")),
+            "memberB", member("memberB", "processB", targetAssignment.get("memberB"))
+        );
+
+        // Nothing to derive, so the target assignment is handed back as-is rather than copied.
+        assertSame(targetAssignment, refine(members, targetAssignment, Map.of(), 2));
+    }
+
+    @Test
+    public void shouldWithholdMovingTaskAndWarmItUpOnItsNewOwner() {
+        // The assignor moved 0_2 from memberA to memberB, which holds no state for it.
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 2, 3))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 3)))
+        );
+
+        assertEquals(
+            Map.of(
+                "memberA", new TasksTuple(mkTasksMap(0, 1, 2), Map.of(), Map.of()),
+                "memberB", new TasksTuple(mkTasksMap(3), Map.of(), mkTasksMap(2))
+            ),
+            refine(members, targetAssignment, Map.of(), 2)
+        );
+    }
+
+    @Test
+    public void shouldLetStatelessTaskMoveWithoutWarmingUp() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 1))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATELESS, 0, 1))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+
+        assertSame(targetAssignment, refine(members, targetAssignment, Map.of(), 2));
+    }
+
+    @Test
+    public void shouldLetTaskMoveWithinTheSameProcessWithoutWarmingUp() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "sharedProcess", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1))),
+            "memberB", member("memberB", "sharedProcess", TasksTuple.EMPTY)
+        );
+
+        // The state directory is already on the process, so there is nothing to restore over the network.
+        assertSame(targetAssignment, refine(members, targetAssignment, Map.of(), 2));
+    }
+
+    @Test
+    public void shouldLetTaskMoveOnceItsNewOwnerHasCaughtUp() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)))
+        );
+
+        assertSame(
+            targetAssignment,
+            refine(members, targetAssignment, lag("memberB", STATEFUL, 1, ACCEPTABLE_RECOVERY_LAG), 2)
+        );
+    }
+
+    @Test
+    public void shouldKeepWithholdingWhileItsNewOwnerIsStillBehind() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)))
+        );
+
+        final Map<String, TasksTuple> refined = refine(
+            members, targetAssignment, lag("memberB", STATEFUL, 1, ACCEPTABLE_RECOVERY_LAG + 1), 2);
+
+        assertEquals(mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)), refined.get("memberA"));
+        assertEquals(mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)), refined.get("memberB"));
+    }
+
+    @Test
+    public void shouldNotTreatUnknownOrCappedOffsetsAsCaughtUp() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1))),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)))
+        );
+
+        // An end-offset capped at MAX_VALUE would otherwise compute a hugely negative lag and read as caught up.
+        final Map<String, MemberTaskOffsets> cappedEndOffset = Map.of("memberB", new MemberTaskOffsets(
+            Map.of(STATEFUL, Map.of(1, 1000L)),
+            Map.of(STATEFUL, Map.of(1, Long.MAX_VALUE))
+        ));
+        assertEquals(
+            mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)),
+            refine(members, targetAssignment, cappedEndOffset, 2).get("memberB")
+        );
+
+        // Only the end offset reported, so the lag is unknown.
+        final Map<String, MemberTaskOffsets> endOffsetOnly = Map.of("memberB", new MemberTaskOffsets(
+            Map.of(),
+            Map.of(STATEFUL, Map.of(1, 1000L))
+        ));
+        assertEquals(
+            mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)),
+            refine(members, targetAssignment, endOffsetOnly, 2).get("memberB")
+        );
+    }
+
+    @Test
+    public void shouldNotWithholdTaskWhoseHandOverAlreadyStarted() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0)),
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+        );
+        // memberA was already told to revoke 0_1, so it is no longer running it -- taking it back now would leave the
+        // task with nobody.
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member(
+                "memberA",
+                "processA",
+                mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1)),
+                mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 1))
+            ),
+            "memberB", member("memberB", "processB", mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 1)))
+        );
+
+        assertSame(targetAssignment, refine(members, targetAssignment, Map.of(), 2));
+    }
+
+    @Test
+    public void shouldWithholdEveryMigrationButOnlyWarmUpAsManyAsTheBudgetAllows() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", TasksTuple.EMPTY,
+            "memberB", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2))
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+
+        final Map<String, TasksTuple> refined = refine(members, targetAssignment, Map.of(), 1);
+
+        // All three stay with memberA; only one of them is being warmed up, and which one is stable across steps
+        // because migrations are ordered by task ID.
+        assertEquals(mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2)), refined.get("memberA"));
+        assertEquals(mkTasksTuple(TaskRole.WARMUP, mkTasks(STATEFUL, 0)), refined.get("memberB"));
+    }
+
+    @Test
+    public void shouldDeferStandbyThatWouldCollideWithARoleHandedOutByTheRefinement() {
+        // The target assignment moves 0_1 to memberB and gives memberA the standby for it. Both of those cannot hold
+        // while memberA keeps running 0_1 as active and memberB warms it up.
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", new TasksTuple(mkTasksMap(0), mkTasksMap(1), Map.of()),
+            "memberB", new TasksTuple(mkTasksMap(1), mkTasksMap(0), Map.of())
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+
+        final Map<String, TasksTuple> refined = refine(members, targetAssignment, Map.of(), 2);
+
+        // memberA keeps 0_1 active, so its standby for it is dropped; memberB warms 0_1 up, so its standby for 0_0 --
+        // which its process does not otherwise hold -- survives.
+        assertEquals(new TasksTuple(mkTasksMap(0, 1), Map.of(), Map.of()), refined.get("memberA"));
+        assertEquals(new TasksTuple(Map.of(), mkTasksMap(0), mkTasksMap(1)), refined.get("memberB"));
+    }
+
+    @Test
+    public void shouldNeverLoseAnActiveTaskOrGiveOneMemberTwoRolesForIt() {
+        final Map<String, TasksTuple> targetAssignment = Map.of(
+            "memberA", new TasksTuple(mkTasksMap(0, 1), mkTasksMap(2, 3), Map.of()),
+            "memberB", new TasksTuple(mkTasksMap(2, 3), mkTasksMap(0, 1), Map.of())
+        );
+        final Map<String, StreamsGroupMember> members = Map.of(
+            "memberA", member("memberA", "processA", mkTasksTuple(TaskRole.ACTIVE, mkTasks(STATEFUL, 0, 1, 2, 3))),
+            "memberB", member("memberB", "processB", TasksTuple.EMPTY)
+        );
+
+        final Map<String, TasksTuple> refined = refine(members, targetAssignment, Map.of(), 4);
+
+        assertTrue(AssignmentRefiner.preservesActiveTaskCount(targetAssignment, refined));
+        refined.forEach((memberId, tasks) -> {
+            assertTrue(disjoint(tasks.activeTasks(), tasks.standbyTasks()), memberId + " active/standby overlap");
+            assertTrue(disjoint(tasks.activeTasks(), tasks.warmupTasks()), memberId + " active/warm-up overlap");
+            assertTrue(disjoint(tasks.standbyTasks(), tasks.warmupTasks()), memberId + " standby/warm-up overlap");
+        });
+    }
+
+    private static boolean disjoint(
+        final Map<String, Set<Integer>> left,
+        final Map<String, Set<Integer>> right
+    ) {
+        return left.entrySet().stream().noneMatch(entry ->
+            right.getOrDefault(entry.getKey(), Set.of()).stream().anyMatch(entry.getValue()::contains));
+    }
+
+    private static Map<String, Set<Integer>> mkTasksMap(final Integer... partitionIds) {
+        return Map.of(STATEFUL, Set.of(partitionIds));
+    }
+}

--- a/group-coordinator/src/testFixtures/java/org/apache/kafka/coordinator/group/streams/LagDrivenAssignmentRefiner.java
+++ b/group-coordinator/src/testFixtures/java/org/apache/kafka/coordinator/group/streams/LagDrivenAssignmentRefiner.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams;
+
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * An {@link AssignmentRefiner} that holds a stateful task back with its current owner until the member the task is
+ * moving to has restored it as a warm-up task. Intended for testing and as a starting point for a real refiner; it is
+ * deliberately simple and is <b>not</b> the derivation the broker will ship.
+ * <p>
+ * For every stateful task whose target owner is not its current owner, it withholds the task from the target owner --
+ * leaving it active where it already runs -- and hands the target owner a warm-up task instead, so it can restore the
+ * state in the background. Once that member reports a lag within {@code acceptableRecoveryLag} for the task, the
+ * withholding stops and the target assignment flows through, at which point the reconciler revokes the task from the
+ * old owner and promotes the warm-up in place. {@code numWarmupReplicas} caps how many warm-up tasks it hands out at a
+ * time; a migration that does not get a slot is still held back, it just runs without anybody warming it up.
+ * <p>
+ * Three cases are deliberately let through without warming up, because there is no state to restore first:
+ * <ul>
+ *     <li>a stateless task, which has no state,</li>
+ *     <li>a task moving between two members of the same process, whose state directory is already local, and</li>
+ *     <li>a task whose old owner was already told to revoke it, which means the hand-over is under way and reversing it
+ *     would strand the task with nobody running it.</li>
+ * </ul>
+ * <p>
+ * What it does <em>not</em> do, and a real refiner has to: rank migrations by how loaded their source and destination
+ * are (this one orders them by task ID, so the warm-up budget is handed out in an arbitrary but stable order),
+ * carry warm-up slots over from the previous step rather than re-deriving them, convert an existing standby into a
+ * warm-up instead of spending a slot on a new one, and defer standbys that cannot be placed yet instead of dropping
+ * them. It also assumes the assignor is sticky enough not to keep re-targeting a task while it is being warmed up.
+ */
+public class LagDrivenAssignmentRefiner implements AssignmentRefiner {
+
+    @Override
+    public Map<String, TasksTuple> refine(
+        Map<String, StreamsGroupMember> members,
+        Map<String, TasksTuple> targetAssignment,
+        Map<String, MemberTaskOffsets> taskOffsets,
+        SortedMap<String, ConfiguredSubtopology> subtopologies,
+        int numWarmupReplicas,
+        long acceptableRecoveryLag
+    ) {
+        final Map<Task, String> currentActiveOwner = new HashMap<>();
+        final Set<Task> handOverStarted = new HashSet<>();
+        for (StreamsGroupMember member : members.values()) {
+            member.assignedTasks().activeTasksWithEpochs().forEach((subtopologyId, tasksByPartition) ->
+                tasksByPartition.keySet().forEach(partitionId ->
+                    currentActiveOwner.put(new Task(subtopologyId, partitionId), member.memberId())));
+            // The old owner has been told to give the task up, so the target owner is only waiting for it to be
+            // released. Withholding the task again now would take it away from a member that has already stopped
+            // running it.
+            member.tasksPendingRevocation().activeTasksWithEpochs().forEach((subtopologyId, tasksByPartition) ->
+                tasksByPartition.keySet().forEach(partitionId ->
+                    handOverStarted.add(new Task(subtopologyId, partitionId))));
+        }
+
+        final Map<Task, String> targetActiveOwner = new TreeMap<>();
+        targetAssignment.forEach((memberId, tasks) ->
+            tasks.activeTasks().forEach((subtopologyId, partitionIds) ->
+                partitionIds.forEach(partitionId ->
+                    targetActiveOwner.put(new Task(subtopologyId, partitionId), memberId))));
+
+        final List<Task> withheld = new ArrayList<>();
+        for (Map.Entry<Task, String> entry : targetActiveOwner.entrySet()) {
+            final Task task = entry.getKey();
+            final String targetOwner = entry.getValue();
+            final String currentOwner = currentActiveOwner.get(task);
+
+            if (currentOwner == null || currentOwner.equals(targetOwner)) {
+                // Nobody is running the task yet, or it is already where it belongs.
+                continue;
+            }
+            if (!isStateful(subtopologies, task) || handOverStarted.contains(task)) {
+                continue;
+            }
+            if (processOf(members, currentOwner).equals(processOf(members, targetOwner))) {
+                // The state directory is on the process already, so there is nothing to restore over the network.
+                continue;
+            }
+            if (isCaughtUp(taskOffsets.get(targetOwner), task, acceptableRecoveryLag)) {
+                continue;
+            }
+            withheld.add(task);
+        }
+
+        if (withheld.isEmpty()) {
+            return targetAssignment;
+        }
+
+        final Map<String, PatchedTasks> patches = new HashMap<>();
+        int warmupsHandedOut = 0;
+        for (Task task : withheld) {
+            final String targetOwner = targetActiveOwner.get(task);
+            final String currentOwner = currentActiveOwner.get(task);
+
+            patchFor(patches, targetAssignment, targetOwner).removeActive(task);
+            patchFor(patches, targetAssignment, currentOwner).addActive(task);
+
+            if (warmupsHandedOut < numWarmupReplicas) {
+                patchFor(patches, targetAssignment, targetOwner).addWarmup(task);
+                warmupsHandedOut++;
+            }
+
+            // A process must never run the same task twice, so any standby the target assignment placed on either of
+            // the two processes involved has to give way to the roles we just handed out. Dropping a standby is always
+            // safe -- a later step can place it again once the migration is done.
+            final Set<String> processes = Set.of(processOf(members, currentOwner), processOf(members, targetOwner));
+            members.values().stream()
+                .filter(member -> processes.contains(member.processId()))
+                .forEach(member -> patchFor(patches, targetAssignment, member.memberId()).removeStandby(task));
+        }
+
+        final Map<String, TasksTuple> refinedAssignment = new HashMap<>(targetAssignment);
+        patches.forEach((memberId, patch) -> refinedAssignment.put(memberId, patch.toTasksTuple()));
+        return refinedAssignment;
+    }
+
+    private static boolean isStateful(
+        final SortedMap<String, ConfiguredSubtopology> subtopologies,
+        final Task task
+    ) {
+        final ConfiguredSubtopology subtopology = subtopologies.get(task.subtopologyId());
+        return subtopology != null && !subtopology.stateChangelogTopics().isEmpty();
+    }
+
+    private static String processOf(final Map<String, StreamsGroupMember> members, final String memberId) {
+        final StreamsGroupMember member = members.get(memberId);
+        // A member that the target assignment mentions but the group does not know cannot share a process with anyone,
+        // so give it one nothing else matches.
+        return member == null ? memberId : member.processId();
+    }
+
+    /**
+     * Whether the member has restored the task closely enough to take it over as an active task. Mirrors the client's
+     * own predicate, so that both ends agree on when a warm-up task is caught up: an offset that is unknown or capped
+     * at {@link Long#MAX_VALUE} counts as not caught up.
+     */
+    private static boolean isCaughtUp(
+        final MemberTaskOffsets memberTaskOffsets,
+        final Task task,
+        final long acceptableRecoveryLag
+    ) {
+        if (memberTaskOffsets == null) {
+            return false;
+        }
+        final Long offset = offsetOf(memberTaskOffsets.taskOffsets(), task);
+        final Long endOffset = offsetOf(memberTaskOffsets.taskEndOffsets(), task);
+        if (offset == null || offset == Long.MAX_VALUE || endOffset == null || endOffset == Long.MAX_VALUE) {
+            return false;
+        }
+        return endOffset - offset <= acceptableRecoveryLag;
+    }
+
+    private static Long offsetOf(final Map<String, Map<Integer, Long>> offsets, final Task task) {
+        final Map<Integer, Long> byPartition = offsets.get(task.subtopologyId());
+        return byPartition == null ? null : byPartition.get(task.partitionId());
+    }
+
+    private static PatchedTasks patchFor(
+        final Map<String, PatchedTasks> patches,
+        final Map<String, TasksTuple> targetAssignment,
+        final String memberId
+    ) {
+        return patches.computeIfAbsent(
+            memberId,
+            __ -> new PatchedTasks(targetAssignment.getOrDefault(memberId, TasksTuple.EMPTY))
+        );
+    }
+
+    private record Task(String subtopologyId, int partitionId) implements Comparable<Task> {
+        @Override
+        public int compareTo(final Task other) {
+            final int bySubtopology = subtopologyId.compareTo(other.subtopologyId);
+            return bySubtopology != 0 ? bySubtopology : Integer.compare(partitionId, other.partitionId);
+        }
+    }
+
+    /**
+     * A member's slice of the target assignment, made mutable so that a refinement step can patch it. Empty subtopology
+     * entries are pruned as tasks are removed, so that a patched slice that ends up holding the same tasks as the
+     * target assignment also compares equal to it -- an equal-but-differently-shaped map would read as a change and
+     * make the coordinator mint a refinement step on every heartbeat.
+     */
+    private static final class PatchedTasks {
+        private final Map<String, Set<Integer>> activeTasks;
+        private final Map<String, Set<Integer>> standbyTasks;
+        private final Map<String, Set<Integer>> warmupTasks;
+
+        private PatchedTasks(final TasksTuple tasks) {
+            this.activeTasks = mutableCopy(tasks.activeTasks());
+            this.standbyTasks = mutableCopy(tasks.standbyTasks());
+            this.warmupTasks = mutableCopy(tasks.warmupTasks());
+        }
+
+        private static Map<String, Set<Integer>> mutableCopy(final Map<String, Set<Integer>> tasks) {
+            final Map<String, Set<Integer>> copy = new HashMap<>();
+            tasks.forEach((subtopologyId, partitionIds) -> copy.put(subtopologyId, new HashSet<>(partitionIds)));
+            return copy;
+        }
+
+        private void addActive(final Task task) {
+            add(activeTasks, task);
+        }
+
+        private void removeActive(final Task task) {
+            remove(activeTasks, task);
+        }
+
+        private void addWarmup(final Task task) {
+            add(warmupTasks, task);
+        }
+
+        private void removeStandby(final Task task) {
+            remove(standbyTasks, task);
+        }
+
+        private static void add(final Map<String, Set<Integer>> tasks, final Task task) {
+            tasks.computeIfAbsent(task.subtopologyId(), __ -> new HashSet<>()).add(task.partitionId());
+        }
+
+        private static void remove(final Map<String, Set<Integer>> tasks, final Task task) {
+            final Set<Integer> partitionIds = tasks.get(task.subtopologyId());
+            if (partitionIds != null && partitionIds.remove(task.partitionId()) && partitionIds.isEmpty()) {
+                tasks.remove(task.subtopologyId());
+            }
+        }
+
+        private TasksTuple toTasksTuple() {
+            return new TasksTuple(activeTasks, standbyTasks, warmupTasks);
+        }
+    }
+}


### PR DESCRIPTION
Adds LagDrivenAssignmentRefiner, the first actual implementation of the
refiner seam: it withholds a stateful task from its new owner and hands
that member a warm-up task instead, until the member reports a lag
within acceptable.recovery.lag. Tasks with no state to restore first --
stateless ones, ones moving within a process, and ones whose hand-over
already started -- are let through directly, and num.warmup.replicas
caps how many warm-ups are handed out at a time.

It lives in main, next to MockAssignor, so that a streams integration
test can load it: streams:integration-tests depends on group-coordinator
main only. Its javadoc spells out what it does not do that a real
refiner has to, so it is not mistaken for the derivation we intend to
ship.

Coverage is the derivation in isolation plus one round trip through the
coordinator -- plant, catch up, revoke, in-place promotion -- which is
what shows the refiner, the seam and the reconciler compose.
