### PR TITLE
KAFKA-21029: [2/2] Remove hamcrest from org.apache.kafka.streams.state.internals package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStoreTest.java
@@ -56,11 +56,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -264,7 +262,7 @@ public class MeteredTimestampedKeyValueStoreTest {
         when(inner.get(KEY_BYTES)).thenReturn(VALUE_AND_TIMESTAMP_BYTES);
         init();
 
-        assertThat(metered.get(KEY), equalTo(VALUE_AND_TIMESTAMP));
+        assertEquals(VALUE_AND_TIMESTAMP, metered.get(KEY));
 
         final KafkaMetric metric = metric("get-rate");
         assertTrue((Double) metric.metricValue() > 0);
@@ -319,7 +317,7 @@ public class MeteredTimestampedKeyValueStoreTest {
         init();
 
         final KeyValueIterator<String, ValueAndTimestamp<String>> iterator = metered.range(KEY, KEY);
-        assertThat(iterator.next().value, equalTo(VALUE_AND_TIMESTAMP));
+        assertEquals(VALUE_AND_TIMESTAMP, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -335,7 +333,7 @@ public class MeteredTimestampedKeyValueStoreTest {
         init();
 
         final KeyValueIterator<String, ValueAndTimestamp<String>> iterator = metered.all();
-        assertThat(iterator.next().value, equalTo(VALUE_AND_TIMESTAMP));
+        assertEquals(VALUE_AND_TIMESTAMP, iterator.next().value);
         assertFalse(iterator.hasNext());
         iterator.close();
 
@@ -440,15 +438,15 @@ public class MeteredTimestampedKeyValueStoreTest {
         init();
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat(openIteratorsMetric, not(nullValue()));
+        assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         try (final KeyValueIterator<String, ValueAndTimestamp<String>> unused = metered.all()) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -460,27 +458,27 @@ public class MeteredTimestampedKeyValueStoreTest {
 
         final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
-        assertThat(iteratorDurationAvgMetric, not(nullValue()));
-        assertThat(iteratorDurationMaxMetric, not(nullValue()));
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
 
-        assertThat((Double) iteratorDurationAvgMetric.metricValue(), equalTo(Double.NaN));
-        assertThat((Double) iteratorDurationMaxMetric.metricValue(), equalTo(Double.NaN));
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<String, ValueAndTimestamp<String>> unused = metered.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(2);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<String, ValueAndTimestamp<String>> iterator = metered.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(3);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -491,7 +489,7 @@ public class MeteredTimestampedKeyValueStoreTest {
         init();
 
         final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
-        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+        assertNotNull(oldestIteratorTimestampMetric);
 
         KeyValueIterator<String, ValueAndTimestamp<String>> second = null;
         final long secondTimestamp;
@@ -499,24 +497,24 @@ public class MeteredTimestampedKeyValueStoreTest {
             try (final KeyValueIterator<String, ValueAndTimestamp<String>> unused = metered.all()) {
 
                 final long oldestTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
 
                 // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
                 second = metered.all();
                 secondTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
             }
 
             // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
-            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+            assertEquals(secondTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
         } finally {
             if (second != null) {
                 second.close();
             }
         }
         // now that all iterators are closed, the metric should be zero
-        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) oldestIteratorTimestampMetric.metricValue());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredVersionedKeyValueStoreTest.java
@@ -63,15 +63,11 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -194,8 +190,8 @@ public class MeteredVersionedKeyValueStoreTest {
 
         final long validto = store.put(KEY, VALUE, TIMESTAMP);
 
-        assertThat(validto, is(PUT_RETURN_CODE_VALID_TO_UNDEFINED));
-        assertThat((Double) getMetric("put-rate").metricValue(), greaterThan(0.0));
+        assertEquals(PUT_RETURN_CODE_VALID_TO_UNDEFINED, validto);
+        assertTrue(Double.compare((Double) getMetric("put-rate").metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -204,8 +200,8 @@ public class MeteredVersionedKeyValueStoreTest {
 
         final VersionedRecord<String> result = store.delete(KEY, TIMESTAMP);
 
-        assertThat(result, is(new VersionedRecord<>(VALUE, TIMESTAMP)));
-        assertThat((Double) getMetric("delete-rate").metricValue(), greaterThan(0.0));
+        assertEquals(new VersionedRecord<>(VALUE, TIMESTAMP), result);
+        assertTrue(Double.compare((Double) getMetric("delete-rate").metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -214,8 +210,8 @@ public class MeteredVersionedKeyValueStoreTest {
 
         final VersionedRecord<String> result = store.get(KEY);
 
-        assertThat(result, is(new VersionedRecord<>(VALUE, TIMESTAMP)));
-        assertThat((Double) getMetric("get-rate").metricValue(), greaterThan(0.0));
+        assertEquals(new VersionedRecord<>(VALUE, TIMESTAMP), result);
+        assertTrue(Double.compare((Double) getMetric("get-rate").metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -224,8 +220,8 @@ public class MeteredVersionedKeyValueStoreTest {
 
         final VersionedRecord<String> result = store.get(KEY, TIMESTAMP);
 
-        assertThat(result, is(new VersionedRecord<>(VALUE, TIMESTAMP)));
-        assertThat((Double) getMetric("get-rate").metricValue(), greaterThan(0.0));
+        assertEquals(new VersionedRecord<>(VALUE, TIMESTAMP), result);
+        assertTrue(Double.compare((Double) getMetric("get-rate").metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -233,32 +229,32 @@ public class MeteredVersionedKeyValueStoreTest {
         store.commit(Map.of());
 
         verify(inner).commit(Map.of());
-        assertThat((Double) getMetric("commit-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) getMetric("commit-rate").metricValue(), 0.0) > 0);
     }
 
     @Test
     public void shouldDelegateAndRemoveMetricsOnClose() {
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
 
         store.close();
 
         verify(inner).close();
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
     public void shouldRemoveMetricsOnCloseEvenIfInnerThrows() {
         doThrow(new RuntimeException("uh oh")).when(inner).close();
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
 
         assertThrows(RuntimeException.class, () -> store.close());
 
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
     public void shouldNotSetFlushListenerIfInnerIsNotCaching() {
-        assertThat(store.setFlushListener(null, false), is(false));
+        assertFalse(store.setFlushListener(null, false));
     }
 
     @Test
@@ -315,7 +311,7 @@ public class MeteredVersionedKeyValueStoreTest {
         when(inner.query(query, positionBound, queryConfig)).thenReturn((QueryResult) result);
         when(queryConfig.isCollectExecutionInfo()).thenReturn(true);
 
-        assertThat(store.query(query, positionBound, queryConfig), is(result));
+        assertEquals(result, store.query(query, positionBound, queryConfig));
         verify(result).addExecutionInfo(anyString());
     }
 
@@ -323,29 +319,29 @@ public class MeteredVersionedKeyValueStoreTest {
     public void shouldDelegateName() {
         when(inner.name()).thenReturn(STORE_NAME);
 
-        assertThat(store.name(), is(STORE_NAME));
+        assertEquals(STORE_NAME, store.name());
     }
 
     @Test
     public void shouldDelegatePersistent() {
         // `persistent = true` case
         when(inner.persistent()).thenReturn(true);
-        assertThat(store.persistent(), is(true));
+        assertTrue(store.persistent());
 
         // `persistent = false` case
         when(inner.persistent()).thenReturn(false);
-        assertThat(store.persistent(), is(false));
+        assertFalse(store.persistent());
     }
 
     @Test
     public void shouldDelegateIsOpen() {
         // `isOpen = true` case
         when(inner.isOpen()).thenReturn(true);
-        assertThat(store.isOpen(), is(true));
+        assertTrue(store.isOpen());
 
         // `isOpen = false` case
         when(inner.isOpen()).thenReturn(false);
-        assertThat(store.isOpen(), is(false));
+        assertFalse(store.isOpen());
     }
 
     @Test
@@ -353,7 +349,7 @@ public class MeteredVersionedKeyValueStoreTest {
         final Position position = mock(Position.class);
         when(inner.getPosition()).thenReturn(position);
 
-        assertThat(store.getPosition(), is(position));
+        assertEquals(position, store.getPosition());
     }
 
     @SuppressWarnings("unused")
@@ -366,17 +362,17 @@ public class MeteredVersionedKeyValueStoreTest {
             QueryResult.forResult(new LogicalSegmentIterator(Collections.emptyListIterator(), RAW_KEY, 0L, 0L, ResultOrder.ANY)));
 
         final KafkaMetric openIteratorsMetric = getMetric("num-open-iterators");
-        assertThat(openIteratorsMetric, not(nullValue()));
+        assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         final QueryResult<VersionedRecordIterator<String>> result = store.query(query, bound, config);
 
         try (final VersionedRecordIterator<String> unused = result.getResult()) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -390,11 +386,11 @@ public class MeteredVersionedKeyValueStoreTest {
 
         final KafkaMetric iteratorDurationAvgMetric = getMetric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMaxMetric = getMetric("iterator-duration-max");
-        assertThat(iteratorDurationAvgMetric, not(nullValue()));
-        assertThat(iteratorDurationMaxMetric, not(nullValue()));
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
 
-        assertThat((Double) iteratorDurationAvgMetric.metricValue(), equalTo(Double.NaN));
-        assertThat((Double) iteratorDurationMaxMetric.metricValue(), equalTo(Double.NaN));
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
         final QueryResult<VersionedRecordIterator<String>> first = store.query(query, bound, config);
         try (final VersionedRecordIterator<String> unused = first.getResult()) {
@@ -402,8 +398,8 @@ public class MeteredVersionedKeyValueStoreTest {
             mockTime.sleep(2);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
         final QueryResult<VersionedRecordIterator<String>> second = store.query(query, bound, config);
         try (final VersionedRecordIterator<String> unused = second.getResult()) {
@@ -411,8 +407,8 @@ public class MeteredVersionedKeyValueStoreTest {
             mockTime.sleep(3);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -425,7 +421,7 @@ public class MeteredVersionedKeyValueStoreTest {
                 QueryResult.forResult(new LogicalSegmentIterator(Collections.emptyListIterator(), RAW_KEY, 0L, 0L, ResultOrder.ANY)));
 
         final KafkaMetric oldestIteratorTimestampMetric = getMetric("oldest-iterator-open-since-ms");
-        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+        assertNotNull(oldestIteratorTimestampMetric);
 
         final QueryResult<VersionedRecordIterator<String>> first = store.query(query, bound, config);
         VersionedRecordIterator<String> secondIterator = null;
@@ -434,7 +430,7 @@ public class MeteredVersionedKeyValueStoreTest {
             try (final VersionedRecordIterator<String> unused = first.getResult()) {
 
                 final long oldestTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
 
                 // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
@@ -442,19 +438,19 @@ public class MeteredVersionedKeyValueStoreTest {
                 secondIterator = second.getResult();
                 secondTime = mockTime.milliseconds();
 
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
             }
 
             // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
-            assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(secondTime));
+            assertEquals(secondTime, (Long) oldestIteratorTimestampMetric.metricValue());
         } finally {
             if (secondIterator != null) {
                 secondIterator.close();
             }
         }
         // no open iterators left, timestamp should be reset to 0
-        assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) oldestIteratorTimestampMetric.metricValue());
     }
 
     private KafkaMetric getMetric(final String name) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -67,13 +67,9 @@ import java.util.stream.Collectors;
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -232,7 +228,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one restore metric since all restore metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("restore-latency-max");
-        assertThat((Double) metric.metricValue(), equalTo((double) restoreTimeNs));
+        assertEquals((double) restoreTimeNs, (Double) metric.metricValue());
     }
 
     @Test
@@ -246,7 +242,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one put metric since all put metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("put-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -260,7 +256,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -292,7 +288,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -306,7 +302,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -329,7 +325,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -342,7 +338,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -355,7 +351,7 @@ public class MeteredWindowStoreTest {
         // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
         // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
-        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric.metricValue(), 0.0) > 0);
     }
 
     @Test
@@ -434,8 +430,8 @@ public class MeteredWindowStoreTest {
         verify(valueDeserializer).deserialize(anyString(), headersCaptor.capture(), any(byte[].class));
 
         final Header capturedLastHeader = headersCaptor.getValue().lastHeader(headerKey);
-        assertThat(capturedLastHeader, not(nullValue()));
-        assertThat(new String(capturedLastHeader.value(), StandardCharsets.UTF_8), equalTo("new"));
+        assertNotNull(capturedLastHeader);
+        assertEquals("new", new String(capturedLastHeader.value(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -456,9 +452,9 @@ public class MeteredWindowStoreTest {
         doNothing().when(innerStoreMock).close();
         store.init(context, store);
 
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         store.close();
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -467,9 +463,9 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         // There's always a "count" metric registered
-        assertThat(storeMetrics(), not(empty()));
+        assertFalse(storeMetrics().isEmpty());
         assertThrows(RuntimeException.class, store::close);
-        assertThat(storeMetrics(), empty());
+        assertTrue(storeMetrics().isEmpty());
     }
 
     @Test
@@ -494,9 +490,9 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         final KafkaMetric numKeysMetric = metric("num-keys");
-        assertThat(numKeysMetric, not(nullValue()));
+        assertNotNull(numKeysMetric);
         // inner store is a mock (not InMemoryWindowStore), so returns -1
-        assertThat((Long) numKeysMetric.metricValue(), equalTo(-1L));
+        assertEquals(-1L, (Long) numKeysMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -506,15 +502,15 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat(openIteratorsMetric, not(nullValue()));
+        assertNotNull(openIteratorsMetric);
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> unused = store.all()) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -525,27 +521,27 @@ public class MeteredWindowStoreTest {
 
         final KafkaMetric iteratorDurationAvgMetric = metric("iterator-duration-avg");
         final KafkaMetric iteratorDurationMaxMetric = metric("iterator-duration-max");
-        assertThat(iteratorDurationAvgMetric, not(nullValue()));
-        assertThat(iteratorDurationMaxMetric, not(nullValue()));
+        assertNotNull(iteratorDurationAvgMetric);
+        assertNotNull(iteratorDurationMaxMetric);
 
-        assertThat((Double) iteratorDurationAvgMetric.metricValue(), equalTo(Double.NaN));
-        assertThat((Double) iteratorDurationMaxMetric.metricValue(), equalTo(Double.NaN));
+        assertEquals(Double.NaN, (Double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(Double.NaN, (Double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> unused = store.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(2);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(2.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(2.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
 
         try (final KeyValueIterator<Windowed<String>, String> unused = store.all()) {
             // nothing to do, just close immediately
             mockTime.sleep(3);
         }
 
-        assertThat((double) iteratorDurationAvgMetric.metricValue(), equalTo(2.5 * TimeUnit.MILLISECONDS.toNanos(1)));
-        assertThat((double) iteratorDurationMaxMetric.metricValue(), equalTo(3.0 * TimeUnit.MILLISECONDS.toNanos(1)));
+        assertEquals(2.5 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationAvgMetric.metricValue());
+        assertEquals(3.0 * TimeUnit.MILLISECONDS.toNanos(1), (double) iteratorDurationMaxMetric.metricValue());
     }
 
     @SuppressWarnings("unused")
@@ -555,34 +551,34 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         final KafkaMetric oldestIteratorTimestampMetric = metric("oldest-iterator-open-since-ms");
-        assertThat(oldestIteratorTimestampMetric, not(nullValue()));
+        assertNotNull(oldestIteratorTimestampMetric);
 
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
 
         KeyValueIterator<Windowed<String>, String> second = null;
         final long secondTimestamp;
         try {
             try (final KeyValueIterator<Windowed<String>, String> unused = store.all()) {
                 final long oldestTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
 
                 // open a second iterator before closing the first to test that we still produce the first iterator's timestamp
                 second = store.all();
                 secondTimestamp = mockTime.milliseconds();
-                assertThat((Long) oldestIteratorTimestampMetric.metricValue(), equalTo(oldestTimestamp));
+                assertEquals(oldestTimestamp, (Long) oldestIteratorTimestampMetric.metricValue());
                 mockTime.sleep(100);
             }
 
             // now that the first iterator is closed, check that the timestamp has advanced to the still open second iterator
-            assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(secondTimestamp));
+            assertEquals(secondTimestamp, oldestIteratorTimestampMetric.metricValue());
         } finally {
             if (second != null) {
                 second.close();
             }
         }
 
-        assertThat(oldestIteratorTimestampMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, oldestIteratorTimestampMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")
@@ -595,8 +591,8 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
-        assertThat(view.fetch(KEY, TIMESTAMP), equalTo(VALUE));
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertEquals(VALUE, view.fetch(KEY, TIMESTAMP));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -611,7 +607,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.fetch(KEY, ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -626,7 +622,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.backwardFetch(KEY, ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -641,7 +637,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.fetch(KEY, KEY, ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -656,7 +652,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.backwardFetch(KEY, KEY, ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -670,7 +666,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.all().close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -684,7 +680,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.backwardAll().close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -698,7 +694,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.fetchAll(ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings("unchecked")
@@ -712,7 +708,7 @@ public class MeteredWindowStoreTest {
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         view.backwardFetchAll(ofEpochMilli(1), ofEpochMilli(1)).close();
-        assertThat((Double) metric("fetch-rate").metricValue(), greaterThan(0.0));
+        assertTrue(Double.compare((Double) metric("fetch-rate").metricValue(), 0.0) > 0);
     }
 
     @SuppressWarnings({"unchecked", "unused"})
@@ -725,14 +721,14 @@ public class MeteredWindowStoreTest {
         store.init(context, store);
 
         final KafkaMetric openIteratorsMetric = metric("num-open-iterators");
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
 
         final ReadOnlyWindowStore<String, String> view = store.readOnly(IsolationLevel.READ_UNCOMMITTED);
         try (final KeyValueIterator<Windowed<String>, String> unused = view.all()) {
-            assertThat((Long) openIteratorsMetric.metricValue(), equalTo(1L));
+            assertEquals(1L, (Long) openIteratorsMetric.metricValue());
         }
 
-        assertThat((Long) openIteratorsMetric.metricValue(), equalTo(0L));
+        assertEquals(0L, (Long) openIteratorsMetric.metricValue());
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/OffsetCheckpointTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/OffsetCheckpointTest.java
@@ -33,10 +33,6 @@ import java.util.Map;
 
 import static org.apache.kafka.streams.state.internals.OffsetCheckpoint.writeEntry;
 import static org.apache.kafka.streams.state.internals.OffsetCheckpoint.writeIntLine;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -96,13 +92,13 @@ public class OffsetCheckpointTest {
 
         checkpoint.write(offsets);
 
-        assertThat(file.exists(), is(true));
-        assertThat(offsets, is(checkpoint.read()));
+        assertTrue(file.exists());
+        assertEquals(offsets, checkpoint.read());
 
         checkpoint.write(Collections.emptyMap());
 
-        assertThat(file.exists(), is(false));
-        assertThat(Collections.emptyMap(), is(checkpoint.read()));
+        assertFalse(file.exists());
+        assertEquals(Map.of(), checkpoint.read());
     }
 
     @Test
@@ -133,7 +129,7 @@ public class OffsetCheckpointTest {
             checkpoint.write(offsetsToWrite);
 
             final Map<TopicPartition, Long> readOffsets = checkpoint.read();
-            assertThat(readOffsets.get(new TopicPartition(topic, 1)), equalTo(sentinelOffset));
+            assertEquals(sentinelOffset, readOffsets.get(new TopicPartition(topic, 1)));
         } finally {
             checkpoint.delete();
         }
@@ -164,7 +160,7 @@ public class OffsetCheckpointTest {
         final OffsetCheckpoint checkpoint = new OffsetCheckpoint(notExistedFile);
         
         final IOException e = assertThrows(IOException.class, () -> checkpoint.write(offsetsToWrite));
-        assertThat(e.getMessage(), containsString("No such file or directory"));
+        assertTrue(e.getMessage().contains("No such file or directory"));
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -136,7 +134,7 @@ public class QueryableStoreProviderTest {
                                 .fromNameAndType(keyValueStore, QueryableStoreTypes.keyValueStore())
                                 .withPartition(partition)).get("1")
         );
-        assertThat(thrown.getMessage(), equalTo(String.format("The specified partition %d for store %s does not exist.", partition, keyValueStore)));
+        assertEquals(String.format("The specified partition %d for store %s does not exist.", partition, keyValueStore), thrown.getMessage());
     }
 
     @Test
@@ -153,6 +151,6 @@ public class QueryableStoreProviderTest {
                                 .fromNameAndType(windowStore, QueryableStoreTypes.windowStore())
                                 .withPartition(partition)).fetch("1", System.currentTimeMillis())
         );
-        assertThat(thrown.getMessage(), equalTo(String.format("The specified partition %d for store %s does not exist.", partition, windowStore)));
+        assertEquals(String.format("The specified partition %d for store %s does not exist.", partition, windowStore), thrown.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlySessionStoreFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlySessionStoreFacadeTest.java
@@ -32,8 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +56,7 @@ public class ReadOnlySessionStoreFacadeTest {
         when(mockedSessionStoreWithHeaders.fetchSession("key", 10L, 20L))
             .thenReturn(AggregationWithHeaders.make("value", new RecordHeaders()));
 
-        assertThat(readOnlySessionStoreFacade.fetchSession("key", 10L, 20L), is("value"));
+        assertEquals("value", readOnlySessionStoreFacade.fetchSession("key", 10L, 20L));
     }
 
     @Test
@@ -83,8 +82,8 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.findSessions("key1", 10L, 40L);
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2"), iterator.next());
     }
 
     @Test
@@ -99,7 +98,7 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.backwardFindSessions("key1", 10L, 40L);
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value1"), iterator.next());
     }
 
     @Test
@@ -114,7 +113,7 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.findSessions("key1", "key2", 10L, 40L);
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1"), iterator.next());
     }
 
     @Test
@@ -129,7 +128,7 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.backwardFindSessions("key1", "key2", 10L, 40L);
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2"), iterator.next());
     }
 
     @Test
@@ -146,8 +145,8 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.fetch("key1");
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1")));
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1"), iterator.next());
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value2"), iterator.next());
     }
 
     @Test
@@ -161,7 +160,7 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.backwardFetch("key1");
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(30L, 40L)), "value1"), iterator.next());
     }
 
     @Test
@@ -175,7 +174,7 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.fetch("key1", "key2");
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1")));
+        assertEquals(KeyValue.pair(new Windowed<>("key1", new SessionWindow(10L, 20L)), "value1"), iterator.next());
     }
 
     @Test
@@ -189,6 +188,6 @@ public class ReadOnlySessionStoreFacadeTest {
         final KeyValueIterator<Windowed<String>, String> iterator =
             readOnlySessionStoreFacade.backwardFetch("key1", "key2");
 
-        assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2")));
+        assertEquals(KeyValue.pair(new Windowed<>("key2", new SessionWindow(30L, 40L)), "value2"), iterator.next());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest.java
@@ -64,10 +64,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
@@ -151,9 +148,9 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             final Set<String> invokedMethodNames = invocations.stream().map(invocation -> invocation.getMethod().getName()).collect(Collectors.toSet());
             assertTrue(invokedMethodNames.contains(method.getName()), "Should have called DBOptions." + method.getName() + "()");
         } catch (final InvocationTargetException undeclaredMockMethodCall) {
-            assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
-            assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
-                matchesPattern("Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
+            assertInstanceOf(AssertionError.class, undeclaredMockMethodCall.getCause());
+            assertTrue(undeclaredMockMethodCall.getCause().getMessage().trim().matches(
+                "Unexpected method call DBOptions\\." + method.getName() + "((.*\n*)*):"));
         } finally {
             optionsFacadeDbOptions.close();
         }
@@ -254,9 +251,9 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
             final Set<String> invokedMethodNames = invocations.stream().map(invocation -> invocation.getMethod().getName()).collect(Collectors.toSet());
             assertTrue(invokedMethodNames.contains(method.getName()), "Should have called ColumnFamilyOptions." + method.getName() + "()");
         } catch (final InvocationTargetException undeclaredMockMethodCall) {
-            assertThat(undeclaredMockMethodCall.getCause(), instanceOf(AssertionError.class));
-            assertThat(undeclaredMockMethodCall.getCause().getMessage().trim(),
-                matchesPattern("Unexpected method call ColumnFamilyOptions\\." + method.getName() +  "(.*)"));
+            assertInstanceOf(AssertionError.class, undeclaredMockMethodCall.getCause());
+            assertTrue(undeclaredMockMethodCall.getCause().getMessage().trim().matches(
+                "Unexpected method call ColumnFamilyOptions\\." + method.getName() + "(.*)"));
         } finally {
             optionsFacadeColumnFamilyOptions.close();
         }
@@ -354,7 +351,8 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
                     .map(LogCaptureAppender.Event::getMessage)
                     .collect(Collectors.toSet());
 
-                walOptions.forEach(option -> assertThat(logMessages, hasItem(String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
+                walOptions.forEach(option -> assertTrue(logMessages.contains(
+                    String.format("WAL is explicitly disabled by Streams in RocksDB. Setting option '%s' will be ignored", option))));
             }
         }
     }
@@ -371,7 +369,8 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapterTest {
                         .filter(e -> e.getLevel().equals("WARN"))
                         .map(LogCaptureAppender.Event::getMessage)
                         .collect(Collectors.toSet());
-                assertThat(logMessages, hasItem("AtomicFlush is explicitly set to True by Streams in RocksDB. Setting this option to 'false' will be ignored"));
+                assertTrue(logMessages.contains(
+                    "AtomicFlush is explicitly set to True by Streams in RocksDB. Setting this option to 'false' will be ignored"));
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBRangeIteratorTest.java
@@ -29,9 +29,10 @@ import org.rocksdb.RocksIterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -78,13 +79,13 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key1Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key1Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(3)).value();
         verify(rocksIterator, times(3)).next();
     }
@@ -112,13 +113,13 @@ public class RocksDBRangeIteratorTest {
             false,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key1Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key1Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(3)).value();
         verify(rocksIterator, times(3)).prev();
     }
@@ -149,15 +150,15 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key1Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key4Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key1Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key4Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(4)).value();
         verify(rocksIterator, times(4)).next();
     }
@@ -188,15 +189,15 @@ public class RocksDBRangeIteratorTest {
             false,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key4Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key1Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key4Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key1Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(4)).value();
         verify(rocksIterator, times(4)).prev();
     }
@@ -216,7 +217,7 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertFalse(rocksDBRangeIterator.hasNext());
     }
 
     @Test
@@ -238,7 +239,7 @@ public class RocksDBRangeIteratorTest {
             false,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertFalse(rocksDBRangeIterator.hasNext());
     }
 
     @Test
@@ -262,11 +263,11 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(2)).value();
         verify(rocksIterator, times(2)).next();
     }
@@ -294,11 +295,11 @@ public class RocksDBRangeIteratorTest {
             false,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key4Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key4Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(2)).value();
         verify(rocksIterator, times(2)).prev();
     }
@@ -324,15 +325,15 @@ public class RocksDBRangeIteratorTest {
             true,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key2Bytes));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key2Bytes));
-        assertThat(rocksDBRangeIterator.next().key, is(key2Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key3Bytes));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key3Bytes));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key2Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key2Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key2Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key3Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         assertThrows(NoSuchElementException.class, rocksDBRangeIterator::peekNextKey);
         verify(rocksIterator, times(2)).value();
         verify(rocksIterator, times(2)).next();
@@ -360,15 +361,15 @@ public class RocksDBRangeIteratorTest {
             false,
             true
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key4Bytes));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key4Bytes));
-        assertThat(rocksDBRangeIterator.next().key, is(key4Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key3Bytes));
-        assertThat(rocksDBRangeIterator.peekNextKey(), is(key3Bytes));
-        assertThat(rocksDBRangeIterator.next().key, is(key3Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key4Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key4Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key4Bytes, rocksDBRangeIterator.next().key);
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key3Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key3Bytes, rocksDBRangeIterator.peekNextKey());
+        assertEquals(key3Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         assertThrows(NoSuchElementException.class, rocksDBRangeIterator::peekNextKey);
         verify(rocksIterator, times(2)).value();
         verify(rocksIterator, times(2)).prev();
@@ -406,7 +407,7 @@ public class RocksDBRangeIteratorTest {
         final AtomicBoolean callbackCalled = new AtomicBoolean(false);
         rocksDBRangeIterator.onClose(() -> callbackCalled.set(true));
         rocksDBRangeIterator.close();
-        assertThat(callbackCalled.get(), is(true));
+        assertTrue(callbackCalled.get());
     }
 
     @Test
@@ -428,9 +429,9 @@ public class RocksDBRangeIteratorTest {
             true,
             false
         );
-        assertThat(rocksDBRangeIterator.hasNext(), is(true));
-        assertThat(rocksDBRangeIterator.next().key, is(key1Bytes));
-        assertThat(rocksDBRangeIterator.hasNext(), is(false));
+        assertTrue(rocksDBRangeIterator.hasNext());
+        assertEquals(key1Bytes, rocksDBRangeIterator.next().key);
+        assertFalse(rocksDBRangeIterator.hasNext());
         verify(rocksIterator, times(2)).value();
         verify(rocksIterator, times(2)).next();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -69,7 +69,6 @@ import org.apache.kafka.test.MockRocksDbConfigSetter;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,15 +112,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.internals.RocksDBStore.DB_FILE_DIR;
-import static org.hamcrest.CoreMatchers.either;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -447,11 +440,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
 
         context.restore(DB_NAME, restoreBytes);
 
-        assertThat(
+        assertEquals(
+            "restoredValue",
             stringDeserializer.deserialize(
                 null,
-                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "restoredKey")))),
-            equalTo("restoredValue"));
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "restoredKey")))));
     }
 
     @Test
@@ -472,7 +465,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         rocksDBStore.init(context, rocksDBStore);
 
         assertTrue(MockRocksDbConfigSetter.called);
-        assertThat(MockRocksDbConfigSetter.configMap.get("abc.def"), equalTo(param));
+        assertEquals(param, MockRocksDbConfigSetter.configMap.get("abc.def"));
     }
 
     @Test
@@ -587,10 +580,10 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 valuesWithPrefix.add(new String(next.value));
                 numberOfKeysReturned++;
             }
-            assertThat(numberOfKeysReturned, is(3));
-            assertThat(valuesWithPrefix.get(0), is("f"));
-            assertThat(valuesWithPrefix.get(1), is("d"));
-            assertThat(valuesWithPrefix.get(2), is("b"));
+            assertEquals(3, numberOfKeysReturned);
+            assertEquals("f", valuesWithPrefix.get(0));
+            assertEquals("d", valuesWithPrefix.get(1));
+            assertEquals("b", valuesWithPrefix.get(2));
         }
     }
 
@@ -621,7 +614,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 numberOfKeysReturned++;
             }
 
-            assertThat(numberOfKeysReturned, is(1));
+            assertEquals(1, numberOfKeysReturned);
         }
     }
 
@@ -632,29 +625,29 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         final Set<KeyValueIterator<Bytes, byte[]>> openIterators = new HashSet<>();
 
         final KeyValueIterator<Bytes, byte[]> prefixScanIterator = rocksDBStore.prefixScan("abcd", stringSerializer, openIterators);
-        assertThat(openIterators.size(), is(1));
+        assertEquals(1, openIterators.size());
         prefixScanIterator.close();
-        assertThat(openIterators.size(), is(0));
+        assertEquals(0, openIterators.size());
 
         final KeyValueIterator<Bytes, byte[]> rangeIterator = rocksDBStore.range(null, new Bytes(stringSerializer.serialize(null, "1")), openIterators);
-        assertThat(openIterators.size(), is(1));
+        assertEquals(1, openIterators.size());
         rangeIterator.close();
-        assertThat(openIterators.size(), is(0));
+        assertEquals(0, openIterators.size());
 
         final KeyValueIterator<Bytes, byte[]> reverseRangeIterator = rocksDBStore.reverseRange(null, new Bytes(stringSerializer.serialize(null, "1")), openIterators);
-        assertThat(openIterators.size(), is(1));
+        assertEquals(1, openIterators.size());
         reverseRangeIterator.close();
-        assertThat(openIterators.size(), is(0));
+        assertEquals(0, openIterators.size());
 
         final KeyValueIterator<Bytes, byte[]> allIterator = rocksDBStore.all(openIterators);
-        assertThat(openIterators.size(), is(1));
+        assertEquals(1, openIterators.size());
         allIterator.close();
-        assertThat(openIterators.size(), is(0));
+        assertEquals(0, openIterators.size());
 
         final KeyValueIterator<Bytes, byte[]> reverseAllIterator = rocksDBStore.reverseAll(openIterators);
-        assertThat(openIterators.size(), is(1));
+        assertEquals(1, openIterators.size());
         reverseAllIterator.close();
-        assertThat(openIterators.size(), is(0));
+        assertEquals(0, openIterators.size());
     }
 
     @SuppressWarnings("resource")
@@ -721,11 +714,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 numberOfKeysReturned++;
             }
 
-            assertThat(numberOfKeysReturned, is(numMatches));
+            assertEquals(numMatches, numberOfKeysReturned);
             if (numMatches == 2) {
-                assertThat(valuesWithPrefix.get(0), either(is("a")).or(is("b")));
+                assertTrue("a".equals(valuesWithPrefix.get(0)) || "b".equals(valuesWithPrefix.get(0)));
             } else {
-                assertThat(valuesWithPrefix.get(0), is("a"));
+                assertEquals("a", valuesWithPrefix.get(0));
             }
         }
     }
@@ -753,7 +746,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 keysWithPrefix.next();
                 numberOfKeysReturned++;
             }
-            assertThat(numberOfKeysReturned, is(0));
+            assertEquals(0, numberOfKeysReturned);
         }
     }
 
@@ -810,7 +803,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
             }
 
-            assertThat(keys, equalTo(Set.of("2", "3")));
+            assertEquals(Set.of("2", "3"), keys);
         }
     }
 
@@ -835,7 +828,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
             }
 
-            assertThat(keys, equalTo(Set.of("1", "2", "3")));
+            assertEquals(Set.of("1", "2", "3"), keys);
 
             assertEquals(
                 "restored",
@@ -894,7 +887,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 keys.add(stringDeserializer.deserialize(null, iterator.next().key.get()));
             }
 
-            assertThat(keys, equalTo(Set.of("2", "3")));
+            assertEquals(Set.of("2", "3"), keys);
         }
     }
 
@@ -977,7 +970,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         int expectedIndex = 0;
         for (final KeyValue<byte[], byte[]> keyValue : keyValues) {
             final byte[] valBytes = rocksDBStore.get(new Bytes(keyValue.key));
-            assertThat(new String(valBytes, UTF_8), is(expectedValues.get(expectedIndex++)));
+            assertEquals(expectedValues.get(expectedIndex++), new String(valBytes, UTF_8));
         }
         assertFalse(TestingBloomFilterRocksDBConfigSetter.bloomFiltersSet);
 
@@ -991,7 +984,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
 
         for (final KeyValue<byte[], byte[]> keyValue : keyValues) {
             final byte[] valBytes = rocksDBStore.get(new Bytes(keyValue.key));
-            assertThat(new String(valBytes, UTF_8), is(expectedValues.get(expectedIndex++)));
+            assertEquals(expectedValues.get(expectedIndex++), new String(valBytes, UTF_8));
         }
 
         assertTrue(TestingBloomFilterRocksDBConfigSetter.bloomFiltersSet);
@@ -1027,7 +1020,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             "description is not verified",
             streamsMetrics.storeLevelTagMap(taskId.toString(), METRICS_SCOPE, DB_NAME)
         ));
-        assertThat((double) bytesWrittenTotal.metricValue(), greaterThan(0d));
+        assertTrue(Double.compare((double) bytesWrittenTotal.metricValue(), 0d) > 0);
     }
 
     @Test
@@ -1058,8 +1051,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
             "description is not verified",
             streamsMetrics.storeLevelTagMap(taskId.toString(), METRICS_SCOPE, DB_NAME)
         ));
-        assertThat(numberOfEntriesActiveMemTable, notNullValue());
-        assertThat((BigInteger) numberOfEntriesActiveMemTable.metricValue(), greaterThan(BigInteger.valueOf(0)));
+        assertNotNull(numberOfEntriesActiveMemTable);
+        assertTrue(((BigInteger) numberOfEntriesActiveMemTable.metricValue()).compareTo(BigInteger.valueOf(0)) > 0);
     }
 
     @Test
@@ -1110,7 +1103,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 "description is not verified",
                 streamsMetrics.storeLevelTagMap(taskId.toString(), METRICS_SCOPE, DB_NAME)
             ));
-            assertThat("Metric " + propertyname + " not found!", metric, notNullValue());
+            assertNotNull(metric, "Metric " + propertyname + " not found!");
             metric.metricValue();
         }
     }
@@ -1191,9 +1184,9 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                         null,
                         rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
 
-        assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions(""), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions(""), hasEntry(0, 3L));
+        assertNotNull(rocksDBStore.getPosition());
+        assertNotNull(rocksDBStore.getPosition().getPartitionPositions(""));
+        assertEquals(3L, rocksDBStore.getPosition().getPartitionPositions("").get(0));
     }
 
     @Test
@@ -1228,11 +1221,11 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                         null,
                         rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))));
 
-        assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), hasEntry(0, 3L));
-        assertThat(rocksDBStore.getPosition().getPartitionPositions("B"), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions("B"), hasEntry(0, 2L));
+        assertNotNull(rocksDBStore.getPosition());
+        assertNotNull(rocksDBStore.getPosition().getPartitionPositions("A"));
+        assertEquals(3L, rocksDBStore.getPosition().getPartitionPositions("A").get(0));
+        assertNotNull(rocksDBStore.getPosition().getPartitionPositions("B"));
+        assertEquals(2L, rocksDBStore.getPosition().getPartitionPositions("B").get(0));
     }
 
     @Test
@@ -1255,8 +1248,8 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
                 null,
                 rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))));
 
-        assertThat(rocksDBStore.getPosition(), Matchers.notNullValue());
-        assertThat(rocksDBStore.getPosition().getPartitionPositions("A"), hasEntry(0, 2L));
+        assertNotNull(rocksDBStore.getPosition());
+        assertEquals(2L, rocksDBStore.getPosition().getPartitionPositions("A").get(0));
     }
 
     @Test
@@ -1274,7 +1267,7 @@ public class RocksDBStoreTest extends AbstractKeyValueStoreTest {
         );
         rocksDBStore.init(context, rocksDBStore);
         context.restore(rocksDBStore.name(), entries);
-        assertThat(rocksDBStore.getPosition(), is(Position.emptyPosition()));
+        assertEquals(Position.emptyPosition(), rocksDBStore.getPosition());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedKeyValueBufferTest.java
@@ -53,11 +53,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,8 +98,8 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         when(serdeGetter.keySerde()).thenReturn((Serde) new Serdes.StringSerde());
         when(serdeGetter.valueSerde()).thenReturn((Serde) new Serdes.StringSerde());
         createBuffer(Duration.ofMillis(1), null);
-        assertThat(pipeRecord("K", "V", 2L), equalTo(true));
-        assertThat(pipeRecord("K", "V", 0L), equalTo(false));
+        assertTrue(pipeRecord("K", "V", 2L));
+        assertFalse(pipeRecord("K", "V", 0L));
     }
 
     @Test
@@ -122,7 +120,7 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
         assertNumSizeAndTimestamp(buffer, 0, Long.MAX_VALUE, 0);
-        assertThat(count.get(), equalTo(1));
+        assertEquals(1, count.get());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -136,12 +134,12 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
         assertNumSizeAndTimestamp(buffer, 0, Long.MAX_VALUE, 0);
-        assertThat(count.get(), equalTo(1));
+        assertEquals(1, count.get());
         pipeRecord("2", "0", 1L);
         assertNumSizeAndTimestamp(buffer, 1, 1, 42);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
         assertNumSizeAndTimestamp(buffer, 0, Long.MAX_VALUE, 0);
-        assertThat(count.get(), equalTo(2));
+        assertEquals(2, count.get());
     }
 
     @Test
@@ -151,11 +149,11 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         pipeRecord("1", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
-        assertThat(count.get(), equalTo(0));
+        assertEquals(0, count.get());
         pipeRecord("2", "0", 1L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
         assertNumSizeAndTimestamp(buffer, 1, 1, 42);
-        assertThat(count.get(), equalTo(1));
+        assertEquals(1, count.get());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -167,10 +165,10 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("1", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 1, r -> count.getAndIncrement());
-        assertThat(count.get(), equalTo(0));
+        assertEquals(0, count.get());
         pipeRecord("2", "0", 1L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
-        assertThat(count.get(), equalTo(2));
+        assertEquals(2, count.get());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -205,16 +203,16 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         final AtomicInteger count = new AtomicInteger(0);
         pipeRecord("2", "0", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
-        assertThat(count.get(), equalTo(0));
+        assertEquals(0, count.get());
         assertNumSizeAndTimestamp(buffer, 1, 0, 42);
         pipeRecord("2", "2", 0L);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
-        assertThat(count.get(), equalTo(0));
+        assertEquals(0, count.get());
         assertNumSizeAndTimestamp(buffer, 2, 0, 84);
         pipeRecord("1", "0", 7L);
         assertNumSizeAndTimestamp(buffer, 3, 0, 126);
         buffer.evictWhile(() -> buffer.numRecords() > 0, r -> count.getAndIncrement());
-        assertThat(count.get(), equalTo(2));
+        assertEquals(2, count.get());
         assertNumSizeAndTimestamp(buffer, 1, 7, 42);
     }
 
@@ -242,11 +240,11 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         final List<TimeOrderedKeyValueBuffer.Eviction<String, String>> evicted = new ArrayList<>();
         buffer.evictWhile(() -> buffer.numRecords() > 0, evicted::add);
 
-        assertThat(evicted.size(), is(1));
+        assertEquals(1, evicted.size());
         // The key/value deserializers must see the headers captured at put time, not the mutated context headers.
-        assertThat(serde.capturedHeaders, hasItem(putHeaders));
-        assertThat(serde.capturedHeaders, everyItem(is(putHeaders)));
-        assertThat(evicted.get(0).recordContext().headers(), is(putHeaders));
+        assertTrue(serde.capturedHeaders.contains(putHeaders));
+        assertTrue(serde.capturedHeaders.stream().allMatch(putHeaders::equals));
+        assertEquals(putHeaders, evicted.get(0).recordContext().headers());
     }
 
     @Test
@@ -280,12 +278,12 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
         buffer.evictWhile(() -> true, evicted::add);
 
         // Only the original "k" record at t=0 falls outside the grace window of t=10.
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).key(), is("k"));
+        assertEquals(1, evicted.size());
+        assertEquals("k", evicted.get(0).key());
         // The deserializers for the evicted record must see its put-time headers, not the later context headers.
-        assertThat(serde.capturedHeaders, hasItem(putHeaders));
-        assertThat(serde.capturedHeaders, everyItem(is(putHeaders)));
-        assertThat(evicted.get(0).recordContext().headers(), is(putHeaders));
+        assertTrue(serde.capturedHeaders.contains(putHeaders));
+        assertTrue(serde.capturedHeaders.stream().allMatch(putHeaders::equals));
+        assertEquals(putHeaders, evicted.get(0).recordContext().headers());
     }
 
     /**
@@ -316,8 +314,8 @@ public class RocksDBTimeOrderedKeyValueBufferTest {
                                            final int num,
                                            final long time,
                                            final long size) {
-        assertThat(buffer.numRecords(), equalTo(num));
-        assertThat(buffer.minTimestamp(), equalTo(time));
-        assertThat(buffer.bufferSize(), equalTo(size));
+        assertEquals(num, buffer.numRecords());
+        assertEquals(time, buffer.minTimestamp());
+        assertEquals(size, buffer.bufferSize());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStoreTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -46,10 +45,8 @@ import java.util.Properties;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.state.internals.RocksDBStore.OFFSETS_COLUMN_FAMILY_NAME;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -69,11 +66,11 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular mode"));
         }
 
         try (final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all()) {
-            assertThat(iterator.hasNext(), is(false));
+            assertFalse(iterator.hasNext());
         }
     }
 
@@ -88,7 +85,7 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular mode"));
         } finally {
             rocksDBStore.close();
         }
@@ -115,10 +112,10 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
             noTimestampColumnFamily = columnFamilies.get(0);
             withTimestampColumnFamily = columnFamilies.get(1);
 
-            assertThat(db.get(noTimestampColumnFamily, "key".getBytes()), new IsNull<>());
-            assertThat(db.getLongProperty(noTimestampColumnFamily, "rocksdb.estimate-num-keys"), is(0L));
-            assertThat(db.get(withTimestampColumnFamily, "key".getBytes()).length, is(11));
-            assertThat(db.getLongProperty(withTimestampColumnFamily, "rocksdb.estimate-num-keys"), is(1L));
+            assertNull(db.get(noTimestampColumnFamily, "key".getBytes()));
+            assertEquals(0L, db.getLongProperty(noTimestampColumnFamily, "rocksdb.estimate-num-keys"));
+            assertEquals(11, db.get(withTimestampColumnFamily, "key".getBytes()).length);
+            assertEquals(1L, db.getLongProperty(withTimestampColumnFamily, "rocksdb.estimate-num-keys"));
         } finally {
             // Order of closing must follow: ColumnFamilyHandle > RocksDB > DBOptions > ColumnFamilyOptions
             if (noTimestampColumnFamily != null) {
@@ -142,25 +139,25 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in upgrade mode"));
         }
 
         // approx: 7 entries on old CF, 0 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // get()
 
         // should be no-op on both CF
-        assertThat(rocksDBStore.get(new Bytes("unknown".getBytes())), new IsNull<>());
+        assertNull(rocksDBStore.get(new Bytes("unknown".getBytes())));
         // approx: 7 entries on old CF, 0 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // should migrate key1 from old to new CF
         // must return timestamp plus value, ie, it's not 1 byte but 9 bytes
-        assertThat(rocksDBStore.get(new Bytes("key1".getBytes())).length, is(8 + 1));
+        assertEquals(8 + 1, rocksDBStore.get(new Bytes("key1".getBytes())).length);
         // one delete on old CF, one put on new CF
         // approx: 6 entries on old CF, 1 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // put()
 
@@ -168,61 +165,61 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         rocksDBStore.put(new Bytes("key2".getBytes()), "timestamp+22".getBytes());
         // one delete on old CF, one put on new CF
         // approx: 5 entries on old CF, 2 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(7L));
+        assertEquals(7L, rocksDBStore.approximateNumEntries());
 
         // should delete key3 from old and new CF
         rocksDBStore.put(new Bytes("key3".getBytes()), null);
         // count is off by one, due to two delete operations (even if one does not delete anything)
         // approx: 4 entries on old CF, 1 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         // should add new key8 to new CF
         rocksDBStore.put(new Bytes("key8new".getBytes()), "timestamp+88888888".getBytes());
         // one delete on old CF, one put on new CF
         // approx: 3 entries on old CF, 2 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(5L));
+        assertEquals(5L, rocksDBStore.approximateNumEntries());
 
         rocksDBStore.put(new Bytes("key9new".getBytes()), null);
         // one delete on old CF, one put on new CF
         // approx: 2 entries on old CF, 1 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         // putIfAbsent()
 
         // should migrate key4 from old to new CF with old value
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "timestamp+4444".getBytes()).length, is(8 + 4));
+        assertEquals(8 + 4, rocksDBStore.putIfAbsent(new Bytes("key4".getBytes()), "timestamp+4444".getBytes()).length);
         // one delete on old CF, one put on new CF
         // approx: 1 entries on old CF, 2 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         // should add new key11 to new CF
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key11new".getBytes()), "timestamp+11111111111".getBytes()), new IsNull<>());
+        assertNull(rocksDBStore.putIfAbsent(new Bytes("key11new".getBytes()), "timestamp+11111111111".getBytes()));
         // one delete on old CF, one put on new CF
         // approx: 0 entries on old CF, 3 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         // should not delete key5 but migrate to new CF
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length, is(8 + 5));
+        assertEquals(8 + 5, rocksDBStore.putIfAbsent(new Bytes("key5".getBytes()), null).length);
         // one delete on old CF, one put on new CF
         // approx: 0 entries on old CF, 4 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(4L));
+        assertEquals(4L, rocksDBStore.approximateNumEntries());
 
         // should be no-op on both CF
-        assertThat(rocksDBStore.putIfAbsent(new Bytes("key12new".getBytes()), null), new IsNull<>());
+        assertNull(rocksDBStore.putIfAbsent(new Bytes("key12new".getBytes()), null));
         // one delete operation, however, not counted because old CF count was zero before already
         // approx: 0 entries on old CF, 4 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(4L));
+        assertEquals(4L, rocksDBStore.approximateNumEntries());
 
         // delete()
 
         // should delete key6 from old and new CF
-        assertThat(rocksDBStore.delete(new Bytes("key6".getBytes())).length, is(8 + 6));
+        assertEquals(8 + 6, rocksDBStore.delete(new Bytes("key6".getBytes())).length);
         // two delete operation, however, only one is counted because old CF count was zero before already
         // approx: 0 entries on old CF, 3 in new CF
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         iteratorsShouldNotMigrateData();
-        assertThat(rocksDBStore.approximateNumEntries(), is(3L));
+        assertEquals(3L, rocksDBStore.approximateNumEntries());
 
         rocksDBStore.close();
 
@@ -400,31 +397,31 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
             noTimestampColumnFamily = columnFamilies.get(0);
             withTimestampColumnFamily = columnFamilies.get(1);
 
-            assertThat(db.get(noTimestampColumnFamily, "unknown".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key1".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key2".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key3".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key4".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key5".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key6".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key7".getBytes()).length, is(7));
-            assertThat(db.get(noTimestampColumnFamily, "key8new".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key9new".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key11new".getBytes()), new IsNull<>());
-            assertThat(db.get(noTimestampColumnFamily, "key12new".getBytes()), new IsNull<>());
+            assertNull(db.get(noTimestampColumnFamily, "unknown".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key1".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key2".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key3".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key4".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key5".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key6".getBytes()));
+            assertEquals(7, db.get(noTimestampColumnFamily, "key7".getBytes()).length);
+            assertNull(db.get(noTimestampColumnFamily, "key8new".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key9new".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key11new".getBytes()));
+            assertNull(db.get(noTimestampColumnFamily, "key12new".getBytes()));
 
-            assertThat(db.get(withTimestampColumnFamily, "unknown".getBytes()), new IsNull<>());
-            assertThat(db.get(withTimestampColumnFamily, "key1".getBytes()).length, is(8 + 1));
-            assertThat(db.get(withTimestampColumnFamily, "key2".getBytes()).length, is(12));
-            assertThat(db.get(withTimestampColumnFamily, "key3".getBytes()), new IsNull<>());
-            assertThat(db.get(withTimestampColumnFamily, "key4".getBytes()).length, is(8 + 4));
-            assertThat(db.get(withTimestampColumnFamily, "key5".getBytes()).length, is(8 + 5));
-            assertThat(db.get(withTimestampColumnFamily, "key6".getBytes()), new IsNull<>());
-            assertThat(db.get(withTimestampColumnFamily, "key7".getBytes()), new IsNull<>());
-            assertThat(db.get(withTimestampColumnFamily, "key8new".getBytes()).length, is(18));
-            assertThat(db.get(noTimestampColumnFamily, "key9new".getBytes()), new IsNull<>());
-            assertThat(db.get(withTimestampColumnFamily, "key11new".getBytes()).length, is(21));
-            assertThat(db.get(withTimestampColumnFamily, "key12new".getBytes()), new IsNull<>());
+            assertNull(db.get(withTimestampColumnFamily, "unknown".getBytes()));
+            assertEquals(8 + 1, db.get(withTimestampColumnFamily, "key1".getBytes()).length);
+            assertEquals(12, db.get(withTimestampColumnFamily, "key2".getBytes()).length);
+            assertNull(db.get(withTimestampColumnFamily, "key3".getBytes()));
+            assertEquals(8 + 4, db.get(withTimestampColumnFamily, "key4".getBytes()).length);
+            assertEquals(8 + 5, db.get(withTimestampColumnFamily, "key5".getBytes()).length);
+            assertNull(db.get(withTimestampColumnFamily, "key6".getBytes()));
+            assertNull(db.get(withTimestampColumnFamily, "key7".getBytes()));
+            assertEquals(18, db.get(withTimestampColumnFamily, "key8new".getBytes()).length);
+            assertNull(db.get(noTimestampColumnFamily, "key9new".getBytes()));
+            assertEquals(21, db.get(withTimestampColumnFamily, "key11new".getBytes()).length);
+            assertNull(db.get(withTimestampColumnFamily, "key12new".getBytes()));
         } catch (final RuntimeException fatal) {
             errorOccurred = true;
         } finally {
@@ -448,7 +445,7 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in upgrade mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in upgrade mode"));
         } finally {
             rocksDBStore.close();
         }
@@ -482,7 +479,7 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
         try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(RocksDBTimestampedStore.class)) {
             rocksDBStore.init(context, rocksDBStore);
 
-            assertThat(appender.getMessages(), hasItem("Opening store " + DB_NAME + " in regular mode"));
+            assertTrue(appender.getMessages().contains("Opening store " + DB_NAME + " in regular mode"));
         }
     }
 
@@ -500,10 +497,11 @@ public class RocksDBTimestampedStoreTest extends RocksDBStoreTest {
                 () -> kvStore.init(context, kvStore)
             );
 
-            assertThat(exception.getMessage(), is(
+            assertEquals(
                 "Store " + DB_NAME + " is a timestamped key-value store and cannot be opened as a regular key-value store. " +
                 "Downgrade from timestamped to regular store is not supported directly. " +
-                "To downgrade, you can delete the local state in the state directory, and rebuild the store as regular key-value store from the changelog."));
+                "To downgrade, you can delete the local state in the state directory, and rebuild the store as regular key-value store from the changelog.",
+                exception.getMessage());
         } finally {
             kvStore.close();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreSegmentValueFormatterTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RocksDBVersionedStoreSegmentValueFormatterTest {
@@ -216,10 +216,10 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
 
             final SegmentSearchResult result = segmentValue.find(entry.getKey(), true);
 
-            assertThat(result.index(), equalTo(entry.getValue()));
-            assertThat(result.value(), equalTo(expectedRecord.value));
-            assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
-            assertThat(result.validTo(), equalTo(expectedValidTo));
+            assertEquals(entry.getValue(), result.index());
+            assertArrayEquals(expectedRecord.value, result.value());
+            assertEquals(expectedRecord.timestamp, result.validFrom());
+            assertEquals(expectedValidTo, result.validTo());
         }
 
         // verify exception when timestamp is out of range
@@ -251,10 +251,10 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
                 continue;
             }
             final long expectedValidTo = index == 0 ? testCase.nextTimestamp : testCase.records.get(index - 1).timestamp;
-            assertThat(results.get(i).index(), equalTo(index));
-            assertThat(results.get(i).value(), equalTo(expectedRecord.value));
-            assertThat(results.get(i).validFrom(), equalTo(expectedRecord.timestamp));
-            assertThat(results.get(i).validTo(), equalTo(expectedValidTo));
+            assertEquals(index, results.get(i).index());
+            assertArrayEquals(expectedRecord.value, results.get(i).value());
+            assertEquals(expectedRecord.timestamp, results.get(i).validFrom());
+            assertEquals(expectedValidTo, results.get(i).validTo());
             i++;
             index++;
         }
@@ -270,8 +270,8 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
     public void shouldGetTimestamps(final TestCase testCase) {
         final byte[] segmentValue = buildSegmentWithInsertLatest(testCase).serialize();
 
-        assertThat(RocksDBVersionedStoreSegmentValueFormatter.nextTimestamp(segmentValue), equalTo(testCase.nextTimestamp));
-        assertThat(RocksDBVersionedStoreSegmentValueFormatter.minTimestamp(segmentValue), equalTo(testCase.minTimestamp));
+        assertEquals(testCase.nextTimestamp, RocksDBVersionedStoreSegmentValueFormatter.nextTimestamp(segmentValue));
+        assertEquals(testCase.minTimestamp, RocksDBVersionedStoreSegmentValueFormatter.minTimestamp(segmentValue));
     }
 
     @ParameterizedTest
@@ -356,10 +356,10 @@ public class RocksDBVersionedStoreSegmentValueFormatterTest {
 
                 final SegmentSearchResult result = segmentValue.find(expectedRecord.timestamp, true);
 
-                assertThat(result.index(), equalTo(recordIdx));
-                assertThat(result.value(), equalTo(expectedRecord.value));
-                assertThat(result.validFrom(), equalTo(expectedRecord.timestamp));
-                assertThat(result.validTo(), equalTo(expectedValidTo));
+                assertEquals(recordIdx, result.index());
+                assertArrayEquals(expectedRecord.value, result.value());
+                assertEquals(expectedRecord.timestamp, result.validFrom());
+                assertEquals(expectedValidTo, result.validTo());
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBVersionedStoreTest.java
@@ -54,10 +54,9 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_NOT_PUT;
 import static org.apache.kafka.streams.state.VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class RocksDBVersionedStoreTest {
 
@@ -355,19 +354,19 @@ public class RocksDBVersionedStoreTest {
         putToStore("k", "vn2", SEGMENT_INTERVAL - 2, SEGMENT_INTERVAL + 10);
 
         VersionedRecord<String> deleted = deleteFromStore("k", SEGMENT_INTERVAL - 5); // delete from segment
-        assertThat(deleted.value(), equalTo("vn10"));
-        assertThat(deleted.timestamp(), equalTo(SEGMENT_INTERVAL - 10));
+        assertEquals("vn10", deleted.value());
+        assertEquals(SEGMENT_INTERVAL - 10, deleted.timestamp());
 
         deleted = deleteFromStore("k", SEGMENT_INTERVAL + 10); // delete existing timestamp
-        assertThat(deleted.value(), equalTo("vp10"));
-        assertThat(deleted.timestamp(), equalTo(SEGMENT_INTERVAL + 10));
+        assertEquals("vp10", deleted.value());
+        assertEquals(SEGMENT_INTERVAL + 10, deleted.timestamp());
 
         deleted = deleteFromStore("k", SEGMENT_INTERVAL + 10); // delete the same timestamp again
-        assertThat(deleted, nullValue());
+        assertNull(deleted);
 
         deleted = deleteFromStore("k", SEGMENT_INTERVAL + 25); // delete from latest value store
-        assertThat(deleted.value(), equalTo("vp20"));
-        assertThat(deleted.timestamp(), equalTo(SEGMENT_INTERVAL + 20));
+        assertEquals("vp20", deleted.value());
+        assertEquals(SEGMENT_INTERVAL + 20, deleted.timestamp());
     }
 
     @Test
@@ -393,13 +392,13 @@ public class RocksDBVersionedStoreTest {
 
         // grace period has not elapsed
         VersionedRecord<String> deleted = deleteFromStore("k1", HISTORY_RETENTION + 10 - GRACE_PERIOD);
-        assertThat(deleted.value(), equalTo("v1"));
-        assertThat(deleted.timestamp(), equalTo(1L));
+        assertEquals("v1", deleted.value());
+        assertEquals(1L, deleted.timestamp());
         verifyGetNullFromStore("k1");
 
         // grace period has elapsed, so this delete does not take place
         deleted = deleteFromStore("k2", HISTORY_RETENTION + 9 - GRACE_PERIOD);
-        assertThat(deleted, nullValue()); // return value is null even though record exists because delete did not take place
+        assertNull(deleted); // return value is null even though record exists because delete did not take place
         verifyGetValueFromStore("k2", "v2", 1L);
 
         verifyExpiredRecordSensor(1);
@@ -848,12 +847,12 @@ public class RocksDBVersionedStoreTest {
 
         final Bytes key = new Bytes(STRING_SERIALIZER.serialize(null, "k"));
         final VersionedRecord<byte[]> uLatest = uncommitted.get(key);
-        assertThat(STRING_DESERIALIZER.deserialize(null, uLatest.value()), equalTo("v2"));
-        assertThat(uLatest.timestamp(), equalTo(BASE_TIMESTAMP + 1));
+        assertEquals("v2", STRING_DESERIALIZER.deserialize(null, uLatest.value()));
+        assertEquals(BASE_TIMESTAMP + 1, uLatest.timestamp());
 
         final VersionedRecord<byte[]> cLatest = committed.get(key);
-        assertThat(STRING_DESERIALIZER.deserialize(null, cLatest.value()), equalTo("v1"));
-        assertThat(cLatest.timestamp(), equalTo(BASE_TIMESTAMP));
+        assertEquals("v1", STRING_DESERIALIZER.deserialize(null, cLatest.value()));
+        assertEquals(BASE_TIMESTAMP, cLatest.timestamp());
     }
 
     @Test
@@ -867,10 +866,10 @@ public class RocksDBVersionedStoreTest {
         final Bytes key = new Bytes(STRING_SERIALIZER.serialize(null, "k"));
 
         final VersionedRecord<byte[]> uAtNew = store.readOnly(IsolationLevel.READ_UNCOMMITTED).get(key, BASE_TIMESTAMP + 2);
-        assertThat(STRING_DESERIALIZER.deserialize(null, uAtNew.value()), equalTo("v2"));
+        assertEquals("v2", STRING_DESERIALIZER.deserialize(null, uAtNew.value()));
 
         final VersionedRecord<byte[]> cAtNew = store.readOnly(IsolationLevel.READ_COMMITTED).get(key, BASE_TIMESTAMP + 2);
-        assertThat(STRING_DESERIALIZER.deserialize(null, cAtNew.value()), equalTo("v1"));
+        assertEquals("v1", STRING_DESERIALIZER.deserialize(null, cAtNew.value()));
     }
 
     @Test
@@ -897,8 +896,8 @@ public class RocksDBVersionedStoreTest {
                 committed.add(STRING_DESERIALIZER.deserialize(null, it.next().value()));
             }
         }
-        assertThat(uncommitted, equalTo(List.of("v1", "v2")));
-        assertThat(committed, equalTo(List.of("v1")));
+        assertEquals(List.of("v1", "v2"), uncommitted);
+        assertEquals(List.of("v1"), committed);
     }
 
     private void reopenWithTransactionalEOS() {
@@ -939,7 +938,7 @@ public class RocksDBVersionedStoreTest {
             STRING_SERIALIZER.serialize(null, value),
             timestamp
         );
-        assertThat(validTo, equalTo(expectedValidTo));
+        assertEquals(expectedValidTo, validTo);
     }
 
     private VersionedRecord<String> deleteFromStore(final String key, final long timestamp) {
@@ -971,24 +970,24 @@ public class RocksDBVersionedStoreTest {
 
     private void verifyGetValueFromStore(final String key, final String expectedValue, final long expectedTimestamp) {
         final VersionedRecord<String> latest = getFromStore(key);
-        assertThat(latest.value(), equalTo(expectedValue));
-        assertThat(latest.timestamp(), equalTo(expectedTimestamp));
-        assertThat(latest.validTo().isPresent(), equalTo(false));
+        assertEquals(expectedValue, latest.value());
+        assertEquals(expectedTimestamp, latest.timestamp());
+        assertFalse(latest.validTo().isPresent());
     }
 
     private void verifyGetNullFromStore(final String key) {
         final VersionedRecord<String> record = getFromStore(key);
-        assertThat(record, nullValue());
+        assertNull(record);
     }
 
     private void verifyTimestampedGetValueFromStore(final String key, final long timestamp, final String expectedValue, final long expectedTimestamp, final long expectedValidTo) {
         final VersionedRecord<String> latest = getFromStore(key, timestamp);
-        assertThat(latest.value(), equalTo(expectedValue));
-        assertThat(latest.timestamp(), equalTo(expectedTimestamp));
+        assertEquals(expectedValue, latest.value());
+        assertEquals(expectedTimestamp, latest.timestamp());
         if (expectedValidTo == PUT_RETURN_CODE_VALID_TO_UNDEFINED) {
-            assertThat(latest.validTo().isPresent(), equalTo(false));
+            assertFalse(latest.validTo().isPresent());
         } else {
-            assertThat(latest.validTo().get(), equalTo(expectedValidTo));
+            assertEquals(expectedValidTo, latest.validTo().get());
         }
     }
 
@@ -1000,27 +999,27 @@ public class RocksDBVersionedStoreTest {
                                                     final List<Long> expectedTimestamps,
                                                     final List<Long> expectedValidTos) {
         final List<VersionedRecord<String>> results = getFromStore(key, fromTime, toTime, order);
-        assertThat(results.size(), equalTo(expectedValues.size()));
+        assertEquals(expectedValues.size(), results.size());
         for (int i = 0; i < results.size(); i++) {
             final VersionedRecord<String> record = results.get(i);
-            assertThat(record.value(), equalTo(expectedValues.get(i)));
-            assertThat(record.timestamp(), equalTo(expectedTimestamps.get(i)));
+            assertEquals(expectedValues.get(i), record.value());
+            assertEquals(expectedTimestamps.get(i), record.timestamp());
             if (expectedValidTos.get(i) == PUT_RETURN_CODE_VALID_TO_UNDEFINED) {
-                assertThat(record.validTo().isPresent(), equalTo(false));
+                assertFalse(record.validTo().isPresent());
             } else {
-                assertThat(record.validTo().get(), equalTo(expectedValidTos.get(i)));
+                assertEquals(expectedValidTos.get(i), record.validTo().get());
             }
         }
     }
 
     private void verifyTimestampedGetNullFromStore(final String key, final long timestamp) {
         final VersionedRecord<String> record = getFromStore(key, timestamp);
-        assertThat(record, nullValue());
+        assertNull(record);
     }
 
     private void verifyTimestampedGetNullFromStore(final String key, final long fromTime, final long toTime) {
         final List<VersionedRecord<String>> results = getFromStore(key, fromTime, toTime, ResultOrder.ANY);
-        assertThat(results.size(), equalTo(0));
+        assertEquals(0, results.size());
     }
 
     private void verifyExpiredRecordSensor(final int expectedValue) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDbIndexedTimeOrderedWindowBytesStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDbIndexedTimeOrderedWindowBytesStoreSupplierTest.java
@@ -23,10 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofMillis;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,8 +59,8 @@ public class RocksDbIndexedTimeOrderedWindowBytesStoreSupplierTest {
     public void shouldCreateRocksDbTimeOrderedWindowStoreWithIndex() {
         final WindowStore<?, ?> store = RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create("store", ofMillis(1L), ofMillis(1L), false, true).get();
         final StateStore wrapped = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(store, instanceOf(RocksDBTimeOrderedWindowStore.class));
-        assertThat(wrapped, instanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class));
+        assertInstanceOf(RocksDBTimeOrderedWindowStore.class, store);
+        assertInstanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class, wrapped);
         assertTrue(((RocksDBTimeOrderedWindowSegmentedBytesStore<?>) wrapped).hasIndex());
     }
 
@@ -69,8 +68,8 @@ public class RocksDbIndexedTimeOrderedWindowBytesStoreSupplierTest {
     public void shouldCreateRocksDbTimeOrderedWindowStoreWithoutIndex() {
         final WindowStore<?, ?> store = RocksDbIndexedTimeOrderedWindowBytesStoreSupplier.create("store", ofMillis(1L), ofMillis(1L), false, false).get();
         final StateStore wrapped = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(store, instanceOf(RocksDBTimeOrderedWindowStore.class));
-        assertThat(wrapped, instanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class));
+        assertInstanceOf(RocksDBTimeOrderedWindowStore.class, store);
+        assertInstanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class, wrapped);
         assertFalse(((RocksDBTimeOrderedWindowSegmentedBytesStore<?>) wrapped).hasIndex());
     }
 
@@ -78,8 +77,8 @@ public class RocksDbIndexedTimeOrderedWindowBytesStoreSupplierTest {
     public void shouldCreateRocksDbTimeOrderedWindowStoreWithHeaders() {
         final WindowStore<?, ?> store = RocksDbIndexedTimeOrderedWindowBytesStoreWithHeadersSupplier.create("store", ofMillis(1L), ofMillis(1L), false, true).get();
         final StateStore wrapped = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(store, instanceOf(RocksDBTimeOrderedWindowStoreWithHeaders.class));
-        assertThat(wrapped, instanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class));
+        assertInstanceOf(RocksDBTimeOrderedWindowStoreWithHeaders.class, store);
+        assertInstanceOf(RocksDBTimeOrderedWindowSegmentedBytesStore.class, wrapped);
         assertTrue(((RocksDBTimeOrderedWindowSegmentedBytesStore<?>) wrapped).hasIndex());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDbVersionedKeyValueBytesStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDbVersionedKeyValueBytesStoreSupplierTest.java
@@ -18,8 +18,7 @@ package org.apache.kafka.streams.state.internals;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RocksDbVersionedKeyValueBytesStoreSupplierTest {
 
@@ -46,8 +45,7 @@ public class RocksDbVersionedKeyValueBytesStoreSupplierTest {
     }
 
     private void verifyExpectedSegmentInterval(final long historyRetention, final long expectedSegmentInterval) {
-        assertThat(
-            new RocksDbVersionedKeyValueBytesStoreSupplier(STORE_NAME, historyRetention).segmentIntervalMs(),
-            is(expectedSegmentInterval));
+        assertEquals(expectedSegmentInterval,
+            new RocksDbVersionedKeyValueBytesStoreSupplier(STORE_NAME, historyRetention).segmentIntervalMs());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunctionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunctionTest.java
@@ -27,8 +27,8 @@ import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SegmentedCacheFunctionTest {
 
@@ -96,10 +96,7 @@ class SegmentedCacheFunctionTest {
     @ParameterizedTest
     @MethodSource("provideKeysAndSchemas")
     void testKey(final Bytes cacheKey, final Bytes key, final SegmentedBytesStore.KeySchema keySchema) {
-        assertThat(
-                createCacheFunction(keySchema).key(cacheKey),
-                equalTo(key)
-        );
+        assertEquals(key, createCacheFunction(keySchema).key(cacheKey));
     }
 
     @ParameterizedTest
@@ -109,11 +106,11 @@ class SegmentedCacheFunctionTest {
         final Bytes actualCacheKey = createCacheFunction(keySchema).cacheKey(key);
         final ByteBuffer buffer = ByteBuffer.wrap(actualCacheKey.get());
 
-        assertThat(buffer.getLong(), equalTo(segmentId));
+        assertEquals(segmentId, buffer.getLong());
 
         final byte[] actualKey = new byte[buffer.remaining()];
         buffer.get(actualKey);
-        assertThat(Bytes.wrap(actualKey), equalTo(key));
+        assertEquals(key, Bytes.wrap(actualKey));
     }
 
     @ParameterizedTest
@@ -121,59 +118,34 @@ class SegmentedCacheFunctionTest {
     void testRoundTripping(final Bytes cacheKey, final Bytes key, final SegmentedBytesStore.KeySchema keySchema) {
         final SegmentedCacheFunction cacheFunction = createCacheFunction(keySchema);
 
-        assertThat(
-            cacheFunction.key(cacheFunction.cacheKey(key)),
-            equalTo(key)
-        );
+        assertEquals(key, cacheFunction.key(cacheFunction.cacheKey(key)));
 
-        assertThat(
-            cacheFunction.cacheKey(cacheFunction.key(cacheKey)),
-            equalTo(cacheKey)
-        );
+        assertEquals(cacheKey, cacheFunction.cacheKey(cacheFunction.key(cacheKey)));
     }
 
     @ParameterizedTest
     @MethodSource("provideKeysForBoundaryChecks")
     void compareSegmentedKeys(final Bytes key, final SegmentedBytesStore.KeySchema keySchema, final Bytes sameKeyInPriorSegment, final Bytes lowerKeyInSameSegment) {
         final SegmentedCacheFunction cacheFunction = createCacheFunction(keySchema);
-        assertThat(
-            "same key in same segment should be ranked the same",
-            cacheFunction.compareSegmentedKeys(
-                cacheFunction.cacheKey(key),
-                key
-            ) == 0
-        );
+        assertEquals(
+            0,
+            cacheFunction.compareSegmentedKeys(cacheFunction.cacheKey(key), key),
+            "same key in same segment should be ranked the same");
 
-        assertThat(
-            "same keys in different segments should be ordered according to segment",
-            cacheFunction.compareSegmentedKeys(
-                cacheFunction.cacheKey(sameKeyInPriorSegment),
-                key
-            ) < 0
-        );
+        assertTrue(
+            cacheFunction.compareSegmentedKeys(cacheFunction.cacheKey(sameKeyInPriorSegment), key) < 0,
+            "same keys in different segments should be ordered according to segment");
 
-        assertThat(
-            "same keys in different segments should be ordered according to segment",
-            cacheFunction.compareSegmentedKeys(
-                cacheFunction.cacheKey(key),
-                sameKeyInPriorSegment
-            ) > 0
-        );
+        assertTrue(
+            cacheFunction.compareSegmentedKeys(cacheFunction.cacheKey(key), sameKeyInPriorSegment) > 0,
+            "same keys in different segments should be ordered according to segment");
 
-        assertThat(
-            "different keys in same segments should be ordered according to key",
-            cacheFunction.compareSegmentedKeys(
-                cacheFunction.cacheKey(key),
-                lowerKeyInSameSegment
-            ) > 0
-        );
+        assertTrue(
+            cacheFunction.compareSegmentedKeys(cacheFunction.cacheKey(key), lowerKeyInSameSegment) > 0,
+            "different keys in same segments should be ordered according to key");
 
-        assertThat(
-            "different keys in same segments should be ordered according to key",
-            cacheFunction.compareSegmentedKeys(
-                cacheFunction.cacheKey(lowerKeyInSameSegment),
-                key
-            ) < 0
-        );
+        assertTrue(
+            cacheFunction.compareSegmentedKeys(cacheFunction.cacheKey(lowerKeyInSameSegment), key) < 0,
+            "different keys in same segments should be ordered according to key");
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionKeySchemaTest.java
@@ -46,11 +46,10 @@ import java.util.function.Function;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SessionKeySchemaTest {
     private static final Map<SchemaType, KeySchema> SCHEMA_TYPE_MAP = mkMap(
@@ -173,7 +172,7 @@ public class SessionKeySchemaTest {
         setUp(type);
         final Bytes key = Bytes.wrap(new byte[]{0});
         final List<Integer> result = getValues(keySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true));
-        assertThat(result, equalTo(asList(2, 4)));
+        assertEquals(List.of(2, 4), result);
     }
 
     @ParameterizedTest
@@ -183,7 +182,7 @@ public class SessionKeySchemaTest {
         final Bytes key = Bytes.wrap(new byte[]{0, 0});
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(key, key, 0, Long.MAX_VALUE, true);
         final List<Integer> results = getValues(hasNextCondition);
-        assertThat(results, equalTo(asList(1, 5)));
+        assertEquals(List.of(1, 5), results);
     }
 
     @ParameterizedTest
@@ -192,7 +191,7 @@ public class SessionKeySchemaTest {
         setUp(type);
         final HasNextCondition hasNextCondition = keySchema.hasNextCondition(null, null, 0, Long.MAX_VALUE, true);
         final List<Integer> results = getValues(hasNextCondition);
-        assertThat(results, equalTo(asList(1, 2, 3, 4, 5, 6)));
+        assertEquals(List.of(1, 2, 3, 4, 5, 6), results);
     }
     
     @ParameterizedTest
@@ -201,35 +200,24 @@ public class SessionKeySchemaTest {
         setUp(type);
         final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
+        assertTrue(
             upper.compareTo(toBinary.apply(
-                new Windowed<>(
-                    Bytes.wrap(new byte[]{0xA}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
-            )) >= 0
-        );
+                new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE)))) >= 0,
+            "shorter key with max timestamp should be in range");
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
+        assertTrue(
             upper.compareTo(toBinary.apply(
-                new Windowed<>(
-                    Bytes.wrap(new byte[]{0xA, 0xB}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
-
-            )) >= 0
-        );
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE)))) >= 0,
+            "shorter key with max timestamp should be in range");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
-            );
+            assertEquals(
+                toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))),
+                upper);
         } else {
-            assertThat(upper, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
-            );
+            assertEquals(
+                toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))),
+                upper);
         }
     }
 
@@ -239,19 +227,15 @@ public class SessionKeySchemaTest {
         setUp(type);
         final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), Long.MAX_VALUE);
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
+        assertTrue(
             upper.compareTo(toBinary.apply(
-                new Windowed<>(
-                    Bytes.wrap(new byte[]{0xA, (byte) 0x8F}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
-                )
-            ) >= 0
-        );
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, (byte) 0x8F}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE)))) >= 0,
+            "shorter key with max timestamp should be in range");
 
-        assertThat(upper, equalTo(toBinary.apply(
-            new Windowed<>(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))))
-        );
+        assertEquals(
+            toBinary.apply(
+                new Windowed<>(Bytes.wrap(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}), new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))),
+            upper);
     }
 
     @ParameterizedTest
@@ -262,13 +246,9 @@ public class SessionKeySchemaTest {
         final Function<Windowed<Bytes>, Bytes> toBinary = WINDOW_TO_STORE_BINARY_MAP.get(schemaType);
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE))))
-            );
+            assertEquals(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE))), upper);
         } else {
-            assertThat(upper, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(0, Long.MAX_VALUE))))
-            );
+            assertEquals(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA}), new SessionWindow(0, Long.MAX_VALUE))), upper);
         }
     }
 
@@ -277,7 +257,7 @@ public class SessionKeySchemaTest {
     public void testLowerBoundWithZeroTimestamp(final SchemaType type) {
         setUp(type);
         final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), 0);
-        assertThat(lower, equalTo(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
+        assertEquals(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0))), lower);
     }
 
     @ParameterizedTest
@@ -286,21 +266,16 @@ public class SessionKeySchemaTest {
         setUp(type);
         final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), Long.MAX_VALUE);
 
-        assertThat(
-            "appending zeros to key should still be in range",
-            lower.compareTo(toBinary.apply(
-                new Windowed<>(
-                    Bytes.wrap(new byte[]{0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-                    new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE))
-            )) < 0
-        );
+        assertTrue(
+            lower.compareTo(toBinary.apply(new Windowed<>(
+                Bytes.wrap(new byte[]{0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+                new SessionWindow(Long.MAX_VALUE, Long.MAX_VALUE)))) < 0,
+            "appending zeros to key should still be in range");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(lower, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE)))));
+            assertEquals(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, Long.MAX_VALUE))), lower);
         } else {
-            assertThat(lower, equalTo(toBinary.apply(
-                new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0)))));
+            assertEquals(toBinary.apply(new Windowed<>(Bytes.wrap(new byte[]{0xA, 0xB, 0xC}), new SessionWindow(0, 0))), lower);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreBuilderTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -34,9 +33,8 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -77,7 +75,7 @@ public class SessionStoreBuilderTest {
     public void shouldHaveMeteredStoreAsOuterStore() {
         setUp();
         final SessionStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredSessionStore.class));
+        assertInstanceOf(MeteredSessionStore.class, store);
     }
 
     @Test
@@ -85,7 +83,7 @@ public class SessionStoreBuilderTest {
         setUp();
         final SessionStore<String, String> store = builder.build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingSessionBytesStore.class));
+        assertInstanceOf(ChangeLoggingSessionBytesStore.class, next);
     }
 
     @Test
@@ -93,7 +91,7 @@ public class SessionStoreBuilderTest {
         setUp();
         final SessionStore<String, String> store = builder.withLoggingDisabled().build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, CoreMatchers.equalTo(inner));
+        assertEquals(inner, next);
     }
 
     @Test
@@ -101,8 +99,8 @@ public class SessionStoreBuilderTest {
         setUp();
         final SessionStore<String, String> store = builder.withCachingEnabled().build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredSessionStore.class));
-        assertThat(wrapped, instanceOf(CachingSessionStore.class));
+        assertInstanceOf(MeteredSessionStore.class, store);
+        assertInstanceOf(CachingSessionStore.class, wrapped);
     }
 
     @Test
@@ -112,9 +110,9 @@ public class SessionStoreBuilderTest {
                 .withLoggingEnabled(Collections.emptyMap())
                 .build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredSessionStore.class));
-        assertThat(wrapped, instanceOf(ChangeLoggingSessionBytesStore.class));
-        assertThat(((WrappedStateStore) wrapped).wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredSessionStore.class, store);
+        assertInstanceOf(ChangeLoggingSessionBytesStore.class, wrapped);
+        assertEquals(inner, ((WrappedStateStore) wrapped).wrapped());
     }
 
     @Test
@@ -126,17 +124,17 @@ public class SessionStoreBuilderTest {
                 .build();
         final WrappedStateStore caching = (WrappedStateStore) ((WrappedStateStore) store).wrapped();
         final WrappedStateStore changeLogging = (WrappedStateStore) caching.wrapped();
-        assertThat(store, instanceOf(MeteredSessionStore.class));
-        assertThat(caching, instanceOf(CachingSessionStore.class));
-        assertThat(changeLogging, instanceOf(ChangeLoggingSessionBytesStore.class));
-        assertThat(changeLogging.wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredSessionStore.class, store);
+        assertInstanceOf(CachingSessionStore.class, caching);
+        assertInstanceOf(ChangeLoggingSessionBytesStore.class, changeLogging);
+        assertEquals(inner, changeLogging.wrapped());
     }
 
     @Test
     public void shouldThrowNullPointerIfStoreSupplierIsNull() {
         setUpWithoutInner();
         final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier cannot be null"));
+        assertEquals("storeSupplier cannot be null", e.getMessage());
     }
 
     @Test
@@ -144,14 +142,14 @@ public class SessionStoreBuilderTest {
         setUpWithoutInner();
         when(supplier.name()).thenReturn(null);
         final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("name cannot be null"));
+        assertEquals("name cannot be null", e.getMessage());
     }
 
     @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
         setUpWithoutInner();
         final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
-        assertThat(e.getMessage(), equalTo("time cannot be null"));
+        assertEquals("time cannot be null", e.getMessage());
     }
 
     @Test
@@ -159,7 +157,7 @@ public class SessionStoreBuilderTest {
         setUpWithoutInner();
         when(supplier.metricsScope()).thenReturn(null);
         final Exception e = assertThrows(NullPointerException.class, () -> new SessionStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
+        assertEquals("storeSupplier's metricsScope can't be null", e.getMessage());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreFetchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SessionStoreFetchTest.java
@@ -61,8 +61,7 @@ import static java.time.Duration.ofMillis;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SessionStoreFetchTest {
@@ -268,7 +267,7 @@ public class SessionStoreFetchTest {
              final KeyValueIterator<Windowed<String>, Long> expectedIterator = forward ? store.fetch(null, null) : store.backwardFetch(null, null)) {
             final List<KeyValue<Windowed<String>, Long>> result = Utils.toList(resultIterator);
             final List<KeyValue<Windowed<String>, Long>> expected = filterList(expectedIterator, from, to);
-            assertThat(result, is(expected));
+            assertEquals(expected, result);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreQueryUtilsTest.java
@@ -41,8 +41,8 @@ import org.mockito.Mockito;
 
 import java.time.Instant;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,13 +64,11 @@ public class StoreQueryUtilsTest {
             position,
             null
         );
-        assertThat(queryResult.isFailure(), is(true));
-        assertThat(queryResult.getFailureReason(), is(FailureReason.NOT_UP_TO_BOUND));
-        assertThat(
-            queryResult.getFailureMessage(),
-            is("The store is not initialized yet, so it is not yet up to the bound"
-                   + " PositionBound{position=Position{position={topic={0=1}}}}")
-        );
+        assertTrue(queryResult.isFailure());
+        assertEquals(FailureReason.NOT_UP_TO_BOUND, queryResult.getFailureReason());
+        assertEquals(
+            "The store is not initialized yet, so it is not yet up to the bound PositionBound{position=Position{position={topic={0=1}}}}",
+            queryResult.getFailureMessage());
     }
 
     @Test
@@ -90,14 +88,13 @@ public class StoreQueryUtilsTest {
             context
         );
 
-        assertThat(queryResult.isFailure(), is(true));
-        assertThat(queryResult.getFailureReason(), is(FailureReason.NOT_UP_TO_BOUND));
-        assertThat(
-            queryResult.getFailureMessage(),
-            is("For store partition 0, the current position Position{position={topic={0=0}}}"
-                   + " is not yet up to the bound"
-                   + " PositionBound{position=Position{position={topic={0=1}}}}")
-        );
+        assertTrue(queryResult.isFailure());
+        assertEquals(FailureReason.NOT_UP_TO_BOUND, queryResult.getFailureReason());
+        assertEquals(
+            "For store partition 0, the current position Position{position={topic={0=0}}}"
+                + " is not yet up to the bound"
+                + " PositionBound{position=Position{position={topic={0=1}}}}",
+            queryResult.getFailureMessage());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreSerdeInitializerTest.java
@@ -30,8 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -62,9 +61,9 @@ public class StoreSerdeInitializerTest {
         final StateSerdes<String, String> result = StoreSerdeInitializer.prepareStoreSerde(
             context, "myStore", "topic", keySerde, valueSerde, WrappingNullableUtils::prepareValueSerde);
 
-        assertThat(result.keySerde(), equalTo(keySerde));
-        assertThat(result.valueSerde(), equalTo(valueSerde));
-        assertThat(result.topic(), equalTo("topic"));
+        assertEquals(keySerde, result.keySerde());
+        assertEquals(valueSerde, result.valueSerde());
+        assertEquals("topic", result.topic());
     }
 
     @Test
@@ -78,8 +77,8 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
-        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
+        assertEquals("Failed to initialize key serdes for store myStore", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -93,8 +92,8 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
-        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
+        assertEquals("Failed to initialize value serdes for store myStore", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -108,8 +107,8 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
-        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG"));
+        assertEquals("Failed to initialize key serdes for store myStore", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -123,8 +122,8 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
-        assertThat(exception.getCause().getMessage(), equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG"));
+        assertEquals("Failed to initialize value serdes for store myStore", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -137,7 +136,7 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for store myStore"));
+        assertEquals("Failed to initialize key serdes for store myStore", exception.getMessage());
     }
 
     @Test
@@ -150,6 +149,6 @@ public class StoreSerdeInitializerTest {
             () -> StoreSerdeInitializer.prepareStoreSerde(context, "myStore", "topic",
                 new Serdes.StringSerde(), new Serdes.StringSerde(), WrappingNullableUtils::prepareValueSerde));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize value serdes for store myStore"));
+        assertEquals("Failed to initialize value serdes for store myStore", exception.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -90,11 +90,9 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -237,9 +235,9 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, kvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: kvStores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -250,9 +248,9 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store: tkvStores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, instanceOf(TimestampedKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertInstanceOf(TimestampedKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -263,15 +261,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.timestampedKeyValueStore()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store kv-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredKeyValueStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store kv-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredKeyValueStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -281,9 +276,9 @@ public class StreamThreadStateStoreProviderTest {
                 provider.stores(StoreQueryParameters.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.keyValueStore()));
         assertEquals(2, tkvStores.size());
         for (final ReadOnlyKeyValueStore<String, String> store: tkvStores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -294,9 +289,9 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStore);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -307,9 +302,9 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store: windowStores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(TimestampedWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(TimestampedWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -320,15 +315,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.timestampedWindowStore()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store window-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredWindowStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store window-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredWindowStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -338,9 +330,9 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("timestamped-window-store", QueryableStoreTypes.windowStore()));
         assertEquals(2, windowStores.size());
         for (final ReadOnlyWindowStore<String, String> store: windowStores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertFalse(store instanceof TimestampedWindowStore);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -351,8 +343,8 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("session-store", QueryableStoreTypes.sessionStore()));
         assertEquals(2, sessionStores.size());
         for (final ReadOnlySessionStore<String, String> store: sessionStores) {
-            assertThat(store, instanceOf(ReadOnlySessionStore.class));
-            assertThat(store, not(instanceOf(SessionStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlySessionStore.class, store);
+            assertFalse(store instanceof SessionStoreWithHeaders);
         }
     }
 
@@ -415,8 +407,8 @@ public class StreamThreadStateStoreProviderTest {
                         .withPartition(0));
             assertEquals(1, kvStores.size());
             for (final ReadOnlyKeyValueStore<String, String> store : kvStores) {
-                assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-                assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
+                assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+                assertFalse(store instanceof TimestampedKeyValueStore);
             }
         }
         {
@@ -427,8 +419,8 @@ public class StreamThreadStateStoreProviderTest {
                         .withPartition(1));
             assertEquals(1, kvStores.size());
             for (final ReadOnlyKeyValueStore<String, String> store : kvStores) {
-                assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-                assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
+                assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+                assertFalse(store instanceof TimestampedKeyValueStore);
             }
         }
     }
@@ -457,8 +449,8 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()));
         assertEquals(2, stores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyKeyValueStore.class));
-            assertThat(store, instanceOf(TimestampedKeyValueStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlyKeyValueStore.class, store);
+            assertInstanceOf(TimestampedKeyValueStoreWithHeaders.class, store);
         }
     }
 
@@ -470,8 +462,8 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.timestampedKeyValueStore()));
         assertEquals(2, stores.size());
         for (final ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyKeyValueStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyKeyValueStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -483,9 +475,9 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.keyValueStore()));
         assertEquals(2, stores.size());
         for (final ReadOnlyKeyValueStore<String, String> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyKeyValueStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStore.class)));
-            assertThat(store, not(instanceOf(TimestampedKeyValueStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyKeyValueStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedKeyValueStore);
+            assertFalse(store instanceof TimestampedKeyValueStoreWithHeaders);
         }
     }
 
@@ -496,15 +488,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store kv-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreWithHeadersType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredKeyValueStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store kv-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreWithHeadersType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredKeyValueStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -514,15 +503,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStoreWithHeaders()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store timestamped-kv-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreWithHeadersType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store timestamped-kv-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedKeyValueStoreWithHeadersType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredTimestampedKeyValueStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -533,8 +519,8 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
         assertEquals(2, stores.size());
         for (final ReadOnlyWindowStore<String, ValueTimestampHeaders<String>> store : stores) {
-            assertThat(store, instanceOf(ReadOnlyWindowStore.class));
-            assertThat(store, instanceOf(TimestampedWindowStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlyWindowStore.class, store);
+            assertInstanceOf(TimestampedWindowStoreWithHeaders.class, store);
         }
     }
 
@@ -546,8 +532,8 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.timestampedWindowStore()));
         assertEquals(2, stores.size());
         for (final ReadOnlyWindowStore<String, ValueAndTimestamp<String>> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyWindowStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyWindowStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -559,9 +545,9 @@ public class StreamThreadStateStoreProviderTest {
                 QueryableStoreTypes.windowStore()));
         assertEquals(2, stores.size());
         for (final ReadOnlyWindowStore<String, String> store : stores) {
-            assertThat(store, instanceOf(GenericReadOnlyWindowStoreFacade.class));
-            assertThat(store, not(instanceOf(TimestampedWindowStore.class)));
-            assertThat(store, not(instanceOf(TimestampedWindowStoreWithHeaders.class)));
+            assertInstanceOf(GenericReadOnlyWindowStoreFacade.class, store);
+            assertFalse(store instanceof TimestampedWindowStore);
+            assertFalse(store instanceof TimestampedWindowStoreWithHeaders);
         }
     }
 
@@ -572,15 +558,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.timestampedWindowStoreWithHeaders()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store window-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreWithHeadersType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredWindowStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store window-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreWithHeadersType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredWindowStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -590,15 +573,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("timestamped-window-store", QueryableStoreTypes.timestampedWindowStoreWithHeaders()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store timestamped-window-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreWithHeadersType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredTimestampedWindowStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store timestamped-window-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$TimestampedWindowStoreWithHeadersType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredTimestampedWindowStore].",
+            exception.getMessage());
     }
 
     @Test
@@ -608,8 +588,8 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("session-store-with-headers", QueryableStoreTypes.sessionStoreWithHeaders()));
         assertEquals(2, sessionStores.size());
         for (final ReadOnlySessionStore<String, AggregationWithHeaders<String>> store: sessionStores) {
-            assertThat(store, instanceOf(ReadOnlySessionStore.class));
-            assertThat(store, instanceOf(SessionStoreWithHeaders.class));
+            assertInstanceOf(ReadOnlySessionStore.class, store);
+            assertInstanceOf(SessionStoreWithHeaders.class, store);
         }
     }
 
@@ -620,8 +600,8 @@ public class StreamThreadStateStoreProviderTest {
             provider.stores(StoreQueryParameters.fromNameAndType("session-store-with-headers", QueryableStoreTypes.sessionStore()));
         assertEquals(2, sessionStores.size());
         for (final ReadOnlySessionStore<String, String> store: sessionStores) {
-            assertThat(store, instanceOf(ReadOnlySessionStoreFacade.class));
-            assertThat(store, not(instanceOf(SessionStoreWithHeaders.class)));
+            assertInstanceOf(ReadOnlySessionStoreFacade.class, store);
+            assertFalse(store instanceof SessionStoreWithHeaders);
         }
     }
 
@@ -632,15 +612,12 @@ public class StreamThreadStateStoreProviderTest {
             InvalidStateStoreException.class,
             () -> provider.stores(StoreQueryParameters.fromNameAndType("session-store", QueryableStoreTypes.sessionStoreWithHeaders()))
         );
-        assertThat(
-            exception.getMessage(),
-            is(
-                "Cannot get state store session-store because the queryable store type " +
-                    "[class org.apache.kafka.streams.state.QueryableStoreTypes$SessionStoreWithHeadersType] " +
-                    "does not accept the actual store type " +
-                    "[class org.apache.kafka.streams.state.internals.MeteredSessionStore]."
-            )
-        );
+        assertEquals(
+            "Cannot get state store session-store because the queryable store type " +
+                "[class org.apache.kafka.streams.state.QueryableStoreTypes$SessionStoreWithHeadersType] " +
+                "does not accept the actual store type " +
+                "[class org.apache.kafka.streams.state.internals.MeteredSessionStore].",
+            exception.getMessage());
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -269,8 +267,8 @@ public class ThreadCacheTest {
         final ThreadCache cache = setupThreadCache(1, 1, 10000L, true);
         final Bytes theByte = Bytes.wrap(new byte[]{1});
         final ThreadCache.MemoryLRUCacheBytesIterator iterator = cache.reverseRange(namespace, Bytes.wrap(new byte[]{0}), theByte);
-        assertThat(iterator.peekNextKey(), is(theByte));
-        assertThat(iterator.peekNextKey(), is(theByte));
+        assertEquals(theByte, iterator.peekNextKey());
+        assertEquals(theByte, iterator.peekNextKey());
     }
 
     @Test
@@ -278,7 +276,9 @@ public class ThreadCacheTest {
         final ThreadCache cache = setupThreadCache(0, 1, 10000L, false);
         final Bytes theByte = Bytes.wrap(new byte[]{0});
         final ThreadCache.MemoryLRUCacheBytesIterator iterator = cache.range(namespace, theByte, Bytes.wrap(new byte[]{1}));
-        assertThat(iterator.peekNextKey(), is(iterator.next().key));
+        final Bytes expectedKey = iterator.peekNextKey();
+        final Bytes actualKey = iterator.next().key;
+        assertEquals(expectedKey, actualKey);
     }
 
     @Test
@@ -286,7 +286,9 @@ public class ThreadCacheTest {
         final ThreadCache cache = setupThreadCache(1, 1, 10000L, true);
         final Bytes theByte = Bytes.wrap(new byte[]{1});
         final ThreadCache.MemoryLRUCacheBytesIterator iterator = cache.reverseRange(namespace, Bytes.wrap(new byte[]{0}), theByte);
-        assertThat(iterator.peekNextKey(), is(iterator.next().key));
+        final Bytes expectedKey = iterator.peekNextKey();
+        final Bytes actualKey = iterator.next().key;
+        assertEquals(expectedKey, actualKey);
     }
 
     private void shouldThrowIfNoPeekNextKey(final Supplier<ThreadCache.MemoryLRUCacheBytesIterator> methodUnderTest) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedCachingPersistentWindowStoreTest.java
@@ -81,10 +81,6 @@ import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.verifyAllWindowedKeyValues;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyWindowedKeyValue;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -154,8 +150,7 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
         final RocksDBTimestampedWindowStore innerWrong = mock(RocksDBTimestampedWindowStore.class);
         final Exception e = assertThrows(IllegalArgumentException.class,
             () -> new TimeOrderedCachingWindowStore(innerWrong, WINDOW_SIZE, SEGMENT_INTERVAL));
-        assertThat(e.getMessage(),
-            containsString("TimeOrderedCachingWindowStore only supports RocksDBTimeOrderedWindowStore backed store"));
+        assertTrue(e.getMessage().contains("TimeOrderedCachingWindowStore only supports RocksDBTimeOrderedWindowStore backed store"));
 
         final RocksDBTimeOrderedWindowStore<?> inner = mock(RocksDBTimeOrderedWindowStore.class);
         // Nothing happens
@@ -198,7 +193,7 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(0));
+                    assertEquals(0, count);
                 }
 
                 @Override
@@ -212,7 +207,7 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(numRecordsProcessed));
+                    assertEquals(numRecordsProcessed, count);
 
                     store.put(record.value(), ValueAndTimestamp.make(record.value(), record.timestamp()), record.timestamp());
 
@@ -269,10 +264,10 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
         cachingStore.put(bytesKey("a"), bytesValue("a"), DEFAULT_TIMESTAMP);
         cachingStore.put(bytesKey("b"), bytesValue("b"), DEFAULT_TIMESTAMP);
 
-        assertThat(cachingStore.fetch(bytesKey("a"), 10), equalTo(bytesValue("a")));
-        assertThat(cachingStore.fetch(bytesKey("b"), 10), equalTo(bytesValue("b")));
-        assertThat(cachingStore.fetch(bytesKey("c"), 10), equalTo(null));
-        assertThat(cachingStore.fetch(bytesKey("a"), 0), equalTo(null));
+        assertArrayEquals(bytesValue("a"), cachingStore.fetch(bytesKey("a"), 10));
+        assertArrayEquals(bytesValue("b"), cachingStore.fetch(bytesKey("b"), 10));
+        assertNull(cachingStore.fetch(bytesKey("c"), 10));
+        assertNull(cachingStore.fetch(bytesKey("a"), 0));
 
         try (final WindowStoreIterator<byte[]> a = cachingStore.fetch(bytesKey("a"), ofEpochMilli(10), ofEpochMilli(10));
              final WindowStoreIterator<byte[]> b = cachingStore.fetch(bytesKey("b"), ofEpochMilli(10), ofEpochMilli(10))) {
@@ -332,8 +327,8 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
     private void verifyKeyValue(final KeyValue<Long, byte[]> next,
                                 final long expectedKey,
                                 final String expectedValue) {
-        assertThat(next.key, equalTo(expectedKey));
-        assertThat(next.value, equalTo(bytesValue(expectedValue)));
+        assertEquals(expectedKey, next.key);
+        assertArrayEquals(bytesValue(expectedValue), next.value);
     }
 
     private static byte[] bytesValue(final String value) {
@@ -1198,13 +1193,11 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -1222,13 +1215,11 @@ public class TimeOrderedCachingPersistentWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBufferTest.java
@@ -71,10 +71,10 @@ import static org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyVal
 import static org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer.OLD_VALUE_HEADERS_KEY;
 import static org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer.PRIOR_VALUE_HEADERS_KEY;
 import static org.apache.kafka.streams.state.internals.Utils.rawValueTimestampHeaders;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<String, String, Change<String>>> {
@@ -199,9 +199,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext<?, ?> context = makeContext();
         buffer.init(context, buffer);
         putRecord(buffer, context, 0L, 0L, "asdf", "qwer");
-        assertThat(buffer.numRecords(), is(1));
+        assertEquals(1, buffer.numRecords());
         buffer.evictWhile(() -> true, kv -> { });
-        assertThat(buffer.numRecords(), is(0));
+        assertEquals(0, buffer.numRecords());
         cleanup(context, buffer);
     }
 
@@ -214,13 +214,11 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.init(context, buffer);
         putRecord(buffer, context, 0L, 0L, "asdf", "eyt");
         putRecord(buffer, context, 1L, 0L, "zxcv", "rtg");
-        assertThat(buffer.numRecords(), is(2));
+        assertEquals(2, buffer.numRecords());
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         buffer.evictWhile(() -> buffer.numRecords() > 1, evicted::add);
-        assertThat(buffer.numRecords(), is(1));
-        assertThat(evicted, is(singletonList(
-            new Eviction<>("asdf", new Change<>("eyt", null), getContext(0L))
-        )));
+        assertEquals(1, buffer.numRecords());
+        assertEquals(List.of(new Eviction<>("asdf", new Change<>("eyt", null), getContext(0L))), evicted);
         cleanup(context, buffer);
     }
 
@@ -232,11 +230,11 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext<?, ?> context = makeContext();
         buffer.init(context, buffer);
         putRecord(buffer, context, 0L, 0L, "asdf", "oin");
-        assertThat(buffer.numRecords(), is(1));
+        assertEquals(1, buffer.numRecords());
         putRecord(buffer, context, 1L, 0L, "asdf", "wekjn");
-        assertThat(buffer.numRecords(), is(1));
+        assertEquals(1, buffer.numRecords());
         putRecord(buffer, context, 0L, 0L, "zxcv", "24inf");
-        assertThat(buffer.numRecords(), is(2));
+        assertEquals(2, buffer.numRecords());
         cleanup(context, buffer);
     }
 
@@ -248,11 +246,11 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext<?, ?> context = makeContext();
         buffer.init(context, buffer);
         putRecord(buffer, context, 0L, 0L, "asdf", "23roni");
-        assertThat(buffer.bufferSize(), is(43L));
+        assertEquals(43L, buffer.bufferSize());
         putRecord(buffer, context, 1L, 0L, "asdf", "3l");
-        assertThat(buffer.bufferSize(), is(39L));
+        assertEquals(39L, buffer.bufferSize());
         putRecord(buffer, context, 0L, 0L, "zxcv", "qfowin");
-        assertThat(buffer.bufferSize(), is(82L));
+        assertEquals(82L, buffer.bufferSize());
         cleanup(context, buffer);
     }
 
@@ -264,9 +262,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext<?, ?> context = makeContext();
         buffer.init(context, buffer);
         putRecord(buffer, context, 1L, 0L, "asdf", "2093j");
-        assertThat(buffer.minTimestamp(), is(1L));
+        assertEquals(1L, buffer.minTimestamp());
         putRecord(buffer, context, 0L, 0L, "zxcv", "3gon4i");
-        assertThat(buffer.minTimestamp(), is(0L));
+        assertEquals(0L, buffer.minTimestamp());
         cleanup(context, buffer);
     }
 
@@ -279,30 +277,30 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.init(context, buffer);
 
         putRecord(buffer, context, 1L, 0L, "zxcv", "o23i4");
-        assertThat(buffer.numRecords(), is(1));
-        assertThat(buffer.bufferSize(), is(42L));
-        assertThat(buffer.minTimestamp(), is(1L));
+        assertEquals(1, buffer.numRecords());
+        assertEquals(42L, buffer.bufferSize());
+        assertEquals(1L, buffer.minTimestamp());
 
         putRecord(buffer, context, 0L, 0L, "asdf", "3ng");
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.bufferSize(), is(82L));
-        assertThat(buffer.minTimestamp(), is(0L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(82L, buffer.bufferSize());
+        assertEquals(0L, buffer.minTimestamp());
 
         final AtomicInteger callbackCount = new AtomicInteger(0);
         buffer.evictWhile(() -> true, kv -> {
             switch (callbackCount.incrementAndGet()) {
                 case 1: {
-                    assertThat(kv.key(), is("asdf"));
-                    assertThat(buffer.numRecords(), is(2));
-                    assertThat(buffer.bufferSize(), is(82L));
-                    assertThat(buffer.minTimestamp(), is(0L));
+                    assertEquals("asdf", kv.key());
+                    assertEquals(2, buffer.numRecords());
+                    assertEquals(82L, buffer.bufferSize());
+                    assertEquals(0L, buffer.minTimestamp());
                     break;
                 }
                 case 2: {
-                    assertThat(kv.key(), is("zxcv"));
-                    assertThat(buffer.numRecords(), is(1));
-                    assertThat(buffer.bufferSize(), is(42L));
-                    assertThat(buffer.minTimestamp(), is(1L));
+                    assertEquals("zxcv", kv.key());
+                    assertEquals(1, buffer.numRecords());
+                    assertEquals(42L, buffer.bufferSize());
+                    assertEquals(1L, buffer.minTimestamp());
                     break;
                 }
                 default: {
@@ -311,10 +309,10 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                 }
             }
         });
-        assertThat(callbackCount.get(), is(2));
-        assertThat(buffer.numRecords(), is(0));
-        assertThat(buffer.bufferSize(), is(0L));
-        assertThat(buffer.minTimestamp(), is(Long.MAX_VALUE));
+        assertEquals(2, callbackCount.get());
+        assertEquals(0, buffer.numRecords());
+        assertEquals(0L, buffer.bufferSize());
+        assertEquals(Long.MAX_VALUE, buffer.minTimestamp());
         cleanup(context, buffer);
     }
 
@@ -326,7 +324,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final MockInternalProcessorContext<?, ?> context = makeContext();
         buffer.init(context, buffer);
 
-        assertThat(buffer.priorValueForBuffered("ASDF"), is(Maybe.undefined()));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("ASDF"));
     }
 
     @ParameterizedTest
@@ -341,8 +339,8 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         context.setRecordContext(recordContext);
         buffer.put(1L, new Record<>("A", new Change<>("new-value", "old-value"), 0L), recordContext);
         buffer.put(1L, new Record<>("B", new Change<>("new-value", null), 0L), recordContext);
-        assertThat(buffer.priorValueForBuffered("A"), is(Maybe.defined(ValueTimestampHeaders.make("old-value", -1, new RecordHeaders()))));
-        assertThat(buffer.priorValueForBuffered("B"), is(Maybe.defined(null)));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("old-value", -1, new RecordHeaders())), buffer.priorValueForBuffered("A"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("B"));
     }
 
     @ParameterizedTest
@@ -363,8 +361,8 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         buffer.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).recordContext().headers(), is(headers));
+        assertEquals(1, evicted.size());
+        assertEquals(headers, evicted.get(0).recordContext().headers());
         cleanup(context, buffer);
     }
 
@@ -416,13 +414,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         buffer.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).value(), is(new Change<>("v2", "v1")));
+        assertEquals(1, evicted.size());
+        assertEquals(new Change<>("v2", "v1"), evicted.get(0).value());
         // New value first with its own headers (B), then the old value with the headers of the record
         // it originally arrived on (A) -- not with B, and not with whatever triggered the eviction.
-        assertThat(headerSeenByDeserializer, is(List.of("B", "A")));
+        assertEquals(List.of("B", "A"), headerSeenByDeserializer);
         // The emitted record carries the new value's headers.
-        assertThat(evicted.get(0).recordContext().headers(), is(headersB));
+        assertEquals(headersB, evicted.get(0).recordContext().headers());
         cleanup(context, buffer);
     }
 
@@ -466,10 +464,10 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         buffer.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
+        assertEquals(1, evicted.size());
         // The buffered value must be deserialized with its own headers ("A"), not the headers of the
         // record that triggered the eviction ("B").
-        assertThat(headerSeenByDeserializer, is(singletonList("A")));
+        assertEquals(List.of("A"), headerSeenByDeserializer);
         cleanup(context, buffer);
     }
 
@@ -508,7 +506,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         context.setRecordContext(recordContext);
         buffer.put(0L, record, recordContext);
 
-        assertThat(new String(record.headers().lastHeader("serialized").value(), UTF_8), is("new"));
+        assertEquals("new", new String(record.headers().lastHeader("serialized").value(), UTF_8));
 
         // A tombstone has no new value to serialize, so the old value's header is the one that stands.
         final Record<String, Change<String>> tombstone =
@@ -517,7 +515,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         context.setRecordContext(tombstoneContext);
         buffer.put(0L, tombstone, tombstoneContext);
 
-        assertThat(new String(tombstone.headers().lastHeader("serialized").value(), UTF_8), is("old"));
+        assertEquals("old", new String(tombstone.headers().lastHeader("serialized").value(), UTF_8));
         cleanup(context, buffer);
     }
 
@@ -548,23 +546,23 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.commit(Map.of());
 
         final List<ProducerRecord<Object, Object>> collected = ((MockRecordCollector) context.recordCollector()).collected();
-        assertThat(collected.size(), is(1));
+        assertEquals(1, collected.size());
         final ProducerRecord<Object, Object> changelogRecord = collected.get(0);
 
         // The version marker stays at V3, so an older version restores this record fine...
-        assertThat(changelogRecord.headers().lastHeader("v").value(), is(new byte[] {(byte) 3}));
+        assertArrayEquals(new byte[] {(byte) 3}, changelogRecord.headers().lastHeader("v").value());
 
         // ...because the value bytes are plain values, exactly as the V3 format prescribes.
         final BufferValue bufferValue = BufferValue.deserialize(ByteBuffer.wrap((byte[]) changelogRecord.value()));
         final StringDeserializer plainDeserializer = new StringDeserializer();
-        assertThat(plainDeserializer.deserialize("topic", bufferValue.newValue()), is("v2"));
-        assertThat(plainDeserializer.deserialize("topic", bufferValue.oldValue()), is("v1"));
+        assertEquals("v2", plainDeserializer.deserialize("topic", bufferValue.newValue()));
+        assertEquals("v1", plainDeserializer.deserialize("topic", bufferValue.oldValue()));
 
         // The new value's headers and timestamp need no Kafka header of their own: the record context
         // encoded in the V3 value already describes that part, since it is the context of the very
         // record the new value came from.
-        assertThat(bufferValue.context().headers(), is(headersB));
-        assertThat(bufferValue.context().timestamp(), is(20L));
+        assertEquals(headersB, bufferValue.context().headers());
+        assertEquals(20L, bufferValue.context().timestamp());
 
         // The prior and old parts have no such carrier, so their headers and timestamps ride in the
         // record's Kafka headers, and recombine with the plain value bytes into the in-memory encoding.
@@ -573,9 +571,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         final ValueTimestampHeaders<String> oldValue = deserializer.deserialize("topic",
             rawValueTimestampHeaders(changelogRecord.headers().lastHeader(OLD_VALUE_HEADERS_KEY).value(), bufferValue.oldValue()));
-        assertThat(oldValue.value(), is("v1"));
-        assertThat(oldValue.timestamp(), is(10L));     // carried forward from the first record
-        assertThat(oldValue.headers(), is(headersA));  // carried forward from the first record
+        assertEquals("v1", oldValue.value());
+        assertEquals(10L, oldValue.timestamp());     // carried forward from the first record
+        assertEquals(headersA, oldValue.headers());  // carried forward from the first record
 
         cleanup(context, buffer);
     }
@@ -598,8 +596,8 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         final ProducerRecord<Object, Object> changelogRecord =
             ((MockRecordCollector) context.recordCollector()).collected().get(0);
-        assertThat(changelogRecord.headers().lastHeader(OLD_VALUE_HEADERS_KEY), is(not(nullValue())));
-        assertThat(changelogRecord.headers().lastHeader(PRIOR_VALUE_HEADERS_KEY), is(nullValue()));
+        assertNotNull(changelogRecord.headers().lastHeader(OLD_VALUE_HEADERS_KEY));
+        assertNull(changelogRecord.headers().lastHeader(PRIOR_VALUE_HEADERS_KEY));
 
         // The prior value must still come back, recovered from the old part rather than from the
         // header the writer deliberately left out.
@@ -609,8 +607,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         restored.init(restoreContext, restored);
         restoreInto(restoreContext, context, STORE_NAME);
 
-        assertThat(restored.priorValueForBuffered("k"),
-            is(Maybe.defined(ValueTimestampHeaders.make("p", RecordQueue.UNKNOWN, new RecordHeaders()))));
+        assertEquals(
+            Maybe.defined(ValueTimestampHeaders.make("p", RecordQueue.UNKNOWN, new RecordHeaders())),
+            restored.priorValueForBuffered("k"));
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -643,7 +642,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         // The parts differ, so this time the prefix must be written under its own key.
         final ProducerRecord<Object, Object> changelogRecord =
             ((MockRecordCollector) context.recordCollector()).collected().get(0);
-        assertThat(changelogRecord.headers().lastHeader(PRIOR_VALUE_HEADERS_KEY), is(not(nullValue())));
+        assertNotNull(changelogRecord.headers().lastHeader(PRIOR_VALUE_HEADERS_KEY));
 
         final InMemoryTimeOrderedKeyValueChangeBuffer<String, String, Change<String>> restored =
             new InMemoryTimeOrderedKeyValueChangeBuffer.Builder<>(STORE_NAME, Serdes.String(), Serdes.String()).build();
@@ -652,8 +651,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         restoreInto(restoreContext, context, STORE_NAME);
 
         // Not (p, 10, A) -- that is the OLD part, and taking it here would be the dedup misfiring.
-        assertThat(restored.priorValueForBuffered("k"),
-            is(Maybe.defined(ValueTimestampHeaders.make("p", RecordQueue.UNKNOWN, new RecordHeaders()))));
+        assertEquals(
+            Maybe.defined(ValueTimestampHeaders.make("p", RecordQueue.UNKNOWN, new RecordHeaders())),
+            restored.priorValueForBuffered("k"));
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -674,8 +674,8 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         // The prior value's original timestamp/headers are unknown when a key is first buffered, so
         // they round-trip through the ValueTimestampHeaders encoding as UNKNOWN/empty.
-        assertThat(buffer.priorValueForBuffered("A"), is(Maybe.defined(ValueTimestampHeaders.make("old-value", -1, new RecordHeaders()))));
-        assertThat(buffer.priorValueForBuffered("B"), is(Maybe.defined(null)));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("old-value", -1, new RecordHeaders())), buffer.priorValueForBuffered("A"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("B"));
         cleanup(context, buffer);
     }
 
@@ -696,7 +696,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.commit(Map.of());
 
         final List<ProducerRecord<Object, Object>> collected = ((MockRecordCollector) context.recordCollector()).collected();
-        assertThat(collected.size(), is(1));
+        assertEquals(1, collected.size());
 
         // Restore the changelog into a fresh buffer and confirm the value, record timestamp and
         // headers all survived the serialization round-trip.
@@ -717,11 +717,11 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         restored.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).key(), is("k"));
-        assertThat(evicted.get(0).value(), is(new Change<>("new", "old")));
-        assertThat(evicted.get(0).recordContext().timestamp(), is(5L));
-        assertThat(evicted.get(0).recordContext().headers(), is(headers));
+        assertEquals(1, evicted.size());
+        assertEquals("k", evicted.get(0).key());
+        assertEquals(new Change<>("new", "old"), evicted.get(0).value());
+        assertEquals(5L, evicted.get(0).recordContext().timestamp());
+        assertEquals(headers, evicted.get(0).recordContext().headers());
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -777,12 +777,12 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         restored.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).value(), is(new Change<>("v2", "v1")));
+        assertEquals(1, evicted.size());
+        assertEquals(new Change<>("v2", "v1"), evicted.get(0).value());
         // New value with its own headers (B), then the old value with the headers of the record it
         // originally arrived on (A) -- both recovered from the changelog, not just the latest one.
-        assertThat(headerSeenByDeserializer, is(List.of("B", "A")));
-        assertThat(evicted.get(0).recordContext().headers(), is(headersB));
+        assertEquals(List.of("B", "A"), headerSeenByDeserializer);
+        assertEquals(headersB, evicted.get(0).recordContext().headers());
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -813,15 +813,15 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         // The prior value has no per-part headers to recover, so it falls back to empty headers and
         // the record-context timestamp rather than the UNKNOWN it would carry in a headers changelog.
-        assertThat(restored.priorValueForBuffered("k"), is(Maybe.defined(ValueTimestampHeaders.make("old", 5L, new RecordHeaders()))));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("old", 5L, new RecordHeaders())), restored.priorValueForBuffered("k"));
 
         final List<Eviction<String, Change<String>>> evicted = new LinkedList<>();
         restored.evictWhile(() -> true, evicted::add);
 
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).key(), is("k"));
-        assertThat(evicted.get(0).value(), is(new Change<>("new", "old")));
-        assertThat(evicted.get(0).recordContext().timestamp(), is(5L));
+        assertEquals(1, evicted.size());
+        assertEquals("k", evicted.get(0).key());
+        assertEquals(new Change<>("new", "old"), evicted.get(0).value());
+        assertEquals(5L, evicted.get(0).recordContext().timestamp());
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -844,16 +844,18 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.put(0L, new Record<>("k", new Change<>("new", "old"), 5L, headers), context.recordContext());
         buffer.commit(Map.of());
 
-        assertThat(buffer.priorValueForBuffered("k"),
-            is(Maybe.defined(ValueTimestampHeaders.make("old", RecordQueue.UNKNOWN, new RecordHeaders()))));
+        assertEquals(
+            Maybe.defined(ValueTimestampHeaders.make("old", RecordQueue.UNKNOWN, new RecordHeaders())),
+            buffer.priorValueForBuffered("k"));
 
         final TimeOrderedKeyValueBuffer<String, String, Change<String>> restored = bufferSupplier.apply(testName);
         final MockInternalProcessorContext<?, ?> restoreContext = makeContext(true);
         restored.init(restoreContext, restored);
         restoreInto(restoreContext, context, testName);
 
-        assertThat(restored.priorValueForBuffered("k"),
-            is(Maybe.defined(ValueTimestampHeaders.make("old", RecordQueue.UNKNOWN, new RecordHeaders()))));
+        assertEquals(
+            Maybe.defined(ValueTimestampHeaders.make("old", RecordQueue.UNKNOWN, new RecordHeaders())),
+            restored.priorValueForBuffered("k"));
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -877,7 +879,7 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         buffer.commit(Map.of());
 
         final List<ProducerRecord<Object, Object>> collected = ((MockRecordCollector) context.recordCollector()).collected();
-        assertThat(collected.size(), is(1));
+        assertEquals(1, collected.size());
 
         // Restore into a buffer configured WITHOUT header stores.
         final TimeOrderedKeyValueBuffer<String, String, Change<String>> restored = bufferSupplier.apply(testName);
@@ -899,10 +901,10 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
 
         // The values come back intact; only the per-part headers are absent, which is exactly what
         // running without a headers store format means.
-        assertThat(evicted.size(), is(1));
-        assertThat(evicted.get(0).key(), is("k"));
-        assertThat(evicted.get(0).value(), is(new Change<>("new", "old")));
-        assertThat(evicted.get(0).recordContext().timestamp(), is(5L));
+        assertEquals(1, evicted.size());
+        assertEquals("k", evicted.get(0).key());
+        assertEquals(new Change<>("new", "old"), evicted.get(0).value());
+        assertEquals(5L, evicted.get(0).recordContext().timestamp());
         cleanup(restoreContext, restored);
         cleanup(context, buffer);
     }
@@ -953,29 +955,27 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                 })
                 .collect(Collectors.toList());
 
-        assertThat(collected, is(asList(
-            new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
-                                 0,   // Producer will assign
-                                 null,
-                                 "deleteme",
-                                 null,
-                                 new RecordHeaders()
-            ),
-            new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
-                                 0,
-                                 null,
-                                 "zxcv",
-                                 new KeyValue<>(1L, getBufferValue("3gon4i", 1)),
-                                 CHANGELOG_HEADERS
-            ),
-            new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
-                                 0,
-                                 null,
-                                 "asdf",
-                                 new KeyValue<>(2L, getBufferValue("2093j", 0)),
-                                 CHANGELOG_HEADERS
-            )
-        )));
+        assertEquals(
+            List.of(
+                new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
+                                     0,   // Producer will assign
+                                     null,
+                                     "deleteme",
+                                     null,
+                                     new RecordHeaders()),
+                new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
+                                     0,
+                                     null,
+                                     "zxcv",
+                                     new KeyValue<>(1L, getBufferValue("3gon4i", 1)),
+                                     CHANGELOG_HEADERS),
+                new ProducerRecord<>(APP_ID + "-" + testName + "-changelog",
+                                     0,
+                                     null,
+                                     "asdf",
+                                     new KeyValue<>(2L, getBufferValue("2093j", 0)),
+                                     CHANGELOG_HEADERS)),
+            collected);
 
         cleanup(context, buffer);
     }
@@ -1048,9 +1048,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(3));
-        assertThat(buffer.minTimestamp(), is(0L));
-        assertThat(buffer.bufferSize(), is(172L));
+        assertEquals(3, buffer.numRecords());
+        assertEquals(0L, buffer.minTimestamp());
+        assertEquals(172L, buffer.bufferSize());
 
         stateRestoreCallback.restoreBatch(singletonList(
             new ConsumerRecord<>("changelog-topic",
@@ -1066,13 +1066,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.minTimestamp(), is(1L));
-        assertThat(buffer.bufferSize(), is(115L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(1L, buffer.minTimestamp());
+        assertEquals(115L, buffer.bufferSize());
 
-        assertThat(buffer.priorValueForBuffered("todelete"), is(Maybe.undefined()));
-        assertThat(buffer.priorValueForBuffered("asdf"), is(Maybe.defined(null)));
-        assertThat(buffer.priorValueForBuffered("zxcv"), is(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders()))));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("todelete"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("asdf"));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders())), buffer.priorValueForBuffered("zxcv"));
 
         // flush the buffer into a list in buffer order so we can make assertions about the contents.
 
@@ -1087,16 +1087,17 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         //   which is fixed in changelog format v1. But upgraded applications still need to be able to handle the
         //   original format.
 
-        assertThat(evicted, is(asList(
-            new Eviction<>(
-                "zxcv",
-                new Change<>("next", "eo4im"),
-                new ProcessorRecordContext(3L, 3, 0, "changelog-topic", new RecordHeaders())),
-            new Eviction<>(
-                "asdf",
-                new Change<>("qwer", null),
-                new ProcessorRecordContext(1L, 1, 0, "changelog-topic", new RecordHeaders()))
-        )));
+        assertEquals(
+            List.of(
+                new Eviction<>(
+                    "zxcv",
+                    new Change<>("next", "eo4im"),
+                    new ProcessorRecordContext(3L, 3, 0, "changelog-topic", new RecordHeaders())),
+                new Eviction<>(
+                    "asdf",
+                    new Change<>("qwer", null),
+                    new ProcessorRecordContext(1L, 1, 0, "changelog-topic", new RecordHeaders()))),
+            evicted);
 
         cleanup(context, buffer);
     }
@@ -1171,9 +1172,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(3));
-        assertThat(buffer.minTimestamp(), is(0L));
-        assertThat(buffer.bufferSize(), is(142L));
+        assertEquals(3, buffer.numRecords());
+        assertEquals(0L, buffer.minTimestamp());
+        assertEquals(142L, buffer.bufferSize());
 
         stateRestoreCallback.restoreBatch(singletonList(
             new ConsumerRecord<>("changelog-topic",
@@ -1189,13 +1190,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.minTimestamp(), is(1L));
-        assertThat(buffer.bufferSize(), is(95L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(1L, buffer.minTimestamp());
+        assertEquals(95L, buffer.bufferSize());
 
-        assertThat(buffer.priorValueForBuffered("todelete"), is(Maybe.undefined()));
-        assertThat(buffer.priorValueForBuffered("asdf"), is(Maybe.defined(null)));
-        assertThat(buffer.priorValueForBuffered("zxcv"), is(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders()))));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("todelete"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("asdf"));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders())), buffer.priorValueForBuffered("zxcv"));
 
         // flush the buffer into a list in buffer order so we can make assertions about the contents.
 
@@ -1210,16 +1211,17 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         // * The record offset preserves the original input record's offset, *not* the offset of the changelog record
 
 
-        assertThat(evicted, is(asList(
-            new Eviction<>(
-                "zxcv",
-                new Change<>("next", "3o4im"),
-                getContext(3L)),
-            new Eviction<>(
-                "asdf",
-                new Change<>("qwer", null),
-                getContext(1L)
-            ))));
+        assertEquals(
+            List.of(
+                new Eviction<>(
+                    "zxcv",
+                    new Change<>("next", "3o4im"),
+                    getContext(3L)),
+                new Eviction<>(
+                    "asdf",
+                    new Change<>("qwer", null),
+                    getContext(1L))),
+            evicted);
 
         cleanup(context, buffer);
     }
@@ -1295,9 +1297,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(3));
-        assertThat(buffer.minTimestamp(), is(0L));
-        assertThat(buffer.bufferSize(), is(142L));
+        assertEquals(3, buffer.numRecords());
+        assertEquals(0L, buffer.minTimestamp());
+        assertEquals(142L, buffer.bufferSize());
 
         stateRestoreCallback.restoreBatch(singletonList(
             new ConsumerRecord<>("changelog-topic",
@@ -1313,13 +1315,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.minTimestamp(), is(1L));
-        assertThat(buffer.bufferSize(), is(95L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(1L, buffer.minTimestamp());
+        assertEquals(95L, buffer.bufferSize());
 
-        assertThat(buffer.priorValueForBuffered("todelete"), is(Maybe.undefined()));
-        assertThat(buffer.priorValueForBuffered("asdf"), is(Maybe.defined(null)));
-        assertThat(buffer.priorValueForBuffered("zxcv"), is(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders()))));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("todelete"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("asdf"));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders())), buffer.priorValueForBuffered("zxcv"));
 
         // flush the buffer into a list in buffer order so we can make assertions about the contents.
 
@@ -1334,16 +1336,17 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         // * The record offset preserves the original input record's offset, *not* the offset of the changelog record
 
 
-        assertThat(evicted, is(asList(
-            new Eviction<>(
-                "zxcv",
-                new Change<>("next", "3o4im"),
-                getContext(3L)),
-            new Eviction<>(
-                "asdf",
-                new Change<>("qwer", null),
-                getContext(1L)
-            ))));
+        assertEquals(
+            List.of(
+                new Eviction<>(
+                    "zxcv",
+                    new Change<>("next", "3o4im"),
+                    getContext(3L)),
+                new Eviction<>(
+                    "asdf",
+                    new Change<>("qwer", null),
+                    getContext(1L))),
+            evicted);
 
         cleanup(context, buffer);
     }
@@ -1421,9 +1424,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(3));
-        assertThat(buffer.minTimestamp(), is(0L));
-        assertThat(buffer.bufferSize(), is(142L));
+        assertEquals(3, buffer.numRecords());
+        assertEquals(0L, buffer.minTimestamp());
+        assertEquals(142L, buffer.bufferSize());
 
         stateRestoreCallback.restoreBatch(singletonList(
             new ConsumerRecord<>("changelog-topic",
@@ -1439,13 +1442,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.minTimestamp(), is(1L));
-        assertThat(buffer.bufferSize(), is(95L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(1L, buffer.minTimestamp());
+        assertEquals(95L, buffer.bufferSize());
 
-        assertThat(buffer.priorValueForBuffered("todelete"), is(Maybe.undefined()));
-        assertThat(buffer.priorValueForBuffered("asdf"), is(Maybe.defined(null)));
-        assertThat(buffer.priorValueForBuffered("zxcv"), is(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders()))));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("todelete"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("asdf"));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders())), buffer.priorValueForBuffered("zxcv"));
 
         // flush the buffer into a list in buffer order so we can make assertions about the contents.
 
@@ -1460,16 +1463,17 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         // * The record offset preserves the original input record's offset, *not* the offset of the changelog record
 
 
-        assertThat(evicted, is(asList(
-            new Eviction<>(
-                "zxcv",
-                new Change<>("next", "3o4im"),
-                getContext(3L)),
-            new Eviction<>(
-                "asdf",
-                new Change<>("qwer", null),
-                getContext(1L)
-            ))));
+        assertEquals(
+            List.of(
+                new Eviction<>(
+                    "zxcv",
+                    new Change<>("next", "3o4im"),
+                    getContext(3L)),
+                new Eviction<>(
+                    "asdf",
+                    new Change<>("qwer", null),
+                    getContext(1L))),
+            evicted);
 
         cleanup(context, buffer);
     }
@@ -1544,9 +1548,9 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(3));
-        assertThat(buffer.minTimestamp(), is(0L));
-        assertThat(buffer.bufferSize(), is(142L));
+        assertEquals(3, buffer.numRecords());
+        assertEquals(0L, buffer.minTimestamp());
+        assertEquals(142L, buffer.bufferSize());
 
         stateRestoreCallback.restoreBatch(singletonList(
             new ConsumerRecord<>("changelog-topic",
@@ -1562,13 +1566,13 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
                                  Optional.empty())
         ));
 
-        assertThat(buffer.numRecords(), is(2));
-        assertThat(buffer.minTimestamp(), is(1L));
-        assertThat(buffer.bufferSize(), is(95L));
+        assertEquals(2, buffer.numRecords());
+        assertEquals(1L, buffer.minTimestamp());
+        assertEquals(95L, buffer.bufferSize());
 
-        assertThat(buffer.priorValueForBuffered("todelete"), is(Maybe.undefined()));
-        assertThat(buffer.priorValueForBuffered("asdf"), is(Maybe.defined(null)));
-        assertThat(buffer.priorValueForBuffered("zxcv"), is(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders()))));
+        assertEquals(Maybe.undefined(), buffer.priorValueForBuffered("todelete"));
+        assertEquals(Maybe.defined(null), buffer.priorValueForBuffered("asdf"));
+        assertEquals(Maybe.defined(ValueTimestampHeaders.make("previous", -1, new RecordHeaders())), buffer.priorValueForBuffered("zxcv"));
 
         // flush the buffer into a list in buffer order so we can make assertions about the contents.
 
@@ -1583,16 +1587,17 @@ public class TimeOrderedKeyValueBufferTest<B extends TimeOrderedKeyValueBuffer<S
         // * The record offset preserves the original input record's offset, *not* the offset of the changelog record
 
 
-        assertThat(evicted, is(asList(
-            new Eviction<>(
-                "zxcv",
-                new Change<>("next", "3o4im"),
-                getContext(3L)),
-            new Eviction<>(
-                "asdf",
-                new Change<>("qwer", null),
-                getContext(1L)
-            ))));
+        assertEquals(
+            List.of(
+                new Eviction<>(
+                    "zxcv",
+                    new Change<>("next", "3o4im"),
+                    getContext(3L)),
+                new Eviction<>(
+                    "asdf",
+                    new Change<>("qwer", null),
+                    getContext(1L))),
+            evicted);
 
         cleanup(context, buffer);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimeOrderedWindowStoreTest.java
@@ -78,10 +78,6 @@ import static org.apache.kafka.test.StreamsTestUtils.toListAndCloseIterator;
 import static org.apache.kafka.test.StreamsTestUtils.verifyAllWindowedKeyValues;
 import static org.apache.kafka.test.StreamsTestUtils.verifyKeyValueList;
 import static org.apache.kafka.test.StreamsTestUtils.verifyWindowedKeyValue;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -154,8 +150,7 @@ public class TimeOrderedWindowStoreTest {
         final RocksDBTimestampedWindowStore innerWrong = mock(RocksDBTimestampedWindowStore.class);
         final Exception e = assertThrows(IllegalArgumentException.class,
             () -> new TimeOrderedCachingWindowStore(innerWrong, WINDOW_SIZE, SEGMENT_INTERVAL));
-        assertThat(e.getMessage(),
-            containsString("TimeOrderedCachingWindowStore only supports RocksDBTimeOrderedWindowStore backed store"));
+        assertTrue(e.getMessage().contains("TimeOrderedCachingWindowStore only supports RocksDBTimeOrderedWindowStore backed store"));
 
         final RocksDBTimeOrderedWindowStore<?> inner = mock(RocksDBTimeOrderedWindowStore.class);
         // Nothing happens
@@ -200,7 +195,7 @@ public class TimeOrderedWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(0));
+                    assertEquals(0, count);
                 }
 
                 @Override
@@ -214,7 +209,7 @@ public class TimeOrderedWindowStoreTest {
                         }
                     }
 
-                    assertThat(count, equalTo(numRecordsProcessed));
+                    assertEquals(numRecordsProcessed, count);
 
                     store.put(record.value(), ValueAndTimestamp.make(record.value(), record.timestamp()), record.timestamp());
 
@@ -273,10 +268,10 @@ public class TimeOrderedWindowStoreTest {
         cachingStore.put(bytesKey("a"), bytesValue("a"), DEFAULT_TIMESTAMP);
         cachingStore.put(bytesKey("b"), bytesValue("b"), DEFAULT_TIMESTAMP);
 
-        assertThat(cachingStore.fetch(bytesKey("a"), 10), equalTo(bytesValue("a")));
-        assertThat(cachingStore.fetch(bytesKey("b"), 10), equalTo(bytesValue("b")));
-        assertThat(cachingStore.fetch(bytesKey("c"), 10), equalTo(null));
-        assertThat(cachingStore.fetch(bytesKey("a"), 0), equalTo(null));
+        assertArrayEquals(bytesValue("a"), cachingStore.fetch(bytesKey("a"), 10));
+        assertArrayEquals(bytesValue("b"), cachingStore.fetch(bytesKey("b"), 10));
+        assertNull(cachingStore.fetch(bytesKey("c"), 10));
+        assertNull(cachingStore.fetch(bytesKey("a"), 0));
 
         try (final WindowStoreIterator<byte[]> a = cachingStore.fetch(bytesKey("a"), ofEpochMilli(10), ofEpochMilli(10));
              final WindowStoreIterator<byte[]> b = cachingStore.fetch(bytesKey("b"), ofEpochMilli(10), ofEpochMilli(10))) {
@@ -336,8 +331,8 @@ public class TimeOrderedWindowStoreTest {
     private void verifyKeyValue(final KeyValue<Long, byte[]> next,
                                 final long expectedKey,
                                 final String expectedValue) {
-        assertThat(next.key, equalTo(expectedKey));
-        assertThat(next.value, equalTo(bytesValue(expectedValue)));
+        assertEquals(expectedKey, next.key);
+        assertArrayEquals(bytesValue(expectedValue), next.value);
     }
 
     private static byte[] bytesValue(final String value) {
@@ -1202,13 +1197,11 @@ public class TimeOrderedWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 
@@ -1226,13 +1219,11 @@ public class TimeOrderedWindowStoreTest {
             assertFalse(iterator.hasNext());
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("Returning empty iterator for fetch with invalid key range: from > to." +
-                    " This may be due to range arguments set in the wrong order, " +
-                    "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
-                    " Note that the built-in numerical serdes do not follow this for negative numbers")
-            );
+            assertTrue(messages.contains(
+                "Returning empty iterator for fetch with invalid key range: from > to." +
+                " This may be due to range arguments set in the wrong order, " +
+                "or serdes that don't preserve ordering when lexicographically comparing the serialized bytes." +
+                " Note that the built-in numerical serdes do not follow this for negative numbers"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyAndJoinSideSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyAndJoinSideSerializerTest.java
@@ -26,9 +26,8 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -50,11 +49,11 @@ public class TimestampedKeyAndJoinSideSerializerTest {
 
         final byte[] serialized = STRING_SERDE.serializer().serialize(TOPIC, HEADERS, timestampedKeyAndJoinSide);
 
-        assertThat(serialized, is(notNullValue()));
+        assertNotNull(serialized);
 
         final TimestampedKeyAndJoinSide<String> deserialized = STRING_SERDE.deserializer().deserialize(TOPIC, HEADERS, serialized);
 
-        assertThat(deserialized, is(timestampedKeyAndJoinSide));
+        assertEquals(timestampedKeyAndJoinSide, deserialized);
     }
 
     @Test
@@ -65,11 +64,11 @@ public class TimestampedKeyAndJoinSideSerializerTest {
 
         final byte[] serialized = STRING_SERDE.serializer().serialize(TOPIC, HEADERS, timestampedKeyAndJoinSide);
 
-        assertThat(serialized, is(notNullValue()));
+        assertNotNull(serialized);
 
         final TimestampedKeyAndJoinSide<String> deserialized = STRING_SERDE.deserializer().deserialize(TOPIC, HEADERS, serialized);
 
-        assertThat(deserialized, is(timestampedKeyAndJoinSide));
+        assertEquals(timestampedKeyAndJoinSide, deserialized);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedKeyValueStoreBuilderTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,9 +32,8 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -70,16 +68,16 @@ public class TimestampedKeyValueStoreBuilderTest {
     public void shouldHaveMeteredStoreAsOuterStore() {
         setUp();
         final TimestampedKeyValueStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
     }
 
     @Test
     public void shouldHaveChangeLoggingStoreByDefault() {
         setUp();
         final TimestampedKeyValueStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class));
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class, next);
     }
 
     @Test
@@ -87,7 +85,7 @@ public class TimestampedKeyValueStoreBuilderTest {
         setUp();
         final TimestampedKeyValueStore<String, String> store = builder.withLoggingDisabled().build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, CoreMatchers.equalTo(inner));
+        assertEquals(inner, next);
     }
 
     @Test
@@ -95,8 +93,8 @@ public class TimestampedKeyValueStoreBuilderTest {
         setUp();
         final TimestampedKeyValueStore<String, String> store = builder.withCachingEnabled().build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
-        assertThat(wrapped, instanceOf(CachingKeyValueStore.class));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, wrapped);
     }
 
     @Test
@@ -106,9 +104,9 @@ public class TimestampedKeyValueStoreBuilderTest {
             .withLoggingEnabled(Collections.emptyMap())
             .build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
-        assertThat(wrapped, instanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class));
-        assertThat(((WrappedStateStore) wrapped).wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class, wrapped);
+        assertEquals(inner, ((WrappedStateStore) wrapped).wrapped());
     }
 
     @Test
@@ -120,10 +118,10 @@ public class TimestampedKeyValueStoreBuilderTest {
             .build();
         final WrappedStateStore caching = (WrappedStateStore) ((WrappedStateStore) store).wrapped();
         final WrappedStateStore changeLogging = (WrappedStateStore) caching.wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(changeLogging, instanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class));
-        assertThat(changeLogging.wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class, changeLogging);
+        assertEquals(inner, changeLogging.wrapped());
     }
 
     @Test
@@ -135,7 +133,7 @@ public class TimestampedKeyValueStoreBuilderTest {
             .withLoggingDisabled()
             .withCachingDisabled()
             .build();
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(RocksDBTimestampedStore.class));
+        assertInstanceOf(RocksDBTimestampedStore.class, ((WrappedStateStore) store).wrapped());
     }
 
     @Test
@@ -147,7 +145,7 @@ public class TimestampedKeyValueStoreBuilderTest {
             .withLoggingDisabled()
             .withCachingDisabled()
             .build();
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(KeyValueToTimestampedKeyValueByteStoreAdapter.class));
+        assertInstanceOf(KeyValueToTimestampedKeyValueByteStoreAdapter.class, ((WrappedStateStore) store).wrapped());
     }
 
     @SuppressWarnings("all")
@@ -184,7 +182,7 @@ public class TimestampedKeyValueStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new TimestampedKeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
+        assertEquals("storeSupplier's metricsScope can't be null", e.getMessage());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
@@ -38,9 +38,7 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,11 +83,11 @@ public class TimestampedSegmentTest {
         final TimestampedSegment segmentDifferentId =
             new TimestampedSegment("anyName", "anyName", 1L, Position.emptyPosition(), metricsRecorder);
 
-        assertThat(segment, equalTo(segment));
-        assertThat(segment, equalTo(segmentSameId));
-        assertThat(segment, not(equalTo(segmentDifferentId)));
-        assertThat(segment, not(equalTo(null)));
-        assertThat(segment, not(equalTo("anyName")));
+        assertTrue(segment.equals(segment));
+        assertTrue(segment.equals(segmentSameId));
+        assertFalse(segment.equals(segmentDifferentId));
+        assertFalse(segment.equals(null));
+        assertFalse(segment.equals("anyName"));
 
         segment.close();
         segmentSameId.close();
@@ -120,13 +118,13 @@ public class TimestampedSegmentTest {
         final TimestampedSegment segment2 = new TimestampedSegment("b", "B", 100L, Position.emptyPosition(), metricsRecorder);
         final TimestampedSegment segment3 = new TimestampedSegment("c", "A", 0L, Position.emptyPosition(), metricsRecorder);
 
-        assertThat(segment1.compareTo(segment1), equalTo(0));
-        assertThat(segment1.compareTo(segment2), equalTo(-1));
-        assertThat(segment2.compareTo(segment1), equalTo(1));
-        assertThat(segment1.compareTo(segment3), equalTo(1));
-        assertThat(segment3.compareTo(segment1), equalTo(-1));
-        assertThat(segment2.compareTo(segment3), equalTo(1));
-        assertThat(segment3.compareTo(segment2), equalTo(-1));
+        assertEquals(0, segment1.compareTo(segment1));
+        assertEquals(-1, segment1.compareTo(segment2));
+        assertEquals(1, segment2.compareTo(segment1));
+        assertEquals(1, segment1.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment1));
+        assertEquals(1, segment2.compareTo(segment3));
+        assertEquals(-1, segment3.compareTo(segment2));
 
         segment1.close();
         segment2.close();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentsTest.java
@@ -27,9 +27,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.SimpleTimeZone;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -323,7 +320,7 @@ public class TimestampedSegmentsTest extends AbstractSegmentsTest<TimestampedSeg
     public void shouldClearSegmentsOnClose() {
         segments.getOrCreateSegmentIfLive(0, context, -1L);
         segments.close();
-        assertThat(segments.segmentForTimestamp(0), is(nullValue()));
+        assertNull(segments.segmentForTimestamp(0));
     }
 
     private void verifyCorrectSegments(final long first, final int numSegments) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedWindowStoreBuilderTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -38,11 +37,9 @@ import org.mockito.quality.Strictness;
 import java.time.Duration;
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +86,7 @@ public class TimestampedWindowStoreBuilderTest {
     public void shouldHaveMeteredStoreAsOuterStore(final String storeName) {
         setUp(storeName);
         final TimestampedWindowStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredTimestampedWindowStore.class));
+        assertInstanceOf(MeteredTimestampedWindowStore.class, store);
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -98,7 +95,7 @@ public class TimestampedWindowStoreBuilderTest {
         setUp(storeName);
         final TimestampedWindowStore<String, String> store = builder.build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingTimestampedWindowBytesStore.class));
+        assertInstanceOf(ChangeLoggingTimestampedWindowBytesStore.class, next);
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -107,7 +104,7 @@ public class TimestampedWindowStoreBuilderTest {
         setUp(storeName);
         final TimestampedWindowStore<String, String> store = builder.withLoggingDisabled().build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, CoreMatchers.equalTo(inner));
+        assertEquals(inner, next);
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -116,11 +113,11 @@ public class TimestampedWindowStoreBuilderTest {
         setUp(storeName);
         final TimestampedWindowStore<String, String> store = builder.withCachingEnabled().build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedWindowStore.class));
+        assertInstanceOf(MeteredTimestampedWindowStore.class, store);
         if (isTimeOrderedStore) {
-            assertThat(wrapped, instanceOf(TimeOrderedCachingWindowStore.class));
+            assertInstanceOf(TimeOrderedCachingWindowStore.class, wrapped);
         } else {
-            assertThat(wrapped, instanceOf(CachingWindowStore.class));
+            assertInstanceOf(CachingWindowStore.class, wrapped);
         }
     }
 
@@ -132,9 +129,9 @@ public class TimestampedWindowStoreBuilderTest {
                 .withLoggingEnabled(Collections.emptyMap())
                 .build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedWindowStore.class));
-        assertThat(wrapped, instanceOf(ChangeLoggingTimestampedWindowBytesStore.class));
-        assertThat(((WrappedStateStore) wrapped).wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredTimestampedWindowStore.class, store);
+        assertInstanceOf(ChangeLoggingTimestampedWindowBytesStore.class, wrapped);
+        assertEquals(inner, ((WrappedStateStore) wrapped).wrapped());
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -147,14 +144,14 @@ public class TimestampedWindowStoreBuilderTest {
                 .build();
         final WrappedStateStore caching = (WrappedStateStore) ((WrappedStateStore) store).wrapped();
         final WrappedStateStore changeLogging = (WrappedStateStore) caching.wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedWindowStore.class));
+        assertInstanceOf(MeteredTimestampedWindowStore.class, store);
         if (isTimeOrderedStore) {
-            assertThat(caching, instanceOf(TimeOrderedCachingWindowStore.class));
+            assertInstanceOf(TimeOrderedCachingWindowStore.class, caching);
         } else {
-            assertThat(caching, instanceOf(CachingWindowStore.class));
+            assertInstanceOf(CachingWindowStore.class, caching);
         }
-        assertThat(changeLogging, instanceOf(ChangeLoggingTimestampedWindowBytesStore.class));
-        assertThat(changeLogging.wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(ChangeLoggingTimestampedWindowBytesStore.class, changeLogging);
+        assertEquals(inner, changeLogging.wrapped());
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -175,7 +172,7 @@ public class TimestampedWindowStoreBuilderTest {
             .withLoggingDisabled()
             .withCachingDisabled()
             .build();
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(RocksDBTimestampedWindowStore.class));
+        assertInstanceOf(RocksDBTimestampedWindowStore.class, ((WrappedStateStore) store).wrapped());
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -196,7 +193,7 @@ public class TimestampedWindowStoreBuilderTest {
             .withLoggingDisabled()
             .withCachingDisabled()
             .build();
-        assertThat(((WrappedStateStore) store).wrapped(), instanceOf(WindowToTimestampedWindowByteStoreAdapter.class));
+        assertInstanceOf(WindowToTimestampedWindowByteStoreAdapter.class, ((WrappedStateStore) store).wrapped());
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})
@@ -221,8 +218,8 @@ public class TimestampedWindowStoreBuilderTest {
 
         // typed as StateStore so this compiles, and fails, when the adapter does not expose it
         final StateStore adapter = ((WrappedStateStore) store).wrapped();
-        assertThat(adapter, instanceOf(WithRetentionPeriod.class));
-        assertThat(((WithRetentionPeriod) adapter).retentionPeriod(), is(retentionMs));
+        assertInstanceOf(WithRetentionPeriod.class, adapter);
+        assertEquals(retentionMs, ((WithRetentionPeriod) adapter).retentionPeriod());
     }
 
     @ValueSource(strings = {TIMESTAMP_STORE_NAME, TIMEORDERED_STORE_NAME})

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializerTest.java
@@ -25,11 +25,10 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,9 +49,9 @@ public class ValueAndTimestampSerializerTest {
 
         final ValueAndTimestamp<String> valueAndTimestamp = ValueAndTimestamp.make(value, TIMESTAMP);
         final byte[] serialized = STRING_SERDE.serializer().serialize(TOPIC, HEADERS, valueAndTimestamp);
-        assertThat(serialized, is(notNullValue()));
+        assertNotNull(serialized);
         final ValueAndTimestamp<String> deserialized = STRING_SERDE.deserializer().deserialize(TOPIC, HEADERS, serialized);
-        assertThat(deserialized, is(valueAndTimestamp));
+        assertEquals(valueAndTimestamp, deserialized);
     }
 
     @Test
@@ -81,7 +80,7 @@ public class ValueAndTimestampSerializerTest {
     public void shouldSerializeNullDataAsNull() {
         final byte[] serialized = STRING_SERDE.serializer().serialize(TOPIC, HEADERS, ValueAndTimestamp.make(null, TIMESTAMP));
 
-        assertThat(serialized, is(nullValue()));
+        assertNull(serialized);
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ValueAndTimestampSerializerTest {
         final Serializer<String> alwaysNullSerializer = (topic, data) -> null;
         final ValueAndTimestampSerializer<String> serializer = new ValueAndTimestampSerializer<>(alwaysNullSerializer);
         final byte[] serialized = serializer.serialize(TOPIC, HEADERS, "non-null-data", TIMESTAMP);
-        assertThat(serialized, is(nullValue()));
+        assertNull(serialized);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueConvertersTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ValueConvertersTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ValueConvertersTest {
@@ -35,7 +34,7 @@ public class ValueConvertersTest {
         final Function<ValueAndTimestamp<String>, String> converter = ValueConverters.extractValue();
 
         final ValueAndTimestamp<String> valueAndTimestamp = ValueAndTimestamp.make("value", 42L);
-        assertThat(converter.apply(valueAndTimestamp), is("value"));
+        assertEquals("value", converter.apply(valueAndTimestamp));
     }
 
     @Test
@@ -50,7 +49,7 @@ public class ValueConvertersTest {
         final Function<ValueTimestampHeaders<String>, String> converter = ValueConverters.extractValueFromHeaders();
 
         final ValueTimestampHeaders<String> vth = ValueTimestampHeaders.make("value", 42L, new RecordHeaders());
-        assertThat(converter.apply(vth), is("value"));
+        assertEquals("value", converter.apply(vth));
     }
 
     @Test
@@ -68,8 +67,8 @@ public class ValueConvertersTest {
         final ValueTimestampHeaders<String> vth = ValueTimestampHeaders.make("value", 42L, new RecordHeaders());
         final ValueAndTimestamp<String> result = converter.apply(vth);
 
-        assertThat(result.value(), is("value"));
-        assertThat(result.timestamp(), is(42L));
+        assertEquals("value", result.value());
+        assertEquals(42L, result.timestamp());
     }
 
     @Test
@@ -92,7 +91,7 @@ public class ValueConvertersTest {
         final ValueAndTimestamp<String> result = converter.apply(vth);
 
         // Should only have value and timestamp, headers are discarded
-        assertThat(result.value(), is("value"));
-        assertThat(result.timestamp(), is(42L));
+        assertEquals("value", result.value());
+        assertEquals(42L, result.timestamp());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/VersionedKeyValueStoreBuilderTest.java
@@ -32,9 +32,8 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +73,7 @@ public class VersionedKeyValueStoreBuilderTest {
         setUp();
         final VersionedKeyValueStore<String, String> store = builder.build();
 
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
     }
 
     @Test
@@ -82,9 +81,9 @@ public class VersionedKeyValueStoreBuilderTest {
         setUp();
         final VersionedKeyValueStore<String, String> store = builder.build();
 
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingVersionedKeyValueBytesStore.class));
+        assertInstanceOf(ChangeLoggingVersionedKeyValueBytesStore.class, next);
     }
 
     @Test
@@ -94,9 +93,9 @@ public class VersionedKeyValueStoreBuilderTest {
             .withLoggingDisabled()
             .build();
 
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, equalTo(inner));
+        assertEquals(inner, next);
 
     }
 
@@ -107,10 +106,10 @@ public class VersionedKeyValueStoreBuilderTest {
             .withLoggingEnabled(Collections.emptyMap())
             .build();
 
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingVersionedKeyValueBytesStore.class));
-        assertThat(((WrappedStateStore) next).wrapped(), equalTo(inner));
+        assertInstanceOf(ChangeLoggingVersionedKeyValueBytesStore.class, next);
+        assertEquals(inner, ((WrappedStateStore) next).wrapped());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowKeySchemaTest.java
@@ -47,11 +47,10 @@ import java.util.function.Function;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WindowKeySchemaTest {
 
@@ -201,7 +200,7 @@ public class WindowKeySchemaTest {
                 results.add(iterator.next().value);
             }
 
-            assertThat(results, equalTo(asList(1, 2, 3, 4, 5, 6)));
+            assertEquals(List.of(1, 2, 3, 4, 5, 6), results);
         }
     }
     
@@ -212,34 +211,18 @@ public class WindowKeySchemaTest {
         final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[] {0xA, 0xB, 0xC}), Long.MAX_VALUE);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
-            upper.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA},
-                    Long.MAX_VALUE,
-                    Integer.MAX_VALUE
-                )
-            ) >= 0
-        );
+        assertTrue(
+            upper.compareTo(toStoreKeyBinary.apply(new byte[] {0xA}, Long.MAX_VALUE, Integer.MAX_VALUE)) >= 0,
+            "shorter key with max timestamp should be in range");
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
-            upper.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA, 0xB},
-                    Long.MAX_VALUE,
-                    Integer.MAX_VALUE
-                )
-            ) >= 0
-        );
+        assertTrue(
+            upper.compareTo(toStoreKeyBinary.apply(new byte[] {0xA, 0xB}, Long.MAX_VALUE, Integer.MAX_VALUE)) >= 0,
+            "shorter key with max timestamp should be in range");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, Long.MAX_VALUE, Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, Long.MAX_VALUE, Integer.MAX_VALUE), upper);
         } else {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{0xA}, Long.MAX_VALUE, Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA}, Long.MAX_VALUE, Integer.MAX_VALUE), upper);
         }
     }
 
@@ -250,24 +233,14 @@ public class WindowKeySchemaTest {
         final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[] {0xA, (byte) 0x8F, (byte) 0x9F}), Long.MAX_VALUE);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
-        assertThat(
-            "shorter key with max timestamp should be in range",
-            upper.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA, (byte) 0x8F},
-                    Long.MAX_VALUE,
-                    Integer.MAX_VALUE
-                )
-            ) >= 0
-        );
+        assertTrue(
+            upper.compareTo(toStoreKeyBinary.apply(new byte[] {0xA, (byte) 0x8F}, Long.MAX_VALUE, Integer.MAX_VALUE)) >= 0,
+            "shorter key with max timestamp should be in range");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, Long.MAX_VALUE, Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, Long.MAX_VALUE, Integer.MAX_VALUE), upper);
         } else {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}, Long.MAX_VALUE,
-                    Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA, (byte) 0x8F, (byte) 0x9F}, Long.MAX_VALUE, Integer.MAX_VALUE), upper);
         }
     }
 
@@ -278,23 +251,15 @@ public class WindowKeySchemaTest {
         final Bytes upper = keySchema.upperRange(Bytes.wrap(new byte[] {0xC, 0xC, 0x9}), 0x0AffffffffffffffL);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
-        assertThat(
-            "shorter key with customized timestamp should be in range",
-            upper.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xC, 0xC},
-                    0x0AffffffffffffffL,
-                    Integer.MAX_VALUE
-                )
-            ) >= 0
-        );
+        assertTrue(
+            upper.compareTo(toStoreKeyBinary.apply(new byte[] {0xC, 0xC}, 0x0AffffffffffffffL, Integer.MAX_VALUE)) >= 0,
+            "shorter key with customized timestamp should be in range");
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 0x0AffffffffffffffL, Integer.MAX_VALUE)));
+            assertEquals(
+                toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 0x0AffffffffffffffL, Integer.MAX_VALUE),
+                upper);
         } else {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{0xC, 0xC}, 0x0AffffffffffffffL,
-                    Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xC, 0xC}, 0x0AffffffffffffffL, Integer.MAX_VALUE), upper);
         }
     }
 
@@ -306,11 +271,9 @@ public class WindowKeySchemaTest {
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
-            assertThat(upper, equalTo(
-                toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 0x0L, Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 0x0L, Integer.MAX_VALUE), upper);
         } else {
-            assertThat(upper,
-                equalTo(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, Integer.MAX_VALUE)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, Integer.MAX_VALUE), upper);
         }
     }
 
@@ -320,16 +283,9 @@ public class WindowKeySchemaTest {
         setup(type);
         final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[] {0xA, 0xB, 0xC}), 0);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
-        assertThat(
-            "Larger key prefix should be in range.",
-            lower.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA, 0xB, 0xC, 0x0},
-                    0L,
-                    0
-                )
-            ) < 0
-        );
+        assertTrue(
+            lower.compareTo(toStoreKeyBinary.apply(new byte[] {0xA, 0xB, 0xC, 0x0}, 0L, 0)) < 0,
+            "Larger key prefix should be in range.");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
             final Bytes expected = Bytes.wrap(ByteBuffer.allocate(1 + 8 + 3)
@@ -337,9 +293,9 @@ public class WindowKeySchemaTest {
                 .putLong(0)
                 .put(new byte[] {0xA, 0xB, 0xC})
                 .array());
-            assertThat(lower, equalTo(expected));
+            assertEquals(expected, lower);
         } else {
-            assertThat(lower, equalTo(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0), lower);
         }
     }
 
@@ -350,16 +306,7 @@ public class WindowKeySchemaTest {
         final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[] {0xA, 0xB, 0xC}), 42);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
-        assertThat(
-            "Larger timestamp should be in range",
-            lower.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA, 0xB, 0xC, 0x0},
-                    43L,
-                    0
-                )
-            ) < 0
-        );
+        assertTrue(lower.compareTo(toStoreKeyBinary.apply(new byte[] {0xA, 0xB, 0xC, 0x0}, 43L, 0)) < 0, "Larger timestamp should be in range");
 
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
             final Bytes expected = Bytes.wrap(ByteBuffer.allocate(1 + 8 + 3)
@@ -367,9 +314,9 @@ public class WindowKeySchemaTest {
                 .putLong(42)
                 .put(new byte[] {0xA, 0xB, 0xC})
                 .array());
-            assertThat(lower, equalTo(expected));
+            assertEquals(expected, lower);
         } else {
-            assertThat(lower, equalTo(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0), lower);
         }
     }
 
@@ -380,25 +327,21 @@ public class WindowKeySchemaTest {
         final Bytes lower = keySchema.lowerRange(Bytes.wrap(new byte[] {0xA, 0xB, 0xC}), Long.MAX_VALUE - 1);
         final TriFunction<byte[], Long, Integer, Bytes> toStoreKeyBinary = getToStoreKeyBinaryBytesParam();
 
-        assertThat(
-            "appending zeros to key should still be in range",
-            lower.compareTo(
-                toStoreKeyBinary.apply(
-                    new byte[] {0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-                    Long.MAX_VALUE - 1,
-                    0
-                )
-            ) < 0
-        );
+        assertTrue(
+            lower.compareTo(toStoreKeyBinary.apply(
+                new byte[] {0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                Long.MAX_VALUE - 1,
+                0)) < 0,
+            "appending zeros to key should still be in range");
         if (schemaType == SchemaType.PrefixedTimeFirstSchema) {
             final Bytes expected = Bytes.wrap(ByteBuffer.allocate(1 + 8 + 3)
                 .put((byte) 0x0)
                 .putLong(Long.MAX_VALUE - 1)
                 .put(new byte[] {0xA, 0xB, 0xC})
                 .array());
-            assertThat(lower, equalTo(expected));
+            assertEquals(expected, lower);
         } else {
-            assertThat(lower, equalTo(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0)));
+            assertEquals(toStoreKeyBinary.apply(new byte[]{0xA, 0xB, 0xC}, 0L, 0), lower);
         }
     }
 
@@ -455,7 +398,7 @@ public class WindowKeySchemaTest {
             results.add(resultWindow.end() - resultWindow.start());
         }
 
-        assertThat(results, equalTo(asList(1L, 10L, 20L)));
+        assertEquals(List.of(1L, 10L, 20L), results);
     }
 
     @EnumSource(SchemaType.class)

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -38,10 +37,9 @@ import org.mockito.quality.Strictness;
 import java.time.Duration;
 import java.util.Collections;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -75,7 +73,7 @@ public class WindowStoreBuilderTest {
     public void shouldHaveMeteredStoreAsOuterStore() {
         setUp();
         final WindowStore<String, String> store = builder.build();
-        assertThat(store, instanceOf(MeteredWindowStore.class));
+        assertInstanceOf(MeteredWindowStore.class, store);
     }
 
     @Test
@@ -83,7 +81,7 @@ public class WindowStoreBuilderTest {
         setUp();
         final WindowStore<String, String> store = builder.build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, instanceOf(ChangeLoggingWindowBytesStore.class));
+        assertInstanceOf(ChangeLoggingWindowBytesStore.class, next);
     }
 
     @Test
@@ -91,7 +89,7 @@ public class WindowStoreBuilderTest {
         setUp();
         final WindowStore<String, String> store = builder.withLoggingDisabled().build();
         final StateStore next = ((WrappedStateStore) store).wrapped();
-        assertThat(next, CoreMatchers.equalTo(inner));
+        assertEquals(inner, next);
     }
 
     @Test
@@ -99,8 +97,8 @@ public class WindowStoreBuilderTest {
         setUp();
         final WindowStore<String, String> store = builder.withCachingEnabled().build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredWindowStore.class));
-        assertThat(wrapped, instanceOf(CachingWindowStore.class));
+        assertInstanceOf(MeteredWindowStore.class, store);
+        assertInstanceOf(CachingWindowStore.class, wrapped);
     }
 
     @Test
@@ -110,9 +108,9 @@ public class WindowStoreBuilderTest {
                 .withLoggingEnabled(Collections.emptyMap())
                 .build();
         final StateStore wrapped = ((WrappedStateStore) store).wrapped();
-        assertThat(store, instanceOf(MeteredWindowStore.class));
-        assertThat(wrapped, instanceOf(ChangeLoggingWindowBytesStore.class));
-        assertThat(((WrappedStateStore) wrapped).wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredWindowStore.class, store);
+        assertInstanceOf(ChangeLoggingWindowBytesStore.class, wrapped);
+        assertEquals(inner, ((WrappedStateStore) wrapped).wrapped());
     }
 
     @Test
@@ -124,10 +122,10 @@ public class WindowStoreBuilderTest {
                 .build();
         final WrappedStateStore caching = (WrappedStateStore) ((WrappedStateStore) store).wrapped();
         final WrappedStateStore changeLogging = (WrappedStateStore) caching.wrapped();
-        assertThat(store, instanceOf(MeteredWindowStore.class));
-        assertThat(caching, instanceOf(CachingWindowStore.class));
-        assertThat(changeLogging, instanceOf(ChangeLoggingWindowBytesStore.class));
-        assertThat(changeLogging.wrapped(), CoreMatchers.equalTo(inner));
+        assertInstanceOf(MeteredWindowStore.class, store);
+        assertInstanceOf(CachingWindowStore.class, caching);
+        assertInstanceOf(ChangeLoggingWindowBytesStore.class, changeLogging);
+        assertEquals(inner, changeLogging.wrapped());
     }
 
     @SuppressWarnings("unchecked")
@@ -160,10 +158,7 @@ public class WindowStoreBuilderTest {
             new MockTime()
         ).withCachingEnabled();
 
-        assertThat(
-            builder.logConfig().get(TopicConfig.CLEANUP_POLICY_CONFIG),
-            equalTo(TopicConfig.CLEANUP_POLICY_DELETE)
-        );
+        assertEquals(TopicConfig.CLEANUP_POLICY_DELETE, builder.logConfig().get(TopicConfig.CLEANUP_POLICY_CONFIG));
     }
 
     @SuppressWarnings("null")
@@ -185,6 +180,6 @@ public class WindowStoreBuilderTest {
 
         final Exception e = assertThrows(NullPointerException.class,
             () -> new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), new MockTime()));
-        assertThat(e.getMessage(), equalTo("storeSupplier's metricsScope can't be null"));
+        assertEquals("storeSupplier's metricsScope can't be null", e.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreFetchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreFetchTest.java
@@ -61,8 +61,7 @@ import static java.time.Duration.ofMillis;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class WindowStoreFetchTest {
@@ -234,7 +233,7 @@ public class WindowStoreFetchTest {
              final KeyValueIterator<Windowed<String>, Long> expectedIterator = forward ? store.fetchAll(0, Long.MAX_VALUE) : store.backwardFetchAll(0, Long.MAX_VALUE)) {
             final List<KeyValue<Windowed<String>, Long>> result = Utils.toList(resultIterator);
             final List<KeyValue<Windowed<String>, Long>> expected = filterList(expectedIterator, from, to);
-            assertThat(result, is(expected));
+            assertEquals(expected, result);
         }
     }
 


### PR DESCRIPTION
Remove hamcrest from a subset of tests in the
`org.apache.kafka.streams.state.internals` package by migrating to JUnit
assertions.

Reviewers: Christo Lolov <lolovc@amazon.com>
