### PR TITLE
KAFKA-21021: fix flaky test_fencing_static_consumer

### DIFF
--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -271,9 +271,13 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         for node in self.nodes:
             node.version = version
 
-    def start(self, **kwargs):
+    def start(self, wait_for_startup: bool = True, **kwargs) -> None:
         super().start(**kwargs)
-        timeout_sec=kwargs.get("timeout_sec", 120)
+
+        if not wait_for_startup:
+            return
+
+        timeout_sec = kwargs.get("timeout_sec", 120)
         wait_until(lambda: len(self.started_nodes()) == len(self.nodes),
                    timeout_sec=timeout_sec,
                    err_msg="Verifiable consumer didn't finish startup in %d seconds" % timeout_sec)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -44,7 +44,7 @@ class ConsumerEventHandler(object):
     def __init__(self, node, verify_offsets, idx, state=ConsumerState.Dead,
                  revoked_count=0, assigned_count=0, assignment=None,
                  position=None, committed=None, total_consumed=0,
-                 shutdown_complete=False):
+                 shutdown_complete=False, startup_complete=False):
         self.node = node
         self.verify_offsets = verify_offsets
         self.idx = idx
@@ -56,6 +56,7 @@ class ConsumerEventHandler(object):
         self.committed = committed if committed is not None else {}
         self.total_consumed = total_consumed
         self.shutdown_complete = shutdown_complete
+        self.startup_complete = startup_complete
 
     def handle_shutdown_complete(self, node=None, logger=None):
         self.state = ConsumerState.Dead
@@ -68,6 +69,7 @@ class ConsumerEventHandler(object):
 
     def handle_startup_complete(self, node, logger):
         self.state = ConsumerState.Started
+        self.startup_complete = True
         logger.debug("Started %s" % node.account.hostname)
 
     def handle_offsets_committed(self, event, node, logger):
@@ -271,16 +273,18 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         for node in self.nodes:
             node.version = version
 
-    def start(self, wait_for_startup: bool = True, **kwargs) -> None:
+    def start(self, **kwargs):
         super().start(**kwargs)
-
-        if not wait_for_startup:
-            return
-
         timeout_sec = kwargs.get("timeout_sec", 120)
-        wait_until(lambda: len(self.started_nodes()) == len(self.nodes),
+        wait_until(lambda: len(self.startup_complete_nodes()) == len(self.nodes),
                    timeout_sec=timeout_sec,
                    err_msg="Verifiable consumer didn't finish startup in %d seconds" % timeout_sec)
+
+    def start_node(self, node, **kwargs):
+        with self.lock:
+            if maybe_already_started_node := self.event_handlers.get(node):
+                maybe_already_started_node.startup_complete = False
+        super().start_node(node, **kwargs)
 
     def java_class_name(self):
         return "VerifiableConsumer"
@@ -296,7 +300,9 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                                      position=existing_handler.position,
                                      committed=existing_handler.committed,
                                      total_consumed=existing_handler.total_consumed,
-                                     shutdown_complete=existing_handler.shutdown_complete)
+                                     shutdown_complete=existing_handler.shutdown_complete,
+                                     startup_complete=existing_handler.startup_complete,
+                                     )
             else:
                 return handler_class(node, self.verify_offsets, idx)
         existing_handler = self.event_handlers[node] if node in self.event_handlers else None
@@ -532,10 +538,10 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
             return max(handler.revoked_count for handler in self.event_handlers.values()
                        if handler.idx <= keep_alive)
 
-    def started_nodes(self):
+    def startup_complete_nodes(self):
         with self.lock:
             return [handler.node for handler in self.event_handlers.values()
-                    if handler.state is not None and handler.state != ConsumerState.Dead]
+                    if handler.startup_complete]
 
     def joined_nodes(self):
         with self.lock:

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -69,7 +69,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
                 self.await_all_members(consumer)
                 self.await_consumed_messages(consumer)
 
-    def setup_consumer(self, topic, **kwargs):
+    def setup_consumer(self, topic, **kwargs) -> VerifiableConsumer:
         # collect verifiable consumer events since this makes debugging much easier
         consumer = super(OffsetValidationTest, self).setup_consumer(topic, **kwargs)
         self.mark_for_collect(consumer, 'verifiable_consumer_stdout')
@@ -309,7 +309,6 @@ class OffsetValidationTest(VerifiableConsumerTest):
         - the same group.instance.id.
         - Let normal consumers and fencing consumers start at the same time, and expect only unique consumers left.
         """
-        partition = TopicPartition(self.TOPIC, 0)
 
         producer = self.setup_producer(self.TOPIC)
 
@@ -328,9 +327,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
             self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=120)
 
             num_rebalances = consumer.num_rebalances()
-            conflict_consumer.start()
             if group_protocol == consumer_group.classic_group_protocol:
                 # Classic protocol: conflicting members should join, and the initial ones with conflicting instance id should fail.
+                conflict_consumer.start()
                 self.await_members(conflict_consumer, num_conflict_consumers)
                 self.await_members(consumer, len(consumer.nodes) - num_conflict_consumers)
 
@@ -339,6 +338,12 @@ class OffsetValidationTest(VerifiableConsumerTest):
                        err_msg="Timed out waiting for the fenced consumers to stop")
             else:
                 # Consumer protocol: Existing members should remain active and new conflicting ones should not be able to join.
+                conflict_consumer.start(wait_for_startup=False)
+
+                # Conflict consumers will terminate due to a fatal UnreleasedInstanceIdException error.
+                # Wait for termination to complete to prevent conflict consumers from immediately re-joining the group while existing nodes are shutting down.
+                self.await_conflict_consumers_fenced(conflict_consumer)
+
                 self.await_consumed_messages(consumer)
                 assert num_rebalances == consumer.num_rebalances(), "Static consumers attempt to join with instance id in use should not cause a rebalance"
                 try:
@@ -349,9 +354,6 @@ class OffsetValidationTest(VerifiableConsumerTest):
                     raise
                 assert len(conflict_consumer.joined_nodes()) == 0
 
-                # Conflict consumers will terminate due to a fatal UnreleasedInstanceIdException error.
-                # Wait for termination to complete to prevent conflict consumers from immediately re-joining the group while existing nodes are shutting down.
-                self.await_conflict_consumers_fenced(conflict_consumer)
 
                 # Stop existing nodes, so conflicting ones should be able to join.
                 consumer.stop_all()
@@ -374,7 +376,11 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         else:
             consumer.start()
-            conflict_consumer.start()
+
+            if group_protocol == consumer_group.consumer_group_protocol:
+                conflict_consumer.start(wait_for_startup=False)
+            else:
+                conflict_consumer.start()
 
             wait_until(lambda: len(consumer.joined_nodes()) + len(conflict_consumer.joined_nodes()) == len(consumer.nodes),
                        timeout_sec=60,

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -69,7 +69,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
                 self.await_all_members(consumer)
                 self.await_consumed_messages(consumer)
 
-    def setup_consumer(self, topic, **kwargs) -> VerifiableConsumer:
+    def setup_consumer(self, topic, **kwargs):
         # collect verifiable consumer events since this makes debugging much easier
         consumer = super(OffsetValidationTest, self).setup_consumer(topic, **kwargs)
         self.mark_for_collect(consumer, 'verifiable_consumer_stdout')
@@ -309,6 +309,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         - the same group.instance.id.
         - Let normal consumers and fencing consumers start at the same time, and expect only unique consumers left.
         """
+        partition = TopicPartition(self.TOPIC, 0)
 
         producer = self.setup_producer(self.TOPIC)
 
@@ -327,9 +328,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
             self.await_all_members_stabilized(self.TOPIC, self.NUM_PARTITIONS, consumer, timeout_sec=120)
 
             num_rebalances = consumer.num_rebalances()
+            conflict_consumer.start()
             if group_protocol == consumer_group.classic_group_protocol:
                 # Classic protocol: conflicting members should join, and the initial ones with conflicting instance id should fail.
-                conflict_consumer.start()
                 self.await_members(conflict_consumer, num_conflict_consumers)
                 self.await_members(consumer, len(consumer.nodes) - num_conflict_consumers)
 
@@ -338,8 +339,6 @@ class OffsetValidationTest(VerifiableConsumerTest):
                        err_msg="Timed out waiting for the fenced consumers to stop")
             else:
                 # Consumer protocol: Existing members should remain active and new conflicting ones should not be able to join.
-                conflict_consumer.start(wait_for_startup=False)
-
                 # Conflict consumers will terminate due to a fatal UnreleasedInstanceIdException error.
                 # Wait for termination to complete to prevent conflict consumers from immediately re-joining the group while existing nodes are shutting down.
                 self.await_conflict_consumers_fenced(conflict_consumer)
@@ -376,11 +375,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
         else:
             consumer.start()
-
-            if group_protocol == consumer_group.consumer_group_protocol:
-                conflict_consumer.start(wait_for_startup=False)
-            else:
-                conflict_consumer.start()
+            conflict_consumer.start()
 
             wait_until(lambda: len(consumer.joined_nodes()) + len(conflict_consumer.joined_nodes()) == len(consumer.nodes),
                        timeout_sec=60,

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -53,7 +53,7 @@ class VerifiableConsumerTest(KafkaTest):
         return super(VerifiableConsumerTest, self).min_cluster_size() + self.num_consumers + self.num_producers
 
     def setup_consumer(self, topic, static_membership=False, enable_autocommit=False,
-                       assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor", group_remote_assignor="range", **kwargs) -> VerifiableConsumer:
+                       assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor", group_remote_assignor="range", **kwargs):
         return VerifiableConsumer(self.test_context, self.num_consumers, self.kafka,
                                   topic, self.group_id, static_membership=static_membership,
                                   assignment_strategy=assignment_strategy, enable_autocommit=enable_autocommit,

--- a/tests/kafkatest/tests/verifiable_consumer_test.py
+++ b/tests/kafkatest/tests/verifiable_consumer_test.py
@@ -53,7 +53,7 @@ class VerifiableConsumerTest(KafkaTest):
         return super(VerifiableConsumerTest, self).min_cluster_size() + self.num_consumers + self.num_producers
 
     def setup_consumer(self, topic, static_membership=False, enable_autocommit=False,
-                       assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor", group_remote_assignor="range", **kwargs):
+                       assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor", group_remote_assignor="range", **kwargs) -> VerifiableConsumer:
         return VerifiableConsumer(self.test_context, self.num_consumers, self.kafka,
                                   topic, self.group_id, static_membership=static_membership,
                                   assignment_strategy=assignment_strategy, enable_autocommit=enable_autocommit,


### PR DESCRIPTION
### Summary
- Fixes test_fencing_static_consumer flakiness by allowing
expected-to-fail conflict consumers to start without waiting for all
nodes to be simultaneously alive.
- Remove unused codes.
- Declare return types for better type inference.

### Test Result
```
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.14.0
session_id:       2026-09-04--002
run time:         5 minutes 51.535 seconds
tests run:        8
passed:           8
flaky:            0
failed:           0
ignored:          0
================================================================================
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=1.fencing_stage=all.metadata_quorum=ISOLATED_KRAFT.group_protocol=classic
status:     PASS
run time:   29.502 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=1.fencing_stage=all.metadata_quorum=ISOLATED_KRAFT.group_protocol=consumer
status:     PASS
run time:   29.419 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=1.fencing_stage=stable.metadata_quorum=ISOLATED_KRAFT.group_protocol=classic
status:     PASS
run time:   30.707 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=1.fencing_stage=stable.metadata_quorum=ISOLATED_KRAFT.group_protocol=consumer
status:     PASS
run time:   1 minute 19.619 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=2.fencing_stage=all.metadata_quorum=ISOLATED_KRAFT.group_protocol=classic
status:     PASS
run time:   30.993 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=2.fencing_stage=all.metadata_quorum=ISOLATED_KRAFT.group_protocol=consumer
status:     PASS
run time:   29.986 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=2.fencing_stage=stable.metadata_quorum=ISOLATED_KRAFT.group_protocol=classic
status:     PASS
run time:   34.358 seconds
--------------------------------------------------------------------------------
test_id:
kafkatest.tests.client.consumer_test.OffsetValidationTest.test_fencing_static_consumer.num_conflict_consumers=2.fencing_stage=stable.metadata_quorum=ISOLATED_KRAFT.group_protocol=consumer
status:     PASS
run time:   1 minute 25.968 seconds
--------------------------------------------------------------------------------
```

Reviewers: Sean Quah <squah@confluent.io>
