### PR TITLE
MINOR: Avoid unnecessary cluster setup in ListConsumerGroupTest

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandTest.java
@@ -16,15 +16,23 @@
  */
 package org.apache.kafka.tools.consumer.group;
 
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.tools.ToolsTestUtils;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
+
+import joptsimple.OptionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConsumerGroupCommandTest {
+    private static final String DUMMY_BOOTSTRAP_SERVERS = "localhost:9092";
+
     @Test
     public void testValidateRegexCommandWithValidRegex() {
         String output = ToolsTestUtils.grabConsoleOutput(
@@ -53,5 +61,60 @@ public class ConsumerGroupCommandTest {
             "The regular expression `[foo.*` is invalid: missing closing ].\n",
             output
         );
+    }
+
+    @Test
+    public void testListWithUnrecognizedNewConsumerOption() {
+        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", DUMMY_BOOTSTRAP_SERVERS, "--list"};
+        assertThrows(OptionException.class, () -> ConsumerGroupCommandOptions.fromArgs(cgcArgs));
+    }
+
+    @Test
+    public void testConsumerGroupStatesFromString() {
+        Set<GroupState> result = ConsumerGroupCommand.groupStatesFromString("Stable");
+        assertEquals(Set.of(GroupState.STABLE), result);
+
+        result = ConsumerGroupCommand.groupStatesFromString("Stable, PreparingRebalance");
+        assertEquals(Set.of(GroupState.STABLE, GroupState.PREPARING_REBALANCE), result);
+
+        result = ConsumerGroupCommand.groupStatesFromString("Dead,CompletingRebalance,");
+        assertEquals(Set.of(GroupState.DEAD, GroupState.COMPLETING_REBALANCE), result);
+
+        result = ConsumerGroupCommand.groupStatesFromString("stable");
+        assertEquals(Set.of(GroupState.STABLE), result);
+
+        result = ConsumerGroupCommand.groupStatesFromString("stable, assigning");
+        assertEquals(Set.of(GroupState.STABLE, GroupState.ASSIGNING), result);
+
+        result = ConsumerGroupCommand.groupStatesFromString("dead,reconciling,");
+        assertEquals(Set.of(GroupState.DEAD, GroupState.RECONCILING), result);
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("bad, wrong"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("  bad, Stable"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("   ,   ,"));
+    }
+
+    @Test
+    public void testConsumerGroupTypesFromString() {
+        Set<GroupType> result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer");
+        assertEquals(Set.of(GroupType.CONSUMER), result);
+
+        result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, classic");
+        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
+
+        result = ConsumerGroupCommand.consumerGroupTypesFromString("Consumer, Classic");
+        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("Share"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("streams"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("  bad, generic"));
+
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"));
     }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -522,34 +523,34 @@ public class ListConsumerGroupTest {
     }
 
     private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, GroupProtocol protocol, String groupId, String topicName) {
-        Map<String, Object> configs = consumerConfigs(clusterInstance, groupId, protocol);
+        Map<String, Object> configs = composeConfigs(clusterInstance, groupId, protocol.name);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
                 false,
                 topicName,
-                () -> new KafkaConsumer<>(configs)
+                () -> new KafkaConsumer<String, String>(configs)
         );
     }
 
     private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, String groupId, Set<TopicPartition> topicPartitions) {
-        Map<String, Object> configs = consumerConfigs(clusterInstance, groupId, GroupProtocol.CLASSIC);
+        Map<String, Object> configs = composeConfigs(clusterInstance, groupId, GroupProtocol.CLASSIC.name);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
                 topicPartitions,
-                () -> new KafkaConsumer<>(configs)
+                () -> new KafkaConsumer<String, String>(configs)
         );
     }
 
-    private static Map<String, Object> consumerConfigs(ClusterInstance clusterInstance, String groupId, GroupProtocol groupProtocol) {
+    private static Map<String, Object> composeConfigs(ClusterInstance clusterInstance, String groupId, String groupProtocol) {
         Map<String, Object> configs = new HashMap<>();
         configs.put(BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
         configs.put(GROUP_ID_CONFIG, groupId);
         configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol.name);
-        if (groupProtocol == GroupProtocol.CLASSIC) {
+        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol);
+        if (GroupProtocol.CLASSIC.name.equalsIgnoreCase(groupProtocol)) {
             configs.put(PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RangeAssignor.class.getName());
         }
         return configs;
@@ -584,15 +585,15 @@ public class ListConsumerGroupTest {
      * @param expectedListing        Expected consumer group listings.
      */
     private static void assertGroupListing(
-            ConsumerGroupCommand.ConsumerGroupService service,
-            Set<GroupType> typeFilterSet,
-            Set<GroupState> groupStateFilterSet,
-            Set<GroupListing> expectedListing
+        ConsumerGroupCommand.ConsumerGroupService service,
+        Set<GroupType> typeFilterSet,
+        Set<GroupState> groupStateFilterSet,
+        Set<GroupListing> expectedListing
     ) throws Exception {
         final AtomicReference<Set<GroupListing>> foundListing = new AtomicReference<>(Set.of());
         TestUtils.waitForCondition(() -> {
             foundListing.set(new HashSet<>(service.listConsumerGroupsWithFilters(typeFilterSet, groupStateFilterSet)));
-            return expectedListing.equals(foundListing.get());
+            return Objects.equals(expectedListing, foundListing.get());
         }, () -> "Expected to show groups " + expectedListing + ", but found " + foundListing.get() + ".");
     }
 
@@ -606,9 +607,9 @@ public class ListConsumerGroupTest {
      * @throws InterruptedException
      */
     private static void validateListOutput(
-            List<String> args,
-            List<String> expectedHeader,
-            Set<List<String>> expectedRows
+        List<String> args,
+        List<String> expectedHeader,
+        Set<List<String>> expectedRows
     ) throws InterruptedException {
         final AtomicReference<String> out = new AtomicReference<>("");
         TestUtils.waitForCondition(() -> {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -102,7 +102,7 @@ public class ListConsumerGroupTest {
                  ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list"})
             ) {
                 Set<String> expectedGroups = Set.of(topicPartitionsGroup, topicGroup, protocolGroup);
-                final AtomicReference<Set<String>> foundGroups = new AtomicReference<>(Set.of());
+                final AtomicReference<Set<String>> foundGroups = new AtomicReference<>();
 
                 TestUtils.waitForCondition(() -> {
                     foundGroups.set(new HashSet<>(service.listConsumerGroups()));
@@ -590,7 +590,7 @@ public class ListConsumerGroupTest {
         Set<GroupState> groupStateFilterSet,
         Set<GroupListing> expectedListing
     ) throws Exception {
-        final AtomicReference<Set<GroupListing>> foundListing = new AtomicReference<>(Set.of());
+        final AtomicReference<Set<GroupListing>> foundListing = new AtomicReference<>();
         TestUtils.waitForCondition(() -> {
             foundListing.set(new HashSet<>(service.listConsumerGroupsWithFilters(typeFilterSet, groupStateFilterSet)));
             return Objects.equals(expectedListing, foundListing.get());

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -30,11 +30,10 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
+import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.tools.ToolsTestUtils;
-
-import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +47,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
-import joptsimple.OptionException;
-
 import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_PROTOCOL_CONFIG;
@@ -62,32 +59,35 @@ import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_IN
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ClusterTestDefaults(
+    types = {Type.CO_KRAFT},
+    serverProperties = {
+        @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+        @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+        @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+        @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+        @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+    }
+)
 public class ListConsumerGroupTest {
     private static final String TOPIC_PREFIX = "test.topic.";
     private static final String TOPIC_PARTITIONS_GROUP_PREFIX = "test.topic.partitions.group.";
     private static final String TOPIC_GROUP_PREFIX = "test.topic.group.";
     private static final String PROTOCOL_GROUP_PREFIX = "test.protocol.group.";
-    private static final String DUMMY_BOOTSTRAP_SERVERS = "localhost:9092";
+    private final ClusterInstance clusterInstance;
 
-    private static List<GroupProtocol> supportedGroupProtocols(ClusterInstance clusterInstance) {
+    ListConsumerGroupTest(ClusterInstance clusterInstance) {
+        this.clusterInstance = clusterInstance;
+    }
+
+    private List<GroupProtocol> supportedGroupProtocols() {
         return new ArrayList<>(clusterInstance.supportedGroupProtocols());
     }
 
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListConsumerGroupsWithoutFilters(ClusterInstance clusterInstance) throws Exception {
-        List<GroupProtocol> groupProtocols = supportedGroupProtocols(clusterInstance);
+    @ClusterTest
+    public void testListConsumerGroupsWithoutFilters() throws Exception {
+        List<GroupProtocol> groupProtocols = supportedGroupProtocols();
         for (int i = 0; i < groupProtocols.size(); i++) {
             GroupProtocol groupProtocol = groupProtocols.get(i);
             String topic = TOPIC_PREFIX + groupProtocol.name;
@@ -96,9 +96,9 @@ public class ListConsumerGroupTest {
             String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + i;
             clusterInstance.createTopic(topic, 1, (short) 1);
 
-            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-                 AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(clusterInstance, GroupProtocol.CLASSIC, topicGroup, topic);
-                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
+            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+                 AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(GroupProtocol.CLASSIC, topicGroup, topic);
+                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
                  ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list"})
             ) {
                 Set<String> expectedGroups = Set.of(topicPartitionsGroup, topicGroup, protocolGroup);
@@ -110,29 +110,14 @@ public class ListConsumerGroupTest {
                 }, () -> "Expected --list to show groups " + expectedGroups + ", but found " + foundGroups.get() + ".");
             }
 
-            removeConsumer(clusterInstance, Set.of(topicPartitionsGroup, topicGroup, protocolGroup));
-            deleteTopic(clusterInstance, topic);
+            removeConsumer(Set.of(topicPartitionsGroup, topicGroup, protocolGroup));
+            deleteTopic(topic);
         }
     }
 
-    @Test
-    public void testListWithUnrecognizedNewConsumerOption() {
-        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", DUMMY_BOOTSTRAP_SERVERS, "--list"};
-        assertThrows(OptionException.class, () -> ConsumerGroupCommandOptions.fromArgs(cgcArgs));
-    }
-
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListConsumerGroupsWithStates(ClusterInstance clusterInstance) throws Exception {
-        List<GroupProtocol> groupProtocols = supportedGroupProtocols(clusterInstance);
+    @ClusterTest
+    public void testListConsumerGroupsWithStates() throws Exception {
+        List<GroupProtocol> groupProtocols = supportedGroupProtocols();
         for (int i = 0; i < groupProtocols.size(); i++) {
             GroupProtocol groupProtocol = groupProtocols.get(i);
             String topic = TOPIC_PREFIX + groupProtocol.name;
@@ -140,8 +125,8 @@ public class ListConsumerGroupTest {
             String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + i;
             clusterInstance.createTopic(topic, 1, (short) 1);
 
-            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
+            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
                  ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--state"})
             ) {
                 Set<GroupListing> expectedListing = Set.of(
@@ -190,30 +175,21 @@ public class ListConsumerGroupTest {
                 );
             }
 
-            removeConsumer(clusterInstance, Set.of(topicPartitionsGroup, protocolGroup));
-            deleteTopic(clusterInstance, topic);
+            removeConsumer(Set.of(topicPartitionsGroup, protocolGroup));
+            deleteTopic(topic);
         }
     }
 
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListConsumerGroupsWithTypesClassicProtocol(ClusterInstance clusterInstance) throws Exception {
+    @ClusterTest
+    public void testListConsumerGroupsWithTypesClassicProtocol() throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CLASSIC;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
         clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
              ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--state"})
         ) {
             Set<GroupListing> expectedListing = Set.of(
@@ -258,17 +234,8 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListConsumerGroupsWithTypesConsumerProtocol(ClusterInstance clusterInstance) throws Exception {
+    @ClusterTest
+    public void testListConsumerGroupsWithTypesConsumerProtocol() throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CONSUMER;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
@@ -276,9 +243,9 @@ public class ListConsumerGroupTest {
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
         clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(clusterInstance, GroupProtocol.CLASSIC, topicGroup, topic);
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(GroupProtocol.CLASSIC, topicGroup, topic);
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
              ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list"})
         ) {
 
@@ -354,25 +321,16 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListGroupCommandClassicProtocol(ClusterInstance clusterInstance) throws Exception {
+    @ClusterTest
+    public void testListGroupCommandClassicProtocol() throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CLASSIC;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
         clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic)
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic)
         ) {
             validateListOutput(
                     List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list"),
@@ -448,25 +406,16 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest(
-        types = {Type.CO_KRAFT},
-        serverProperties = {
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
-        }
-    )
-    public void testListGroupCommandConsumerProtocol(ClusterInstance clusterInstance) throws Exception {
+    @ClusterTest
+    public void testListGroupCommandConsumerProtocol() throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CONSUMER;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
         clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic)
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic)
         ) {
             validateListOutput(
                     List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list"),
@@ -522,8 +471,8 @@ public class ListConsumerGroupTest {
         }
     }
 
-    private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, GroupProtocol protocol, String groupId, String topicName) {
-        Map<String, Object> configs = composeConfigs(clusterInstance, groupId, protocol.name);
+    private AutoCloseable consumerGroupClosable(GroupProtocol protocol, String groupId, String topicName) {
+        Map<String, Object> configs = composeConfigs(groupId, protocol.name);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
@@ -533,8 +482,8 @@ public class ListConsumerGroupTest {
         );
     }
 
-    private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, String groupId, Set<TopicPartition> topicPartitions) {
-        Map<String, Object> configs = composeConfigs(clusterInstance, groupId, GroupProtocol.CLASSIC.name);
+    private AutoCloseable consumerGroupClosable(String groupId, Set<TopicPartition> topicPartitions) {
+        Map<String, Object> configs = composeConfigs(groupId, GroupProtocol.CLASSIC.name);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
@@ -543,7 +492,7 @@ public class ListConsumerGroupTest {
         );
     }
 
-    private static Map<String, Object> composeConfigs(ClusterInstance clusterInstance, String groupId, String groupProtocol) {
+    private Map<String, Object> composeConfigs(String groupId, String groupProtocol) {
         Map<String, Object> configs = new HashMap<>();
         configs.put(BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
         configs.put(GROUP_ID_CONFIG, groupId);
@@ -556,7 +505,7 @@ public class ListConsumerGroupTest {
         return configs;
     }
 
-    private static ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
+    private ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
         ConsumerGroupCommandOptions opts = ConsumerGroupCommandOptions.fromArgs(args);
         return new ConsumerGroupCommand.ConsumerGroupService(
                 opts,
@@ -564,15 +513,15 @@ public class ListConsumerGroupTest {
         );
     }
 
-    private static void removeConsumer(ClusterInstance clusterInstance, Set<String> groupIds) {
+    private void deleteTopic(String topic) {
         try (Admin admin = clusterInstance.admin()) {
-            assertDoesNotThrow(() -> admin.deleteConsumerGroups(groupIds).all().get());
+            assertDoesNotThrow(() -> admin.deleteTopics(Set.of(topic)).all().get());
         }
     }
 
-    private static void deleteTopic(ClusterInstance clusterInstance, String topic) {
+    private void removeConsumer(Set<String> groupIds) {
         try (Admin admin = clusterInstance.admin()) {
-            assertDoesNotThrow(() -> admin.deleteTopics(Set.of(topic)).all().get());
+            assertDoesNotThrow(() -> admin.deleteConsumerGroups(groupIds).all().get());
         }
     }
 
@@ -637,52 +586,4 @@ public class ListConsumerGroupTest {
         }, () -> String.format("Expected header=%s and groups=%s, but found:%n%s", expectedHeader, expectedRows, out.get()));
     }
 
-    @Test
-    public void testConsumerGroupStatesFromString() {
-        Set<GroupState> result = ConsumerGroupCommand.groupStatesFromString("Stable");
-        assertEquals(Set.of(GroupState.STABLE), result);
-
-        result = ConsumerGroupCommand.groupStatesFromString("Stable, PreparingRebalance");
-        assertEquals(Set.of(GroupState.STABLE, GroupState.PREPARING_REBALANCE), result);
-
-        result = ConsumerGroupCommand.groupStatesFromString("Dead,CompletingRebalance,");
-        assertEquals(Set.of(GroupState.DEAD, GroupState.COMPLETING_REBALANCE), result);
-
-        result = ConsumerGroupCommand.groupStatesFromString("stable");
-        assertEquals(Set.of(GroupState.STABLE), result);
-
-        result = ConsumerGroupCommand.groupStatesFromString("stable, assigning");
-        assertEquals(Set.of(GroupState.STABLE, GroupState.ASSIGNING), result);
-
-        result = ConsumerGroupCommand.groupStatesFromString("dead,reconciling,");
-        assertEquals(Set.of(GroupState.DEAD, GroupState.RECONCILING), result);
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("bad, wrong"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("  bad, Stable"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("   ,   ,"));
-    }
-
-    @Test
-    public void testConsumerGroupTypesFromString() {
-        Set<GroupType> result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer");
-        assertEquals(Set.of(GroupType.CONSUMER), result);
-
-        result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, classic");
-        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
-
-        result = ConsumerGroupCommand.consumerGroupTypesFromString("Consumer, Classic");
-        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("Share"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("streams"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("  bad, generic"));
-
-        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"));
-    }
 }

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -106,7 +106,7 @@ public class ListConsumerGroupTest {
 
                 TestUtils.waitForCondition(() -> {
                     foundGroups.set(new HashSet<>(service.listConsumerGroups()));
-                    return expectedGroups.equals(foundGroups.get());
+                    return Objects.equals(expectedGroups, foundGroups.get());
                 }, () -> "Expected --list to show groups " + expectedGroups + ", but found " + foundGroups.get() + ".");
             }
 

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ListConsumerGroupTest.java
@@ -16,11 +16,9 @@
  */
 package org.apache.kafka.tools.consumer.group;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.GroupListing;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.RangeAssignor;
@@ -32,23 +30,19 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
-import org.apache.kafka.common.test.api.ClusterTestDefaults;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.tools.ToolsTestUtils;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -66,78 +60,87 @@ import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.CONSUMER
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG;
 import static org.apache.kafka.coordinator.group.GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ClusterTestDefaults(
-    types = {Type.CO_KRAFT},
-    serverProperties = {
-        @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
-        @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
-        @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
-        @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-        @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
-    }
-)
 public class ListConsumerGroupTest {
     private static final String TOPIC_PREFIX = "test.topic.";
     private static final String TOPIC_PARTITIONS_GROUP_PREFIX = "test.topic.partitions.group.";
     private static final String TOPIC_GROUP_PREFIX = "test.topic.group.";
     private static final String PROTOCOL_GROUP_PREFIX = "test.protocol.group.";
-    private final ClusterInstance clusterInstance;
+    private static final String DUMMY_BOOTSTRAP_SERVERS = "localhost:9092";
 
-    ListConsumerGroupTest(ClusterInstance clusterInstance) {
-        this.clusterInstance = clusterInstance;
-    }
-
-    private List<GroupProtocol> supportedGroupProtocols() {
+    private static List<GroupProtocol> supportedGroupProtocols(ClusterInstance clusterInstance) {
         return new ArrayList<>(clusterInstance.supportedGroupProtocols());
     }
 
-    @ClusterTest
-    public void testListConsumerGroupsWithoutFilters() throws Exception {
-        for (int i = 0; i < supportedGroupProtocols().size(); i++) {
-            GroupProtocol groupProtocol = supportedGroupProtocols().get(i);
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListConsumerGroupsWithoutFilters(ClusterInstance clusterInstance) throws Exception {
+        List<GroupProtocol> groupProtocols = supportedGroupProtocols(clusterInstance);
+        for (int i = 0; i < groupProtocols.size(); i++) {
+            GroupProtocol groupProtocol = groupProtocols.get(i);
             String topic = TOPIC_PREFIX + groupProtocol.name;
             String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
             String topicGroup = TOPIC_GROUP_PREFIX + i;
             String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + i;
-            createTopic(topic);
+            clusterInstance.createTopic(topic, 1, (short) 1);
 
-            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-                 AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(GroupProtocol.CLASSIC, topicGroup, topic);
-                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
+            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+                 AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(clusterInstance, GroupProtocol.CLASSIC, topicGroup, topic);
+                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
                  ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list"})
             ) {
-                Set<String> expectedGroups = set(List.of(topicPartitionsGroup, topicGroup, protocolGroup));
-                final AtomicReference<Set> foundGroups = new AtomicReference<>();
+                Set<String> expectedGroups = Set.of(topicPartitionsGroup, topicGroup, protocolGroup);
+                final AtomicReference<Set<String>> foundGroups = new AtomicReference<>(Set.of());
 
                 TestUtils.waitForCondition(() -> {
-                    foundGroups.set(set(service.listConsumerGroups()));
-                    return Objects.equals(expectedGroups, foundGroups.get());
+                    foundGroups.set(new HashSet<>(service.listConsumerGroups()));
+                    return expectedGroups.equals(foundGroups.get());
                 }, () -> "Expected --list to show groups " + expectedGroups + ", but found " + foundGroups.get() + ".");
             }
 
-            removeConsumer(set(List.of(topicPartitionsGroup, topicGroup, protocolGroup)));
-            deleteTopic(topic);
+            removeConsumer(clusterInstance, Set.of(topicPartitionsGroup, topicGroup, protocolGroup));
+            deleteTopic(clusterInstance, topic);
         }
     }
 
-    @ClusterTest
+    @Test
     public void testListWithUnrecognizedNewConsumerOption() {
-        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", clusterInstance.bootstrapServers(), "--list"};
-        Assertions.assertThrows(OptionException.class, () -> getConsumerGroupService(cgcArgs));
+        String[] cgcArgs = new String[]{"--new-consumer", "--bootstrap-server", DUMMY_BOOTSTRAP_SERVERS, "--list"};
+        assertThrows(OptionException.class, () -> ConsumerGroupCommandOptions.fromArgs(cgcArgs));
     }
 
-    @ClusterTest
-    public void testListConsumerGroupsWithStates() throws Exception {
-        for (int i = 0; i < supportedGroupProtocols().size(); i++) {
-            GroupProtocol groupProtocol = supportedGroupProtocols().get(i);
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListConsumerGroupsWithStates(ClusterInstance clusterInstance) throws Exception {
+        List<GroupProtocol> groupProtocols = supportedGroupProtocols(clusterInstance);
+        for (int i = 0; i < groupProtocols.size(); i++) {
+            GroupProtocol groupProtocol = groupProtocols.get(i);
             String topic = TOPIC_PREFIX + groupProtocol.name;
             String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
             String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + i;
-            createTopic(topic);
+            clusterInstance.createTopic(topic, 1, (short) 1);
 
-            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
+            try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+                 AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
                  ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--state"})
             ) {
                 Set<GroupListing> expectedListing = Set.of(
@@ -186,21 +189,30 @@ public class ListConsumerGroupTest {
                 );
             }
 
-            removeConsumer(set(List.of(topicPartitionsGroup, protocolGroup)));
-            deleteTopic(topic);
+            removeConsumer(clusterInstance, Set.of(topicPartitionsGroup, protocolGroup));
+            deleteTopic(clusterInstance, topic);
         }
     }
 
-    @ClusterTest
-    public void testListConsumerGroupsWithTypesClassicProtocol() throws Exception {
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListConsumerGroupsWithTypesClassicProtocol(ClusterInstance clusterInstance) throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CLASSIC;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
-        createTopic(topic);
+        clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
              ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list", "--state"})
         ) {
             Set<GroupListing> expectedListing = Set.of(
@@ -245,18 +257,27 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest
-    public void testListConsumerGroupsWithTypesConsumerProtocol() throws Exception {
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListConsumerGroupsWithTypesConsumerProtocol(ClusterInstance clusterInstance) throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CONSUMER;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicGroup = TOPIC_GROUP_PREFIX + "0";
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
-        createTopic(topic);
+        clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(GroupProtocol.CLASSIC, topicGroup, topic);
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic);
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable topicConsumerGroupExecutor = consumerGroupClosable(clusterInstance, GroupProtocol.CLASSIC, topicGroup, topic);
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic);
              ConsumerGroupCommand.ConsumerGroupService service = getConsumerGroupService(new String[]{"--bootstrap-server", clusterInstance.bootstrapServers(), "--list"})
         ) {
 
@@ -332,16 +353,25 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest
-    public void testListGroupCommandClassicProtocol() throws Exception {
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListGroupCommandClassicProtocol(ClusterInstance clusterInstance) throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CLASSIC;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
-        createTopic(topic);
+        clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic)
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic)
         ) {
             validateListOutput(
                     List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list"),
@@ -417,16 +447,25 @@ public class ListConsumerGroupTest {
         }
     }
 
-    @ClusterTest
-    public void testListGroupCommandConsumerProtocol() throws Exception {
+    @ClusterTest(
+        types = {Type.CO_KRAFT},
+        serverProperties = {
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_PARTITIONS_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, value = "1"),
+            @ClusterConfigProperty(key = GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, value = "1000"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500"),
+            @ClusterConfigProperty(key = CONSUMER_GROUP_MIN_HEARTBEAT_INTERVAL_MS_CONFIG, value = "500")
+        }
+    )
+    public void testListGroupCommandConsumerProtocol(ClusterInstance clusterInstance) throws Exception {
         GroupProtocol groupProtocol = GroupProtocol.CONSUMER;
         String topic = TOPIC_PREFIX + groupProtocol.name;
         String protocolGroup = PROTOCOL_GROUP_PREFIX + groupProtocol.name;
         String topicPartitionsGroup = TOPIC_PARTITIONS_GROUP_PREFIX + "0";
-        createTopic(topic);
+        clusterInstance.createTopic(topic, 1, (short) 1);
 
-        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
-             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(groupProtocol, protocolGroup, topic)
+        try (AutoCloseable topicPartitionsConsumerGroupExecutor = consumerGroupClosable(clusterInstance, topicPartitionsGroup, Set.of(new TopicPartition(topic, 0)));
+             AutoCloseable protocolConsumerGroupExecutor = consumerGroupClosable(clusterInstance, groupProtocol, protocolGroup, topic)
         ) {
             validateListOutput(
                     List.of("--bootstrap-server", clusterInstance.bootstrapServers(), "--list"),
@@ -482,75 +521,57 @@ public class ListConsumerGroupTest {
         }
     }
 
-    private AutoCloseable consumerGroupClosable(GroupProtocol protocol, String groupId, String topicName) {
-        Map<String, Object> configs = composeConfigs(
-                groupId,
-                protocol.name,
-                Map.of()
-        );
+    private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, GroupProtocol protocol, String groupId, String topicName) {
+        Map<String, Object> configs = consumerConfigs(clusterInstance, groupId, protocol);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
                 false,
                 topicName,
-                () -> new KafkaConsumer<String, String>(configs)
+                () -> new KafkaConsumer<>(configs)
         );
     }
 
-    private AutoCloseable consumerGroupClosable(String groupId, Set<TopicPartition> topicPartitions) {
-        Map<String, Object> configs = composeConfigs(
-                groupId,
-                GroupProtocol.CLASSIC.name,
-                Map.of()
-        );
+    private static AutoCloseable consumerGroupClosable(ClusterInstance clusterInstance, String groupId, Set<TopicPartition> topicPartitions) {
+        Map<String, Object> configs = consumerConfigs(clusterInstance, groupId, GroupProtocol.CLASSIC);
 
         return ConsumerGroupCommandTestUtils.buildConsumers(
                 1,
                 topicPartitions,
-                () -> new KafkaConsumer<String, String>(configs)
+                () -> new KafkaConsumer<>(configs)
         );
     }
 
-    private Map<String, Object> composeConfigs(String groupId, String groupProtocol, Map<String, Object> customConfigs) {
+    private static Map<String, Object> consumerConfigs(ClusterInstance clusterInstance, String groupId, GroupProtocol groupProtocol) {
         Map<String, Object> configs = new HashMap<>();
         configs.put(BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers());
         configs.put(GROUP_ID_CONFIG, groupId);
         configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol);
-        if (GroupProtocol.CLASSIC.name.equalsIgnoreCase(groupProtocol)) {
+        configs.put(GROUP_PROTOCOL_CONFIG, groupProtocol.name);
+        if (groupProtocol == GroupProtocol.CLASSIC) {
             configs.put(PARTITION_ASSIGNMENT_STRATEGY_CONFIG, RangeAssignor.class.getName());
         }
-
-        configs.putAll(customConfigs);
         return configs;
     }
 
-    private ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
+    private static ConsumerGroupCommand.ConsumerGroupService getConsumerGroupService(String[] args) {
         ConsumerGroupCommandOptions opts = ConsumerGroupCommandOptions.fromArgs(args);
-        ConsumerGroupCommand.ConsumerGroupService service = new ConsumerGroupCommand.ConsumerGroupService(
+        return new ConsumerGroupCommand.ConsumerGroupService(
                 opts,
                 Map.of(AdminClientConfig.RETRIES_CONFIG, Integer.toString(Integer.MAX_VALUE))
         );
-
-        return service;
     }
 
-    private void createTopic(String topic) {
-        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            Assertions.assertDoesNotThrow(() -> admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).topicId(topic).get());
+    private static void removeConsumer(ClusterInstance clusterInstance, Set<String> groupIds) {
+        try (Admin admin = clusterInstance.admin()) {
+            assertDoesNotThrow(() -> admin.deleteConsumerGroups(groupIds).all().get());
         }
     }
 
-    private void deleteTopic(String topic) {
-        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            Assertions.assertDoesNotThrow(() -> admin.deleteTopics(Set.of(topic)).all().get());
-        }
-    }
-
-    private void removeConsumer(Set<String> groupIds) {
-        try (Admin admin = Admin.create(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, clusterInstance.bootstrapServers()))) {
-            Assertions.assertDoesNotThrow(() -> admin.deleteConsumerGroups(groupIds).all().get());
+    private static void deleteTopic(ClusterInstance clusterInstance, String topic) {
+        try (Admin admin = clusterInstance.admin()) {
+            assertDoesNotThrow(() -> admin.deleteTopics(Set.of(topic)).all().get());
         }
     }
 
@@ -563,15 +584,15 @@ public class ListConsumerGroupTest {
      * @param expectedListing        Expected consumer group listings.
      */
     private static void assertGroupListing(
-        ConsumerGroupCommand.ConsumerGroupService service,
-        Set<GroupType> typeFilterSet,
-        Set<GroupState> groupStateFilterSet,
-        Set<GroupListing> expectedListing
+            ConsumerGroupCommand.ConsumerGroupService service,
+            Set<GroupType> typeFilterSet,
+            Set<GroupState> groupStateFilterSet,
+            Set<GroupListing> expectedListing
     ) throws Exception {
-        final AtomicReference<Set<GroupListing>> foundListing = new AtomicReference<>();
+        final AtomicReference<Set<GroupListing>> foundListing = new AtomicReference<>(Set.of());
         TestUtils.waitForCondition(() -> {
-            foundListing.set(set(service.listConsumerGroupsWithFilters(set(typeFilterSet), set(groupStateFilterSet))));
-            return Objects.equals(set(expectedListing), foundListing.get());
+            foundListing.set(new HashSet<>(service.listConsumerGroupsWithFilters(typeFilterSet, groupStateFilterSet)));
+            return expectedListing.equals(foundListing.get());
         }, () -> "Expected to show groups " + expectedListing + ", but found " + foundListing.get() + ".");
     }
 
@@ -585,9 +606,9 @@ public class ListConsumerGroupTest {
      * @throws InterruptedException
      */
     private static void validateListOutput(
-        List<String> args,
-        List<String> expectedHeader,
-        Set<List<String>> expectedRows
+            List<String> args,
+            List<String> expectedHeader,
+            Set<List<String>> expectedRows
     ) throws InterruptedException {
         final AtomicReference<String> out = new AtomicReference<>("");
         TestUtils.waitForCondition(() -> {
@@ -615,58 +636,52 @@ public class ListConsumerGroupTest {
         }, () -> String.format("Expected header=%s and groups=%s, but found:%n%s", expectedHeader, expectedRows, out.get()));
     }
 
-    public static <T> Set<T> set(Collection<T> set) {
-        return new HashSet<>(set);
-    }
-}
-
-class ListConsumerGroupUnitTest {
     @Test
     public void testConsumerGroupStatesFromString() {
         Set<GroupState> result = ConsumerGroupCommand.groupStatesFromString("Stable");
-        Assertions.assertEquals(ListConsumerGroupTest.set(Set.of(GroupState.STABLE)), result);
+        assertEquals(Set.of(GroupState.STABLE), result);
 
         result = ConsumerGroupCommand.groupStatesFromString("Stable, PreparingRebalance");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupState.STABLE, GroupState.PREPARING_REBALANCE)), result);
+        assertEquals(Set.of(GroupState.STABLE, GroupState.PREPARING_REBALANCE), result);
 
         result = ConsumerGroupCommand.groupStatesFromString("Dead,CompletingRebalance,");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupState.DEAD, GroupState.COMPLETING_REBALANCE)), result);
+        assertEquals(Set.of(GroupState.DEAD, GroupState.COMPLETING_REBALANCE), result);
 
         result = ConsumerGroupCommand.groupStatesFromString("stable");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupState.STABLE)), result);
+        assertEquals(Set.of(GroupState.STABLE), result);
 
         result = ConsumerGroupCommand.groupStatesFromString("stable, assigning");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupState.STABLE, GroupState.ASSIGNING)), result);
+        assertEquals(Set.of(GroupState.STABLE, GroupState.ASSIGNING), result);
 
         result = ConsumerGroupCommand.groupStatesFromString("dead,reconciling,");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupState.DEAD, GroupState.RECONCILING)), result);
+        assertEquals(Set.of(GroupState.DEAD, GroupState.RECONCILING), result);
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("bad, wrong"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("bad, wrong"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("  bad, Stable"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("  bad, Stable"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("   ,   ,"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.groupStatesFromString("   ,   ,"));
     }
 
     @Test
     public void testConsumerGroupTypesFromString() {
         Set<GroupType> result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer");
-        Assertions.assertEquals(ListConsumerGroupTest.set(Set.of(GroupType.CONSUMER)), result);
+        assertEquals(Set.of(GroupType.CONSUMER), result);
 
         result = ConsumerGroupCommand.consumerGroupTypesFromString("consumer, classic");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupType.CONSUMER, GroupType.CLASSIC)), result);
+        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
 
         result = ConsumerGroupCommand.consumerGroupTypesFromString("Consumer, Classic");
-        Assertions.assertEquals(ListConsumerGroupTest.set(List.of(GroupType.CONSUMER, GroupType.CLASSIC)), result);
+        assertEquals(Set.of(GroupType.CONSUMER, GroupType.CLASSIC), result);
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("Share"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("Share"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("streams"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("streams"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("bad, wrong"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("  bad, generic"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("  bad, generic"));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"));
+        assertThrows(IllegalArgumentException.class, () -> ConsumerGroupCommand.consumerGroupTypesFromString("   ,   ,"));
     }
 }


### PR DESCRIPTION
### Summary

Move tests that do not require a cluster from `ListConsumerGroupTest` to
`ConsumerGroupCommandTest`.

This keeps `ListConsumerGroupTest` focused on cluster-backed tests while
avoiding unnecessary cluster startup for argument and string parsing
tests.

Additional cleanup includes:

- Use `ClusterInstance` for topic creation and Admin client access.
- Remove the redundant `set(...)` helper.
- Use typed `Set` and `AtomicReference` declarations.

### Testing

Passed locally:

```bash
./gradlew :tools:spotlessJavaCheck :tools:test \
  --tests org.apache.kafka.tools.consumer.group.ConsumerGroupCommandTest
\
  --tests org.apache.kafka.tools.consumer.group.ListConsumerGroupTest
```

Reviewers: Andrew Schofield <aschofield@confluent.io>, Ken Huang
 <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
