### PR TITLE
KAFKA-21045 Register NoOpAssignmentRefiner in native image reflect-config

### DIFF
--- a/docker/native/native-image-configs/reflect-config.json
+++ b/docker/native/native-image-configs/reflect-config.json
@@ -1081,6 +1081,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"org.apache.kafka.metadata.authorizer.StandardAuthorizer",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-21045

Problem : Consumer groups fail to load on the native image with a
NoSuchMethodException for NoOpAssignmentRefiner.<init>() when a
__consumer_offsets partition loads — independent of the security
protocol.

```
kafka19583-broker  | [2026-09-07 14:07:23,272] ERROR [GroupCoordinator
id=1] Execution of Load(tp=__consumer_offsets-35, epoch=0) failed due to
Could not find a public no-argument constructor for
org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner.
(org.apache.kafka.coordinator.common.runtime.CoordinatorRuntime)
kafka19583-broker  | org.apache.kafka.common.KafkaException: Could not
find a public no-argument constructor for
org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner
kafka19583-broker  |    at
org.apache.kafka.common.utils.Utils.newInstance(Utils.java:414)
kafka19583-broker  |    at
org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:411)
```

Reviewers: Matthias J. Sax <matthias@confluent.io>, Chia-Ping Tsai
 <chia7712@gmail.com>
