### PR TITLE
KAFKA-1983: Remove redundant offset commits from EndToEndLatency

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
+++ b/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
@@ -136,14 +136,13 @@ public class EndToEndLatency {
             }
 
             printResults(numRecords, totalTime, latencies);
-            consumer.commitSync();
         }
     }
 
     // Visible for testing
     static void validate(KafkaConsumer<byte[], byte[]> consumer, byte[] sentRecordValue, ConsumerRecords<byte[], byte[]> records, byte[] sentRecordKey, Iterable<Header> sentHeaders) {
         if (records.isEmpty()) {
-            commitAndThrow(consumer, "poll() timed out before finding a result (timeout:[" + POLL_TIMEOUT_MS + "ms])");
+            throw new RuntimeException("poll() timed out before finding a result (timeout:[" + POLL_TIMEOUT_MS + "ms])");
         }
 
         ConsumerRecord<byte[], byte[]> record = records.iterator().next();
@@ -151,40 +150,34 @@ public class EndToEndLatency {
         String read = new String(record.value(), StandardCharsets.UTF_8);
 
         if (!read.equals(sent)) {
-            commitAndThrow(consumer, "The message value read [" + read + "] did not match the message value sent [" + sent + "]");
+            throw new RuntimeException("The message value read [" + read + "] did not match the message value sent [" + sent + "]");
         }
 
         if (sentRecordKey != null) {
             if (record.key() == null) {
-                commitAndThrow(consumer, "Expected message key but received null");
+                throw new RuntimeException("Expected message key but received null");
             }
             String sentKey = new String(sentRecordKey, StandardCharsets.UTF_8);
             String readKey = new String(record.key(), StandardCharsets.UTF_8);
             if (!readKey.equals(sentKey)) {
-                commitAndThrow(consumer, "The message key read [" + readKey + "] did not match the message key sent [" + sentKey + "]");
+                throw new RuntimeException("The message key read [" + readKey + "] did not match the message key sent [" + sentKey + "]");
             }
         } else if (record.key() != null) {
-            commitAndThrow(consumer, "Expected null message key but received [" + new String(record.key(), StandardCharsets.UTF_8) + "]");
+            throw new RuntimeException("Expected null message key but received [" + new String(record.key(), StandardCharsets.UTF_8) + "]");
         }
 
         validateHeaders(consumer, sentHeaders, record);
 
         //Check we only got the one message
         if (records.count() != 1) {
-            int count = records.count();
-            commitAndThrow(consumer, "Only one result was expected during this test. We found [" + count + "]");
+            throw new RuntimeException("Only one result was expected during this test. We found [" + records.count() + "]");
         }
-    }
-
-    private static void commitAndThrow(KafkaConsumer<byte[], byte[]> consumer, String message) {
-        consumer.commitSync();
-        throw new RuntimeException(message);
     }
 
     private static void validateHeaders(KafkaConsumer<byte[], byte[]> consumer, Iterable<Header> sentHeaders, ConsumerRecord<byte[], byte[]> record) {
         if (sentHeaders != null && sentHeaders.iterator().hasNext()) {
             if (!record.headers().iterator().hasNext()) {
-                commitAndThrow(consumer, "Expected message headers but received none");
+                throw new RuntimeException("Expected message headers but received none");
             }
             
             Iterator<Header> sentIterator = sentHeaders.iterator();
@@ -196,13 +189,13 @@ public class EndToEndLatency {
                 if (!receivedHeader.key().equals(sentHeader.key()) || !Arrays.equals(receivedHeader.value(), sentHeader.value())) {
                     String receivedValueStr = receivedHeader.value() == null ? "null" : Arrays.toString(receivedHeader.value());
                     String sentValueStr = sentHeader.value() == null ? "null" : Arrays.toString(sentHeader.value());
-                    commitAndThrow(consumer, "The message header read [" + receivedHeader.key() + ":" + receivedValueStr +
+                    throw new RuntimeException("The message header read [" + receivedHeader.key() + ":" + receivedValueStr +
                             "] did not match the message header sent [" + sentHeader.key() + ":" + sentValueStr + "]");
                 }
             }
             
             if (sentIterator.hasNext() || receivedIterator.hasNext()) {
-                commitAndThrow(consumer, "Header count mismatch between sent and received messages");
+                throw new RuntimeException("Header count mismatch between sent and received messages");
             }
         }
     }


### PR DESCRIPTION
The tool uses a timestamp-based group.id and calls seekToEnd() on
startup, so committed offsets are never read back. This PR removes the
commitSync() in execute(), replaces commitAndThrow with a plain throw at
its call sites, and deletes the helper.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>, Ken Huang <s7133700@gmail.com>
