### PR TITLE
KAFKA-21033: Back off once per round when creating Streams internal topics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -492,7 +492,7 @@ public class InternalTopicManager {
                 break;
             }
             if (!topicsToCreate.isEmpty()) {
-                final Set<String> createdTopics = createTopics(topicsToCreate, topicsNotReady, deadlineMs);
+                final Set<String> createdTopics = createTopics(topicsToCreate, topicsNotReady);
                 topicsNotReady.removeAll(createdTopics);
                 newlyCreatedTopics.addAll(createdTopics);
             }
@@ -504,7 +504,7 @@ public class InternalTopicManager {
                     String.format("Could not create topics within %d milliseconds. This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs),
                     null
                 ));
-
+                maybeSleep(List.of(topicsNotReady), deadlineMs, "made ready");
             }
         }
         log.debug("Completed validating internal topics and created {}", newlyCreatedTopics);
@@ -543,8 +543,7 @@ public class InternalTopicManager {
     }
 
     private Set<String> createTopics(final Set<NewTopic> topicsToCreate,
-                                     final Set<String> topicsNotReady,
-                                     final long deadlineMs) {
+                                     final Set<String> topicsNotReady) {
         final CreateTopicsResult createTopicsResult = adminClient.createTopics(topicsToCreate);
         final Set<String> createdTopics = new HashSet<>();
 
@@ -554,7 +553,6 @@ public class InternalTopicManager {
                 createTopicResult.getValue().get();
                 topicsNotReady.remove(topicName);
                 createdTopics.add(topicName);
-                
             } catch (final InterruptedException fatalException) {
                 // this should not happen; if it ever happens it indicate a bug
                 Thread.currentThread().interrupt();
@@ -594,27 +592,10 @@ public class InternalTopicManager {
                 }
             }
 
-            if (!topicsNotReady.isEmpty()) {
-                maybeThrowTimeout(new TimeoutContext(
-                        topicsNotReady,
-                        deadlineMs,
-                        "createTopics timeout",
-                        String.format(
-                                "Could not create topics within %d milliseconds. This can happen if the Kafka cluster is temporarily not available.",
-                                retryTimeoutMs),
-                        null));
-                log.info(
-                    "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
-                    topicsNotReady,
-                    retryBackOffMs,
-                    deadlineMs - time.milliseconds()
-                );
-                Utils.sleep(retryBackOffMs);
-            }
-        } 
+        }
+
         return createdTopics;
-    } 
-        
+    }
 
     /**
      * Try to get the partition information for the given topics; return the partition info for topics that already exists.
@@ -939,7 +920,7 @@ public class InternalTopicManager {
                 retryBackOffMs,
                 deadline - now
             );
-            Utils.sleep(retryBackOffMs);
+            time.sleep(retryBackOffMs);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -57,6 +57,7 @@ import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -133,6 +134,42 @@ public class InternalTopicManagerTest {
     @AfterEach
     public void shutdown() {
         mockAdminClient.close();
+    }
+
+    @Test
+    public void shouldNotBackOffPerTopicWhenCreatingATopicBatch() {
+        final Map<String, InternalTopicConfig> topicConfigs = new HashMap<>();
+        for (int i = 0; i < 25; i++) {
+            final String topicName = "batch-topic-" + i;
+            topicConfigs.put(topicName, setupRepartitionTopicConfig(topicName, 1));
+        }
+
+        final long before = time.milliseconds();
+        internalTopicManager.makeReady(topicConfigs);
+
+        // Every create succeeds immediately, so makeReady must not back off at all.
+        assertEquals(0L, time.milliseconds() - before);
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldBackOffBetweenRoundsWhenTopicIsMarkedForDeletion() {
+        mockAdminClient.addTopic(
+            false,
+            topic1,
+            Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList())),
+            null);
+        mockAdminClient.markTopicForDeletion(topic1);
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
+
+        final long before = time.milliseconds();
+        // The clock has no auto-tick, so only the round backoff can advance it toward the
+        // deadline: reaching the timeout at all proves the round backs off instead of spinning.
+        assertThrows(
+            TimeoutException.class,
+            () -> internalTopicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig))
+        );
+        assertEquals(50L, time.milliseconds() - before);
     }
 
     @Test


### PR DESCRIPTION
The KAFKA-10357 refactoring (#20326) extracted the internal-topic
creation loop of  `InternalTopicManager.makeReady` into a `createTopics`
helper and carried the end-of-round  backoff block into the per-topic
result loop. Since 4.3.0, after every successfully  created topic, the
manager logs "Topics ... could not be made ready" and sleeps
`retry.backoff.ms` when other topics of the same batch are not yet
iterated. The first  initialization of a topology with N internal topics
pays ~(N-1) * retry.backoff.ms of  sleep even when every create succeeds
immediately: with the 100 ms default, a topology  with 168 internal
topics loses ~17 seconds before its first rebalance completes, plus one
spurious INFO line per topic. The misplaced block also checked the
deadline mid-round, so  `makeReady` could throw `TimeoutException` while
the remaining futures of the round had  already succeeded, and the INFO
line listed not-yet-iterated topics as "could not be made  ready".

The refactor also dropped the backoff for rounds that create nothing:
when a topic is  marked for deletion or a describe transiently fails,
`tempUnknownTopics` is non-empty  while `topicsToCreate` is empty, and
`makeReady` re-describes in a hot loop until the  deadline (by default
`max.poll.interval.ms / 2`).

Move the backoff to the end of `makeReady`'s round, next to its existing
deadline check,  through the `maybeSleep` helper the file already uses
for setup and validation rounds.  This restores the pre-4.3 semantics:
one backoff per round, covering both the create path  and the
unknown-topics path. The retry log line now reads "Internal topics ...
could not  be made ready", consistent with the other rounds.
`maybeSleep` switches from `Utils.sleep`  to `time.sleep` so more
backoff calls in the file are observable with `MockTime`, and the
now-unused  deadline parameter of `createTopics` is dropped.

Fix derived with Claude Fable

Reviewers: Hrishi-Baskaran (github:Hrishi-Baskaran)
