### PR TITLE
KAFKA-21119: Replace temp file handler with JUnit 5 @TempDir in generator, tools, and test-common tests

### DIFF
--- a/generator/src/test/java/org/apache/kafka/message/checker/CheckerTestUtils.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/CheckerTestUtils.java
@@ -24,6 +24,7 @@ import org.apache.kafka.message.MessageSpec;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.OptionalInt;
 
 public class CheckerTestUtils {
@@ -143,9 +144,8 @@ public class CheckerTestUtils {
             false);
     }
 
-    static String messageSpecStringToTempFile(String input) throws IOException {
-        File file = Files.createTempFile("MetadataSchemaCheckerToolTest", null).toFile();
-        file.deleteOnExit();
+    static String messageSpecStringToTempFile(Path tempDir, String input) throws IOException {
+        File file = Files.createFile(tempDir.resolve("MetadataSchemaCheckerToolTest.json")).toFile();
         MessageSpec messageSpec = MessageGenerator.JSON_SERDE.
                 readValue(input.replaceAll("'", "\""), MessageSpec.class);
         MessageGenerator.JSON_SERDE.writeValue(file, messageSpec);

--- a/generator/src/test/java/org/apache/kafka/message/checker/CheckerUtilsTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/CheckerUtilsTest.java
@@ -20,6 +20,9 @@ package org.apache.kafka.message.checker;
 import org.apache.kafka.message.Versions;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.apache.kafka.message.checker.CheckerTestUtils.field;
 import static org.apache.kafka.message.checker.CheckerTestUtils.fieldWithTag;
@@ -28,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CheckerUtilsTest {
+    @TempDir
+    private Path tempDir;
+
     @Test
     public void testMin0and1() {
         assertEquals((short) 0, CheckerUtils.min((short) 0, (short) 1));
@@ -82,7 +88,7 @@ public class CheckerUtilsTest {
 
     @Test
     public void testReadMessageSpecFromFile() throws Exception {
-        CheckerUtils.readMessageSpecFromFile(messageSpecStringToTempFile(
+        CheckerUtils.readMessageSpecFromFile(messageSpecStringToTempFile(tempDir,
             "{'apiKey':62, 'type': 'request', 'name': 'BrokerRegistrationRequest', " +
             "'validVersions': '0-2', 'flexibleVersions': '0+', " +
             "'fields': [{'name': 'BrokerId', 'type': 'int32', 'versions': '0+'}]}"));

--- a/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/checker/MetadataSchemaCheckerToolTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.message.checker;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -30,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class MetadataSchemaCheckerToolTest {
+    @TempDir
+    private Path tempDir;
+
     @Test
     public void testVerifyEvolutionGit() throws Exception {
         // Try to find the Git root directory
@@ -62,7 +66,7 @@ public class MetadataSchemaCheckerToolTest {
     @Test
     public void testSuccessfulParse() throws Exception {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            String path = messageSpecStringToTempFile(
+            String path = messageSpecStringToTempFile(tempDir,
                 "{'apiKey':62, 'type': 'request', 'name': 'BrokerRegistrationRequest', " +
                 "'validVersions': '0-2', 'flexibleVersions': '0+', " +
                 "'fields': [{'name': 'BrokerId', 'type': 'int32', 'versions': '0+'}]}");
@@ -74,7 +78,7 @@ public class MetadataSchemaCheckerToolTest {
     @Test
     public void testSuccessfulVerifyEvolution() throws Exception {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            String path = messageSpecStringToTempFile(
+            String path = messageSpecStringToTempFile(tempDir,
                 "{'apiKey':62, 'type': 'request', 'name': 'BrokerRegistrationRequest', " +
                 "'validVersions': '0-2', 'flexibleVersions': '0+', " +
                 "'fields': [{'name': 'BrokerId', 'type': 'int32', 'versions': '0+'}]}");

--- a/test-common/test-common-internal-api/src/test/java/org/apache/kafka/common/test/api/ClusterConfigTest.java
+++ b/test-common/test-common-internal-api/src/test/java/org/apache/kafka/common/test/api/ClusterConfigTest.java
@@ -23,11 +23,13 @@ import org.apache.kafka.server.common.MetadataVersion;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,9 @@ import static org.apache.kafka.common.test.api.TestKitDefaults.DEFAULT_CONTROLLE
 
 public class ClusterConfigTest {
 
+    @TempDir
+    private Path tempDir;
+
     private static Map<String, Object> fields(ClusterConfig config) {
         return Arrays.stream(config.getClass().getDeclaredFields()).collect(Collectors.toMap(Field::getName, f -> {
             f.setAccessible(true);
@@ -50,8 +55,7 @@ public class ClusterConfigTest {
 
     @Test
     public void testCopy() throws IOException {
-        File trustStoreFile = Files.createTempFile("kafka", ".tmp").toFile();
-        trustStoreFile.deleteOnExit();
+        File trustStoreFile = Files.createFile(tempDir.resolve("kafka.tmp")).toFile();
 
         ClusterConfig clusterConfig = ClusterConfig.builder()
                 .setTypes(Set.of(Type.KRAFT))

--- a/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ProducerPerformanceTest.java
@@ -28,6 +28,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -40,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -74,9 +76,11 @@ public class ProducerPerformanceTest {
     @Spy
     ProducerPerformance producerPerformanceSpy;
 
+    @TempDir
+    private Path tempDir;
+
     private File createTempFile(String contents) throws IOException {
-        File file = File.createTempFile("ProducerPerformanceTest", ".tmp");
-        file.deleteOnExit();
+        File file = Files.createFile(tempDir.resolve("ProducerPerformanceTest-" + System.nanoTime() + ".tmp")).toFile();
         Files.write(file.toPath(), contents.getBytes());
         return file;
     }


### PR DESCRIPTION
## Summary

Main Jira -
[KAFKA-14218](https://issues.apache.org/jira/browse/KAFKA-14218)
Sub Task -
[KAFKA-21119](https://issues.apache.org/jira/browse/KAFKA-21119)

Replace `File.createTempFile()` and `Files.createTempFile()` with JUnit 5 `@TempDir` annotation in three modules:

* `CheckerTestUtils.java`, `CheckerUtilsTest.java`, `MetadataSchemaCheckerToolTest.java` (generator module)
* `ClusterConfigTest.java` (test-common module)
* `ProducerPerformanceTest.java` (tools module)

This removes the need for manual `deleteOnExit()` calls as JUnit 5 handles temporary directory lifecycle automatically.

## Changes

* Updated `CheckerTestUtils.messageSpecStringToTempFile()` to accept a `Path tempDir` parameter instead of using `Files.createTempFile()`
* Added `@TempDir private Path tempDir` field to `CheckerUtilsTest` and `MetadataSchemaCheckerToolTest`, updated their calls
* Added `@TempDir private Path tempDir` field to `ClusterConfigTest`, replaced `Files.createTempFile()` with `Files.createFile(tempDir.resolve(...))`
* Added `@TempDir private Path tempDir` field to `ProducerPerformanceTest`, replaced `File.createTempFile()` with `Files.createFile(tempDir.resolve(...))` in the helper method

## Scope

This is a follow-up to #23280 which covered the connect module. This PR covers the three modules with the smallest change footprint (1 occurrence each). Additional modules (clients, remaining connect files) can be migrated in follow-up PRs.

## Test plan

* `ProducerPerformanceTest` - all tests pass
* `ClusterConfigTest` - all tests pass
* `CheckerUtilsTest` - all tests pass
* `MetadataSchemaCheckerToolTest` - all tests pass
* Verified locally with `./gradlew tools:test --tests ProducerPerformanceTest`
* Verified locally with `./gradlew :test-common:test-common-internal-api:test --tests ClusterConfigTest`
* Verified locally with `./gradlew generator:test --tests CheckerUtilsTest --tests MetadataSchemaCheckerToolTest`
* Checkstyle and Spotless checks pass

Reviewers: Uros (github:uros-b), ashwinpankaj <apankaj@confluent.io>
