### PR TITLE
MINOR: Replace Collections and Arrays factory methods with Java 9+ equivalents in tools

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConfigCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConfigCommand.java
@@ -67,7 +67,6 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -465,7 +464,7 @@ public class ConfigCommand {
 
         Collection<ClientQuotaAlteration.Op> alterOps = Stream.concat(addOps.stream(), deleteOps.stream()).toList();
 
-        adminClient.alterClientQuotas(Collections.singleton(new ClientQuotaAlteration(entity, alterOps)), alterOptions)
+        adminClient.alterClientQuotas(Set.of(new ClientQuotaAlteration(entity, alterOps)), alterOptions)
                 .all().get(60, TimeUnit.SECONDS);
     }
 
@@ -672,7 +671,7 @@ public class ConfigCommand {
                 ? Optional.empty()
                 : Optional.of(context.dynamicConfigSource());
         DescribeConfigsOptions describeOptions = new DescribeConfigsOptions().includeSynonyms(includeSynonyms);
-        Map<ConfigResource, Config> configs = adminClient.describeConfigs(Collections.singleton(context.configResource()), describeOptions)
+        Map<ConfigResource, Config> configs = adminClient.describeConfigs(Set.of(context.configResource()), describeOptions)
                     .all().get(30, TimeUnit.SECONDS);
 
         return filterAndSortEntries(configs.get(context.configResource()), configSourceFilter);

--- a/tools/src/test/java/org/apache/kafka/tools/ConnectInternalTopicsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConnectInternalTopicsTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -139,7 +138,7 @@ public class ConnectInternalTopicsTest {
     @ClusterTest(brokers = 3)
     void testCreateMissingTopics(ClusterInstance cluster) throws Exception {
         try (var adminClient = cluster.admin()) {
-            adminClient.createTopics(Collections.singleton(
+            adminClient.createTopics(Set.of(
                     new NewTopic(CONFIG_TOPIC_NAME, 1, (short) 1)
                             .configs(Map.of("retention.ms", "1000"))
             ));
@@ -181,20 +180,20 @@ public class ConnectInternalTopicsTest {
 
     private static void assertTopicConfig(Admin admin, String topic, String configKey, String expectedValue) throws Exception {
         var resource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-        var describeResult = admin.describeConfigs(Collections.singleton(resource));
+        var describeResult = admin.describeConfigs(Set.of(resource));
         var config = describeResult.all().get().get(resource);
         assertEquals(expectedValue, config.get(configKey).value());
     }
 
     private static void assertTopicReplicationFactor(Admin admin, String topic, short expectedReplicationFactor) throws Exception {
-        var topicDescriptionFuture = admin.describeTopics(Collections.singleton(topic)).topicNameValues().get(topic);
+        var topicDescriptionFuture = admin.describeTopics(Set.of(topic)).topicNameValues().get(topic);
         var topicDescription = topicDescriptionFuture.get();
         var replicationFactor = topicDescription.partitions().get(0).replicas().size();
         assertEquals(expectedReplicationFactor, replicationFactor);
     }
 
     private static void assertTopicPartitions(Admin admin, String topic, int expectedPartitions) throws Exception {
-        var topicDescriptionFuture = admin.describeTopics(Collections.singleton(topic)).topicNameValues().get(topic);
+        var topicDescriptionFuture = admin.describeTopics(Set.of(topic)).topicNameValues().get(topic);
         var topicDescription = topicDescriptionFuture.get();
         var partitions = topicDescription.partitions().size();
         assertEquals(expectedPartitions, partitions);

--- a/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
@@ -799,14 +799,14 @@ public class DumpLogSegmentsTest {
 
         // Get all the batches
         String output = runDumpLogSegments(new String[] {"--files", logFilePath});
-        ListIterator<String> lines = Arrays.asList(output.split("\n")).listIterator();
+        ListIterator<String> lines = List.of(output.split("\n")).listIterator();
 
         // Get total bytes of the partial batches
         int partialBatchesBytes = readPartialBatchesBytes(lines, partialBatches);
 
         // Request only the partial batches by bytes
         String partialOutput = runDumpLogSegments(new String[] {"--max-bytes", Integer.toString(partialBatchesBytes), "--files", logFilePath});
-        ListIterator<String> partialLines = Arrays.asList(partialOutput.split("\n")).listIterator();
+        ListIterator<String> partialLines = List.of(partialOutput.split("\n")).listIterator();
 
         // Count the total of partial batches limited by bytes
         int partialBatchesCount = countBatches(partialLines);
@@ -1140,7 +1140,7 @@ public class DumpLogSegmentsTest {
         FetchDataInfo logReadInfo = log.read(0, Integer.MAX_VALUE, FetchIsolation.LOG_END, true);
 
         String output = runDumpLogSegments(new String[] {"--deep-iteration", "--files", logFilePath});
-        ListIterator<String> lines = Arrays.asList(output.split("\n")).listIterator();
+        ListIterator<String> lines = List.of(output.split("\n")).listIterator();
 
         for (RecordBatch batch : logReadInfo.records.batches()) {
             Optional<String> parsedBatchOpt = readBatchMetadata(lines);

--- a/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DumpLogSegmentsTest.java
@@ -114,7 +114,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -314,7 +313,7 @@ public class DumpLogSegmentsTest {
 
         Map<String, Map<Long, Long>> offsetMismatches = new HashMap<>();
         DumpLogSegments.dumpIndex(new File(indexFilePath), false, true, offsetMismatches, Integer.MAX_VALUE);
-        assertEquals(Collections.emptyMap(), offsetMismatches);
+        assertEquals(Map.of(), offsetMismatches);
     }
 
     @Test
@@ -325,9 +324,9 @@ public class DumpLogSegmentsTest {
 
         DumpLogSegments.TimeIndexDumpErrors errors = new DumpLogSegments.TimeIndexDumpErrors();
         DumpLogSegments.dumpTimeIndex(new File(timeIndexFilePath), false, true, errors);
-        assertEquals(Collections.emptyMap(), errors.misMatchesForTimeIndexFilesMap);
-        assertEquals(Collections.emptyMap(), errors.outOfOrderTimestamp);
-        assertEquals(Collections.emptyMap(), errors.shallowOffsetNotFound);
+        assertEquals(Map.of(), errors.misMatchesForTimeIndexFilesMap);
+        assertEquals(Map.of(), errors.outOfOrderTimestamp);
+        assertEquals(Map.of(), errors.shallowOffsetNotFound);
     }
 
     @Test
@@ -862,7 +861,7 @@ public class DumpLogSegmentsTest {
                         .setProtocol("range")
                         .setLeader("member")
                         .setGeneration(10)
-                        .setMembers(Collections.singletonList(
+                        .setMembers(List.of(
                             new GroupMetadataValue.MemberMetadata()
                                 .setMemberId("member")
                                 .setClientId("client")
@@ -872,13 +871,13 @@ public class DumpLogSegmentsTest {
                                 .setRebalanceTimeout(1000)
                                 .setSubscription(Utils.toArray(ConsumerProtocol.serializeSubscription(
                                     new Subscription(
-                                        Collections.singletonList("foo"),
+                                        List.of("foo"),
                                         null,
-                                        Collections.singletonList(new TopicPartition("foo", 0)),
+                                        List.of(new TopicPartition("foo", 0)),
                                         0,
                                         Optional.of("rack")))))
                                 .setAssignment(Utils.toArray(ConsumerProtocol.serializeAssignment(
-                                    new Assignment(Collections.singletonList(new TopicPartition("foo", 0))))))
+                                    new Assignment(List.of(new TopicPartition("foo", 0))))))
                         )),
                     GroupMetadataValue.HIGHEST_SUPPORTED_VERSION
                 )
@@ -903,7 +902,7 @@ public class DumpLogSegmentsTest {
                         .setProtocol("range")
                         .setLeader("member")
                         .setGeneration(10)
-                        .setMembers(Collections.singletonList(
+                        .setMembers(List.of(
                             new GroupMetadataValue.MemberMetadata()
                                 .setMemberId("member")
                                 .setClientId("client")

--- a/tools/src/test/java/org/apache/kafka/tools/streams/StreamsGroupCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/streams/StreamsGroupCommandTest.java
@@ -518,7 +518,7 @@ public class StreamsGroupCommandTest {
         Admin adminClient = mock(KafkaAdminClient.class);
         String groupId = "foo-group";
         String topic = "topic";
-        List<String> args = new ArrayList<>(Arrays.asList("--bootstrap-server", "localhost:9092", "--group", groupId, "--reset-offsets", "--input-topic", "topic:3", "--to-latest"));
+        List<String> args = new ArrayList<>(List.of("--bootstrap-server", "localhost:9092", "--group", groupId, "--reset-offsets", "--input-topic", "topic:3", "--to-latest"));
         
         when(adminClient.describeStreamsGroups(eq(List.of(groupId)), any(DescribeStreamsGroupsOptions.class)))
             .thenReturn(describeStreamsResult(groupId, GroupState.DEAD));


### PR DESCRIPTION
Replaces legacy collection factory methods in the tools module with
their Set.of() / List.of() / Map.of() equivalents, and removes imports
that become unused

Changed
- ConfigCommand — Collections.singleton() → Set.of()
- ConnectInternalTopicsTest — Collections.singleton() → Set.of()
- DumpLogSegmentsTest — Collections.singletonList() → List.of(),
Collections.emptyMap() → Map.of(), Arrays.asList() → List.of()
- StreamsGroupCommandTest — Arrays.asList() → List.of()

Deliberately left unchanged
- ConfigCommandTest#511 and ShareGroupCommandTest#265 —
Collections.singletonMap() with a null value; Map.of() rejects nulls
- Collections.nCopies(), disjoint(), emptyIterator() — no
List.of()-style equivalent
- java.util.Arrays imports in the two files above — still needed for
Arrays.stream()

Verification
- ./gradlew tools:test --tests ConfigCommandTest --tests
DumpLogSegmentsTest --tests ConnectInternalTopicsTest --tests
StreamsGroupCommandTest
- ./gradlew tools:checkstyleMain tools:checkstyleTest
tools:spotlessCheck

Reviewers: Ken Huang <s7133700@gmail.com>
