### PR TITLE
KAFKA-21027: Remove hamcrest from org.apache.kafka.streams.integration package

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -38,7 +38,6 @@ import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.TestUtils;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -46,9 +45,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests all available joins of Kafka Streams DSL.
@@ -184,11 +183,11 @@ public abstract class AbstractJoinIntegrationTest {
                     }
 
                     final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
-                    assertThat(output, equalTo(updatedExpected));
+                    assertEquals(updatedExpected, output);
                     expectedFinalResult = updatedExpected.get(expected.size() - 1);
                 } else {
                     final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
-                    assertThat(output, equalTo(Collections.emptyList()));
+                    assertTrue(output.isEmpty());
                 }
             }
 
@@ -228,7 +227,7 @@ public abstract class AbstractJoinIntegrationTest {
 
             final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
 
-            assertThat(output.get(output.size() - 1), equalTo(updatedExpectedFinalResult));
+            assertEquals(updatedExpectedFinalResult, output.get(output.size() - 1));
 
             if (storeName != null) {
                 checkQueryableStore(storeName, updatedExpectedFinalResult, driver);
@@ -258,7 +257,7 @@ public abstract class AbstractJoinIntegrationTest {
                     }
 
                     final List<TestRecord<Long, String>> output = outputTopic.readRecordsToList();
-                    assertThat(output, equalTo(updatedExpected));
+                    assertEquals(updatedExpected, output);
                 }
             }
         }
@@ -270,10 +269,10 @@ public abstract class AbstractJoinIntegrationTest {
         try (final KeyValueIterator<Long, ValueAndTimestamp<String>> all = store.all()) {
             final KeyValue<Long, ValueAndTimestamp<String>> onlyEntry = all.next();
 
-            assertThat(onlyEntry.key, is(expectedFinalResult.key()));
-            assertThat(onlyEntry.value.value(), is(expectedFinalResult.value()));
-            assertThat(onlyEntry.value.timestamp(), is(expectedFinalResult.timestamp()));
-            assertThat(all.hasNext(), is(false));
+            assertEquals(expectedFinalResult.key(), onlyEntry.key);
+            assertEquals(expectedFinalResult.value(), onlyEntry.value.value());
+            assertEquals(expectedFinalResult.timestamp(), onlyEntry.value.timestamp());
+            assertFalse(all.hasNext());
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -71,10 +70,7 @@ import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -184,10 +180,11 @@ public class AdjustStreamThreadCountTest {
         waitForRunning();
 
         final int historySize = stateTransitionHistory.size();
-        assertThat("Client did not transit from REBALANCING to RUNNING. The observed state transitions are: " + stateTransitionHistory,
+        assertTrue(
             historySize >= 2 &&
                 stateTransitionHistory.get(historySize - 2).equals(KafkaStreams.State.REBALANCING) &&
-                stateTransitionHistory.get(historySize - 1).equals(KafkaStreams.State.RUNNING), is(true));
+                stateTransitionHistory.get(historySize - 1).equals(KafkaStreams.State.RUNNING),
+            "Client did not transit from REBALANCING to RUNNING. The observed state transitions are: " + stateTransitionHistory);
     }
 
     @Test
@@ -197,26 +194,31 @@ public class AdjustStreamThreadCountTest {
             startStreamsAndWaitForRunning(kafkaStreams);
 
             final int oldThreadCount = kafkaStreams.metadataForLocalThreads().size();
-            assertThat(kafkaStreams.metadataForLocalThreads().stream().map(t -> t.threadName().split("-StreamThread-")[1]).sorted().toArray(), equalTo(new String[] {"1", "2"}));
+            assertArrayEquals(
+                new String[] {"1", "2"},
+                kafkaStreams.metadataForLocalThreads().stream()
+                    .map(t -> t.threadName().split("-StreamThread-")[1])
+                    .sorted()
+                    .toArray());
 
             stateTransitionHistory.clear();
             final Optional<String> name = kafkaStreams.addStreamThread();
 
-            assertThat(name, not(Optional.empty()));
+            assertTrue(name.isPresent());
             TestUtils.waitForCondition(
                 () -> kafkaStreams.metadataForLocalThreads().stream().sequential()
                     .map(ThreadMetadata::threadName).anyMatch(t -> t.equals(name.orElse(""))),
                 "Wait for the thread to be added"
             );
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount + 1));
-            assertThat(
+            assertEquals(oldThreadCount + 1, kafkaStreams.metadataForLocalThreads().size());
+            assertArrayEquals(
+                new String[] {"1", "2", "3"},
                 kafkaStreams
                     .metadataForLocalThreads()
                     .stream()
                     .map(t -> t.threadName().split("-StreamThread-")[1])
-                    .sorted().toArray(),
-                equalTo(new String[] {"1", "2", "3"})
-            );
+                    .sorted()
+                    .toArray());
 
             waitForTransitionFromRebalancingToRunning();
         }
@@ -230,8 +232,8 @@ public class AdjustStreamThreadCountTest {
 
             final int oldThreadCount = kafkaStreams.metadataForLocalThreads().size();
             stateTransitionHistory.clear();
-            assertThat(kafkaStreams.removeStreamThread().get().split("-")[0], equalTo(appId));
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount - 1));
+            assertEquals(appId, kafkaStreams.removeStreamThread().get().split("-")[0]);
+            assertEquals(oldThreadCount - 1, kafkaStreams.metadataForLocalThreads().size());
 
             waitForTransitionFromRebalancingToRunning();
         }
@@ -246,8 +248,8 @@ public class AdjustStreamThreadCountTest {
 
             final int oldThreadCount = kafkaStreams.metadataForLocalThreads().size();
             stateTransitionHistory.clear();
-            assertThat(kafkaStreams.removeStreamThread().get().split("-")[0], equalTo(appId));
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount - 1));
+            assertEquals(appId, kafkaStreams.removeStreamThread().get().split("-")[0]);
+            assertEquals(oldThreadCount - 1, kafkaStreams.metadataForLocalThreads().size());
 
             waitForTransitionFromRebalancingToRunning();
         }
@@ -292,7 +294,7 @@ public class AdjustStreamThreadCountTest {
                 );
                 
                 threadMetadata = kafkaStreams.metadataForLocalThreads();
-                assertThat(threadMetadata.size(), equalTo(oldThreadCount));
+                assertEquals(oldThreadCount, threadMetadata.size());
             } catch (final AssertionError e) {
                 System.err.println(threadMetadata);
                 testError = e;
@@ -343,7 +345,7 @@ public class AdjustStreamThreadCountTest {
                 listener.onChange(thread1, newState, oldState);
             });
             final Optional<String> threadName = kafkaStreams.removeStreamThread();
-            assertThat(threadName.isPresent(), Matchers.is(true));
+            assertTrue(threadName.isPresent());
             assertEquals(thread.getName(), threadName.get());
             waitForTransitionFromRebalancingToRunning();
             latchBeforeDead.countDown();
@@ -359,18 +361,17 @@ public class AdjustStreamThreadCountTest {
             int oldThreadCount = kafkaStreams.metadataForLocalThreads().size();
             stateTransitionHistory.clear();
 
-            assertThat(
+            assertArrayEquals(
+                new String[] {"1", "2"},
                 kafkaStreams.metadataForLocalThreads()
                     .stream()
                     .map(t -> t.threadName().split("-StreamThread-")[1])
                     .sorted()
-                    .toArray(),
-                equalTo(new String[] {"1", "2"})
-            );
+                    .toArray());
 
             final Optional<String> name = kafkaStreams.addStreamThread();
 
-            assertThat("New thread has index 3", "3".equals(name.get().split("-StreamThread-")[1]));
+            assertEquals("3", name.get().split("-StreamThread-")[1], "New thread has index 3");
             TestUtils.waitForCondition(
                 () -> kafkaStreams
                     .metadataForLocalThreads()
@@ -379,16 +380,15 @@ public class AdjustStreamThreadCountTest {
                     .anyMatch(t -> t.equals(name.get())),
                 "Stream thread has not been added"
             );
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount + 1));
-            assertThat(
+            assertEquals(oldThreadCount + 1, kafkaStreams.metadataForLocalThreads().size());
+            assertArrayEquals(
+                new String[] {"1", "2", "3"},
                 kafkaStreams
                     .metadataForLocalThreads()
                     .stream()
                     .map(t -> t.threadName().split("-StreamThread-")[1])
                     .sorted()
-                    .toArray(),
-                equalTo(new String[] {"1", "2", "3"})
-            );
+                    .toArray());
             waitForTransitionFromRebalancingToRunning();
 
             oldThreadCount = kafkaStreams.metadataForLocalThreads().size();
@@ -396,32 +396,31 @@ public class AdjustStreamThreadCountTest {
 
             final Optional<String> removedThread = kafkaStreams.removeStreamThread();
 
-            assertThat(removedThread, not(Optional.empty()));
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount - 1));
+            assertTrue(removedThread.isPresent());
+            assertEquals(oldThreadCount - 1, kafkaStreams.metadataForLocalThreads().size());
             waitForTransitionFromRebalancingToRunning();
 
             stateTransitionHistory.clear();
 
             final Optional<String> name2 = kafkaStreams.addStreamThread();
 
-            assertThat(name2, not(Optional.empty()));
+            assertTrue(name2.isPresent());
             TestUtils.waitForCondition(
                 () -> kafkaStreams.metadataForLocalThreads().stream().sequential()
                     .map(ThreadMetadata::threadName).anyMatch(t -> t.equals(name2.orElse(""))),
                 "Wait for the thread to be added"
             );
-            assertThat(kafkaStreams.metadataForLocalThreads().size(), equalTo(oldThreadCount));
-            assertThat(
+            assertEquals(oldThreadCount, kafkaStreams.metadataForLocalThreads().size());
+            assertArrayEquals(
+                new String[] {"1", "2", "3"},
                 kafkaStreams
                     .metadataForLocalThreads()
                     .stream()
                     .map(t -> t.threadName().split("-StreamThread-")[1])
                     .sorted()
-                    .toArray(),
-                equalTo(new String[] {"1", "2", "3"})
-            );
+                    .toArray());
 
-            assertThat("the new thread should have received the old threads name", name2.equals(removedThread));
+            assertEquals(removedThread, name2, "the new thread should have received the old threads name");
             waitForTransitionFromRebalancingToRunning();
         }
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ColdStartStickinessIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ColdStartStickinessIntegrationTest.java
@@ -70,8 +70,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.wa
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyStreamGroup;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(600)
 @Tag("integration")
@@ -169,10 +168,8 @@ public class ColdStartStickinessIntegrationTest {
             startApplicationAndWaitUntilRunning(asList(restarted1, restarted2), Duration.ofSeconds(60));
 
             final long totalRestored = restore1.totalNumRestored() + restore2.totalNumRestored();
-            assertThat(
-                "Tasks should be assigned to the instance that already holds their state, so nothing is restored",
-                totalRestored,
-                equalTo(0L));
+            assertEquals(0L, totalRestored,
+                "Tasks should be assigned to the instance that already holds their state, so nothing is restored");
         } finally {
             restarted1.close(Duration.ofSeconds(60));
             restarted2.close(Duration.ofSeconds(60));
@@ -246,7 +243,7 @@ public class ColdStartStickinessIntegrationTest {
         final List<File> taskDirs = new ArrayList<>();
         taskDirs.addAll(listTaskDirectories(appDir1));
         taskDirs.addAll(listTaskDirectories(appDir2));
-        assertThat("expected one state directory per task", taskDirs.size(), equalTo(NUM_PARTITIONS));
+        assertEquals(NUM_PARTITIONS, taskDirs.size(), "expected one state directory per task");
 
         for (final File taskDir : taskDirs) {
             final int partition = Integer.parseInt(taskDir.getName().substring(taskDir.getName().indexOf('_') + 1));

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ConsistencyVectorIntegrationTest.java
@@ -61,9 +61,8 @@ import java.util.stream.IntStream;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 @Timeout(600)
@@ -120,9 +119,9 @@ public class ConsistencyVectorIntegrationTest {
             produceValueRange();
 
             // Assert that all messages in the first batch were processed in a timely manner
-            assertThat(
-                "Did not process all message in time.",
-                semaphore.tryAcquire(NUMBER_OF_MESSAGES, 120, TimeUnit.SECONDS), is(equalTo(true))
+            assertTrue(
+                semaphore.tryAcquire(NUMBER_OF_MESSAGES, 120, TimeUnit.SECONDS),
+                "Did not process all message in time."
             );
 
             // Assert that both active and standby have the same position bound
@@ -155,13 +154,10 @@ public class ConsistencyVectorIntegrationTest {
                 stateQueryResult.getPartitionResults().get(0);
             if (queryResult.isSuccess() && queryResult.getResult() != null) {
                 // invariant: each value is also at the equivalent offset
-                assertThat(
-                    "Result:" + queryResult,
+                assertEquals(
+                    Position.emptyPosition().withComponent(INPUT_TOPIC_NAME, 0, queryResult.getResult()),
                     queryResult.getPosition(),
-                    is(
-                        Position.emptyPosition()
-                                .withComponent(INPUT_TOPIC_NAME, 0, queryResult.getResult())
-                    )
+                    "Result:" + queryResult
                 );
 
                 if (queryResult.getResult() == NUMBER_OF_MESSAGES - 1) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -115,10 +115,8 @@ import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
 import static org.apache.kafka.test.TestUtils.consumerConfig;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
@@ -240,8 +238,8 @@ public class EosIntegrationTest {
             final long consumerPosition = consumer.position(topicPartition);
             final long endOffset = consumer.endOffsets(topicPartitions).get(topicPartition);
 
-            assertThat(committedOffset, equalTo(consumerPosition));
-            assertThat(committedOffset, equalTo(endOffset));
+            assertEquals(consumerPosition, committedOffset);
+            assertEquals(endOffset, committedOffset);
         }
     }
 
@@ -341,7 +339,7 @@ public class EosIntegrationTest {
         addAllKeys(allKeys, expectedResult);
 
         for (final Long key : allKeys) {
-            assertThat(reason, getAllRecordPerKey(key, result), equalTo(getAllRecordPerKey(key, expectedResult)));
+            assertEquals(getAllRecordPerKey(key, expectedResult), getAllRecordPerKey(key, result), reason);
         }
     }
 
@@ -398,7 +396,7 @@ public class EosIntegrationTest {
             );
 
             final List<KeyValue<Long, Long>> firstCommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, firstBurstOfData.size(), CONSUMER_GROUP_ID);
-            assertThat(firstCommittedRecords, equalTo(firstBurstOfData));
+            assertEquals(firstBurstOfData, firstCommittedRecords);
 
             IntegrationTestUtils.produceKeyValuesSynchronously(
                 SINGLE_PARTITION_INPUT_TOPIC,
@@ -408,7 +406,7 @@ public class EosIntegrationTest {
             );
 
             final List<KeyValue<Long, Long>> secondCommittedRecords = readResult(SINGLE_PARTITION_OUTPUT_TOPIC, secondBurstOfData.size(), CONSUMER_GROUP_ID);
-            assertThat(secondCommittedRecords, equalTo(secondBurstOfData));
+            assertEquals(secondBurstOfData, secondCommittedRecords);
         }
     }
 
@@ -510,7 +508,7 @@ public class EosIntegrationTest {
                 expectedCommittedRecordsAfterRecovery,
                 "The committed records after recovery do not match what expected");
 
-            assertThat("Should only get one uncaught exception from Streams.", hasUnexpectedError, is(false));
+            assertFalse(hasUnexpectedError, "Should only get one uncaught exception from Streams.");
         }
     }
 
@@ -630,7 +628,7 @@ public class EosIntegrationTest {
                 getMaxPerKey(expectedResult),
                 "The state store content after recovery do not match what expected");
 
-            assertThat("Should only get one uncaught exception from Streams.", hasUnexpectedError, is(false));
+            assertFalse(hasUnexpectedError, "Should only get one uncaught exception from Streams.");
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FineGrainedAutoResetIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FineGrainedAutoResetIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serde;
@@ -30,6 +31,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
@@ -426,8 +428,8 @@ public class FineGrainedAutoResetIntegrationTest {
         boolean correctExceptionThrown = false;
         @Override
         public StreamThreadExceptionResponse handle(final Throwable throwable) {
-            assertEquals("StreamsException", throwable.getClass().getSimpleName());
-            assertEquals("NoOffsetForPartitionException", throwable.getCause().getClass().getSimpleName());
+            assertEquals(StreamsException.class, throwable.getClass());
+            assertEquals(NoOffsetForPartitionException.class, throwable.getCause().getClass());
             correctExceptionThrown = true;
             return StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FineGrainedAutoResetIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/FineGrainedAutoResetIntegrationTest.java
@@ -60,9 +60,7 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Timeout(600)
@@ -244,7 +242,7 @@ public class FineGrainedAutoResetIntegrationTest {
 
         Collections.sort(actualValues);
         Collections.sort(expectedReceivedValues);
-        assertThat(actualValues, equalTo(expectedReceivedValues));
+        assertEquals(expectedReceivedValues, actualValues);
     }
 
     private void commitInvalidOffsets() {
@@ -352,13 +350,13 @@ public class FineGrainedAutoResetIntegrationTest {
 
         Collections.sort(actualValuesOne);
         Collections.sort(expectedValues);
-        assertThat(actualValuesOne, equalTo(expectedValues));
+        assertEquals(expectedValues, actualValuesOne);
 
         Collections.sort(actualValuesTwo);
         Collections.sort(allExpectedValues);
-        assertThat(actualValuesTwo, equalTo(allExpectedValues));
+        assertEquals(allExpectedValues, actualValuesTwo);
 
-        assertThat(actualValuesThree, equalTo(singleFinalExpectedValues));
+        assertEquals(singleFinalExpectedValues, actualValuesThree);
     }
 
     @Test
@@ -428,8 +426,8 @@ public class FineGrainedAutoResetIntegrationTest {
         boolean correctExceptionThrown = false;
         @Override
         public StreamThreadExceptionResponse handle(final Throwable throwable) {
-            assertThat(throwable.getClass().getSimpleName(), is("StreamsException"));
-            assertThat(throwable.getCause().getClass().getSimpleName(), is("NoOffsetForPartitionException"));
+            assertEquals("StreamsException", throwable.getClass().getSimpleName());
+            assertEquals("NoOffsetForPartitionException", throwable.getCause().getClass().getSimpleName());
             correctExceptionThrown = true;
             return StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -71,8 +71,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -203,7 +202,7 @@ public class GlobalKTableIntegrationTest {
         final ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> replicatedStoreWithTimestamp = IntegrationTestUtils
             .getStore(globalStore, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
         assertNotNull(replicatedStoreWithTimestamp);
-        assertThat(replicatedStoreWithTimestamp.get(5L), equalTo(ValueAndTimestamp.make("J", firstTimestamp + 4L)));
+        assertEquals(ValueAndTimestamp.make("J", firstTimestamp + 4L), replicatedStoreWithTimestamp.get(5L));
 
         firstTimestamp = mockTime.milliseconds();
         produceTopicValues(streamTopic);
@@ -290,7 +289,7 @@ public class GlobalKTableIntegrationTest {
         final ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> replicatedStoreWithTimestamp = IntegrationTestUtils
             .getStore(globalStore, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
         assertNotNull(replicatedStoreWithTimestamp);
-        assertThat(replicatedStoreWithTimestamp.get(5L), equalTo(ValueAndTimestamp.make("J", firstTimestamp + 4L)));
+        assertEquals(ValueAndTimestamp.make("J", firstTimestamp + 4L), replicatedStoreWithTimestamp.get(5L));
 
         firstTimestamp = mockTime.milliseconds();
         produceTopicValues(streamTopic);
@@ -332,20 +331,20 @@ public class GlobalKTableIntegrationTest {
             .getStore(globalStore, kafkaStreams, QueryableStoreTypes.keyValueStore());
         assertNotNull(store);
 
-        assertThat(store.approximateNumEntries(), equalTo(4L));
+        assertEquals(4L, store.approximateNumEntries());
 
         ReadOnlyKeyValueStore<Long, ValueAndTimestamp<String>> timestampedStore = IntegrationTestUtils
             .getStore(globalStore, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
         assertNotNull(timestampedStore);
 
-        assertThat(timestampedStore.approximateNumEntries(), equalTo(4L));
+        assertEquals(4L, timestampedStore.approximateNumEntries());
         kafkaStreams.close();
 
         startStreams();
         store = IntegrationTestUtils.getStore(globalStore, kafkaStreams, QueryableStoreTypes.keyValueStore());
-        assertThat(store.approximateNumEntries(), equalTo(4L));
+        assertEquals(4L, store.approximateNumEntries());
         timestampedStore = IntegrationTestUtils.getStore(globalStore, kafkaStreams, QueryableStoreTypes.timestampedKeyValueStore());
-        assertThat(timestampedStore.approximateNumEntries(), equalTo(4L));
+        assertEquals(4L, timestampedStore.approximateNumEntries());
     }
 
     @ParameterizedTest

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/GlobalStateReprocessTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/GlobalStateReprocessTest.java
@@ -58,8 +58,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
@@ -155,7 +154,7 @@ public class GlobalStateReprocessTest {
             30000,
             "Has not processed record within 30 seconds");
 
-        assertThat(storeContents(kafkaStreams).get(0), containsString("- this is the right value."));
+        assertTrue(storeContents(kafkaStreams).get(0).contains("- this is the right value."));
 
 
         kafkaStreams.close();
@@ -169,7 +168,7 @@ public class GlobalStateReprocessTest {
             30000,
             "Has not processed record within 30 seconds");
 
-        assertThat(storeContents(kafkaStreams).get(0), containsString("- this is the right value."));
+        assertTrue(storeContents(kafkaStreams).get(0).contains("- this is the right value."));
     }
 
     private void createTopics() throws Exception {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HandlingSourceTopicDeletionIntegrationTest.java
@@ -42,8 +42,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 public class HandlingSourceTopicDeletionIntegrationTest {
@@ -128,8 +127,8 @@ public class HandlingSourceTopicDeletionIntegrationTest {
                 () -> "Kafka Streams clients did not reach state ERROR"
             );
 
-            assertThat(calledUncaughtExceptionHandler1.get(), is(true));
-            assertThat(calledUncaughtExceptionHandler2.get(), is(true));
+            assertTrue(calledUncaughtExceptionHandler1.get());
+            assertTrue(calledUncaughtExceptionHandler2.get());
         }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -72,8 +72,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(600)
 @Tag("integration")
@@ -251,9 +250,9 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
             restoreCompleteLatch.await();
             // We should finalize the restoration without having restored any records (because they're already in
             // the store). Otherwise, we failed to properly re-use the state from the standby.
-            assertThat(instance1TotalRestored.get(), is(0L));
+            assertEquals(0L, instance1TotalRestored.get());
             // Belt-and-suspenders check that we never even attempt to restore any records.
-            assertThat(instance1NumRestored.get(), is(-1L));
+            assertEquals(-1L, instance1NumRestored.get());
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2IntegrationTest.java
@@ -85,11 +85,9 @@ import java.util.stream.Stream;
 import static java.util.Collections.singleton;
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
@@ -138,7 +136,7 @@ public class IQv2IntegrationTest {
 
             for (final Future<RecordMetadata> future : futures) {
                 final RecordMetadata recordMetadata = future.get(1, TimeUnit.MINUTES);
-                assertThat(recordMetadata.hasOffset(), is(true));
+                assertTrue(recordMetadata.hasOffset());
                 INPUT_POSITION.withComponent(
                     recordMetadata.topic(),
                     recordMetadata.partition(),
@@ -147,12 +145,12 @@ public class IQv2IntegrationTest {
             }
         }
 
-        assertThat(INPUT_POSITION, equalTo(
+        assertEquals(
             Position
                 .emptyPosition()
                 .withComponent(INPUT_TOPIC_NAME, 0, 1L)
-                .withComponent(INPUT_TOPIC_NAME, 1, 0L)
-        ));
+                .withComponent(INPUT_TOPIC_NAME, 1, 0L),
+            INPUT_POSITION);
     }
 
     private void setup(final String groupProtocol, final TestInfo testInfo) {
@@ -260,17 +258,13 @@ public class IQv2IntegrationTest {
                     partitions
                 );
 
-            assertThat(result.getPartitionResults().keySet(), is(partitions));
+            assertEquals(partitions, result.getPartitionResults().keySet());
             for (final Integer partition : partitions) {
-                assertThat(result.getPartitionResults().get(partition).isFailure(), is(true));
-                assertThat(
-                    result.getPartitionResults().get(partition).getFailureReason(),
-                    is(FailureReason.NOT_ACTIVE)
-                );
-                assertThat(
-                    result.getPartitionResults().get(partition).getFailureMessage(),
-                    is("Query requires a running active task,"
-                        + " but partition was in state PARTITIONS_ASSIGNED and was active.")
+                assertTrue(result.getPartitionResults().get(partition).isFailure());
+                assertEquals(FailureReason.NOT_ACTIVE, result.getPartitionResults().get(partition).getFailureReason());
+                assertEquals(
+                    "Query requires a running active task, but partition was in state PARTITIONS_ASSIGNED and was active.",
+                    result.getPartitionResults().get(partition).getFailureMessage()
                 );
             }
         }
@@ -290,7 +284,7 @@ public class IQv2IntegrationTest {
         final StateQueryResult<ValueAndTimestamp<Integer>> result =
             IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
 
-        assertThat(result.getPartitionResults().keySet(), equalTo(partitions));
+        assertEquals(partitions, result.getPartitionResults().keySet());
     }
 
     @ParameterizedTest(name = "{1}")
@@ -306,7 +300,7 @@ public class IQv2IntegrationTest {
         final StateQueryResult<ValueAndTimestamp<Integer>> result =
             IntegrationTestUtils.iqv2WaitForPartitions(kafkaStreams, request, partitions);
 
-        assertThat(result.getPartitionResults().keySet(), equalTo(partitions));
+        assertEquals(partitions, result.getPartitionResults().keySet());
     }
 
     @ParameterizedTest(name = "{1}")
@@ -458,9 +452,9 @@ public class IQv2IntegrationTest {
 
         final QueryResult<ValueAndTimestamp<Integer>> queryResult =
             result.getPartitionResults().get(partition);
-        assertThat(queryResult.isFailure(), is(true));
-        assertThat(queryResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-        assertThat(queryResult.getFailureMessage(), matchesPattern(
+        assertTrue(queryResult.isFailure());
+        assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, queryResult.getFailureReason());
+        assertTrue(queryResult.getFailureMessage().matches(
             "This store (.*) doesn't know how to execute the given query (.*)."
                 + " Contact the store maintainer if you need support for a new query type."
         ));

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2StoreIntegrationTest.java
@@ -110,14 +110,10 @@ import java.util.stream.Stream;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("integration")
@@ -424,7 +420,7 @@ public class IQv2StoreIntegrationTest {
 
             for (final Future<RecordMetadata> future : futures) {
                 final RecordMetadata recordMetadata = future.get(1, TimeUnit.MINUTES);
-                assertThat(recordMetadata.hasOffset(), is(true));
+                assertTrue(recordMetadata.hasOffset());
                 INPUT_POSITION.withComponent(
                     recordMetadata.topic(),
                     recordMetadata.partition(),
@@ -433,12 +429,12 @@ public class IQv2StoreIntegrationTest {
             }
         }
 
-        assertThat(INPUT_POSITION, equalTo(
+        assertEquals(
             Position
                 .emptyPosition()
                 .withComponent(INPUT_TOPIC_NAME, 0, 5L)
-                .withComponent(INPUT_TOPIC_NAME, 1, 3L)
-        ));
+                .withComponent(INPUT_TOPIC_NAME, 1, 3L),
+            INPUT_POSITION);
     }
 
     public void setup(final boolean cache, final boolean log, final StoresToTest storeToTest, final String kind, final String groupProtocol, final boolean withHeaders) {
@@ -1325,8 +1321,8 @@ public class IQv2StoreIntegrationTest {
                 if (!failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(partitionResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-                assertThat(partitionResult.getFailureMessage(), matchesPattern(
+                assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, partitionResult.getFailureReason());
+                assertTrue(partitionResult.getFailureMessage().matches(
                     "This store"
                         + " \\(class org.apache.kafka.streams.state.internals.Metered.*WindowStore.*\\)"
                         + " doesn't know how to execute the given query"
@@ -1438,8 +1434,8 @@ public class IQv2StoreIntegrationTest {
                 if (!failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(partitionResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-                assertThat(partitionResult.getFailureMessage(), matchesPattern(
+                assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, partitionResult.getFailureReason());
+                assertTrue(partitionResult.getFailureMessage().matches(
                     "This store"
                         + " \\(class org.apache.kafka.streams.state.internals.Metered.*WindowStore\\)"
                         + " doesn't know how to execute the given query"
@@ -1511,11 +1507,9 @@ public class IQv2StoreIntegrationTest {
                 if (!failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(partitionResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-                assertThat(partitionResult.getFailureMessage(),
-                    containsString("doesn't know how to execute the given query"));
-                assertThat(partitionResult.getFailureMessage(),
-                    containsString("because SessionStores only support WindowRangeQuery.withKey."));
+                assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, partitionResult.getFailureReason());
+                assertTrue(partitionResult.getFailureMessage().contains("doesn't know how to execute the given query"));
+                assertTrue(partitionResult.getFailureMessage().contains("because SessionStores only support WindowRangeQuery.withKey."));
             }
         }
     }
@@ -1580,11 +1574,9 @@ public class IQv2StoreIntegrationTest {
                 if (!failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(partitionResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-                assertThat(partitionResult.getFailureMessage(),
-                    containsString("doesn't know how to execute the given query"));
-                assertThat(partitionResult.getFailureMessage(),
-                    containsString("because SessionStores only support WindowRangeQuery.withKey."));
+                assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, partitionResult.getFailureReason());
+                assertTrue(partitionResult.getFailureMessage().contains("doesn't know how to execute the given query"));
+                assertTrue(partitionResult.getFailureMessage().contains("because SessionStores only support WindowRangeQuery.withKey."));
             }
         }
     }
@@ -1598,15 +1590,11 @@ public class IQv2StoreIntegrationTest {
 
         final StateQueryResult<ValueAndTimestamp<Integer>> result = kafkaStreams.query(request);
 
-        assertThat(result.getGlobalResult().isFailure(), is(true));
-        assertThat(
-            result.getGlobalResult().getFailureReason(),
-            is(FailureReason.UNKNOWN_QUERY_TYPE)
-        );
-        assertThat(
-            result.getGlobalResult().getFailureMessage(),
-            is("Global stores do not yet support the KafkaStreams#query API."
-                + " Use KafkaStreams#store instead.")
+        assertTrue(result.getGlobalResult().isFailure());
+        assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, result.getGlobalResult().getFailureReason());
+        assertEquals(
+            "Global stores do not yet support the KafkaStreams#query API. Use KafkaStreams#store instead.",
+            result.getGlobalResult().getFailureMessage()
         );
     }
 
@@ -1623,15 +1611,11 @@ public class IQv2StoreIntegrationTest {
             partitions,
             result,
             queryResult -> {
-                assertThat(queryResult.isFailure(), is(true));
-                assertThat(queryResult.isSuccess(), is(false));
-                assertThat(
-                    queryResult.getFailureReason(),
-                    is(FailureReason.UNKNOWN_QUERY_TYPE)
-                );
-                assertThat(
-                    queryResult.getFailureMessage(),
-                    matchesPattern(
+                assertTrue(queryResult.isFailure());
+                assertFalse(queryResult.isSuccess());
+                assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, queryResult.getFailureReason());
+                assertTrue(
+                    queryResult.getFailureMessage().matches(
                         "This store (.*)"
                             + " doesn't know how to execute the given query"
                             + " (.*)."
@@ -1640,7 +1624,7 @@ public class IQv2StoreIntegrationTest {
                 );
                 assertThrows(IllegalArgumentException.class, queryResult::getResult);
 
-                assertThat(queryResult.getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.getExecutionInfo().isEmpty());
             }
         );
     }
@@ -1664,7 +1648,7 @@ public class IQv2StoreIntegrationTest {
         if (failure) {
             throw new AssertionError(queryResult.toString());
         }
-        assertThat(queryResult.isSuccess(), is(true));
+        assertTrue(queryResult.isSuccess());
 
         assertThrows(IllegalArgumentException.class, queryResult::getFailureReason);
         assertThrows(
@@ -1674,9 +1658,9 @@ public class IQv2StoreIntegrationTest {
 
         final V result1 = queryResult.getResult();
         final Integer integer = (Integer) result1;
-        assertThat(integer, is(expectedValue));
-        assertThat(queryResult.getExecutionInfo(), is(empty()));
-        assertThat(queryResult.getPosition(), is(POSITION_0));
+        assertEquals(expectedValue, integer);
+        assertTrue(queryResult.getExecutionInfo().isEmpty());
+        assertEquals(POSITION_0, queryResult.getPosition());
     }
 
     public <V> void shouldHandleTimestampedKeyQuery(
@@ -1700,7 +1684,7 @@ public class IQv2StoreIntegrationTest {
         if (failure) {
             throw new AssertionError(queryResult.toString());
         }
-        assertThat(queryResult.isSuccess(), is(true));
+        assertTrue(queryResult.isSuccess());
 
         assertThrows(IllegalArgumentException.class, queryResult::getFailureReason);
         assertThrows(
@@ -1709,9 +1693,9 @@ public class IQv2StoreIntegrationTest {
         );
 
         final ValueAndTimestamp<V> valueAndTimestamp = queryResult.getResult();
-        assertThat(valueAndTimestamp, is(expectedValueAndTimestamp));
-        assertThat(queryResult.getExecutionInfo(), is(empty()));
-        assertThat(queryResult.getPosition(), is(POSITION_0));
+        assertEquals(expectedValueAndTimestamp, valueAndTimestamp);
+        assertTrue(queryResult.getExecutionInfo().isEmpty());
+        assertEquals(POSITION_0, queryResult.getPosition());
     }
 
     public <V> void shouldHandleFailedTimestampedKeyQuery(final Integer key) {
@@ -1728,9 +1712,9 @@ public class IQv2StoreIntegrationTest {
         final QueryResult<ValueAndTimestamp<V>> queryResult =
                 result.getOnlyPartitionResult();
 
-        assertThat(queryResult.isFailure(), is(true));
-        assertThat(queryResult.getFailureReason(), is(FailureReason.UNKNOWN_QUERY_TYPE));
-        assertThat(queryResult.getFailureMessage(), containsString("TimestampedKeyQuery"));
+        assertTrue(queryResult.isFailure());
+        assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, queryResult.getFailureReason());
+        assertTrue(queryResult.getFailureMessage().contains("TimestampedKeyQuery"));
 
         assertThrows(IllegalArgumentException.class, queryResult::getResult);
     }
@@ -1766,7 +1750,7 @@ public class IQv2StoreIntegrationTest {
                 if (failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(queryResult.get(partition).isSuccess(), is(true));
+                assertTrue(queryResult.get(partition).isSuccess());
 
                 assertThrows(
                     IllegalArgumentException.class,
@@ -1781,10 +1765,10 @@ public class IQv2StoreIntegrationTest {
                         actualValues.add((Integer) iterator.next().value);
                     }
                 }
-                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.get(partition).getExecutionInfo().isEmpty());
             }
-            assertThat("Result:" + result, actualValues, is(expectedValues));
-            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+            assertEquals(expectedValues, actualValues, "Result:" + result);
+            assertEquals(INPUT_POSITION, result.getPosition(), "Result:" + result);
         }
     }
 
@@ -1821,7 +1805,7 @@ public class IQv2StoreIntegrationTest {
                 if (failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(queryResult.get(partition).isSuccess(), is(true));
+                assertTrue(queryResult.get(partition).isSuccess());
 
                 assertThrows(
                     IllegalArgumentException.class,
@@ -1837,10 +1821,10 @@ public class IQv2StoreIntegrationTest {
                         actualValueAndTimestamp.add(iterator.next().value);
                     }
                 }
-                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.get(partition).getExecutionInfo().isEmpty());
             }
-            assertThat("Result:" + result, actualValueAndTimestamp, is(expectedValueAndTimestamp));
-            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+            assertEquals(expectedValueAndTimestamp, actualValueAndTimestamp, "Result:" + result);
+            assertEquals(INPUT_POSITION, result.getPosition(), "Result:" + result);
         }
     }
 
@@ -1876,7 +1860,7 @@ public class IQv2StoreIntegrationTest {
                 if (failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(queryResult.get(partition).isSuccess(), is(true));
+                assertTrue(queryResult.get(partition).isSuccess());
 
                 assertThrows(
                     IllegalArgumentException.class,
@@ -1892,10 +1876,10 @@ public class IQv2StoreIntegrationTest {
                         actualValues.add(valueExtractor.apply(iterator.next().value));
                     }
                 }
-                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.get(partition).getExecutionInfo().isEmpty());
             }
-            assertThat("Result:" + result, actualValues, is(expectedValues));
-            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+            assertEquals(expectedValues, actualValues, "Result:" + result);
+            assertEquals(INPUT_POSITION, result.getPosition(), "Result:" + result);
         }
     }
 
@@ -1926,7 +1910,7 @@ public class IQv2StoreIntegrationTest {
                 if (failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(queryResult.get(partition).isSuccess(), is(true));
+                assertTrue(queryResult.get(partition).isSuccess());
 
                 assertThrows(
                     IllegalArgumentException.class,
@@ -1942,10 +1926,10 @@ public class IQv2StoreIntegrationTest {
                         actualValues.add(valueExtractor.apply(iterator.next().value));
                     }
                 }
-                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.get(partition).getExecutionInfo().isEmpty());
             }
-            assertThat("Result:" + result, actualValues, is(expectedValues));
-            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+            assertEquals(expectedValues, actualValues, "Result:" + result);
+            assertEquals(INPUT_POSITION, result.getPosition(), "Result:" + result);
         }
     }
 
@@ -1973,7 +1957,7 @@ public class IQv2StoreIntegrationTest {
                 if (failure) {
                     throw new AssertionError(queryResult.toString());
                 }
-                assertThat(queryResult.get(partition).isSuccess(), is(true));
+                assertTrue(queryResult.get(partition).isSuccess());
 
                 assertThrows(
                     IllegalArgumentException.class,
@@ -1989,10 +1973,10 @@ public class IQv2StoreIntegrationTest {
                         actualValues.add((Integer) iterator.next().value);
                     }
                 }
-                assertThat(queryResult.get(partition).getExecutionInfo(), is(empty()));
+                assertTrue(queryResult.get(partition).getExecutionInfo().isEmpty());
             }
-            assertThat("Result:" + result, actualValues, is(expectedValues));
-            assertThat("Result:" + result, result.getPosition(), is(INPUT_POSITION));
+            assertEquals(expectedValues, actualValues, "Result:" + result);
+            assertEquals(INPUT_POSITION, result.getPosition(), "Result:" + result);
         }
     }
 
@@ -2016,7 +2000,7 @@ public class IQv2StoreIntegrationTest {
         makeAssertions(
             partitions,
             result,
-            queryResult -> assertThat(queryResult.getExecutionInfo(), not(empty()))
+            queryResult -> assertFalse(queryResult.getExecutionInfo().isEmpty())
         );
     }
 
@@ -2040,7 +2024,7 @@ public class IQv2StoreIntegrationTest {
         makeAssertions(
             partitions,
             result,
-            queryResult -> assertThat(queryResult.getExecutionInfo(), not(empty()))
+            queryResult -> assertFalse(queryResult.getExecutionInfo().isEmpty())
         );
     }
 
@@ -2052,7 +2036,7 @@ public class IQv2StoreIntegrationTest {
         if (result.getGlobalResult() != null) {
             assertion.accept(result.getGlobalResult());
         } else {
-            assertThat(result.getPartitionResults().keySet(), is(partitions));
+            assertEquals(partitions, result.getPartitionResults().keySet());
             for (final Integer partition : partitions) {
                 assertion.accept(result.getPartitionResults().get(partition));
             }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/IQv2VersionedStoreIntegrationTest.java
@@ -63,13 +63,11 @@ import java.util.Properties;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 public class IQv2VersionedStoreIntegrationTest {
@@ -217,17 +215,17 @@ public class IQv2VersionedStoreIntegrationTest {
             throw new AssertionError("The query returned null.");
         }
 
-        assertThat(queryResult.isSuccess(), is(true));
+        assertTrue(queryResult.isSuccess());
         final VersionedRecord<Integer> result1 = queryResult.getResult();
-        assertThat(result1.value(), is(expectedValue));
-        assertThat(result1.timestamp(), is(expectedTimestamp));
-        assertThat(result1.validTo(), is(expectedValidToTime));
-        assertThat(queryResult.getExecutionInfo(), is(empty()));
+        assertEquals(expectedValue, result1.value());
+        assertEquals(expectedTimestamp, result1.timestamp());
+        assertEquals(expectedValidToTime, result1.validTo());
+        assertTrue(queryResult.getExecutionInfo().isEmpty());
     }
 
     private void shouldVerifyGetNullForVersionedKeyQuery(final Integer key, final Instant queryTimestamp) {
         final VersionedKeyQuery<Integer, Integer> query = defineQuery(key, Optional.of(queryTimestamp));
-        assertThat(sendRequestAndReceiveResults(query, kafkaStreams), nullValue());
+        assertNull(sendRequestAndReceiveResults(query, kafkaStreams));
     }
 
     private void shouldHandleMultiVersionedKeyQuery(final Optional<Instant> fromTime, final Optional<Instant> toTime,
@@ -250,14 +248,14 @@ public class IQv2VersionedStoreIntegrationTest {
                     final Integer value = record.value();
 
                     final Optional<Long> expectedValidTo = i < expectedArrayUpperBound ? Optional.of(RECORD_TIMESTAMPS[i + 1]) : Optional.empty();
-                    assertThat(value, is(RECORD_VALUES[i]));
-                    assertThat(timestamp, is(RECORD_TIMESTAMPS[i]));
-                    assertThat(validTo, is(expectedValidTo));
+                    assertEquals(RECORD_VALUES[i], value);
+                    assertEquals(RECORD_TIMESTAMPS[i], timestamp);
+                    assertEquals(expectedValidTo, validTo);
                     i = order.equals(ResultOrder.ASCENDING) ? i + 1 : i - 1;
                     iteratorSize++;
                 }
                 // The number of returned records by query is equal to expected number of records
-                assertThat(iteratorSize, equalTo(expectedArrayUpperBound - expectedArrayLowerBound + 1));
+                assertEquals(expectedArrayUpperBound - expectedArrayLowerBound + 1, iteratorSize);
             }
         }
     }
@@ -301,9 +299,9 @@ public class IQv2VersionedStoreIntegrationTest {
                     final Integer value = record.value();
 
                     final Optional<Long> expectedValidTo = i < LAST_INDEX ? Optional.of(RECORD_TIMESTAMPS[i + 1]) : Optional.empty();
-                    assertThat(value, is(RECORD_VALUES[i]));
-                    assertThat(timestamp, is(RECORD_TIMESTAMPS[i]));
-                    assertThat(validTo, is(expectedValidTo));
+                    assertEquals(RECORD_VALUES[i], value);
+                    assertEquals(RECORD_TIMESTAMPS[i], timestamp);
+                    assertEquals(expectedValidTo, validTo);
                     i--;
                     iteratorSize++;
                     if (i == 2) {
@@ -322,15 +320,15 @@ public class IQv2VersionedStoreIntegrationTest {
                     final Integer value = record.value();
 
                     final Optional<Long> expectedValidTo = Optional.of(RECORD_TIMESTAMPS[i + 1]);
-                    assertThat(value, is(RECORD_VALUES[i]));
-                    assertThat(timestamp, is(RECORD_TIMESTAMPS[i]));
-                    assertThat(validTo, is(expectedValidTo));
+                    assertEquals(RECORD_VALUES[i], value);
+                    assertEquals(RECORD_TIMESTAMPS[i], timestamp);
+                    assertEquals(expectedValidTo, validTo);
                     i--;
                     iteratorSize++;
                 }
 
                 // The number of returned records by query is equal to expected number of records
-                assertThat(iteratorSize, equalTo(RECORD_NUMBER));
+                assertEquals(RECORD_NUMBER, iteratorSize);
             }
         }
     }
@@ -370,11 +368,11 @@ public class IQv2VersionedStoreIntegrationTest {
     }
 
     private static void verifyPartitionResult(final QueryResult<VersionedRecordIterator<Integer>> result) {
-        assertThat(result.getExecutionInfo(), is(empty()));
+        assertTrue(result.getExecutionInfo().isEmpty());
         if (result.isFailure()) {
             throw new AssertionError(result.toString());
         }
-        assertThat(result.isSuccess(), is(true));
+        assertTrue(result.isSuccess());
         assertThrows(IllegalArgumentException.class, result::getFailureReason);
         assertThrows(IllegalArgumentException.class, result::getFailureMessage);
     }
@@ -393,7 +391,7 @@ public class IQv2VersionedStoreIntegrationTest {
         }
 
         inputPosition = inputPosition.withComponent(INPUT_TOPIC_NAME, 0, 4);
-        assertThat(inputPosition, equalTo(Position.emptyPosition().withComponent(INPUT_TOPIC_NAME, 0, 4)));
+        assertEquals(Position.emptyPosition().withComponent(INPUT_TOPIC_NAME, 0, 4), inputPosition);
 
         // make sure that the new value is picked up by the store
         final Properties consumerProps = new Properties();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinGracePeriodDurabilityIntegrationTest.java
@@ -66,8 +66,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cl
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.getStartedStreams;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.quietlyCleanStateAfterTest;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -157,7 +156,7 @@ public class JoinGracePeriodDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k2", "v2+v2", scaledTime(2L))
                 )
             );
-            assertThat(eventCount.get(), is(2));
+            assertEquals(2, eventCount.get());
 
             produceSynchronouslyToPartitionZero(
                 streamInput,
@@ -172,7 +171,7 @@ public class JoinGracePeriodDurabilityIntegrationTest {
 
             // restart the driver
             driver.close();
-            assertThat(driver.state(), is(KafkaStreams.State.NOT_RUNNING));
+            assertEquals(KafkaStreams.State.NOT_RUNNING, driver.state());
             driver = startStream(streamsConfig, builder, false, withHeaders);
 
 
@@ -191,7 +190,7 @@ public class JoinGracePeriodDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k3", "v3+v3", scaledTime(7L))
                     )
             );
-            assertThat("There should only be 5 output events.", eventCount.get(), is(5));
+            assertEquals(5, eventCount.get(), "There should only be 5 output events.");
 
         } finally {
             driver.close();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/JoinStoreIntegrationTest.java
@@ -55,8 +55,7 @@ import java.util.stream.Stream;
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("deprecation")
@@ -134,10 +133,9 @@ public class JoinStoreIntegrationTest {
                     UnknownStateStoreException.class,
                     () -> kafkaStreams.store(fromNameAndType("join-store", keyValueStore()))
                 );
-            assertThat(
-                exception.getMessage(),
-                is("Cannot get state store join-store because no such store is registered in the topology.")
-            );
+            assertEquals(
+                "Cannot get state store join-store because no such store is registered in the topology.",
+                exception.getMessage());
         }
     }
 
@@ -179,12 +177,7 @@ public class JoinStoreIntegrationTest {
 
             final Map<ConfigResource, org.apache.kafka.clients.admin.Config> topicConfig
                 = admin.describeConfigs(changelogTopics).all().get();
-            topicConfig.values().forEach(
-                tc -> assertThat(
-                    tc.get("cleanup.policy").value(),
-                    is("delete")
-                )
-            );
+            topicConfig.values().forEach(tc -> assertEquals("delete", tc.get("cleanup.policy").value()));
         }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -101,9 +101,7 @@ import static java.time.Duration.ofMinutes;
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -225,9 +223,8 @@ public class KStreamAggregationIntegrationTest {
 
         results.sort(KStreamAggregationIntegrationTest::compare);
 
-        assertThat(
-            results,
-            is(Arrays.asList(
+        assertEquals(
+            List.of(
                 new KeyValueTimestamp<>("A", "A", mockTime.milliseconds()),
                 new KeyValueTimestamp<>("A", "A:A", mockTime.milliseconds()),
                 new KeyValueTimestamp<>("B", "B", mockTime.milliseconds()),
@@ -237,9 +234,8 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValueTimestamp<>("D", "D", mockTime.milliseconds()),
                 new KeyValueTimestamp<>("D", "D:D", mockTime.milliseconds()),
                 new KeyValueTimestamp<>("E", "E", mockTime.milliseconds()),
-                new KeyValueTimestamp<>("E", "E:E", mockTime.milliseconds())
-            ))
-        );
+                new KeyValueTimestamp<>("E", "E:E", mockTime.milliseconds())),
+            results);
     }
 
     private static <K extends Comparable<K>, V extends Comparable<V>> int compare(final KeyValueTimestamp<K, V> o1,
@@ -323,7 +319,7 @@ public class KStreamAggregationIntegrationTest {
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(secondBatchWindowStart, secondBatchWindowEnd)), "E", secondBatchTimestamp),
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(secondBatchWindowStart, secondBatchWindowEnd)), "E:E", secondBatchTimestamp)
         );
-        assertThat(windowedOutput, is(expectResult));
+        assertEquals(expectResult, windowedOutput);
 
         final Set<String> expectResultString = new HashSet<>(expectResult.size());
         for (final KeyValueTimestamp<Windowed<String>, String> eachRecord: expectResult) {
@@ -364,9 +360,8 @@ public class KStreamAggregationIntegrationTest {
 
         results.sort(KStreamAggregationIntegrationTest::compare);
 
-        assertThat(
-            results,
-            is(Arrays.asList(
+        assertEquals(
+            List.of(
                 new KeyValueTimestamp<>("A", 1, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("A", 2, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("B", 1, mockTime.milliseconds()),
@@ -376,9 +371,8 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValueTimestamp<>("D", 1, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("D", 2, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("E", 1, mockTime.milliseconds()),
-                new KeyValueTimestamp<>("E", 2, mockTime.milliseconds())
-           ))
-        );
+                new KeyValueTimestamp<>("E", 2, mockTime.milliseconds())),
+            results);
     }
 
     @ParameterizedTest
@@ -448,7 +442,7 @@ public class KStreamAggregationIntegrationTest {
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(secondWindowStart, secondWindowEnd)), 2, secondTimestamp)
         );
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
 
         final Set<String> expectResultString = new HashSet<>(expectResult.size());
         for (final KeyValueTimestamp<Windowed<String>, Integer> eachRecord: expectResult) {
@@ -475,9 +469,8 @@ public class KStreamAggregationIntegrationTest {
         );
         results.sort(KStreamAggregationIntegrationTest::compare);
 
-        assertThat(
-            results,
-            is(Arrays.asList(
+        assertEquals(
+            List.of(
                 new KeyValueTimestamp<>("A", 1L, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("A", 2L, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("B", 1L, mockTime.milliseconds()),
@@ -487,9 +480,8 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValueTimestamp<>("D", 1L, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("D", 2L, mockTime.milliseconds()),
                 new KeyValueTimestamp<>("E", 1L, mockTime.milliseconds()),
-                new KeyValueTimestamp<>("E", 2L, mockTime.milliseconds())
-            ))
-        );
+                new KeyValueTimestamp<>("E", 2L, mockTime.milliseconds())),
+            results);
     }
 
     @ParameterizedTest
@@ -545,9 +537,8 @@ public class KStreamAggregationIntegrationTest {
         results.sort(KStreamAggregationIntegrationTest::compare);
 
         final long window = timestamp / 500 * 500;
-        assertThat(
-            results,
-            is(Arrays.asList(
+        assertEquals(
+            List.of(
                 new KeyValueTimestamp<>("1@" + window, 1L, timestamp),
                 new KeyValueTimestamp<>("1@" + window, 2L, timestamp),
                 new KeyValueTimestamp<>("2@" + window, 1L, timestamp),
@@ -557,9 +548,8 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValueTimestamp<>("4@" + window, 1L, timestamp),
                 new KeyValueTimestamp<>("4@" + window, 2L, timestamp),
                 new KeyValueTimestamp<>("5@" + window, 1L, timestamp),
-                new KeyValueTimestamp<>("5@" + window, 2L, timestamp)
-            ))
-        );
+                new KeyValueTimestamp<>("5@" + window, 2L, timestamp)),
+            results);
     }
 
     @ParameterizedTest
@@ -657,7 +647,7 @@ public class KStreamAggregationIntegrationTest {
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(firstBatchRightWindowStart, firstBatchRightWindowEnd)), "E:E", thirdBatchTimestamp),
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(thirdBatchLeftWindowStart, thirdBatchLeftWindowEnd)), "E:E:E", thirdBatchTimestamp)
         );
-        assertThat(windowedOutput, is(expectResult));
+        assertEquals(expectResult, windowedOutput);
 
         final Set<String> expectResultString = new HashSet<>(expectResult.size());
         for (final KeyValueTimestamp<Windowed<String>, String> eachRecord: expectResult) {
@@ -772,7 +762,7 @@ public class KStreamAggregationIntegrationTest {
             new KeyValueTimestamp<>(new Windowed<>("E", new TimeWindow(thirdBatchLeftWindowStart, thirdBatchLeftWindowEnd)), 3, thirdBatchTimestamp)
         );
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
 
         final Set<String> expectResultString = new HashSet<>(expectResult.size());
         for (final KeyValueTimestamp<Windowed<String>, Integer> eachRecord: expectResult) {
@@ -881,13 +871,13 @@ public class KStreamAggregationIntegrationTest {
         startStreams();
         latch.await(30, TimeUnit.SECONDS);
 
-        assertThat(results.get(new Windowed<>("bob", new SessionWindow(t1, t1))), equalTo(KeyValue.pair(1L, t1)));
-        assertThat(results.get(new Windowed<>("penny", new SessionWindow(t1, t1))), equalTo(KeyValue.pair(1L, t1)));
-        assertThat(results.get(new Windowed<>("jo", new SessionWindow(t1, t1))), equalTo(KeyValue.pair(1L, t1)));
-        assertThat(results.get(new Windowed<>("jo", new SessionWindow(t5, t4))), equalTo(KeyValue.pair(2L, t4)));
-        assertThat(results.get(new Windowed<>("emily", new SessionWindow(t1, t2))), equalTo(KeyValue.pair(2L, t2)));
-        assertThat(results.get(new Windowed<>("bob", new SessionWindow(t3, t4))), equalTo(KeyValue.pair(2L, t4)));
-        assertThat(results.get(new Windowed<>("penny", new SessionWindow(t3, t3))), equalTo(KeyValue.pair(1L, t3)));
+        assertEquals(KeyValue.pair(1L, t1), results.get(new Windowed<>("bob", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair(1L, t1), results.get(new Windowed<>("penny", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair(1L, t1), results.get(new Windowed<>("jo", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair(2L, t4), results.get(new Windowed<>("jo", new SessionWindow(t5, t4))));
+        assertEquals(KeyValue.pair(2L, t2), results.get(new Windowed<>("emily", new SessionWindow(t1, t2))));
+        assertEquals(KeyValue.pair(2L, t4), results.get(new Windowed<>("bob", new SessionWindow(t3, t4))));
+        assertEquals(KeyValue.pair(1L, t3), results.get(new Windowed<>("penny", new SessionWindow(t3, t3))));
     }
 
     @ParameterizedTest
@@ -932,13 +922,13 @@ public class KStreamAggregationIntegrationTest {
         latch.await(30, TimeUnit.SECONDS);
 
         // verify correct data received
-        assertThat(results.get(new Windowed<>("bob", new SessionWindow(t1, t1))), equalTo(KeyValue.pair("start", t1)));
-        assertThat(results.get(new Windowed<>("penny", new SessionWindow(t1, t1))), equalTo(KeyValue.pair("start", t1)));
-        assertThat(results.get(new Windowed<>("jo", new SessionWindow(t1, t1))), equalTo(KeyValue.pair("pause", t1)));
-        assertThat(results.get(new Windowed<>("jo", new SessionWindow(t5, t4))), equalTo(KeyValue.pair("resume:late", t4)));
-        assertThat(results.get(new Windowed<>("emily", new SessionWindow(t1, t2))), equalTo(KeyValue.pair("pause:resume", t2)));
-        assertThat(results.get(new Windowed<>("bob", new SessionWindow(t3, t4))), equalTo(KeyValue.pair("pause:resume", t4)));
-        assertThat(results.get(new Windowed<>("penny", new SessionWindow(t3, t3))), equalTo(KeyValue.pair("stop", t3)));
+        assertEquals(KeyValue.pair("start", t1), results.get(new Windowed<>("bob", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair("start", t1), results.get(new Windowed<>("penny", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair("pause", t1), results.get(new Windowed<>("jo", new SessionWindow(t1, t1))));
+        assertEquals(KeyValue.pair("resume:late", t4), results.get(new Windowed<>("jo", new SessionWindow(t5, t4))));
+        assertEquals(KeyValue.pair("pause:resume", t2), results.get(new Windowed<>("emily", new SessionWindow(t1, t2))));
+        assertEquals(KeyValue.pair("pause:resume", t4), results.get(new Windowed<>("bob", new SessionWindow(t3, t4))));
+        assertEquals(KeyValue.pair("stop", t3), results.get(new Windowed<>("penny", new SessionWindow(t3, t3))));
 
         verifySessionStore(userSessionsStore, t1, t3, t4);
 
@@ -996,8 +986,8 @@ public class KStreamAggregationIntegrationTest {
             IntegrationTestUtils.getStore(storeName, kafkaStreams, QueryableStoreTypes.sessionStore());
 
         try (final KeyValueIterator<Windowed<String>, String> bob = sessionStore.fetch("bob")) {
-            assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t1, t1)), "start")));
-            assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume")));
+            assertEquals(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t1, t1)), "start"), bob.next());
+            assertEquals(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume"), bob.next());
             assertFalse(bob.hasNext());
         }
     }
@@ -1079,10 +1069,10 @@ public class KStreamAggregationIntegrationTest {
         startStreams();
         assertTrue(latch.await(30, TimeUnit.SECONDS));
 
-        assertThat(results.get(new Windowed<>("bob", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(2L, t4)));
-        assertThat(results.get(new Windowed<>("penny", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t3)));
-        assertThat(results.get(new Windowed<>("jo", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t4)));
-        assertThat(results.get(new Windowed<>("emily", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t2)));
+        assertEquals(KeyValue.pair(2L, t4), results.get(new Windowed<>("bob", new UnlimitedWindow(startTime))));
+        assertEquals(KeyValue.pair(1L, t3), results.get(new Windowed<>("penny", new UnlimitedWindow(startTime))));
+        assertEquals(KeyValue.pair(1L, t4), results.get(new Windowed<>("jo", new UnlimitedWindow(startTime))));
+        assertEquals(KeyValue.pair(1L, t2), results.get(new Windowed<>("emily", new UnlimitedWindow(startTime))));
     }
 
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KStreamKStreamIntegrationTest.java
@@ -57,8 +57,7 @@ import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(600)
 @Tag("integration")
@@ -159,7 +158,7 @@ public class KStreamKStreamIntegrationTest {
             OUTPUT,
             expectedResult.size()));
 
-        assertThat(expectedResult, equalTo(result));
+        assertEquals(expectedResult, result);
     }
 
     private Properties getStreamsConfig(final String testName) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableEfficientRangeQueryTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableEfficientRangeQueryTest.java
@@ -49,8 +49,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
@@ -173,7 +172,7 @@ public class KTableEfficientRangeQueryTest {
              final KeyValueIterator<String, String> expectedIterator = forward ? store.all() : store.reverseAll()) {
             final List<KeyValue<String, String>> result = Utils.toList(resultIterator);
             final List<KeyValue<String, String>> expected = filterList(expectedIterator, from, to);
-            assertThat(result, is(expected));
+            assertEquals(expected, result);
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest.java
@@ -73,8 +73,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.st
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(600)
 @Tag("integration")
@@ -213,7 +212,9 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
 
         for (final KafkaStreams stream: kafkaStreamsList) {
             stream.setUncaughtExceptionHandler(e -> {
-                assertThat(e.getCause().getMessage(), equalTo("The partitions returned by StreamPartitioner#partitions method when used for FK join should be a singleton set"));
+                assertEquals(
+                    "The partitions returned by StreamPartitioner#partitions method when used for FK join should be a singleton set",
+                    e.getCause().getMessage());
                 return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
             });
         }
@@ -246,7 +247,7 @@ public class KTableKTableForeignKeyInnerJoinCustomPartitionerIntegrationTest {
             OUTPUT,
             expectedResult.size()));
 
-        assertThat(expectedResult, equalTo(result));
+        assertEquals(expectedResult, result);
     }
 
     private Properties getStreamsConfig(final String testName) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinIntegrationTest.java
@@ -64,14 +64,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 @Timeout(600)
@@ -249,21 +247,12 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             right.pipeInput("rhs2", "rhsValue2", baseTimestamp + 1);
             right.pipeInput("rhs3", "rhsValue3", baseTimestamp + 2); // this unreferenced FK won't show up in any results
 
-            assertThat(
-                outputTopic.readKeyValuesToList(),
-                is(emptyList())
-            );
+            assertTrue(outputTopic.readKeyValuesToList().isEmpty());
             if (rejoin) {
-                assertThat(
-                    rejoinOutputTopic.readKeyValuesToList(),
-                    is(emptyList())
-                );
+                assertTrue(rejoinOutputTopic.readKeyValuesToList().isEmpty());
             }
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(emptyMap())
-                );
+                assertTrue(asMap(store).isEmpty());
             }
 
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 3);
@@ -274,80 +263,50 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                     KeyValue.pair("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
                     KeyValue.pair("lhs2", "(lhsValue2|rhs2,rhsValue2)")
                 );
-                assertThat(
-                    outputTopic.readKeyValuesToList(),
-                    is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToList());
                 if (rejoin) {
-                    assertThat(
-                        rejoinOutputTopic.readKeyValuesToList(),
-                        is(asList(
+                    assertEquals(
+                        List.of(
                             KeyValue.pair("lhs1", "rejoin((lhsValue1|rhs1,rhsValue1),lhsValue1|rhs1)"),
-                            KeyValue.pair("lhs2", "rejoin((lhsValue2|rhs2,rhsValue2),lhsValue2|rhs2)")
-                        ))
-                    );
+                            KeyValue.pair("lhs2", "rejoin((lhsValue2|rhs2,rhsValue2),lhsValue2|rhs2)")),
+                        rejoinOutputTopic.readKeyValuesToList());
                 }
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(expected.stream().collect(Collectors.toMap(kv -> kv.key, kv -> kv.value)))
-                    );
+                    assertEquals(expected.stream().collect(Collectors.toMap(kv -> kv.key, kv -> kv.value)), asMap(store));
                 }
             }
 
             // Add another reference to an existing FK
             left.pipeInput("lhs3", "lhsValue3|rhs1", baseTimestamp + 5);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToList(),
-                    is(List.of(
-                        new KeyValue<>("lhs3", "(lhsValue3|rhs1,rhsValue1)")
-                    ))
-                );
+                assertEquals(List.of(new KeyValue<>("lhs3", "(lhsValue3|rhs1,rhsValue1)")), outputTopic.readKeyValuesToList());
                 if (rejoin) {
-                    assertThat(
-                        rejoinOutputTopic.readKeyValuesToList(),
-                        is(List.of(
-                            new KeyValue<>("lhs3", "rejoin((lhsValue3|rhs1,rhsValue1),lhsValue3|rhs1)")
-                        ))
-                    );
+                    assertEquals(List.of(new KeyValue<>("lhs3", "rejoin((lhsValue3|rhs1,rhsValue1),lhsValue3|rhs1)")),
+                        rejoinOutputTopic.readKeyValuesToList());
                 }
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(mkMap(
-                            mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                            mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                            mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
-                        ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                            "lhs2", "(lhsValue2|rhs2,rhsValue2)",
+                            "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                        asMap(store));
                 }
             }
 
             // Now delete one LHS entity such that one delete is propagated down to the output.
 
             left.pipeInput("lhs1", null, baseTimestamp + 6);
-            assertThat(
-                outputTopic.readKeyValuesToList(),
-                is(List.of(
-                    new KeyValue<>("lhs1", null)
-                ))
-            );
+            assertEquals(List.of(new KeyValue<>("lhs1", null)), outputTopic.readKeyValuesToList());
             if (rejoin) {
-                assertThat(
-                    rejoinOutputTopic.readKeyValuesToList(),
-                    hasItem(
-                        KeyValue.pair("lhs1", null))
-                );
+                assertTrue(rejoinOutputTopic.readKeyValuesToList().contains(KeyValue.pair("lhs1", null)));
             }
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(mkMap(
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)")
-                    ))
-                );
+                assertEquals(
+                    Map.of(
+                        "lhs2", "(lhsValue2|rhs2,rhsValue2)",
+                        "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                    asMap(store));
             }
         }
     }
@@ -374,21 +333,12 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             right.pipeInput("rhs1", "rhsValue1", baseTimestamp);
             right.pipeInput("rhs2", "rhsValue2", baseTimestamp + 1);
 
-            assertThat(
-                outputTopic.readKeyValuesToList(),
-                is(emptyList())
-            );
+            assertTrue(outputTopic.readKeyValuesToList().isEmpty());
             if (rejoin) {
-                assertThat(
-                    rejoinOutputTopic.readKeyValuesToList(),
-                    is(emptyList())
-                );
+                assertTrue(rejoinOutputTopic.readKeyValuesToList().isEmpty());
             }
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(emptyMap())
-                );
+                assertTrue(asMap(store).isEmpty());
             }
 
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 3);
@@ -397,32 +347,19 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final List<KeyValue<String, String>> expected = asList(
                     KeyValue.pair("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                 );
-                assertThat(
-                    outputTopic.readKeyValuesToList(),
-                    is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToList());
             }
 
             // Add another reference to an existing FK
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 5);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToList(),
-                    is(List.of(
-                        new KeyValue<>("lhs1", "(lhsValue1|rhs2,rhsValue2)")
-                    ))
-                );
+                assertEquals(List.of(new KeyValue<>("lhs1", "(lhsValue1|rhs2,rhsValue2)")), outputTopic.readKeyValuesToList());
             }
 
             // Now revert back the foreign key to earlier reference
 
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 6);
-            assertThat(
-                outputTopic.readKeyValuesToList(),
-                is(List.of(
-                    new KeyValue<>("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                ))
-            );
+            assertEquals(List.of(new KeyValue<>("lhs1", "(lhsValue1|rhs1,rhsValue1)")), outputTopic.readKeyValuesToList());
         }
     }
 
@@ -449,101 +386,82 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs2", "lhsValue2|rhs2", baseTimestamp + 1);
             left.pipeInput("lhs3", "lhsValue3|rhs1", baseTimestamp + 2);
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(leftJoin
-                    ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                    mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                    mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
-                    : emptyMap()
-                )
-            );
+            assertEquals(
+                leftJoin ? Map.of(
+                    "lhs1", "(lhsValue1|rhs1,null)",
+                    "lhs2", "(lhsValue2|rhs2,null)",
+                    "lhs3", "(lhsValue3|rhs1,null)")
+                    : Map.of(),
+                outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
-                        : emptyMap()
-                    )
-                );
+                assertEquals(
+                    leftJoin ? Map.of(
+                        "lhs1", "(lhsValue1|rhs1,null)",
+                        "lhs2", "(lhsValue2|rhs2,null)",
+                        "lhs3", "(lhsValue3|rhs1,null)")
+                        : Map.of(),
+                    asMap(store));
             }
 
             right.pipeInput("rhs1", "rhsValue1", baseTimestamp + 3);
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                    mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
-                )
-            );
+            assertEquals(
+                Map.of(
+                    "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                    "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,null)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
-
-                        : mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
-                    )
-                );
+                assertEquals(
+                    leftJoin ? Map.of(
+                        "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                        "lhs2", "(lhsValue2|rhs2,null)",
+                        "lhs3", "(lhsValue3|rhs1,rhsValue1)")
+                        : Map.of(
+                            "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                            "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                    asMap(store));
             }
 
             right.pipeInput("rhs2", "rhsValue2", baseTimestamp + 4);
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)")))
-            );
+            assertEquals(Map.of("lhs2", "(lhsValue2|rhs2,rhsValue2)"), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
-                    )
-                );
+                assertEquals(
+                    Map.of(
+                        "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                        "lhs2", "(lhsValue2|rhs2,rhsValue2)",
+                        "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                    asMap(store));
             }
 
             right.pipeInput("rhs3", "rhsValue3", baseTimestamp + 5); // this unreferenced FK won't show up in any results
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(emptyMap())
-            );
+            assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,rhsValue1)"))
-                    )
-                );
+                assertEquals(
+                    Map.of(
+                        "lhs1", "(lhsValue1|rhs1,rhsValue1)",
+                        "lhs2", "(lhsValue2|rhs2,rhsValue2)",
+                        "lhs3", "(lhsValue3|rhs1,rhsValue1)"),
+                    asMap(store));
             }
 
             // Now delete the RHS entity such that all matching keys have deletes propagated.
             right.pipeInput("rhs1", null, baseTimestamp + 6);
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs1,null)" : null),
-                    mkEntry("lhs3", leftJoin ? "(lhsValue3|rhs1,null)" : null))
-                )
-            );
+            assertEquals(
+                mkMap(
+                    mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs1,null)" : null),
+                    mkEntry("lhs3", leftJoin ? "(lhsValue3|rhs1,null)" : null)),
+                outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin
-                        ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)"),
-                        mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
-                        mkEntry("lhs3", "(lhsValue3|rhs1,null)"))
-
-                        : mkMap(mkEntry("lhs2", "(lhsValue2|rhs2,rhsValue2)"))
-                    )
-                );
+                assertEquals(
+                    leftJoin ? Map.of(
+                        "lhs1", "(lhsValue1|rhs1,null)",
+                        "lhs2", "(lhsValue2|rhs2,rhsValue2)",
+                        "lhs3", "(lhsValue3|rhs1,null)")
+                        : Map.of("lhs2", "(lhsValue2|rhs2,rhsValue2)"),
+                    asMap(store));
             }
         }
     }
@@ -569,15 +487,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             {
                 final Map<String, String> expected =
                     leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap();
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
@@ -586,30 +498,18 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             // For the left join, the tombstone is necessary.
             left.pipeInput("lhs1", null, baseTimestamp + 1);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(mkMap(mkEntry("lhs1", null)))
-                );
+                assertEquals(mkMap(mkEntry("lhs1", null)), outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                    );
+                    assertTrue(asMap(store).isEmpty());
                 }
             }
 
             // Deleting a non-existing record is idempotent
             left.pipeInput("lhs1", null, baseTimestamp + 2);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                    );
+                    assertTrue(asMap(store).isEmpty());
                 }
             }
         }
@@ -634,15 +534,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             // Deleting a record that never existed doesn't need to emit tombstones.
             left.pipeInput("lhs1", null, baseTimestamp);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                    );
+                    assertTrue(asMap(store).isEmpty());
                 }
             }
         }
@@ -668,90 +562,48 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp);
             // no output for a new inner join on a non-existent FK
             // the left join of course emits the half-joined output
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
-            );
+            assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs1,null)") : Map.of(), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs1,null)")) : emptyMap())
-                );
+                assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs1,null)") : Map.of(), asMap(store));
             }
             // "moving" our subscription to another non-existent FK results in an unnecessary tombstone for inner join,
             // since it impossible to know whether the prior FK existed or not (and thus whether any results have
             // previously been emitted)
             // The left join emits a _necessary_ update (since the lhs record has actually changed)
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 1);
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)))
-            );
+            assertEquals(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
-                );
+                assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs2,null)") : Map.of(), asMap(store));
             }
             // of course, moving it again to yet another non-existent FK has the same effect
             left.pipeInput("lhs1", "lhsValue1|rhs3", baseTimestamp + 2);
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)))
-            );
+            assertEquals(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs3,null)" : null)), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
-                );
+                assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs3,null)") : Map.of(), asMap(store));
             }
 
             // Adding an RHS record now, so that we can demonstrate "moving" from a non-existent FK to an existent one
             // This RHS key was previously referenced, but it's not referenced now, so adding this record should
             // result in no changes whatsoever.
             right.pipeInput("rhs1", "rhsValue1", baseTimestamp + 3);
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(emptyMap())
-            );
+            assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs3,null)")) : emptyMap())
-                );
+                assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs3,null)") : Map.of(), asMap(store));
             }
 
             // now, we change to a FK that exists, and see the join completes
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 4);
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(
-                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                ))
-            );
+            assertEquals(Map.of("lhs1", "(lhsValue1|rhs1,rhsValue1)"), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(mkMap(
-                        mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                    ))
-                );
+                assertEquals(Map.of("lhs1", "(lhsValue1|rhs1,rhsValue1)"), asMap(store));
             }
 
             // but if we update it again to a non-existent one, we'll get a tombstone for the inner join, and the
             // left join updates appropriately.
             left.pipeInput("lhs1", "lhsValue1|rhs2", baseTimestamp + 5);
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(mkMap(
-                    mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)
-                ))
-            );
+            assertEquals(mkMap(mkEntry("lhs1", leftJoin ? "(lhsValue1|rhs2,null)" : null)), outputTopic.readKeyValuesToMap());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(leftJoin ? mkMap(mkEntry("lhs1", "(lhsValue1|rhs2,null)")) : emptyMap())
-                );
+                assertEquals(leftJoin ? Map.of("lhs1", "(lhsValue1|rhs2,null)") : Map.of(), asMap(store));
             }
         }
     }
@@ -778,15 +630,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             right.pipeInput("rhs1", "rhsValue1", baseTimestamp);
             right.pipeInput("rhs2", "rhsValue2", baseTimestamp + 1);
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(emptyMap())
-            );
+            assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
             if (materialized) {
-                assertThat(
-                    asMap(store),
-                    is(emptyMap())
-                );
+                assertTrue(asMap(store).isEmpty());
             }
 
             left.pipeInput("lhs1", "lhsValue1|rhs1", baseTimestamp + 2);
@@ -794,15 +640,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final Map<String, String> expected = mkMap(
                     mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
                 );
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
@@ -812,32 +652,18 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final Map<String, String> expected = mkMap(
                     mkEntry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
                 );
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
             // Populate RHS update on old LHS foreign key ref
             right.pipeInput("rhs1", "rhsValue1Delta", baseTimestamp + 4);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                        asMap(store),
-                        is(mkMap(
-                            mkEntry("lhs1", "(lhsValue1|rhs2,rhsValue2)")
-                        ))
-                    );
+                    assertEquals(Map.of("lhs1", "(lhsValue1|rhs2,rhsValue2)"), asMap(store));
                 }
             }
         }
@@ -863,9 +689,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final Map<String, String> expected = mkMap(
                     mkEntry("lhs1", "(lhsValue1|rhs1,null)")
                 );
-                assertThat(outputTopic.readKeyValuesToMap(), is(expected));
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(asMap(store), is(expected));
+                    assertEquals(expected, asMap(store));
                 }
             }
         }
@@ -906,9 +732,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final Map<String, String> expected = mkMap(
                     mkEntry("lhs1", "(lhsValue1|rhs1,null)")
                 );
-                assertThat(outputTopic.readKeyValuesToMap(), is(expected));
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(asMap(store), is(expected));
+                    assertEquals(expected, asMap(store));
                 }
                 Assertions.assertNotNull(subscriptionStore.get(key));
             }
@@ -917,9 +743,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                 final Map<String, String> expected = mkMap(
                     mkEntry("lhs1", "(lhsValue1|returnNull,null)")
                 );
-                assertThat(outputTopic.readKeyValuesToMap(), is(expected));
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(asMap(store), is(expected));
+                    assertEquals(expected, asMap(store));
                 }
                 Assertions.assertNull(subscriptionStore.get(key));
             }
@@ -1089,15 +915,9 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             // RHS record
             right.pipeInput("rhs1", "rhsValue1", baseTimestamp + 4);
 
-            assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(emptyMap())
-            );
+            assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
             if (materialized) {
-                assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                );
+                assertTrue(asMap(store).isEmpty());
             }
 
             // LHS records with match to existing RHS record
@@ -1108,34 +928,18 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                         mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)"),
                         mkEntry("lhs2", "(lhsValue2|rhs1,rhsValue1)")
                 );
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
             // replace with tombstone, to validate behavior when latest record is null
             left.pipeInput("lhs2", null, baseTimestamp + 6);
             {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(mkMap(
-                                mkEntry("lhs2", null)
-                        ))
-                );
+                assertEquals(mkMap(mkEntry("lhs2", null)), outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(Map.of("lhs1", "(lhsValue1|rhs1,rhsValue1)"), asMap(store));
                 }
             }
 
@@ -1143,64 +947,32 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             left.pipeInput("lhs1", "lhsValue1_ooo|rhs1", baseTimestamp + 2);
             left.pipeInput("lhs2", "lhsValue2_ooo|rhs1", baseTimestamp + 2);
             if (leftVersioned) {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(Map.of("lhs1", "(lhsValue1|rhs1,rhsValue1)"), asMap(store));
                 }
             } else {
                 final Map<String, String> expected = mkMap(
                         mkEntry("lhs1", "(lhsValue1_ooo|rhs1,rhsValue1)"),
                         mkEntry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
                 );
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
             // out-of-order LHS tombstone (for existing key) is similarly ignored (iff LHS is versioned)
             left.pipeInput("lhs1", null, baseTimestamp + 2);
             if (leftVersioned) {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(Map.of("lhs1", "(lhsValue1|rhs1,rhsValue1)"), asMap(store));
                 }
             } else {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(mkMap(
-                                mkEntry("lhs1", null)
-                        ))
-                );
+                assertEquals(mkMap(mkEntry("lhs1", null)), outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(Map.of("lhs2", "(lhsValue2_ooo|rhs1,rhsValue1)"), asMap(store));
                 }
             }
 
@@ -1212,100 +984,71 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
                         mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
                         mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
                 );
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(expected)
-                );
+                assertEquals(expected, outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(expected)
-                    );
+                    assertEquals(expected, asMap(store));
                 }
             }
 
             // out-of-order RHS record (for existing key) does not produce a new result iff RHS is versioned
             right.pipeInput("rhs1", "rhsValue1_ooo", baseTimestamp + 1);
             if (rightVersioned) {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1_new|rhs1,rhsValue1)",
+                            "lhs2", "(lhsValue2_new|rhs1,rhsValue1)"),
+                        asMap(store));
                 }
             } else {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(mkMap(
-                                mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
-                                mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
-                        ))
-                );
+                assertEquals(
+                    Map.of(
+                        "lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)",
+                        "lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)"),
+                    outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)")
-                            ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1_new|rhs1,rhsValue1_ooo)",
+                            "lhs2", "(lhsValue2_new|rhs1,rhsValue1_ooo)"),
+                        asMap(store));
                 }
             }
 
             // out-of-order RHS tombstone (for existing key) is similarly ignored (iff RHS is versioned)
             right.pipeInput("rhs1", null, baseTimestamp + 1);
             if (rightVersioned) {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1)")
-                            ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1_new|rhs1,rhsValue1)",
+                            "lhs2", "(lhsValue2_new|rhs1,rhsValue1)"),
+                        asMap(store));
                 }
             } else {
                 if (leftJoin) {
-                    assertThat(
-                            outputTopic.readKeyValuesToMap(),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,null)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,null)")
-                            ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1_new|rhs1,null)",
+                            "lhs2", "(lhsValue2_new|rhs1,null)"),
+                        outputTopic.readKeyValuesToMap());
                     if (materialized) {
-                        assertThat(
-                                asMap(store),
-                                is(mkMap(
-                                        mkEntry("lhs1", "(lhsValue1_new|rhs1,null)"),
-                                        mkEntry("lhs2", "(lhsValue2_new|rhs1,null)")
-                                ))
-                        );
+                        assertEquals(
+                            Map.of(
+                                "lhs1", "(lhsValue1_new|rhs1,null)",
+                                "lhs2", "(lhsValue2_new|rhs1,null)"),
+                            asMap(store));
                     }
                 } else {
-                    assertThat(
-                            outputTopic.readKeyValuesToMap(),
-                            is(mkMap(
-                                    mkEntry("lhs1", null),
-                                    mkEntry("lhs2", null)
-                            ))
-                    );
+                    assertEquals(
+                        mkMap(
+                            mkEntry("lhs1", null),
+                            mkEntry("lhs2", null)),
+                        outputTopic.readKeyValuesToMap());
                     if (materialized) {
-                        assertThat(
-                                asMap(store),
-                                is(emptyMap())
-                        );
+                        assertTrue(asMap(store).isEmpty());
                     }
                 }
             }
@@ -1313,21 +1056,17 @@ public class KTableKTableForeignKeyJoinIntegrationTest {
             // RHS record with larger timestamps always produces new results
             right.pipeInput("rhs1", "rhsValue1_new", baseTimestamp + 6);
             {
-                assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(mkMap(
-                                mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
-                                mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
-                        ))
-                );
+                assertEquals(
+                    Map.of(
+                        "lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)",
+                        "lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)"),
+                    outputTopic.readKeyValuesToMap());
                 if (materialized) {
-                    assertThat(
-                            asMap(store),
-                            is(mkMap(
-                                    mkEntry("lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)"),
-                                    mkEntry("lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)")
-                            ))
-                    );
+                    assertEquals(
+                        Map.of(
+                            "lhs1", "(lhsValue1_new|rhs1,rhsValue1_new)",
+                            "lhs2", "(lhsValue2_new|rhs1,rhsValue1_new)"),
+                        asMap(store));
                 }
             }
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinMaterializationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinMaterializationIntegrationTest.java
@@ -47,12 +47,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
 
-import static java.util.Collections.emptyMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 @Timeout(600)
@@ -82,15 +81,9 @@ public class KTableKTableForeignKeyJoinMaterializationIntegrationTest {
 
             left.pipeInput("lhs1", "lhsValue1|rhs1");
 
-            assertThat(
-                outputTopic.readKeyValuesToMap(),
-                is(emptyMap())
-            );
+            assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
             if (materialized && queryable) {
-                assertThat(
-                    asMap(store),
-                    is(emptyMap())
-                );
+                assertTrue(asMap(store).isEmpty());
             }
 
             // Deleting a non-joining record produces an unnecessary tombstone for inner joins, because
@@ -102,35 +95,20 @@ public class KTableKTableForeignKeyJoinMaterializationIntegrationTest {
                     // suppress the unnecessary tombstone. This is because the cache is able to determine
                     // for sure that there has never been a previous result. (Because the "old" and "new" values
                     // are both null, and the underlying store is also missing the record in question).
-                    assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(emptyMap())
-                    );
+                    assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
 
-                    assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                    );
+                    assertTrue(asMap(store).isEmpty());
                 } else {
-                    assertThat(
-                        outputTopic.readKeyValuesToMap(),
-                        is(mkMap(mkEntry("lhs1", null)))
-                    );
+                    assertEquals(mkMap(mkEntry("lhs1", null)), outputTopic.readKeyValuesToMap());
                 }
             }
 
             // Deleting a non-existing record is idempotent
             left.pipeInput("lhs1", (String) null);
             {
-                assertThat(
-                    outputTopic.readKeyValuesToMap(),
-                    is(emptyMap())
-                );
+                assertTrue(outputTopic.readKeyValuesToMap().isEmpty());
                 if (materialized && queryable) {
-                    assertThat(
-                        asMap(store),
-                        is(emptyMap())
-                    );
+                    assertTrue(asMap(store).isEmpty());
                 }
             }
         }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/LagFetchIntegrationTest.java
@@ -68,8 +68,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
@@ -209,25 +208,25 @@ public class LagFetchIntegrationTest {
                 WAIT_TIMEOUT_MS);
             // Check the active reports proper lag values.
             Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = getFirstNonEmptyLagMap(activeStreams);
-            assertThat(offsetLagInfoMap.size(), equalTo(1));
-            assertThat(offsetLagInfoMap.keySet(), equalTo(Set.of(stateStoreName)));
-            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            assertEquals(1, offsetLagInfoMap.size());
+            assertEquals(Set.of(stateStoreName), offsetLagInfoMap.keySet());
+            assertEquals(1, offsetLagInfoMap.get(stateStoreName).size());
             LagInfo lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
-            assertThat(lagInfo.currentOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.offsetLag(), equalTo(0L));
+            assertEquals(5L, lagInfo.currentOffsetPosition());
+            assertEquals(5L, lagInfo.endOffsetPosition());
+            assertEquals(0L, lagInfo.offsetLag());
 
             // start up the standby & make it pause right after it has partition assigned
             standbyStreams.start();
             latchTillStandbyHasPartitionsAssigned.await(60, TimeUnit.SECONDS);
             offsetLagInfoMap = getFirstNonEmptyLagMap(standbyStreams);
-            assertThat(offsetLagInfoMap.size(), equalTo(1));
-            assertThat(offsetLagInfoMap.keySet(), equalTo(Set.of(stateStoreName)));
-            assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+            assertEquals(1, offsetLagInfoMap.size());
+            assertEquals(Set.of(stateStoreName), offsetLagInfoMap.keySet());
+            assertEquals(1, offsetLagInfoMap.get(stateStoreName).size());
             lagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
-            assertThat(lagInfo.currentOffsetPosition(), equalTo(0L));
-            assertThat(lagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(lagInfo.offsetLag(), equalTo(5L));
+            assertEquals(0L, lagInfo.currentOffsetPosition());
+            assertEquals(5L, lagInfo.endOffsetPosition());
+            assertEquals(5L, lagInfo.offsetLag());
             // standby thread won't proceed to RUNNING before this barrier is crossed
             lagCheckBarrier.await(60, TimeUnit.SECONDS);
 
@@ -294,20 +293,20 @@ public class LagFetchIntegrationTest {
             // check for proper lag values.
             TestUtils.waitForCondition(() -> {
                 final Map<String, Map<Integer, LagInfo>> offsetLagInfoMap = streams.allLocalStorePartitionLags();
-                assertThat(offsetLagInfoMap.size(), equalTo(1));
-                assertThat(offsetLagInfoMap.keySet(), equalTo(Set.of(stateStoreName)));
-                assertThat(offsetLagInfoMap.get(stateStoreName).size(), equalTo(1));
+                assertEquals(1, offsetLagInfoMap.size());
+                assertEquals(Set.of(stateStoreName), offsetLagInfoMap.keySet());
+                assertEquals(1, offsetLagInfoMap.get(stateStoreName).size());
 
                 final LagInfo zeroLagInfo = offsetLagInfoMap.get(stateStoreName).get(0);
-                assertThat(zeroLagInfo.currentOffsetPosition(), equalTo(5L));
-                assertThat(zeroLagInfo.endOffsetPosition(), equalTo(5L));
-                assertThat(zeroLagInfo.offsetLag(), equalTo(0L));
+                assertEquals(5L, zeroLagInfo.currentOffsetPosition());
+                assertEquals(5L, zeroLagInfo.endOffsetPosition());
+                assertEquals(0L, zeroLagInfo.offsetLag());
                 zeroLagRef.set(zeroLagInfo);
                 return true;
             }, WAIT_TIMEOUT_MS, "Eventually should reach zero lag.");
 
             // Kill instance, delete state to force restoration.
-            assertThat("Streams instance did not close within timeout", streams.close(Duration.ofSeconds(60)));
+            assertTrue(streams.close(Duration.ofSeconds(60)), "Streams instance did not close within timeout");
             IntegrationTestUtils.purgeLocalStreamsState(streamsConfiguration);
             Files.walk(stateDir.toPath()).sorted(Comparator.reverseOrder())
                 .map(Path::toFile)
@@ -355,11 +354,11 @@ public class LagFetchIntegrationTest {
                 WAIT_TIMEOUT_MS,
                 "Standby should eventually catchup and have zero lag.");
             final LagInfo fullLagInfo = restoreStartLagInfo.get(stateStoreName).get(0);
-            assertThat(fullLagInfo.currentOffsetPosition(), equalTo(0L));
-            assertThat(fullLagInfo.endOffsetPosition(), equalTo(5L));
-            assertThat(fullLagInfo.offsetLag(), equalTo(5L));
+            assertEquals(0L, fullLagInfo.currentOffsetPosition());
+            assertEquals(5L, fullLagInfo.endOffsetPosition());
+            assertEquals(5L, fullLagInfo.offsetLag());
 
-            assertThat(restoreEndLagInfo.get(stateStoreName).get(0), equalTo(zeroLagRef.get()));
+            assertEquals(zeroLagRef.get(), restoreEndLagInfo.get(stateStoreName).get(0));
         } finally {
             restartedStreams.close();
             restartedStreams.cleanUp();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -65,8 +65,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -457,8 +455,8 @@ public class MetricsIntegrationTest {
             .filter(m -> m.metricName().name().equals(ALIVE_STREAM_THREADS) &&
                 m.metricName().group().equals(STREAM_CLIENT_NODE_METRICS))
             .collect(Collectors.toList());
-        assertThat(metricsList.size(), is(1));
-        assertThat(metricsList.get(0).metricValue(), is(NUM_THREADS));
+        assertEquals(1, metricsList.size());
+        assertEquals(NUM_THREADS, metricsList.get(0).metricValue());
     }
 
     private void verifyStateMetric(final String state) {
@@ -466,9 +464,9 @@ public class MetricsIntegrationTest {
             .filter(m -> m.metricName().name().equals(STATE) &&
                 m.metricName().group().equals(STREAM_CLIENT_NODE_METRICS))
             .collect(Collectors.toList());
-        assertThat(metricsList.size(), is(1));
-        assertThat(metricsList.get(0).metricValue(), is(state));
-        assertThat(metricsList.get(0).metricValue().toString(), is(state));
+        assertEquals(1, metricsList.size());
+        assertEquals(state, metricsList.get(0).metricValue());
+        assertEquals(state, metricsList.get(0).metricValue().toString());
     }
 
     private void verifyTopologyDescriptionMetric(final String topologyDescription) {
@@ -476,8 +474,8 @@ public class MetricsIntegrationTest {
             .filter(m -> m.metricName().name().equals(TOPOLOGY_DESCRIPTION) &&
                 m.metricName().group().equals(STREAM_CLIENT_NODE_METRICS))
             .collect(Collectors.toList());
-        assertThat(metricsList.size(), is(1));
-        assertThat(metricsList.get(0).metricValue(), is(topologyDescription));
+        assertEquals(1, metricsList.size());
+        assertEquals(topologyDescription, metricsList.get(0).metricValue());
     }
 
     private void verifyApplicationIdMetric() {
@@ -485,8 +483,8 @@ public class MetricsIntegrationTest {
             .filter(m -> m.metricName().name().equals(APPLICATION_ID) &&
                 m.metricName().group().equals(STREAM_CLIENT_NODE_METRICS))
             .collect(Collectors.toList());
-        assertThat(metricsList.size(), is(1));
-        assertThat(metricsList.get(0).metricValue(), is(appId));
+        assertEquals(1, metricsList.size());
+        assertEquals(appId, metricsList.get(0).metricValue());
     }
 
     private void checkClientLevelMetrics() {
@@ -654,7 +652,7 @@ public class MetricsIntegrationTest {
         final List<Metric> listMetricAfterClosingApp = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
             .filter(m -> m.metricName().group().contains(STREAM_STRING))
             .collect(Collectors.toList());
-        assertThat(listMetricAfterClosingApp.size(), is(0));
+        assertEquals(0, listMetricAfterClosingApp.size());
     }
 
     private void checkCacheMetrics() {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/MetricsReporterIntegrationTest.java
@@ -43,8 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Timeout(600)
 @Tag("integration")
@@ -123,7 +122,7 @@ public class MetricsReporterIntegrationTest {
         try (KafkaStreams kafkaStreams = new KafkaStreams(topology, streamsConfiguration)) {
             kafkaStreams.metrics().keySet().forEach(metricName -> {
                 final Object initialMetricValue = METRIC_NAME_TO_INITIAL_VALUE.get(metricName.name());
-                assertThat(initialMetricValue, notNullValue());
+                assertNotNull(initialMetricValue);
             });
         }
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/NamedTopologyIntegrationTest.java
@@ -73,7 +73,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
@@ -81,17 +80,15 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singleton;
 import static org.apache.kafka.streams.KeyQueryMetadata.NOT_AVAILABLE;
 import static org.apache.kafka.streams.KeyValue.pair;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.DEFAULT_TIMEOUT;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
@@ -242,7 +239,7 @@ public class NamedTopologyIntegrationTest {
 
         CLUSTER.getAllTopicsInCluster().stream().filter(t -> t.contains("-changelog") || t.contains("-repartition")).forEach(t -> {
             try {
-                assertThat("topic was not decorated", t.contains(TOPIC_PREFIX));
+                assertTrue(t.contains(TOPIC_PREFIX), "topic was not decorated");
                 CLUSTER.deleteTopics(t);
             } catch (final RuntimeException e) {
                 e.printStackTrace();
@@ -291,15 +288,16 @@ public class NamedTopologyIntegrationTest {
             .filter(t -> t.contains(TOPIC_PREFIX))
             .filter(t -> t.endsWith("-repartition") || t.endsWith("-changelog") || t.endsWith("-topic"))
             .collect(Collectors.toSet());
-        assertThat(internalTopics, is(Set.of(
-            countTopicPrefix + "-KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition",
-            countTopicPrefix + "-KSTREAM-AGGREGATE-STATE-STORE-0000000002-changelog",
-            fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000006-topic",
-            fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-0000000014-topic",
-            fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-STATE-STORE-0000000010-changelog",
-            fkjTopicPrefix + "-" + INPUT_STREAM_2 + "-STATE-STORE-0000000000-changelog",
-            fkjTopicPrefix + "-" + INPUT_STREAM_3 + "-STATE-STORE-0000000003-changelog"))
-        );
+        assertEquals(
+            Set.of(
+                countTopicPrefix + "-KSTREAM-AGGREGATE-STATE-STORE-0000000002-repartition",
+                countTopicPrefix + "-KSTREAM-AGGREGATE-STATE-STORE-0000000002-changelog",
+                fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000006-topic",
+                fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-0000000014-topic",
+                fkjTopicPrefix + "-KTABLE-FK-JOIN-SUBSCRIPTION-STATE-STORE-0000000010-changelog",
+                fkjTopicPrefix + "-" + INPUT_STREAM_2 + "-STATE-STORE-0000000000-changelog",
+                fkjTopicPrefix + "-" + INPUT_STREAM_3 + "-STATE-STORE-0000000003-changelog"),
+            internalTopics);
     }
 
     @Test
@@ -312,11 +310,11 @@ public class NamedTopologyIntegrationTest {
         streams.addNamedTopology(topology1Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
         final List<KeyValue<String, Long>> results = waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5);
-        assertThat(results, equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, results);
 
         final Set<String> allTopics = CLUSTER.getAllTopicsInCluster();
-        assertThat(allTopics.contains(TOPIC_PREFIX + "-" + "topology-1" + "-store-changelog"), is(true));
-        assertThat(allTopics.contains(TOPIC_PREFIX + "-" + "topology-1" + "-store-repartition"), is(true));
+        assertTrue(allTopics.contains(TOPIC_PREFIX + "-" + "topology-1" + "-store-changelog"));
+        assertTrue(allTopics.contains(TOPIC_PREFIX + "-" + "topology-1" + "-store-repartition"));
     }
 
     @Test
@@ -329,11 +327,11 @@ public class NamedTopologyIntegrationTest {
         streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5));
 
-        assertThat(CLUSTER.getAllTopicsInCluster().containsAll(asList(changelog1, changelog2, changelog3)), is(true));
+        assertTrue(CLUSTER.getAllTopicsInCluster().containsAll(List.of(changelog1, changelog2, changelog3)));
     }
 
     @Test
@@ -354,13 +352,13 @@ public class NamedTopologyIntegrationTest {
             topology2Builder.stream(SINGLE_PARTITION_INPUT_STREAM).groupByKey().count(Materialized.as(topology2Store)).toStream().to(SINGLE_PARTITION_OUTPUT_STREAM);
             streams.addNamedTopology(topology1Builder.build());
             streams.removeNamedTopology(TOPOLOGY_1);
-            assertThat(streams.getTopologyByName(TOPOLOGY_1), is(Optional.empty()));
+            assertTrue(streams.getTopologyByName(TOPOLOGY_1).isEmpty());
             streams.addNamedTopology(topology1Builder.build());
             streams.addNamedTopology(topology2Builder.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SINGLE_PARTITION_OUTPUT_STREAM, 3), equalTo(COUNT_OUTPUT_DATA));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SINGLE_PARTITION_OUTPUT_STREAM, 3));
 
             final ReadOnlyKeyValueStore<String, Long> store =
                 streams.store(NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType(
@@ -368,26 +366,26 @@ public class NamedTopologyIntegrationTest {
                     topology1Store,
                     QueryableStoreTypes.keyValueStore())
                 );
-            assertThat(store.get("A"), equalTo(2L));
+            assertEquals(2L, store.get("A"));
 
             final Collection<StreamsMetadata> streamsMetadata = streams.streamsMetadataForStore(topology1Store, TOPOLOGY_1);
             final Collection<StreamsMetadata> streamsMetadata2 = streams.streamsMetadataForStore(topology2Store, TOPOLOGY_2);
-            assertThat(streamsMetadata.size(), equalTo(1));
-            assertThat(streamsMetadata2.size(), equalTo(1));
+            assertEquals(1, streamsMetadata.size());
+            assertEquals(1, streamsMetadata2.size());
 
             final KeyQueryMetadata keyMetadata = streams.queryMetadataForKey(topology1Store, "A", new StringSerializer(), TOPOLOGY_1);
             final KeyQueryMetadata keyMetadata2 = streams.queryMetadataForKey(topology2Store, "A", new StringSerializer(), TOPOLOGY_2);
 
-            assertThat(keyMetadata, not(NOT_AVAILABLE));
-            assertThat(keyMetadata, equalTo(keyMetadata2));
+            assertNotEquals(NOT_AVAILABLE, keyMetadata);
+            assertEquals(keyMetadata2, keyMetadata);
 
             final Map<String, Map<Integer, LagInfo>> partitionLags1 = streams.allLocalStorePartitionLagsForTopology(TOPOLOGY_1);
             final Map<String, Map<Integer, LagInfo>> partitionLags2 = streams.allLocalStorePartitionLagsForTopology(TOPOLOGY_2);
 
-            assertThat(partitionLags1.keySet(), equalTo(singleton(topology1Store)));
-            assertThat(partitionLags1.get(topology1Store).keySet(), equalTo(Set.of(0, 1)));
-            assertThat(partitionLags2.keySet(), equalTo(singleton(topology2Store)));
-            assertThat(partitionLags2.get(topology2Store).keySet(), equalTo(singleton(0))); // only one copy of the store in topology-2
+            assertEquals(Set.of(topology1Store), partitionLags1.keySet());
+            assertEquals(Set.of(0, 1), partitionLags1.get(topology1Store).keySet());
+            assertEquals(Set.of(topology2Store), partitionLags2.keySet());
+            assertEquals(Set.of(0), partitionLags2.get(topology2Store).keySet()); // only one copy of the store in topology-2
 
             // Start up a second node with both topologies
             setupSecondKafkaStreams();
@@ -407,14 +405,14 @@ public class NamedTopologyIntegrationTest {
                 streams.streamsMetadataForStore(topology2Store, TOPOLOGY_2),
                 streams2.streamsMetadataForStore(topology2Store, TOPOLOGY_2));
 
-            assertThat(streams.allStreamsClientsMetadataForTopology(TOPOLOGY_1).size(), equalTo(2));
-            assertThat(streams2.allStreamsClientsMetadataForTopology(TOPOLOGY_1).size(), equalTo(2));
+            assertEquals(2, streams.allStreamsClientsMetadataForTopology(TOPOLOGY_1).size());
+            assertEquals(2, streams2.allStreamsClientsMetadataForTopology(TOPOLOGY_1).size());
             verifyMetadataForTopology(
                 TOPOLOGY_1,
                 streams.allStreamsClientsMetadataForTopology(TOPOLOGY_1),
                 streams2.allStreamsClientsMetadataForTopology(TOPOLOGY_1));
-            assertThat(streams.allStreamsClientsMetadataForTopology(TOPOLOGY_2).size(), equalTo(2));
-            assertThat(streams2.allStreamsClientsMetadataForTopology(TOPOLOGY_2).size(), equalTo(2));
+            assertEquals(2, streams.allStreamsClientsMetadataForTopology(TOPOLOGY_2).size());
+            assertEquals(2, streams2.allStreamsClientsMetadataForTopology(TOPOLOGY_2).size());
             verifyMetadataForTopology(
                 TOPOLOGY_2,
                 streams.allStreamsClientsMetadataForTopology(TOPOLOGY_2),
@@ -431,7 +429,7 @@ public class NamedTopologyIntegrationTest {
         streams.start();
         streams.addNamedTopology(topology1Builder.build()).all().get();
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
     }
 
     @Test
@@ -445,8 +443,8 @@ public class NamedTopologyIntegrationTest {
 
         waitForApplicationState(Collections.singletonList(streams), State.RUNNING, Duration.ofMillis(DEFAULT_TIMEOUT));
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
     }
 
     @Test
@@ -463,9 +461,9 @@ public class NamedTopologyIntegrationTest {
 
         waitForApplicationState(Collections.singletonList(streams), State.RUNNING, Duration.ofMillis(DEFAULT_TIMEOUT));
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5));
     }
 
     @Test
@@ -481,14 +479,14 @@ public class NamedTopologyIntegrationTest {
         streams2.addNamedTopology(topology1Builder2.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
 
         final AddNamedTopologyResult result = streams.addNamedTopology(topology2Builder.build());
         final AddNamedTopologyResult result2 = streams2.addNamedTopology(topology2Builder2.build());
         result.all().get();
         result2.all().get();
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
     }
 
     @Test
@@ -501,17 +499,17 @@ public class NamedTopologyIntegrationTest {
         streams2.addNamedTopology(topology1Builder2.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(asList(streams, streams2));
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
 
         final RemoveNamedTopologyResult result = streams.removeNamedTopology(TOPOLOGY_1, true);
         streams2.removeNamedTopology(TOPOLOGY_1, true).all().get();
         result.all().get();
 
-        assertThat(streams.getTopologyByName(TOPOLOGY_1), equalTo(Optional.empty()));
-        assertThat(streams2.getTopologyByName(TOPOLOGY_1), equalTo(Optional.empty()));
+        assertTrue(streams.getTopologyByName(TOPOLOGY_1).isEmpty());
+        assertTrue(streams2.getTopologyByName(TOPOLOGY_1).isEmpty());
 
-        assertThat(streams.getAllTopologies().isEmpty(), is(true));
-        assertThat(streams2.getAllTopologies().isEmpty(), is(true));
+        assertTrue(streams.getAllTopologies().isEmpty());
+        assertTrue(streams2.getAllTopologies().isEmpty());
 
         streams.cleanUpNamedTopology(TOPOLOGY_1);
         streams2.cleanUpNamedTopology(TOPOLOGY_1);
@@ -534,10 +532,10 @@ public class NamedTopologyIntegrationTest {
         streams2.addNamedTopology(topology2Client2).all().get();
         result1.all().get();
 
-        assertThat(streams.getAllTopologies(), equalTo(singleton(topology2Client1)));
-        assertThat(streams2.getAllTopologies(), equalTo(singleton(topology2Client2)));
+        assertEquals(Set.of(topology2Client1), streams.getAllTopologies());
+        assertEquals(Set.of(topology2Client2), streams2.getAllTopologies());
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
     }
 
     @Test
@@ -553,8 +551,8 @@ public class NamedTopologyIntegrationTest {
             streams.addNamedTopology(topology1Builder.build());
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+            assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
             streams.removeNamedTopology(TOPOLOGY_1).all().get();
             streams.cleanUpNamedTopology(TOPOLOGY_1);
 
@@ -567,8 +565,8 @@ public class NamedTopologyIntegrationTest {
             produceToInputTopics(DELAYED_INPUT_STREAM_1, STANDARD_INPUT_DATA);
             streams.addNamedTopology(topology1Builder2.build()).all().get();
 
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+            assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
         } finally {
             CLUSTER.deleteTopics(SUM_OUTPUT, COUNT_OUTPUT);
             CLUSTER.deleteTopics(DELAYED_INPUT_STREAM_1);
@@ -585,9 +583,9 @@ public class NamedTopologyIntegrationTest {
         streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5));
     }
 
     @Test
@@ -600,9 +598,9 @@ public class NamedTopologyIntegrationTest {
         streams.addNamedTopology(topology3Builder.build());
         IntegrationTestUtils.startApplicationAndWaitUntilRunning(streams);
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5), equalTo(COUNT_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_1, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_2, 5));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, OUTPUT_STREAM_3, 5));
     }
 
     @Test
@@ -617,8 +615,8 @@ public class NamedTopologyIntegrationTest {
             final NamedTopology namedTopology = topology1Builder.build();
             streams.addNamedTopology(namedTopology).all().get();
 
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+            assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
             streams.removeNamedTopology("topology-1", true).all().get();
             streams.cleanUpNamedTopology("topology-1");
 
@@ -637,8 +635,8 @@ public class NamedTopologyIntegrationTest {
             final NamedTopology namedTopologyDup = topology1BuilderDup.build();
             streams.addNamedTopology(namedTopologyDup).all().get();
 
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-            assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+            assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+            assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
         } finally {
             CLUSTER.deleteTopics(SUM_OUTPUT, COUNT_OUTPUT);
         }
@@ -655,8 +653,8 @@ public class NamedTopologyIntegrationTest {
         final NamedTopology namedTopology = topology1Builder.build();
         streams.addNamedTopology(namedTopology).all().get();
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+        assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
 
         TestUtils.waitForCondition(
                 () -> streams.areAllLocalTasksRunningForTopology(TOPOLOGY_1),
@@ -691,8 +689,8 @@ public class NamedTopologyIntegrationTest {
         final NamedTopology namedTopologyDup = topology1BuilderDup.build();
         streams.addNamedTopology(namedTopologyDup).all().get();
 
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5), equalTo(COUNT_OUTPUT_DATA));
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5), equalTo(SUM_OUTPUT_DATA));
+        assertEquals(COUNT_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, COUNT_OUTPUT, 5));
+        assertEquals(SUM_OUTPUT_DATA, waitUntilMinKeyValueRecordsReceived(consumerConfig, SUM_OUTPUT, 5));
 
         CLUSTER.deleteTopics(SUM_OUTPUT, COUNT_OUTPUT);
     }
@@ -704,7 +702,7 @@ public class NamedTopologyIntegrationTest {
     private void verifyMetadataForTopology(final String topologyName,
                                            final Collection<StreamsMetadata> left,
                                            final Collection<StreamsMetadata> right) {
-        assertThat(left.size(), equalTo(right.size()));
+        assertEquals(right.size(), left.size());
         final Iterator<StreamsMetadata> leftIter = left.iterator();
         final Iterator<StreamsMetadata> rightIter = right.iterator();
 
@@ -715,39 +713,35 @@ public class NamedTopologyIntegrationTest {
             verifyPartitionsAndStoresForTopology(topologyName, leftMetadata);
             verifyPartitionsAndStoresForTopology(topologyName, rightMetadata);
 
-            assertThat(verifyEquivalentMetadataForHost(leftMetadata, rightMetadata), is(true));
+            assertTrue(verifyEquivalentMetadataForHost(leftMetadata, rightMetadata));
         }
     }
 
     private void verifyPartitionsAndStoresForTopology(final String topologyName, final StreamsMetadataImpl metadata) {
-        assertThat(metadata.topologyName(), equalTo(topologyName));
-        assertThat(streams.getTopologyByName(topologyName).isPresent(), is(true));
-        assertThat(streams2.getTopologyByName(topologyName).isPresent(), is(true));
+        assertEquals(topologyName, metadata.topologyName());
+        assertTrue(streams.getTopologyByName(topologyName).isPresent());
+        assertTrue(streams2.getTopologyByName(topologyName).isPresent());
         final List<String> streams1SourceTopicsForTopology = streams.getTopologyByName(topologyName).get().sourceTopics();
         final List<String> streams2SourceTopicsForTopology = streams2.getTopologyByName(topologyName).get().sourceTopics();
 
         // first check that all partitions in the metadata correspond to the given named topology
-        assertThat(
-            streams1SourceTopicsForTopology.containsAll(metadata.topicPartitions().stream()
-                                                            .map(TopicPartition::topic)
-                                                            .collect(Collectors.toList())),
-            is(true));
-        assertThat(
-            streams2SourceTopicsForTopology.containsAll(metadata.topicPartitions().stream()
-                                                            .map(TopicPartition::topic)
-                                                            .collect(Collectors.toList())),
-            is(true));
+        assertTrue(streams1SourceTopicsForTopology.containsAll(metadata.topicPartitions().stream()
+                                                                   .map(TopicPartition::topic)
+                                                                   .collect(Collectors.toList())));
+        assertTrue(streams2SourceTopicsForTopology.containsAll(metadata.topicPartitions().stream()
+                                                                   .map(TopicPartition::topic)
+                                                                   .collect(Collectors.toList())));
 
         // then verify that only this topology's one store appears if the host has partitions assigned
         if (!metadata.topicPartitions().isEmpty()) {
-            assertThat(metadata.stateStoreNames(), equalTo(singleton("store-" + topologyName)));
+            assertEquals(Set.of("store-" + topologyName), metadata.stateStoreNames());
         } else {
-            assertThat(metadata.stateStoreNames().isEmpty(), is(true));
+            assertTrue(metadata.stateStoreNames().isEmpty());
         }
 
         // finally make sure the standby fields are empty since they are not enabled for this test
-        assertThat(metadata.standbyTopicPartitions().isEmpty(), is(true));
-        assertThat(metadata.standbyStateStoreNames().isEmpty(), is(true));
+        assertTrue(metadata.standbyTopicPartitions().isEmpty());
+        assertTrue(metadata.standbyStateStoreNames().isEmpty());
     }
 
     /**

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/OptimizedKTableIntegrationTest.java
@@ -64,9 +64,8 @@ import java.util.stream.IntStream;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
@@ -130,7 +129,7 @@ public class OptimizedKTableIntegrationTest {
             produceValueRange(key, 0, batch1NumMessages);
 
             // Assert that all messages in the first batch were processed in a timely manner
-            assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+            assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
 
             final AtomicReference<ReadOnlyKeyValueStore<Integer, Integer>> newActiveStore = new AtomicReference<>(null);
             TestUtils.retryOnExceptionWithTimeout(() -> {
@@ -142,11 +141,11 @@ public class OptimizedKTableIntegrationTest {
                 try {
                     // Assert that the current value in store reflects all messages being processed
                     if ((keyQueryMetadata.activeHost().port() % 2) == 1) {
-                        assertThat(store1.get(key), is(equalTo(batch1NumMessages - 1)));
+                        assertEquals(batch1NumMessages - 1, store1.get(key));
                         kafkaStreams1.close();
                         newActiveStore.set(store2);
                     } else {
-                        assertThat(store2.get(key), is(equalTo(batch1NumMessages - 1)));
+                        assertEquals(batch1NumMessages - 1, store2.get(key));
                         kafkaStreams2.close();
                         newActiveStore.set(store1);
                     }
@@ -162,7 +161,7 @@ public class OptimizedKTableIntegrationTest {
             // Wait for failover
             TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
                 // Assert that after failover we have recovered to the last store write
-                assertThat(newActiveStore.get().get(key), is(equalTo(batch1NumMessages - 1)));
+                assertEquals(batch1NumMessages - 1, newActiveStore.get().get(key));
             });
 
             final int totalNumMessages = batch1NumMessages + batch2NumMessages;
@@ -170,11 +169,11 @@ public class OptimizedKTableIntegrationTest {
             produceValueRange(key, batch1NumMessages, totalNumMessages);
 
             // Assert that all messages in the second batch were processed in a timely manner
-            assertThat(semaphore.tryAcquire(batch2NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+            assertTrue(semaphore.tryAcquire(batch2NumMessages, 60, TimeUnit.SECONDS));
 
             TestUtils.retryOnExceptionWithTimeout(60 * 1000, 100, () -> {
                 // Assert that the current value in store reflects all messages being processed
-                assertThat(newActiveStore.get().get(key), is(equalTo(totalNumMessages - 1)));
+                assertEquals(totalNumMessages - 1, newActiveStore.get().get(key));
             });
         } finally {
             kafkaStreams1.close();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PauseResumeIntegrationTest.java
@@ -37,7 +37,6 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,7 +62,6 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.wa
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -387,7 +385,7 @@ public class PauseResumeIntegrationTest {
 
     private void awaitOutput(final String topicName, final int count, final List<KeyValue<String, Long>> output)
         throws Exception {
-        assertThat(waitUntilMinKeyValueRecordsReceived(consumerConfig, topicName, count), CoreMatchers.equalTo(output));
+        assertEquals(output, waitUntilMinKeyValueRecordsReceived(consumerConfig, topicName, count));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/PositionRestartIntegrationTest.java
@@ -96,9 +96,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.query.StateQueryRequest.inStore;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 @Timeout(600)
@@ -320,7 +319,7 @@ public class PositionRestartIntegrationTest {
 
             for (final Future<RecordMetadata> future : futures) {
                 final RecordMetadata recordMetadata = future.get(1, TimeUnit.MINUTES);
-                assertThat(recordMetadata.hasOffset(), is(true));
+                assertTrue(recordMetadata.hasOffset());
                 inputPosition.withComponent(
                     recordMetadata.topic(),
                     recordMetadata.partition(),
@@ -329,12 +328,12 @@ public class PositionRestartIntegrationTest {
             }
         }
 
-        assertThat(inputPosition, equalTo(
+        assertEquals(
             Position
                 .emptyPosition()
                 .withComponent(INPUT_TOPIC_NAME, 0, 1L)
-                .withComponent(INPUT_TOPIC_NAME, 1, 1L)
-        ));
+                .withComponent(INPUT_TOPIC_NAME, 1, 1L),
+            inputPosition);
     }
 
     public static StreamsBuilder getStreamBuilder(final boolean cache,
@@ -416,7 +415,7 @@ public class PositionRestartIntegrationTest {
         final StateQueryResult<?> result =
             IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
 
-        assertThat(result.getPosition(), is(inputPosition));
+        assertEquals(inputPosition, result.getPosition());
     }
 
     private static void setUpSessionDSLTopology(final SessionBytesStoreSupplier supplier,

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -59,7 +59,6 @@ import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,12 +110,12 @@ import static org.apache.kafka.streams.state.QueryableStoreTypes.sessionStore;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(600)
 @Tag("integration")
@@ -285,9 +284,9 @@ public class QueryableStateIntegrationTest {
         for (int i = 0; i < streamsList.size(); i++) {
             final Map<String, Map<Integer, LagInfo>> localLags = streamsList.get(i).allLocalStorePartitionLags();
             final int expectedPartitions = partitionsPerStreamsInstance.get(i);
-            assertThat(localLags.values().stream().mapToInt(Map::size).sum(), equalTo(expectedPartitions));
+            assertEquals(expectedPartitions, localLags.values().stream().mapToInt(Map::size).sum());
             if (expectedPartitions > 0) {
-                assertThat(localLags.keySet(), equalTo(stores));
+                assertEquals(stores, localLags.keySet());
             }
         }
     }
@@ -314,7 +313,7 @@ public class QueryableStateIntegrationTest {
                         continue;
                     }
                     if (!pickInstanceByPort) {
-                        assertThat("Should have standbys to query from", !queryMetadata.standbyHosts().isEmpty());
+                        assertFalse(queryMetadata.standbyHosts().isEmpty(), "Should have standbys to query from");
                     }
 
                     final int index = queryMetadata.activeHost().port();
@@ -368,9 +367,9 @@ public class QueryableStateIntegrationTest {
                         continue;
                     }
                     if (pickInstanceByPort) {
-                        assertThat(queryMetadata.standbyHosts().size(), equalTo(0));
+                        assertEquals(0, queryMetadata.standbyHosts().size());
                     } else {
-                        assertThat("Should have standbys to query from", !queryMetadata.standbyHosts().isEmpty());
+                        assertFalse(queryMetadata.standbyHosts().isEmpty(), "Should have standbys to query from");
                     }
 
                     final int index = queryMetadata.activeHost().port();
@@ -437,8 +436,9 @@ public class QueryableStateIntegrationTest {
             }
         }
 
-        assertThat(reason.toString(),
-            noMetadataKeys.isEmpty() && nullStoreKeys.isEmpty() && nullValueKeys.isEmpty() && exceptionalKeys.isEmpty());
+        assertTrue(
+            noMetadataKeys.isEmpty() && nullStoreKeys.isEmpty() && nullValueKeys.isEmpty() && exceptionalKeys.isEmpty(),
+            reason.toString());
     }
 
     @Test
@@ -466,15 +466,15 @@ public class QueryableStateIntegrationTest {
         try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
             final ReadOnlyKeyValueStore<String, String> store =
                 streams.store(fromNameAndType(storeName, keyValueStore()));
-            assertThat(store, Matchers.notNullValue());
+            assertNotNull(store);
 
             final UnknownStateStoreException exception = assertThrows(
                 UnknownStateStoreException.class,
                 () -> streams.store(fromNameAndType("no-table", keyValueStore()))
             );
-            assertThat(
-                exception.getMessage(),
-                is("Cannot get state store no-table because no such store is registered in the topology.")
+            assertEquals(
+                "Cannot get state store no-table because no such store is registered in the topology.",
+                exception.getMessage()
             );
         }
     }
@@ -504,7 +504,7 @@ public class QueryableStateIntegrationTest {
         try (final KafkaStreams streams = getRunningStreams(properties, builder, true)) {
             final ReadOnlyKeyValueStore<String, String> store =
                 streams.store(fromNameAndType(storeName, keyValueStore()));
-            assertThat(store, Matchers.notNullValue());
+            assertNotNull(store);
 
             // Note that to check the type we actually need a store reference,
             // so we can't check when you get the IQ store, only when you
@@ -515,14 +515,12 @@ public class QueryableStateIntegrationTest {
                 InvalidStateStoreException.class,
                 () -> sessionStore.fetch("a")
             );
-            assertThat(
-                exception.getMessage(),
-                is(
-                    "Cannot get state store " + storeName + " because the queryable store type" +
-                        " [class org.apache.kafka.streams.state.QueryableStoreTypes$SessionStoreType]" +
-                        " does not accept the actual store type" +
-                        " [class org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore]."
-                )
+            assertEquals(
+                "Cannot get state store " + storeName + " because the queryable store type" +
+                    " [class org.apache.kafka.streams.state.QueryableStoreTypes$SessionStoreType]" +
+                    " does not accept the actual store type" +
+                    " [class org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore].",
+                exception.getMessage()
             );
         }
     }
@@ -585,8 +583,8 @@ public class QueryableStateIntegrationTest {
             // kill N-1 threads
             for (int i = 1; i < streamsList.size(); i++) {
                 final Duration closeTimeout = Duration.ofSeconds(60);
-                assertThat(String.format("Streams instance %s did not close in %d ms", i, closeTimeout.toMillis()),
-                    streamsList.get(i).close(closeTimeout));
+                assertTrue(streamsList.get(i).close(closeTimeout),
+                    String.format("Streams instance %s did not close in %d ms", i, closeTimeout.toMillis()));
             }
 
             waitForApplicationState(streamsList.subList(1, numThreads), State.NOT_RUNNING, Duration.ofSeconds(60));
@@ -687,8 +685,8 @@ public class QueryableStateIntegrationTest {
             // kill N-1 threads
             for (int i = 1; i < streamsList.size(); i++) {
                 final Duration closeTimeout = Duration.ofSeconds(60);
-                assertThat(String.format("Streams instance %s did not close in %d ms", i, closeTimeout.toMillis()),
-                    streamsList.get(i).close(closeTimeout));
+                assertTrue(streamsList.get(i).close(closeTimeout),
+                    String.format("Streams instance %s did not close in %d ms", i, closeTimeout.toMillis()));
             }
 
             waitForApplicationState(streamsList.subList(1, numThreads), State.NOT_RUNNING, Duration.ofSeconds(60));
@@ -1189,8 +1187,8 @@ public class QueryableStateIntegrationTest {
             }
         }
 
-        assertThat(countRangeResults, equalTo(expectedRangeResults));
-        assertThat(countAllResults, equalTo(expectedCount));
+        assertEquals(expectedRangeResults, countRangeResults);
+        assertEquals(expectedCount, countAllResults);
     }
 
     private void verifyCanGetByKey(final String[] keys,
@@ -1214,8 +1212,8 @@ public class QueryableStateIntegrationTest {
                 }
             }
         }
-        assertThat(windowState, equalTo(expectedWindowState));
-        assertThat(countState, equalTo(expectedCount));
+        assertEquals(expectedWindowState, windowState);
+        assertEquals(expectedCount, countState);
     }
 
     private void waitUntilAtLeastNumRecordProcessed(final String topic,

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RangeQueryIntegrationTest.java
@@ -61,8 +61,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
@@ -221,7 +220,7 @@ public class RangeQueryIntegrationTest {
              final KeyValueIterator<String, String> expectedIterator = forward ? store.all() : store.reverseAll()) {
             final List<KeyValue<String, String>> result = Utils.toList(resultIterator);
             final List<KeyValue<String, String>> expected = filterList(expectedIterator, from, to);
-            assertThat(name, result, is(expected));
+            assertEquals(expected, result, name);
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceIntegrationTest.java
@@ -55,8 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -113,7 +112,8 @@ public class RebalanceIntegrationTest {
         addAllKeys(allKeys, expectedResult);
 
         for (final Long key : allKeys) {
-            assertThat("The records do not match what expected", getAllRecordPerKey(key, result), equalTo(getAllRecordPerKey(key, expectedResult)));
+            assertEquals(getAllRecordPerKey(key, expectedResult), getAllRecordPerKey(key, result),
+                "The records do not match what expected");
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceProtocolMigrationIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RebalanceProtocolMigrationIntegrationTest.java
@@ -51,8 +51,7 @@ import java.util.Properties;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 public class RebalanceProtocolMigrationIntegrationTest {
@@ -219,7 +218,7 @@ public class RebalanceProtocolMigrationIntegrationTest {
                 expected.size(),
                 60 * 1000);
 
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
 
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -72,10 +72,8 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * End-to-end integration test based on using regex and named topics for creating sources, using
@@ -223,7 +221,7 @@ public class RegexSourceIntegrationTest {
                 .toStream().to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
             final Topology topology = builder.build();
-            assertThat(topology.describe().subtopologies().size(), greaterThan(1));
+            assertTrue(topology.describe().subtopologies().size() > 1);
             streams = new KafkaStreams(topology, streamsConfiguration);
 
             startApplicationAndWaitUntilRunning(streams);
@@ -276,7 +274,7 @@ public class RegexSourceIntegrationTest {
                 .toStream().to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
             final Topology topology = builder.build();
-            assertThat(topology.describe().subtopologies().size(), greaterThan(1));
+            assertTrue(topology.describe().subtopologies().size() > 1);
             streams = new KafkaStreams(builder.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
                 @Override
                 public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
@@ -426,7 +424,7 @@ public class RegexSourceIntegrationTest {
 
         Collections.sort(actualValues);
         Collections.sort(expectedReceivedValues);
-        assertThat(actualValues, equalTo(expectedReceivedValues));
+        assertEquals(expectedReceivedValues, actualValues);
     }
 
     @Test
@@ -529,7 +527,7 @@ public class RegexSourceIntegrationTest {
             // this is fine
         }
 
-        assertThat(expectError.get(), is(true));
+        assertTrue(expectError.get());
     }
 
     private static class TheConsumerRebalanceListener implements ConsumerRebalanceListener {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
@@ -56,8 +56,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.cl
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.getStartedStreams;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.quietlyCleanStateAfterTest;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -126,11 +125,11 @@ public class ResetPartitionTimeIntegrationTest {
                     new KeyValueTimestamp<>("k3", "v3", NOW + 5000)
                 )
             );
-            assertThat(lastRecordedTimestamp, is(-1L));
+            assertEquals(-1L, lastRecordedTimestamp);
             lastRecordedTimestamp = -2L;
 
             kafkaStreams.close();
-            assertThat(kafkaStreams.state(), is(KafkaStreams.State.NOT_RUNNING));
+            assertEquals(KafkaStreams.State.NOT_RUNNING, kafkaStreams.state());
 
             kafkaStreams = getStartedStreams(streamsConfig, builder, true);
 
@@ -147,7 +146,7 @@ public class ResetPartitionTimeIntegrationTest {
                     new KeyValueTimestamp<>("k5", "v5", NOW + 4999)
                 )
             );
-            assertThat(lastRecordedTimestamp, is(NOW + 5000L));
+            assertEquals(NOW + 5000L, lastRecordedTimestamp);
         } finally {
             kafkaStreams.close();
             quietlyCleanStateAfterTest(CLUSTER, kafkaStreams);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -67,7 +67,6 @@ import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,11 +110,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.wa
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForStandbyCompletion;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -334,10 +329,10 @@ public class RestoreIntegrationTest {
             startApplicationAndWaitUntilRunning(kafkaStreams);
         }
 
-        assertThat(restored.get(), equalTo((long) numberOfKeys - offsetLimitDelta * 2 - offsetCheckpointed * 2));
+        assertEquals((long) numberOfKeys - offsetLimitDelta * 2 - offsetCheckpointed * 2, restored.get());
 
         assertTrue(shutdownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(numReceived.get(), equalTo(offsetLimitDelta * 2));
+        assertEquals(offsetLimitDelta * 2, numReceived.get());
     }
 
     @ParameterizedTest
@@ -400,10 +395,10 @@ public class RestoreIntegrationTest {
 
         }
 
-        assertThat(restored.get(), equalTo((long) numberOfKeys - offsetLimitDelta * 2 - offsetCheckpointed * 2));
+        assertEquals((long) numberOfKeys - offsetLimitDelta * 2 - offsetCheckpointed * 2, restored.get());
 
         assertTrue(shutdownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(numReceived.get(), equalTo(offsetLimitDelta * 2));
+        assertEquals(offsetLimitDelta * 2, numReceived.get());
     }
 
     // Adds a transactional dimension on top of (useNewProtocol, withHeaders). When transactional is true the
@@ -465,10 +460,10 @@ public class RestoreIntegrationTest {
         kafkaStreams.start();
 
         assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
-        assertThat(restored.get(), equalTo((long) numberOfKeys - 2 * offsetCheckpointed));
+        assertEquals((long) numberOfKeys - 2 * offsetCheckpointed, restored.get());
 
         assertTrue(shutdownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(numReceived.get(), equalTo(numberOfKeys));
+        assertEquals(numberOfKeys, numReceived.get());
     }
 
     @ParameterizedTest
@@ -619,18 +614,18 @@ public class RestoreIntegrationTest {
             waitForCompletion(streams1, 1, 30 * 1000L);
             waitForStandbyCompletion(streams1, 1, 30 * 1000L);
 
-            assertThat(restoreListener.totalNumRestored(), CoreMatchers.equalTo(initialNunRestoredCount));
+            assertEquals(initialNunRestoredCount, restoreListener.totalNumRestored());
 
             // After stopping instance 2 and letting instance 1 take over its tasks, we should have closed just two stores
             // total: the active and standby tasks on instance 2. The new protocol used to close one store more, because
             // the standby that instance 1 already held was closed and re-created instead of being promoted in place;
             // now that the reconciler changes the role in place, both protocols close the same two stores.
-            assertThat(CloseCountingInMemoryStore.numStoresClosed(), equalTo(initialStoreCloseCount + 2));
+            assertEquals(initialStoreCloseCount + 2, CloseCountingInMemoryStore.numStoresClosed());
         } finally {
             streams1.close(Duration.ofSeconds(60));
         }
         waitForTransitionTo(transitionedStates1, State.NOT_RUNNING, Duration.ofSeconds(60));
-        assertThat(CloseCountingInMemoryStore.numStoresClosed(), CoreMatchers.equalTo(initialStoreCloseCount + 4));
+        assertEquals(initialStoreCloseCount + 4, CloseCountingInMemoryStore.numStoresClosed());
     }
 
     @ParameterizedTest
@@ -740,7 +735,7 @@ public class RestoreIntegrationTest {
         kafkaStreams.start();
 
         assertTrue(shutdownLatch.await(30, TimeUnit.SECONDS));
-        assertThat(numReceived.get(), equalTo(numberOfKeys));
+        assertEquals(numberOfKeys, numReceived.get());
 
         final Map<String, Long> taskIdToMetricValue = kafkaStreams.metrics().entrySet().stream()
                 .filter(e -> e.getKey().name().equals("restore-latency-max"))
@@ -749,7 +744,8 @@ public class RestoreIntegrationTest {
         for (final Map.Entry<TopicPartition, Long> entry : restoreListener.changelogToRestoreTime().entrySet()) {
             final long lowerBound = entry.getValue() - TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
             final long upperBound = entry.getValue() + TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
-            assertThat(taskIdToMetricValue.get("0_" + entry.getKey().partition()), allOf(greaterThanOrEqualTo(lowerBound), lessThanOrEqualTo(upperBound)));
+            final Long metricValue = taskIdToMetricValue.get("0_" + entry.getKey().partition());
+            assertTrue(metricValue != null && metricValue >= lowerBound && metricValue <= upperBound);
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -61,9 +61,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
 @Timeout(600)
@@ -304,13 +303,10 @@ public class RocksDBMetricsIntegrationTest {
         final List<Metric> metrics = listMetric.stream()
             .filter(m -> m.metricName().name().equals(metricName))
             .collect(Collectors.toList());
-        assertThat(
-            "Size of metrics of type:'" + metricName + "' must be equal to " + numMetric + " but it's equal to " + metrics.size(),
-            metrics.size(),
-            is(numMetric)
-        );
+        assertEquals(numMetric, metrics.size(),
+            "Size of metrics of type:'" + metricName + "' must be equal to " + numMetric + " but it's equal to " + metrics.size());
         for (final Metric metric : metrics) {
-            assertThat("Metric:'" + metric.metricName() + "' must be not null", metric.metricValue(), is(notNullValue()));
+            assertNotNull(metric.metricValue(), "Metric:'" + metric.metricName() + "' must be not null");
         }
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SelfJoinUpgradeIntegrationTest.java
@@ -57,8 +57,7 @@ import static java.time.Duration.ofMinutes;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @Tag("integration")
@@ -290,7 +289,7 @@ public class SelfJoinUpgradeIntegrationTest {
             expected.size(),
             60 * 1000);
 
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
 
         return actual.equals(expected);
     }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SlidingWindowedKStreamIntegrationTest.java
@@ -73,8 +73,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings({"unchecked"})
 @Tag("integration")
@@ -220,7 +219,7 @@ public class SlidingWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     @ParameterizedTest
@@ -299,7 +298,7 @@ public class SlidingWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     @ParameterizedTest
@@ -392,7 +391,7 @@ public class SlidingWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
 
         kafkaStreams.close();
         kafkaStreams.cleanUp(); // Purge store to force restoration
@@ -431,7 +430,7 @@ public class SlidingWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     private void produceMessages(final String topic, final KeyValueTimestamp<String, String>... records) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSMultiRebalanceIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSMultiRebalanceIntegrationTest.java
@@ -38,7 +38,6 @@ import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,8 +58,8 @@ import java.util.stream.IntStream;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 public class StandbyTaskEOSMultiRebalanceIntegrationTest {
@@ -215,11 +214,12 @@ public class StandbyTaskEOSMultiRebalanceIntegrationTest {
 
         outputRecords.stream().collect(Collectors.groupingBy(ConsumerRecord::value)).forEach(this::logIfDuplicate);
 
-        assertThat("Each output should correspond to one distinct value", outputRecords.stream().map(ConsumerRecord::value).distinct().count(), is(Matchers.equalTo((long) outputRecords.size())));
+        assertEquals((long) outputRecords.size(), outputRecords.stream().map(ConsumerRecord::value).distinct().count(),
+            "Each output should correspond to one distinct value");
     }
 
     private void logIfDuplicate(final Integer id, final List<ConsumerRecord<Integer, Integer>> record) {
-        assertThat("The id and the value in the records must match", record.stream().allMatch(r -> id.equals(r.value())));
+        assertTrue(record.stream().allMatch(r -> id.equals(r.value())), "The id and the value in the records must match");
         if (record.size() > 1) {
             LOG.warn("Id : " + id + " is assigned to the following " + record.stream().map(ConsumerRecord::key).collect(Collectors.toList()));
         }
@@ -256,7 +256,7 @@ public class StandbyTaskEOSMultiRebalanceIntegrationTest {
                             public void process(final Record<Integer, Integer> record) {
                                 final Integer key = record.key();
                                 final Integer unused = record.value();
-                                assertThat("Key and value mus be equal", key.equals(unused));
+                                assertEquals(key, unused, "Key and value mus be equal");
                                 Integer id = store.get(key);
                                 // Only assign a new id if the value have not been observed before
                                 if (id == null) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -47,7 +47,6 @@ import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -80,15 +79,10 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.st
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Timeout(600)
@@ -153,7 +147,7 @@ public class StoreQueryIntegrationTest {
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
         until(() -> {
 
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
@@ -166,11 +160,11 @@ public class StoreQueryIntegrationTest {
 
             try {
                 if (kafkaStreams1IsActive) {
-                    assertThat(store1.get(key), is(notNullValue()));
-                    assertThat(store2.get(key), is(nullValue()));
+                    assertNotNull(store1.get(key));
+                    assertNull(store2.get(key));
                 } else {
-                    assertThat(store1.get(key), is(nullValue()));
-                    assertThat(store2.get(key), is(notNullValue()));
+                    assertNull(store1.get(key));
+                    assertNotNull(store2.get(key));
                 }
                 return true;
             } catch (final InvalidStateStoreException exception) {
@@ -201,7 +195,7 @@ public class StoreQueryIntegrationTest {
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
         until(() -> {
             final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
                     .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
@@ -225,11 +219,11 @@ public class StoreQueryIntegrationTest {
             }
 
             if (kafkaStreams1IsActive) {
-                assertThat(store1, is(notNullValue()));
-                assertThat(store2, is(nullValue()));
+                assertNotNull(store1);
+                assertNull(store2);
             } else {
-                assertThat(store2, is(notNullValue()));
-                assertThat(store1, is(nullValue()));
+                assertNotNull(store2);
+                assertNull(store1);
             }
 
             final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> storeQueryParam2 =
@@ -241,23 +235,17 @@ public class StoreQueryIntegrationTest {
                 // If kafkaStreams1 is active for keyPartition, kafkaStreams2 would be active for keyDontBelongPartition
                 // So, in that case, store3 would be null and the store4 would not return the value for key as wrong partition was requested
                 if (kafkaStreams1IsActive) {
-                    assertThat(store1.get(key), is(notNullValue()));
-                    assertThat(getStore(kafkaStreams2, storeQueryParam2).get(key), is(nullValue()));
+                    assertNotNull(store1.get(key));
+                    assertNull(getStore(kafkaStreams2, storeQueryParam2).get(key));
                     final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams1, storeQueryParam2).get(key));
-                    assertThat(
-                        exception.getMessage(),
-                        containsString("The specified partition 1 for store source-table does not exist.")
-                    );
+                    assertTrue(exception.getMessage().contains("The specified partition 1 for store source-table does not exist."));
                 } else {
-                    assertThat(store2.get(key), is(notNullValue()));
-                    assertThat(getStore(kafkaStreams1, storeQueryParam2).get(key), is(nullValue()));
+                    assertNotNull(store2.get(key));
+                    assertNull(getStore(kafkaStreams1, storeQueryParam2).get(key));
                     final InvalidStateStoreException exception =
                         assertThrows(InvalidStateStoreException.class, () -> getStore(kafkaStreams2, storeQueryParam2).get(key));
-                    assertThat(
-                        exception.getMessage(),
-                        containsString("The specified partition 1 for store source-table does not exist.")
-                    );
+                    assertTrue(exception.getMessage().contains("The specified partition 1 for store source-table does not exist."));
                 }
                 return true;
             } catch (final InvalidStateStoreException exception) {
@@ -287,7 +275,7 @@ public class StoreQueryIntegrationTest {
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
 
         final QueryableStoreType<ReadOnlyKeyValueStore<Integer, Integer>> queryableStoreType = keyValueStore();
 
@@ -321,7 +309,7 @@ public class StoreQueryIntegrationTest {
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1
                 .queryMetadataForKey(TABLE_NAME, key, new FixedPartitionPartitioner<>(0));
 
@@ -354,8 +342,8 @@ public class StoreQueryIntegrationTest {
         final ReadOnlyKeyValueStore<Integer, Integer> store4 = getStore(kafkaStreams2, otherParam);
 
         // Assert that
-        assertThat(store3.get(key), is(nullValue()));
-        assertThat(store4.get(key), is(nullValue()));
+        assertNull(store3.get(key));
+        assertNull(store4.get(key));
     }
 
     @ParameterizedTest
@@ -381,13 +369,13 @@ public class StoreQueryIntegrationTest {
 
         startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
 
-        assertThat(kafkaStreams1.metadataForLocalThreads().size(), greaterThan(1));
-        assertThat(kafkaStreams2.metadataForLocalThreads().size(), greaterThan(1));
+        assertTrue(kafkaStreams1.metadataForLocalThreads().size() > 1);
+        assertTrue(kafkaStreams2.metadataForLocalThreads().size() > 1);
 
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new IntegerSerializer());
 
         //key belongs to this partition
@@ -419,8 +407,8 @@ public class StoreQueryIntegrationTest {
         final ReadOnlyKeyValueStore<Integer, Integer> store4 = getStore(kafkaStreams2, otherParam);
 
         // Assert that
-        assertThat(store3.get(key), is(nullValue()));
-        assertThat(store4.get(key), is(nullValue()));
+        assertNull(store3.get(key));
+        assertNull(store4.get(key));
     }
 
     @ParameterizedTest
@@ -454,13 +442,13 @@ public class StoreQueryIntegrationTest {
         kafkaStreams2.start(builder2A.build());
         waitForApplicationState(kafkaStreamsList, State.RUNNING, Duration.ofSeconds(60));
 
-        assertThat(kafkaStreams1.metadataForLocalThreads().size(), greaterThan(1));
-        assertThat(kafkaStreams2.metadataForLocalThreads().size(), greaterThan(1));
+        assertTrue(kafkaStreams1.metadataForLocalThreads().size() > 1);
+        assertTrue(kafkaStreams2.metadataForLocalThreads().size() > 1);
 
         produceValueRange(key, 0, batch1NumMessages);
 
         // Assert that all messages in the first batch were processed in a timely manner
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
         final KeyQueryMetadata keyQueryMetadata = kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new IntegerSerializer(), topologyA);
 
         //key belongs to this partition
@@ -492,8 +480,8 @@ public class StoreQueryIntegrationTest {
         final ReadOnlyKeyValueStore<Integer, Integer> store4 = getStore(kafkaStreams2, otherParam);
 
         // Assert that
-        assertThat(store3.get(key), is(nullValue()));
-        assertThat(store4.get(key), is(nullValue()));
+        assertNull(store3.get(key));
+        assertNull(store4.get(key));
     }
 
     @ParameterizedTest
@@ -516,7 +504,7 @@ public class StoreQueryIntegrationTest {
         startApplicationAndWaitUntilRunning(singletonList(kafkaStreams1), Duration.ofSeconds(60));
         //Add thread
         final Optional<String> streamThread = kafkaStreams1.addStreamThread();
-        assertThat(streamThread.isPresent(), is(true));
+        assertTrue(streamThread.isPresent());
         until(() -> kafkaStreams1.state().isRunningOrRebalancing());
 
         produceValueRange(key, 0, batch1NumMessages);
@@ -524,7 +512,7 @@ public class StoreQueryIntegrationTest {
         produceValueRange(key3, 0, batch1NumMessages);
 
         // Assert that all messages in the batches were processed in a timely manner
-        assertThat(semaphore.tryAcquire(3 * batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(3 * batch1NumMessages, 60, TimeUnit.SECONDS));
 
         until(() -> KafkaStreams.State.RUNNING.equals(kafkaStreams1.state()));
         until(() -> {
@@ -532,9 +520,9 @@ public class StoreQueryIntegrationTest {
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
 
             try {
-                assertThat(store1.get(key), is(notNullValue()));
-                assertThat(store1.get(key2), is(notNullValue()));
-                assertThat(store1.get(key3), is(notNullValue()));
+                assertNotNull(store1.get(key));
+                assertNotNull(store1.get(key2));
+                assertNotNull(store1.get(key3));
                 return true;
             } catch (final InvalidStateStoreException exception) {
                 verifyRetriableException(exception);
@@ -544,7 +532,7 @@ public class StoreQueryIntegrationTest {
         });
 
         final Optional<String> removedThreadName = kafkaStreams1.removeStreamThread();
-        assertThat(removedThreadName.isPresent(), is(true));
+        assertTrue(removedThreadName.isPresent());
         until(() -> kafkaStreams1.state().isRunningOrRebalancing());
 
         until(() -> KafkaStreams.State.RUNNING.equals(kafkaStreams1.state()));
@@ -553,9 +541,9 @@ public class StoreQueryIntegrationTest {
             final ReadOnlyKeyValueStore<Integer, Integer> store1 = getStore(TABLE_NAME, kafkaStreams1, queryableStoreType);
 
             try {
-                assertThat(store1.get(key), is(notNullValue()));
-                assertThat(store1.get(key2), is(notNullValue()));
-                assertThat(store1.get(key3), is(notNullValue()));
+                assertNotNull(store1.get(key));
+                assertNotNull(store1.get(key2));
+                assertNotNull(store1.get(key3));
                 return true;
             } catch (final InvalidStateStoreException exception) {
                 verifyRetriableException(exception);
@@ -594,28 +582,20 @@ public class StoreQueryIntegrationTest {
         startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams1), Duration.ofSeconds(60));
         produceValueRange(key, 0, batch1NumMessages);
 
-        assertThat(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS), is(equalTo(true)));
+        assertTrue(semaphore.tryAcquire(batch1NumMessages, 60, TimeUnit.SECONDS));
 
         assertThrows(IllegalArgumentException.class, () -> kafkaStreams1.queryMetadataForKey(TABLE_NAME, key, new BroadcastingPartitioner()));
     }
 
 
-    private Matcher<String> retriableException() {
-        return is(
-            anyOf(
-                containsString("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING"),
-                containsString("The state store, source-table, may have migrated to another instance"),
-                containsString("Cannot get state store source-table because the stream thread is STARTING, not RUNNING"),
-                containsString("The specified partition 1 for store source-table does not exist.")
-            )
-        );
-    }
-
     private void verifyRetriableException(final Exception exception) {
-        assertThat(
-            "Unexpected exception thrown while getting the value from store.",
-            exception.getMessage(),
-            retriableException()
+        final String message = exception.getMessage();
+        assertTrue(
+            message.contains("Cannot get state store source-table because the stream thread is PARTITIONS_ASSIGNED, not RUNNING")
+                || message.contains("The state store, source-table, may have migrated to another instance")
+                || message.contains("Cannot get state store source-table because the stream thread is STARTING, not RUNNING")
+                || message.contains("The specified partition 1 for store source-table does not exist."),
+            "Unexpected exception thrown while getting the value from store."
         );
     }
 

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUncaughtExceptionHandlerIntegrationTest.java
@@ -81,8 +81,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.pu
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.utils.TestUtils.waitForApplicationState;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("integration")
@@ -169,7 +168,7 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
             produceMessages(NOW, inputTopic, "A");
             waitForApplicationState(Collections.singletonList(kafkaStreams), KafkaStreams.State.ERROR, DEFAULT_DURATION);
 
-            assertThat(processorValueCollector.size(), equalTo(1));
+            assertEquals(1, processorValueCollector.size());
         }
     }
 
@@ -261,7 +260,7 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
             produceMessages(NOW, inputTopic2, "A");
             waitForApplicationState(Collections.singletonList(kafkaStreams), KafkaStreams.State.ERROR, DEFAULT_DURATION);
 
-            assertThat(processorValueCollector.size(), equalTo(1));
+            assertEquals(1, processorValueCollector.size());
         }
     }
 
@@ -377,9 +376,10 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
             produceMessages(NOW, inputTopic, "A");
             waitForApplicationState(asList(kafkaStreams1, kafkaStreams2), KafkaStreams.State.ERROR, DEFAULT_DURATION);
 
-            assertThat(processorValueCollector.size(), equalTo(1));
-            assertThat("Shutdown warning log message should be exported exactly once",
-                    logCaptureAppender.getMessages("WARN").stream().filter(msg -> msg.contains("Detected that shutdown was requested")).count(), equalTo(1L));
+            assertEquals(1, processorValueCollector.size());
+            assertEquals(1L,
+                logCaptureAppender.getMessages("WARN").stream().filter(msg -> msg.contains("Detected that shutdown was requested")).count(),
+                "Shutdown warning log message should be exported exactly once");
         }
     }
 
@@ -401,8 +401,8 @@ public class StreamsUncaughtExceptionHandlerIntegrationTest {
             kafkaStreams.close();
             waitForApplicationState(Collections.singletonList(kafkaStreams), KafkaStreams.State.NOT_RUNNING, DEFAULT_DURATION);
 
-            assertThat("All initial threads have failed and the replacement thread had processed on record",
-                processorValueCollector.size(), equalTo(numThreads + 1));
+            assertEquals(numThreads + 1, processorValueCollector.size(),
+                "All initial threads have failed and the replacement thread had processed on record");
         }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/StreamsUpgradeTestIntegrationTest.java
@@ -39,8 +39,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.test.TestUtils.retryOnExceptionWithTimeout;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -83,23 +82,23 @@ public class StreamsUpgradeTestIntegrationTest {
         final AtomicInteger usedVersion4 = new AtomicInteger();
         final KafkaStreams kafkaStreams4 = buildFutureStreams(usedVersion4);
         startSync(kafkaStreams4);
-        assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION));
+        assertEquals(LATEST_SUPPORTED_VERSION, usedVersion4.get());
 
         // second roll
         kafkaStreams2.close();
         final AtomicInteger usedVersion5 = new AtomicInteger();
         final KafkaStreams kafkaStreams5 = buildFutureStreams(usedVersion5);
         startSync(kafkaStreams5);
-        assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION));
+        assertEquals(LATEST_SUPPORTED_VERSION, usedVersion5.get());
 
         // third roll, upgrade complete
         kafkaStreams3.close();
         final AtomicInteger usedVersion6 = new AtomicInteger();
         final KafkaStreams kafkaStreams6 = buildFutureStreams(usedVersion6);
         startSync(kafkaStreams6);
-        retryOnExceptionWithTimeout(() -> assertThat(usedVersion6.get(), is(LATEST_SUPPORTED_VERSION + 1)));
-        retryOnExceptionWithTimeout(() -> assertThat(usedVersion5.get(), is(LATEST_SUPPORTED_VERSION + 1)));
-        retryOnExceptionWithTimeout(() -> assertThat(usedVersion4.get(), is(LATEST_SUPPORTED_VERSION + 1)));
+        retryOnExceptionWithTimeout(() -> assertEquals(LATEST_SUPPORTED_VERSION + 1, usedVersion6.get()));
+        retryOnExceptionWithTimeout(() -> assertEquals(LATEST_SUPPORTED_VERSION + 1, usedVersion5.get()));
+        retryOnExceptionWithTimeout(() -> assertEquals(LATEST_SUPPORTED_VERSION + 1, usedVersion4.get()));
 
         kafkaStreams4.close(Duration.ZERO);
         kafkaStreams5.close(Duration.ZERO);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
@@ -75,9 +75,7 @@ import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.qu
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords;
 import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -189,7 +187,7 @@ public class SuppressionDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k3", 1L, scaledTime(3L))
                 )
             );
-            assertThat(eventCount.get(), is(0));
+            assertEquals(0, eventCount.get());
 
             // flush two of the first three events out.
             produceSynchronouslyToPartitionZero(
@@ -206,7 +204,7 @@ public class SuppressionDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k5", 1L, scaledTime(5L))
                 )
             );
-            assertThat(eventCount.get(), is(2));
+            assertEquals(2, eventCount.get());
             verifyOutput(
                 outputSuppressed,
                 asList(
@@ -220,7 +218,7 @@ public class SuppressionDurabilityIntegrationTest {
 
             // restart the driver
             driver.close();
-            assertThat(driver.state(), is(KafkaStreams.State.NOT_RUNNING));
+            assertEquals(KafkaStreams.State.NOT_RUNNING, driver.state());
             driver = getStartedStreams(streamsConfig, builder, false);
 
 
@@ -241,8 +239,8 @@ public class SuppressionDurabilityIntegrationTest {
                     new KeyValueTimestamp<>("k8", 1L, scaledTime(8L))
                 )
             );
-            assertThat("suppress has apparently produced some duplicates. There should only be 5 output events.",
-                       eventCount.get(), is(5));
+            assertEquals(5, eventCount.get(),
+                "suppress has apparently produced some duplicates. There should only be 5 output events.");
 
             verifyOutput(
                 outputSuppressed,
@@ -283,7 +281,7 @@ public class SuppressionDurabilityIntegrationTest {
                 @Override
                 public void process(final Record<String, Long> record) {
                     try {
-                        assertThat(context.recordMetadata().get().topic(), equalTo(topic));
+                        assertEquals(topic, context.recordMetadata().get().topic());
                     } catch (final Throwable e) {
                         firstException.compareAndSet(null, e);
                         LOG.error("Validation Failed", e);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -45,7 +45,6 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -78,10 +77,8 @@ import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxBytes;
 import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords;
 import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 @Timeout(600)
@@ -160,8 +157,8 @@ public class SuppressionIntegrationTest {
             );
             final boolean rawRecords = waitForAnyRecord(outputRaw);
             final boolean suppressedRecords = waitForAnyRecord(outputSuppressed);
-            assertThat(rawRecords, Matchers.is(true));
-            assertThat(suppressedRecords, is(true));
+            assertTrue(rawRecords);
+            assertTrue(suppressedRecords);
         } finally {
             driver.close();
             quietlyCleanStateAfterTest(CLUSTER, driver);
@@ -214,8 +211,8 @@ public class SuppressionIntegrationTest {
             );
             final boolean rawRecords = waitForAnyRecord(outputRaw);
             final boolean suppressedRecords = waitForAnyRecord(outputSuppressed);
-            assertThat(rawRecords, Matchers.is(true));
-            assertThat(suppressedRecords, is(true));
+            assertTrue(rawRecords);
+            assertTrue(suppressedRecords);
         } finally {
             driver.close();
             quietlyCleanStateAfterTest(CLUSTER, driver);
@@ -388,10 +385,10 @@ public class SuppressionIntegrationTest {
             final boolean suppressedRecords = waitForAnyRecord(outputSuppressed);
             final Properties config = CLUSTER.getLogConfig(changeLog);
 
-            assertThat(config.getProperty("retention.ms"), is(logConfig.get("retention.ms")));
-            assertThat(CLUSTER.getAllTopicsInCluster(), hasItem(changeLog));
-            assertThat(rawRecords, Matchers.is(true));
-            assertThat(suppressedRecords, is(true));
+            assertEquals(logConfig.get("retention.ms"), config.getProperty("retention.ms"));
+            assertTrue(CLUSTER.getAllTopicsInCluster().contains(changeLog));
+            assertTrue(rawRecords);
+            assertTrue(suppressedRecords);
         } finally {
             driver.close();
             quietlyCleanStateAfterTest(CLUSTER, driver);
@@ -446,9 +443,9 @@ public class SuppressionIntegrationTest {
             final boolean rawRecords = waitForAnyRecord(outputRaw);
             final boolean suppressedRecords = waitForAnyRecord(outputSuppressed);
 
-            assertThat(CLUSTER.getAllTopicsInCluster(), hasItem(changeLog));
-            assertThat(rawRecords, Matchers.is(true));
-            assertThat(suppressedRecords, is(true));
+            assertTrue(CLUSTER.getAllTopicsInCluster().contains(changeLog));
+            assertTrue(rawRecords);
+            assertTrue(suppressedRecords);
         } finally {
             driver.close();
             quietlyCleanStateAfterTest(CLUSTER, driver);
@@ -508,9 +505,9 @@ public class SuppressionIntegrationTest {
                 .filter(s -> s.contains("KTABLE-SUPPRESS"))
                 .collect(Collectors.toSet());
 
-            assertThat(suppressChangeLog, is(empty()));
-            assertThat(rawRecords, Matchers.is(true));
-            assertThat(suppressedRecords, is(true));
+            assertTrue(suppressChangeLog.isEmpty());
+            assertTrue(rawRecords);
+            assertTrue(suppressedRecords);
         } finally {
             driver.close();
             quietlyCleanStateAfterTest(CLUSTER, driver);

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -51,10 +51,9 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 @Tag("integration")
 @Timeout(600)
@@ -134,7 +133,7 @@ public class TaskAssignorIntegrationTest {
             final Field delegate = KafkaConsumer.class.getDeclaredField("delegate");
             delegate.setAccessible(true);
             final Consumer<?, ?> consumer = (Consumer<?, ?>)  delegate.get(parentConsumer);
-            assertThat(consumer, instanceOf(ClassicKafkaConsumer.class));
+            assertInstanceOf(ClassicKafkaConsumer.class, consumer);
 
             final Field assignors = ClassicKafkaConsumer.class.getDeclaredField("assignors");
             assignors.setAccessible(true);
@@ -155,12 +154,12 @@ public class TaskAssignorIntegrationTest {
                 (Supplier<LegacyTaskAssignor>) taskAssignorSupplierField.get(streamsPartitionAssignor);
             final LegacyTaskAssignor taskAssignor = taskAssignorSupplier.get();
 
-            assertThat(configs.numStandbyReplicas(), is(5));
-            assertThat(configs.acceptableRecoveryLag(), is(6L));
-            assertThat(configs.maxWarmupReplicas(), is(7));
-            assertThat(configs.probingRebalanceIntervalMs(), is(480000L));
-            assertThat(actualAssignmentListener, sameInstance(configuredAssignmentListener));
-            assertThat(taskAssignor, instanceOf(MyLegacyTaskAssignor.class));
+            assertEquals(5, configs.numStandbyReplicas());
+            assertEquals(6L, configs.acceptableRecoveryLag());
+            assertEquals(7, configs.maxWarmupReplicas());
+            assertEquals(480000L, configs.probingRebalanceIntervalMs());
+            assertSame(configuredAssignmentListener, actualAssignmentListener);
+            assertInstanceOf(MyLegacyTaskAssignor.class, taskAssignor);
         }
     }
 }

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -54,8 +54,7 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 @Timeout(600)
@@ -116,7 +115,7 @@ public class TaskMetadataIntegrationTest {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
-            assertThat(taskMetadata.committedOffsets().size(), equalTo(1));
+            assertEquals(1, taskMetadata.committedOffsets().size());
             final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
 
             produceMessages(0L, inputTopic, "test");
@@ -142,7 +141,7 @@ public class TaskMetadataIntegrationTest {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
-            assertThat(taskMetadata.endOffsets().size(), equalTo(1));
+            assertEquals(1, taskMetadata.endOffsets().size());
             final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
             commit.set(false);
 
@@ -151,7 +150,7 @@ public class TaskMetadataIntegrationTest {
                 TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
                 process.set(true);
             }
-            assertThat(taskMetadata.endOffsets().get(topicPartition), equalTo(9L));
+            assertEquals(9L, taskMetadata.endOffsets().get(topicPartition));
 
         } catch (final Exception e) {
             e.printStackTrace();

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TimeWindowedKStreamIntegrationTest.java
@@ -77,8 +77,7 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"unchecked"})
@@ -214,7 +213,7 @@ public class TimeWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     @ParameterizedTest
@@ -291,7 +290,7 @@ public class TimeWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     @ParameterizedTest
@@ -390,7 +389,7 @@ public class TimeWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
 
         // Leave the group on close so the immediate restart below does not have to wait for the
         // previous member to be evicted via session timeout (~45s) before its rebalance completes.
@@ -438,7 +437,7 @@ public class TimeWindowedKStreamIntegrationTest {
             );
         }
 
-        assertThat(windowedMessages, is(expectResult));
+        assertEquals(expectResult, windowedMessages);
     }
 
     @ParameterizedTest

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/VersionedKeyValueStoreIntegrationTest.java
@@ -80,8 +80,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.kafka.streams.utils.TestUtils.safeUniqueTestName;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
 public class VersionedKeyValueStoreIntegrationTest {
@@ -176,7 +175,7 @@ public class VersionedKeyValueStoreIntegrationTest {
 
         for (final KeyValue<Integer, Integer> receivedRecord : receivedRecords) {
             // verify zero failed checks for each record
-            assertThat(receivedRecord.value, equalTo(0));
+            assertEquals(0, receivedRecord.value);
         }
     }
 
@@ -215,8 +214,8 @@ public class VersionedKeyValueStoreIntegrationTest {
         // verify changelog topic properties
         final String changelogTopic = props.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) + "-versioned-store-changelog";
         final Properties changelogTopicConfig = CLUSTER.getLogConfig(changelogTopic);
-        assertThat(changelogTopicConfig.getProperty("cleanup.policy"), equalTo("compact"));
-        assertThat(changelogTopicConfig.getProperty("min.compaction.lag.ms"), equalTo(Long.toString(HISTORY_RETENTION + 24 * 60 * 60 * 1000L)));
+        assertEquals("compact", changelogTopicConfig.getProperty("cleanup.policy"));
+        assertEquals(Long.toString(HISTORY_RETENTION + 24 * 60 * 60 * 1000L), changelogTopicConfig.getProperty("min.compaction.lag.ms"));
     }
 
     @ParameterizedTest
@@ -296,7 +295,7 @@ public class VersionedKeyValueStoreIntegrationTest {
 
         for (final KeyValue<Integer, Integer> receivedRecord : receivedRecords) {
             // verify zero failed checks for each record
-            assertThat(receivedRecord.value, equalTo(0));
+            assertEquals(0, receivedRecord.value);
         }
     }
 
@@ -327,7 +326,7 @@ public class VersionedKeyValueStoreIntegrationTest {
                 .withPartitions(Collections.singleton(0));
         final StateQueryResult<String> result =
             IntegrationTestUtils.iqv2WaitForResult(kafkaStreams, request);
-        assertThat(result.getOnlyPartitionResult().getResult(), equalTo("success"));
+        assertEquals("success", result.getOnlyPartitionResult().getResult());
     }
 
     @Test
@@ -396,7 +395,7 @@ public class VersionedKeyValueStoreIntegrationTest {
 
         for (final KeyValue<Integer, Integer> receivedRecord : receivedRecords) {
             // verify zero failed checks for each record
-            assertThat(receivedRecord.value, equalTo(0));
+            assertEquals(0, receivedRecord.value);
         }
 
         // wipe out state store to trigger restore process on restart
@@ -435,7 +434,7 @@ public class VersionedKeyValueStoreIntegrationTest {
 
         for (final KeyValue<Integer, Integer> receivedRecord : receivedRecords) {
             // verify zero failed checks for each record
-            assertThat(receivedRecord.value, equalTo(0));
+            assertEquals(0, receivedRecord.value);
         }
     }
 


### PR DESCRIPTION
Remove hamcrest from the `org.apache.kafka.streams.integration` package
by migrating its assertions to JUnit.

Reviewers: Ken Huang <s7133700@gmail.com>
