### PR TITLE
KAFKA-21029: [1/2] Remove hamcrest from org.apache.kafka.streams.state.internals package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractDualSchemaRocksDBSegmentedBytesStoreTest.java
@@ -57,7 +57,6 @@ import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,13 +80,9 @@ import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -967,7 +962,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             bytesStore.putIndex(serializedKey1, new byte[0]);
 
             byte[] value = bytesStore.getIndex(serializedKey1);
-            assertThat(Bytes.wrap(value), is(Bytes.wrap(new byte[0])));
+            assertEquals(Bytes.wrap(new byte[0]), Bytes.wrap(value));
 
             final Bytes serializedKey0 = serializeKey(new Windowed<>(keyA, windows[0]));
             bytesStore.put(serializedKey0, serializeValue(10L));
@@ -1002,7 +997,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
 
             // Dangling index should be deleted.
             value = bytesStore.getIndex(serializedKey1);
-            assertThat(value, is(nullValue()));
+            assertNull(value);
         }
     }
 
@@ -1052,7 +1047,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
             // Index should also be removed.
             final Bytes indexKey = serializeKeyForIndex(new Windowed<>("a", windows[0]));
             final byte[] value = bytesStore.getIndex(indexKey);
-            assertThat(value, is(nullValue()));
+            assertNull(value);
         }
     }
 
@@ -1213,15 +1208,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
 
         bytesStore.init(context, bytesStore);
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0L, 60_000L));
-        assertThat(
-            results,
-            equalTo(
-                asList(
-                    KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
-                    KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
-                )
-            )
-        );
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[3]), 100L)),
+            results);
 
         segments.close();
     }
@@ -1245,15 +1236,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
 
         bytesStore.init(context, bytesStore);
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0L, 60_000L));
-        assertThat(
-            results,
-            equalTo(
-                asList(
-                    KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
-                    KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
-                )
-            )
-        );
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[3]), 100L)),
+            results);
 
         segments.close();
     }
@@ -1369,9 +1356,9 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
         // after restoration, only non expired segments should be returned which is one as actual from is 59001
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.all());
         assertEquals(expected, results);
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions(""), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions(""), hasEntry(0, 3L));
+        assertNotNull(bytesStore.getPosition());
+        assertNotNull(bytesStore.getPosition().getPartitionPositions(""));
+        assertEquals(3L, bytesStore.getPosition().getPartitionPositions("").get(0));
     }
 
     @Test
@@ -1406,11 +1393,11 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
 
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.all());
         assertEquals(expected, results);
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 3L));
-        assertThat(bytesStore.getPosition().getPartitionPositions("B"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("B"), hasEntry(0, 2L));
+        assertNotNull(bytesStore.getPosition());
+        assertNotNull(bytesStore.getPosition().getPartitionPositions("A"));
+        assertEquals(3L, bytesStore.getPosition().getPartitionPositions("A").get(0));
+        assertNotNull(bytesStore.getPosition().getPartitionPositions("B"));
+        assertEquals(2L, bytesStore.getPosition().getPartitionPositions("B").get(0));
     }
 
     @Test
@@ -1450,8 +1437,8 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
 
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.all());
         assertEquals(expected, results);
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
+        assertNotNull(bytesStore.getPosition());
+        assertEquals(2L, bytesStore.getPosition().getPartitionPositions("A").get(0));
     }
 
     @Test
@@ -1472,7 +1459,7 @@ public abstract class AbstractDualSchemaRocksDBSegmentedBytesStoreTest {
         bytesStore = getBytesStore();
         bytesStore.init(context, bytesStore);
         bytesStore.restoreAllInternal(getChangelogRecordsWithoutHeaders());
-        assertThat(bytesStore.getPosition(), is(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), bytesStore.getPosition());
     }
 
     private List<ConsumerRecord<byte[], byte[]>> getChangelogRecords() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -43,9 +43,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -507,7 +504,7 @@ public abstract class AbstractKeyValueStoreTest {
         final List<KeyValue<Integer, String>> expectedReturned =
             Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
 
-        assertThat(allReturned, equalTo(expectedReturned));
+        assertEquals(expectedReturned, allReturned);
     }
 
     @Test
@@ -522,7 +519,7 @@ public abstract class AbstractKeyValueStoreTest {
         final List<KeyValue<Integer, String>> expectedReturned =
             Arrays.asList(KeyValue.pair(2, "two"), KeyValue.pair(1, "one"));
 
-        assertThat(allReturned, equalTo(expectedReturned));
+        assertEquals(expectedReturned, allReturned);
     }
 
     @Test
@@ -583,13 +580,10 @@ public abstract class AbstractKeyValueStoreTest {
             }
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains("Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -601,13 +595,10 @@ public abstract class AbstractKeyValueStoreTest {
             }
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains("Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -619,13 +610,10 @@ public abstract class AbstractKeyValueStoreTest {
             }
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains("Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -637,13 +625,10 @@ public abstract class AbstractKeyValueStoreTest {
             }
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains("Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -56,7 +56,6 @@ import org.apache.kafka.test.MockRecordCollector;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -72,7 +71,6 @@ import org.rocksdb.WriteBatch;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -89,12 +87,9 @@ import java.util.stream.Stream;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -458,15 +453,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         bytesStore.init(context, bytesStore);
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0L, 60_000L));
-        assertThat(
-            results,
-            equalTo(
-                Arrays.asList(
-                    KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
-                    KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
-                )
-            )
-        );
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[3]), 100L)),
+            results);
 
         segments.close();
     }
@@ -492,15 +483,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         bytesStore.init(context, bytesStore);
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.fetch(Bytes.wrap(key.getBytes()), 0L, 60_000L));
-        assertThat(
-            results,
-            equalTo(
-                Arrays.asList(
-                    KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
-                    KeyValue.pair(new Windowed<>(key, windows[3]), 100L)
-                )
-            )
-        );
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>(key, windows[0]), 50L),
+                KeyValue.pair(new Windowed<>(key, windows[3]), 100L)),
+            results);
 
         segments.close();
     }
@@ -681,9 +668,9 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.all());
         assertEquals(expected, results);
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions(""), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions(""), hasEntry(0, 3L));
+        assertNotNull(bytesStore.getPosition());
+        assertNotNull(bytesStore.getPosition().getPartitionPositions(""));
+        assertEquals(3L, bytesStore.getPosition().getPartitionPositions("").get(0));
     }
 
     @ParameterizedTest
@@ -721,11 +708,11 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
 
         final List<KeyValue<Windowed<String>, Long>> results = toListAndCloseIterator(bytesStore.all());
         assertEquals(expected, results);
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 3L));
-        assertThat(bytesStore.getPosition().getPartitionPositions("B"), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("B"), hasEntry(0, 2L));
+        assertNotNull(bytesStore.getPosition());
+        assertNotNull(bytesStore.getPosition().getPartitionPositions("A"));
+        assertEquals(3L, bytesStore.getPosition().getPartitionPositions("A").get(0));
+        assertNotNull(bytesStore.getPosition().getPartitionPositions("B"));
+        assertEquals(2L, bytesStore.getPosition().getPartitionPositions("B").get(0));
     }
 
     @ParameterizedTest
@@ -768,8 +755,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
             assertEquals(expected, results);
         }
-        assertThat(bytesStore.getPosition(), Matchers.notNullValue());
-        assertThat(bytesStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
+        assertNotNull(bytesStore.getPosition());
+        assertEquals(2L, bytesStore.getPosition().getPartitionPositions("A").get(0));
     }
 
     @ParameterizedTest
@@ -792,7 +779,7 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         bytesStore = getBytesStore();
         bytesStore.init(context, bytesStore);
         bytesStore.restoreAllInternal(getChangelogRecordsWithoutHeaders());
-        assertThat(bytesStore.getPosition(), is(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), bytesStore.getPosition());
     }
 
     @ParameterizedTest

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -65,10 +65,6 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.toList;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSet;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -609,43 +605,43 @@ public abstract class AbstractSessionBytesStoreTest {
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("a", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 3L, 5L)));
+            assertEquals(Set.of(1L, 3L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(2L, 4L)));
+            assertEquals(Set.of(2L, 4L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("a", "aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("a", "aa", 10, 0)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(2L)));
+            assertEquals(Set.of(2L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions(null, "aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions("a", null, 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.findSessions(null, null, 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
     }
 
@@ -665,43 +661,43 @@ public abstract class AbstractSessionBytesStoreTest {
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions("a", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 3L, 5L)));
+            assertEquals(Set.of(1L, 3L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions("aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(2L, 4L)));
+            assertEquals(Set.of(2L, 4L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions("a", "aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions("a", "aa", 10, 0)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(2L)));
+            assertEquals(Set.of(2L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions(null, "aa", 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions("a", null, 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
 
         try (final KeyValueIterator<Windowed<String>, Long> iterator =
                  sessionStore.backwardFindSessions(null, null, 0, Long.MAX_VALUE)
         ) {
-            assertThat(valuesToSet(iterator), equalTo(Set.of(1L, 2L, 3L, 4L, 5L)));
+            assertEquals(Set.of(1L, 2L, 3L, 4L, 5L), valuesToSet(iterator));
         }
     }
 
@@ -728,17 +724,17 @@ public abstract class AbstractSessionBytesStoreTest {
 
         final List<String> expectedKey1 = asList("1", "4", "7");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key1, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey1)));
+            assertEquals(new HashSet<>(expectedKey1), valuesToSet(iterator));
         }
 
         final List<String> expectedKey2 = asList("2", "5", "8");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key2, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey2)));
+            assertEquals(new HashSet<>(expectedKey2), valuesToSet(iterator));
         }
 
         final List<String> expectedKey3 = asList("3", "6", "9");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key3, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey3)));
+            assertEquals(new HashSet<>(expectedKey3), valuesToSet(iterator));
         }
 
         sessionStore.close();
@@ -768,17 +764,17 @@ public abstract class AbstractSessionBytesStoreTest {
 
         final List<String> expectedKey1 = asList("7", "4", "1");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key1, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey1)));
+            assertEquals(new HashSet<>(expectedKey1), valuesToSet(iterator));
         }
 
         final List<String> expectedKey2 = asList("8", "5", "2");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key2, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey2)));
+            assertEquals(new HashSet<>(expectedKey2), valuesToSet(iterator));
         }
 
         final List<String> expectedKey3 = asList("9", "6", "3");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key3, 0L, Long.MAX_VALUE)) {
-            assertThat(valuesToSet(iterator), equalTo(new HashSet<>(expectedKey3)));
+            assertEquals(new HashSet<>(expectedKey3), valuesToSet(iterator));
         }
 
         sessionStore.close();
@@ -980,13 +976,11 @@ public abstract class AbstractSessionBytesStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
                     " This may be due to range arguments set in the wrong order, " +
                     "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+                    " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -1031,7 +1025,7 @@ public abstract class AbstractSessionBytesStoreTest {
 
         final Position expected = Position.fromMap(mkMap(mkEntry("", mkMap(mkEntry(0, 3L)))));
         final Position actual = sessionStore.getPosition();
-        assertThat(expected, is(actual));
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -722,19 +721,16 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>(key2, new SessionWindow(8, 100)), "8");
         sessionStore.put(new Windowed<>(key3, new SessionWindow(9, 100)), "9");
 
-        final List<String> expectedKey1 = asList("1", "4", "7");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key1, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey1), valuesToSet(iterator));
+            assertEquals(Set.of("1", "4", "7"), valuesToSet(iterator));
         }
 
-        final List<String> expectedKey2 = asList("2", "5", "8");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key2, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey2), valuesToSet(iterator));
+            assertEquals(Set.of("2", "5", "8"), valuesToSet(iterator));
         }
 
-        final List<String> expectedKey3 = asList("3", "6", "9");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.findSessions(key3, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey3), valuesToSet(iterator));
+            assertEquals(Set.of("3", "6", "9"), valuesToSet(iterator));
         }
 
         sessionStore.close();
@@ -762,19 +758,16 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.put(new Windowed<>(key3, new SessionWindow(9, 100)), "9");
 
 
-        final List<String> expectedKey1 = asList("7", "4", "1");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key1, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey1), valuesToSet(iterator));
+            assertEquals(Set.of("7", "4", "1"), valuesToSet(iterator));
         }
 
-        final List<String> expectedKey2 = asList("8", "5", "2");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key2, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey2), valuesToSet(iterator));
+            assertEquals(Set.of("8", "5", "2"), valuesToSet(iterator));
         }
 
-        final List<String> expectedKey3 = asList("9", "6", "3");
         try (KeyValueIterator<Windowed<Bytes>, String> iterator = sessionStore.backwardFindSessions(key3, 0L, Long.MAX_VALUE)) {
-            assertEquals(new HashSet<>(expectedKey3), valuesToSet(iterator));
+            assertEquals(Set.of("9", "6", "3"), valuesToSet(iterator));
         }
 
         sessionStore.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -61,9 +61,6 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.toSet;
 import static org.apache.kafka.test.StreamsTestUtils.valuesToSetAndCloseIterator;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -861,30 +858,23 @@ public abstract class AbstractWindowBytesStoreTest {
         windowStore.put("a", "0005", 0x7a00000000000000L - 1);
 
         final Set<String> expected = Set.of("0001", "0003", "0005");
-        assertThat(
-            valuesToSetAndCloseIterator(windowStore.fetch("a", ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))),
-            equalTo(expected)
-        );
+        assertEquals(expected, valuesToSetAndCloseIterator(windowStore.fetch("a", ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))));
 
         Set<KeyValue<Windowed<String>, String>> set =
             toSet(windowStore.fetch("a", "a", ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE)));
-        assertThat(
-            set,
-            equalTo(Set.of(
+        assertEquals(
+            Set.of(
                 windowedPair("a", "0001", 0, windowSize),
                 windowedPair("a", "0003", 1, windowSize),
-                windowedPair("a", "0005", 0x7a00000000000000L - 1, windowSize)
-            ))
-        );
+                windowedPair("a", "0005", 0x7a00000000000000L - 1, windowSize)),
+            set);
 
         set = toSet(windowStore.fetch("aa", "aa", ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE)));
-        assertThat(
-            set,
-            equalTo(Set.of(
+        assertEquals(
+            Set.of(
                 windowedPair("aa", "0002", 0, windowSize),
-                windowedPair("aa", "0004", 1, windowSize)
-            ))
-        );
+                windowedPair("aa", "0004", 1, windowSize)),
+            set);
         windowStore.close();
     }
 
@@ -943,20 +933,11 @@ public abstract class AbstractWindowBytesStoreTest {
         windowStore.put(key3, "9", 59999);
 
         final Set<String> expectedKey1 = Set.of("1", "4", "7");
-        assertThat(
-            valuesToSetAndCloseIterator(windowStore.fetch(key1, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))),
-            equalTo(expectedKey1)
-        );
+        assertEquals(expectedKey1, valuesToSetAndCloseIterator(windowStore.fetch(key1, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))));
         final Set<String> expectedKey2 = Set.of("2", "5", "8");
-        assertThat(
-            valuesToSetAndCloseIterator(windowStore.fetch(key2, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))),
-            equalTo(expectedKey2)
-        );
+        assertEquals(expectedKey2, valuesToSetAndCloseIterator(windowStore.fetch(key2, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))));
         final Set<String> expectedKey3 = Set.of("3", "6", "9");
-        assertThat(
-            valuesToSetAndCloseIterator(windowStore.fetch(key3, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))),
-            equalTo(expectedKey3)
-        );
+        assertEquals(expectedKey3, valuesToSetAndCloseIterator(windowStore.fetch(key3, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))));
 
         windowStore.close();
     }
@@ -985,13 +966,11 @@ public abstract class AbstractWindowBytesStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/BlockBasedTableConfigWithAccessibleCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/BlockBasedTableConfigWithAccessibleCacheTest.java
@@ -22,9 +22,8 @@ import org.rocksdb.Cache;
 import org.rocksdb.LRUCache;
 import org.rocksdb.RocksDB;
 
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BlockBasedTableConfigWithAccessibleCacheTest {
 
@@ -37,7 +36,7 @@ public class BlockBasedTableConfigWithAccessibleCacheTest {
         final BlockBasedTableConfigWithAccessibleCache configWithAccessibleCache =
             new BlockBasedTableConfigWithAccessibleCache();
 
-        assertThat(configWithAccessibleCache.blockCache(), nullValue());
+        assertNull(configWithAccessibleCache.blockCache());
     }
 
     @Test
@@ -48,8 +47,8 @@ public class BlockBasedTableConfigWithAccessibleCacheTest {
 
             final BlockBasedTableConfig updatedConfig = configWithAccessibleCache.setBlockCache(blockCache);
 
-            assertThat(updatedConfig, sameInstance(configWithAccessibleCache));
-            assertThat(configWithAccessibleCache.blockCache(), sameInstance(blockCache));
+            assertSame(configWithAccessibleCache, updatedConfig);
+            assertSame(blockCache, configWithAccessibleCache.blockCache());
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/BufferValueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/BufferValueTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -101,7 +100,7 @@ public class BufferValueTest {
         final byte[] bytes = new BufferValue(null, null, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
-        assertThat(withoutContext, is(ByteBuffer.allocate(Integer.BYTES * 3).putInt(-1).putInt(-1).putInt(-1).array()));
+        assertArrayEquals(ByteBuffer.allocate(Integer.BYTES * 3).putInt(-1).putInt(-1).putInt(-1).array(), withoutContext);
     }
 
     @Test
@@ -112,7 +111,7 @@ public class BufferValueTest {
         final byte[] bytes = new BufferValue(priorValue, null, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
-        assertThat(withoutContext, is(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(1).put(priorValue).putInt(-1).putInt(-1).array()));
+        assertArrayEquals(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(1).put(priorValue).putInt(-1).putInt(-1).array(), withoutContext);
     }
 
     @Test
@@ -123,7 +122,7 @@ public class BufferValueTest {
         final byte[] bytes = new BufferValue(null, oldValue, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
-        assertThat(withoutContext, is(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(-1).putInt(1).put(oldValue).putInt(-1).array()));
+        assertArrayEquals(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(-1).putInt(1).put(oldValue).putInt(-1).array(), withoutContext);
     }
 
     @Test
@@ -134,7 +133,7 @@ public class BufferValueTest {
         final byte[] bytes = new BufferValue(null, null, newValue, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
-        assertThat(withoutContext, is(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(-1).putInt(-1).putInt(1).put(newValue).array()));
+        assertArrayEquals(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(-1).putInt(-1).putInt(1).put(newValue).array(), withoutContext);
     }
 
     @Test
@@ -145,7 +144,7 @@ public class BufferValueTest {
         final byte[] bytes = new BufferValue(duplicate, duplicate, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
-        assertThat(withoutContext, is(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(1).put(duplicate).putInt(-2).putInt(-1).array()));
+        assertArrayEquals(ByteBuffer.allocate(Integer.BYTES * 3 + 1).putInt(1).put(duplicate).putInt(-2).putInt(-1).array(), withoutContext);
     }
 
     @Test
@@ -160,7 +159,7 @@ public class BufferValueTest {
         serialValue.position(0);
 
         final BufferValue deserialize = BufferValue.deserialize(serialValue);
-        assertThat(deserialize, is(new BufferValue(priorValue, null, null, context)));
+        assertEquals(new BufferValue(priorValue, null, null, context), deserialize);
     }
 
     @Test
@@ -174,7 +173,7 @@ public class BufferValueTest {
                 .put(serializedContext).putInt(-1).putInt(1).put(oldValue).putInt(-1);
         serialValue.position(0);
 
-        assertThat(BufferValue.deserialize(serialValue), is(new BufferValue(null, oldValue, null, context)));
+        assertEquals(new BufferValue(null, oldValue, null, context), BufferValue.deserialize(serialValue));
     }
 
     @Test
@@ -188,7 +187,7 @@ public class BufferValueTest {
                 .put(serializedContext).putInt(-1).putInt(-1).putInt(1).put(newValue);
         serialValue.position(0);
 
-        assertThat(BufferValue.deserialize(serialValue), is(new BufferValue(null, null, newValue, context)));
+        assertEquals(new BufferValue(null, null, newValue, context), BufferValue.deserialize(serialValue));
     }
 
     @Test
@@ -203,7 +202,7 @@ public class BufferValueTest {
         serialValue.position(0);
 
         final BufferValue bufferValue = BufferValue.deserialize(serialValue);
-        assertThat(bufferValue, is(new BufferValue(duplicate, duplicate, null, context)));
+        assertEquals(new BufferValue(duplicate, duplicate, null, context), bufferValue);
         assertSame(bufferValue.priorValue(), bufferValue.oldValue());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemoryKeyValueStoreTest.java
@@ -56,9 +56,7 @@ import java.util.Map;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -194,8 +192,8 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     public void shouldPutGetToFromCache() {
         store.put(bytesKey("key"), bytesValue("value"));
         store.put(bytesKey("key2"), bytesValue("value2"));
-        assertThat(store.get(bytesKey("key")), equalTo(bytesValue("value")));
-        assertThat(store.get(bytesKey("key2")), equalTo(bytesValue("value2")));
+        assertArrayEquals(bytesValue("value"), store.get(bytesKey("key")));
+        assertArrayEquals(bytesValue("value2"), store.get(bytesKey("key2")));
         // nothing evicted so underlying store should be empty
         assertEquals(2, cache.size());
         assertEquals(0, underlyingStore.approximateNumEntries());
@@ -604,10 +602,10 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
     @Test
     public void shouldPutIfAbsent() {
         store.putIfAbsent(bytesKey("b"), bytesValue("2"));
-        assertThat(store.get(bytesKey("b")), equalTo(bytesValue("2")));
+        assertArrayEquals(bytesValue("2"), store.get(bytesKey("b")));
 
         store.putIfAbsent(bytesKey("b"), bytesValue("3"));
-        assertThat(store.get(bytesKey("b")), equalTo(bytesValue("2")));
+        assertArrayEquals(bytesValue("2"), store.get(bytesKey("b")));
     }
 
     @Test
@@ -616,8 +614,8 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         entries.add(new KeyValue<>(bytesKey("a"), bytesValue("1")));
         entries.add(new KeyValue<>(bytesKey("b"), bytesValue("2")));
         store.putAll(entries);
-        assertThat(store.get(bytesKey("a")), equalTo(bytesValue("1")));
-        assertThat(store.get(bytesKey("b")), equalTo(bytesValue("2")));
+        assertArrayEquals(bytesValue("1"), store.get(bytesKey("a")));
+        assertArrayEquals(bytesValue("2"), store.get(bytesKey("b")));
     }
 
     @Test
@@ -653,14 +651,14 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         store.put(bytesKey("c"), bytesValue("cache-val"));
         assertEquals(0, underlyingStore.approximateNumEntries());
         final ReadOnlyKeyValueStore<Bytes, byte[]> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.get(bytesKey("c")), equalTo(bytesValue("cache-val")));
+        assertArrayEquals(bytesValue("cache-val"), view.get(bytesKey("c")));
     }
 
     @Test
     public void shouldReadUncommittedViewGetFromStoreOnly() {
         underlyingStore.put(bytesKey("s"), bytesValue("store-val"));
         final ReadOnlyKeyValueStore<Bytes, byte[]> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.get(bytesKey("s")), equalTo(bytesValue("store-val")));
+        assertArrayEquals(bytesValue("store-val"), view.get(bytesKey("s")));
     }
 
     @Test
@@ -668,7 +666,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         underlyingStore.put(bytesKey("k"), bytesValue("store-val"));
         store.put(bytesKey("k"), bytesValue("cache-val"));
         final ReadOnlyKeyValueStore<Bytes, byte[]> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.get(bytesKey("k")), equalTo(bytesValue("cache-val")));
+        assertArrayEquals(bytesValue("cache-val"), view.get(bytesKey("k")));
     }
 
     @Test
@@ -757,7 +755,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingKeyValueStore.class);
              final KeyValueIterator<Bytes, byte[]> it = store.range(bytesKey("z"), bytesKey("a"))) {
             assertFalse(it.hasNext());
-            assertThat(appender.getMessages(), hasItem(
+            assertTrue(appender.getMessages().contains(
                 "Returning empty iterator for fetch with invalid key range: from > to. " +
                 "This may be due to range arguments set in the wrong order, " +
                 "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +
@@ -771,7 +769,7 @@ public class CachingInMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(CachingKeyValueStore.class);
              final KeyValueIterator<Bytes, byte[]> it = view.range(bytesKey("z"), bytesKey("a"))) {
             assertFalse(it.hasNext());
-            assertThat(appender.getMessages(), hasItem(
+            assertTrue(appender.getMessages().contains(
                 "Returning empty iterator for fetch with invalid key range: from > to. " +
                 "This may be due to range arguments set in the wrong order, " +
                 "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes. " +

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingInMemorySessionStoreTest.java
@@ -63,9 +63,6 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyWindowedKeyValue;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -458,7 +455,7 @@ public class CachingInMemorySessionStoreTest {
             assertFalse(rangeIter.hasNext());
 
             assertNull(cachingStore.fetchSession(keyA, 0, 0));
-            assertThat(cachingStore.fetchSession(keyB, 0, 0), equalTo("2".getBytes()));
+            assertArrayEquals("2".getBytes(), cachingStore.fetchSession(keyB, 0, 0));
         }
     }
 
@@ -796,15 +793,11 @@ public class CachingInMemorySessionStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem(
-                    "Returning empty iterator for fetch with invalid key range: from > to." +
-                        " This may be due to range arguments set in the wrong order, " +
-                        "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                        " Note that the built-in numerical serdes do not follow this for negative numbers"
-                )
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                    " This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                    " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -819,13 +812,11 @@ public class CachingInMemorySessionStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
                     " This may be due to range arguments set in the wrong order, " +
                     "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+                    " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -65,9 +65,6 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyWindowedKeyValue;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -472,7 +469,7 @@ public class CachingPersistentSessionStoreTest {
         }
 
         assertNull(cachingStore.fetchSession(keyA, 0, 0));
-        assertThat(cachingStore.fetchSession(keyB, 0, 0), equalTo("2".getBytes()));
+        assertArrayEquals("2".getBytes(), cachingStore.fetchSession(keyB, 0, 0));
 
     }
 
@@ -827,15 +824,11 @@ public class CachingPersistentSessionStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem(
-                    "Returning empty iterator for fetch with invalid key range: from > to." +
-                        " This may be due to range arguments set in the wrong order, " +
-                        "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                        " Note that the built-in numerical serdes do not follow this for negative numbers"
-                )
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                    " This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                    " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -850,15 +843,11 @@ public class CachingPersistentSessionStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem(
-                    "Returning empty iterator for fetch with invalid key range: from > to." +
-                        " This may be due to range arguments set in the wrong order, " +
-                        "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                        " Note that the built-in numerical serdes do not follow this for negative numbers"
-                )
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                    " This may be due to range arguments set in the wrong order, " +
+                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                    " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -82,9 +82,6 @@ import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.verifyAllWindowedKeyValues;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyWindowedKeyValue;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -180,7 +177,7 @@ public class CachingPersistentWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(0));
+                    assertEquals(0, count);
                 }
 
                 @Override
@@ -194,7 +191,7 @@ public class CachingPersistentWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(numRecordsProcessed));
+                    assertEquals(numRecordsProcessed, count);
 
                     store.put(record.value(), record.value(), record.timestamp());
 
@@ -250,10 +247,10 @@ public class CachingPersistentWindowStoreTest {
         cachingStore.put(bytesKey("a"), bytesValue("a"), DEFAULT_TIMESTAMP);
         cachingStore.put(bytesKey("b"), bytesValue("b"), DEFAULT_TIMESTAMP);
 
-        assertThat(cachingStore.fetch(bytesKey("a"), 10), equalTo(bytesValue("a")));
-        assertThat(cachingStore.fetch(bytesKey("b"), 10), equalTo(bytesValue("b")));
-        assertThat(cachingStore.fetch(bytesKey("c"), 10), equalTo(null));
-        assertThat(cachingStore.fetch(bytesKey("a"), 0), equalTo(null));
+        assertArrayEquals(bytesValue("a"), cachingStore.fetch(bytesKey("a"), 10));
+        assertArrayEquals(bytesValue("b"), cachingStore.fetch(bytesKey("b"), 10));
+        assertNull(cachingStore.fetch(bytesKey("c"), 10));
+        assertNull(cachingStore.fetch(bytesKey("a"), 0));
 
         try (final WindowStoreIterator<byte[]> a = cachingStore.fetch(bytesKey("a"), ofEpochMilli(10), ofEpochMilli(10));
              final WindowStoreIterator<byte[]> b = cachingStore.fetch(bytesKey("b"), ofEpochMilli(10), ofEpochMilli(10))) {
@@ -308,8 +305,8 @@ public class CachingPersistentWindowStoreTest {
     private void verifyKeyValue(final KeyValue<Long, byte[]> next,
                                 final long expectedKey,
                                 final String expectedValue) {
-        assertThat(next.key, equalTo(expectedKey));
-        assertThat(next.value, equalTo(bytesValue(expectedValue)));
+        assertEquals(expectedKey, next.key);
+        assertArrayEquals(bytesValue(expectedValue), next.value);
     }
 
     private static byte[] bytesValue(final String value) {
@@ -1012,13 +1009,11 @@ public class CachingPersistentWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -1034,13 +1029,11 @@ public class CachingPersistentWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -59,13 +59,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -126,72 +125,72 @@ public class ChangeLoggingKeyValueBytesStoreTest {
     @Test
     public void shouldWriteKeyValueBytesToInnerStoreOnPut() {
         store.put(hi, there);
-        assertThat(inner.get(hi), equalTo(there));
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there));
+        assertArrayEquals(there, inner.get(hi));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there, (byte[]) collector.collected().get(0).value());
     }
 
     @Test
     public void shouldWriteAllKeyValueToInnerStoreOnPutAll() {
         store.putAll(Arrays.asList(KeyValue.pair(hi, there),
                                    KeyValue.pair(hello, world)));
-        assertThat(inner.get(hi), equalTo(there));
-        assertThat(inner.get(hello), equalTo(world));
+        assertArrayEquals(there, inner.get(hi));
+        assertArrayEquals(world, inner.get(hello));
 
-        assertThat(collector.collected().size(), equalTo(2));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there));
-        assertThat(collector.collected().get(1).key(), equalTo(hello));
-        assertThat(collector.collected().get(1).value(), equalTo(world));
+        assertEquals(2, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there, (byte[]) collector.collected().get(0).value());
+        assertEquals(hello, collector.collected().get(1).key());
+        assertArrayEquals(world, (byte[]) collector.collected().get(1).value());
     }
 
     @Test
     public void shouldPropagateDelete() {
         store.put(hi, there);
         store.delete(hi);
-        assertThat(inner.approximateNumEntries(), equalTo(0L));
-        assertThat(inner.get(hi), nullValue());
+        assertEquals(0L, inner.approximateNumEntries());
+        assertNull(inner.get(hi));
     }
 
     @Test
     public void shouldReturnOldValueOnDelete() {
         store.put(hi, there);
-        assertThat(store.delete(hi), equalTo(there));
+        assertArrayEquals(there, store.delete(hi));
     }
 
     @Test
     public void shouldLogKeyNullOnDelete() {
         store.put(hi, there);
-        assertThat(store.delete(hi), equalTo(there));
+        assertArrayEquals(there, store.delete(hi));
 
-        assertThat(collector.collected().size(), equalTo(2));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there));
-        assertThat(collector.collected().get(1).key(), equalTo(hi));
-        assertThat(collector.collected().get(1).value(), nullValue());
+        assertEquals(2, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there, (byte[]) collector.collected().get(0).value());
+        assertEquals(hi, collector.collected().get(1).key());
+        assertNull(collector.collected().get(1).value());
     }
 
     @Test
     public void shouldWriteToInnerOnPutIfAbsentNoPreviousValue() {
         store.putIfAbsent(hi, there);
-        assertThat(inner.get(hi), equalTo(there));
+        assertArrayEquals(there, inner.get(hi));
     }
 
     @Test
     public void shouldNotWriteToInnerOnPutIfAbsentWhenValueForKeyExists() {
         store.put(hi, there);
         store.putIfAbsent(hi, world);
-        assertThat(inner.get(hi), equalTo(there));
+        assertArrayEquals(there, inner.get(hi));
     }
 
     @Test
     public void shouldWriteToChangelogOnPutIfAbsentWhenNoPreviousValue() {
         store.putIfAbsent(hi, there);
 
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there, (byte[]) collector.collected().get(0).value());
     }
 
     @Test
@@ -199,26 +198,26 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         store.put(hi, there);
         store.putIfAbsent(hi, world);
 
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there, (byte[]) collector.collected().get(0).value());
     }
 
     @Test
     public void shouldReturnCurrentValueOnPutIfAbsent() {
         store.put(hi, there);
-        assertThat(store.putIfAbsent(hi, world), equalTo(there));
+        assertArrayEquals(there, store.putIfAbsent(hi, world));
     }
 
     @Test
     public void shouldReturnNullOnPutIfAbsentWhenNoPreviousValue() {
-        assertThat(store.putIfAbsent(hi, there), is(nullValue()));
+        assertNull(store.putIfAbsent(hi, there));
     }
 
     @Test
     public void shouldReturnValueOnGetWhenExists() {
         store.put(hello, world);
-        assertThat(store.get(hello), equalTo(world));
+        assertArrayEquals(world, store.get(hello));
     }
 
     @Test
@@ -239,14 +238,14 @@ public class ChangeLoggingKeyValueBytesStoreTest {
             }
         }
 
-        assertThat(numberOfKeysReturned, is(1));
-        assertThat(keys, is(Collections.singletonList(hi)));
-        assertThat(values, is(Collections.singletonList(Bytes.wrap(there))));
+        assertEquals(1, numberOfKeysReturned);
+        assertEquals(List.of(hi), keys);
+        assertEquals(List.of(Bytes.wrap(there)), values);
     }
 
     @Test
     public void shouldReturnNullOnGetWhenDoesntExist() {
-        assertThat(store.get(hello), is(nullValue()));
+        assertNull(store.get(hello));
     }
 
     @Test
@@ -254,16 +253,16 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         context.setRecordContext(new ProcessorRecordContext(-1, INPUT_OFFSET, INPUT_PARTITION, INPUT_TOPIC_NAME, new RecordHeaders()));
         context.setTime(1L);
         store.put(hi, there);
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).headers(), is(notNullValue()));
+        assertEquals(1, collector.collected().size());
+        assertNotNull(collector.collected().get(0).headers());
         final Header versionHeader = collector.collected().get(0).headers().lastHeader(ChangelogRecordDeserializationHelper.CHANGELOG_VERSION_HEADER_KEY);
-        assertThat(versionHeader, is(notNullValue()));
-        assertThat(versionHeader.equals(ChangelogRecordDeserializationHelper.CHANGELOG_VERSION_HEADER_RECORD_CONSISTENCY), is(true));
+        assertNotNull(versionHeader);
+        assertTrue(versionHeader.equals(ChangelogRecordDeserializationHelper.CHANGELOG_VERSION_HEADER_RECORD_CONSISTENCY));
         final Header vectorHeader = collector.collected().get(0).headers().lastHeader(ChangelogRecordDeserializationHelper.CHANGELOG_POSITION_HEADER_KEY);
-        assertThat(vectorHeader, is(notNullValue()));
+        assertNotNull(vectorHeader);
         final Position position = PositionSerde.deserialize(ByteBuffer.wrap(vectorHeader.value()));
-        assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), is(notNullValue()));
-        assertThat(position.getPartitionPositions(INPUT_TOPIC_NAME), hasEntry(0, 100L));
+        assertNotNull(position.getPartitionPositions(INPUT_TOPIC_NAME));
+        assertEquals(100L, position.getPartitionPositions(INPUT_TOPIC_NAME).get(0));
 
     }
 
@@ -275,7 +274,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         final ReadOnlyKeyValueStore<Bytes, byte[]> view = mock(ReadOnlyKeyValueStore.class);
         when(innerMock.readOnly(IsolationLevel.READ_UNCOMMITTED)).thenReturn(view);
 
-        assertThat(outer.readOnly(IsolationLevel.READ_UNCOMMITTED), sameInstance(view));
+        assertSame(view, outer.readOnly(IsolationLevel.READ_UNCOMMITTED));
         verify(innerMock).readOnly(IsolationLevel.READ_UNCOMMITTED);
     }
 
@@ -287,7 +286,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
         final ReadOnlyKeyValueStore<Bytes, byte[]> view = mock(ReadOnlyKeyValueStore.class);
         when(innerMock.readOnly(IsolationLevel.READ_COMMITTED)).thenReturn(view);
 
-        assertThat(outer.readOnly(IsolationLevel.READ_COMMITTED), sameInstance(view));
+        assertSame(view, outer.readOnly(IsolationLevel.READ_COMMITTED));
         verify(innerMock).readOnly(IsolationLevel.READ_COMMITTED);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStoreTest.java
@@ -41,8 +41,7 @@ import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -199,12 +198,12 @@ public class ChangeLoggingSessionBytesStoreTest {
     @Test
     public void shouldDelegateReadOnlyUncommittedToInner() {
         when(inner.readOnly(IsolationLevel.READ_UNCOMMITTED)).thenReturn(view);
-        assertThat(store.readOnly(IsolationLevel.READ_UNCOMMITTED), sameInstance(view));
+        assertSame(view, store.readOnly(IsolationLevel.READ_UNCOMMITTED));
     }
 
     @Test
     public void shouldDelegateReadOnlyCommittedToInner() {
         when(inner.readOnly(IsolationLevel.READ_COMMITTED)).thenReturn(view);
-        assertThat(store.readOnly(IsolationLevel.READ_COMMITTED), sameInstance(view));
+        assertSame(view, store.readOnly(IsolationLevel.READ_COMMITTED));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingTimestampedKeyValueBytesStoreTest.java
@@ -39,10 +39,9 @@ import org.mockito.quality.Strictness;
 
 import java.util.Arrays;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -98,19 +97,19 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
     public void shouldWriteKeyValueBytesToInnerStoreOnPut() {
         store.put(hi, rawThere);
 
-        assertThat(root.get(hi), equalTo(rawThere));
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there.value()));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(there.timestamp()));
+        assertArrayEquals(rawThere, root.get(hi));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there.value(), (byte[]) collector.collected().get(0).value());
+        assertEquals(there.timestamp(), collector.collected().get(0).timestamp());
     }
 
     @Test
     public void shouldWriteAllKeyValueToInnerStoreOnPutAll() {
         store.putAll(Arrays.asList(KeyValue.pair(hi, rawThere),
                                    KeyValue.pair(hello, rawWorld)));
-        assertThat(root.get(hi), equalTo(rawThere));
-        assertThat(root.get(hello), equalTo(rawWorld));
+        assertArrayEquals(rawThere, root.get(hi));
+        assertArrayEquals(rawWorld, root.get(hello));
     }
 
     @Test
@@ -118,27 +117,27 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
         store.putAll(Arrays.asList(KeyValue.pair(hi, rawThere),
                                    KeyValue.pair(hello, rawWorld)));
 
-        assertThat(collector.collected().size(), equalTo(2));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there.value()));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(there.timestamp()));
-        assertThat(collector.collected().get(1).key(), equalTo(hello));
-        assertThat(collector.collected().get(1).value(), equalTo(world.value()));
-        assertThat(collector.collected().get(1).timestamp(), equalTo(world.timestamp()));
+        assertEquals(2, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there.value(), (byte[]) collector.collected().get(0).value());
+        assertEquals(there.timestamp(), collector.collected().get(0).timestamp());
+        assertEquals(hello, collector.collected().get(1).key());
+        assertArrayEquals(world.value(), (byte[]) collector.collected().get(1).value());
+        assertEquals(world.timestamp(), collector.collected().get(1).timestamp());
     }
 
     @Test
     public void shouldPropagateDelete() {
         store.put(hi, rawThere);
         store.delete(hi);
-        assertThat(root.approximateNumEntries(), equalTo(0L));
-        assertThat(root.get(hi), nullValue());
+        assertEquals(0L, root.approximateNumEntries());
+        assertNull(root.get(hi));
     }
 
     @Test
     public void shouldReturnOldValueOnDelete() {
         store.put(hi, rawThere);
-        assertThat(store.delete(hi), equalTo(rawThere));
+        assertArrayEquals(rawThere, store.delete(hi));
     }
 
     @Test
@@ -146,37 +145,37 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
         store.put(hi, rawThere);
         store.delete(hi);
 
-        assertThat(collector.collected().size(), equalTo(2));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there.value()));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(there.timestamp()));
-        assertThat(collector.collected().get(1).key(), equalTo(hi));
-        assertThat(collector.collected().get(1).value(), nullValue());
-        assertThat(collector.collected().get(1).timestamp(), equalTo(0L));
+        assertEquals(2, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there.value(), (byte[]) collector.collected().get(0).value());
+        assertEquals(there.timestamp(), collector.collected().get(0).timestamp());
+        assertEquals(hi, collector.collected().get(1).key());
+        assertNull(collector.collected().get(1).value());
+        assertEquals(0L, collector.collected().get(1).timestamp());
 
     }
 
     @Test
     public void shouldWriteToInnerOnPutIfAbsentNoPreviousValue() {
         store.putIfAbsent(hi, rawThere);
-        assertThat(root.get(hi), equalTo(rawThere));
+        assertArrayEquals(rawThere, root.get(hi));
     }
 
     @Test
     public void shouldNotWriteToInnerOnPutIfAbsentWhenValueForKeyExists() {
         store.put(hi, rawThere);
         store.putIfAbsent(hi, rawWorld);
-        assertThat(root.get(hi), equalTo(rawThere));
+        assertArrayEquals(rawThere, root.get(hi));
     }
 
     @Test
     public void shouldWriteToChangelogOnPutIfAbsentWhenNoPreviousValue() {
         store.putIfAbsent(hi, rawThere);
 
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there.value()));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(there.timestamp()));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there.value(), (byte[]) collector.collected().get(0).value());
+        assertEquals(there.timestamp(), collector.collected().get(0).timestamp());
     }
 
     @Test
@@ -184,31 +183,31 @@ public class ChangeLoggingTimestampedKeyValueBytesStoreTest {
         store.put(hi, rawThere);
         store.putIfAbsent(hi, rawWorld);
 
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(hi));
-        assertThat(collector.collected().get(0).value(), equalTo(there.value()));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(there.timestamp()));
+        assertEquals(1, collector.collected().size());
+        assertEquals(hi, collector.collected().get(0).key());
+        assertArrayEquals(there.value(), (byte[]) collector.collected().get(0).value());
+        assertEquals(there.timestamp(), collector.collected().get(0).timestamp());
     }
 
     @Test
     public void shouldReturnCurrentValueOnPutIfAbsent() {
         store.put(hi, rawThere);
-        assertThat(store.putIfAbsent(hi, rawWorld), equalTo(rawThere));
+        assertArrayEquals(rawThere, store.putIfAbsent(hi, rawWorld));
     }
 
     @Test
     public void shouldReturnNullOnPutIfAbsentWhenNoPreviousValue() {
-        assertThat(store.putIfAbsent(hi, rawThere), is(nullValue()));
+        assertNull(store.putIfAbsent(hi, rawThere));
     }
 
     @Test
     public void shouldReturnValueOnGetWhenExists() {
         store.put(hello, rawWorld);
-        assertThat(store.get(hello), equalTo(rawWorld));
+        assertArrayEquals(rawWorld, store.get(hello));
     }
 
     @Test
     public void shouldReturnNullOnGetWhenDoesntExist() {
-        assertThat(store.get(hello), is(nullValue()));
+        assertNull(store.get(hello));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingVersionedKeyValueBytesStoreTest.java
@@ -42,9 +42,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -114,12 +114,12 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
 
         final long validTo = store.put(rawKey, rawBytes(value), timestamp);
 
-        assertThat(validTo, equalTo(PUT_RETURN_CODE_VALID_TO_UNDEFINED));
-        assertThat(inner.get(rawKey), equalTo(rawValueAndTimestamp(value, timestamp)));
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
-        assertThat(collector.collected().get(0).value(), equalTo(rawBytes(value)));
-        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+        assertEquals(PUT_RETURN_CODE_VALID_TO_UNDEFINED, validTo);
+        assertArrayEquals(rawValueAndTimestamp(value, timestamp), inner.get(rawKey));
+        assertEquals(1, collector.collected().size());
+        assertEquals(rawKey, collector.collected().get(0).key());
+        assertArrayEquals(rawBytes(value), (byte[]) collector.collected().get(0).value());
+        assertEquals(timestamp, collector.collected().get(0).timestamp());
     }
 
     @Test
@@ -128,16 +128,16 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         final long timestamp = 10L;
         // put initial record to inner, so that later verification confirms that store.put() has an effect
         inner.put(rawKey, rawBytes("foo"), timestamp - 1);
-        assertThat(inner.get(rawKey), equalTo(rawValueAndTimestamp("foo", timestamp - 1)));
+        assertArrayEquals(rawValueAndTimestamp("foo", timestamp - 1), inner.get(rawKey));
 
         final long validTo = store.put(rawKey, null, timestamp);
 
-        assertThat(validTo, equalTo(PUT_RETURN_CODE_VALID_TO_UNDEFINED));
-        assertThat(inner.get(rawKey), nullValue());
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
-        assertThat(collector.collected().get(0).value(), nullValue());
-        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+        assertEquals(PUT_RETURN_CODE_VALID_TO_UNDEFINED, validTo);
+        assertNull(inner.get(rawKey));
+        assertEquals(1, collector.collected().size());
+        assertEquals(rawKey, collector.collected().get(0).key());
+        assertNull(collector.collected().get(0).value());
+        assertEquals(timestamp, collector.collected().get(0).timestamp());
     }
 
     @Test
@@ -147,16 +147,16 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         final byte[] rawValueAndTimestamp = rawValueAndTimestamp("foo", timestamp - 1);
         // put initial record to inner, so that later verification confirms that store.put() has an effect
         inner.put(rawKey, rawBytes("foo"), timestamp - 1);
-        assertThat(inner.get(rawKey), equalTo(rawValueAndTimestamp));
+        assertArrayEquals(rawValueAndTimestamp, inner.get(rawKey));
 
         final byte[] result = store.delete(rawKey, timestamp);
 
-        assertThat(result, equalTo(rawValueAndTimestamp));
-        assertThat(inner.get(rawKey), nullValue());
-        assertThat(collector.collected().size(), equalTo(1));
-        assertThat(collector.collected().get(0).key(), equalTo(rawKey));
-        assertThat(collector.collected().get(0).value(), nullValue());
-        assertThat(collector.collected().get(0).timestamp(), equalTo(timestamp));
+        assertArrayEquals(rawValueAndTimestamp, result);
+        assertNull(inner.get(rawKey));
+        assertEquals(1, collector.collected().size());
+        assertEquals(rawKey, collector.collected().get(0).key());
+        assertNull(collector.collected().get(0).value());
+        assertEquals(timestamp, collector.collected().get(0).timestamp());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         assertThrows(UnsupportedOperationException.class, () -> inner.delete(rawKey));
 
         assertThrows(UnsupportedOperationException.class, () -> store.delete(rawKey));
-        assertThat(collector.collected().size(), equalTo(0));
+        assertEquals(0, collector.collected().size());
     }
 
     @Test
@@ -176,7 +176,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         assertThrows(UnsupportedOperationException.class, () -> inner.putAll(entries));
 
         assertThrows(UnsupportedOperationException.class, () -> store.putAll(entries));
-        assertThat(collector.collected().size(), equalTo(0));
+        assertEquals(0, collector.collected().size());
     }
 
     @Test
@@ -186,7 +186,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         assertThrows(UnsupportedOperationException.class, () -> inner.putIfAbsent(rawKey, rawValue));
 
         assertThrows(UnsupportedOperationException.class, () -> store.putIfAbsent(rawKey, rawValue));
-        assertThat(collector.collected().size(), equalTo(0));
+        assertEquals(0, collector.collected().size());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         final Bytes rawKey = Bytes.wrap(rawBytes("k"));
         inner.put(rawKey, rawBytes("v"), 8L);
 
-        assertThat(store.get(rawKey), equalTo(rawValueAndTimestamp("v", 8L)));
+        assertArrayEquals(rawValueAndTimestamp("v", 8L), store.get(rawKey));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class ChangeLoggingVersionedKeyValueBytesStoreTest {
         final Bytes rawKey = Bytes.wrap(rawBytes("k"));
         inner.put(rawKey, rawBytes("v"), 8L);
 
-        assertThat(store.get(rawKey, 10L), equalTo(rawValueAndTimestamp("v", 8L)));
+        assertArrayEquals(rawValueAndTimestamp("v", 8L), store.get(rawKey, 10L));
     }
 
     private static byte[] rawBytes(final String s) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingWindowBytesStoreTest.java
@@ -40,8 +40,7 @@ import org.mockito.quality.Strictness;
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -133,13 +132,13 @@ public class ChangeLoggingWindowBytesStoreTest {
     @Test
     public void shouldDelegateReadOnlyUncommittedToInner() {
         when(inner.readOnly(IsolationLevel.READ_UNCOMMITTED)).thenReturn(view);
-        assertThat(store.readOnly(IsolationLevel.READ_UNCOMMITTED), sameInstance(view));
+        assertSame(view, store.readOnly(IsolationLevel.READ_UNCOMMITTED));
     }
 
     @Test
     public void shouldDelegateReadOnlyCommittedToInner() {
         when(inner.readOnly(IsolationLevel.READ_COMMITTED)).thenReturn(view);
-        assertThat(store.readOnly(IsolationLevel.READ_COMMITTED), sameInstance(view));
+        assertSame(view, store.readOnly(IsolationLevel.READ_COMMITTED));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -38,8 +38,6 @@ import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -149,9 +147,11 @@ public class CompositeReadOnlySessionStoreTest {
         underlyingSessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 0L);
         secondUnderlying.put(new Windowed<>("b", new SessionWindow(0, 0)), 10L);
         final List<KeyValue<Windowed<String>, Long>> results = StreamsTestUtils.toListAndCloseIterator(sessionStore.fetch("a", "b"));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
-            KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
+                KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L)),
+            results);
     }
 
     @Test
@@ -162,9 +162,11 @@ public class CompositeReadOnlySessionStoreTest {
         underlyingSessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 0L);
         secondUnderlying.put(new Windowed<>("b", new SessionWindow(0, 0)), 10L);
         final List<KeyValue<Windowed<String>, Long>> results = StreamsTestUtils.toListAndCloseIterator(sessionStore.fetch(null, "b"));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
-            KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
+                KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L)),
+            results);
     }
 
     @Test
@@ -175,9 +177,11 @@ public class CompositeReadOnlySessionStoreTest {
         underlyingSessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 0L);
         secondUnderlying.put(new Windowed<>("b", new SessionWindow(0, 0)), 10L);
         final List<KeyValue<Windowed<String>, Long>> results = StreamsTestUtils.toListAndCloseIterator(sessionStore.fetch("a", null));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
-            KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
+                KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L)),
+            results);
     }
 
     @Test
@@ -188,9 +192,11 @@ public class CompositeReadOnlySessionStoreTest {
         underlyingSessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 0L);
         secondUnderlying.put(new Windowed<>("b", new SessionWindow(0, 0)), 10L);
         final List<KeyValue<Windowed<String>, Long>> results = StreamsTestUtils.toListAndCloseIterator(sessionStore.fetch(null, null));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
-            KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new SessionWindow(0, 0)), 0L),
+                KeyValue.pair(new Windowed<>("b", new SessionWindow(0, 0)), 10L)),
+            results);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -34,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -43,11 +42,10 @@ import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -351,9 +349,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.fetch("a", "b", ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -365,9 +365,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.fetch("b", null, ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
+                KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c")),
+            results);
     }
 
     @Test
@@ -379,9 +381,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.fetch(null, "b", ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -393,10 +397,12 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.fetch(null, null, ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"),
+                KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c")),
+            results);
     }
 
     @Test
@@ -408,9 +414,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.backwardFetch("b", null, ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -422,10 +430,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.backwardFetch(null, "b", ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")
-            )));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -437,10 +446,12 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("c", "c", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.backwardFetch(null, null, ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("c", new TimeWindow(10, 10 + WINDOW_SIZE)), "c"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -451,9 +462,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.backwardFetch("a", "b", ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -462,10 +475,10 @@ public class CompositeReadOnlyWindowStoreTest {
         stubProviderTwo.addStore(storeName, secondUnderlyingWindowStore);
         underlyingWindowStore.put("a", "a", 0L);
         secondUnderlyingWindowStore.put("b", "b", 10L);
-        assertThat(windowStore.fetch("a", 0L), equalTo("a"));
-        assertThat(windowStore.fetch("b", 10L), equalTo("b"));
-        assertThat(windowStore.fetch("c", 10L), equalTo(null));
-        assertThat(windowStore.fetch("a", 10L), equalTo(null));
+        assertEquals("a", windowStore.fetch("a", 0L));
+        assertEquals("b", windowStore.fetch("b", 10L));
+        assertNull(windowStore.fetch("c", 10L));
+        assertNull(windowStore.fetch("a", 10L));
     }
 
     @Test
@@ -476,9 +489,11 @@ public class CompositeReadOnlyWindowStoreTest {
         underlyingWindowStore.put("a", "a", 0L);
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results = StreamsTestUtils.toListAndCloseIterator(windowStore.all());
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -489,9 +504,11 @@ public class CompositeReadOnlyWindowStoreTest {
         underlyingWindowStore.put("a", "a", 0L);
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results = StreamsTestUtils.toListAndCloseIterator(windowStore.backwardAll());
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -503,9 +520,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.fetchAll(ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test
@@ -517,9 +536,11 @@ public class CompositeReadOnlyWindowStoreTest {
         secondUnderlying.put("b", "b", 10L);
         final List<KeyValue<Windowed<String>, String>> results =
             StreamsTestUtils.toListAndCloseIterator(windowStore.backwardFetchAll(ofEpochMilli(0), ofEpochMilli(10)));
-        assertThat(results, equalTo(Arrays.asList(
-            KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
-            KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b"))));
+        assertEquals(
+            List.of(
+                KeyValue.pair(new Windowed<>("a", new TimeWindow(0, WINDOW_SIZE)), "a"),
+                KeyValue.pair(new Windowed<>("b", new TimeWindow(10, 10 + WINDOW_SIZE)), "b")),
+            results);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
@@ -25,14 +25,12 @@ import org.apache.kafka.test.GenericInMemoryKeyValueStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -82,7 +80,7 @@ public class FilteredCacheIteratorTest {
     @Test
     public void shouldAllowEntryMatchingHasNextCondition() {
         final List<KeyValue<Bytes, LRUCacheEntry>> keyValues = toListAndCloseIterator(allIterator);
-        assertThat(keyValues, equalTo(entries));
+        assertEquals(entries, keyValues);
     }
 
     @Test
@@ -90,7 +88,7 @@ public class FilteredCacheIteratorTest {
         while (allIterator.hasNext()) {
             final Bytes nextKey = allIterator.peekNextKey();
             final KeyValue<Bytes, LRUCacheEntry> next = allIterator.next();
-            assertThat(next.key, equalTo(nextKey));
+            assertEquals(nextKey, next.key);
         }
     }
 
@@ -99,7 +97,7 @@ public class FilteredCacheIteratorTest {
         while (allIterator.hasNext()) {
             final KeyValue<Bytes, LRUCacheEntry> peeked = allIterator.peekNext();
             final KeyValue<Bytes, LRUCacheEntry> next = allIterator.next();
-            assertThat(peeked, equalTo(next));
+            assertEquals(next, peeked);
         }
     }
 
@@ -113,7 +111,7 @@ public class FilteredCacheIteratorTest {
     @Test
     public void shouldFilterEntriesNotMatchingHasNextCondition() {
         final List<KeyValue<Bytes, LRUCacheEntry>> keyValues = toListAndCloseIterator(firstEntryIterator);
-        assertThat(keyValues, equalTo(Collections.singletonList(firstEntry)));
+        assertEquals(List.of(firstEntry), keyValues);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericKeyValueIteratorFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericKeyValueIteratorFacadeTest.java
@@ -30,8 +30,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,8 +58,8 @@ public class GenericKeyValueIteratorFacadeTest {
             .thenReturn(KeyValue.pair("key1", ValueAndTimestamp.make("value1", 42L)))
             .thenReturn(KeyValue.pair("key2", ValueAndTimestamp.make("value2", 84L)));
 
-        assertThat(facade.next(), is(KeyValue.pair("key1", "value1")));
-        assertThat(facade.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", "value1"), facade.next());
+        assertEquals(KeyValue.pair("key2", "value2"), facade.next());
     }
 
     @Test
@@ -69,8 +68,8 @@ public class GenericKeyValueIteratorFacadeTest {
             .thenReturn(KeyValue.pair("key1", null))
             .thenReturn(KeyValue.pair("key2", ValueAndTimestamp.make("value2", 42L)));
 
-        assertThat(facade.next(), is(KeyValue.pair("key1", null)));
-        assertThat(facade.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", null), facade.next());
+        assertEquals(KeyValue.pair("key2", "value2"), facade.next());
     }
 
     @Test
@@ -85,7 +84,7 @@ public class GenericKeyValueIteratorFacadeTest {
     public void shouldDelegatePeekNextKey() {
         when(mockedInnerIterator.peekNextKey()).thenReturn("peekedKey", (String) null);
 
-        assertThat(facade.peekNextKey(), is("peekedKey"));
+        assertEquals("peekedKey", facade.peekNextKey());
         assertNull(facade.peekNextKey());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericReadOnlyKeyValueStoreFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericReadOnlyKeyValueStoreFacadeTest.java
@@ -33,8 +33,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +61,7 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.get("unknownKey"))
             .thenReturn(null);
 
-        assertThat(facade.get("key"), is("value"));
+        assertEquals("value", facade.get("key"));
         assertNull(facade.get("unknownKey"));
     }
 
@@ -77,7 +76,7 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedHeadersStore.get("unknownKey"))
             .thenReturn(null);
 
-        assertThat(facade.get("key"), is("value"));
+        assertEquals("value", facade.get("key"));
         assertNull(facade.get("unknownKey"));
     }
 
@@ -94,8 +93,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
             .thenReturn(null);
 
         final ValueAndTimestamp<String> result = facade.get("key");
-        assertThat(result.value(), is("value"));
-        assertThat(result.timestamp(), is(42L));
+        assertEquals("value", result.value());
+        assertEquals(42L, result.timestamp());
         assertNull(facade.get("unknownKey"));
     }
 
@@ -111,8 +110,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.range("key1", "key2")).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.range("key1", "key2");
-        assertThat(iterator.next(), is(KeyValue.pair("key1", "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", "value1"), iterator.next());
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
     }
 
     @Test
@@ -127,8 +126,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.reverseRange("key1", "key2")).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.reverseRange("key1", "key2");
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair("key1", "value1")));
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
+        assertEquals(KeyValue.pair("key1", "value1"), iterator.next());
     }
 
     @Test
@@ -144,8 +143,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.prefixScan("key", stringSerializer)).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.prefixScan("key", stringSerializer);
-        assertThat(iterator.next(), is(KeyValue.pair("key1", "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", "value1"), iterator.next());
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
     }
 
     @Test
@@ -160,8 +159,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.all()).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.all();
-        assertThat(iterator.next(), is(KeyValue.pair("key1", "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", "value1"), iterator.next());
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
     }
 
     @Test
@@ -176,8 +175,8 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.reverseAll()).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.reverseAll();
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair("key1", "value1")));
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
+        assertEquals(KeyValue.pair("key1", "value1"), iterator.next());
     }
 
     @Test
@@ -188,7 +187,7 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
 
         when(mockedTimestampedStore.approximateNumEntries()).thenReturn(42L);
 
-        assertThat(facade.approximateNumEntries(), is(42L));
+        assertEquals(42L, facade.approximateNumEntries());
     }
 
     @Test
@@ -203,7 +202,7 @@ public class GenericReadOnlyKeyValueStoreFacadeTest {
         when(mockedTimestampedStore.all()).thenReturn(mockedTimestampedIterator);
 
         final KeyValueIterator<String, String> iterator = facade.all();
-        assertThat(iterator.next(), is(KeyValue.pair("key1", null)));
-        assertThat(iterator.next(), is(KeyValue.pair("key2", "value2")));
+        assertEquals(KeyValue.pair("key1", null), iterator.next());
+        assertEquals(KeyValue.pair("key2", "value2"), iterator.next());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericReadOnlyWindowStoreFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericReadOnlyWindowStoreFacadeTest.java
@@ -36,8 +36,7 @@ import org.mockito.quality.Strictness;
 import java.time.Instant;
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +68,7 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         when(mockedTimestampedStore.fetch("unknownKey", 21L))
             .thenReturn(null);
 
-        assertThat(facade.fetch("key1", 21L), is("value1"));
+        assertEquals("value1", facade.fetch("key1", 21L));
         assertNull(facade.fetch("unknownKey", 21L));
     }
 
@@ -84,7 +83,7 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         when(mockedHeadersStore.fetch("unknownKey", 21L))
             .thenReturn(null);
 
-        assertThat(facade.fetch("key1", 21L), is("value1"));
+        assertEquals("value1", facade.fetch("key1", 21L));
         assertNull(facade.fetch("unknownKey", 21L));
     }
 
@@ -99,8 +98,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
             .thenReturn(ValueTimestampHeaders.make("value1", 42L, new RecordHeaders()));
 
         final ValueAndTimestamp<String> result = facade.fetch("key1", 21L);
-        assertThat(result.value(), is("value1"));
-        assertThat(result.timestamp(), is(42L));
+        assertEquals("value1", result.value());
+        assertEquals(42L, result.timestamp());
     }
 
     @Test
@@ -118,8 +117,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final WindowStoreIterator<String> iterator =
             facade.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(21L, "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
+        assertEquals(KeyValue.pair(21L, "value1"), iterator.next());
+        assertEquals(KeyValue.pair(42L, "value2"), iterator.next());
     }
 
     @Test
@@ -137,8 +136,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final WindowStoreIterator<String> iterator =
             facade.backwardFetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair(21L, "value1")));
+        assertEquals(KeyValue.pair(42L, "value2"), iterator.next());
+        assertEquals(KeyValue.pair(21L, "value1"), iterator.next());
     }
 
     @Test
@@ -160,8 +159,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             facade.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
     }
 
     @Test
@@ -183,8 +182,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             facade.backwardFetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
     }
 
     @Test
@@ -206,8 +205,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             facade.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
     }
 
     @Test
@@ -229,8 +228,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             facade.backwardFetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
     }
 
     @Test
@@ -250,8 +249,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
 
         final KeyValueIterator<Windowed<String>, String> iterator = facade.all();
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
     }
 
     @Test
@@ -271,8 +270,8 @@ public class GenericReadOnlyWindowStoreFacadeTest {
 
         final KeyValueIterator<Windowed<String>, String> iterator = facade.backwardAll();
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1"), iterator.next());
     }
 
     @Test
@@ -290,7 +289,7 @@ public class GenericReadOnlyWindowStoreFacadeTest {
         final WindowStoreIterator<String> iterator =
             facade.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
-        assertThat(iterator.next(), is(KeyValue.pair(21L, null)));
-        assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
+        assertEquals(KeyValue.pair(21L, null), iterator.next());
+        assertEquals(KeyValue.pair(42L, "value2"), iterator.next());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericWindowStoreIteratorFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GenericWindowStoreIteratorFacadeTest.java
@@ -31,8 +31,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,8 +59,8 @@ public class GenericWindowStoreIteratorFacadeTest {
             .thenReturn(KeyValue.pair(100L, ValueAndTimestamp.make("value1", 42L)))
             .thenReturn(KeyValue.pair(200L, ValueAndTimestamp.make("value2", 84L)));
 
-        assertThat(facade.next(), is(KeyValue.pair(100L, "value1")));
-        assertThat(facade.next(), is(KeyValue.pair(200L, "value2")));
+        assertEquals(KeyValue.pair(100L, "value1"), facade.next());
+        assertEquals(KeyValue.pair(200L, "value2"), facade.next());
     }
 
     @Test
@@ -70,8 +69,8 @@ public class GenericWindowStoreIteratorFacadeTest {
             .thenReturn(KeyValue.pair(100L, null))
             .thenReturn(KeyValue.pair(200L, ValueAndTimestamp.make("value2", 42L)));
 
-        assertThat(facade.next(), is(KeyValue.pair(100L, null)));
-        assertThat(facade.next(), is(KeyValue.pair(200L, "value2")));
+        assertEquals(KeyValue.pair(100L, null), facade.next());
+        assertEquals(KeyValue.pair(200L, "value2"), facade.next());
     }
 
     @Test
@@ -86,7 +85,7 @@ public class GenericWindowStoreIteratorFacadeTest {
     public void shouldDelegatePeekNextKey() {
         when(mockedInnerIterator.peekNextKey()).thenReturn(100L, (Long) null);
 
-        assertThat(facade.peekNextKey(), is(100L));
+        assertEquals(100L, facade.peekNextKey());
         assertNull(facade.peekNextKey());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -55,10 +55,9 @@ import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -184,9 +183,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -197,9 +196,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-kv-store", QueryableStoreTypes.timestampedKeyValueStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, instanceOf(TimestampedKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertInstanceOf(TimestampedKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -218,9 +217,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-kv-store", QueryableStoreTypes.keyValueStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -231,9 +230,9 @@ public class GlobalStateStoreProviderTest {
                 provider.stores("w-store", QueryableStoreTypes.windowStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStore);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -244,9 +243,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-w-store", QueryableStoreTypes.timestampedWindowStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(TimestampedWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(TimestampedWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -265,9 +264,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-w-store", QueryableStoreTypes.windowStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStore);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -278,8 +277,8 @@ public class GlobalStateStoreProviderTest {
                 provider.stores("s-store", QueryableStoreTypes.sessionStore());
         assertEquals(1, stores.size());
         for (final ReadOnlySessionStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlySessionStore.class));
-            assertThat(store, not(instanceOf(SessionStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlySessionStore.class, store);
+            assertFalse(store instanceof SessionStoreWithHeaders);
         }
     }
 
@@ -290,8 +289,8 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-kv-store-with-headers", QueryableStoreTypes.timestampedKeyValueStoreWithHeaders());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, ValueTimestampHeaders<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, instanceOf(TimestampedKeyValueStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertInstanceOf(TimestampedKeyValueStoreWithHeaders.class, store);
         }
     }
 
@@ -302,8 +301,8 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-kv-store-with-headers", QueryableStoreTypes.timestampedKeyValueStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyKeyValueStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyKeyValueStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -314,9 +313,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-kv-store-with-headers", QueryableStoreTypes.keyValueStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyKeyValueStore<String, String> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyKeyValueStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyKeyValueStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -343,8 +342,8 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-w-store-with-headers", QueryableStoreTypes.timestampedWindowStoreWithHeaders());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(TimestampedWindowStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(TimestampedWindowStoreWithHeaders.class, store);
         }
     }
 
@@ -355,9 +354,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-w-store-with-headers", QueryableStoreTypes.timestampedWindowStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(GenericReadOnlyWindowStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(GenericReadOnlyWindowStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -368,9 +367,9 @@ public class GlobalStateStoreProviderTest {
             provider.stores("ts-w-store-with-headers", QueryableStoreTypes.windowStore());
         assertEquals(1, stores.size());
         for (final ReadOnlyWindowStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(GenericReadOnlyWindowStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(GenericReadOnlyWindowStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -397,8 +396,8 @@ public class GlobalStateStoreProviderTest {
             provider.stores("s-store-with-headers", QueryableStoreTypes.sessionStoreWithHeaders());
         assertEquals(1, stores.size());
         for (final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlySessionStore.class));
-            assertThat(store, instanceOf(SessionStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlySessionStore.class, store);
+            assertInstanceOf(SessionStoreWithHeaders.class, store);
         }
     }
 
@@ -409,8 +408,8 @@ public class GlobalStateStoreProviderTest {
             provider.stores("s-store-with-headers", QueryableStoreTypes.sessionStore());
         assertEquals(1, stores.size());
         for (final ReadOnlySessionStore<String, String> store : stores) {
-            assertThat(store, instanceOf(ReadOnlySessionStore.class));
-            assertThat(store, not(instanceOf(SessionStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlySessionStore.class, store);
+            assertFalse(store instanceof SessionStoreWithHeaders);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -59,12 +59,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -128,7 +126,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         assertEquals(3, driver.sizeOf(store));
 
-        assertThat(store.get(0), nullValue());
+        assertNull(store.get(0));
     }
 
 
@@ -169,10 +167,10 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
             }
         }
 
-        assertThat(numberOfKeysReturned, is(3));
-        assertThat(valuesWithPrefix.get(0), is("f"));
-        assertThat(valuesWithPrefix.get(1), is("d"));
-        assertThat(valuesWithPrefix.get(2), is("b"));
+        assertEquals(3, numberOfKeysReturned);
+        assertEquals("f", valuesWithPrefix.get(0));
+        assertEquals("d", valuesWithPrefix.get(1));
+        assertEquals("b", valuesWithPrefix.get(2));
     }
 
     @Test
@@ -201,7 +199,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
                 numberOfKeysReturned++;
             }
 
-            assertThat(numberOfKeysReturned, is(1));
+            assertEquals(1, numberOfKeysReturned);
         }
     }
 
@@ -234,8 +232,8 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
             }
         }
 
-        assertThat(numberOfKeysReturned, is(1));
-        assertThat(valuesWithPrefix.get(0), is("a"));
+        assertEquals(1, numberOfKeysReturned);
+        assertEquals("a", valuesWithPrefix.get(0));
     }
 
     @Test
@@ -262,7 +260,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
             }
         }
 
-        assertThat(numberOfKeysReturned, is(0));
+        assertEquals(0, numberOfKeysReturned);
     }
 
     @SuppressWarnings("resource")
@@ -471,7 +469,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
             assertArrayEquals(bytesValue("v1-staged"), uncommitted.get(k1));
             assertArrayEquals(bytesValue("v2-staged"), uncommitted.get(k2));
             assertArrayEquals(bytesValue("v1"), committed.get(k1));
-            assertThat(committed.get(k2), nullValue());
+            assertNull(committed.get(k2));
 
             try (KeyValueIterator<Bytes, byte[]> it = committed.all()) {
                 final List<String> keys = new ArrayList<>();
@@ -502,7 +500,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
             txnStore.delete(k);
 
-            assertThat(txnStore.readOnly(IsolationLevel.READ_UNCOMMITTED).get(k), nullValue());
+            assertNull(txnStore.readOnly(IsolationLevel.READ_UNCOMMITTED).get(k));
             assertArrayEquals(bytesValue("v"), txnStore.readOnly(IsolationLevel.READ_COMMITTED).get(k));
         } finally {
             txnStore.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -42,8 +42,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,10 +70,10 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
         store.putAll(kvPairs);
 
-        assertThat(store.approximateNumEntries(), equalTo(3L));
+        assertEquals(3L, store.approximateNumEntries());
 
         for (final KeyValue<Integer, String> kvPair : kvPairs) {
-            assertThat(store.get(kvPair.key), equalTo(kvPair.value));
+            assertEquals(kvPair.value, store.get(kvPair.key));
         }
     }
 
@@ -94,10 +92,10 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
         store.putAll(updatedKvPairs);
 
-        assertThat(store.approximateNumEntries(), equalTo(3L));
+        assertEquals(3L, store.approximateNumEntries());
         
         for (final KeyValue<Integer, String> kvPair : updatedKvPairs) {
-            assertThat(store.get(kvPair.key), equalTo(kvPair.value));
+            assertEquals(kvPair.value, store.get(kvPair.key));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueChangeBufferTest.java
@@ -24,10 +24,9 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InMemoryTimeOrderedKeyValueChangeBufferTest {
 
@@ -50,8 +49,8 @@ public class InMemoryTimeOrderedKeyValueChangeBufferTest {
             new InMemoryTimeOrderedKeyValueChangeBuffer.Builder<>(null, null, null)
                 .withLoggingEnabled(logConfig);
 
-        assertThat(builder.logConfig(), is(singletonMap("min.insync.replicas", expect)));
-        assertThat(builder.loggingEnabled(), is(true));
+        assertEquals(Map.of("min.insync.replicas", expect), builder.logConfig());
+        assertTrue(builder.loggingEnabled());
     }
 
     @Test
@@ -60,7 +59,7 @@ public class InMemoryTimeOrderedKeyValueChangeBufferTest {
             = new InMemoryTimeOrderedKeyValueChangeBuffer.Builder<>(null, null, null)
                 .withLoggingDisabled();
 
-        assertThat(builder.logConfig(), is(emptyMap()));
-        assertThat(builder.loggingEnabled(), is(false));
+        assertTrue(builder.logConfig().isEmpty());
+        assertFalse(builder.loggingEnabled());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
@@ -38,9 +38,7 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -84,11 +82,11 @@ public class KeyValueSegmentTest {
             new KeyValueSegment("someOtherName", "someOtherName", 0L, Position.emptyPosition(), metricsRecorder);
         final KeyValueSegment segmentDifferentId = new KeyValueSegment("anyName", "anyName", 1L, Position.emptyPosition(), metricsRecorder);
 
-        assertThat(segment, equalTo(segment));
-        assertThat(segment, equalTo(segmentSameId));
-        assertThat(segment, not(equalTo(segmentDifferentId)));
-        assertThat(segment, not(equalTo(null)));
-        assertThat(segment, not(equalTo("anyName")));
+        assertTrue(segment.equals(segment));
+        assertTrue(segment.equals(segmentSameId));
+        assertFalse(segment.equals(segmentDifferentId));
+        assertFalse(segment.equals(null));
+        assertFalse(segment.equals("anyName"));
 
         segment.close();
     }
@@ -114,13 +112,13 @@ public class KeyValueSegmentTest {
         final KeyValueSegment segment2 = new KeyValueSegment("b", "B", 100L, Position.emptyPosition(), metricsRecorder);
         final KeyValueSegment segment3 = new KeyValueSegment("c", "A", 0L, Position.emptyPosition(), metricsRecorder);
 
-        assertThat(segment1.compareTo(segment1), equalTo(0));
-        assertThat(segment1.compareTo(segment2), equalTo(-1));
-        assertThat(segment2.compareTo(segment1), equalTo(1));
-        assertThat(segment1.compareTo(segment3), equalTo(1));
-        assertThat(segment3.compareTo(segment1), equalTo(-1));
-        assertThat(segment2.compareTo(segment3), equalTo(1));
-        assertThat(segment3.compareTo(segment2), equalTo(-1));
+        assertEquals(0, segment1.compareTo(segment1));
+        assertEquals(-1, segment1.compareTo(segment2));
+        assertEquals(1, segment2.compareTo(segment1));
+        assertEquals(1, segment1.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment1));
+        assertEquals(1, segment2.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment2));
 
         segment1.close();
         segment2.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentsTest.java
@@ -25,9 +25,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.SimpleTimeZone;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -316,7 +313,7 @@ public class KeyValueSegmentsTest extends AbstractSegmentsTest<KeyValueSegments>
     public void shouldClearSegmentsOnClose() {
         segments.getOrCreateSegmentIfLive(0, context, -1L);
         segments.close();
-        assertThat(segments.segmentForTimestamp(0), is(nullValue()));
+        assertNull(segments.segmentForTimestamp(0));
     }
 
     private void verifyCorrectSegments(final long first, final int numSegments) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -34,9 +33,8 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -70,16 +68,16 @@ public class KeyValueStoreBuilderTest {
     public void shouldHaveMeteredStoreAsOuterStore() {
         setUp();
         final KeyValueStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredKeyValueStore.class));
+        assertInstanceOf(MeteredKeyValueStore.class, store);
     }
 
     @Test
     public void shouldHaveChangeLoggingStoreByDefault() {
         setUp();
         final KeyValueStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredKeyValueStore.class));
+        assertInstanceOf(MeteredKeyValueStore.class, store);
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingKeyValueBytesStore.class));
+        assertInstanceOf(ChangeLoggingKeyValueBytesStore.class, next);
     }
 
     @Test
@@ -87,7 +85,7 @@ public class KeyValueStoreBuilderTest {
         setUp();
         final KeyValueStore<String, String> store = builder.withLoggingDisabled().build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, CoreMatchers.equalTo(inner));
+        assertEquals(inner, next);
     }
 
     @Test
@@ -95,8 +93,8 @@ public class KeyValueStoreBuilderTest {
         setUp();
         final KeyValueStore<String, String> store = builder.withCachingEnabled().build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredKeyValueStore.class));
-        assertThat(wrapped, instanceOf(CachingKeyValueStore.class));
+        assertInstanceOf(MeteredKeyValueStore.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, wrapped);
     }
 
     @Test
@@ -106,9 +104,9 @@ public class KeyValueStoreBuilderTest {
                 .withLoggingEnabled(Collections.emptyMap())
                 .build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredKeyValueStore.class));
-        assertThat(wrapped, instanceOf(ChangeLoggingKeyValueBytesStore.class));
-        assertThat(((WrappedStateStore) wrapped).wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredKeyValueStore.class, store);
+        assertInstanceOf(ChangeLoggingKeyValueBytesStore.class, wrapped);
+        assertEquals(inner, ((WrappedStateStore) wrapped).wrapped());
     }
 
     @Test
@@ -120,10 +118,10 @@ public class KeyValueStoreBuilderTest {
                 .build();
         final WrappedStateStore caching = (WrappedStateStore) ((WrappedStateStore) store).wrapped();
         final WrappedStateStore changeLogging = (WrappedStateStore) caching.wrapped();
-        assertThat(store, instanceOf(MeteredKeyValueStore.class));
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(changeLogging, instanceOf(ChangeLoggingKeyValueBytesStore.class));
-        assertThat(changeLogging.wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredKeyValueStore.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertInstanceOf(ChangeLoggingKeyValueBytesStore.class, changeLogging);
+        assertEquals(inner, changeLogging.wrapped());
     }
 
     @SuppressWarnings("all")
@@ -148,7 +146,7 @@ public class KeyValueStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
+        assertEquals("storeSupplier's metricsScope can't be null", e.getMessage());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapperTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreWrapperTest.java
@@ -41,10 +41,11 @@ import org.mockito.quality.Strictness;
 import java.util.Map;
 
 import static org.apache.kafka.streams.state.internals.KeyValueStoreWrapper.PUT_RETURN_CODE_IS_LATEST;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithHeadersStore();
         when(headersStore.get(KEY)).thenReturn(VALUE_TIMESTAMP_HEADERS);
 
-        assertThat(wrapper.get(KEY), equalTo(VALUE_TIMESTAMP_HEADERS));
+        assertEquals(VALUE_TIMESTAMP_HEADERS, wrapper.get(KEY));
     }
 
     @Test
@@ -101,7 +102,7 @@ public class KeyValueStoreWrapperTest {
                 VALUE_TIMESTAMP_HEADERS.timestamp())
         );
 
-        assertThat(wrapper.get(KEY), equalTo(VALUE_TIMESTAMP_HEADERS));
+        assertEquals(VALUE_TIMESTAMP_HEADERS, wrapper.get(KEY));
     }
 
     @Test
@@ -109,7 +110,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithHeadersStore();
         when(headersStore.get(KEY)).thenReturn(null);
 
-        assertThat(wrapper.get(KEY), nullValue());
+        assertNull(wrapper.get(KEY));
     }
 
     @Test
@@ -117,7 +118,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithVersionedStore();
         when(versionedStore.get(KEY)).thenReturn(null);
 
-        assertThat(wrapper.get(KEY), nullValue());
+        assertNull(wrapper.get(KEY));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class KeyValueStoreWrapperTest {
 
         final long putReturnCode = wrapper.put(KEY, VALUE_TIMESTAMP_HEADERS.value(), VALUE_TIMESTAMP_HEADERS.timestamp(), VALUE_TIMESTAMP_HEADERS.headers());
 
-        assertThat(putReturnCode, equalTo(PUT_RETURN_CODE_IS_LATEST));
+        assertEquals(PUT_RETURN_CODE_IS_LATEST, putReturnCode);
         verify(headersStore).put(KEY, VALUE_TIMESTAMP_HEADERS);
     }
 
@@ -137,7 +138,7 @@ public class KeyValueStoreWrapperTest {
 
         final long putReturnCode = wrapper.put(KEY, VALUE_TIMESTAMP_HEADERS.value(), VALUE_TIMESTAMP_HEADERS.timestamp(), VALUE_TIMESTAMP_HEADERS.headers());
 
-        assertThat(putReturnCode, equalTo(12L));
+        assertEquals(12L, putReturnCode);
     }
 
     @Test
@@ -146,7 +147,7 @@ public class KeyValueStoreWrapperTest {
 
         final long putReturnCode = wrapper.put(KEY, null, VALUE_TIMESTAMP_HEADERS.timestamp(), VALUE_TIMESTAMP_HEADERS.headers());
 
-        assertThat(putReturnCode, equalTo(PUT_RETURN_CODE_IS_LATEST));
+        assertEquals(PUT_RETURN_CODE_IS_LATEST, putReturnCode);
         verify(headersStore).put(KEY, null);
     }
 
@@ -157,21 +158,21 @@ public class KeyValueStoreWrapperTest {
 
         final long putReturnCode = wrapper.put(KEY, null, VALUE_TIMESTAMP_HEADERS.timestamp(), VALUE_TIMESTAMP_HEADERS.headers());
 
-        assertThat(putReturnCode, equalTo(12L));
+        assertEquals(12L, putReturnCode);
     }
 
     @Test
     public void shouldGetHeadersStore() {
         givenWrapperWithHeadersStore();
 
-        assertThat(wrapper.store(), equalTo(headersStore));
+        assertEquals(headersStore, wrapper.store());
     }
 
     @Test
     public void shouldGetVersionedStore() {
         givenWrapperWithVersionedStore();
 
-        assertThat(wrapper.store(), equalTo(versionedStore));
+        assertEquals(versionedStore, wrapper.store());
     }
 
     @Test
@@ -179,7 +180,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithHeadersStore();
         when(headersStore.name()).thenReturn(STORE_NAME);
 
-        assertThat(wrapper.name(), equalTo(STORE_NAME));
+        assertEquals(STORE_NAME, wrapper.name());
     }
 
     @Test
@@ -187,7 +188,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithVersionedStore();
         when(versionedStore.name()).thenReturn(STORE_NAME);
 
-        assertThat(wrapper.name(), equalTo(STORE_NAME));
+        assertEquals(STORE_NAME, wrapper.name());
     }
 
     @Test
@@ -252,11 +253,11 @@ public class KeyValueStoreWrapperTest {
 
         // test "persistent = true"
         when(headersStore.persistent()).thenReturn(true);
-        assertThat(wrapper.persistent(), equalTo(true));
+        assertTrue(wrapper.persistent());
 
         // test "persistent = false"
         when(headersStore.persistent()).thenReturn(false);
-        assertThat(wrapper.persistent(), equalTo(false));
+        assertFalse(wrapper.persistent());
     }
 
     @Test
@@ -265,11 +266,11 @@ public class KeyValueStoreWrapperTest {
 
         // test "persistent = true"
         when(versionedStore.persistent()).thenReturn(true);
-        assertThat(wrapper.persistent(), equalTo(true));
+        assertTrue(wrapper.persistent());
 
         // test "persistent = false"
         when(versionedStore.persistent()).thenReturn(false);
-        assertThat(wrapper.persistent(), equalTo(false));
+        assertFalse(wrapper.persistent());
     }
 
     @Test
@@ -278,11 +279,11 @@ public class KeyValueStoreWrapperTest {
 
         // test "isOpen = true"
         when(headersStore.isOpen()).thenReturn(true);
-        assertThat(wrapper.isOpen(), equalTo(true));
+        assertTrue(wrapper.isOpen());
 
         // test "isOpen = false"
         when(headersStore.isOpen()).thenReturn(false);
-        assertThat(wrapper.isOpen(), equalTo(false));
+        assertFalse(wrapper.isOpen());
     }
 
     @Test
@@ -291,11 +292,11 @@ public class KeyValueStoreWrapperTest {
 
         // test "isOpen = true"
         when(versionedStore.isOpen()).thenReturn(true);
-        assertThat(wrapper.isOpen(), equalTo(true));
+        assertTrue(wrapper.isOpen());
 
         // test "isOpen = false"
         when(versionedStore.isOpen()).thenReturn(false);
-        assertThat(wrapper.isOpen(), equalTo(false));
+        assertFalse(wrapper.isOpen());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -304,7 +305,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithHeadersStore();
         when(headersStore.query(query, positionBound, queryConfig)).thenReturn((QueryResult) result);
 
-        assertThat(wrapper.query(query, positionBound, queryConfig), equalTo(result));
+        assertEquals(result, wrapper.query(query, positionBound, queryConfig));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -313,7 +314,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithVersionedStore();
         when(versionedStore.query(query, positionBound, queryConfig)).thenReturn((QueryResult) result);
 
-        assertThat(wrapper.query(query, positionBound, queryConfig), equalTo(result));
+        assertEquals(result, wrapper.query(query, positionBound, queryConfig));
     }
 
     @Test
@@ -321,7 +322,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithHeadersStore();
         when(headersStore.getPosition()).thenReturn(position);
 
-        assertThat(wrapper.getPosition(), equalTo(position));
+        assertEquals(position, wrapper.getPosition());
     }
 
     @Test
@@ -329,7 +330,7 @@ public class KeyValueStoreWrapperTest {
         givenWrapperWithVersionedStore();
         when(versionedStore.getPosition()).thenReturn(position);
 
-        assertThat(wrapper.getPosition(), equalTo(position));
+        assertEquals(position, wrapper.getPosition());
     }
 
     private void givenWrapperWithHeadersStore() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LeftOrRightValueSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LeftOrRightValueSerializerTest.java
@@ -24,9 +24,8 @@ import org.apache.kafka.common.serialization.StringSerializer;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -46,11 +45,11 @@ public class LeftOrRightValueSerializerTest {
 
         final byte[] serialized = STRING_OR_INTEGER_SERDE.serializer().serialize(TOPIC, HEADERS, leftOrRightValue);
 
-        assertThat(serialized, is(notNullValue()));
+        assertNotNull(serialized);
 
         final LeftOrRightValue<String, Integer> deserialized = STRING_OR_INTEGER_SERDE.deserializer().deserialize(TOPIC, HEADERS, serialized);
 
-        assertThat(deserialized, is(leftOrRightValue));
+        assertEquals(leftOrRightValue, deserialized);
     }
 
     @Test
@@ -61,11 +60,11 @@ public class LeftOrRightValueSerializerTest {
 
         final byte[] serialized = STRING_OR_INTEGER_SERDE.serializer().serialize(TOPIC, HEADERS, leftOrRightValue);
 
-        assertThat(serialized, is(notNullValue()));
+        assertNotNull(serialized);
 
         final LeftOrRightValue<String, Integer> deserialized = STRING_OR_INTEGER_SERDE.deserializer().deserialize(TOPIC, HEADERS, serialized);
 
-        assertThat(deserialized, is(leftOrRightValue));
+        assertEquals(leftOrRightValue, deserialized);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LegacyCheckpointingStateStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LegacyCheckpointingStateStoreTest.java
@@ -50,13 +50,9 @@ import java.util.Set;
 
 import static org.apache.kafka.streams.state.internals.LegacyCheckpointingStateStore.CHECKPOINT_FILE_NAME;
 import static org.apache.kafka.streams.state.internals.LegacyCheckpointingStateStore.OFFSET_DELTA_THRESHOLD_FOR_CHECKPOINT;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -110,7 +106,7 @@ public class LegacyCheckpointingStateStoreTest {
         final StateStore result = LegacyCheckpointingStateStore.maybeWrapStore(
             persistentStore, false, Set.of(partition), stateDirectory, taskId, LOG_PREFIX);
 
-        assertThat(result, instanceOf(LegacyCheckpointingStateStore.class));
+        assertInstanceOf(LegacyCheckpointingStateStore.class, result);
     }
 
     @Test
@@ -120,7 +116,7 @@ public class LegacyCheckpointingStateStoreTest {
         final StateStore result = LegacyCheckpointingStateStore.maybeWrapStore(
             nonPersistentStore, false, Set.of(partition), stateDirectory, taskId, LOG_PREFIX);
 
-        assertThat(result, not(instanceOf(LegacyCheckpointingStateStore.class)));
+        assertFalse(result instanceof LegacyCheckpointingStateStore);
     }
 
     @Test
@@ -136,7 +132,7 @@ public class LegacyCheckpointingStateStoreTest {
         final StateStore result = LegacyCheckpointingStateStore.maybeWrapStore(
             offsetManagingStore, false, Set.of(partition), stateDirectory, taskId, LOG_PREFIX);
 
-        assertThat(result, not(instanceOf(LegacyCheckpointingStateStore.class)));
+        assertFalse(result instanceof LegacyCheckpointingStateStore);
     }
 
     // =====================================================================
@@ -494,8 +490,7 @@ public class LegacyCheckpointingStateStoreTest {
                  LogCaptureAppender.createAndRegister(LegacyCheckpointingStateStore.class)) {
             store.checkpoint(); // should log a warning, not throw
 
-            assertThat(appender.getMessages(),
-                hasItem(containsString("Failed to write offset checkpoint file")));
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("Failed to write offset checkpoint file")));
         }
     }
 
@@ -630,8 +625,7 @@ public class LegacyCheckpointingStateStoreTest {
             LegacyCheckpointingStateStore.migrateLegacyOffsets(
                 LOG_PREFIX, stateDirectory, taskId, Collections.singletonMap(partition, persistentStore));
 
-            assertThat(appender.getMessages(),
-                hasItem(containsString("does not manage its own offsets")));
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("does not manage its own offsets")));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/LogicalKeyValueSegmentsTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -199,8 +196,8 @@ public class LogicalKeyValueSegmentsTest extends AbstractSegmentsTest<LogicalKey
 
         segments.close();
 
-        assertThat(segments.segmentForTimestamp(0), is(nullValue()));
-        assertThat(segments.getReservedSegment(), is(nullValue()));
+        assertNull(segments.segmentForTimestamp(0));
+        assertNull(segments.getReservedSegment());
         // verify iterators closed as well
         assertThrows(InvalidStateStoreException.class, all1::hasNext);
         assertThrows(InvalidStateStoreException.class, all2::hasNext);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MaybeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MaybeTest.java
@@ -20,23 +20,24 @@ import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MaybeTest {
     @Test
     public void shouldReturnDefinedValue() {
-        assertThat(Maybe.defined(null).getNullableValue(), nullValue());
-        assertThat(Maybe.defined("ASDF").getNullableValue(), is("ASDF"));
+        assertNull(Maybe.defined(null).getNullableValue());
+        assertEquals("ASDF", Maybe.defined("ASDF").getNullableValue());
     }
 
     @Test
     public void shouldAnswerIsDefined() {
-        assertThat(Maybe.defined(null).isDefined(), is(true));
-        assertThat(Maybe.defined("ASDF").isDefined(), is(true));
-        assertThat(Maybe.undefined().isDefined(), is(false));
+        assertTrue(Maybe.defined(null).isDefined());
+        assertTrue(Maybe.defined("ASDF").isDefined());
+        assertFalse(Maybe.undefined().isDefined());
     }
 
     @Test
@@ -52,19 +53,19 @@ public class MaybeTest {
 
     @Test
     public void shouldUpholdEqualityCorrectness() {
-        assertThat(Maybe.undefined().equals(Maybe.undefined()), is(true));
-        assertThat(Maybe.defined(null).equals(Maybe.defined(null)), is(true));
-        assertThat(Maybe.defined("q").equals(Maybe.defined("q")), is(true));
+        assertTrue(Maybe.undefined().equals(Maybe.undefined()));
+        assertTrue(Maybe.defined(null).equals(Maybe.defined(null)));
+        assertTrue(Maybe.defined("q").equals(Maybe.defined("q")));
 
-        assertThat(Maybe.undefined().equals(Maybe.defined(null)), is(false));
-        assertThat(Maybe.undefined().equals(Maybe.defined("x")), is(false));
+        assertFalse(Maybe.undefined().equals(Maybe.defined(null)));
+        assertFalse(Maybe.undefined().equals(Maybe.defined("x")));
 
-        assertThat(Maybe.defined(null).equals(Maybe.undefined()), is(false));
-        assertThat(Maybe.defined(null).equals(Maybe.defined("x")), is(false));
+        assertFalse(Maybe.defined(null).equals(Maybe.undefined()));
+        assertFalse(Maybe.defined(null).equals(Maybe.defined("x")));
 
-        assertThat(Maybe.defined("a").equals(Maybe.undefined()), is(false));
-        assertThat(Maybe.defined("a").equals(Maybe.defined(null)), is(false));
-        assertThat(Maybe.defined("a").equals(Maybe.defined("b")), is(false));
+        assertFalse(Maybe.defined("a").equals(Maybe.undefined()));
+        assertFalse(Maybe.defined("a").equals(Maybe.defined(null)));
+        assertFalse(Maybe.defined("a").equals(Maybe.defined("b")));
     }
 
     @Test
@@ -72,8 +73,8 @@ public class MaybeTest {
         // This specifies the current implementation, which is simpler to write than an exhaustive test.
         // As long as this implementation doesn't change, then the equals/hashcode contract is upheld.
 
-        assertThat(Maybe.undefined().hashCode(), is(-1));
-        assertThat(Maybe.defined(null).hashCode(), is(0));
-        assertThat(Maybe.defined("a").hashCode(), is("a".hashCode()));
+        assertEquals(-1, Maybe.undefined().hashCode());
+        assertEquals(0, Maybe.defined(null).hashCode());
+        assertEquals("a".hashCode(), Maybe.defined("a").hashCode());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedSessionStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedSessionStoreIteratorTest.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Iterator;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,25 +68,25 @@ public class MergedSortedCacheWrappedSessionStoreIteratorTest {
     @Test
     public void shouldGetNextFromStore() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(storeKvs, Collections.emptyIterator(), false);
-        assertThat(mergeIterator.next(), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get()), mergeIterator.next());
     }
 
     @Test
     public void shouldGetNextFromReverseStore() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(storeKvs, Collections.emptyIterator(), true);
-        assertThat(mergeIterator.next(), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get()), mergeIterator.next());
     }
 
     @Test
     public void shouldPeekNextKeyFromStore() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(storeKvs, Collections.emptyIterator(), false);
-        assertThat(mergeIterator.peekNextKey(), equalTo(new Windowed<>(storeKey, storeWindow)));
+        assertEquals(new Windowed<>(storeKey, storeWindow), mergeIterator.peekNextKey());
     }
 
     @Test
     public void shouldPeekNextKeyFromReverseStore() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(storeKvs, Collections.emptyIterator(), true);
-        assertThat(mergeIterator.peekNextKey(), equalTo(new Windowed<>(storeKey, storeWindow)));
+        assertEquals(new Windowed<>(storeKey, storeWindow), mergeIterator.peekNextKey());
     }
 
     @Test
@@ -105,40 +104,40 @@ public class MergedSortedCacheWrappedSessionStoreIteratorTest {
     @Test
     public void shouldGetNextFromCache() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(Collections.emptyIterator(), cacheKvs, false);
-        assertThat(mergeIterator.next(), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get()), mergeIterator.next());
     }
 
     @Test
     public void shouldGetNextFromReverseCache() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(Collections.emptyIterator(), cacheKvs, true);
-        assertThat(mergeIterator.next(), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get()), mergeIterator.next());
     }
 
     @Test
     public void shouldPeekNextKeyFromCache() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(Collections.emptyIterator(), cacheKvs, false);
-        assertThat(mergeIterator.peekNextKey(), equalTo(new Windowed<>(cacheKey, cacheWindow)));
+        assertEquals(new Windowed<>(cacheKey, cacheWindow), mergeIterator.peekNextKey());
     }
 
     @Test
     public void shouldPeekNextKeyFromReverseCache() {
         final MergedSortedCacheSessionStoreIterator mergeIterator = createIterator(Collections.emptyIterator(), cacheKvs, true);
-        assertThat(mergeIterator.peekNextKey(), equalTo(new Windowed<>(cacheKey, cacheWindow)));
+        assertEquals(new Windowed<>(cacheKey, cacheWindow), mergeIterator.peekNextKey());
     }
 
     @Test
     public void shouldIterateBothStoreAndCache() {
         final MergedSortedCacheSessionStoreIterator iterator = createIterator(storeKvs, cacheKvs, true);
-        assertThat(iterator.next(), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get())));
-        assertThat(iterator.next(), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get()), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get()), iterator.next());
         assertFalse(iterator.hasNext());
     }
 
     @Test
     public void shouldReverseIterateBothStoreAndCache() {
         final MergedSortedCacheSessionStoreIterator iterator = createIterator(storeKvs, cacheKvs, false);
-        assertThat(iterator.next(), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get())));
-        assertThat(iterator.next(), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get())));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey.get()), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey.get()), iterator.next());
         assertFalse(iterator.hasNext());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
@@ -38,8 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -183,9 +181,9 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
         final MergedSortedCacheWindowStoreIterator iterator = new MergedSortedCacheWindowStoreIterator(
             cacheIterator, storeIterator, true, tsExtractor
         );
-        assertThat(iterator.peekNextKey(), equalTo(0L));
+        assertEquals(0L, iterator.peekNextKey());
         iterator.next();
-        assertThat(iterator.peekNextKey(), equalTo(10L));
+        assertEquals(10L, iterator.peekNextKey());
         iterator.close();
     }
 
@@ -206,9 +204,9 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
         final MergedSortedCacheWindowStoreIterator iterator = new MergedSortedCacheWindowStoreIterator(
             cacheIterator, storeIterator, false, tsExtractor
         );
-        assertThat(iterator.peekNextKey(), equalTo(10L));
+        assertEquals(10L, iterator.peekNextKey());
         iterator.next();
-        assertThat(iterator.peekNextKey(), equalTo(0L));
+        assertEquals(0L, iterator.peekNextKey());
         iterator.close();
     }
 
@@ -233,9 +231,9 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
             true,
             tsExtractor
         );
-        assertThat(iterator.peekNextKey(), equalTo(0L));
+        assertEquals(0L, iterator.peekNextKey());
         iterator.next();
-        assertThat(iterator.peekNextKey(), equalTo(10L));
+        assertEquals(10L, iterator.peekNextKey());
         iterator.close();
     }
 
@@ -260,9 +258,9 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
             false,
             tsExtractor
         );
-        assertThat(iterator.peekNextKey(), equalTo(10L));
+        assertEquals(10L, iterator.peekNextKey());
         iterator.next();
-        assertThat(iterator.peekNextKey(), equalTo(0L));
+        assertEquals(0L, iterator.peekNextKey());
         iterator.close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest.java
@@ -38,8 +38,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.Collections;
 import java.util.Iterator;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -133,7 +132,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(storeKvs, Collections.emptyIterator(), false);
-        assertThat(convertKeyValuePair(mergeIterator.next()), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey), convertKeyValuePair(mergeIterator.next()));
     }
 
     @ParameterizedTest
@@ -142,7 +141,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(storeKvs, Collections.emptyIterator(), true);
-        assertThat(convertKeyValuePair(mergeIterator.next()), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey), convertKeyValuePair(mergeIterator.next()));
     }
 
     @ParameterizedTest
@@ -151,7 +150,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(storeKvs, Collections.emptyIterator(), false);
-        assertThat(convertWindowedKey(mergeIterator.peekNextKey()), equalTo(new Windowed<>(storeKey, storeWindow)));
+        assertEquals(new Windowed<>(storeKey, storeWindow), convertWindowedKey(mergeIterator.peekNextKey()));
     }
 
     @ParameterizedTest
@@ -160,7 +159,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(storeKvs, Collections.emptyIterator(), true);
-        assertThat(convertWindowedKey(mergeIterator.peekNextKey()), equalTo(new Windowed<>(storeKey, storeWindow)));
+        assertEquals(new Windowed<>(storeKey, storeWindow), convertWindowedKey(mergeIterator.peekNextKey()));
     }
 
     @ParameterizedTest
@@ -187,7 +186,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(Collections.emptyIterator(), cacheKvs, false);
-        assertThat(convertKeyValuePair(mergeIterator.next()), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey), convertKeyValuePair(mergeIterator.next()));
     }
 
     @ParameterizedTest
@@ -196,7 +195,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(Collections.emptyIterator(), cacheKvs, true);
-        assertThat(convertKeyValuePair(mergeIterator.next()), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey), convertKeyValuePair(mergeIterator.next()));
     }
 
     @ParameterizedTest
@@ -205,7 +204,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(Collections.emptyIterator(), cacheKvs, false);
-        assertThat(convertWindowedKey(mergeIterator.peekNextKey()), equalTo(new Windowed<>(cacheKey, cacheWindow)));
+        assertEquals(new Windowed<>(cacheKey, cacheWindow), convertWindowedKey(mergeIterator.peekNextKey()));
     }
 
     @ParameterizedTest
@@ -214,7 +213,7 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator mergeIterator =
             createIterator(Collections.emptyIterator(), cacheKvs, true);
-        assertThat(convertWindowedKey(mergeIterator.peekNextKey()), equalTo(new Windowed<>(cacheKey, cacheWindow)));
+        assertEquals(new Windowed<>(cacheKey, cacheWindow), convertWindowedKey(mergeIterator.peekNextKey()));
     }
 
     @ParameterizedTest
@@ -222,8 +221,8 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
     public void shouldIterateBothStoreAndCache(final SchemaType schemaType) {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator iterator = createIterator(storeKvs, cacheKvs, true);
-        assertThat(convertKeyValuePair(iterator.next()), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey)));
-        assertThat(convertKeyValuePair(iterator.next()), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey), convertKeyValuePair(iterator.next()));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey), convertKeyValuePair(iterator.next()));
         assertFalse(iterator.hasNext());
     }
 
@@ -232,8 +231,8 @@ public class MergedSortedCacheWrappedWindowStoreKeyValueIteratorTest {
     public void shouldReverseIterateBothStoreAndCache(final SchemaType schemaType) {
         setUp(schemaType);
         final MergedSortedCacheWindowStoreKeyValueIterator iterator = createIterator(storeKvs, cacheKvs, false);
-        assertThat(convertKeyValuePair(iterator.next()), equalTo(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey)));
-        assertThat(convertKeyValuePair(iterator.next()), equalTo(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey)));
+        assertEquals(KeyValue.pair(new Windowed<>(cacheKey, cacheWindow), cacheKey), convertKeyValuePair(iterator.next()));
+        assertEquals(KeyValue.pair(new Windowed<>(storeKey, storeWindow), storeKey), convertKeyValuePair(iterator.next()));
         assertFalse(iterator.hasNext());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -70,11 +70,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -241,7 +237,7 @@ public class MeteredKeyValueStoreTest {
         // it suffices to verify one restore metric since all restore metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("restore-latency-max");
-        assertThat((Double) metric.metricValue(), equalTo((double) restoreTimeNs));
+        assertEquals((double) restoreTimeNs, (Double) metric.metricValue());
     }
 
     @Test
@@ -262,7 +258,7 @@ public class MeteredKeyValueStoreTest {
         when(inner.get(KEY_BYTES)).thenReturn(VALUE_BYTES);
         init();
 
-        assertThat(metered.get(KEY), equalTo(VALUE));
+        assertEquals(VALUE, metered.get(KEY));
 
         final KafkaMetric metric = metric("get-rate");
         assertTrue((Double) metric.metricValue() > 0);
@@ -313,7 +309,7 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KeyValueIterator<String, String> iterator = metered.range(KEY, KEY);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -328,7 +324,7 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KeyValueIterator<String, String> iterator = metered.all();
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -415,7 +411,7 @@ public class MeteredKeyValueStoreTest {
 
         final Header capturedLastHeader = headersCaptor.getValue().lastHeader(headerKey);
         assertNotNull(capturedLastHeader);
-        assertThat(new String(capturedLastHeader.value(), StandardCharsets.UTF_8), equalTo("new"));
+        assertEquals("new", new String(capturedLastHeader.value(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -440,9 +436,9 @@ public class MeteredKeyValueStoreTest {
         init(); // replays "inner"
 
         // There's always a "count" metric registered
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         metered.close();
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -451,9 +447,9 @@ public class MeteredKeyValueStoreTest {
         doThrow(new RuntimeException("Oops!")).when(inner).close();
         init(); // replays "inner"
 
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         assertThrows(RuntimeException.class, metered::close);
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -536,7 +532,7 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KeyValueIterator<String, String> iterator = metered.prefixScan(KEY, mockSerializer);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         iterator.close();
 
         final KafkaMetric metric = metrics.metric(new MetricName("prefix-scan-rate", STORE_LEVEL_GROUP, "", tags));
@@ -550,9 +546,9 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KafkaMetric numKeysMetric = metric("num-keys");
-        assertThat(numKeysMetric, not(nullValue()));
+        assertNotNull(numKeysMetric);
         // inner store is a mock (not InMemoryKeyValueStore), so returns -1
-        assertThat((Long) numKeysMetric.metricValue(), equalTo(-1L));
+        assertEquals(-1L, (Long) numKeysMetric.metricValue());
     }
 
     @SuppressWarnings({"unused", "unchecked"})
@@ -569,15 +565,15 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat(openIteratorsMetric, not(nullValue()));
+        assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         try (final KeyValueIterator<String, String> unused = metered.prefixScan(KEY, mockSerializer)) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
         verify(mockSerializer).serialize(null, headers, KEY);
     }
 
@@ -590,27 +586,27 @@ public class MeteredKeyValueStoreTest {
 
         final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
-        assertThat(iteratorDurationAvgMetric, not(nullValue()));
-        assertThat(iteratorDurationMaxMetric, not(nullValue()));
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
 
-        assertThat((Double) iteratorDurationAvgMetric.metricValue(), equalTo(Double.NaN));
-        assertThat((Double) iteratorDurationMaxMetric.metricValue(), equalTo(Double.NaN));
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<String, String> unused = metered.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(2);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<String, String> iterator = metered.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(3);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -621,34 +617,34 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
-        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+        assertNotNull(oldestIteratorTimestampMetric);
 
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
 
         KeyValueIterator<String, String> second = null;
         final long secondTimestamp;
         try {
             try (final KeyValueIterator<String, String> unused = metered.all()) {
                 final long oldestTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
 
                 // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
                 second = metered.all();
                 secondTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
             }
 
             // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
-            assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+            assertEquals(secondTimestamp, oldestIteratorTimestampMetric.metricValue());
         } finally {
             if (second != null) {
                 second.close();
             }
         }
         // no open iterators left, timestamp should be reset to 0
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")
@@ -661,7 +657,7 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.get(KEY), equalTo(VALUE));
+        assertEquals(VALUE, view.get(KEY));
 
         assertTrue((Double) metric("get-rate").metricValue() > 0);
     }
@@ -678,7 +674,7 @@ public class MeteredKeyValueStoreTest {
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<String, String> it = view.range(KEY, KEY)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
             assertFalse(it.hasNext());
         }
 
@@ -697,7 +693,7 @@ public class MeteredKeyValueStoreTest {
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<String, String> it = view.reverseRange(KEY, KEY)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
             assertFalse(it.hasNext());
         }
 
@@ -716,7 +712,7 @@ public class MeteredKeyValueStoreTest {
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<String, String> it = view.all()) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
             assertFalse(it.hasNext());
         }
 
@@ -735,7 +731,7 @@ public class MeteredKeyValueStoreTest {
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<String, String> it = view.reverseAll()) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
             assertFalse(it.hasNext());
         }
 
@@ -759,7 +755,7 @@ public class MeteredKeyValueStoreTest {
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<String, String> it = view.prefixScan(KEY, mockSerializer)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
             assertFalse(it.hasNext());
         }
 
@@ -778,7 +774,7 @@ public class MeteredKeyValueStoreTest {
         init();
 
         final ReadOnlyKeyValueStore<String, String> view = metered.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.approximateNumEntries(), equalTo(42L));
+        assertEquals(42L, view.approximateNumEntries());
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -71,12 +71,9 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -252,7 +249,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.findSessions(KEY, 0, 0);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -274,7 +271,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFindSessions(KEY, 0, 0);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -293,7 +290,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.findSessions(KEY, KEY, 0, 0);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -315,7 +312,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFindSessions(KEY, KEY, 0, 0);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -349,7 +346,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.fetch(KEY);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -371,7 +368,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFetch(KEY);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -390,7 +387,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.fetch(KEY, KEY);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -412,7 +409,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFetch(KEY, KEY);
-        assertThat(iterator.next().value, equalTo(VALUE));
+        assertEquals(VALUE, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -485,7 +482,7 @@ public class MeteredSessionStoreTest {
         // it suffices to verify one restore metric since all restore metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("restore-latency-max");
-        assertThat((Double) metric.metricValue(), equalTo((double) restoreTimeNs));
+        assertEquals((double) restoreTimeNs, (Double) metric.metricValue());
     }
 
     @Test
@@ -689,8 +686,8 @@ public class MeteredSessionStoreTest {
         verify(valueDeserializer).deserialize(anyString(), headersCaptor.capture(), any(byte[].class));
 
         final Header capturedLastHeader = headersCaptor.getValue().lastHeader(headerKey);
-        assertThat(capturedLastHeader, not(nullValue()));
-        assertThat(new String(capturedLastHeader.value(), StandardCharsets.UTF_8), equalTo("new"));
+        assertNotNull(capturedLastHeader);
+        assertEquals("new", new String(capturedLastHeader.value(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -706,9 +703,9 @@ public class MeteredSessionStoreTest {
         init(); // replays "inner"
 
         // There's always a "count" metric registered
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         store.close();
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -717,9 +714,9 @@ public class MeteredSessionStoreTest {
         doThrow(new RuntimeException("Oops!")).when(innerStore).close();
         init(); // replays "inner"
 
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         assertThrows(RuntimeException.class, store::close);
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -728,9 +725,9 @@ public class MeteredSessionStoreTest {
         init();
 
         final KafkaMetric numKeysMetric = metric("num-keys");
-        assertThat(numKeysMetric, not(nullValue()));
+        assertNotNull(numKeysMetric);
         // inner store is a mock (not InMemorySessionStore), so returns -1
-        assertThat((Long) numKeysMetric.metricValue(), equalTo(-1L));
+        assertEquals(-1L, (Long) numKeysMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -741,15 +738,15 @@ public class MeteredSessionStoreTest {
         init();
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat(openIteratorsMetric, not(nullValue()));
+        assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> unused = store.backwardFetch(KEY)) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -761,27 +758,27 @@ public class MeteredSessionStoreTest {
 
         final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
-        assertThat(iteratorDurationAvgMetric, not(nullValue()));
-        assertThat(iteratorDurationMaxMetric, not(nullValue()));
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
 
-        assertThat((Double) iteratorDurationAvgMetric.metricValue(), equalTo(Double.NaN));
-        assertThat((Double) iteratorDurationMaxMetric.metricValue(), equalTo(Double.NaN));
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> unused = store.backwardFetch(KEY)) {
             // nothing to do, just close immediately
             mockTime.sleep(2);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> iterator = store.backwardFetch(KEY)) {
             // nothing to do, just close immediately
             mockTime.sleep(3);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -792,34 +789,34 @@ public class MeteredSessionStoreTest {
         init();
 
         final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
-        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+        assertNotNull(oldestIteratorTimestampMetric);
 
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
 
         KeyValueIterator<Windowed<String>, String> second = null;
         final long secondTimestamp;
         try {
             try (final KeyValueIterator<Windowed<String>, String> unused = store.backwardFetch(KEY)) {
                 final long oldestTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
 
                 // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
                 second = store.backwardFetch(KEY);
                 secondTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
             }
 
             // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
-            assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+            assertEquals(secondTimestamp, oldestIteratorTimestampMetric.metricValue());
         } finally {
             if (second != null) {
                 second.close();
             }
         }
 
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")
@@ -832,7 +829,7 @@ public class MeteredSessionStoreTest {
         init();
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.fetchSession(KEY, 0, 0), equalTo(VALUE));
+        assertEquals(VALUE, view.fetchSession(KEY, 0, 0));
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
 
@@ -849,7 +846,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.findSessions(KEY, 0, 0)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
@@ -867,7 +864,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.backwardFindSessions(KEY, 0, 0)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
@@ -885,7 +882,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.findSessions(KEY, KEY, 0, 0)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
@@ -903,7 +900,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.fetch(KEY)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
@@ -921,7 +918,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.backwardFetch(KEY)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }
@@ -939,7 +936,7 @@ public class MeteredSessionStoreTest {
 
         final ReadOnlySessionStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> it = view.fetch(KEY, KEY)) {
-            assertThat(it.next().value, equalTo(VALUE));
+            assertEquals(VALUE, it.next().value);
         }
         assertTrue((Double) metric("fetch-rate").metricValue() > 0);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreWithHeadersTest.java
@@ -72,10 +72,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -486,7 +482,7 @@ public class MeteredSessionStoreWithHeadersTest {
             .filter(metricName -> metricName.name().equals("restore-rate"))
             .collect(Collectors.toList());
 
-        assertThat(restoreMetrics, not(empty()));
+        assertFalse(restoreMetrics.isEmpty());
     }
 
     @Test
@@ -598,15 +594,15 @@ public class MeteredSessionStoreWithHeadersTest {
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
         assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(KEY);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+        assertEquals(1L, (Long) openIteratorsMetric.metricValue());
 
         iterator.close();
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @Test
@@ -628,7 +624,7 @@ public class MeteredSessionStoreWithHeadersTest {
         final KafkaMetric oldestIteratorMetric = metric("oldest-iterator-open-since-ms");
         assertNotNull(oldestIteratorMetric);
 
-        assertThat(oldestIteratorMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorMetric.metricValue());
 
         final long beforeOpen = mockTime.milliseconds();
         final KeyValueIterator<Windowed<String>, AggregationWithHeaders<String>> iterator = store.fetch(KEY);
@@ -639,7 +635,7 @@ public class MeteredSessionStoreWithHeadersTest {
 
         iterator.close();
 
-        assertThat(oldestIteratorMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorMetric.metricValue());
     }
 
     @Test
@@ -743,9 +739,9 @@ public class MeteredSessionStoreWithHeadersTest {
         doThrow(new RuntimeException("Oops!")).when(innerStore).close();
         init();
 
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         assertThrows(RuntimeException.class, store::close);
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -1006,7 +1002,7 @@ public class MeteredSessionStoreWithHeadersTest {
                 Collections.singleton(KeyValue.pair(windowedKeyBytes, serializedValue)).iterator())));
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         final QueryResult<ReadOnlyRecordIterator<Windowed<String>, String>> result = store.query(
             TimestampedWindowRangeWithHeadersQuery.<String, String>withKey(KEY),
@@ -1015,9 +1011,9 @@ public class MeteredSessionStoreWithHeadersTest {
         assertTrue(result.isSuccess());
 
         try (ReadOnlyRecordIterator<Windowed<String>, String> iterator = result.getResult()) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")
@@ -1039,13 +1035,13 @@ public class MeteredSessionStoreWithHeadersTest {
             PositionBound.unbounded(),
             new QueryConfig(false)).getResult();
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+        assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         iterator.close();
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
         // close() is intentionally not idempotent (matching the sibling metered iterators): each call
         // decrements, so a repeated close drives the gauge below zero. Callers must close exactly once.
         iterator.close();
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(-1L));
+        assertEquals(-1L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Remove hamcrest from a subset of tests in the
`org.apache.kafka.streams.state.internals` package by migrating their
assertions to JUnit.

Reviewers: Ken Huang <s7133700@gmail.com>, Christo Lolov
 <lolovc@amazon.com>
