### PR TITLE
KAFKA-21035: Keep the move failure when flushDir also fails in atomicMoveWithFallback

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -936,9 +936,12 @@ public final class Utils {
      * to repeatedly flush the same parent directory.
      *
      * @throws IOException if both atomic and non-atomic moves fail,
-     * or parent dir flush fails if needFlushParentDir is true.
+     * or parent dir flush fails if needFlushParentDir is true. If both the move and the parent
+     * dir flush fail, the move failure is thrown with the flush failure added as a suppressed
+     * exception, so callers always see why the move failed.
      */
     public static void atomicMoveWithFallback(Path source, Path target, boolean needFlushParentDir) throws IOException {
+        IOException moveException = null;
         try {
             Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException outer) {
@@ -948,11 +951,20 @@ public final class Utils {
                 log.debug("Non-atomic move of {} to {} succeeded after atomic move failed", source, target);
             } catch (IOException inner) {
                 inner.addSuppressed(outer);
+                moveException = inner;
                 throw inner;
             }
         } finally {
             if (needFlushParentDir) {
-                flushDir(target.toAbsolutePath().normalize().getParent());
+                try {
+                    flushDir(target.toAbsolutePath().normalize().getParent());
+                } catch (Throwable flushException) {
+                    if (moveException == null)
+                        throw flushException;
+                    // Throwing from a finally block would discard the in-flight move failure, so attach
+                    // the flush failure to it instead and let the move failure reach the caller.
+                    moveException.addSuppressed(flushException);
+                }
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.internals.OperatingSystem;
 import org.apache.kafka.common.utils.internals.SingleByteBufferOutputStream;
 import org.apache.kafka.test.TestUtils;
 
@@ -36,12 +37,16 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.spi.FileSystemProvider;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -55,6 +60,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -93,6 +99,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -806,6 +814,55 @@ public class UtilsTest {
         assertDoesNotThrow(() -> Utils.delete(spyRootFile));
         assertFalse(Files.exists(rootDir.toPath()));
         assertFalse(Files.exists(subDir.toPath()));
+    }
+
+    @Test
+    public void testAtomicMoveWithFallbackShouldNotMaskMoveFailureWithFlushFailure() throws IOException {
+        // Flushing a directory is a no-op on Windows and z/OS, so the flush cannot fail there.
+        assumeFalse(OperatingSystem.IS_WINDOWS);
+        assumeFalse(OperatingSystem.IS_ZOS);
+
+        Path tempDir = TestUtils.tempDirectory().toPath();
+        Path source = tempDir.resolve("non-existent-source");
+        Path target = tempDir.resolve("non-existent-dir").resolve("target");
+
+        // The atomic move and the fallback move both fail because the source does not exist, and flushing
+        // the parent directory of the target fails as well because that directory does not exist either.
+        // The move failure must be the exception the caller sees, otherwise callers such as checkpoint
+        // files and partition directory renames log and handle the wrong root cause.
+        NoSuchFileException thrown = assertThrows(NoSuchFileException.class, () -> Utils.atomicMoveWithFallback(source, target, true));
+        assertEquals(source.toString(), thrown.getFile(),
+            "Expected the failed move of " + source + " to be thrown, but got " + thrown +
+                " with suppressed " + Arrays.toString(thrown.getSuppressed()));
+        assertTrue(
+            Arrays.stream(thrown.getSuppressed())
+                .anyMatch(t -> t instanceof NoSuchFileException && target.getParent().toString().equals(((NoSuchFileException) t).getFile())),
+            "Expected the flush failure of " + target.getParent() + " to be suppressed, but got " + thrown +
+                " with suppressed " + Arrays.toString(thrown.getSuppressed()));
+    }
+
+    @Test
+    public void testAtomicMoveWithFallbackShouldPropagateFlushFailureAfterSuccessfulMove() throws IOException {
+        // Flushing a directory is a no-op on Windows and z/OS, and removing the read permission below
+        // requires a file system with POSIX permissions.
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        assumeFalse(OperatingSystem.IS_ZOS);
+
+        Path targetDir = TestUtils.tempDirectory().toPath();
+        Path source = TestUtils.tempFile().toPath();
+        Path target = targetDir.resolve("target");
+
+        // Moving a file into the target directory only needs write and execute permissions on it, while
+        // flushing it requires read permission to open it. Dropping read makes the move succeed and the
+        // subsequent flush fail, and that flush failure must reach the caller.
+        Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(targetDir);
+        Files.setPosixFilePermissions(targetDir, EnumSet.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE));
+        try {
+            assertThrows(AccessDeniedException.class, () -> Utils.atomicMoveWithFallback(source, target, true));
+        } finally {
+            Files.setPosixFilePermissions(targetDir, originalPermissions);
+        }
+        assertTrue(Files.exists(target), "The move should have succeeded before the flush failure");
     }
 
     @Test


### PR DESCRIPTION
Utils.atomicMoveWithFallback fsyncs the parent directory of the target in a finally block. When both moves fail and the fsync fails too, the exception thrown from finally replaces the move exception: the caller gets the fsync failure with nothing suppressed, and the failed move survives only in the WARN that Utils logs for the atomic attempt.

The two failures usually share a cause (directory gone, disk failing), so this is how a log dir failure normally surfaces. Every caller that flushes the parent is affected: CheckpointFile, PartitionMetadataFile, PropertiesUtils (meta.properties), FileQuorumStateStore, FileRawSnapshotWriter, LocalLog.renameDir and Streams OffsetCheckpoint. On a broker the exception under LogDirFailureChannel's "Error while renaming dir" ERROR is the fsync failure from Utils.flushDir, not the rename's own failure.

Catch the flush failure in the finally block. If a move failure is in flight, attach the flush failure with addSuppressed and let the move failure propagate, as Utils.closeAll and Utils.tryAll do. If the move succeeded, rethrow the flush failure unchanged. Throwable is caught, as in tryAll, so an unchecked failure from FileChannel.open cannot mask the move failure either.

Two UtilsTest cases. In the first, both moves and the flush fail; it asserts the thrown exception is the move failure and the flush failure is suppressed, and fails on trunk, which throws only the flush failure. In the second the move succeeds and the flush fails because the target directory lost read permission; the flush failure must still propagate. Also reproduced on a single-node KRaft broker by moving a log dir away and deleting a topic in it (steps in KAFKA-21035): trunk logs the parent dir fsync error, with this change it logs the failed rename with the fsync error suppressed.
