### PR TITLE
KAFKA-21120: Replace temp file handler with JUnit 5 @TempDir in clients and connect tests

### DIFF
--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AlterConfigsIntegrationTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/admin/AlterConfigsIntegrationTest.java
@@ -30,8 +30,8 @@ import org.apache.kafka.common.test.JaasUtils;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.server.config.ServerConfigs;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -50,6 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AlterConfigsIntegrationTest {
 
     private final ClusterInstance clusterInstance;
+    @TempDir
+    private Path tempDir;
     private Path file;
 
     AlterConfigsIntegrationTest(ClusterInstance clusterInstance) {
@@ -58,13 +60,8 @@ public class AlterConfigsIntegrationTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        file = Files.createTempFile("provider", ".properties");
+        file = Files.createFile(tempDir.resolve("provider.properties"));
         Files.writeString(file, "key=token");
-    }
-
-    @AfterEach
-    public void teardown() throws IOException {
-        Files.deleteIfExists(file);
     }
 
     @ClusterTest

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/OAuthBearerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/secured/OAuthBearerTest.java
@@ -37,6 +37,7 @@ import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,6 +47,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -72,6 +75,9 @@ import static org.mockito.Mockito.when;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public abstract class OAuthBearerTest {
+
+    @TempDir
+    protected Path tempDir;
 
     protected ObjectMapper mapper = new ObjectMapper();
 
@@ -236,7 +242,7 @@ public abstract class OAuthBearerTest {
     }
 
     protected File generatePrivateKey(PrivateKey privateKey) throws IOException {
-        File file = File.createTempFile("private-", ".key");
+        File file = Files.createFile(tempDir.resolve("private-" + System.nanoTime() + ".key")).toFile();
         byte[] bytes = Base64.getEncoder().encode(privateKey.getEncoded());
 
         try (FileChannel channel = FileChannel.open(file.toPath(), EnumSet.of(StandardOpenOption.WRITE))) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorValidationIntegrationTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -78,11 +79,13 @@ public class ConnectorValidationIntegrationTest {
 
     // Use a single embedded cluster for all test cases in order to cut down on runtime
     private static EmbeddedConnectCluster connect;
+    @TempDir
+    private static Path tempDir;
     private static Path providerFile;
 
     @BeforeAll
     public static void setup() throws Exception {
-        providerFile = Files.createTempFile("provider", ".properties");
+        providerFile = Files.createFile(tempDir.resolve("provider.properties"));
         Files.writeString(providerFile, KEY + "=" + VALUE);
 
         Map<String, String> workerProps = new HashMap<>();
@@ -114,7 +117,6 @@ public class ConnectorValidationIntegrationTest {
         if (connect != null) {
             Utils.closeQuietly(connect::stop, "Embedded Connect cluster");
         }
-        Files.deleteIfExists(providerFile);
     }
 
     @Test
@@ -546,14 +548,10 @@ public class ConnectorValidationIntegrationTest {
     @Test
     public void testValidationErrorMessagesDoNotContainResolvedValueOnValidatorRejection() throws Exception {
         String value = "-9999";
-        Path providerFile = Files.createTempFile("provider", ".properties");
-        try {
-            Files.writeString(providerFile, KEY + "=" + value);
-            String placeholder = "${file:" + providerFile.toAbsolutePath() + ":" + KEY + "}";
-            assertErrorMessages(placeholder, value);
-        } finally {
-            Files.deleteIfExists(providerFile);
-        }
+        Path localProviderFile = Files.createFile(tempDir.resolve("provider-validator.properties"));
+        Files.writeString(localProviderFile, KEY + "=" + value);
+        String placeholder = "${file:" + localProviderFile.toAbsolutePath() + ":" + KEY + "}";
+        assertErrorMessages(placeholder, value);
     }
 
     private void assertErrorMessages(String placeholder, String value) {


### PR DESCRIPTION
Main Jira -
[KAFKA-14218](https://issues.apache.org/jira/browse/KAFKA-14218)
Sub Task -
[KAFKA-21120](https://issues.apache.org/jira/browse/KAFKA-21120)
## Summary

Replace `File.createTempFile()` and `Files.createTempFile()` with JUnit 5 `@TempDir` annotation in clients and connect modules:

* `AlterConfigsIntegrationTest.java` (clients integration tests)
* `OAuthBearerTest.java` (clients — abstract base class)
* `ConnectorValidationIntegrationTest.java` (connect/runtime integration tests)

This removes the need for manual `@AfterEach`/`@AfterAll` cleanup and `deleteOnExit()` calls as JUnit 5 handles temporary directory lifecycle automatically.

## Changes

* Added `@TempDir private Path tempDir` to `AlterConfigsIntegrationTest`, replaced `Files.createTempFile()` with `Files.createFile(tempDir.resolve(...))`, removed `@AfterEach teardown()`
* Added `@TempDir protected Path tempDir` to `OAuthBearerTest` abstract base class, replaced `File.createTempFile()` in `generatePrivateKey()`
* Added `@TempDir private static Path tempDir` to `ConnectorValidationIntegrationTest`, replaced `Files.createTempFile()` in `@BeforeAll setup()` and `testValidationErrorMessagesDoNotContainResolvedValueOnValidatorRejection()`, removed manual cleanup in `@AfterAll close()`

## Intentionally excluded

* `ClientAssertionKeycloakIntegrationTest` — static lifecycle tied to Docker container setup/teardown with explicit finally-block cleanup; not a clean `@TempDir` conversion
* `TestPlugins` — static initializer in a utility class, not a test class

## Scope

This is a follow-up to #23280 (connect module) and #23381 (generator, tools, test-common). This PR covers the remaining clients and connect files that are clean `@TempDir` conversions.

## Test plan

* `OAuthBearerTest` subclasses — all tests pass
* `AlterConfigsIntegrationTest` — verified compilation
* `ConnectorValidationIntegrationTest` — verified compilation
* Checkstyle and Spotless checks pass

Reviewers: Uros (github:uros-b), ashwinpankaj <apankaj@confluent.io>
