### PR TITLE
KAFKA-20745: extend OffsetMapTest to verify different hash algorithms

### DIFF
--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
@@ -31,12 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class OffsetMapTest {
+public class OffsetMapTest {
 
     private static final int MEMORY_SIZE = 4096;
 
     static Stream<String> hashAlgorithms() {
-        return Stream.of("MD5", "SHA-1", "SHA-256", "SHA-512");
+        return Stream.of("MD2", "MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512");
     }
 
     static Stream<Arguments> algorithmsAndItems() {
@@ -46,7 +46,7 @@ class OffsetMapTest {
 
     @ParameterizedTest
     @MethodSource("algorithmsAndItems")
-    void testBasicValidation(String algorithm, int items) throws Exception {
+    public void testBasicValidation(String algorithm, int items) throws Exception {
         int bytesPerEntry = MessageDigest.getInstance(algorithm).getDigestLength() + 8;
         SkimpyOffsetMap map = new SkimpyOffsetMap(items * bytesPerEntry * 2, algorithm);
         IntStream.range(0, items).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
@@ -56,7 +56,7 @@ class OffsetMapTest {
     }
 
     @Test
-    void testClear() throws Exception {
+    public void testClear() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         IntStream.range(0, 10).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
         for (int i = 0; i < 10; i++) {
@@ -70,7 +70,7 @@ class OffsetMapTest {
 
     @ParameterizedTest
     @MethodSource("hashAlgorithms")
-    void testGetWhenFull(String algorithm) throws Exception {
+    public void testGetWhenFull(String algorithm) throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE, algorithm);
         int i = 37;
         while (map.size() < map.slots()) {
@@ -82,7 +82,7 @@ class OffsetMapTest {
     }
 
     @Test
-    void testUpdateLatestOffset() throws Exception {
+    public void testUpdateLatestOffset() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         while (map.size() < map.slots()) {
@@ -96,7 +96,7 @@ class OffsetMapTest {
     }
 
     @Test
-    void testLatestOffset() throws Exception {
+    public void testLatestOffset() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         while (map.size() < map.slots()) {
@@ -107,7 +107,7 @@ class OffsetMapTest {
     }
 
     @Test
-    void testUtilization() throws Exception {
+    public void testUtilization() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         assertEquals(0.0, map.utilization());

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/OffsetMapTest.java
@@ -18,22 +18,37 @@ package org.apache.kafka.storage.internals.log;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class OffsetMapTest {
+class OffsetMapTest {
 
     private static final int MEMORY_SIZE = 4096;
 
+    static Stream<String> hashAlgorithms() {
+        return Stream.of("MD5", "SHA-1", "SHA-256", "SHA-512");
+    }
+
+    static Stream<Arguments> algorithmsAndItems() {
+        return hashAlgorithms().flatMap(algorithm ->
+            IntStream.of(10, 100, 1000, 5000).mapToObj(items -> Arguments.of(algorithm, items)));
+    }
+
     @ParameterizedTest
-    @ValueSource(ints = {10, 100, 1000, 5000})
-    public void testBasicValidation(int items) throws Exception {
-        SkimpyOffsetMap map = new SkimpyOffsetMap(items * 48);
+    @MethodSource("algorithmsAndItems")
+    void testBasicValidation(String algorithm, int items) throws Exception {
+        int bytesPerEntry = MessageDigest.getInstance(algorithm).getDigestLength() + 8;
+        SkimpyOffsetMap map = new SkimpyOffsetMap(items * bytesPerEntry * 2, algorithm);
         IntStream.range(0, items).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
         for (int i = 0; i < items; i++) {
             assertEquals(i, map.get(key(i)));
@@ -41,7 +56,7 @@ public class OffsetMapTest {
     }
 
     @Test
-    public void testClear() throws Exception {
+    void testClear() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         IntStream.range(0, 10).forEach(i -> assertDoesNotThrow(() -> map.put(key(i), i)));
         for (int i = 0; i < 10; i++) {
@@ -53,9 +68,10 @@ public class OffsetMapTest {
         }
     }
 
-    @Test
-    public void testGetWhenFull() throws Exception {
-        SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
+    @ParameterizedTest
+    @MethodSource("hashAlgorithms")
+    void testGetWhenFull(String algorithm) throws Exception {
+        SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE, algorithm);
         int i = 37;
         while (map.size() < map.slots()) {
             map.put(key(i), i);
@@ -66,7 +82,7 @@ public class OffsetMapTest {
     }
 
     @Test
-    public void testUpdateLatestOffset() throws Exception {
+    void testUpdateLatestOffset() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         while (map.size() < map.slots()) {
@@ -80,7 +96,7 @@ public class OffsetMapTest {
     }
 
     @Test
-    public void testLatestOffset() throws Exception {
+    void testLatestOffset() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         while (map.size() < map.slots()) {
@@ -89,9 +105,9 @@ public class OffsetMapTest {
         }
         assertEquals(i - 1, map.latestOffset());
     }
-    
+
     @Test
-    public void testUtilization() throws Exception {
+    void testUtilization() throws Exception {
         SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE);
         int i = 37;
         assertEquals(0.0, map.utilization());
@@ -100,6 +116,19 @@ public class OffsetMapTest {
             assertEquals((double) map.size() / map.slots(), map.utilization());
             i++;
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("hashAlgorithms")
+    void testBytesPerEntryMatchesDigestLength(String algorithm) throws Exception {
+        int expected = MessageDigest.getInstance(algorithm).getDigestLength() + 8;
+        SkimpyOffsetMap map = new SkimpyOffsetMap(MEMORY_SIZE, algorithm);
+        assertEquals(expected, map.bytesPerEntry);
+    }
+
+    @Test
+    void testUnknownAlgorithmThrows() {
+        assertThrows(NoSuchAlgorithmException.class, () -> new SkimpyOffsetMap(MEMORY_SIZE, "NOT-A-REAL-HASH"));
     }
 
     private ByteBuffer key(Integer key) {


### PR DESCRIPTION
`SkimpyOffsetMap` supports configurable hash algorithms, but the tests
only covered the default (`MD5`).
- Parameterize the tests to also run against `MD2`, `SHA-1`, `SHA-256`,
`SHA-384`, and `SHA-512`.
- Add tests to check entry size based on each algorithm (`bytesPerEntry`
is public already)
- Add test for negative case to fail on unknown-algorithm.

No production changes.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang
 <s7133700@gmail.com>
