### PR TITLE
KAFKA-20880: Remove TaskId from StandbyUpdateListener callback

### DIFF
--- a/docs/streams/developer-guide/running-app.md
+++ b/docs/streams/developer-guide/running-app.md
@@ -141,8 +141,8 @@ Example:
 
         @Override
         public void onBatchLoaded(TopicPartition topicPartition, String storeName,
-                                  TaskId taskId, long batchEndOffset,
-                                  long batchSize, long currentEndOffset) {
+                                  long batchEndOffset, long batchSize,
+                                  long currentEndOffset) {
             // track standby replication progress
         }
 
@@ -224,5 +224,4 @@ If your Kafka Streams application does crash or fail, it will first enter the `P
   * [Documentation](/documentation)
   * [Kafka Streams](/documentation/streams)
   * [Developer Guide](/documentation/streams/developer-guide/)
-
 

--- a/docs/streams/upgrade-guide.md
+++ b/docs/streams/upgrade-guide.md
@@ -67,6 +67,10 @@ Since 2.6.0 release, Kafka Streams depends on a RocksDB version that requires Ma
 
 ## Streams API changes in 4.5.0
 
+`StandbyUpdateListener#onBatchLoaded` no longer requires a `TaskId`. The overload that accepts a `TaskId` is
+deprecated, and users should implement the new overload instead. Existing implementations continue to receive
+callbacks through the deprecated overload.
+
 Upgraded RocksDB dependency to version 10.10.1(from 10.1.3). RocksDB deleted `max_write_buffer_number_to_maintain` from its `ColumnFamilyOptions` in version 10.5.0. To preserve compatibility, Kafka Streams' `Options#setMaxWriteBufferNumberToMaintain` and `Options#maxWriteBufferNumberToMaintain` are now deprecated no-ops: the setter has no effect, and the getter always returns `0` regardless of what was previously configured. This change is primarily relevant to users implementing custom RocksDB configurations via `rocksdb.config.setter`. Users relying on `max_write_buffer_number_to_maintain` should remove that configuration, since it no longer has any effect. Consult the [RocksDB changelog](https://github.com/facebook/rocksdb/blob/main/HISTORY.md) between 10.1.3 and 10.10.1 for other changes.
 
 ## Streams API changes in 4.4.0

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1446,7 +1446,7 @@ public class IntegrationTestUtils {
         }
 
         @Override
-        public void onBatchLoaded(final TopicPartition topicPartition, final String storeName, final TaskId taskId, final long batchEndOffset, final long batchSize, final long currentEndOffset) {
+        public void onBatchLoaded(final TopicPartition topicPartition, final String storeName, final long batchEndOffset, final long batchSize, final long currentEndOffset) {
 
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StandbyUpdateListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StandbyUpdateListener.java
@@ -108,6 +108,29 @@ public interface StandbyUpdateListener {
      *        the changelog {@link TopicPartition} for this task
      * @param storeName
      *        the name of the store being loaded
+     * @param batchEndOffset
+     *        the changelog end offset (inclusive) of the batch that was just loaded
+     * @param batchSize
+     *        the total number of records in the batch that was just loaded
+     * @param currentEndOffset
+     *        the current end offset of the changelog topic partition
+     */
+    default void onBatchLoaded(
+        final TopicPartition topicPartition,
+        final String storeName,
+        final long batchEndOffset,
+        final long batchSize,
+        final long currentEndOffset
+    ) {
+    }
+
+    /**
+     * Method called after loading a batch of records.
+     *
+     * @param topicPartition
+     *        the changelog {@link TopicPartition} for this task
+     * @param storeName
+     *        the name of the store being loaded
      * @param taskId
      *        the {@link TaskId} of the task that owns the store being loaded
      * @param batchEndOffset
@@ -116,15 +139,19 @@ public interface StandbyUpdateListener {
      *        the total number of records in the batch that was just loaded
      * @param currentEndOffset
      *        the current end offset of the changelog topic partition
+     * @deprecated Since 4.5. Use {@link #onBatchLoaded(TopicPartition, String, long, long, long)} instead.
      */
-    void onBatchLoaded(
+    @Deprecated(since = "4.5")
+    default void onBatchLoaded(
         final TopicPartition topicPartition,
         final String storeName,
         final TaskId taskId,
         final long batchEndOffset,
         final long batchSize,
         final long currentEndOffset
-    );
+    ) {
+        onBatchLoaded(topicPartition, storeName, batchEndOffset, batchSize, currentEndOffset);
+    }
 
     /**
      * Method called when the corresponding standby or warm-up task stops being updated, for the provided reason.

--- a/streams/src/test/java/org/apache/kafka/test/MockStandbyUpdateListener.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockStandbyUpdateListener.java
@@ -18,7 +18,6 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.StandbyUpdateListener;
-import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +41,7 @@ public final class MockStandbyUpdateListener implements StandbyUpdateListener {
     }
 
     @Override
-    public void onBatchLoaded(TopicPartition topicPartition, String storeName, TaskId taskId, long batchEndOffset, long batchSize, long currentEndOffset) {
+    public void onBatchLoaded(TopicPartition topicPartition, String storeName, long batchEndOffset, long batchSize, long currentEndOffset) {
         storeNameCalledUpdate.put(UPDATE_BATCH, storeName);
     }
 


### PR DESCRIPTION
## Description

KAFKA-20880: This change resolves the inconsistency in the `StandbyUpdateListener` API by adding an `onBatchLoaded` overload without the `TaskId` parameter.

The existing overload is deprecated and delegates to the new method. This compatibility bridge allows existing implementations that override the deprecated overload to continue receiving callbacks, while new implementations can use the simplified overload. Kafka’s internal callback path remains unchanged during the compatibility window.

The Kafka Streams developer guide, upgrade guide, and test listener implementations are updated to use and document the new overload.

## Testing

Existing `StoreChangelogReaderTest` coverage exercises the compatibility bridge through `MockStandbyUpdateListener`.

Static validation:

```text
git diff --check
```

No behavior outside listener callback dispatch is changed.

Reviewers: Matthias J. Sax (@mjsax )