### PR TITLE
KAFKA-19583: Enable OAUTHBEARER SASL in the native image

### DIFF
--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1041,6 +1041,30 @@
   "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
 },
 {
+  "name":"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerRefreshingLogin",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClient$OAuthBearerSaslClientFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClientCallbackHandler",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServer$OAuthBearerSaslServerFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"org.apache.kafka.common.security.plain.PlainLoginModule",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },

--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1035,10 +1035,32 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever"
+  "name":"org.apache.kafka.common.security.oauthbearer.ClientCredentialsJwtRetriever",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
+  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.FileJwtRetriever",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.JwtBearerJwtRetriever",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.ClientJwtValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler",

--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1041,7 +1041,15 @@
   "name":"org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
 },
 {
+  "name":"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {


### PR DESCRIPTION
The native Kafka image failed to start with
KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER, throwing "Could not find a
public no-argument constructor" for
OAuthBearerUnsecuredLoginCallbackHandler. GraalVM native-image prunes
the no-arg constructors of classes that Kafka instantiates reflectively
(via Utils.newInstance, JAAS LoginContext and the SASL JCA providers)
unless they are listed in the reachability metadata.

Register the OAUTHBEARER classes in
docker/native/native-image-configs/reflect-config.json, mirroring how
PLAIN, SCRAM and Kerberos are already registered:

- OAuthBearerLoginModule, OAuthBearerRefreshingLogin
- OAuthBearerLoginCallbackHandler, OAuthBearerValidatorCallbackHandler,
  OAuthBearerSaslClientCallbackHandler,
  OAuthBearerUnsecuredLoginCallbackHandler
- JwtRetriever implementations (ClientCredentials, Default, File,
  JwtBearer) and JwtValidator implementations (Broker, Client, Default)
- OAuthBearerSaslClientFactory, OAuthBearerSaslServerFactory

This covers both the unsecured and the secured (OIDC) OAUTHBEARER flows.

Verified manually with the native image: unsecured OAUTHBEARER
produce/consume, and the OIDC client-credentials flow against Entra ID
using OAuthBearerLoginCallbackHandler /
OAuthBearerValidatorCallbackHandler.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
