### PR TITLE
MINOR: Replace try/fail/catch with assertThrows in DescribeUserScramCredentialsResultTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/DescribeUserScramCredentialsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/DescribeUserScramCredentialsResultTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.errors.DuplicateResourceException;
+import org.apache.kafka.common.errors.ResourceNotFoundException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -26,34 +28,28 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DescribeUserScramCredentialsResultTest {
     @Test
     public void testTopLevelError() {
         KafkaFutureImpl<DescribeUserScramCredentialsResponseData> dataFuture = new KafkaFutureImpl<>();
-        dataFuture.completeExceptionally(new RuntimeException());
+        RuntimeException topLevelError = new RuntimeException();
+        dataFuture.completeExceptionally(topLevelError);
         DescribeUserScramCredentialsResult results = new DescribeUserScramCredentialsResult(dataFuture);
-        try {
-            results.all().get();
-            fail("expected all() to fail when there is a top-level error");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
-        try {
-            results.users().get();
-            fail("expected users() to fail when there is a top-level error");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
-        try {
-            results.description("whatever").get();
-            fail("expected description() to fail when there is a top-level error");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
+
+        ExecutionException e = assertThrows(ExecutionException.class, () -> results.all().get());
+        assertEquals(topLevelError, e.getCause());
+
+        e = assertThrows(ExecutionException.class, () -> results.users().get());
+        assertEquals(topLevelError, e.getCause());
+
+        e = assertThrows(ExecutionException.class, () -> results.description("whatever").get());
+        assertEquals(topLevelError, e.getCause());
     }
 
     @Test
@@ -70,27 +66,19 @@ public class DescribeUserScramCredentialsResultTest {
                 new DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult().setUser(unknownUser).setErrorCode(Errors.RESOURCE_NOT_FOUND.code()),
                 new DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult().setUser(failedUser).setErrorCode(Errors.DUPLICATE_RESOURCE.code()))));
         DescribeUserScramCredentialsResult results = new DescribeUserScramCredentialsResult(dataFuture);
-        try {
-            results.all().get();
-            fail("expected all() to fail when there is a user-level error");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
+
+        ExecutionException e = assertThrows(ExecutionException.class, () -> results.all().get());
+        assertInstanceOf(DuplicateResourceException.class, e.getCause());
+
         assertEquals(Arrays.asList(goodUser, failedUser), results.users().get(), "Expected 2 users with credentials");
         UserScramCredentialsDescription goodUserDescription = results.description(goodUser).get();
         assertEquals(new UserScramCredentialsDescription(goodUser, Collections.singletonList(new ScramCredentialInfo(scramSha256, iterations))), goodUserDescription);
-        try {
-            results.description(failedUser).get();
-            fail("expected description(failedUser) to fail when there is a user-level error");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
-        try {
-            results.description(unknownUser).get();
-            fail("expected description(unknownUser) to fail when there is no such user");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
+
+        e = assertThrows(ExecutionException.class, () -> results.description(failedUser).get());
+        assertInstanceOf(DuplicateResourceException.class, e.getCause());
+
+        e = assertThrows(ExecutionException.class, () -> results.description(unknownUser).get());
+        assertInstanceOf(ResourceNotFoundException.class, e.getCause());
     }
 
     @Test
@@ -110,11 +98,8 @@ public class DescribeUserScramCredentialsResultTest {
         UserScramCredentialsDescription goodUserDescriptionViaAll = allResults.get(goodUser);
         assertEquals(new UserScramCredentialsDescription(goodUser, Collections.singletonList(new ScramCredentialInfo(scramSha256, iterations))), goodUserDescriptionViaAll);
         assertEquals(goodUserDescriptionViaAll, results.description(goodUser).get(), "Expected same thing via all() and description()");
-        try {
-            results.description(unknownUser).get();
-            fail("expected description(unknownUser) to fail when there is no such user even when all() succeeds");
-        } catch (Exception expected) {
-            // ignore, expected
-        }
+
+        ExecutionException e = assertThrows(ExecutionException.class, () -> results.description(unknownUser).get());
+        assertInstanceOf(ResourceNotFoundException.class, e.getCause());
     }
 }


### PR DESCRIPTION
Modernize the seven exception assertions in `DescribeUserScramCredentialsResultTest` from the try/call/fail/catch idiom to `assertThrows`.

Each of the old blocks caught a bare `Exception` and asserted nothing about the failure, so a test passed as long as anything at all was thrown. `assertThrows` fails on its own when nothing is thrown and pins the exception type. Every accessor returns a `KafkaFuture`, so the thrown type is `ExecutionException`, and the return value is used to check the cause the result class actually produces: the top-level error handed to `completeExceptionally`, `DuplicateResourceException` from `all()` and `description(failedUser)` when a user result carries `DUPLICATE_RESOURCE`, and `ResourceNotFoundException` from `description(unknownUser)`, both when the user's result carries `RESOURCE_NOT_FOUND` and when the user is absent from the response.

Follows the same cleanup as #23277 and #19975.

Testing: `:clients:test --tests org.apache.kafka.clients.admin.DescribeUserScramCredentialsResultTest` with Gradle 9.7.1 on Temurin 17, which also runs `checkstyleMain` and `checkstyleTest` for the module, plus `:clients:spotlessCheck`, all green.
Reviewers: Uros (github:uros-b)
