### PR TITLE
KAFKA-21049: Prevent async consumer busy loop with zero retry backoff

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumer.java
@@ -1987,27 +1987,29 @@ public class AsyncKafkaConsumer<K, V> implements ConsumerDelegate<K, V> {
 
         long pollTimeout = Math.min(applicationEventHandler.maximumTimeToWait(), timer.remainingMs());
 
-        // Bound the wait when background progress may make fetching possible soon.
+        // Bound the wait when background progress may make fetching possible soon. retry.backoff.ms may be 0,
+        // but the application thread still needs a positive wait to avoid polling continuously.
+        long pollBackoffMs = Math.max(1L, retryBackoffMs);
         // Use the current application-thread state to avoid relying on stale state from the network thread.
-        if (pollTimeout > retryBackoffMs) {
+        if (pollTimeout > pollBackoffMs) {
             if (subscriptions.numAssignedPartitions() == 0) {
                 // If there are no assigned partitions, reduce the fetch buffer wait time. This may happen when
                 // group membership has not been established yet, assignments have been revoked but not reassigned,
                 // bootstrap DNS resolution is still in progress, or manual assignment has not happened yet.
-                pollTimeout = retryBackoffMs;
+                pollTimeout = pollBackoffMs;
             } else if (!subscriptions.hasAllFetchPositions()) {
                 // If some partitions do not have valid positions, the background thread may still be resolving them,
                 // for example by fetching committed offsets, looking up offsets by timestamp, or backing off after a
                 // failure. Reduce the wait time so the application thread can consume data promptly once positions are
                 // resolved.
-                pollTimeout = retryBackoffMs;
+                pollTimeout = pollBackoffMs;
             } else {
                 Set<TopicPartition> buffered = fetchBuffer.bufferedPartitions();
                 if (subscriptions.hasFetchablePartitions(tp -> !buffered.contains(tp))) {
                     // If any fetchable partition has no buffered data, it may have been skipped due to reconnect
                     // backoff, an in-flight request, or a missing leader. Bound the wait so the application thread
                     // can retry once the condition clears.
-                    pollTimeout = retryBackoffMs;
+                    pollTimeout = pollBackoffMs;
                 }
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchRequestManager.java
@@ -81,7 +81,9 @@ public class FetchRequestManager extends AbstractFetch implements RequestManager
      */
     @Override
     public long maximumTimeToWait(long currentTimeMs) {
-        return nodesWithPendingFetchRequests.isEmpty() ? retryBackoffMs : Long.MAX_VALUE;
+        // retry.backoff.ms may be configured to 0, but returning 0 here would cause the application thread
+        // to poll continuously while there is no fetch request in flight.
+        return nodesWithPendingFetchRequests.isEmpty() ? Math.max(1L, retryBackoffMs) : Long.MAX_VALUE;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AsyncKafkaConsumerTest.java
@@ -259,6 +259,15 @@ public class AsyncKafkaConsumerTest {
         ConsumerInterceptors<String, String> interceptors,
         ConsumerRebalanceListenerInvoker rebalanceListenerInvoker,
         SubscriptionState subscriptions) {
+        return newConsumer(fetchBuffer, interceptors, rebalanceListenerInvoker, subscriptions, 100L);
+    }
+
+    private AsyncKafkaConsumer<String, String> newConsumer(
+        FetchBuffer fetchBuffer,
+        ConsumerInterceptors<String, String> interceptors,
+        ConsumerRebalanceListenerInvoker rebalanceListenerInvoker,
+        SubscriptionState subscriptions,
+        long retryBackoffMs) {
         int requestTimeoutMs = 30000;
         int defaultApiTimeoutMs = 1000;
         return new AsyncKafkaConsumer<>(
@@ -278,7 +287,7 @@ public class AsyncKafkaConsumerTest {
             metrics,
             subscriptions,
             metadata,
-            100L,
+            retryBackoffMs,
             requestTimeoutMs,
             defaultApiTimeoutMs,
             "group-id",
@@ -2164,6 +2173,34 @@ public class AsyncKafkaConsumerTest {
             "Expected poll wait timer to use the full user timeout (no busy loop), but was " + awaitTimerInitialMs.get());
 
         // Only a single wait cycle should have happened
+        verify(fetchBuffer, times(1)).awaitWakeup(any(Timer.class));
+    }
+
+    @Test
+    public void testPollDoesNotBusyLoopWhenRetryBackoffIsZero() {
+        FetchBuffer fetchBuffer = mock(FetchBuffer.class);
+        SubscriptionState subscriptions = new SubscriptionState(new LogContext(), AutoOffsetResetStrategy.NONE);
+        consumer = newConsumer(fetchBuffer, mock(ConsumerInterceptors.class),
+                mock(ConsumerRebalanceListenerInvoker.class), subscriptions, 0L);
+
+        TopicPartition tp = new TopicPartition("topic1", 0);
+        subscriptions.assignFromUser(singleton(tp));
+        doReturn(Long.MAX_VALUE).when(applicationEventHandler).maximumTimeToWait();
+        doReturn(Fetch.empty()).when(fetchCollector).collectFetch(any(FetchBuffer.class));
+
+        AtomicReference<Long> awaitTimerInitialMs = new AtomicReference<>();
+        doAnswer(invocation -> {
+            Timer pollTimer = invocation.getArgument(0, Timer.class);
+            awaitTimerInitialMs.compareAndSet(null, pollTimer.remainingMs());
+            time.sleep(500);
+            pollTimer.update();
+            return null;
+        }).when(fetchBuffer).awaitWakeup(any(Timer.class));
+
+        consumer.poll(Duration.ofMillis(500));
+
+        assertEquals(1L, awaitTimerInitialMs.get(),
+                "Expected a positive minimum wait when retry.backoff.ms is 0");
         verify(fetchBuffer, times(1)).awaitWakeup(any(Timer.class));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchRequestManagerTest.java
@@ -185,7 +185,7 @@ public class FetchRequestManagerTest {
     private final int maxBytes = Integer.MAX_VALUE;
     private final int maxWaitMs = 0;
     private final int fetchSize = 1000;
-    private final long retryBackoffMs = 100;
+    private long retryBackoffMs = 100;
     private final int requestTimeoutMs = 30000;
     private final ApiVersions apiVersions = new ApiVersions();
     private MockTime time = new MockTime(1);
@@ -404,6 +404,18 @@ public class FetchRequestManagerTest {
 
         assertEquals(0, sendFetches());
         assertEquals(retryBackoffMs, fetcher.maximumTimeToWait(time.milliseconds()));
+    }
+
+    @Test
+    public void testMaximumTimeToWaitDoesNotSpinWhenRetryBackoffIsZero() {
+        retryBackoffMs = 0;
+        buildFetcher();
+
+        long maximumTimeToWaitMs = fetcher.maximumTimeToWait(time.milliseconds());
+
+        assertTrue(maximumTimeToWaitMs > 0,
+                "maximumTimeToWait must be > 0 when there is no in-flight fetch request, even if " +
+                        "retry.backoff.ms is configured to 0; got " + maximumTimeToWaitMs);
     }
 
     @Test


### PR DESCRIPTION
When `retry.backoff.ms` is 0, the async consumer can use a 0 ms wait
while  waiting for fetch progress, causing the outer poll loop to repeat
without  blocking.

This change applies a minimum 1 ms application-thread wait without
changing  request retry behavior, and adds tests for both affected
paths.
