### PR TITLE
KAFKA-21023: Improve the dependency-check configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Core Module (:core): `core/build/reports/scoverageTest/index.html`
 
 Other Modules: `<module>/build/reports/jacoco/test/html/index.html`
 
+### Running dependency vulnerability checks
+To reduce NVD API rate limiting, supply an [NVD API key](https://nvd.nist.gov/developers/request-an-api-key)
+through the `NVD_API_KEY` environment variable when running a dependency check:
+
+```bash
+NVD_API_KEY=your-nvd-api-key ./gradlew dependencyCheckAggregate
+```
+
 ### Building a binary release gzipped tarball
 ```bash
 ./gradlew clean releaseTarGz

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To reduce NVD API rate limiting, supply an [NVD API key](https://nvd.nist.gov/de
 through the `NVD_API_KEY` environment variable when running a dependency check:
 
 ```bash
-NVD_API_KEY=your-nvd-api-key ./gradlew dependencyCheckAggregate
+NVD_API_KEY=your-nvd-api-key ./gradlew dependencyCheckAggregate --no-parallel
 ```
 
 ### Building a binary release gzipped tarball

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ plugins {
   id 'idea'
   id 'jacoco'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '12.2.2'
+  id 'org.owasp.dependencycheck' version '13.0.0'
   id 'org.nosphere.apache.rat' version "0.8.1"
   id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
 
@@ -935,9 +935,19 @@ kafkaPublicApiChecker {
   }
 
   dependencyCheck {
+    nvd.apiKey = System.getenv('NVD_API_KEY')
     suppressionFile = "$rootDir/gradle/resources/dependencycheck-suppressions.xml"
     skipProjects = [ ":jmh-benchmarks", ":trogdor" ]
-    skipConfigurations = [ "zinc" ]
+    skipConfigurations = [
+      "checkstyle",
+      "jacocoAgent",
+      "jacocoAnt",
+      "scoverage",
+      "spotbugs",
+      "spotbugsPlugins",
+      "spotbugsSlf4j",
+      "zinc"
+    ]
   }
   apply plugin: 'com.diffplug.spotless'
   spotless {


### PR DESCRIPTION
Upgrade the OWASP dependency-check Gradle plugin to 13.0.0 and read the
NVD API key from the NVD_API_KEY environment variable.

Exclude build-tool-only configurations from dependency analysis because
they are not shipped with Kafka. Document how to run the aggregate
dependency check with an NVD API key and disabled Gradle parallel
execution, which avoids unsafe cross-project configuration resolution
with Gradle 9.

Testing:
- `./gradlew help --task dependencyCheckAggregate`
- `NVD_API_KEY=*** ./gradlew dependencyCheckAggregate --no-parallel`

```
./gradlew clean dependencyCheckAggregate --no-parallel

> Configure project :  Starting build with version 4.5.0-SNAPSHOT
(commit id c2b868da) using Gradle 9.7.1, Java 26 and Scala 2.13.18
Build properties: ignoreFailures=false, maxParallelForks=10,
maxScalacThreads=8, maxTestRetries=0

> Task :dependencyCheckAggregate
Verifying dependencies for project kafka
Checking for updates and analyzing dependencies for vulnerabilities
----------------------------------------------------
.NET Assembly Analyzer could not be initialized and at least one 'exe'
or 'dll' was scanned. The 'dotnet' executable could not be found on the
path; either disable the Assembly Analyzer or add the path to dotnet
core in the configuration.
The dotnet 8.0 core runtime or SDK is required to analyze assemblies
----------------------------------------------------
Sonatype OSS Index Analyzer disabled due to missing credentials.
Authentication with token is now required, and OSS Index is migrating to
Sonatype Guide. See
https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html
for more information on authentication with Sonatype Guide OSS Index.
Generating report for project kafka
Found 6 vulnerabilities in project kafka

One or more dependencies were identified with known vulnerabilities in
kafka:

opentelemetry-proto-1.3.2-alpha.jar
(pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.3.2-alpha,
cpe:2.3:a:opentelemetry:opentelemetry:1.3.2:alpha:*:*:*:*:*:*) :
CVE-2026-41078, CVE-2026-39882, CVE-2026-40894, CVE-2026-41178,
CVE-2026-44967, CVE-2026-54285

See the dependency-check report for more details.

[Incubating] Problems report is available at:
file:///[redacted]/kafka/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it
incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation
warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to
https://docs.gradle.org/9.7.1/userguide/command_line_interface.html#sec:command_line_warnings
in the Gradle documentation.

BUILD SUCCESSFUL in 5s
74 actionable tasks: 68 executed, 6 up-to-date

```
