### PR TITLE
MINOR: Fix GroupsCommand exiting from execute() and masking failures

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/GroupsCommand.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -57,8 +56,7 @@ public class GroupsCommand {
             execute(args);
             return 0;
         } catch (Throwable e) {
-            System.err.println(e.getMessage());
-            System.err.println(Utils.stackTrace(e));
+            printException(e);
             return 1;
         }
     }
@@ -69,20 +67,13 @@ public class GroupsCommand {
         Properties config = opts.commandConfig();
         config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.bootstrapServer());
 
-        int exitCode = 0;
         try (GroupsService service = new GroupsService(config)) {
             if (opts.hasListOption()) {
                 service.listGroups(opts);
             }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
-            printException(Objects.requireNonNullElse(cause, e));
-            exitCode = 1;
-        } catch (Throwable t) {
-            printException(t);
-            exitCode = 1;
-        } finally {
-            Exit.exit(exitCode);
+            throw cause instanceof Exception ? (Exception) cause : e;
         }
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GroupsCommandTest.java
@@ -52,6 +52,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +64,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -461,6 +465,43 @@ public class GroupsCommandTest {
         assertThrows(ExecutionException.class, () -> service.listGroups(new GroupsCommand.GroupsCommandOptions(
             new String[]{"--bootstrap-server", bootstrapServer, "--list"}
         )));
+    }
+
+    @Test
+    public void testMainNoExitReturnsNonZeroWithoutExitingOnFailure() throws Exception {
+        // An invalid security protocol makes the admin client creation inside execute() fail.
+        // mainNoExit must report that failure by returning a non-zero code, and execute() must
+        // not terminate the JVM itself.
+        assertEquals(1, GroupsCommand.mainNoExit(
+            "--bootstrap-server", bootstrapServer,
+            "--list",
+            "--command-config", invalidCommandConfig()));
+        assertFalse(exitProcedure.hasExited(), "execute() must not call Exit.exit(); only main() may exit");
+    }
+
+    @Test
+    public void testExecuteDoesNotExitOnFailure() throws Exception {
+        // execute() propagates the failure to its caller rather than terminating the JVM.
+        String commandConfig = invalidCommandConfig();
+        assertThrows(Exception.class, () -> GroupsCommand.execute(
+            "--bootstrap-server", bootstrapServer,
+            "--list",
+            "--command-config", commandConfig));
+        assertFalse(exitProcedure.hasExited(), "execute() must not call Exit.exit(); only main() may exit");
+    }
+
+    /**
+     * Writes a command config file which parses correctly but makes the admin client creation
+     * inside {@link GroupsCommand#execute} fail.
+     */
+    private String invalidCommandConfig() throws IOException {
+        Properties props = new Properties();
+        props.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "NOT_A_PROTOCOL");
+        File file = TestUtils.tempFile();
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            props.store(out, "invalid admin client config");
+        }
+        return file.getAbsolutePath();
     }
 
     @SuppressWarnings({"NPathComplexity", "CyclomaticComplexity"})


### PR DESCRIPTION
## Problem

`GroupsCommand.execute()` calls `Exit.exit(exitCode)` in a `finally` block:

```java
} catch (Throwable t) {
    printException(t);
    exitCode = 1;
} finally {
    Exit.exit(exitCode);
}
```

Every other tool in this package (`FeatureCommand`, `DelegationTokenCommand`, `MetadataQuorumCommand`, `GetOffsetShell`, `LeaderElectionCommand`) calls `Exit.exit` exactly once, from `main()`, and lets `execute()` propagate failures to `mainNoExit()`. `GroupsCommand` is the only one that exits from inside `execute()`.

This has two consequences:

- **Under the default exit procedure**, `execute()` terminates the JVM directly, so `mainNoExit()` never returns and the exit code it computes is unreachable.
- **Under a replaced exit procedure** (for example the `MockExitProcedure` used in tests, which records the code and returns), `execute()` swallows the exception and returns normally, so `mainNoExit()` reports **success with code 0 for a command that actually failed**.

The `mainNoExit()` / `execute()` pair exists precisely so the exit code can be observed without killing the JVM, and this defeats it.

## Fix

Remove the `Exit.exit()` call and the `exitCode` bookkeeping from `execute()`, letting the exception propagate so `mainNoExit()` maps it to a non-zero code and `main()` passes that to `Exit.exit()`. `ExecutionException` is still unwrapped so the underlying cause is what surfaces to the user. Error reporting in `mainNoExit()` now goes through `printException()` so the message and stack trace are rendered the same way on both paths.

## Testing

Added two tests covering `mainNoExit()` and `execute()` on the failure path, which had no coverage — the gap that let this go unnoticed. Both fail before this change:

```
testMainNoExitReturnsNonZeroWithoutExitingOnFailure() :: expected: <1> but was: <0>
testExecuteDoesNotExitOnFailure() :: Expected java.lang.Exception to be thrown, but nothing was thrown.
```

and pass after it. The tests make the admin client creation *inside* the `try` block fail (via an invalid security protocol in the command config), so they exercise the affected path rather than failing earlier during option parsing.

`GroupsCommandTest` passes in full (33 tests), as do `LeaderElectionCommandTest` and `TopicCommandTest` (146 tests total). `./gradlew :tools:checkstyleMain :tools:checkstyleTest :tools:spotlessCheck` is clean.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvbzZgK7eH63iPswf8tV6v