### PR TITLE
KAFKA-17429 Avoid dirtying cached entries for unchanged records

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/LRUCacheEntry.java
@@ -84,6 +84,10 @@ class LRUCacheEntry {
         return record.recordContext();
     }
 
+    boolean hasSameRecord(final LRUCacheEntry other) {
+        return record.equals(other.record);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -172,6 +172,10 @@ class NamedCache {
             );
         }
         LRUNode node = cache.get(key);
+        if (node != null && node.entry.hasSameRecord(value)) {
+            updateLRU(node);
+            return;
+        }
         if (node != null) {
             numOverwrites++;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -194,6 +194,23 @@ public class NamedCacheTest {
     }
 
     @Test
+    public void shouldNotDirtyEntryWhenReentrantPutDoesNotChangeRecord() {
+        final Bytes key = Bytes.wrap(new byte[]{0});
+        final byte[] value = new byte[]{10};
+        final List<ThreadCache.DirtyEntry> flushed = new ArrayList<>();
+        cache.setListener(entries -> {
+            flushed.addAll(entries);
+            cache.put(key, new LRUCacheEntry(value, headers, true, 0, 0, 0, "", rawKey, rawValue));
+        });
+        cache.put(key, new LRUCacheEntry(value, headers, true, 0, 0, 0, "", rawKey, rawValue));
+
+        cache.flush();
+        cache.flush();
+
+        assertEquals(1, flushed.size());
+    }
+
+    @Test
     public void shouldBeReentrantAndNotBreakLRU() {
         final LRUCacheEntry dirty = new LRUCacheEntry(new byte[]{3}, new RecordHeaders(), true, 0, 0, 0, "", rawKey, rawValue);
         final LRUCacheEntry clean = new LRUCacheEntry(new byte[]{3});

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -53,6 +54,7 @@ import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.TestUtils;
@@ -1631,6 +1633,47 @@ public abstract class TopologyTestDriverTest {
 
         store = testDriver.getKeyValueStore("aggStore");
         store.put("a", 21L);
+    }
+
+    @Test
+    public void shouldCloseWhenProcessorUpdatesCachedUpstreamStore() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream("input-topic", Consumed.with(Serdes.String(), Serdes.Integer()))
+            .groupByKey()
+            .aggregate(
+                () -> 0,
+                (key, value, aggregate) -> aggregate + value,
+                Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("aggregate-store")
+                    .withKeySerde(Serdes.String())
+                    .withValueSerde(Serdes.Integer())
+            )
+            .toStream()
+            .process(() -> new Processor<String, Integer, Void, Void>() {
+                private KeyValueStore<String, ValueAndTimestamp<Integer>> aggregateStore;
+
+                @Override
+                public void init(final ProcessorContext<Void, Void> context) {
+                    aggregateStore = context.getStateStore("aggregate-store");
+                }
+
+                @Override
+                public void process(final Record<String, Integer> record) {
+                    final ValueAndTimestamp<Integer> aggregate = aggregateStore.get(record.key());
+                    aggregateStore.put(record.key(), aggregate);
+                }
+            }, "aggregate-store");
+
+        testDriver = new TopologyTestDriverBuilder(builder.build()).withConfig(config).build();
+        testDriver.pipeRecord(
+            "input-topic",
+            new TestRecord<>("key", 1),
+            new StringSerializer(),
+            new IntegerSerializer(),
+            Instant.now()
+        );
+
+        testDriver.close();
+        testDriver = null;
     }
 
     @Test


### PR DESCRIPTION
When a downstream processor writes an unchanged record back into its
cached aggregate store, the cache marks it dirty again during flushing.
The pending entry is later forwarded during TopologyTestDriver.close(),
after the processors have closed, causing a ProcessorStateException.

Preserve the existing cache entry when both its value and record context
are unchanged, while updating its LRU position. This prevents the
redundant write from leaving another record to flush.

Validation: the regression test fails before the fix and passes
afterward in both at-least-once and exactly-once modes. NamedCacheTest,
Checkstyle, SpotBugs, Spotless, and git diff --check also pass.

Jira: https://issues.apache.org/jira/browse/KAFKA-17429
