### PR TITLE
KAFKA-19327: Batch topic creation requests in MirrorSourceConnector

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -89,6 +89,8 @@ public class MirrorSourceConnector extends SourceConnector {
     private static final AclBindingFilter ANY_TOPIC_ACL = new AclBindingFilter(ANY_TOPIC, AccessControlEntryFilter.ANY);
     private static final String READ_COMMITTED = IsolationLevel.READ_COMMITTED.toString();
     private static final String EXACTLY_ONCE_SUPPORT_CONFIG = "exactly.once.support";
+    // Keep topic creation requests within the controller's default maximum number of metadata records per batch.
+    private static final int MAX_ESTIMATED_RECORDS_PER_CREATE_TOPICS_REQUEST = 10_000;
 
     private final AtomicBoolean noAclAuthorizer = new AtomicBoolean(false);
 
@@ -514,18 +516,59 @@ public class MirrorSourceConnector extends SourceConnector {
     void createNewTopics(Map<String, NewTopic> newTopics) throws ExecutionException, InterruptedException {
         adminCall(
                 () -> {
-                    targetAdminClient.createTopics(newTopics.values(), new CreateTopicsOptions()).values()
-                            .forEach((k, v) -> v.whenComplete((x, e) -> {
-                                if (e != null) {
-                                    log.warn("Could not create topic {}.", k, e);
-                                } else {
-                                    log.info("Created remote topic {} with {} partitions.", k, newTopics.get(k).numPartitions());
-                                }
-                            }));
+                    topicCreationBatches(newTopics.values()).forEach(this::submitTopicCreationRequest);
                     return null;
                 },
                 () -> String.format("create topics %s on %s cluster", newTopics, config.targetClusterAlias())
         );
+    }
+
+    private void submitTopicCreationRequest(List<NewTopic> newTopics) {
+        Map<String, NewTopic> topicsByName = newTopics.stream()
+                .collect(Collectors.toMap(NewTopic::name, Function.identity()));
+        targetAdminClient.createTopics(newTopics, new CreateTopicsOptions()).values()
+                .forEach((name, future) -> future.whenComplete((ignored, error) -> {
+                    if (error != null) {
+                        log.warn("Could not create topic {}.", name, error);
+                    } else {
+                        log.info("Created remote topic {} with {} partitions.",
+                                name, topicsByName.get(name).numPartitions());
+                    }
+                }));
+    }
+
+    private static List<List<NewTopic>> topicCreationBatches(Collection<NewTopic> newTopics) {
+        List<List<NewTopic>> batches = new ArrayList<>();
+        List<NewTopic> currentBatch = new ArrayList<>();
+        long currentBatchRecords = 0;
+        for (NewTopic topic : newTopics) {
+            long topicRecords = estimatedTopicCreationRecords(topic);
+            if (!currentBatch.isEmpty()
+                    && currentBatchRecords + topicRecords > MAX_ESTIMATED_RECORDS_PER_CREATE_TOPICS_REQUEST) {
+                batches.add(currentBatch);
+                currentBatch = new ArrayList<>();
+                currentBatchRecords = 0;
+            }
+            currentBatch.add(topic);
+            currentBatchRecords += topicRecords;
+        }
+        if (!currentBatch.isEmpty()) {
+            batches.add(currentBatch);
+        }
+        return batches;
+    }
+
+    private static long estimatedTopicCreationRecords(NewTopic topic) {
+        long partitionRecords;
+        if (topic.numPartitions() > 0) {
+            partitionRecords = topic.numPartitions();
+        } else if (topic.replicasAssignments() != null) {
+            partitionRecords = topic.replicasAssignments().size();
+        } else {
+            partitionRecords = 1;
+        }
+        long configRecords = topic.configs() == null ? 0 : topic.configs().size();
+        return 1 + partitionRecords + configRecords;
     }
 
     void createNewPartitions(Map<String, NewPartitions> newPartitions) throws ExecutionException, InterruptedException {

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.connect.mirror;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeAclsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -30,8 +32,10 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
@@ -48,12 +52,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
 import static org.apache.kafka.connect.mirror.MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX;
@@ -395,6 +402,52 @@ public class MirrorSourceConnectorTest {
         }).when(connector).createNewTopics(any());
         connector.createNewTopics(Set.of(topic), Map.of(topic, 1L));
         verify(connector).createNewTopics(any(), any());
+    }
+
+    @Test
+    public void testCreateNewTopicsBatchesByEstimatedRecordCount() throws Exception {
+        Admin targetAdmin = mock(Admin.class);
+        MirrorSourceConnector connector = new MirrorSourceConnector(mock(Admin.class), targetAdmin,
+                new MirrorSourceConfig(makeProps()));
+        List<List<String>> requests = new ArrayList<>();
+        when(targetAdmin.createTopics(any(), any(CreateTopicsOptions.class))).thenAnswer(invocation -> {
+            Collection<NewTopic> topics = invocation.getArgument(0);
+            requests.add(topics.stream().map(NewTopic::name).collect(Collectors.toList()));
+            return createTopicsResult(topics, topic -> null);
+        });
+
+        Map<String, NewTopic> topics = new LinkedHashMap<>();
+        topics.put("a", new NewTopic("a", 4_999, (short) 1).configs(Map.of("cleanup.policy", "compact")));
+        topics.put("b", new NewTopic("b", 4_999, (short) 1).configs(Map.of("cleanup.policy", "compact")));
+        topics.put("c", new NewTopic("c", 1, (short) 1));
+        connector.createNewTopics(topics);
+
+        assertEquals(List.of(
+                List.of("a"),
+                List.of("b", "c")
+        ), requests);
+    }
+
+    @Test
+    public void testCreateNewTopicsSendsOversizedTopicAloneWithoutRetry() throws Exception {
+        Admin targetAdmin = mock(Admin.class);
+        MirrorSourceConnector connector = new MirrorSourceConnector(mock(Admin.class), targetAdmin,
+                new MirrorSourceConfig(makeProps()));
+        List<List<String>> requests = new ArrayList<>();
+        when(targetAdmin.createTopics(any(), any(CreateTopicsOptions.class))).thenAnswer(invocation -> {
+            Collection<NewTopic> topics = invocation.getArgument(0);
+            requests.add(topics.stream().map(NewTopic::name).collect(Collectors.toList()));
+            return createTopicsResult(topics, topic -> topic.name().equals("a")
+                    ? new PolicyViolationException("Too many partitions in request.")
+                    : null);
+        });
+
+        Map<String, NewTopic> topics = new LinkedHashMap<>();
+        topics.put("a", new NewTopic("a", 10_001, (short) 1));
+        topics.put("b", new NewTopic("b", 1, (short) 1));
+        connector.createNewTopics(topics);
+
+        assertEquals(List.of(List.of("a"), List.of("b")), requests);
     }
 
     @Test
@@ -783,5 +836,25 @@ public class MirrorSourceConnectorTest {
                 new TopicPartition(topic, partition),
                 sourceClusterAlias
         );
+    }
+
+    private static CreateTopicsResult createTopicsResult(
+            Collection<NewTopic> topics,
+            Function<NewTopic, Throwable> errorForTopic
+    ) {
+        CreateTopicsResult result = mock(CreateTopicsResult.class);
+        Map<String, KafkaFuture<Void>> futures = new HashMap<>();
+        for (NewTopic topic : topics) {
+            KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+            Throwable error = errorForTopic.apply(topic);
+            if (error == null) {
+                future.complete(null);
+            } else {
+                future.completeExceptionally(new CompletionException(error));
+            }
+            futures.put(topic.name(), future);
+        }
+        when(result.values()).thenReturn(futures);
+        return result;
     }
 }


### PR DESCRIPTION
MirrorSourceConnector currently submits all newly discovered topics in a
single  `CreateTopics` request, which may exceed the controller batch
limit.

Retrying dynamically on `PolicyViolationException` is unsafe because the
same  exception can also be returned by a custom `CreateTopicPolicy`.
Until an  oversized-request-specific exception allows AdminClient to
split requests  reliably, this change proactively batches topics using
the controller's default  limit of 10,000 estimated metadata records.

The estimate includes the topic, its partitions, and supplied
configurations.
