### PR TITLE
KAFKA-20815: Remove unnecessary jline deps and bump to latest 3.x

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -312,7 +312,9 @@ BSD 2-Clause
 ---------------------------------------
 BSD 3-Clause
 
-- jline-3.30.4, see: licenses/jline-BSD-3-clause
+- jline-native-3.30.15, see: licenses/jline-BSD-3-clause
+- jline-reader-3.30.15, see: licenses/jline-BSD-3-clause
+- jline-terminal-3.30.15, see: licenses/jline-BSD-3-clause
 - protobuf-java-3.25.5, see: licenses/protobuf-java-BSD-3-clause
 - jakarta.activation-2.0.1, see: licenses/jakarta-BSD-3-clause
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ versions += [
   jetty: "12.0.37",
   jersey: "3.1.10",
   jgit: "7.5.0.202512021534-r",
-  jline: "3.30.4",
+  jline: "3.30.15",
   jmh: "1.37",
   hamcrest: "3.0",
   scalaLogging: "3.9.6",
@@ -183,7 +183,7 @@ libs += [
   jgitSshApache: "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit",
   // GPG support for JGit based on BouncyCastle (commit signing)
   jgitGpgBc: "org.eclipse.jgit:org.eclipse.jgit.gpg.bc:$versions.jgit",
-  jline: "org.jline:jline:$versions.jline",
+  jline: "org.jline:jline-reader:$versions.jline",
   jmhCore: "org.openjdk.jmh:jmh-core:$versions.jmh",
   jmhCoreBenchmarks: "org.openjdk.jmh:jmh-core-benchmarks:$versions.jmh",
   jmhGeneratorAnnProcess: "org.openjdk.jmh:jmh-generator-annprocess:$versions.jmh",


### PR DESCRIPTION
backport
https://github.com/apache/kafka/commit/8cce6e5b085aee30dd685960491007bfb206aa2b
to 4.3

Reviewers: PoAn Yang <payang@apache.org>
