### PR TITLE
KAFKA-20423: Fix flakiness of testWakeupWithFetchDataAvailable (More)

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.ClientRequest;
-import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.MockClient;
@@ -28,6 +27,7 @@ import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerProtocol;
+import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.GroupCoordinatorNode;
 import org.apache.kafka.clients.consumer.internals.MockRebalanceListener;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState;
@@ -1597,21 +1597,7 @@ public class KafkaConsumerTest {
     @EnumSource(value = GroupProtocol.class, names = "CLASSIC")
     public void testWakeupWithFetchDataAvailable(GroupProtocol groupProtocol) throws Exception {
         ConsumerMetadata metadata = createMetadata(subscription);
-
-        AtomicInteger fetchCorrelationId = new AtomicInteger(-1);
-        AtomicBoolean fetchResponseCompleted = new AtomicBoolean(false);
-        MockClient client = new MockClient(time, metadata) {
-            @Override
-            public List<ClientResponse> poll(long timeoutMs, long now) {
-                List<ClientResponse> completed = super.poll(timeoutMs, now);
-                completed.stream()
-                        .filter(response -> response.requestHeader().apiKey() == ApiKeys.FETCH)
-                        .filter(response -> response.requestHeader().correlationId() == fetchCorrelationId.get())
-                        .findAny()
-                        .ifPresent(response -> fetchResponseCompleted.set(true));
-                return completed;
-            }
-        };
+        MockClient client = new MockClient(time, metadata);
 
         initMetadata(client, Map.of(topic, 1));
         Node node = metadata.fetch().nodes().get(0);
@@ -1624,14 +1610,14 @@ public class KafkaConsumerTest {
         consumer.poll(Duration.ZERO);
 
         // respond to the outstanding fetch so that we have data available on the next poll
-        ClientRequest fetchRequest = findRequest(client, ApiKeys.FETCH);
-        fetchCorrelationId.set(fetchRequest.correlationId());
-
         client.respondFrom(fetchResponse(tp0, 0, 5), node);
+
+        ClassicKafkaConsumer<?, ?> delegate = TestUtils.fieldValue(consumer, KafkaConsumer.class, "delegate");
+        Fetcher<?, ?> fetcher = TestUtils.fieldValue(delegate, ClassicKafkaConsumer.class, "fetcher");
         TestUtils.waitForCondition(() -> {
             client.poll(0, time.milliseconds());
-            return fetchResponseCompleted.get();
-        }, "Fetch response was not completed.");
+            return fetcher.hasAvailableFetches();
+        }, "Fetch data was not buffered.");
         
         consumer.wakeup();
 


### PR DESCRIPTION
- Previous PR - https://github.com/apache/kafka/pull/22364/

The previous PR changed the test to wait until `MockClient` invokes the
completion callback for the fetch response. However, this callback only
registers a completion handler in `pendingCompletion`; it does not
guarantee that the fetch data has already been added to the
`FetchBuffer`.

As a result, the following race condition can still occur:

1. The test worker finishes waiting for `fetchResponseCompleted`, then
verifies the wakeup exception and the position.
2. After the second `consumer.poll(Duration.ZERO)` has passed
coordinator processing, the heartbeat thread removes the handler from
`pendingCompletion`.
3. If the heartbeat thread is descheduled before executing the handler,
the test worker may observe both the completion queue and the
`FetchBuffer` as empty and return an empty result.
4. The heartbeat thread then resumes and adds the fetch data to the
buffer.

This PR changes the wait condition to `fetcher.hasAvailableFetches()`,
ensuring that fetch data that can actually be returned is present in the
buffer before calling `wakeup()`.

This removes the dependency of the subsequent poll's record verification
on the timing of the heartbeat thread's completion processing.
