### PR TITLE
KAFKA-18141: Show default user/client-id/ip quotas in kafka-metadata-shell

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
+++ b/metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java
@@ -62,26 +62,40 @@ public class ClientQuotasImageNode implements MetadataNode {
         String clientId = null;
         String ip = null;
         String user = null;
+        boolean hasClientId = false;
+        boolean hasIp = false;
+        boolean hasUser = false;
         for (Map.Entry<String, String> entry : entity.entries().entrySet()) {
             switch (entry.getKey()) {
-                case CLIENT_ID -> clientId = entry.getValue();
-                case IP -> ip = entry.getValue();
-                case USER -> user = entry.getValue();
+                case CLIENT_ID -> {
+                    clientId = entry.getValue();
+                    hasClientId = true;
+                }
+                case IP -> {
+                    ip = entry.getValue();
+                    hasIp = true;
+                }
+                case USER -> {
+                    user = entry.getValue();
+                    hasUser = true;
+                }
                 default -> throw new RuntimeException("Invalid entity type " + entry.getKey());
             }
         }
+        // A null entity name denotes the built-in default entity (see ClientQuotaEntity), so it
+        // must still be rendered (as an empty name) rather than being treated as absent.
         StringBuilder bld = new StringBuilder();
         String prefix = "";
-        if (clientId != null) {
-            bld.append(prefix).append("clientId(").append(escape(clientId)).append(")");
+        if (hasClientId) {
+            bld.append(prefix).append("clientId(").append(escape(clientId == null ? "" : clientId)).append(")");
             prefix = "_";
         }
-        if (ip != null) {
-            bld.append(prefix).append("ip(").append(escape(ip)).append(")");
+        if (hasIp) {
+            bld.append(prefix).append("ip(").append(escape(ip == null ? "" : ip)).append(")");
             prefix = "_";
         }
-        if (user != null) {
-            bld.append(prefix).append("user(").append(escape(user)).append(")");
+        if (hasUser) {
+            bld.append(prefix).append("user(").append(escape(user == null ? "" : user)).append(")");
         }
         return bld.toString();
     }
@@ -128,7 +142,9 @@ public class ClientQuotasImageNode implements MetadataNode {
                 } else {
                     switch (c) {
                         case ')':
-                            entries.put(type, value.toString());
+                            // An empty name denotes the built-in default entity, which is
+                            // represented by a null value (see ClientQuotaEntity).
+                            entries.put(type, value.length() == 0 ? null : value.toString());
                             type = null;
                             value = new StringBuilder();
                             break;

--- a/metadata/src/test/java/org/apache/kafka/image/node/ClientQuotasImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/ClientQuotasImageNodeTest.java
@@ -91,6 +91,16 @@ public class ClientQuotasImageNodeTest {
     }
 
     @Test
+    public void defaultClientIdWithSpecificUserEntityRoundTrip() {
+        // Mixes a default (null) value with a specific value across two entity types, to
+        // exercise the has*/value split for each type independently of the others.
+        Map<String, String> entityMap = new HashMap<>();
+        entityMap.put("client-id", null);
+        entityMap.put("user", "bob");
+        entityToStringRoundTrip(new ClientQuotaEntity(entityMap), "clientId()_user(bob)");
+    }
+
+    @Test
     public void clientIdAndUserEntityRoundTrip() {
         Map<String, String> entityMap = new HashMap<>();
         entityMap.put("user", "bob");

--- a/metadata/src/test/java/org/apache/kafka/image/node/ClientQuotasImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/ClientQuotasImageNodeTest.java
@@ -18,6 +18,8 @@
 package org.apache.kafka.image.node;
 
 import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.image.ClientQuotaImage;
+import org.apache.kafka.image.ClientQuotasImage;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -26,7 +28,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
@@ -66,8 +70,9 @@ public class ClientQuotasImageNodeTest {
 
     @Test
     public void defaultClientIdEntityRoundTrip() {
-        entityToStringRoundTrip(new ClientQuotaEntity(Map.of("client-id", "")),
-            "clientId()");
+        Map<String, String> entityMap = new HashMap<>();
+        entityMap.put("client-id", null);
+        entityToStringRoundTrip(new ClientQuotaEntity(entityMap), "clientId()");
     }
 
     @Test
@@ -78,8 +83,11 @@ public class ClientQuotasImageNodeTest {
 
     @Test
     public void defaultUserEntityRoundTrip() {
-        entityToStringRoundTrip(new ClientQuotaEntity(Map.of("user", "")),
-            "user()");
+        // A null entity name denotes the built-in default entity (see ClientQuotaEntity's
+        // javadoc); this is how default quotas are actually represented in the metadata image.
+        Map<String, String> entityMap = new HashMap<>();
+        entityMap.put("user", null);
+        entityToStringRoundTrip(new ClientQuotaEntity(entityMap), "user()");
     }
 
     @Test
@@ -99,8 +107,9 @@ public class ClientQuotasImageNodeTest {
 
     @Test
     public void defaultIpEntityRoundTrip() {
-        entityToStringRoundTrip(new ClientQuotaEntity(Map.of("ip", "")),
-            "ip()");
+        Map<String, String> entityMap = new HashMap<>();
+        entityMap.put("ip", null);
+        entityToStringRoundTrip(new ClientQuotaEntity(entityMap), "ip()");
     }
 
     @Test
@@ -129,5 +138,19 @@ public class ClientQuotasImageNodeTest {
             assertThrows(RuntimeException.class, () -> ClientQuotasImageNode.
                 clientQuotaEntityToString(new ClientQuotaEntity(Map.of("foobar", "baz")))).
                     getMessage());
+    }
+
+    @Test
+    public void testDefaultUserEntityIsListedAndReachable() {
+        Map<String, String> defaultUserEntries = new HashMap<>();
+        defaultUserEntries.put("user", null);
+        ClientQuotaEntity defaultUserEntity = new ClientQuotaEntity(defaultUserEntries);
+        ClientQuotasImageNode node = new ClientQuotasImageNode(new ClientQuotasImage(
+            Map.of(defaultUserEntity, new ClientQuotaImage(Map.of("consumer_byte_rate", 1000000.0)))));
+
+        assertTrue(node.childNames().contains("user()"),
+            "Expected the default user-principal quota to appear in the listing");
+        assertNotNull(node.child("user()"),
+            "Expected to be able to navigate into the default user-principal quota");
     }
 }


### PR DESCRIPTION
## Summary

`kafka-metadata-shell` does not show the default user-principal quota (or the default client-id/IP quotas), even though `kafka-configs.sh --describe` shows them correctly.

`ClientQuotaEntity`'s javadoc states that a `null` entity name denotes the built-in default entity, and that's exactly how default quotas are represented in the metadata image (`ClientQuotaImage.dataToEntity`, sourced from the nullable `EntityName` field of `ClientQuotaRecord`).

`ClientQuotasImageNode#clientQuotaEntityToString` only appended an entity segment (`user(...)`, `clientId(...)`, `ip(...)`) when that entity's value was non-null. For a default entity, the value is `null`, so the check silently skipped it — for a single-entry default entity (e.g. just `user=null`) this produced an empty child name, and `ls` effectively lost the entry. `decodeEntity` had the mirrored gap: it never produced a `null` value, so navigating back into a default entity by name (`user()`) could not match the corresponding key already present in the image.

## Fix

- Track whether each entity type (`clientId`/`ip`/`user`) was present independently of its (possibly `null`) value, and render an empty name for a `null`/default value instead of omitting the segment.
- Treat an empty parsed name in `decodeEntity` as the default (`null`) value, so it round-trips to the same key used in `ClientQuotasImage`.
- Updated the existing default-entity round-trip tests to use `null` values (matching real production data) instead of empty strings, since `Map.of` can't hold `null` and the tests were previously exercising a case the shell doesn't actually hit.
- Added a regression test at the `ClientQuotasImageNode` level reproducing the reported scenario: listing and navigating into a default user-principal quota entity.

## Test plan

- `./gradlew :metadata:test --tests "org.apache.kafka.image.node.ClientQuotasImageNodeTest"` — all 16 tests pass, including the new regression test.
- `./gradlew :metadata:checkstyleMain :metadata:checkstyleTest :metadata:spotlessCheck` — clean.

## AI assistance disclosure

Per `AI_POLICY`/`CONTRIBUTING.md`: Claude Code (Sonnet 5) was used to investigate the root cause, implement the fix, and write the tests in `metadata/src/main/java/org/apache/kafka/image/node/ClientQuotasImageNode.java` and `metadata/src/test/java/org/apache/kafka/image/node/ClientQuotasImageNodeTest.java`. All changes were reviewed by me before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

