### PR TITLE
KAFKA-21039: Remove hamcrest from KTable* basic tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -52,10 +52,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class KTableFilterTest {
@@ -412,8 +412,8 @@ public class KTableFilterTest {
 
         table2.enableSendingOldValues(true);
 
-        assertThat(table1.sendingOldValueEnabled(), is(true));
-        assertThat(table2.sendingOldValueEnabled(), is(true));
+        assertTrue(table1.sendingOldValueEnabled());
+        assertTrue(table2.sendingOldValueEnabled());
 
         doTestSendingOldValue(builder, table1, table2, topic1);
     }
@@ -432,8 +432,8 @@ public class KTableFilterTest {
 
         table2.enableSendingOldValues(true);
 
-        assertThat(table1.sendingOldValueEnabled(), is(false));
-        assertThat(table2.sendingOldValueEnabled(), is(true));
+        assertFalse(table1.sendingOldValueEnabled());
+        assertTrue(table2.sendingOldValueEnabled());
 
         doTestSendingOldValue(builder, table1, table2, topic1);
     }
@@ -452,8 +452,8 @@ public class KTableFilterTest {
 
         table2.enableSendingOldValues(false);
 
-        assertThat(table1.sendingOldValueEnabled(), is(true));
-        assertThat(table2.sendingOldValueEnabled(), is(true));
+        assertTrue(table1.sendingOldValueEnabled());
+        assertTrue(table2.sendingOldValueEnabled());
 
         doTestSendingOldValue(builder, table1, table2, topic1);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -68,13 +68,13 @@ import java.util.List;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -412,7 +412,7 @@ public class KTableImplTest {
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
         table.enableSendingOldValues(false);
 
-        assertThat(table.sendingOldValueEnabled(), is(false));
+        assertFalse(table.sendingOldValueEnabled());
     }
 
     @ParameterizedTest
@@ -424,7 +424,7 @@ public class KTableImplTest {
         final var table = assertInstanceOf(KTableImpl.class, builder.table("topic1", consumed));
         table.enableSendingOldValues(true);
 
-        assertThat(table.sendingOldValueEnabled(), is(true));
+        assertTrue(table.sendingOldValueEnabled());
     }
 
     private void assertTopologyContainsProcessor(final Topology topology, final String processorName) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -47,11 +47,10 @@ import java.time.Instant;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class KTableMapValuesTest {
@@ -268,8 +267,8 @@ public class KTableMapValuesTest {
 
         table2.enableSendingOldValues(true);
 
-        assertThat(table1.sendingOldValueEnabled(), is(true));
-        assertThat(table2.sendingOldValueEnabled(), is(true));
+        assertTrue(table1.sendingOldValueEnabled());
+        assertTrue(table2.sendingOldValueEnabled());
 
         testSendingOldValues(builder, topic1, table2);
     }
@@ -291,8 +290,8 @@ public class KTableMapValuesTest {
 
         table2.enableSendingOldValues(true);
 
-        assertThat(table1.sendingOldValueEnabled(), is(false));
-        assertThat(table2.sendingOldValueEnabled(), is(true));
+        assertFalse(table1.sendingOldValueEnabled());
+        assertTrue(table2.sendingOldValueEnabled());
 
         testSendingOldValues(builder, topic1, table2);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -53,8 +53,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -152,12 +150,12 @@ public class KTableSourceTest {
                 );
             inputTopic.pipeInput(null, "value");
 
-            assertThat(
+            assertTrue(
                 appender.getEvents().stream()
                     .filter(e -> e.getLevel().equals("WARN"))
                     .map(Event::getMessage)
-                    .collect(Collectors.toList()),
-                hasItem("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]")
+                    .collect(Collectors.toList())
+                    .contains("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]")
             );
         }
     }
@@ -182,12 +180,12 @@ public class KTableSourceTest {
             inputTopic.pipeInput("key", "value", 10L);
             inputTopic.pipeInput("key", "value", 5L);
 
-            assertThat(
+            assertTrue(
                 appender.getEvents().stream()
                     .filter(e -> e.getLevel().equals("WARN"))
                     .map(Event::getMessage)
-                    .collect(Collectors.toList()),
-                hasItem("Detected out-of-order KTable update for store, old timestamp=[10] new timestamp=[5]. topic=[topic] partition=[0] offset=[1].")
+                    .collect(Collectors.toList())
+                    .contains("Detected out-of-order KTable update for store, old timestamp=[10] new timestamp=[5]. topic=[topic] partition=[0] offset=[1].")
             );
         }
     }


### PR DESCRIPTION
Replace Hamcrest matchers with plain JUnit 5 assertions in KTableFilterTest, KTableImplTest, KTableMapValuesTest and KTableSourceTest:
- assertThat(x, is(true/false)) -> assertTrue/assertFalse(x)
- assertThat(list, hasItem(s))  -> assertTrue(list.contains(s))

Removes the now-unused org.hamcrest.* static imports. Test-only change, no production code affected.
Co-Authored-By: Claude Opus 4.8 <claude@anthropic.com>

Reviewers: Uros (github:uros-b)
