### PR TITLE
MINOR: Remove unused setUpAndVerifyImmutableMetric

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -199,19 +199,4 @@ public class ClientMetricsTest {
                 eq(value)
         );
     }
-
-    private void setUpAndVerifyImmutableMetric(final String name,
-                                               final String description,
-                                               final int value,
-                                               final Runnable metricAdder) {
-
-        metricAdder.run();
-
-        verify(streamsMetrics).addClientLevelImmutableMetric(
-                eq(name),
-                eq(description),
-                eq(RecordingLevel.INFO),
-                eq(value)
-        );
-    }
 }


### PR DESCRIPTION
Remove unused setUpAndVerifyImmutableMetric in ClientMetricsTest.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
