### PR TITLE
MINOR: Remove quotaConfig() from AbstractKafkaConfig

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1251,6 +1251,8 @@ private[kafka] class Processor(
 
 class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends Logging with AutoCloseable {
 
+  private val quotaConfig = new QuotaConfig(config)
+
   @volatile private var defaultMaxConnectionsPerIp: Int = config.maxConnectionsPerIp
   @volatile private var maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides.asScala.map { case (host, count) => (InetAddress.getByName(host), count.intValue()) }.toMap
   @volatile private var brokerMaxConnections = config.maxConnections
@@ -1266,7 +1268,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   private val connectionRatePerIp = new ConcurrentHashMap[InetAddress, Int]()
   // sensor that tracks broker-wide connection creation rate and limit (quota)
   private val brokerConnectionRateSensor = getOrCreateConnectionRateQuotaSensor(config.maxConnectionCreationRate, ConnectionQuotaEntity.brokerQuotaEntity())
-  private val maxThrottleTimeMs = TimeUnit.SECONDS.toMillis(config.quotaConfig.quotaWindowSizeSeconds.toLong)
+  private val maxThrottleTimeMs = TimeUnit.SECONDS.toMillis(quotaConfig.quotaWindowSizeSeconds.toLong)
 
   def inc(listenerName: ListenerName, address: InetAddress, acceptorBlockedPercentMeter: com.yammer.metrics.core.Meter): Unit = {
     counts.synchronized {
@@ -1602,8 +1604,8 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
 
   private def rateQuotaMetricConfig(quotaLimit: Int): MetricConfig = {
     new MetricConfig()
-      .timeWindow(config.quotaConfig.quotaWindowSizeSeconds.toLong, TimeUnit.SECONDS)
-      .samples(config.quotaConfig.numQuotaSamples)
+      .timeWindow(quotaConfig.quotaWindowSizeSeconds.toLong, TimeUnit.SECONDS)
+      .samples(quotaConfig.numQuotaSamples)
       .quota(new Quota(quotaLimit, true))
   }
 

--- a/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
+++ b/server/src/main/java/org/apache/kafka/server/config/AbstractKafkaConfig.java
@@ -89,17 +89,8 @@ public abstract class AbstractKafkaConfig extends AbstractConfig {
         AddPartitionsToTxnConfig.CONFIG_DEF
     ));
 
-    private volatile QuotaConfig quotaConfig;
-
     public AbstractKafkaConfig(ConfigDef definition, Map<?, ?> originals, Map<String, ?> configProviderProps, boolean doLog) {
         super(definition, originals, configProviderProps, doLog);
-    }
-
-    public QuotaConfig quotaConfig() {
-        if (quotaConfig == null) {
-            quotaConfig = new QuotaConfig(this);
-        }
-        return quotaConfig;
     }
 
     public List<String> logDirs() {

--- a/server/src/main/java/org/apache/kafka/server/quota/QuotaFactory.java
+++ b/server/src/main/java/org/apache/kafka/server/quota/QuotaFactory.java
@@ -84,15 +84,16 @@ public class QuotaFactory {
         String role
     ) {
         Optional<Plugin<ClientQuotaCallback>> clientQuotaCallbackPlugin = createClientQuotaCallback(cfg, metrics, role);
+        var quotaConfig = new QuotaConfig(cfg);
 
         return new QuotaManagers(
-            new ClientQuotaManager(clientConfig(cfg), metrics, QuotaType.FETCH, time, threadNamePrefix, clientQuotaCallbackPlugin),
-            new ClientQuotaManager(clientConfig(cfg), metrics, QuotaType.PRODUCE, time, threadNamePrefix, clientQuotaCallbackPlugin),
-            new ClientRequestQuotaManager(clientConfig(cfg), metrics, time, threadNamePrefix, clientQuotaCallbackPlugin),
-            new ControllerMutationQuotaManager(clientControllerMutationConfig(cfg), metrics, time, threadNamePrefix, clientQuotaCallbackPlugin),
-            new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.LEADER_REPLICATION, time),
-            new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.FOLLOWER_REPLICATION, time),
-            new ReplicationQuotaManager(alterLogDirsReplicationConfig(cfg), metrics, QuotaType.ALTER_LOG_DIRS_REPLICATION, time),
+            new ClientQuotaManager(clientConfig(quotaConfig), metrics, QuotaType.FETCH, time, threadNamePrefix, clientQuotaCallbackPlugin),
+            new ClientQuotaManager(clientConfig(quotaConfig), metrics, QuotaType.PRODUCE, time, threadNamePrefix, clientQuotaCallbackPlugin),
+            new ClientRequestQuotaManager(clientConfig(quotaConfig), metrics, time, threadNamePrefix, clientQuotaCallbackPlugin),
+            new ControllerMutationQuotaManager(clientControllerMutationConfig(quotaConfig), metrics, time, threadNamePrefix, clientQuotaCallbackPlugin),
+            new ReplicationQuotaManager(replicationConfig(quotaConfig), metrics, QuotaType.LEADER_REPLICATION, time),
+            new ReplicationQuotaManager(replicationConfig(quotaConfig), metrics, QuotaType.FOLLOWER_REPLICATION, time),
+            new ReplicationQuotaManager(alterLogDirsReplicationConfig(quotaConfig), metrics, QuotaType.ALTER_LOG_DIRS_REPLICATION, time),
             clientQuotaCallbackPlugin
         );
     }
@@ -112,31 +113,31 @@ public class QuotaFactory {
         ));
     }
 
-    private static ClientQuotaManagerConfig clientConfig(AbstractKafkaConfig cfg) {
+    private static ClientQuotaManagerConfig clientConfig(QuotaConfig quotaConfig) {
         return new ClientQuotaManagerConfig(
-            cfg.quotaConfig().numQuotaSamples(),
-            cfg.quotaConfig().quotaWindowSizeSeconds()
+            quotaConfig.numQuotaSamples(),
+            quotaConfig.quotaWindowSizeSeconds()
         );
     }
 
-    private static ClientQuotaManagerConfig clientControllerMutationConfig(AbstractKafkaConfig cfg) {
+    private static ClientQuotaManagerConfig clientControllerMutationConfig(QuotaConfig quotaConfig) {
         return new ClientQuotaManagerConfig(
-            cfg.quotaConfig().numControllerQuotaSamples(),
-            cfg.quotaConfig().controllerQuotaWindowSizeSeconds()
+            quotaConfig.numControllerQuotaSamples(),
+            quotaConfig.controllerQuotaWindowSizeSeconds()
         );
     }
 
-    private static ReplicationQuotaManagerConfig replicationConfig(AbstractKafkaConfig cfg) {
+    private static ReplicationQuotaManagerConfig replicationConfig(QuotaConfig quotaConfig) {
         return new ReplicationQuotaManagerConfig(
-            cfg.quotaConfig().numReplicationQuotaSamples(),
-            cfg.quotaConfig().replicationQuotaWindowSizeSeconds()
+            quotaConfig.numReplicationQuotaSamples(),
+            quotaConfig.replicationQuotaWindowSizeSeconds()
         );
     }
 
-    private static ReplicationQuotaManagerConfig alterLogDirsReplicationConfig(AbstractKafkaConfig cfg) {
+    private static ReplicationQuotaManagerConfig alterLogDirsReplicationConfig(QuotaConfig quotaConfig) {
         return new ReplicationQuotaManagerConfig(
-            cfg.quotaConfig().numAlterLogDirsReplicationQuotaSamples(),
-            cfg.quotaConfig().alterLogDirsReplicationQuotaWindowSizeSeconds()
+            quotaConfig.numAlterLogDirsReplicationQuotaSamples(),
+            quotaConfig.alterLogDirsReplicationQuotaWindowSizeSeconds()
         );
     }
 }


### PR DESCRIPTION
As suggested in
https://github.com/apache/kafka/pull/22721#discussion_r3918957218, this
removes `AbstractKafkaConfig#quotaConfig()`.

`QuotaConfig` only reads values that are already parsed, so creating it
is cheap and we don't need to cache it. The two callers, `QuotaFactory`
and `ConnectionQuotas`, now create their own `QuotaConfig`. This also
gets rid of the lazy `volatile` field in `AbstractKafkaConfig`.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai
 <chia7712@gmail.com>
