### PR TITLE
KAFKA-17719: Recover task configs lost after config topic compaction

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -169,6 +169,18 @@ public interface Herder {
     void putTaskConfigs(String connName, List<Map<String, String>> configs, Callback<Void> callback, InternalRequestSignature requestSignature);
 
     /**
+     * Re-publish the current task configurations for a connector. This is used by a worker that was assigned a task
+     * but could not reconstruct its configuration after compaction of the config topic.
+     *
+     * @param connName connector whose task configurations should be re-published
+     * @param expectedConfigOffset config offset used to create the caller's assignment
+     * @param callback callback to invoke upon completion
+     * @param requestSignature the signature of the request; may be null if no signature was provided
+     */
+    void refreshTaskConfigs(String connName, long expectedConfigOffset, Callback<Void> callback,
+                            InternalRequestSignature requestSignature);
+
+    /**
      * Fence out any older task generations for a source connector, and then write a record to the config topic
      * indicating that it is safe to bring up a new generation of tasks. If that record is already present, do nothing
      * and invoke the callback successfully.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -156,7 +156,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     private static final long FORWARD_REQUEST_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
     private static final long START_AND_STOP_SHUTDOWN_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(1);
-    private static final long RECONFIGURE_CONNECTOR_TASKS_BACKOFF_INITIAL_MS = 250;
+    static final long RECONFIGURE_CONNECTOR_TASKS_BACKOFF_INITIAL_MS = 250;
     static final long RECONFIGURE_CONNECTOR_TASKS_BACKOFF_MAX_MS = 60000;
     private static final long CONFIG_TOPIC_WRITE_PRIVILEGES_BACKOFF_MS = 250;
     private static final int START_STOP_THREAD_POOL_SIZE = 8;
@@ -193,7 +193,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private ExtendedAssignment runningAssignment = ExtendedAssignment.empty();
     private final Set<ConnectorTaskId> tasksToRestart = new HashSet<>();
     // visible for testing
-    ExtendedAssignment assignment;
+    volatile ExtendedAssignment assignment;
     private boolean canReadConfigs;
     // visible for testing
     protected ClusterConfigState configState;
@@ -210,6 +210,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private Set<String> connectorTargetStateChanges = new HashSet<>();
     // Access to this map is protected by the herder's monitor
     private final Map<String, ZombieFencing> activeZombieFencings = new HashMap<>();
+    private final TaskConfigRefreshRecovery taskConfigRefreshRecovery = new TaskConfigRefreshRecovery();
     private final List<String> restNamespace;
     private boolean needsReconfigRebalance;
     private volatile boolean fencedFromConfigTopic;
@@ -1276,6 +1277,248 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         );
     }
 
+    @Override
+    public void refreshTaskConfigs(final String connName, final long expectedConfigOffset,
+                                   final Callback<Void> callback, InternalRequestSignature requestSignature) {
+        log.trace("Submitting task configuration refresh request for connector {} at config offset {}",
+                connName, expectedConfigOffset);
+        if (requestNotSignedProperly(requestSignature, callback)) {
+            return;
+        }
+
+        refreshTaskConfigs(connName, expectedConfigOffset, callback);
+    }
+
+    // Visible for testing
+    void refreshTaskConfigs(final String connName, final long expectedConfigOffset,
+                            final Callback<Void> callback) {
+        addRequest(() -> {
+            doRefreshTaskConfigs(connName, expectedConfigOffset, callback);
+            return null;
+        }, forwardErrorAndTickThreadStages(callback));
+    }
+
+    // Visible for testing
+    void doRefreshTaskConfigs(String connName, long expectedConfigOffset, Callback<Void> callback) {
+        if (!isLeader()) {
+            callback.onCompletion(
+                    new NotLeaderException("Only the leader may refresh task configurations.", leaderUrl()),
+                    null
+            );
+            return;
+        }
+
+        if (!refreshConfigSnapshot(workerSyncTimeoutMs)) {
+            callback.onCompletion(
+                    new ConnectException("Failed to read to the end of the config topic before refreshing task configurations"),
+                    null
+            );
+            return;
+        }
+
+        if (configState.offset() != expectedConfigOffset) {
+            callback.onCompletion(
+                    new RebalanceNeededException(
+                            "Cannot refresh task configurations for connector " + connName
+                                    + " because the assignment was created at config offset " + expectedConfigOffset
+                                    + " but the leader is at offset " + configState.offset()
+                    ),
+                    null
+            );
+        } else if (!configState.contains(connName)) {
+            callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), null);
+        } else if (configState.targetState(connName) == TargetState.STOPPED) {
+            callback.onCompletion(
+                    new BadRequestException("Cannot refresh task configurations for stopped connector " + connName),
+                    null
+            );
+        } else {
+            int taskCount = configState.taskCount(connName);
+            if (taskCount == 0) {
+                callback.onCompletion(
+                        new ConnectException("Cannot refresh task configurations for connector " + connName
+                                + " because the leader does not have any task configurations"),
+                        null
+                );
+                return;
+            }
+            List<Map<String, String>> taskConfigs = new ArrayList<>(taskCount);
+            for (int taskIndex = 0; taskIndex < taskCount; taskIndex++) {
+                ConnectorTaskId taskId = new ConnectorTaskId(connName, taskIndex);
+                Map<String, String> taskConfig = configState.rawTaskConfig(taskId);
+                if (taskConfig == null) {
+                    callback.onCompletion(
+                            new ConnectException("Cannot refresh task configurations for connector " + connName
+                                    + " because the leader is missing the configuration for task " + taskId),
+                            null
+                    );
+                    return;
+                }
+                taskConfigs.add(taskConfig);
+            }
+
+            writeTaskConfigs(connName, taskConfigs);
+            callback.onCompletion(null, null);
+        }
+    }
+
+    // A task on this worker is missing its configuration and asks the current leader to re-publish the complete set.
+    void refreshTaskConfigs(final ConnectorTaskId id, final long expectedConfigOffset, Callback<Void> callback) {
+        refreshTaskConfigs(id.connector(), expectedConfigOffset, (error, ignored) -> {
+            if (error == null) {
+                callback.onCompletion(null, null);
+            } else if (error instanceof NotLeaderException) {
+                if (restClient != null) {
+                    String workerUrl = ((NotLeaderException) error).forwardUrl();
+                    String refreshUrl = namespacedUrl(workerUrl)
+                            .path("connectors")
+                            .path(id.connector())
+                            .path("tasks")
+                            .path("refresh")
+                            .build()
+                            .toString();
+                    log.trace("Forwarding task configuration refresh request for connector {} to leader at {}",
+                            id.connector(), refreshUrl);
+                    forwardRequestExecutor.execute(() -> {
+                        try {
+                            String stageDescription = "Forwarding task configuration refresh request to the leader at "
+                                    + workerUrl;
+                            try (TemporaryStage stage = new TemporaryStage(stageDescription, callback, time)) {
+                                restClient.httpRequest(
+                                        refreshUrl,
+                                        "POST",
+                                        null,
+                                        expectedConfigOffset,
+                                        sessionKey,
+                                        requestSignatureAlgorithm
+                                );
+                            }
+                            callback.onCompletion(null, null);
+                        } catch (Throwable t) {
+                            callback.onCompletion(t, null);
+                        }
+                    });
+                } else {
+                    callback.onCompletion(
+                            new ConnectException(
+                                    "This worker is not able to communicate with the leader of the cluster, "
+                                            + "which is required to recover task configurations missing after "
+                                            + "config topic compaction. If running MirrorMaker 2 in dedicated mode, "
+                                            + "consider enabling inter-worker communication via the "
+                                            + "'dedicated.mode.enable.internal.rest' property."
+                            ),
+                            null
+                    );
+                }
+            } else {
+                callback.onCompletion(
+                        ConnectUtils.maybeWrap(error, "Failed to refresh task configurations for connector " + id.connector()),
+                        null
+                );
+            }
+        });
+    }
+
+    // Visible for testing
+    void requestTaskConfigRefresh(ConnectorTaskId taskId) {
+        TaskConfigRefreshRecovery.Attempt refreshAttempt =
+                taskConfigRefreshRecovery.begin(taskId.connector(), assignment);
+        if (refreshAttempt == null) {
+            return;
+        }
+
+        ExponentialBackoff exponentialBackoff = new ExponentialBackoff(
+                RECONFIGURE_CONNECTOR_TASKS_BACKOFF_INITIAL_MS,
+                2,
+                RECONFIGURE_CONNECTOR_TASKS_BACKOFF_MAX_MS,
+                0
+        );
+        refreshTaskConfigsWithRetry(taskId, refreshAttempt, exponentialBackoff, 0);
+    }
+
+    private void refreshTaskConfigsWithRetry(ConnectorTaskId taskId, TaskConfigRefreshRecovery.Attempt refreshAttempt,
+                                             ExponentialBackoff exponentialBackoff, int attempts) {
+        if (!taskConfigRefreshStillNeeded(taskId.connector(), refreshAttempt)) {
+            return;
+        }
+
+        refreshTaskConfigs(taskId, refreshAttempt.configOffset(), (error, ignored) -> {
+            if (error == null) {
+                taskConfigRefreshRecovery.complete(taskId.connector(), refreshAttempt);
+                log.info("Requested recovery of the missing configuration for task {} at config offset {}",
+                        taskId, refreshAttempt.configOffset());
+                return;
+            }
+
+            if (!taskConfigRefreshStillNeeded(taskId.connector(), refreshAttempt)) {
+                return;
+            }
+
+            if (TaskConfigRefreshRecovery.requiresRejoin(error)) {
+                requestRejoinAfterTaskConfigRefreshFailure(taskId.connector(), refreshAttempt, error);
+                return;
+            }
+
+            if (attempts >= TaskConfigRefreshRecovery.MAX_RETRIES) {
+                log.warn("Failed to recover task configurations for connector {} at config offset {} after {} retries; "
+                                + "requesting a new assignment",
+                        taskId.connector(), refreshAttempt.configOffset(), attempts, error);
+                requestRejoinAfterTaskConfigRefreshFailure(taskId.connector(), refreshAttempt, error);
+                return;
+            }
+
+            long delayMs = exponentialBackoff.backoff(attempts);
+            log.warn("Failed to recover task configurations for connector {} at config offset {}; retrying in {} ms",
+                    taskId.connector(), refreshAttempt.configOffset(), delayMs, error);
+            addRequest(
+                    delayMs,
+                    () -> {
+                        refreshTaskConfigsWithRetry(
+                                taskId,
+                                refreshAttempt,
+                                exponentialBackoff,
+                                attempts + 1
+                        );
+                        return null;
+                    },
+                    (requestError, result) -> {
+                        if (requestError != null) {
+                            taskConfigRefreshRecovery.complete(taskId.connector(), refreshAttempt);
+                            log.error("Unexpected error while scheduling task configuration recovery for connector {}",
+                                    taskId.connector(), requestError);
+                        }
+                    }
+            );
+        });
+    }
+
+    private void requestRejoinAfterTaskConfigRefreshFailure(
+            String connName,
+            TaskConfigRefreshRecovery.Attempt refreshAttempt,
+            Throwable error
+    ) {
+        log.info("Task configuration recovery for connector {} at config offset {} requires a new assignment",
+                connName, refreshAttempt.configOffset(), error);
+        runOnTickThread(
+                () -> {
+                    member.requestRejoin();
+                    return null;
+                },
+                (rejoinError, result) -> { }
+        );
+    }
+
+    private synchronized boolean taskConfigRefreshStillNeeded(
+            String connName,
+            TaskConfigRefreshRecovery.Attempt refreshAttempt
+    ) {
+        if (taskConfigRefreshRecovery.isActive(connName, refreshAttempt, assignment)) {
+            return true;
+        }
+        log.debug("Skipping task configuration recovery for connector {} because its assignment changed", connName);
+        return false;
+    }
+
     // Another worker has forwarded a request to this worker (which it believes is the leader) to perform a round of zombie fencing
     @Override
     public void fenceZombieSourceTasks(final String connName, final Callback<Void> callback, InternalRequestSignature requestSignature) {
@@ -2002,13 +2245,23 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     private boolean startTask(ConnectorTaskId taskId) {
         log.info("Starting task {}", taskId);
         Map<String, String> connProps = configState.connectorConfig(taskId.connector());
+        Map<String, String> taskProps = configState.taskConfig(taskId);
+        if (taskProps == null) {
+            log.warn("Cannot start task {} because its configuration is missing; requesting that the leader "
+                    + "re-publish task configurations for the connector", taskId);
+            synchronized (this) {
+                tasksToRestart.add(taskId);
+            }
+            requestTaskConfigRefresh(taskId);
+            return false;
+        }
         switch (connectorType(connProps)) {
             case SINK:
                 return worker.startSinkTask(
                         taskId,
                         configState,
                         connProps,
-                        configState.taskConfig(taskId),
+                        taskProps,
                         this,
                         configState.targetState(taskId.connector())
                 );
@@ -2019,7 +2272,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             taskId,
                             configState,
                             connProps,
-                            configState.taskConfig(taskId),
+                            taskProps,
                             this,
                             configState.targetState(taskId.connector()),
                             () -> {
@@ -2041,7 +2294,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             taskId,
                             configState,
                             connProps,
-                            configState.taskConfig(taskId),
+                            taskProps,
                             this,
                             configState.targetState(taskId.connector())
                     );
@@ -2632,6 +2885,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             );
             synchronized (DistributedHerder.this) {
                 DistributedHerder.this.assignment = assignment;
+                taskConfigRefreshRecovery.prune(assignment);
                 DistributedHerder.this.generation = generation;
                 int delay = assignment.delay();
                 DistributedHerder.this.scheduledRebalance = delay > 0

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.runtime.distributed;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.ExponentialBackoff;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.ConnectorsAndTasks;
 import org.apache.kafka.connect.runtime.distributed.WorkerCoordinator.WorkerLoad;
 import org.apache.kafka.connect.storage.ClusterConfigState;
@@ -267,6 +268,20 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         log.debug("Deleted connectors and tasks to revoke from each worker: {}", deletedToRevoke);
         addAll(toRevoke, deletedToRevoke);
 
+        // Restart connectors whose task configs could not be reconstructed from the config topic.
+        // The existing connector startup path will regenerate and publish their task configs.
+        Set<String> inconsistentStartedConnectors = configSnapshot.inconsistentConnectors().stream()
+                .filter(connector -> configSnapshot.targetState(connector) == TargetState.STARTED)
+                .collect(Collectors.toSet());
+        ConnectorsAndTasks inconsistentConnectors = new ConnectorsAndTasks.Builder()
+                .with(inconsistentStartedConnectors, Set.of())
+                .build();
+        Map<String, ConnectorsAndTasks> inconsistentConnectorsToRevoke =
+                intersection(inconsistentConnectors, memberAssignments);
+        log.debug("Connectors with inconsistent task configs to revoke from each worker: {}",
+                inconsistentConnectorsToRevoke);
+        addAll(toRevoke, inconsistentConnectorsToRevoke);
+
         // Revoking redundant connectors/tasks if the workers have duplicate assignments
         Map<String, ConnectorsAndTasks> duplicatedToRevoke = intersection(duplicated, memberAssignments);
         log.debug("Duplicated connectors and tasks to revoke from each worker: {}", duplicatedToRevoke);
@@ -277,6 +292,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         // and load-balancing revocations will be removed from them.
         List<WorkerLoad> nextWorkerAssignment = workerLoads(memberAssignments);
         removeAll(nextWorkerAssignment, deletedToRevoke);
+        removeAll(nextWorkerAssignment, inconsistentConnectorsToRevoke);
         removeAll(nextWorkerAssignment, duplicatedToRevoke);
 
         // Collect the lost assignments that are ready to be reassigned because the workers that were

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/TaskConfigRefreshRecovery.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/TaskConfigRefreshRecovery.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.distributed;
+
+import org.apache.kafka.connect.errors.NotFoundException;
+import org.apache.kafka.connect.runtime.rest.errors.BadRequestException;
+import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.ws.rs.core.Response;
+
+final class TaskConfigRefreshRecovery {
+
+    // Allow the exponential backoff to reach its 60-second cap before requesting a rejoin.
+    static final int MAX_RETRIES = 9;
+
+    private final Map<String, Attempt> activeAttempts = new HashMap<>();
+
+    synchronized Attempt begin(String connector, ExtendedAssignment assignment) {
+        if (assignment == null) {
+            return null;
+        }
+        Attempt attempt = Attempt.from(assignment);
+        if (Objects.equals(activeAttempts.get(connector), attempt)) {
+            return null;
+        }
+        activeAttempts.put(connector, attempt);
+        return attempt;
+    }
+
+    synchronized void complete(String connector, Attempt attempt) {
+        activeAttempts.remove(connector, attempt);
+    }
+
+    synchronized void prune(ExtendedAssignment assignment) {
+        activeAttempts.entrySet().removeIf(entry -> !entry.getValue().matches(assignment)
+                || assignment.tasks().stream().noneMatch(id -> id.connector().equals(entry.getKey())));
+    }
+
+    synchronized boolean isActive(String connector, Attempt attempt, ExtendedAssignment assignment) {
+        boolean active = Objects.equals(activeAttempts.get(connector), attempt)
+                && assignment != null
+                && attempt.matches(assignment)
+                && assignment.tasks().stream().anyMatch(id -> id.connector().equals(connector));
+        if (!active) {
+            activeAttempts.remove(connector, attempt);
+        }
+        return active;
+    }
+
+    static boolean requiresRejoin(Throwable error) {
+        if (error instanceof RebalanceNeededException
+                || error instanceof NotFoundException
+                || error instanceof BadRequestException) {
+            return true;
+        }
+        if (error instanceof ConnectRestException restError) {
+            return restError.statusCode() == Response.Status.BAD_REQUEST.getStatusCode()
+                    || restError.statusCode() == Response.Status.NOT_FOUND.getStatusCode()
+                    || restError.statusCode() == Response.Status.CONFLICT.getStatusCode();
+        }
+        return false;
+    }
+
+    record Attempt(long configOffset, String leader, String leaderUrl) {
+        static Attempt from(ExtendedAssignment assignment) {
+            return new Attempt(assignment.offset(), assignment.leader(), assignment.leaderUrl());
+        }
+
+        boolean matches(ExtendedAssignment assignment) {
+            return configOffset == assignment.offset()
+                    && Objects.equals(leader, assignment.leader())
+                    && Objects.equals(leaderUrl, assignment.leaderUrl());
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/InternalClusterResource.java
@@ -90,6 +90,32 @@ public abstract class InternalClusterResource {
         );
     }
 
+    @POST
+    @Path("/{connector}/tasks/refresh")
+    @Operation(hidden = true, summary = "This operation is only for inter-worker communications")
+    public void refreshTaskConfigs(
+            final @PathParam("connector") String connector,
+            final @Context HttpHeaders headers,
+            final @QueryParam("forward") Boolean forward,
+            final byte[] requestBody) throws Throwable {
+        long expectedConfigOffset = new ObjectMapper().readValue(requestBody, Long.class);
+        FutureCallback<Void> cb = new FutureCallback<>();
+        herderForRequest().refreshTaskConfigs(
+                connector,
+                expectedConfigOffset,
+                cb,
+                InternalRequestSignature.fromHeaders(Crypto.SYSTEM, requestBody, headers)
+        );
+        requestHandler.completeOrForwardRequest(
+                cb,
+                uriInfo.getPath(),
+                "POST",
+                headers,
+                expectedConfigOffset,
+                forward
+        );
+    }
+
     @PUT
     @Path("/{connector}/fence")
     @Operation(hidden = true, summary = "This operation is only for inter-worker communications")

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -324,6 +324,12 @@ public final class StandaloneHerder extends AbstractHerder {
     }
 
     @Override
+    public void refreshTaskConfigs(String connName, long expectedConfigOffset, Callback<Void> callback,
+                                   InternalRequestSignature requestSignature) {
+        throw new UnsupportedOperationException("Kafka Connect in standalone mode does not support refreshing task configurations.");
+    }
+
+    @Override
     public void fenceZombieSourceTasks(String connName, Callback<Void> callback, InternalRequestSignature requestSignature) {
         throw new UnsupportedOperationException("Kafka Connect in standalone mode does not support exactly-once source connectors.");
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -305,6 +305,10 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
     // Set of connectors where we saw a task commit with an incomplete set of task config updates, indicating the data
     // is in an inconsistent state and we cannot safely use them until they have been refreshed.
     final Set<String> inconsistent = new HashSet<>();
+    // Connectors whose task commit was encountered before their connector config while replaying the config topic.
+    // This can happen after compaction has removed an older connector config and leaves it ambiguous whether the
+    // task configs belong to a deleted connector or to the connector config that appears later in the log.
+    private final Set<String> connectorsPendingTaskConfigRecovery = new HashSet<>();
     // The most recently read offset. This does not take into account deferred task updates/commits, so we may have
     // outstanding data to be applied.
     private volatile long offset;
@@ -396,7 +400,13 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
             throw new ConfigException(msg);
         }
 
-        started = true;
+        synchronized (lock) {
+            // During startup, any connector that appears later in the log has already been marked inconsistent.
+            // The remaining entries belong to deleted connectors and no longer need to be retained. Set started
+            // under the same lock so that records received after startup cannot have their marker cleared here.
+            connectorsPendingTaskConfigRecovery.clear();
+            started = true;
+        }
         log.info("Started KafkaConfigBackingStore");
     }
 
@@ -1013,6 +1023,10 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
                 Map<String, String> stringsConnectorConfig = (Map<String, String>) newConnectorConfig;
                 connectorConfigs.put(connectorName, stringsConnectorConfig);
 
+                if (connectorsPendingTaskConfigRecovery.remove(connectorName)) {
+                    inconsistent.add(connectorName);
+                }
+
                 // Set the initial state of the connector to STARTED, which ensures that any connectors
                 // which were created with 0.9 Connect will be initialized in the STARTED state.
                 if (!connectorTargetStates.containsKey(connectorName))
@@ -1063,6 +1077,7 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
             Map<String, String> appliedConnectorConfig = connectorConfigs.get(connectorName);
             if (appliedConnectorConfig == null) {
                 processConnectorRemoval(connectorName);
+                connectorsPendingTaskConfigRecovery.add(connectorName);
                 log.debug(
                         "Ignoring task configs for connector {}; it appears that the connector was deleted previously "
                             + "and that log compaction has since removed any trace of its previous configurations "
@@ -1263,6 +1278,7 @@ public final class KafkaConfigBackingStore extends KafkaTopicBasedBackingStore i
         taskConfigs.keySet().removeIf(taskId -> taskId.connector().equals(connectorName));
         deferredTaskUpdates.remove(connectorName);
         appliedConnectorConfigs.remove(connectorName);
+        connectorsPendingTaskConfigRecovery.remove(connectorName);
     }
 
     private ConnectorTaskId parseTaskId(String key) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -113,7 +113,10 @@ import java.util.stream.IntStream;
 
 import javax.crypto.SecretKey;
 
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.apache.kafka.common.utils.Utils.UncheckedCloseable;
 import static org.apache.kafka.connect.runtime.AbstractStatus.State.FAILED;
@@ -129,6 +132,7 @@ import static org.apache.kafka.connect.source.SourceTask.TransactionBoundary.CON
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -136,6 +140,7 @@ import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -228,6 +233,18 @@ public class DistributedHerderTest {
             Map.of(),
             Map.of(CONN1, new AppliedConnectorConfig(CONN1_CONFIG)),
             Set.of(),
+            Set.of());
+    private static final ClusterConfigState SNAPSHOT_WITH_MISSING_TASK_CONFIGS = new ClusterConfigState(
+            1,
+            null,
+            Map.of(),
+            Map.of(CONN1, CONN1_CONFIG),
+            Map.of(CONN1, TargetState.STARTED),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Set.of(CONN1),
             Set.of());
     private static final ClusterConfigState SNAPSHOT_PAUSED_CONN1 = new ClusterConfigState(
             1,
@@ -359,6 +376,115 @@ public class DistributedHerderTest {
         time.sleep(1000L);
         assertStatistics(3, 1, 100, 1000L);
         verifyNoMoreInteractions(member, configBackingStore, statusBackingStore, worker);
+    }
+
+    @Test
+    public void testDoesNotStartAssignedTaskWithoutLocalTaskConfig() {
+        // A long-running leader may retain a task config that a newly-started worker cannot
+        // reconstruct from the compacted config topic, even when both have the same config offset.
+        when(member.memberId()).thenReturn("member");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        expectRebalance(1, List.of(), List.of(TASK1));
+        expectConfigRefreshAndSnapshot(SNAPSHOT_WITH_MISSING_TASK_CONFIGS);
+        expectMemberPoll();
+
+        herder.tick();
+
+        verify(worker, never()).startSourceTask(
+                eq(TASK1),
+                any(),
+                eq(CONN1_CONFIG),
+                isNull(),
+                eq(herder),
+                eq(TargetState.STARTED));
+        verify(herder).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+    }
+
+    @Test
+    public void testStartsTaskAfterRefreshedTaskConfigsTriggerRebalance() {
+        when(member.memberId()).thenReturn("member");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V0);
+        expectRebalance(1, List.of(), List.of(TASK1));
+        expectConfigRefreshAndSnapshot(SNAPSHOT_WITH_MISSING_TASK_CONFIGS);
+        expectMemberPoll();
+        doAnswer(invocation -> {
+            invocation.<Callback<Void>>getArgument(2).onCompletion(null, null);
+            return null;
+        }).when(herder).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+
+        herder.tick();
+
+        configUpdateListener.onTaskConfigUpdate(List.of(TASK1));
+        expectMemberEnsureActive();
+        when(configBackingStore.snapshot()).thenReturn(SNAPSHOT);
+        doNothing().when(member).requestRejoin();
+
+        herder.tick();
+
+        expectRebalance(
+                List.of(),
+                List.of(TASK1),
+                ConnectProtocol.Assignment.NO_ERROR,
+                1,
+                List.of(),
+                List.of(TASK1)
+        );
+        when(herder.connectorType(anyMap())).thenReturn(ConnectorType.SOURCE);
+        when(worker.startSourceTask(
+                eq(TASK1),
+                any(),
+                eq(CONN1_CONFIG),
+                eq(TASK_CONFIG),
+                eq(herder),
+                eq(TargetState.STARTED)
+        )).thenReturn(true);
+        expectMemberPoll();
+
+        herder.tick();
+
+        verify(worker).startSourceTask(
+                eq(TASK1),
+                any(),
+                eq(CONN1_CONFIG),
+                eq(TASK_CONFIG),
+                eq(herder),
+                eq(TargetState.STARTED)
+        );
+    }
+
+    @Test
+    public void testRetriesMissingTaskAfterAssignmentOffsetChanges() {
+        connectProtocolVersion = CONNECT_PROTOCOL_V1;
+        when(member.memberId()).thenReturn("member");
+        when(member.currentProtocolVersion()).thenReturn(CONNECT_PROTOCOL_V1);
+        expectRebalance(1, List.of(), List.of(TASK1));
+        expectConfigRefreshAndSnapshot(SNAPSHOT_WITH_MISSING_TASK_CONFIGS);
+        expectMemberPoll();
+        doNothing().when(herder).refreshTaskConfigs(eq(TASK1), anyLong(), any());
+
+        herder.tick();
+
+        ClusterConfigState newerSnapshotWithMissingTaskConfigs = new ClusterConfigState(
+                2,
+                null,
+                Map.of(),
+                Map.of(CONN1, CONN1_CONFIG),
+                Map.of(CONN1, TargetState.STARTED),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Set.of(CONN1),
+                Set.of()
+        );
+        expectRebalance(2, List.of(), List.of(TASK1));
+        expectConfigRefreshAndSnapshot(newerSnapshotWithMissingTaskConfigs);
+        expectMemberPoll();
+
+        herder.tick();
+
+        verify(herder).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+        verify(herder).refreshTaskConfigs(eq(TASK1), eq(2L), any());
     }
 
     @Test
@@ -2796,6 +2922,210 @@ public class DistributedHerderTest {
     }
 
     @Test
+    public void testRefreshTaskConfigsRepublishesLeaderTaskConfigs() throws Exception {
+        when(member.memberId()).thenReturn("leader");
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.leader()).thenReturn("leader");
+        herder.configState = SNAPSHOT;
+        expectConfigRefreshAndSnapshot(SNAPSHOT);
+
+        FutureCallback<Void> callback = new FutureCallback<>();
+        herder.doRefreshTaskConfigs(CONN1, SNAPSHOT.offset(), callback);
+
+        callback.get(0, TimeUnit.MILLISECONDS);
+        verify(configBackingStore).putTaskConfigs(CONN1, TASK_CONFIGS);
+    }
+
+    @Test
+    public void testRefreshTaskConfigsRefreshesSnapshotBeforeCheckingAssignmentOffset() {
+        when(member.memberId()).thenReturn("leader");
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.leader()).thenReturn("leader");
+        herder.configState = SNAPSHOT;
+        ClusterConfigState newerSnapshot = new ClusterConfigState(
+                SNAPSHOT.offset() + 1,
+                null,
+                Map.of(CONN1, 3),
+                Map.of(CONN1, CONN1_CONFIG),
+                Map.of(CONN1, TargetState.STARTED),
+                TASK_CONFIGS_MAP,
+                Map.of(),
+                Map.of(),
+                Map.of(CONN1, new AppliedConnectorConfig(CONN1_CONFIG)),
+                Set.of(),
+                Set.of()
+        );
+        expectConfigRefreshAndSnapshot(newerSnapshot);
+
+        FutureCallback<Void> callback = new FutureCallback<>();
+        herder.doRefreshTaskConfigs(CONN1, SNAPSHOT.offset(), callback);
+
+        ExecutionException exception = assertThrows(
+                ExecutionException.class,
+                () -> callback.get(0, TimeUnit.MILLISECONDS)
+        );
+        assertInstanceOf(RebalanceNeededException.class, exception.getCause());
+        verify(configBackingStore, never()).putTaskConfigs(any(), any());
+    }
+
+    @Test
+    public void testRefreshTaskConfigsDoesNotGuessWhenLeaderIsMissingConfigs() {
+        when(member.memberId()).thenReturn("leader");
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.leader()).thenReturn("leader");
+        herder.configState = SNAPSHOT_WITH_MISSING_TASK_CONFIGS;
+        expectConfigRefreshAndSnapshot(SNAPSHOT_WITH_MISSING_TASK_CONFIGS);
+
+        FutureCallback<Void> callback = new FutureCallback<>();
+        herder.doRefreshTaskConfigs(CONN1, SNAPSHOT_WITH_MISSING_TASK_CONFIGS.offset(), callback);
+
+        ExecutionException exception = assertThrows(
+                ExecutionException.class,
+                () -> callback.get(0, TimeUnit.MILLISECONDS)
+        );
+        assertInstanceOf(ConnectException.class, exception.getCause());
+        verify(configBackingStore, never()).putTaskConfigs(any(), any());
+    }
+
+    @Test
+    public void testTaskConfigRefreshIsForwardedToLeader() throws Exception {
+        ExecutorService forwardRequestExecutor = mock(ExecutorService.class);
+        herder.forwardRequestExecutor = forwardRequestExecutor;
+
+        doAnswer(invocation -> {
+            Callback<Void> callback = invocation.getArgument(2);
+            callback.onCompletion(new NotLeaderException("Not leader", "http://leader:8083"), null);
+            return null;
+        }).when(herder).refreshTaskConfigs(eq(CONN1), eq(1L), any());
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(forwardRequestExecutor).execute(any());
+        doAnswer(invocation -> null).when(restClient).httpRequest(
+                anyString(), eq("POST"), isNull(), eq(1L), isNull(), anyString()
+        );
+
+        FutureCallback<Void> callback = new FutureCallback<>();
+        herder.refreshTaskConfigs(TASK1, 1L, callback);
+
+        callback.get(0, TimeUnit.MILLISECONDS);
+        ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
+        verify(restClient).httpRequest(
+                url.capture(), eq("POST"), isNull(), eq(1L), isNull(), anyString()
+        );
+        assertEquals("http://leader:8083/connectors/" + CONN1 + "/tasks/refresh", url.getValue());
+    }
+
+    @Test
+    public void testTaskConfigRefreshIsDeduplicatedPerConnectorAndAssignment() {
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.offset()).thenReturn(1L);
+        when(herder.assignment.tasks()).thenReturn(List.of(TASK0, TASK1));
+        doNothing().when(herder).refreshTaskConfigs(eq(TASK0), eq(1L), any());
+
+        herder.requestTaskConfigRefresh(TASK0);
+        herder.requestTaskConfigRefresh(TASK1);
+
+        verify(herder, times(1)).refreshTaskConfigs(eq(TASK0), eq(1L), any());
+        verify(herder, never()).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+
+        when(herder.assignment.leader()).thenReturn("new-leader");
+        when(herder.assignment.leaderUrl()).thenReturn("http://new-leader:8083");
+        herder.requestTaskConfigRefresh(TASK1);
+
+        verify(herder).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+    }
+
+    @Test
+    public void testTaskConfigRefreshRetriesWithBackoff() throws Exception {
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.offset()).thenReturn(1L);
+        when(herder.assignment.tasks()).thenReturn(List.of(TASK1));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<Void>> callback = ArgumentCaptor.forClass(Callback.class);
+        doNothing().when(herder).refreshTaskConfigs(eq(TASK1), eq(1L), callback.capture());
+
+        herder.requestTaskConfigRefresh(TASK1);
+        callback.getValue().onCompletion(new ConnectException("Transient failure"), null);
+
+        assertEquals(1, herder.requests.size());
+        time.sleep(DistributedHerder.RECONFIGURE_CONNECTOR_TASKS_BACKOFF_INITIAL_MS);
+        DistributedHerder.DistributedHerderRequest retry = herder.requests.pollFirst();
+        assertNotNull(retry);
+        retry.action().call();
+
+        verify(herder, times(2)).refreshTaskConfigs(eq(TASK1), eq(1L), any());
+    }
+
+    @Test
+    public void testTerminalTaskConfigRefreshFailuresRequestRejoinWithoutRetry() throws Exception {
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.tasks()).thenReturn(List.of(TASK1));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<Void>> callback = ArgumentCaptor.forClass(Callback.class);
+        doNothing().when(herder).refreshTaskConfigs(eq(TASK1), anyLong(), callback.capture());
+
+        List<ConnectException> terminalFailures = List.of(
+                new RebalanceNeededException("Stale assignment"),
+                new NotFoundException("Connector not found"),
+                new BadRequestException("Connector is stopped"),
+                new ConnectRestException(BAD_REQUEST, "Connector is stopped"),
+                new ConnectRestException(NOT_FOUND, "Connector or refresh endpoint not found"),
+                new ConnectRestException(CONFLICT, "Stale assignment")
+        );
+        for (int i = 0; i < terminalFailures.size(); i++) {
+            long offset = i + 1L;
+            when(herder.assignment.offset()).thenReturn(offset);
+            herder.requestTaskConfigRefresh(TASK1);
+            callback.getAllValues().get(i).onCompletion(terminalFailures.get(i), null);
+
+            DistributedHerder.DistributedHerderRequest rejoinRequest = herder.requests.pollFirst();
+            assertNotNull(rejoinRequest);
+            rejoinRequest.action().call();
+
+            // A rejoin may produce the same assignment and leader, especially during a rolling upgrade
+            // where the leader does not support the refresh endpoint. Do not repeat the same failed request.
+            herder.requestTaskConfigRefresh(TASK1);
+            verify(herder, times(i + 1)).refreshTaskConfigs(eq(TASK1), anyLong(), any());
+        }
+
+        verify(herder, times(terminalFailures.size())).refreshTaskConfigs(eq(TASK1), anyLong(), any());
+        verify(member, times(terminalFailures.size())).requestRejoin();
+        assertTrue(herder.requests.isEmpty());
+    }
+
+    @Test
+    public void testTaskConfigRefreshStopsRetryingAndRequestsRejoin() throws Exception {
+        herder.assignment = mock(ExtendedAssignment.class);
+        when(herder.assignment.offset()).thenReturn(1L);
+        when(herder.assignment.tasks()).thenReturn(List.of(TASK1));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Callback<Void>> callback = ArgumentCaptor.forClass(Callback.class);
+        doNothing().when(herder).refreshTaskConfigs(eq(TASK1), eq(1L), callback.capture());
+
+        herder.requestTaskConfigRefresh(TASK1);
+        for (int attempt = 0; attempt <= TaskConfigRefreshRecovery.MAX_RETRIES; attempt++) {
+            callback.getAllValues().get(attempt).onCompletion(new ConnectException("Transient failure"), null);
+            DistributedHerder.DistributedHerderRequest request = herder.requests.pollFirst();
+            assertNotNull(request);
+            request.action().call();
+        }
+
+        verify(herder, times(TaskConfigRefreshRecovery.MAX_RETRIES + 1))
+                .refreshTaskConfigs(eq(TASK1), eq(1L), any());
+        ArgumentCaptor<Long> retryDelay = ArgumentCaptor.forClass(Long.class);
+        verify(herder, times(TaskConfigRefreshRecovery.MAX_RETRIES + 1))
+                .addRequest(retryDelay.capture(), any(), any());
+        assertTrue(retryDelay.getAllValues().contains(DistributedHerder.RECONFIGURE_CONNECTOR_TASKS_BACKOFF_MAX_MS));
+        verify(member).requestRejoin();
+        assertTrue(herder.requests.isEmpty());
+
+        herder.requestTaskConfigRefresh(TASK1);
+        verify(herder, times(TaskConfigRefreshRecovery.MAX_RETRIES + 1))
+                .refreshTaskConfigs(eq(TASK1), eq(1L), any());
+    }
+
+    @Test
     public void testFailedToWriteSessionKey() {
         // First tick -- after joining the group, we try to write a new
         // session key to the config topic, and fail
@@ -3391,12 +3721,6 @@ public class DistributedHerderTest {
             time.milliseconds(),
             new ConnectRestException(FORBIDDEN.getStatusCode(), "")
         ));
-    }
-
-    @Test
-    public void testInconsistentConfigs() {
-        // FIXME: if we have inconsistent configs, we need to request forced reconfig + write of the connector's task configs
-        // This requires inter-worker communication, so needs the REST API
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -130,6 +130,93 @@ public class IncrementalCooperativeAssignorTest {
     }
 
     @Test
+    public void testInconsistentTaskConfigsRevokeAndReassignConnector() {
+        connectors.clear();
+        addNewConnector("connector1", 1);
+        memberAssignments.clear();
+        ConnectorTaskId task = new ConnectorTaskId("connector1", 0);
+        addNewWorker("connector-worker", List.of("connector1"), List.of());
+        addNewWorker("task-worker", List.of(), List.of(task));
+        initAssignor();
+
+        // Establish the previous generation in which both the connector and its task were active.
+        performStandardRebalance();
+        assertEmptyAssignment();
+
+        // Model a new leader that reconstructed the connector, but not its task configs, from a
+        // compacted config topic. The connector remains configured, while no tasks are usable.
+        Map<String, Map<String, String>> connectorConfigs = Map.of("connector1", Map.of());
+        ClusterConfigState inconsistentConfigState = new ClusterConfigState(
+                CONFIG_OFFSET,
+                null,
+                Map.of(),
+                connectorConfigs,
+                Map.of("connector1", TargetState.STARTED),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of("connector1", new AppliedConnectorConfig(Map.of())),
+                Set.of(),
+                Set.of("connector1")
+        );
+
+        performRebalance(inconsistentConfigState);
+
+        assertEquals(Set.of(task), new HashSet<>(returnedAssignments.newlyRevokedTasks("task-worker")));
+        assertEquals(Set.of("connector1"), new HashSet<>(returnedAssignments.newlyRevokedConnectors("connector-worker")));
+        assertTrue(memberAssignments.values().stream().allMatch(assignment -> assignment.connectors().isEmpty()));
+        assertTrue(memberAssignments.values().stream().allMatch(assignment -> assignment.tasks().isEmpty()));
+
+        // The next rebalance reassigns the connector. Starting it invokes the existing task config
+        // reconfiguration path, which regenerates and republishes its task configs.
+        performRebalance(inconsistentConfigState);
+        assertNoRevocations();
+        assertConnectorAllocations(0, 1);
+        assertTaskAllocations(0, 0);
+
+        // Once the regenerated task configs reach the config snapshot, the task is assigned again
+        // without another connector restart.
+        performStandardRebalance();
+        assertNoRevocations();
+        assertConnectorAllocations(0, 1);
+        assertTaskAllocations(0, 1);
+    }
+
+    @Test
+    public void testInconsistentTaskConfigsDoNotRestartPausedConnector() {
+        connectors.clear();
+        addNewConnector("connector1", 1);
+        memberAssignments.clear();
+        ConnectorTaskId task = new ConnectorTaskId("connector1", 0);
+        addNewWorker("worker", List.of("connector1"), List.of(task));
+        initAssignor();
+
+        performStandardRebalance();
+        assertEmptyAssignment();
+
+        ClusterConfigState inconsistentPausedConfigState = new ClusterConfigState(
+                CONFIG_OFFSET,
+                null,
+                Map.of(),
+                Map.of("connector1", Map.of()),
+                Map.of("connector1", TargetState.PAUSED),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of("connector1", new AppliedConnectorConfig(Map.of())),
+                Set.of(),
+                Set.of("connector1")
+        );
+
+        performRebalance(inconsistentPausedConfigState);
+
+        assertEquals(Set.of(task), new HashSet<>(returnedAssignments.newlyRevokedTasks("worker")));
+        assertEquals(Set.of(), new HashSet<>(returnedAssignments.newlyRevokedConnectors("worker")));
+        assertEquals(Set.of("connector1"), new HashSet<>(memberAssignments.get("worker").connectors()));
+        assertEquals(Set.of(), new HashSet<>(memberAssignments.get("worker").tasks()));
+    }
+
+    @Test
     public void testAssignmentsWhenWorkersJoinAfterRevocations()  {
         // Customize assignor for this test case
         time = new MockTime();
@@ -1302,6 +1389,14 @@ public class IncrementalCooperativeAssignorTest {
     }
 
     private void performRebalance(boolean assignmentFailure, boolean generationMismatch) {
+        performRebalance(assignmentFailure, generationMismatch, configState());
+    }
+
+    private void performRebalance(ClusterConfigState configState) {
+        performRebalance(false, false, configState);
+    }
+
+    private void performRebalance(boolean assignmentFailure, boolean generationMismatch, ClusterConfigState configState) {
         generationId++;
         int lastCompletedGenerationId = generationMismatch ? generationId - 2 : generationId - 1;
         try {
@@ -1310,7 +1405,7 @@ public class IncrementalCooperativeAssignorTest {
                             Map.Entry::getKey,
                             e -> new ConnectorsAndTasks.Builder().with(e.getValue().connectors(), e.getValue().tasks()).build()
                     ));
-            returnedAssignments = assignor.performTaskAssignment(configState(), lastCompletedGenerationId, generationId, memberAssignmentsCopy);
+            returnedAssignments = assignor.performTaskAssignment(configState, lastCompletedGenerationId, generationId, memberAssignmentsCopy);
         } catch (RuntimeException e) {
             if (assignmentFailure) {
                 RequestFuture.failure(e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/InternalConnectResourceTest.java
@@ -70,6 +70,8 @@ public class InternalConnectResourceTest {
     }
     private static final String FENCE_PATH = "/connectors/" + CONNECTOR_NAME + "/fence";
     private static final String TASK_CONFIGS_PATH = "/connectors/" + CONNECTOR_NAME + "/tasks";
+    private static final String REFRESH_TASK_CONFIGS_PATH = TASK_CONFIGS_PATH + "/refresh";
+    private static final long EXPECTED_CONFIG_OFFSET = 42L;
     private static final RestRequestTimeout REST_REQUEST_TIMEOUT = RestRequestTimeout.constant(
             RestServer.DEFAULT_REST_REQUEST_TIMEOUT_MS,
             RestServer.DEFAULT_HEALTH_CHECK_TIMEOUT_MS
@@ -154,6 +156,59 @@ public class InternalConnectResourceTest {
 
         assertThrows(NotFoundException.class, () -> internalResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS,
                 FORWARD, serializeAsBytes(TASK_CONFIGS)));
+    }
+
+    @Test
+    public void testRefreshConnectorTaskConfigsNoInternalRequestSignature() throws Throwable {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        expectAndCallbackResult(cb, null).when(herder).refreshTaskConfigs(
+                eq(CONNECTOR_NAME),
+                eq(EXPECTED_CONFIG_OFFSET),
+                cb.capture(),
+                isNull()
+        );
+        expectRequestPath(REFRESH_TASK_CONFIGS_PATH);
+
+        internalResource.refreshTaskConfigs(
+                CONNECTOR_NAME,
+                NULL_HEADERS,
+                FORWARD,
+                serializeAsBytes(EXPECTED_CONFIG_OFFSET)
+        );
+    }
+
+    @Test
+    public void testRefreshConnectorTaskConfigsWithInternalRequestSignature() throws Throwable {
+        final String signatureAlgorithm = "HmacSHA256";
+        final String encodedSignature = "Kv1/OSsxzdVIwvZ4e30avyRIVrngDfhzVUm/kAZEKc4=";
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Callback<Void>> cb = ArgumentCaptor.forClass(Callback.class);
+        final ArgumentCaptor<InternalRequestSignature> signatureCapture = ArgumentCaptor.forClass(InternalRequestSignature.class);
+        expectAndCallbackResult(cb, null).when(herder).refreshTaskConfigs(
+                eq(CONNECTOR_NAME),
+                eq(EXPECTED_CONFIG_OFFSET),
+                cb.capture(),
+                signatureCapture.capture()
+        );
+
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_ALGORITHM_HEADER))
+                .thenReturn(signatureAlgorithm);
+        when(headers.getHeaderString(InternalRequestSignature.SIGNATURE_HEADER))
+                .thenReturn(encodedSignature);
+        expectRequestPath(REFRESH_TASK_CONFIGS_PATH);
+
+        byte[] requestBody = serializeAsBytes(EXPECTED_CONFIG_OFFSET);
+        internalResource.refreshTaskConfigs(CONNECTOR_NAME, headers, FORWARD, requestBody);
+
+        InternalRequestSignature expectedSignature = new InternalRequestSignature(
+                requestBody,
+                Mac.getInstance(signatureAlgorithm),
+                Base64.getDecoder().decode(encodedSignature)
+        );
+        assertEquals(expectedSignature, signatureCapture.getValue());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -842,6 +842,7 @@ public class KafkaConfigBackingStoreTest {
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
         deserialized.put(CONFIGS_SERIALIZED.get(3), CONNECTOR_TASK_COUNT_RECORD_STRUCTS.get(2));
+        deserialized.put(CONFIGS_SERIALIZED.get(4), CONNECTOR_CONFIG_STRUCTS.get(0));
         logOffset = offset;
         expectStart(existingRecords, deserialized);
         when(configLog.partitionCount()).thenReturn(1);
@@ -866,6 +867,69 @@ public class KafkaConfigBackingStoreTest {
         // where there are still zombie instances of the tasks for this long-deleted connector
         // running somewhere on the cluster
         assertEquals(2, (int) configState.taskCountRecord(CONNECTOR_1_NAME));
+
+        // A connector created after startup must not inherit the recovery marker from the
+        // compacted records of a connector that was deleted before this worker started.
+        capturedConsumedCallback.getValue().onCompletion(
+                null,
+                new ConsumerRecord<>(
+                        TOPIC,
+                        0,
+                        offset,
+                        0L,
+                        TimestampType.CREATE_TIME,
+                        0,
+                        0,
+                        CONNECTOR_CONFIG_KEYS.get(0),
+                        CONFIGS_SERIALIZED.get(4),
+                        new RecordHeaders(),
+                        Optional.empty()
+                )
+        );
+        configState = configStorage.snapshot();
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_1_NAME));
+        assertEquals(Set.of(), configState.inconsistentConnectors());
+        verify(configUpdateListener).onConnectorConfigUpdate(CONNECTOR_1_NAME);
+    }
+
+    @Test
+    public void testMarkCompactedConnectorConfigUpdateInconsistent() {
+        // After compaction, an active connector's latest config record may appear after its last
+        // committed task configs. Do not apply the ambiguous task configs, since they may instead
+        // belong to a deleted connector with the same name, but mark the connector for recovery.
+        int offset = 0;
+        List<ConsumerRecord<String, byte[]>> existingRecords = List.of(
+            new ConsumerRecord<>(TOPIC, 0, offset++, 0L, TimestampType.CREATE_TIME, 0, 0,
+                TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(0), new RecordHeaders(), Optional.empty()),
+            new ConsumerRecord<>(TOPIC, 0, offset++, 0L, TimestampType.CREATE_TIME, 0, 0,
+                TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(1), new RecordHeaders(), Optional.empty()),
+            new ConsumerRecord<>(TOPIC, 0, offset++, 0L, TimestampType.CREATE_TIME, 0, 0,
+                COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(2), new RecordHeaders(), Optional.empty()),
+            new ConsumerRecord<>(TOPIC, 0, offset++, 0L, TimestampType.CREATE_TIME, 0, 0,
+                CONNECTOR_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(3), new RecordHeaders(), Optional.empty()));
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
+        deserialized.put(CONFIGS_SERIALIZED.get(0), TASK_CONFIG_STRUCTS.get(0));
+        deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(1));
+        deserialized.put(CONFIGS_SERIALIZED.get(2), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);
+        deserialized.put(CONFIGS_SERIALIZED.get(3), CONNECTOR_CONFIG_STRUCTS.get(0));
+        logOffset = offset;
+        expectStart(existingRecords, deserialized);
+        when(configLog.partitionCount()).thenReturn(1);
+
+        configStorage.setupAndCreateKafkaBasedLog(TOPIC, config);
+        verifyConfigure();
+        configStorage.start();
+
+        ClusterConfigState configState = configStorage.snapshot();
+        assertEquals(Set.of(CONNECTOR_1_NAME), configState.connectors());
+        assertEquals(SAMPLE_CONFIGS.get(0), configState.connectorConfig(CONNECTOR_1_NAME));
+        assertEquals(0, configState.taskCount(CONNECTOR_1_NAME));
+        assertNull(configState.rawTaskConfig(TASK_IDS.get(0)));
+        assertNull(configState.rawTaskConfig(TASK_IDS.get(1)));
+        assertEquals(Set.of(CONNECTOR_1_NAME), configState.inconsistentConnectors());
+
+        configStorage.stop();
+        verify(configLog).stop();
     }
 
     @Test


### PR DESCRIPTION
## Design rationale

The compacted log cannot distinguish task configurations for an active
connector from zombie tasks left by a deleted connector with the same
name.  Buffering and applying those records would therefore reintroduce
the behavior  prevented by KAFKA-16838.

Adding a connector incarnation ID would solve this cleanly, but requires
persisted record-format changes and mixed-version upgrade semantics.
This  change instead preserves the existing safety rule and recovers
configurations  through leader republishing or connector regeneration,
without changing the  config topic format.

## Summary

After config topic compaction, committed task configurations may appear
before  the latest connector configuration. Connect currently treats
these task  configurations as belonging to a deleted connector and
discards them, even when  the connector still exists. This can leave an
assigned task without a local  configuration and cause it to fail during
startup.

This change detects the inconsistent connector, prevents the task from
starting  without a configuration, and recovers the complete task
configuration set.

## Recovery flow

```mermaid
flowchart TD;
    A[Replay compacted config topic] --> B{Task commit before connector
config?};
    B -->|No| C[Restore configs normally];
    B -->|Yes| D[Discard ambiguous task configs];
    D --> E{Connector config appears later?};
    E -->|No| F[Treat as a deleted connector];
    E -->|Yes| G[Mark connector inconsistent];
    G --> H{Assigned task has a local config?};
    H -->|Yes| I[Start task normally];
    H -->|No| J[Block task startup];
    J --> K[Request task config refresh from leader];
    K --> L{Leader can republish complete configs?};
    L -->|Yes| M[Republish task configs];
    L -->|No or refresh fails| N[Request rejoin];
    N --> O[Recompute assignment];
    O --> P[Revoke inconsistent STARTED connector];
    P --> Q[Restart connector and regenerate configs];
    M --> R[Workers consume recovered configs];
    Q --> R;
    R --> S[Rebalance using latest config offset];
    S --> T[Start assigned task];
```

Ambiguous task configurations are not applied directly because they may
belong  to a deleted connector that was later recreated with the same
name.

Refresh failures are handled as follows:

- terminal `400`, `404`, and `409` responses request a rejoin
immediately
- transient failures are retried up to five times with exponential
backoff
- after retries are exhausted, a rejoin is requested
- the same failed recovery is not repeated until the assignment or
leader changes

## Testing

Added unit tests for:

- compacted config log reconstruction
- missing task configuration handling
- leader refresh and connector regeneration
- forwarded terminal errors
- bounded retries and rejoin behavior
- duplicate recovery suppression across unchanged assignments
