### PR TITLE
KAFKA-21041: Allow equals signs in client metrics match patterns

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
+++ b/server/src/main/java/org/apache/kafka/server/metrics/ClientMetricsConfigs.java
@@ -195,7 +195,8 @@ public class ClientMetricsConfigs extends AbstractConfig {
 
         Map<String, Pattern> patternsMap = new HashMap<>();
         patterns.forEach(pattern -> {
-            String[] nameValuePair = pattern.split("=");
+            // The pattern value may contain '=' characters, so split only at the first occurrence.
+            String[] nameValuePair = pattern.split("=", 2);
             if (nameValuePair.length != 2) {
                 throw new InvalidConfigurationException("Illegal client matching pattern: " + pattern);
             }

--- a/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsConfigsTest.java
+++ b/server/src/test/java/org/apache/kafka/server/metrics/ClientMetricsConfigsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.metrics;
+
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClientMetricsConfigsTest {
+
+    @Test
+    public void testMatchingPatternMayContainEqualsSign() {
+        Map<String, Pattern> patterns = ClientMetricsConfigs.parseMatchingPatterns(
+            List.of("client_id=foo=bar")
+        );
+
+        Pattern clientIdPattern = patterns.get(ClientMetricsConfigs.CLIENT_ID);
+        assertEquals("foo=bar", clientIdPattern.pattern());
+        assertTrue(clientIdPattern.matcher("foo=bar").matches());
+    }
+
+    @Test
+    public void testMatchingPatternWithoutEqualsSignIsRejected() {
+        assertThrows(InvalidConfigurationException.class,
+            () -> ClientMetricsConfigs.parseMatchingPatterns(List.of(ClientMetricsConfigs.CLIENT_ID)));
+    }
+}


### PR DESCRIPTION
ClientMetricsConfigs.parseMatchingPatterns currently splits client match patterns on every '=' character. As a result, a valid pattern such as client_id=foo=bar is rejected because it produces more than two parts.

The method Javadoc specifies that the input should be split at the first occurrence of '='. This change uses split("=", 2), preserving additional equals signs in the regular expression.

Reviewers: Uros (github:uros-b), Andrew Schofield <aschofield@confluent.io>, Anand Maurya (github:AnandMaurya24)
