### PR TITLE
MINOR: Move ConsumerPerformance local state into consume

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConsumerPerformance.java
@@ -67,22 +67,13 @@ public class ConsumerPerformance {
             AtomicLong totalRecordsRead = new AtomicLong(0);
             AtomicLong totalBytesRead = new AtomicLong(0);
             AtomicLong joinTimeMs = new AtomicLong(0);
-            AtomicLong joinTimeMsInSingleRound = new AtomicLong(0);
 
             if (!options.hideHeader())
                 printHeader(options.showDetailedStats());
 
             try (Consumer<byte[], byte[]> consumer = consumerCreator.apply(options.props())) {
-                long bytesRead = 0L;
-                long recordsRead = 0L;
-                long lastBytesRead = 0L;
-                long lastRecordsRead = 0L;
-                long currentTimeMs = System.currentTimeMillis();
-                long joinStartMs = currentTimeMs;
-                long startMs = currentTimeMs;
-                consume(consumer, options, totalRecordsRead, totalBytesRead, joinTimeMs,
-                    bytesRead, recordsRead, lastBytesRead, lastRecordsRead,
-                    joinStartMs, joinTimeMsInSingleRound);
+                long startMs = System.currentTimeMillis();
+                consume(consumer, options, totalRecordsRead, totalBytesRead, joinTimeMs, startMs);
                 long endMs = System.currentTimeMillis();
 
                 // print final stats
@@ -128,19 +119,19 @@ public class ConsumerPerformance {
                                 AtomicLong totalRecordsRead,
                                 AtomicLong totalBytesRead,
                                 AtomicLong joinTimeMs,
-                                long bytesRead,
-                                long recordsRead,
-                                long lastBytesRead,
-                                long lastRecordsRead,
-                                long joinStartMs,
-                                AtomicLong joinTimeMsInSingleRound) {
+                                long startMs) {
+        long bytesRead = 0L;
+        long recordsRead = 0L;
+        long lastBytesRead = 0L;
+        long lastRecordsRead = 0L;
+        AtomicLong joinTimeMsInSingleRound = new AtomicLong(0);
         long numRecords = options.numRecords();
         long recordFetchTimeoutMs = options.recordFetchTimeoutMs();
         long reportingIntervalMs = options.reportingIntervalMs();
         boolean showDetailedStats = options.showDetailedStats();
         SimpleDateFormat dateFormat = options.dateFormat();
 
-        ConsumerPerfRebListener listener = new ConsumerPerfRebListener(joinTimeMs, joinStartMs, joinTimeMsInSingleRound);
+        ConsumerPerfRebListener listener = new ConsumerPerfRebListener(joinTimeMs, startMs, joinTimeMsInSingleRound);
         consumer.setRebalanceListener(listener);
         if (options.topic().isPresent()) {
             consumer.subscribe(options.topic().get());


### PR DESCRIPTION
This PR moves consumption-specific local state from `run` into
`consume`, where it is exclusively used.

The change:

- Reduces the `consume` parameter list.
- Keeps the consumption counters close to the consumption loop.
- Removes the redundant `joinStartMs` alias by reusing `startMs`.
- Preserves the existing consumption, rebalance timing, and reporting behavior.

This is a follow-up to:
https://github.com/apache/kafka/pull/13215#discussion_r3927390720

### Testing

- `./gradlew tools:test --tests org.apache.kafka.tools.ConsumerPerformanceTest`
- `./gradlew tools:spotlessCheck`

Reviewers: Uros (github:uros-b), Ken Huang <s7133700@gmail.com>
