### PR TITLE
MINOR: remove redundant stream round-trip in MirrorSourceConnector

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -455,11 +455,9 @@ public class MirrorSourceConnector extends SourceConnector {
     void computeAndCreateTopicPartitions() throws ExecutionException, InterruptedException {
         // get source and target topics with respective partition counts
         Map<String, Long> sourceTopicToPartitionCounts = knownSourceTopicPartitions.stream()
-                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting()));
         Map<String, Long> targetTopicToPartitionCounts = knownTargetTopicPartitions.stream()
-                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting()));
 
         Set<String> knownSourceTopics = sourceTopicToPartitionCounts.keySet();
         Set<String> knownTargetTopics = targetTopicToPartitionCounts.keySet();


### PR DESCRIPTION
`computeAndCreateTopicPartitions` collected the partition counts with
`Collectors.groupingBy(..., counting())` and then immediately streamed
the resulting entry set back into `Collectors.toMap(Entry::getKey,
Entry::getValue)`. That second pass rebuilds an identical map, so it is
pure overhead.

This removes the redundant round-trip for both
`sourceTopicToPartitionCounts` and `targetTopicToPartitionCounts`.

Reviewers: Mickael Maison <mickael.maison@gmail.com>
