### PR TITLE
KAFKA-20986: Speed up testDescribeConfigsNonexistent

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeConfigsTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/DescribeConfigsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.test.ClusterInstance;
+import org.apache.kafka.common.test.api.ClusterTest;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DescribeConfigsTest {
+
+    @ClusterTest
+    public void testDescribeConfigsNonexistent(ClusterInstance cluster) throws Exception {
+        try (Admin admin = cluster.admin()) {
+            // BROKER and BROKER_LOGGER requests are routed to the node named by the resource, so a nonexistent node id
+            // can only be reported as a timeout. Use a short timeout to avoid waiting for the default API timeout.
+            DescribeConfigsOptions shortTimeout = new DescribeConfigsOptions().timeoutMs(1000);
+
+            ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, "-1");
+            ExecutionException brokerException = assertThrows(ExecutionException.class,
+                () -> admin.describeConfigs(List.of(brokerResource), shortTimeout).all().get());
+            assertInstanceOf(TimeoutException.class, brokerException.getCause());
+
+            ConfigResource brokerLoggerResource = new ConfigResource(ConfigResource.Type.BROKER_LOGGER, "-1");
+            ExecutionException brokerLoggerException = assertThrows(ExecutionException.class,
+                () -> admin.describeConfigs(List.of(brokerLoggerResource), shortTimeout).all().get());
+            assertInstanceOf(TimeoutException.class, brokerLoggerException.getCause());
+
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, "none_topic");
+            ExecutionException topicException = assertThrows(ExecutionException.class,
+                () -> admin.describeConfigs(List.of(topicResource)).all().get());
+            assertInstanceOf(UnknownTopicOrPartitionException.class, topicException.getCause());
+
+            // a nonexistent group is not an error: the default group configs are returned
+            ConfigResource groupResource = new ConfigResource(ConfigResource.Type.GROUP, "none_group");
+            Config groupConfig = admin.describeConfigs(List.of(groupResource)).all().get().get(groupResource);
+            assertNotEquals(0, groupConfig.entries().size());
+        }
+    }
+}

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -830,35 +830,6 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   }
 
   @Test
-  def testDescribeConfigsNonexistent(): Unit = {
-    client = createAdminClient
-
-    val brokerException = assertThrows(classOf[ExecutionException], () => {
-      client.describeConfigs(util.List.of(new ConfigResource(ConfigResource.Type.BROKER, "-1"))).all().get()
-    })
-    assertInstanceOf(classOf[TimeoutException], brokerException.getCause)
-
-    val topicException = assertThrows(classOf[ExecutionException], () => {
-      client.describeConfigs(util.List.of(new ConfigResource(ConfigResource.Type.TOPIC, "none_topic"))).all().get()
-    })
-    assertInstanceOf(classOf[UnknownTopicOrPartitionException], topicException.getCause)
-
-    val brokerLoggerException = assertThrows(classOf[ExecutionException], () => {
-      client.describeConfigs(util.List.of(new ConfigResource(ConfigResource.Type.BROKER_LOGGER, "-1"))).all().get()
-    })
-    assertInstanceOf(classOf[TimeoutException], brokerLoggerException.getCause)
-  }
-
-  @Test
-  def testDescribeConfigsNonexistentForKraft(): Unit = {
-    client = createAdminClient
-
-    val groupResource = new ConfigResource(ConfigResource.Type.GROUP, "none_group")
-    val groupResult = client.describeConfigs(util.List.of(groupResource)).all().get().get(groupResource)
-    assertNotEquals(0, groupResult.entries().size())
-  }
-
-  @Test
   def testDescribeAndAlterConfigs(): Unit = {
     client = createAdminClient
 


### PR DESCRIPTION
Migrate `testDescribeConfigsNonexistent` from
`PlaintextAdminIntegrationTest` to a Java `ClusterTest`.

Use a one-second operation timeout when describing nonexistent broker
and broker logger resources. These requests can only complete by timing
out, so using the default 40-second API timeout made the original test
unnecessarily slow. The existing coverage for nonexistent topic and
group resources is preserved.

Speedup:
- Before: `PlaintextAdminIntegrationTest.testDescribeConfigsNonexistent`
— 1m 22s (two back-to-back 40s default timeouts)
- After: `DescribeConfigsTest` — 7s

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
