### PR TITLE
KAFKA-21031: Another busy loop happens while a heartbeat is in flight and the heartbeat timer is expired

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -86,7 +86,7 @@
 
     <!-- Clients tests -->
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer|CommitRequestManager)Test.java"/>
+              files="(Sender|Fetcher|FetchRequestManager|OffsetFetcher|KafkaConsumer|Metrics|RequestResponse|TransactionManager|KafkaAdminClient|Message|KafkaProducer|CommitRequestManager|ConsumerHeartbeatRequestManager)Test.java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(ConsumerCoordinator|KafkaConsumer|RequestResponse|Fetcher|FetchRequestManager|KafkaAdminClient|Message|KafkaProducer|NetworkClient|StreamsGroupHeartbeatRequestManager|CommitRequestManager)Test.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestState.java
@@ -29,6 +29,13 @@ import org.apache.kafka.common.utils.internals.LogContext;
 public class HeartbeatRequestState extends RequestState {
 
     /**
+     * Lower bound for the wait returned while a heartbeat is in flight. retry.backoff.ms and
+     * retry.backoff.max.ms both accept 0, and callers use this value as a poll timeout, so it must
+     * never be 0.
+     */
+    private static final long MIN_IN_FLIGHT_WAIT_MS = 1L;
+
+    /**
      * The heartbeat timer tracks the time since the last heartbeat was sent
      */
     private final Timer heartbeatTimer;
@@ -66,6 +73,17 @@ public class HeartbeatRequestState extends RequestState {
 
     public long timeToNextHeartbeatMs(final long currentTimeMs) {
         if (heartbeatTimer.isExpired()) {
+            if (requestInFlight()) {
+                // The timer can be expired while a request is in flight both for the first heartbeat (the
+                // interval is initialised to 0 and only learned from the first response) and for any later
+                // heartbeat whose response takes longer than the interval. No heartbeat can be sent until
+                // the in-flight one completes. The remaining backoff is measured from the last response and,
+                // with default settings, is already 0 here, which would busy-spin both the application and
+                // network threads. Wait the initial retry backoff (floored at 1 ms) instead of waiting forever: the network thread still has to notice a request timeout promptly
+                // (NetworkClient only checks timed-out requests after selector.poll returns, and
+                // ConsumerNetworkThread caps the poll at 5s), so it must come back and re-check.
+                return Math.max(MIN_IN_FLIGHT_WAIT_MS, exponentialBackoff.initialInterval());
+            }
             return remainingBackoffMs(currentTimeMs);
         }
         return heartbeatTimer.remainingMs();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerHeartbeatRequestManagerTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.BootstrapConfiguration;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.MetadataRecoveryStrategy;
+import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.SubscriptionPattern;
@@ -25,6 +29,7 @@ import org.apache.kafka.clients.consumer.internals.AbstractMembershipManager.Loc
 import org.apache.kafka.clients.consumer.internals.ConsumerHeartbeatRequestManager.HeartbeatState;
 import org.apache.kafka.clients.consumer.internals.events.BackgroundEventHandler;
 import org.apache.kafka.clients.consumer.internals.events.ErrorEvent;
+import org.apache.kafka.clients.consumer.internals.metrics.AsyncConsumerMetrics;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
@@ -32,6 +37,7 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.internals.UnsupportedProtocolFieldException;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
@@ -42,10 +48,12 @@ import org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest;
 import org.apache.kafka.common.requests.ConsumerGroupHeartbeatRequest.Builder;
 import org.apache.kafka.common.requests.ConsumerGroupHeartbeatResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.test.MockSelector;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -147,10 +155,14 @@ public class ConsumerHeartbeatRequestManagerTest
     }
 
     private void createHeartbeatRequestStateWithZeroHeartbeatInterval() {
+        createHeartbeatRequestStateWithHeartbeatInterval(0);
+    }
+
+    private void createHeartbeatRequestStateWithHeartbeatInterval(final long heartbeatIntervalMs) {
         this.heartbeatRequestState = spy(new HeartbeatRequestState(
                 logContext,
                 time,
-                0,
+                heartbeatIntervalMs,
                 DEFAULT_RETRY_BACKOFF_MS,
                 DEFAULT_RETRY_BACKOFF_MAX_MS,
                 DEFAULT_HEARTBEAT_JITTER_MS));
@@ -324,6 +336,348 @@ public class ConsumerHeartbeatRequestManagerTest
         assertTrue(result > 0,
             "maximumTimeToWait must be > 0 when the coordinator is unavailable to avoid a busy-spin; got " + result);
         assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, result);
+    }
+
+    /**
+     * A heartbeat request is in flight and the heartbeat timer is already expired. That happens both
+     * while the very first heartbeat is in flight, when the interval is still unknown (it is initialised
+     * to 0 and only learned from the first heartbeat response), and later on, when a response takes
+     * longer than the interval. In that window no heartbeat can be sent until the in-flight one
+     * completes, so both {@link NetworkClientDelegate.PollResult#timeUntilNextPollMs} and
+     * {@link AbstractHeartbeatRequestManager#maximumTimeToWait(long)} must return a positive delay;
+     * returning 0 busy-spins the consumer network thread and the application thread until the in-flight
+     * request completes, which can be as long as request.timeout.ms when the coordinator is unreachable.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {0, 5000})
+    public void testMaximumTimeToWaitWhileHeartbeatInFlightDoesNotSpin(final long heartbeatIntervalMs) {
+        createHeartbeatRequestStateWithHeartbeatInterval(heartbeatIntervalMs);
+        // The member keeps joining for both intervals, so the heartbeat below is sent without waiting for
+        // the interval and the total simulated time stays under max.poll.interval.ms.
+        when(membershipManager.state()).thenReturn(MemberState.JOINING);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        if (heartbeatIntervalMs > 0) {
+            // A non-zero interval is only known after a heartbeat response, which also arms the backoff.
+            heartbeatRequestState.onSuccessfulAttempt(time.milliseconds());
+        }
+
+        NetworkClientDelegate.PollResult firstResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, firstResult.unsentRequests.size(),
+            "A heartbeat should be sent as soon as the coordinator is known");
+
+        // Deliberately do not complete the request, so it stays in flight while the heartbeat timer expires.
+        time.sleep(heartbeatIntervalMs + 1);
+
+        NetworkClientDelegate.PollResult secondResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, secondResult.unsentRequests.size(),
+            "No heartbeat should be sent while another one is in flight");
+        assertTrue(secondResult.timeUntilNextPollMs > 0,
+            "timeUntilNextPollMs must be > 0 while a heartbeat is in flight to avoid a busy-spin; got "
+                + secondResult.timeUntilNextPollMs);
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, secondResult.timeUntilNextPollMs);
+
+        long result = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(result > 0,
+            "maximumTimeToWait must be > 0 while a heartbeat is in flight to avoid a busy-spin; got " + result);
+        // maximumTimeToWait is min(pollTimer.remainingMs() / 2, retry backoff), and half of the remaining
+        // max.poll.interval.ms is still larger than the backoff at this point.
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, result);
+    }
+
+    /**
+     * The "response slower than the interval" way of reaching the same window, driven end to end through the
+     * manager instead of by priming the request state directly. The member joins, learns its heartbeat interval
+     * from a real successful heartbeat response, becomes STABLE, and then sends its steady-state heartbeat when
+     * the interval elapses. That response never arrives, so the heartbeat timer expires again while the request
+     * is still in flight. This complements
+     * {@link #testMaximumTimeToWaitWhileHeartbeatInFlightDoesNotSpin(long)}, which constructs the request state
+     * with a known interval, by proving that the interval learned through
+     * {@code onResponse -> updateHeartbeatIntervalMs} lands the manager in exactly the same state: no heartbeat
+     * can be sent, and both {@link NetworkClientDelegate.PollResult#timeUntilNextPollMs} and
+     * {@link AbstractHeartbeatRequestManager#maximumTimeToWait(long)} must return a positive delay rather than
+     * busy-spinning the application and network threads.
+     */
+    @Test
+    public void testMaximumTimeToWaitWhenResponseIsSlowerThanIntervalDoesNotSpin() {
+        // The interval is unknown until the first heartbeat response, exactly as on a freshly created consumer.
+        createHeartbeatRequestStateWithZeroHeartbeatInterval();
+        when(membershipManager.state()).thenReturn(MemberState.JOINING);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+
+        NetworkClientDelegate.PollResult joinResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, joinResult.unsentRequests.size(),
+            "A heartbeat should be sent as soon as the coordinator is known");
+
+        // A real successful response teaches the manager the interval and clears the in-flight flag.
+        joinResult.unsentRequests.get(0).handler().onComplete(
+            createHeartbeatResponse(joinResult.unsentRequests.get(0), Errors.NONE, DEFAULT_HEARTBEAT_INTERVAL_MS));
+        assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, heartbeatRequestState.heartbeatIntervalMs(),
+            "The heartbeat interval should have been learned from the heartbeat response");
+
+        // The membership manager is a mock, so onHeartbeatSuccess does not move it; stub the joined member state.
+        when(membershipManager.state()).thenReturn(MemberState.STABLE);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(false);
+        when(membershipManager.shouldSkipHeartbeat()).thenReturn(false);
+
+        // The interval elapses, so the steady-state heartbeat is sent. Deliberately leave it in flight.
+        time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS);
+        NetworkClientDelegate.PollResult heartbeatResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, heartbeatResult.unsentRequests.size(),
+            "A heartbeat should be sent once the heartbeat interval has expired");
+
+        // The response is slower than the interval, so the heartbeat timer expires again while it is in flight.
+        time.sleep(DEFAULT_HEARTBEAT_INTERVAL_MS + 1);
+
+        NetworkClientDelegate.PollResult inFlightResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, inFlightResult.unsentRequests.size(),
+            "No heartbeat should be sent while another one is in flight");
+        assertTrue(inFlightResult.timeUntilNextPollMs > 0,
+            "timeUntilNextPollMs must be > 0 while a heartbeat is in flight to avoid a busy-spin; got "
+                + inFlightResult.timeUntilNextPollMs);
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, inFlightResult.timeUntilNextPollMs);
+
+        long result = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(result > 0,
+            "maximumTimeToWait must be > 0 while a heartbeat is in flight to avoid a busy-spin; got " + result);
+        // maximumTimeToWait is min(pollTimer.remainingMs() / 2, retry backoff), and half of the remaining
+        // max.poll.interval.ms is still larger than the backoff at this point.
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, result);
+    }
+
+    /**
+     * The same busy-spin, driven through a real {@link NetworkClient} on a {@link MockSelector} and a real
+     * {@link NetworkClientDelegate}, so that the heartbeat really is in flight rather than only marked as such.
+     * Both ways of reaching the "heartbeat timer expired while a request is in flight" window are covered:
+     * an interval of 0, which is the very first heartbeat (the interval is initialised to 0 and only learned
+     * from the first heartbeat response), and a known interval of 5000 ms whose response never arrives, so the
+     * timer expires while the request is still on the wire.
+     *
+     * <p>The loop mirrors {@link ConsumerNetworkThread#runOnce()}: the network client is polled for
+     * {@code min(MAX_POLL_TIMEOUT_MS, result.timeUntilNextPollMs)} and {@link MockSelector#poll(long)} advances
+     * {@link MockTime} by exactly that timeout. The manager's own return value therefore drives the clock, which
+     * turns "does it busy-spin?" into a count of iterations: with the fix every in-flight iteration advances the
+     * clock by the retry backoff, so a bounded number of iterations covers the whole request timeout. Without it
+     * the manager returns 0 and the clock stops moving, which is caught twice over: by the per-iteration assertion
+     * on the wait itself, and, should that ever be relaxed, by the iteration cap and the in-flight iteration count.
+     *
+     * <p>The heartbeat is never answered, so it is finally failed by the request timeout. The last phase asserts
+     * that the manager recovers from that: the failure clears the in-flight flag and the member, which is still
+     * JOINING, sends a second heartbeat.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {0, 5000})
+    public void testMaximumTimeToWaitDoesNotSpinWhileHeartbeatInFlightOnRealNetworkClient(final long heartbeatIntervalMs) throws Exception {
+        // The request must outlive the heartbeat timer, otherwise the "timer expired while a request is in flight"
+        // window would never exist for the non-zero interval. Keeping it just above the interval also keeps the
+        // simulated run short (it is all MockTime, so there is no wall-clock cost) and, more importantly, well
+        // below max.poll.interval.ms, so the poll timer never expires and turns the heartbeat into a leave request.
+        long requestTimeoutMs = heartbeatIntervalMs + 1000;
+
+        ConsumerConfig config = new ConsumerConfig(Map.of(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+            ConsumerConfig.GROUP_ID_CONFIG, DEFAULT_GROUP_ID,
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(DEFAULT_MAX_POLL_INTERVAL_MS),
+            ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(requestTimeoutMs),
+            ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, String.valueOf(DEFAULT_RETRY_BACKOFF_MS),
+            ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG, String.valueOf(DEFAULT_RETRY_BACKOFF_MAX_MS)
+        ));
+
+        ConsumerMetadata consumerMetadata = new ConsumerMetadata(config, subscriptions, logContext, new ClusterResourceListeners());
+        // Seed the metadata so that the client neither bootstraps nor sends a metadata request of its own,
+        // which would make the heartbeat impossible to single out among the in-flight requests.
+        consumerMetadata.updateWithCurrentRequestVersion(
+            RequestTestUtils.metadataUpdateWith(1, Map.of()), false, time.milliseconds());
+        Node coordinator = consumerMetadata.fetch().nodes().get(0);
+
+        MockSelector selector = new MockSelector(time);
+        NetworkClient networkClient = new NetworkClient(selector, consumerMetadata, "test-client",
+            Integer.MAX_VALUE, 50, 1000, 64 * 1024, 64 * 1024, (int) requestTimeoutMs, 1000, 5000,
+            time, false, new ApiVersions(), logContext,
+            MetadataRecoveryStrategy.NONE, BootstrapConfiguration.DISABLED, false);
+
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(coordinator));
+        createHeartbeatRequestStateWithHeartbeatInterval(heartbeatIntervalMs);
+        if (heartbeatIntervalMs > 0) {
+            // A non-zero interval is only known after a heartbeat response, which also arms the backoff.
+            heartbeatRequestState.onSuccessfulAttempt(time.milliseconds());
+        }
+        // The member keeps joining for both intervals, so the heartbeat below is sent without waiting for the
+        // interval and the total simulated time stays under max.poll.interval.ms. A real HeartbeatState is
+        // needed so the request can be serialized.
+        mockJoiningMemberData(null);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        ConsumerHeartbeatRequestManager realHeartbeatRequestManager = createHeartbeatRequestManager(
+            coordinatorRequestManager,
+            membershipManager,
+            new HeartbeatState(subscriptions, membershipManager, DEFAULT_MAX_POLL_INTERVAL_MS),
+            heartbeatRequestState,
+            backgroundEventHandler);
+
+        try (NetworkClientDelegate networkClientDelegate = new NetworkClientDelegate(time, config, logContext, networkClient,
+                consumerMetadata, mock(BackgroundEventHandler.class), false, mock(AsyncConsumerMetrics.class))
+        ) {
+            // The request timeout is measured from the moment the request is enqueued on the delegate, which is
+            // also the moment the heartbeat timer is re-armed, so both deadlines are anchored on createdAtMs.
+            long createdAtMs = -1L;
+            long deadlineMs = Long.MAX_VALUE;
+            long sentAtMs = -1L;
+            long timedOutAtMs = -1L;
+            long resentAtMs = -1L;
+            boolean requestInFlightAtTimeout = true;
+            boolean assertedWhileInFlight = false;
+            int heartbeatsSent = 0;
+            int previousCompletedSends = 0;
+            int iterations = 0;
+            int inFlightIterations = 0;
+            int preSendIterations = 0;
+            long lastTimeUntilNextPollMs = -1L;
+            // One iteration per retry backoff covers the request timeout plus the tail; the spare 100 covers the
+            // connection handshake and the 1 ms steps taken while the client waits out its reconnect backoff
+            // after the timeout. Hitting this cap means the clock stopped moving, i.e. the manager kept asking to
+            // be polled again immediately.
+            int maxIterations = (int) ((requestTimeoutMs + 500) / DEFAULT_RETRY_BACKOFF_MS) + 100;
+
+            while (time.milliseconds() < deadlineMs) {
+                assertClockKeepsMoving(++iterations, maxIterations, deadlineMs, time.milliseconds(), lastTimeUntilNextPollMs);
+
+                long pollStartMs = time.milliseconds();
+                boolean inFlight = networkClient.hasInFlightRequests();
+                NetworkClientDelegate.PollResult result = realHeartbeatRequestManager.poll(pollStartMs);
+                lastTimeUntilNextPollMs = result.timeUntilNextPollMs;
+                if (createdAtMs < 0 && result.unsentRequests.size() == 1) {
+                    // The heartbeat has just been built, which is where HeartbeatRequestState re-arms its timer
+                    // and where NetworkClientDelegate starts counting request.timeout.ms.
+                    createdAtMs = pollStartMs;
+                    deadlineMs = createdAtMs + requestTimeoutMs + 500;
+                }
+
+                if (inFlight && timedOutAtMs < 0) {
+                    // The first heartbeat is on the wire and has not been failed yet: this is the window the fix
+                    // is about. Once it has timed out the manager starts a fresh heartbeat cycle, whose timer is
+                    // re-armed with the interval again, so the assertions below no longer apply.
+                    inFlightIterations++;
+                    assertedWhileInFlight |= assertHeartbeatInFlightWaitDoesNotSpin(
+                        realHeartbeatRequestManager, result, pollStartMs, pollStartMs >= createdAtMs + heartbeatIntervalMs);
+                } else if (sentAtMs < 0) {
+                    // Before the heartbeat is on the wire the manager legitimately returns 0, asking to be polled
+                    // again so that the request it just built can be sent. Those iterations say nothing about the
+                    // busy-spin, so they are counted and bounded separately instead of feeding inFlightIterations.
+                    preSendIterations++;
+                }
+
+                networkClientDelegate.addAll(result);
+                // ConsumerNetworkThread.runOnce polls for min(MAX_POLL_TIMEOUT_MS, timeUntilNextPollMs), and
+                // MockSelector.poll advances MockTime by exactly that timeout, so the manager's own answer drives
+                // the clock: a zero wait freezes it, which is precisely the busy-spin this test is about. The
+                // floor of 1 ms is only applied when nothing is in flight, where a zero wait is legitimate (the
+                // manager is asking to be re-polled so the request it just built can be sent, and after the
+                // timeout while the client sits in its reconnect backoff); it keeps those phases moving without
+                // hiding a spin in the in-flight window.
+                networkClientDelegate.poll(networkPollTimeoutMs(inFlight, result.timeUntilNextPollMs), pollStartMs);
+
+                // MockSelector.close(nodeId), which NetworkClient calls when it times a request out, drops that
+                // node's entries from completedSends(), so the sends have to be accumulated as they happen.
+                int completedSends = selector.completedSends().size();
+                heartbeatsSent += Math.max(0, completedSends - previousCompletedSends);
+                previousCompletedSends = completedSends;
+
+                if (sentAtMs < 0 && heartbeatsSent == 1) {
+                    sentAtMs = pollStartMs;
+                } else if (sentAtMs >= 0 && timedOutAtMs < 0 && !networkClient.hasInFlightRequests()) {
+                    timedOutAtMs = time.milliseconds();
+                    requestInFlightAtTimeout = heartbeatRequestState.requestInFlight();
+                } else if (heartbeatsSent >= 2) {
+                    // The resend that was being waited for has happened; stop before the reconnect storm that
+                    // follows a disconnect can put further heartbeats on the wire.
+                    resentAtMs = time.milliseconds();
+                    deadlineMs = resentAtMs;
+                }
+            }
+
+            assertTrue(assertedWhileInFlight, "The heartbeat was never in flight with an expired timer, so nothing was verified");
+            assertTrue(preSendIterations <= 3,
+                "The manager should only ask to be re-polled a couple of times before the heartbeat is on the wire; got "
+                    + preSendIterations);
+            // One poll per retry backoff is the expected, non-spinning rate while the heartbeat is in flight.
+            long maxInFlightIterations = requestTimeoutMs / DEFAULT_RETRY_BACKOFF_MS + 2;
+            assertTrue(inFlightIterations <= maxInFlightIterations,
+                "Expected about one poll per retry backoff while the heartbeat is in flight (at most "
+                    + maxInFlightIterations + "), got " + inFlightIterations);
+
+            String timeoutMessage = "The in-flight heartbeat should be failed by the request timeout, not earlier or much "
+                + "later; timed out " + (timedOutAtMs - createdAtMs) + " ms after the request was built, request.timeout.ms="
+                + requestTimeoutMs;
+            assertTrue(timedOutAtMs >= createdAtMs + requestTimeoutMs, timeoutMessage);
+            assertTrue(timedOutAtMs < createdAtMs + requestTimeoutMs + 100, timeoutMessage);
+            assertFalse(requestInFlightAtTimeout, "The request timeout should have cleared the in-flight heartbeat");
+            // The failure resets the heartbeat timer and clears the in-flight flag, so the still JOINING member
+            // sends the next heartbeat as soon as the coordinator is reachable again. coordinatorRequestManager is
+            // a mock, so handleCoordinatorDisconnect is a no-op and coordinator() keeps returning the same node;
+            // the resend therefore only has to wait for the network client's reconnect backoff.
+            assertEquals(2, heartbeatsSent,
+                "A second heartbeat should have been sent after the first one timed out, within "
+                    + (requestTimeoutMs + 500) + " ms of the first one; resent at " + (resentAtMs - createdAtMs));
+        }
+    }
+
+    /**
+     * Fails once the loop has run more iterations than the clock could possibly need, which is what a manager that
+     * asks to be polled again immediately looks like when {@link MockSelector} drives {@link MockTime}.
+     */
+    private static void assertClockKeepsMoving(final int iterations,
+                                               final int maxIterations,
+                                               final long deadlineMs,
+                                               final long currentTimeMs,
+                                               final long lastTimeUntilNextPollMs) {
+        if (iterations <= maxIterations) {
+            return;
+        }
+        throw new AssertionError("The network thread would have spun: " + iterations
+            + " iterations without the clock reaching " + deadlineMs + " (now " + currentTimeMs
+            + "); last timeUntilNextPollMs=" + lastTimeUntilNextPollMs);
+    }
+
+    /**
+     * The poll timeout {@link ConsumerNetworkThread#runOnce()} would use, floored at 1 ms while nothing is in
+     * flight. {@link MockSelector#poll(long)} advances {@link MockTime} by exactly the timeout, so a zero wait
+     * freezes the clock; that is the busy-spin under test while a heartbeat is in flight, but it is expected
+     * before the request is on the wire and while the client waits out its reconnect backoff after a timeout.
+     */
+    private static long networkPollTimeoutMs(final boolean inFlight, final long timeUntilNextPollMs) {
+        long pollTimeoutMs = Math.min(ConsumerNetworkThread.MAX_POLL_TIMEOUT_MS, timeUntilNextPollMs);
+        return inFlight ? pollTimeoutMs : Math.max(1, pollTimeoutMs);
+    }
+
+    /**
+     * Asserts the wait the manager asks for while a heartbeat is in flight. Once the heartbeat timer is expired
+     * nothing can be sent until the in-flight request completes, so the wait must be exactly the retry backoff;
+     * before that it is the timer's remaining time, which only has to be positive.
+     *
+     * @return true if the expired-timer case was asserted
+     */
+    private boolean assertHeartbeatInFlightWaitDoesNotSpin(final ConsumerHeartbeatRequestManager manager,
+                                                           final NetworkClientDelegate.PollResult result,
+                                                           final long pollStartMs,
+                                                           final boolean heartbeatTimerExpired) {
+        assertTrue(result.timeUntilNextPollMs > 0,
+            "timeUntilNextPollMs must be > 0 while a heartbeat is in flight to avoid a busy-spin; got "
+                + result.timeUntilNextPollMs);
+        if (!heartbeatTimerExpired) {
+            // Only reachable with a non-zero interval: the request is in flight but the timer has not expired yet,
+            // so the wait is the timer's remaining time rather than the backoff.
+            return false;
+        }
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, result.timeUntilNextPollMs);
+
+        long waitMs = manager.maximumTimeToWait(pollStartMs);
+        assertTrue(waitMs > 0,
+            "maximumTimeToWait must be > 0 while a heartbeat is in flight to avoid a busy-spin; got " + waitMs);
+        // maximumTimeToWait is min(pollTimer.remainingMs() / 2, retry backoff), and half of the remaining
+        // max.poll.interval.ms is still larger than the backoff at this point.
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, waitMs);
+        return true;
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatRequestStateTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.LogContext;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -133,5 +135,68 @@ public class HeartbeatRequestStateTest {
 
         assertFalse(heartbeatRequestState.canSendRequest(time.milliseconds()));
         assertTrue(heartbeatRequestState.timeToNextHeartbeatMs(time.milliseconds()) > 0);
+    }
+
+    /**
+     * retry.backoff.ms and retry.backoff.max.ms both accept 0. The in-flight wait is used as a poll
+     * timeout, so it must stay positive even then.
+     */
+    @Test
+    public void testTimeToNextHeartbeatMsWhileRequestInFlightWithZeroRetryBackoffDoesNotSpin() {
+        final HeartbeatRequestState heartbeatRequestState = new HeartbeatRequestState(
+            LOG_CONTEXT,
+            time,
+            0,
+            0,
+            0,
+            JITTER
+        );
+
+        heartbeatRequestState.onSendAttempt(time.milliseconds());
+        heartbeatRequestState.resetTimer();
+        time.sleep(1);
+
+        final long timeToNextHeartbeatMs = heartbeatRequestState.timeToNextHeartbeatMs(time.milliseconds());
+        assertTrue(timeToNextHeartbeatMs > 0,
+            "timeToNextHeartbeatMs must be > 0 while a heartbeat request is in flight even with a zero retry backoff; got "
+                + timeToNextHeartbeatMs);
+        // The 1 ms floor applied when the configured backoff is 0.
+        assertEquals(1L, timeToNextHeartbeatMs);
+    }
+
+    /**
+     * A heartbeat request is in flight and the heartbeat timer is expired. That happens both before the
+     * first heartbeat response, when the interval is still unknown and initialised to 0, and later on,
+     * when a response takes longer than the interval. No heartbeat can be sent until the in-flight one
+     * completes, so the wait must stay positive; returning the remaining backoff gives 0 and busy-spins
+     * the callers that use it as a poll timeout.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {0, 5000})
+    public void testTimeToNextHeartbeatMsWhileRequestInFlightDoesNotSpin(final long heartbeatIntervalMs) {
+        final HeartbeatRequestState heartbeatRequestState = new HeartbeatRequestState(
+            LOG_CONTEXT,
+            time,
+            heartbeatIntervalMs,
+            RETRY_BACKOFF_MS,
+            RETRY_BACKOFF_MAX_MS,
+            JITTER
+        );
+        if (heartbeatIntervalMs > 0) {
+            // A non-zero interval is only known after a heartbeat response, which also arms the backoff.
+            heartbeatRequestState.onSuccessfulAttempt(time.milliseconds());
+        }
+
+        heartbeatRequestState.onSendAttempt(time.milliseconds());
+        heartbeatRequestState.resetTimer();
+        time.sleep(heartbeatIntervalMs + 1);
+
+        assertFalse(heartbeatRequestState.canSendRequest(time.milliseconds()),
+            "No request should be sendable while one is in flight");
+        final long timeToNextHeartbeatMs = heartbeatRequestState.timeToNextHeartbeatMs(time.milliseconds());
+        assertTrue(timeToNextHeartbeatMs > 0,
+            "timeToNextHeartbeatMs must be > 0 while a heartbeat request is in flight to avoid a busy-spin; got "
+                + timeToNextHeartbeatMs);
+        assertEquals(RETRY_BACKOFF_MS, heartbeatRequestState.timeToNextHeartbeatMs(time.milliseconds()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ShareHeartbeatRequestManagerTest.java
@@ -129,9 +129,13 @@ public class ShareHeartbeatRequestManagerTest
     }
 
     private void createHeartbeatRequestStateWithZeroHeartbeatInterval() {
+        createHeartbeatRequestStateWithHeartbeatInterval(0);
+    }
+
+    private void createHeartbeatRequestStateWithHeartbeatInterval(final long heartbeatIntervalMs) {
         heartbeatRequestState = spy(new HeartbeatRequestState(logContext,
                 time,
-                0,
+                heartbeatIntervalMs,
                 DEFAULT_RETRY_BACKOFF_MS,
                 DEFAULT_RETRY_BACKOFF_MAX_MS,
                 DEFAULT_HEARTBEAT_JITTER_MS));
@@ -173,6 +177,52 @@ public class ShareHeartbeatRequestManagerTest
         assertTrue(result > 0,
             "maximumTimeToWait must be > 0 while heartbeats are skipped to avoid a busy-spin; got " + result);
         assertEquals(DEFAULT_HEARTBEAT_INTERVAL_MS, result);
+    }
+
+    /**
+     * A heartbeat request is in flight and the heartbeat timer is already expired. That happens both
+     * while the very first heartbeat is in flight, when the interval is still unknown (it is initialised
+     * to 0 and only learned from the first heartbeat response), and later on, when a response takes
+     * longer than the interval. In that window no heartbeat can be sent until the in-flight one
+     * completes, so both {@link NetworkClientDelegate.PollResult#timeUntilNextPollMs} and
+     * {@link AbstractHeartbeatRequestManager#maximumTimeToWait(long)} must return a positive delay;
+     * returning 0 busy-spins the consumer network thread and the application thread until the in-flight
+     * request completes, which can be as long as request.timeout.ms when the coordinator is unreachable.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {0, 5000})
+    public void testMaximumTimeToWaitWhileHeartbeatInFlightDoesNotSpin(final long heartbeatIntervalMs) {
+        createHeartbeatRequestStateWithHeartbeatInterval(heartbeatIntervalMs);
+        // The member keeps joining for both intervals, so the heartbeat below is sent without waiting for
+        // the interval and the total simulated time stays under max.poll.interval.ms.
+        when(membershipManager.state()).thenReturn(MemberState.JOINING);
+        when(membershipManager.shouldHeartbeatNow()).thenReturn(true);
+        if (heartbeatIntervalMs > 0) {
+            // A non-zero interval is only known after a heartbeat response, which also arms the backoff.
+            heartbeatRequestState.onSuccessfulAttempt(time.milliseconds());
+        }
+
+        NetworkClientDelegate.PollResult firstResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, firstResult.unsentRequests.size(),
+            "A heartbeat should be sent as soon as the coordinator is known");
+
+        // Deliberately do not complete the request, so it stays in flight while the heartbeat timer expires.
+        time.sleep(heartbeatIntervalMs + 1);
+
+        NetworkClientDelegate.PollResult secondResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, secondResult.unsentRequests.size(),
+            "No heartbeat should be sent while another one is in flight");
+        assertTrue(secondResult.timeUntilNextPollMs > 0,
+            "timeUntilNextPollMs must be > 0 while a heartbeat is in flight to avoid a busy-spin; got "
+                + secondResult.timeUntilNextPollMs);
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, secondResult.timeUntilNextPollMs);
+
+        long result = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(result > 0,
+            "maximumTimeToWait must be > 0 while a heartbeat is in flight to avoid a busy-spin; got " + result);
+        // maximumTimeToWait is min(pollTimer.remainingMs() / 2, retry backoff), and half of the remaining
+        // max.poll.interval.ms is still larger than the backoff at this point.
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, result);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/StreamsGroupHeartbeatRequestManagerTest.java
@@ -97,6 +97,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
     private static final int RECEIVED_TASK_OFFSET_INTERVAL_MS = 7000;
     private static final long RECEIVED_ACCEPTABLE_RECOVERY_LAG = 4242;
     private static final int DEFAULT_MAX_POLL_INTERVAL_MS = 10000;
+    private static final long DEFAULT_RETRY_BACKOFF_MS = 100;
     private static final String GROUP_ID = "group-id";
     private static final String MEMBER_ID = "member-id";
     private static final int MEMBER_EPOCH = 1;
@@ -2482,6 +2483,55 @@ class StreamsGroupHeartbeatRequestManagerTest {
         assertEquals(INSTANCE_ID, streamsRequest.data().instanceId());
     }
 
+    /**
+     * A heartbeat request is in flight and the heartbeat timer is already expired. That happens both
+     * while the very first heartbeat is in flight, when the interval is still unknown (it is initialised
+     * to 0 and only learned from the first heartbeat response), and later on, when a response takes
+     * longer than the interval. In that window no heartbeat can be sent until the in-flight one
+     * completes, so both {@link NetworkClientDelegate.PollResult#timeUntilNextPollMs} and
+     * {@link StreamsGroupHeartbeatRequestManager#maximumTimeToWait(long)} must return a positive delay;
+     * returning 0 busy-spins the consumer network thread and the application thread until the in-flight
+     * request completes, which can be as long as request.timeout.ms when the coordinator is unreachable.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {0, 5000})
+    public void testMaximumTimeToWaitWhileHeartbeatInFlightDoesNotSpin(final long heartbeatIntervalMs) {
+        final StreamsGroupHeartbeatRequestManager heartbeatRequestManager = createStreamsGroupHeartbeatRequestManager();
+        when(coordinatorRequestManager.coordinator()).thenReturn(Optional.of(coordinatorNode));
+        // The member keeps joining for both intervals, so the heartbeat below is sent without waiting for
+        // the interval and the total simulated time stays under max.poll.interval.ms.
+        when(membershipManager.state()).thenReturn(MemberState.JOINING);
+
+        if (heartbeatIntervalMs > 0) {
+            // The manager always starts with a zero (unknown) interval, so the only way to give it a
+            // non-zero one is to complete a first heartbeat with a response carrying that interval.
+            completeSuccessfulHeartbeat(heartbeatRequestManager, buildClientResponseWithConfig(
+                (int) heartbeatIntervalMs, RECEIVED_TASK_OFFSET_INTERVAL_MS, RECEIVED_ACCEPTABLE_RECOVERY_LAG));
+        }
+
+        final NetworkClientDelegate.PollResult firstResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(1, firstResult.unsentRequests.size(),
+            "A heartbeat should be sent as soon as the coordinator is known");
+
+        // Deliberately do not complete the request, so it stays in flight while the heartbeat timer expires.
+        time.sleep(heartbeatIntervalMs + 1);
+
+        final NetworkClientDelegate.PollResult secondResult = heartbeatRequestManager.poll(time.milliseconds());
+        assertEquals(0, secondResult.unsentRequests.size(),
+            "No heartbeat should be sent while another one is in flight");
+        assertTrue(secondResult.timeUntilNextPollMs > 0,
+            "timeUntilNextPollMs must be > 0 while a heartbeat is in flight to avoid a busy-spin; got "
+                + secondResult.timeUntilNextPollMs);
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, secondResult.timeUntilNextPollMs);
+
+        final long result = heartbeatRequestManager.maximumTimeToWait(time.milliseconds());
+        assertTrue(result > 0,
+            "maximumTimeToWait must be > 0 while a heartbeat is in flight to avoid a busy-spin; got " + result);
+        // maximumTimeToWait is min(pollTimer.remainingMs() / 2, retry backoff), and half of the remaining
+        // max.poll.interval.ms is still larger than the backoff at this point.
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, result);
+    }
+
     @Test
     public void testMaximumTimeToWaitPollTimerExpired() {
         try (
@@ -2720,6 +2770,7 @@ class StreamsGroupHeartbeatRequestManagerTest {
         prop.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         prop.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         prop.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(DEFAULT_MAX_POLL_INTERVAL_MS));
+        prop.setProperty(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, String.valueOf(DEFAULT_RETRY_BACKOFF_MS));
         prop.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         return new ConsumerConfig(prop);
     }


### PR DESCRIPTION
Return the initial retry backoff when the heartbeat timer has expired
but a heartbeat request is still in flight. The remaining backoff can
already be zero in this state, causing a busy loop.

Tests cover the first heartbeat awaiting a response and a later
heartbeat whose response takes longer than the known interval, including
propagation of the wait through the heartbeat managers.

Related: KAFKA-20253 (#22836), KAFKA-20970 (#23227), KAFKA-21010
(#23348).

Generated-by: OpenAI Codex

Reviewers: Doyeon Kim (@dybyte), Lianet Magrans
 <[lmagrans@confluent.io](mailto:lmagrans@confluent.io)>
