### PR TITLE
KAFKA-21028: [1/2] Remove hamcrest from org.apache.kafka.streams.processor.internals package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -48,13 +48,10 @@ import java.time.Instant;
 import java.util.Properties;
 
 import static org.apache.kafka.test.StreamsTestUtils.getStreamsConfig;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractProcessorContextTest {
 
@@ -72,12 +69,8 @@ public class AbstractProcessorContextTest {
     @Test
     public void shouldThrowIllegalStateExceptionOnRegisterWhenContextIsInitialized() {
         context.initialize();
-        try {
-            context.register(stateStore, null);
-            fail("should throw illegal state exception when context already initialized");
-        } catch (final IllegalStateException e) {
-            // pass
-        }
+        assertThrows(IllegalStateException.class, () -> context.register(stateStore, null),
+            "should throw illegal state exception when context already initialized");
     }
 
     @Test
@@ -93,35 +86,35 @@ public class AbstractProcessorContextTest {
     @Test
     public void shouldReturnNullTopicIfNoRecordContext() {
         context.setRecordContext(null);
-        assertThat(context.topic(), is(nullValue()));
+        assertNull(context.topic());
     }
 
     @Test
     public void shouldNotThrowNullPointerExceptionOnTopicIfRecordContextTopicIsNull() {
         context.setRecordContext(new ProcessorRecordContext(0, 0, 0, null, new RecordHeaders()));
-        assertThat(context.topic(), nullValue());
+        assertNull(context.topic());
     }
 
     @Test
     public void shouldReturnTopicFromRecordContext() {
-        assertThat(context.topic(), equalTo(recordContext.topic()));
+        assertEquals(recordContext.topic(), context.topic());
     }
 
     @Test
     public void shouldReturnNullIfTopicEqualsNonExistTopic() {
         context.setRecordContext(null);
-        assertThat(context.topic(), nullValue());
+        assertNull(context.topic());
     }
 
     @Test
     public void shouldReturnDummyPartitionIfNoRecordContext() {
         context.setRecordContext(null);
-        assertThat(context.partition(), is(-1));
+        assertEquals(-1, context.partition());
     }
 
     @Test
     public void shouldReturnPartitionFromRecordContext() {
-        assertThat(context.partition(), equalTo(recordContext.partition()));
+        assertEquals(recordContext.partition(), context.partition());
     }
 
     @Test
@@ -136,45 +129,39 @@ public class AbstractProcessorContextTest {
 
     @Test
     public void shouldReturnOffsetFromRecordContext() {
-        assertThat(context.offset(), equalTo(recordContext.offset()));
+        assertEquals(recordContext.offset(), context.offset());
     }
 
     @Test
     public void shouldReturnDummyTimestampIfNoRecordContext() {
         context.setRecordContext(null);
-        assertThat(context.timestamp(), is(0L));
+        assertEquals(0L, context.timestamp());
     }
 
     @Test
     public void shouldReturnTimestampFromRecordContext() {
-        assertThat(context.timestamp(), equalTo(recordContext.timestamp()));
+        assertEquals(recordContext.timestamp(), context.timestamp());
     }
 
     @Test
     public void shouldReturnHeadersFromRecordContext() {
-        assertThat(context.headers(), equalTo(recordContext.headers()));
+        assertEquals(recordContext.headers(), context.headers());
     }
 
     @Test
     public void shouldReturnEmptyHeadersIfHeadersAreNotSet() {
         context.setRecordContext(null);
-        assertThat(context.headers(), is(emptyIterable()));
+        assertFalse(context.headers().iterator().hasNext());
     }
 
     @Test
     public void appConfigsShouldReturnParsedValues() {
-        assertThat(
-            context.appConfigs().get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG),
-            equalTo(RocksDBConfigSetter.class)
-        );
+        assertEquals(RocksDBConfigSetter.class, context.appConfigs().get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG));
     }
 
     @Test
     public void appConfigsShouldReturnUnrecognizedValues() {
-        assertThat(
-            context.appConfigs().get("user.supplied.config"),
-            equalTo("user-supplied-value")
-        );
+        assertEquals("user-supplied-value", context.appConfigs().get("user.supplied.config"));
     }
     @Test
     public void shouldThrowErrorIfSerdeDefaultNotSet() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -52,11 +52,9 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptySet;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +92,7 @@ public class ActiveTaskCreatorTest {
 
         final String clientIds = activeTaskCreator.producerClientIds();
 
-        assertThat(clientIds, is("clientId-StreamThread-0-producer"));
+        assertEquals("clientId-StreamThread-0-producer", clientIds);
     }
 
     @Test
@@ -103,7 +101,7 @@ public class ActiveTaskCreatorTest {
 
         activeTaskCreator.close();
 
-        assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+        assertTrue(mockClientSupplier.producers.get(0).closed());
     }
 
     @Test
@@ -113,7 +111,7 @@ public class ActiveTaskCreatorTest {
         final MockProducer<?, ?> producer = mockClientSupplier.producers.get(0);
         addMetric(producer, "flush-time-ns-total", blockedTime);
 
-        assertThat(activeTaskCreator.totalProducerBlockedTime(), closeTo(blockedTime, 0.01));
+        assertEquals(blockedTime, activeTaskCreator.totalProducerBlockedTime(), 0.01);
     }
 
     // error handling
@@ -124,8 +122,8 @@ public class ActiveTaskCreatorTest {
 
         final StreamsProducer threadProducer = activeTaskCreator.streamsProducer();
 
-        assertThat(mockClientSupplier.producers.size(), is(1));
-        assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
+        assertEquals(1, mockClientSupplier.producers.size());
+        assertEquals(mockClientSupplier.producers.get(0), threadProducer.kafkaProducer());
     }
 
     @Test
@@ -138,8 +136,8 @@ public class ActiveTaskCreatorTest {
             activeTaskCreator::close
         );
 
-        assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
-        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+        assertEquals("Thread producer encounter error trying to close.", thrown.getMessage());
+        assertEquals("KABOOM!", thrown.getCause().getMessage());
     }
 
 
@@ -157,8 +155,8 @@ public class ActiveTaskCreatorTest {
 
         final StreamsProducer threadProducer = activeTaskCreator.streamsProducer();
 
-        assertThat(mockClientSupplier.producers.size(), is(1));
-        assertThat(threadProducer.kafkaProducer(), is(mockClientSupplier.producers.get(0)));
+        assertEquals(1, mockClientSupplier.producers.size());
+        assertEquals(mockClientSupplier.producers.get(0), threadProducer.kafkaProducer());
     }
 
     @Test
@@ -177,7 +175,7 @@ public class ActiveTaskCreatorTest {
 
         final String clientIds = activeTaskCreator.producerClientIds();
 
-        assertThat(clientIds, is("clientId-StreamThread-0-producer"));
+        assertEquals("clientId-StreamThread-0-producer", clientIds);
     }
 
     @Test
@@ -188,8 +186,8 @@ public class ActiveTaskCreatorTest {
 
         activeTaskCreator.close();
 
-        assertThat(activeTaskCreator.isClosed(), is(true));
-        assertThat(mockClientSupplier.producers.get(0).closed(), is(true));
+        assertTrue(activeTaskCreator.isClosed());
+        assertTrue(mockClientSupplier.producers.get(0).closed());
     }
 
     @Test
@@ -197,15 +195,13 @@ public class ActiveTaskCreatorTest {
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
         mockClientSupplier.setApplicationIdForProducer("appId");
         createTasks();
-        assertThat(mockClientSupplier.producers.size(), is(1));
+        assertEquals(1, mockClientSupplier.producers.size());
 
         activeTaskCreator.close();
         activeTaskCreator.reInitializeProducer();
         // Verifies that disableReset() prevents reInitializeProducer() from creating a new producer instance
         // Without disabling reset, the producers collection would contain more than one producer
-        assertThat("Producer should not be recreated after disabling reset",
-            mockClientSupplier.producers.size(),
-            is(1));
+        assertEquals(1, mockClientSupplier.producers.size(), "Producer should not be recreated after disabling reset");
     }
 
     // error handling
@@ -222,8 +218,8 @@ public class ActiveTaskCreatorTest {
             activeTaskCreator::close
         );
 
-        assertThat(thrown.getMessage(), is("Thread producer encounter error trying to close."));
-        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+        assertEquals("Thread producer encounter error trying to close.", thrown.getMessage());
+        assertEquals("KABOOM!", thrown.getCause().getMessage());
     }
 
     private void shouldConstructStreamsProducerMetric() {
@@ -237,12 +233,12 @@ public class ActiveTaskCreatorTest {
             null,
             new MockTime());
         mockClientSupplier.producers.get(0).setMockMetrics(testMetricName, testMetric);
-        assertThat(mockClientSupplier.producers.size(), is(1));
+        assertEquals(1, mockClientSupplier.producers.size());
 
         final Map<MetricName, Metric> producerMetrics = activeTaskCreator.producerMetrics();
 
-        assertThat(producerMetrics.size(), is(1));
-        assertThat(producerMetrics.get(testMetricName), is(testMetric));
+        assertEquals(1, producerMetrics.size());
+        assertEquals(testMetric, producerMetrics.get(testMetricName));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -277,15 +273,15 @@ public class ActiveTaskCreatorTest {
             new LogContext(),
             false);
 
-        assertThat(
+        assertEquals(
+            Set.of(task00, task01),
             activeTaskCreator.createTasks(
                 mockClientSupplier.consumer,
                 mkMap(
                     mkEntry(task00, Collections.singleton(new TopicPartition("topic", 0))),
                     mkEntry(task01, Collections.singleton(new TopicPartition("topic", 1)))
                 )
-            ).stream().map(Task::id).collect(Collectors.toSet()),
-            equalTo(Set.of(task00, task01))
+            ).stream().map(Task::id).collect(Collectors.toSet())
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -34,8 +34,8 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -93,11 +93,11 @@ public class ChangelogTopicsTest {
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
         changelogTopics.setup();
 
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_0).isEmpty());
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_1).isEmpty());
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_2).isEmpty());
+        assertTrue(changelogTopics.preExistingSourceTopicBasedPartitions().isEmpty());
+        assertTrue(changelogTopics.preExistingNonSourceTopicBasedPartitions().isEmpty());
     }
 
     @Test
@@ -112,12 +112,12 @@ public class ChangelogTopicsTest {
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
         changelogTopics.setup();
 
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
-        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertEquals(3, CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE));
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_0).isEmpty());
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_1).isEmpty());
+        assertTrue(changelogTopics.preExistingPartitionsFor(TASK_0_2).isEmpty());
+        assertTrue(changelogTopics.preExistingSourceTopicBasedPartitions().isEmpty());
+        assertTrue(changelogTopics.preExistingNonSourceTopicBasedPartitions().isEmpty());
     }
 
     @Test
@@ -132,18 +132,15 @@ public class ChangelogTopicsTest {
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
         changelogTopics.setup();
 
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertEquals(3, CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE));
         final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
         final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
         final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Set.of(changelogPartition0)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Set.of(changelogPartition1)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Set.of(changelogPartition2)));
-        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
-        assertThat(
-            changelogTopics.preExistingNonSourceTopicBasedPartitions(),
-            is(Set.of(changelogPartition0, changelogPartition1, changelogPartition2))
-        );
+        assertEquals(Set.of(changelogPartition0), changelogTopics.preExistingPartitionsFor(TASK_0_0));
+        assertEquals(Set.of(changelogPartition1), changelogTopics.preExistingPartitionsFor(TASK_0_1));
+        assertEquals(Set.of(changelogPartition2), changelogTopics.preExistingPartitionsFor(TASK_0_2));
+        assertTrue(changelogTopics.preExistingSourceTopicBasedPartitions().isEmpty());
+        assertEquals(Set.of(changelogPartition0, changelogPartition1, changelogPartition2), changelogTopics.preExistingNonSourceTopicBasedPartitions());
     }
 
     @Test
@@ -160,14 +157,11 @@ public class ChangelogTopicsTest {
         final TopicPartition changelogPartition0 = new TopicPartition(SOURCE_TOPIC_NAME, 0);
         final TopicPartition changelogPartition1 = new TopicPartition(SOURCE_TOPIC_NAME, 1);
         final TopicPartition changelogPartition2 = new TopicPartition(SOURCE_TOPIC_NAME, 2);
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Set.of(changelogPartition0)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Set.of(changelogPartition1)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Set.of(changelogPartition2)));
-        assertThat(
-            changelogTopics.preExistingSourceTopicBasedPartitions(),
-            is(Set.of(changelogPartition0, changelogPartition1, changelogPartition2))
-        );
-        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertEquals(Set.of(changelogPartition0), changelogTopics.preExistingPartitionsFor(TASK_0_0));
+        assertEquals(Set.of(changelogPartition1), changelogTopics.preExistingPartitionsFor(TASK_0_1));
+        assertEquals(Set.of(changelogPartition2), changelogTopics.preExistingPartitionsFor(TASK_0_2));
+        assertEquals(Set.of(changelogPartition0, changelogPartition1, changelogPartition2), changelogTopics.preExistingSourceTopicBasedPartitions());
+        assertTrue(changelogTopics.preExistingNonSourceTopicBasedPartitions().isEmpty());
     }
 
     @Test
@@ -182,23 +176,17 @@ public class ChangelogTopicsTest {
                 new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
         changelogTopics.setup();
 
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertEquals(3, CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE));
         final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
         final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
         final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
         final TopicPartition sourcePartition0 = new TopicPartition(SOURCE_TOPIC_NAME, 0);
         final TopicPartition sourcePartition1 = new TopicPartition(SOURCE_TOPIC_NAME, 1);
         final TopicPartition sourcePartition2 = new TopicPartition(SOURCE_TOPIC_NAME, 2);
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Set.of(sourcePartition0, changelogPartition0)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Set.of(sourcePartition1, changelogPartition1)));
-        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Set.of(sourcePartition2, changelogPartition2)));
-        assertThat(
-            changelogTopics.preExistingSourceTopicBasedPartitions(),
-            is(Set.of(sourcePartition0, sourcePartition1, sourcePartition2))
-        );
-        assertThat(
-            changelogTopics.preExistingNonSourceTopicBasedPartitions(),
-            is(Set.of(changelogPartition0, changelogPartition1, changelogPartition2))
-        );
+        assertEquals(Set.of(sourcePartition0, changelogPartition0), changelogTopics.preExistingPartitionsFor(TASK_0_0));
+        assertEquals(Set.of(sourcePartition1, changelogPartition1), changelogTopics.preExistingPartitionsFor(TASK_0_1));
+        assertEquals(Set.of(sourcePartition2, changelogPartition2), changelogTopics.preExistingPartitionsFor(TASK_0_2));
+        assertEquals(Set.of(sourcePartition0, sourcePartition1, sourcePartition2), changelogTopics.preExistingSourceTopicBasedPartitions());
+        assertEquals(Set.of(changelogPartition0, changelogPartition1, changelogPartition2), changelogTopics.preExistingNonSourceTopicBasedPartitions());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ClientUtilsTest.java
@@ -50,8 +50,7 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.consumerR
 import static org.apache.kafka.streams.processor.internals.ClientUtils.fetchCommittedOffsets;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.fetchEndOffsets;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.producerRecordSizeInBytes;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -198,7 +197,7 @@ public class ClientUtilsTest {
             Optional.empty()
         );
 
-        assertThat(consumerRecordSizeInBytes(record), equalTo(SIZE_IN_BYTES));
+        assertEquals(SIZE_IN_BYTES, consumerRecordSizeInBytes(record));
     }
 
     @Test
@@ -211,7 +210,7 @@ public class ClientUtilsTest {
             VALUE,
             HEADERS
         );
-        assertThat(producerRecordSizeInBytes(record), equalTo(SIZE_IN_BYTES));
+        assertEquals(SIZE_IN_BYTES, producerRecordSizeInBytes(record));
     }
 
     @Test
@@ -229,7 +228,7 @@ public class ClientUtilsTest {
             HEADERS,
             Optional.empty()
         );
-        assertThat(consumerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
+        assertEquals(NULL_KEY_SIZE_IN_BYTES, consumerRecordSizeInBytes(record));
     }
 
     @Test
@@ -242,7 +241,7 @@ public class ClientUtilsTest {
             VALUE,
             HEADERS
         );
-        assertThat(producerRecordSizeInBytes(record), equalTo(NULL_KEY_SIZE_IN_BYTES));
+        assertEquals(NULL_KEY_SIZE_IN_BYTES, producerRecordSizeInBytes(record));
     }
 
     @Test
@@ -260,7 +259,7 @@ public class ClientUtilsTest {
             HEADERS,
             Optional.empty()
         );
-        assertThat(consumerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+        assertEquals(TOMBSTONE_SIZE_IN_BYTES, consumerRecordSizeInBytes(record));
     }
 
     @Test
@@ -273,6 +272,6 @@ public class ClientUtilsTest {
             null,
             HEADERS
         );
-        assertThat(producerRecordSizeInBytes(record), equalTo(TOMBSTONE_SIZE_IN_BYTES));
+        assertEquals(TOMBSTONE_SIZE_IN_BYTES, producerRecordSizeInBytes(record));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
@@ -33,8 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -83,7 +81,7 @@ public class CopartitionedTopicsEnforcerTest {
                           Collections.singletonMap(config.name(), config),
                           cluster.withPartitions(partitions));
 
-        assertThat(config.numberOfPartitions(), equalTo(Optional.of(2)));
+        assertEquals(Optional.of(2), config.numberOfPartitions());
     }
 
 
@@ -105,9 +103,9 @@ public class CopartitionedTopicsEnforcerTest {
                           cluster
         );
 
-        assertThat(one.numberOfPartitions(), equalTo(Optional.of(15)));
-        assertThat(two.numberOfPartitions(), equalTo(Optional.of(15)));
-        assertThat(three.numberOfPartitions(), equalTo(Optional.of(15)));
+        assertEquals(Optional.of(15), one.numberOfPartitions());
+        assertEquals(Optional.of(15), two.numberOfPartitions());
+        assertEquals(Optional.of(15), three.numberOfPartitions());
     }
 
     @Test
@@ -143,8 +141,8 @@ public class CopartitionedTopicsEnforcerTest {
                                       Utils.mkEntry(topic2.name(), topic2)),
                           cluster.withPartitions(partitions));
 
-        assertThat(topic1.numberOfPartitions(), equalTo(Optional.of(10)));
-        assertThat(topic2.numberOfPartitions(), equalTo(Optional.of(10)));
+        assertEquals(Optional.of(10), topic1.numberOfPartitions());
+        assertEquals(Optional.of(10), topic2.numberOfPartitions());
     }
 
     @Test
@@ -172,7 +170,7 @@ public class CopartitionedTopicsEnforcerTest {
                           Utils.mkMap(Utils.mkEntry(topic1.name(), topic1)),
                           cluster.withPartitions(partitions));
 
-        assertThat(topic1.numberOfPartitions(), equalTo(Optional.of(2)));
+        assertEquals(Optional.of(2), topic1.numberOfPartitions());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/DefaultStateUpdaterTest.java
@@ -34,7 +34,6 @@ import org.apache.kafka.streams.processor.internals.Task.State;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.test.TestUtils;
 
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -58,6 +57,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -69,13 +69,10 @@ import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.apache.kafka.test.StreamsTestUtils.TopologyMetadataBuilder.unnamedTopology;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -633,7 +630,7 @@ class DefaultStateUpdaterTest {
 
     @Test
     public void shouldPublishEmptyTaskEndOffsetSumSnapshotBeforeStart() {
-        assertThat(stateUpdater.taskEndOffsetSumSnapshot(), is(Collections.emptyMap()));
+        assertTrue(stateUpdater.taskEndOffsetSumSnapshot().isEmpty());
     }
 
     @Test
@@ -1949,7 +1946,7 @@ class DefaultStateUpdaterTest {
         stateUpdater.add(standbyTask4);
 
         verifyPausedTasks(activeTask2, standbyTask4);
-        assertThat(metrics.metrics().size(), is(11));
+        assertEquals(11, metrics.metrics().size());
 
         final Map<String, String> tagMap = new LinkedHashMap<>();
         tagMap.put("thread-id", "test-state-updater");
@@ -1958,64 +1955,64 @@ class DefaultStateUpdaterTest {
             "stream-state-updater-metrics",
             "The number of active tasks currently undergoing restoration",
             tagMap);
-        verifyMetric(metrics, metricName, is(1.0));
+        verifyMetric(metrics, metricName, value -> assertEquals(1.0, value));
 
         metricName = new MetricName("standby-updating-tasks",
             "stream-state-updater-metrics",
             "The number of standby tasks currently undergoing state update",
             tagMap);
-        verifyMetric(metrics, metricName, is(1.0));
+        verifyMetric(metrics, metricName, value -> assertEquals(1.0, value));
 
         metricName = new MetricName("active-paused-tasks",
             "stream-state-updater-metrics",
             "The number of active tasks paused restoring",
             tagMap);
-        verifyMetric(metrics, metricName, is(1.0));
+        verifyMetric(metrics, metricName, value -> assertEquals(1.0, value));
 
         metricName = new MetricName("standby-paused-tasks",
             "stream-state-updater-metrics",
             "The number of standby tasks paused state update",
             tagMap);
-        verifyMetric(metrics, metricName, is(1.0));
+        verifyMetric(metrics, metricName, value -> assertEquals(1.0, value));
 
         metricName = new MetricName("idle-ratio",
             "stream-state-updater-metrics",
             "The ratio, over a rolling measurement window, of the time this thread spent being idle",
             tagMap);
-        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
+        verifyMetric(metrics, metricName, value -> assertTrue(Double.compare((Double) value, 0.0d) >= 0));
 
         metricName = new MetricName("active-restore-ratio",
             "stream-state-updater-metrics",
             "The ratio, over a rolling measurement window, of the time this thread spent restoring active tasks",
             tagMap);
-        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
+        verifyMetric(metrics, metricName, value -> assertTrue(Double.compare((Double) value, 0.0d) >= 0));
 
         metricName = new MetricName("standby-update-ratio",
             "stream-state-updater-metrics",
             "The ratio, over a rolling measurement window, of the time this thread spent updating standby tasks",
             tagMap);
-        verifyMetric(metrics, metricName, is(0.0d));
+        verifyMetric(metrics, metricName, value -> assertEquals(0.0d, value));
 
         metricName = new MetricName("checkpoint-ratio",
             "stream-state-updater-metrics",
             "The ratio, over a rolling measurement window, of the time this thread spent checkpointing tasks restored progress",
             tagMap);
-        verifyMetric(metrics, metricName, greaterThanOrEqualTo(0.0d));
+        verifyMetric(metrics, metricName, value -> assertTrue(Double.compare((Double) value, 0.0d) >= 0));
 
         metricName = new MetricName("restore-records-rate",
             "stream-state-updater-metrics",
             "The average per-second number of records restored",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, value -> assertNotEquals(0.0d, value));
 
         metricName = new MetricName("restore-call-rate",
             "stream-state-updater-metrics",
             "The average per-second number of restore calls triggered",
             tagMap);
-        verifyMetric(metrics, metricName, not(0.0d));
+        verifyMetric(metrics, metricName, value -> assertNotEquals(0.0d, value));
 
         stateUpdater.shutdown(Duration.ofMinutes(1));
-        assertThat(metrics.metrics().size(), is(1));
+        assertEquals(1, metrics.metrics().size());
     }
 
     @Test
@@ -2292,13 +2289,12 @@ class DefaultStateUpdaterTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
-    private static <T> void verifyMetric(final StreamsMetricsImpl metrics,
-                                         final MetricName metricName,
-                                         final Matcher<T> matcher) {
-        assertThat(metrics.metrics().get(metricName).metricName().description(), is(metricName.description()));
-        assertThat(metrics.metrics().get(metricName).metricName().tags(), is(metricName.tags()));
-        assertThat((T) metrics.metrics().get(metricName).metricValue(), matcher);
+    private static void verifyMetric(final StreamsMetricsImpl metrics,
+                                     final MetricName metricName,
+                                     final Consumer<Object> valueAssertion) {
+        assertEquals(metricName.description(), metrics.metrics().get(metricName).metricName().description());
+        assertEquals(metricName.tags(), metrics.metrics().get(metricName).metricName().tags());
+        valueAssertion.accept(metrics.metrics().get(metricName).metricValue());
     }
 
     private void verifyGetTasks(final Set<StreamTask> expectedActiveTasks,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.WindowStore;
 
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,10 +35,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -88,7 +86,7 @@ public class GlobalProcessorContextImplTest {
     @Test
     public void shouldReturnGlobalOrNullStore() {
         when(stateManager.globalStore(GLOBAL_STORE_NAME)).thenReturn(mock(StateStore.class));
-        assertThat(globalContext.getStateStore(GLOBAL_STORE_NAME), new IsInstanceOf(StateStore.class));
+        assertInstanceOf(StateStore.class, globalContext.getStateStore(GLOBAL_STORE_NAME));
         assertNull(globalContext.getStateStore(UNKNOWN_STORE));
     }
 
@@ -120,100 +118,70 @@ public class GlobalProcessorContextImplTest {
     public void shouldNotAllowInitForKeyValueStore() {
         when(stateManager.globalStore(GLOBAL_KEY_VALUE_STORE_NAME)).thenReturn(mock(KeyValueStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_KEY_VALUE_STORE_NAME);
-        try {
-            store.init(null, null);
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, () -> store.init(null, null), "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowInitForTimestampedKeyValueStore() {
         when(stateManager.globalStore(GLOBAL_TIMESTAMPED_KEY_VALUE_STORE_NAME)).thenReturn(mock(TimestampedKeyValueStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_TIMESTAMPED_KEY_VALUE_STORE_NAME);
-        try {
-            store.init(null, null);
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, () -> store.init(null, null), "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowInitForWindowStore() {
         when(stateManager.globalStore(GLOBAL_WINDOW_STORE_NAME)).thenReturn(mock(WindowStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_WINDOW_STORE_NAME);
-        try {
-            store.init(null, null);
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, () -> store.init(null, null), "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowInitForTimestampedWindowStore() {
         when(stateManager.globalStore(GLOBAL_TIMESTAMPED_WINDOW_STORE_NAME)).thenReturn(mock(TimestampedWindowStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_TIMESTAMPED_WINDOW_STORE_NAME);
-        try {
-            store.init(null, null);
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, () -> store.init(null, null), "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowInitForSessionStore() {
         when(stateManager.globalStore(GLOBAL_SESSION_STORE_NAME)).thenReturn(mock(SessionStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_SESSION_STORE_NAME);
-        try {
-            store.init(null, null);
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, () -> store.init(null, null), "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowCloseForKeyValueStore() {
         when(stateManager.globalStore(GLOBAL_KEY_VALUE_STORE_NAME)).thenReturn(mock(KeyValueStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_KEY_VALUE_STORE_NAME);
-        try {
-            store.close();
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, store::close, "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowCloseForTimestampedKeyValueStore() {
         when(stateManager.globalStore(GLOBAL_TIMESTAMPED_KEY_VALUE_STORE_NAME)).thenReturn(mock(TimestampedKeyValueStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_TIMESTAMPED_KEY_VALUE_STORE_NAME);
-        try {
-            store.close();
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, store::close, "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowCloseForWindowStore() {
         when(stateManager.globalStore(GLOBAL_WINDOW_STORE_NAME)).thenReturn(mock(WindowStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_WINDOW_STORE_NAME);
-        try {
-            store.close();
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, store::close, "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowCloseForTimestampedWindowStore() {
         when(stateManager.globalStore(GLOBAL_TIMESTAMPED_WINDOW_STORE_NAME)).thenReturn(mock(TimestampedWindowStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_TIMESTAMPED_WINDOW_STORE_NAME);
-        try {
-            store.close();
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, store::close, "Should have thrown UnsupportedOperationException.");
     }
 
     @Test
     public void shouldNotAllowCloseForSessionStore() {
         when(stateManager.globalStore(GLOBAL_SESSION_STORE_NAME)).thenReturn(mock(SessionStore.class));
         final StateStore store = globalContext.getStateStore(GLOBAL_SESSION_STORE_NAME);
-        try {
-            store.close();
-            fail("Should have thrown UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) { }
+        assertThrows(UnsupportedOperationException.class, store::close, "Should have thrown UnsupportedOperationException.");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -71,16 +71,11 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -211,7 +206,7 @@ public class GlobalStateManagerImplTest {
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(LegacyCheckpointingStateStore.class)) {
             stateManager.commit();
-            assertThat(appender.getMessages(), hasItem(containsString(
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains(
                 "Failed to write offset checkpoint file to [" + storeCheckpointFile.getPath() + "]. " +
                 "This may occur if OS cleaned the state.dir in case when it located in ${java.io.tmpdir} directory. " +
                 "This may also occur due to running multiple instances on the same machine using the same state dir. " +
@@ -246,12 +241,9 @@ public class GlobalStateManagerImplTest {
         initializeConsumer(0, 0, t1, t2, t3, t4, t5);
         stateManager.initialize();
 
-        try {
-            stateManager.registerStore(new NoOpReadOnlyStore<>("not-in-topology"), stateRestoreCallback, null);
-            fail("should have raised an illegal argument exception as store is not in the topology");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class,
+            () -> stateManager.registerStore(new NoOpReadOnlyStore<>("not-in-topology"), stateRestoreCallback, null),
+            "should have raised an illegal argument exception as store is not in the topology");
     }
 
     @Test
@@ -260,23 +252,16 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         initializeConsumer(2, 0, t1);
         stateManager.registerStore(store1, stateRestoreCallback, null);
-        try {
-            stateManager.registerStore(store1, stateRestoreCallback, null);
-            fail("should have raised an illegal argument exception as store has already been registered");
-        } catch (final IllegalArgumentException e) {
-            // pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> stateManager.registerStore(store1, stateRestoreCallback, null),
+            "should have raised an illegal argument exception as store has already been registered");
     }
 
     @Test
     public void shouldThrowStreamsExceptionIfNoPartitionsFoundForStore() {
-        try {
+        assertThrows(StreamsException.class, () -> {
             stateManager.initialize();
             stateManager.registerStore(store1, stateRestoreCallback, null);
-            fail("Should have raised a StreamsException as there are no partition for the store");
-        } catch (final StreamsException e) {
-            // pass
-        }
+        }, "Should have raised a StreamsException as there are no partition for the store");
     }
 
     @Test
@@ -353,10 +338,10 @@ public class GlobalStateManagerImplTest {
 
         stateManager.initialize();
 
-        assertThat(stateRestoreListener.numBatchRestored, equalTo(2L));
-        assertThat(stateRestoreListener.restoreStartOffset, equalTo(1L));
-        assertThat(stateRestoreListener.restoreEndOffset, equalTo(7L));
-        assertThat(stateRestoreListener.totalNumRestored, equalTo(6L));
+        assertEquals(2L, stateRestoreListener.numBatchRestored);
+        assertEquals(1L, stateRestoreListener.restoreStartOffset);
+        assertEquals(7L, stateRestoreListener.restoreEndOffset);
+        assertEquals(6L, stateRestoreListener.totalNumRestored);
     }
 
     @Test
@@ -368,15 +353,15 @@ public class GlobalStateManagerImplTest {
 
         stateManager.initialize();
 
-        assertThat(stateRestoreListener.numBatchRestored, equalTo(2L));
-        assertThat(stateRestoreListener.restoreStartOffset, equalTo(1L));
-        assertThat(stateRestoreListener.restoreEndOffset, equalTo(7L));
-        assertThat(stateRestoreListener.totalNumRestored, equalTo(6L));
+        assertEquals(2L, stateRestoreListener.numBatchRestored);
+        assertEquals(1L, stateRestoreListener.restoreStartOffset);
+        assertEquals(7L, stateRestoreListener.restoreEndOffset);
+        assertEquals(6L, stateRestoreListener.totalNumRestored);
 
 
-        assertThat(stateRestoreListener.storeNameCalledStates.get(RESTORE_START), equalTo(store1.name()));
-        assertThat(stateRestoreListener.storeNameCalledStates.get(RESTORE_BATCH), equalTo(store1.name()));
-        assertThat(stateRestoreListener.storeNameCalledStates.get(RESTORE_END), equalTo(store1.name()));
+        assertEquals(store1.name(), stateRestoreListener.storeNameCalledStates.get(RESTORE_START));
+        assertEquals(store1.name(), stateRestoreListener.storeNameCalledStates.get(RESTORE_BATCH));
+        assertEquals(store1.name(), stateRestoreListener.storeNameCalledStates.get(RESTORE_END));
     }
 
     @Test
@@ -486,12 +471,8 @@ public class GlobalStateManagerImplTest {
     public void shouldThrowIllegalArgumentExceptionIfCallbackIsNull() {
         initializeConsumer(0, 0, t1, t2, t3, t4, t5);
         stateManager.initialize();
-        try {
-            stateManager.registerStore(store1, null, null);
-            fail("should have thrown due to null callback");
-        } catch (final IllegalArgumentException e) {
-            //pass
-        }
+        assertThrows(IllegalArgumentException.class, () -> stateManager.registerStore(store1, null, null),
+            "should have thrown due to null callback");
     }
 
     @Test
@@ -550,14 +531,17 @@ public class GlobalStateManagerImplTest {
         stateManager.updateChangelogOffsets(offsets);
         stateManager.commit();
 
-        assertThat(readOffsetsCheckpoint(storeName1), equalTo(offsets));
-        assertThat(stateManager.changelogOffsets(), equalTo(mkMap(
-                mkEntry(t1, 25_000L),
-                mkEntry(t2, 0L),
-                mkEntry(t3, 0L),
-                mkEntry(t4, 0L),
-                mkEntry(t5, 0L)
-        )));
+        assertEquals(offsets, readOffsetsCheckpoint(storeName1));
+        assertEquals(
+            Map.of(
+                t1, 25_000L,
+                t2, 0L,
+                t3, 0L,
+                t4, 0L,
+                t5, 0L
+            ),
+            stateManager.changelogOffsets()
+        );
     }
 
     @Test
@@ -574,8 +558,8 @@ public class GlobalStateManagerImplTest {
         stateManager.commit();
 
         final Map<TopicPartition, Long> updatedCheckpoint = stateManager.changelogOffsets();
-        assertThat(updatedCheckpoint.get(t2), equalTo(initialCheckpoint.get(t2)));
-        assertThat(updatedCheckpoint.get(t1), equalTo(101L));
+        assertEquals(initialCheckpoint.get(t2), updatedCheckpoint.get(t2));
+        assertEquals(101L, updatedCheckpoint.get(t1));
     }
 
     @Test
@@ -597,7 +581,7 @@ public class GlobalStateManagerImplTest {
 
         stateManager.initialize();
         final KeyValue<byte[], byte[]> restoredKv = stateRestoreCallback.restored.get(0);
-        assertThat(stateRestoreCallback.restored, equalTo(Collections.singletonList(KeyValue.pair(restoredKv.key, restoredKv.value))));
+        assertEquals(List.of(KeyValue.pair(restoredKv.key, restoredKv.value)), stateRestoreCallback.restored);
     }
 
     @Test
@@ -613,16 +597,19 @@ public class GlobalStateManagerImplTest {
 
         final Map<TopicPartition, Long> checkpointMap = stateManager.changelogOffsets();
         // changelogOffsets() returns offsets for *all* stores
-        assertThat(checkpointMap, equalTo(mkMap(
-                mkEntry(t1, 10L),
-                mkEntry(t2, 0L),
-                mkEntry(t3, 0L),
-                mkEntry(t4, 0L),
-                mkEntry(t5, 0L)
-        )));
+        assertEquals(
+            Map.of(
+                t1, 10L,
+                t2, 0L,
+                t3, 0L,
+                t4, 0L,
+                t5, 0L
+            ),
+            checkpointMap
+        );
 
-        assertThat(readOffsetsCheckpoint(storeName1), equalTo(mkMap(mkEntry(t1, 10L))));
-        assertThat(readOffsetsCheckpoint(storeName2), equalTo(mkMap(mkEntry(t2, 0L))));
+        assertEquals(Map.of(t1, 10L), readOffsetsCheckpoint(storeName1));
+        assertEquals(Map.of(t2, 0L), readOffsetsCheckpoint(storeName2));
     }
 
     @Test
@@ -632,7 +619,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize();
         stateManager.close();
 
-        assertThat(readOffsetsCheckpoint(storeName3), equalTo(Collections.emptyMap()));
+        assertTrue(readOffsetsCheckpoint(storeName3).isEmpty());
     }
 
     private Map<TopicPartition, Long> readOffsetsCheckpoint(final String storeName) throws IOException {
@@ -677,8 +664,8 @@ public class GlobalStateManagerImplTest {
             () -> stateManager.initialize()
         );
         final Throwable cause = expected.getCause();
-        assertThat(cause, instanceOf(TimeoutException.class));
-        assertThat(cause.getMessage(), equalTo("KABOOM!"));
+        assertInstanceOf(TimeoutException.class, cause);
+        assertEquals("KABOOM!", cause.getMessage());
 
         assertEquals(1, numberOfCalls.get());
     }
@@ -719,7 +706,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(2, numberOfCalls.get());
     }
@@ -760,7 +747,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(11, numberOfCalls.get());
     }
@@ -843,8 +830,8 @@ public class GlobalStateManagerImplTest {
             () -> stateManager.initialize()
         );
         final Throwable cause = expected.getCause();
-        assertThat(cause, instanceOf(TimeoutException.class));
-        assertThat(cause.getMessage(), equalTo("KABOOM!"));
+        assertInstanceOf(TimeoutException.class, cause);
+        assertEquals("KABOOM!", cause.getMessage());
 
         assertEquals(1, numberOfCalls.get());
     }
@@ -885,7 +872,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(2, numberOfCalls.get());
     }
@@ -926,7 +913,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(11, numberOfCalls.get());
     }
@@ -1009,8 +996,8 @@ public class GlobalStateManagerImplTest {
             () -> stateManager.initialize()
         );
         final Throwable cause = expected.getCause();
-        assertThat(cause, instanceOf(TimeoutException.class));
-        assertThat(cause.getMessage(), equalTo("KABOOM!"));
+        assertInstanceOf(TimeoutException.class, cause);
+        assertEquals("KABOOM!", cause.getMessage());
 
         assertEquals(1, numberOfCalls.get());
     }
@@ -1051,7 +1038,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 100 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(2, numberOfCalls.get());
     }
@@ -1092,7 +1079,7 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(expected.getMessage(), equalTo("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed."));
+        assertEquals("Global task did not make progress to restore state within 1000 ms. Adjust `task.timeout.ms` if needed.", expected.getMessage());
 
         assertEquals(11, numberOfCalls.get());
     }
@@ -1178,11 +1165,8 @@ public class GlobalStateManagerImplTest {
             TimeoutException.class,
             () -> stateManager.initialize()
         );
-        assertThat(
-            exception.getMessage(),
-            equalTo("Global task did not make progress to restore state within 301000 ms. Adjust `task.timeout.ms` if needed.")
-        );
-        assertThat(time.milliseconds() - startTime, equalTo(331_100L));
+        assertEquals("Global task did not make progress to restore state within 301000 ms. Adjust `task.timeout.ms` if needed.", exception.getMessage());
+        assertEquals(331_100L, time.milliseconds() - startTime);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -61,15 +61,12 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.DEAD;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.RUNNING;
 import static org.apache.kafka.streams.processor.internals.testutil.ConsumerRecordUtil.record;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class GlobalStreamThreadTest {
     private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
@@ -151,7 +148,7 @@ public class GlobalStreamThreadTest {
             "Should have thrown StreamsException if start up failed.");
 
         globalStreamThread.join();
-        assertThat(globalStore.isOpen(), is(false));
+        assertFalse(globalStore.isOpen());
         assertFalse(globalStreamThread.stillRunning());
     }
 
@@ -178,15 +175,14 @@ public class GlobalStreamThreadTest {
             e -> { }
         );
 
-        try {
-            globalStreamThread.start();
-            fail("Should have thrown StreamsException if start up failed");
-        } catch (final StreamsException e) {
-            assertThat(e.getCause(), instanceOf(RuntimeException.class));
-            assertThat(e.getCause().getMessage(), equalTo("KABOOM!"));
-        }
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            globalStreamThread::start,
+            "Should have thrown StreamsException if start up failed");
+        assertInstanceOf(RuntimeException.class, exception.getCause());
+        assertEquals("KABOOM!", exception.getCause().getMessage());
         globalStreamThread.join();
-        assertThat(globalStore.isOpen(), is(false));
+        assertFalse(globalStore.isOpen());
         assertFalse(globalStreamThread.stillRunning());
     }
 
@@ -288,7 +284,7 @@ public class GlobalStreamThreadTest {
         );
         globalStreamThread.join();
 
-        assertThat(globalStore.isOpen(), is(false));
+        assertFalse(globalStore.isOpen());
         assertFalse(new File(baseDirectoryName + File.separator + "testAppId" + File.separator + "global").exists());
     }
 
@@ -325,7 +321,7 @@ public class GlobalStreamThreadTest {
         );
         globalStreamThread.join();
 
-        assertThat(globalStore.isOpen(), is(false));
+        assertFalse(globalStore.isOpen());
         assertFalse(new File(baseDirectoryName + File.separator + "testAppId" + File.separator + "global").exists());
     }
 
@@ -341,7 +337,7 @@ public class GlobalStreamThreadTest {
             final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ZERO);
             final Uuid result = future.get();
 
-            assertThat(result, equalTo(instanceId));
+            assertEquals(instanceId, result);
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
@@ -361,7 +357,7 @@ public class GlobalStreamThreadTest {
             final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ZERO);
             final Uuid result = future.get();
 
-            assertThat(result, equalTo(instanceId));
+            assertEquals(instanceId, result);
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
@@ -378,7 +374,7 @@ public class GlobalStreamThreadTest {
             final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ZERO);
             final Uuid result = future.get();
 
-            assertThat(result, equalTo(null));
+            assertNull(result);
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
@@ -394,8 +390,8 @@ public class GlobalStreamThreadTest {
             final KafkaFuture<Uuid> future = globalStreamThread.globalConsumerInstanceId(Duration.ZERO);
 
             final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-            assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
-            assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+            assertInstanceOf(UnsupportedOperationException.class, error.getCause());
+            assertEquals("clientInstanceId not set", error.getCause().getMessage());
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
@@ -416,11 +412,8 @@ public class GlobalStreamThreadTest {
             time.sleep(1L);
 
             final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-            assertThat(error.getCause(), instanceOf(TimeoutException.class));
-            assertThat(
-                error.getCause().getMessage(),
-                equalTo("Could not retrieve global consumer client instance id.")
-            );
+            assertInstanceOf(TimeoutException.class, error.getCause());
+            assertEquals("Could not retrieve global consumer client instance id.", error.getCause().getMessage());
         } finally {
             globalStreamThread.shutdown();
             globalStreamThread.join();
@@ -451,15 +444,14 @@ public class GlobalStreamThreadTest {
                 e -> { }
         );
 
-        try {
-            globalStreamThread.start();
-            fail("Should have thrown StreamsException if start up failed");
-        } catch (final StreamsException e) {
-            assertThat(e.getCause(), instanceOf(Throwable.class));
-            assertThat(e.getCause().getMessage(), equalTo(exceptionMessage));
-        }
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            globalStreamThread::start,
+            "Should have thrown StreamsException if start up failed");
+        assertInstanceOf(Throwable.class, exception.getCause());
+        assertEquals(exceptionMessage, exception.getCause().getMessage());
         globalStreamThread.join();
-        assertThat(globalStore.isOpen(), is(false));
+        assertFalse(globalStore.isOpen());
         assertFalse(globalStreamThread.stillRunning());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -68,11 +68,8 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_0_2;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -203,17 +200,13 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
         // The tasks were returned to their prior owner
         final ArrayList<TaskId> sortedExpectedTasks = new ArrayList<>(allTasks);
         Collections.sort(sortedExpectedTasks);
-        assertThat(firstConsumerActiveTasks, equalTo(sortedExpectedTasks));
-        assertThat(newConsumerActiveTasks, empty());
+        assertEquals(sortedExpectedTasks, firstConsumerActiveTasks);
+        assertTrue(newConsumerActiveTasks.isEmpty());
 
         // There is a rebalance scheduled
-        assertThat(
-            time.milliseconds() + rebalanceInterval,
-            anyOf(
-                is(firstConsumerUserData.nextRebalanceMs()),
-                is(newConsumerUserData.nextRebalanceMs())
-            )
-        );
+        final long nextScheduledRebalance = time.milliseconds() + rebalanceInterval;
+        assertTrue(nextScheduledRebalance == firstConsumerUserData.nextRebalanceMs()
+            || nextScheduledRebalance == newConsumerUserData.nextRebalanceMs());
     }
 
     @Test
@@ -257,18 +250,18 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
 
         final ArrayList<TaskId> sortedExpectedTasks = new ArrayList<>(allTasks);
         Collections.sort(sortedExpectedTasks);
-        assertThat(firstConsumerActiveTasks, equalTo(sortedExpectedTasks));
-        assertThat(newConsumerActiveTasks, empty());
+        assertEquals(sortedExpectedTasks, firstConsumerActiveTasks);
+        assertTrue(newConsumerActiveTasks.isEmpty());
 
-        assertThat(referenceContainer.assignmentErrorCode.get(), equalTo(AssignorError.NONE.code()));
+        assertEquals(AssignorError.NONE.code(), referenceContainer.assignmentErrorCode.get());
 
         final long nextScheduledRebalanceOnThisClient =
             AssignmentInfo.decode(assignments.get(firstConsumer).userData()).nextRebalanceMs();
         final long nextScheduledRebalanceOnOtherClient =
             AssignmentInfo.decode(assignments.get(newConsumer).userData()).nextRebalanceMs();
 
-        assertThat(nextScheduledRebalanceOnThisClient, equalTo(time.milliseconds() + rebalanceInterval));
-        assertThat(nextScheduledRebalanceOnOtherClient, equalTo(Long.MAX_VALUE));
+        assertEquals(time.milliseconds() + rebalanceInterval, nextScheduledRebalanceOnThisClient);
+        assertEquals(Long.MAX_VALUE, nextScheduledRebalanceOnOtherClient);
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -74,18 +74,11 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -146,9 +139,9 @@ public class InternalTopicManagerTest {
         ));
 
         final Set<String> newlyCreatedTopics = mockAdminClient.listTopics().names().get();
-        assertThat(newlyCreatedTopics.size(), is(2));
-        assertThat(newlyCreatedTopics, hasItem(topic1));
-        assertThat(newlyCreatedTopics, hasItem(topic2));
+        assertEquals(2, newlyCreatedTopics.size());
+        assertTrue(newlyCreatedTopics.contains(topic1));
+        assertTrue(newlyCreatedTopics.contains(topic2));
     }
 
     @Test
@@ -157,7 +150,7 @@ public class InternalTopicManagerTest {
         internalTopicManager.setup(Collections.emptyMap());
 
         final Set<String> newlyCreatedTopics = mockAdminClient.listTopics().names().get();
-        assertThat(newlyCreatedTopics, empty());
+        assertTrue(newlyCreatedTopics.isEmpty());
     }
 
     @Test
@@ -269,10 +262,10 @@ public class InternalTopicManagerTest {
             StreamsException.class,
             () -> topicManager.makeReady(Collections.singletonMap(topic1, topicConfig))
         );
-        assertThat(
-            exception.getMessage(),
-            equalTo("Could not create topic " + topic1 + ", because brokers don't support configuration replication.factor=-1."
-                + " You can change the replication.factor config or upgrade your brokers to version 2.4 or newer to avoid this error."));
+        assertEquals(
+            "Could not create topic " + topic1 + ", because brokers don't support configuration replication.factor=-1."
+                + " You can change the replication.factor config or upgrade your brokers to version 2.4 or newer to avoid this error.",
+            exception.getMessage());
     }
 
     @Test
@@ -289,10 +282,9 @@ public class InternalTopicManagerTest {
             () -> internalTopicManager.getTopicPartitionInfo(Collections.singleton(topic1))
         );
 
-        assertThat(
-            exception.getMessage(),
-            is("Could not create topics within 50 milliseconds. This can happen if the Kafka cluster is temporarily not available.")
-        );
+        assertEquals(
+            "Could not create topics within 50 milliseconds. This can happen if the Kafka cluster is temporarily not available.",
+            exception.getMessage());
     }
 
     @Test
@@ -310,15 +302,14 @@ public class InternalTopicManagerTest {
             () -> internalTopicManager.setup(Collections.singletonMap(topic1, internalTopicConfig))
         );
 
-        assertThat(
-            exception.getMessage(),
-            is("Setup timeout: Could not create internal topics within " +
-                    (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 2 +
+        assertEquals(
+            "Setup timeout: Could not create internal topics within " +
+                (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 2 +
                 " milliseconds. This can happen if the Kafka cluster is temporarily not available or a topic is marked" +
-                    " for deletion and the broker did not complete its deletion within the timeout." +
-                    " The last errors seen per topic are:" +
-                    " {" + topic1 + "=org.apache.kafka.common.errors.TopicExistsException: Topic test_topic exists already.}")
-        );
+                " for deletion and the broker did not complete its deletion within the timeout." +
+                " The last errors seen per topic are:" +
+                " {" + topic1 + "=org.apache.kafka.common.errors.TopicExistsException: Topic test_topic exists already.}",
+            exception.getMessage());
     }
 
     @Test
@@ -816,12 +807,11 @@ public class InternalTopicManagerTest {
             null
         );
 
-        try {
+        assertThrows(StreamsException.class, () -> {
             final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
             internalTopicConfig.setNumberOfPartitions(1);
             internalTopicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig));
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException expected) { /* pass */ }
+        }, "Should have thrown StreamsException");
     }
 
     @Test
@@ -861,13 +851,13 @@ public class InternalTopicManagerTest {
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic1, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
-        try {
-            topicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig));
-            fail("Should have thrown TimeoutException.");
-        } catch (final TimeoutException expected) {
-            assertThat(expected.getMessage(), is("MakeReady timeout: Could not create topics within 50 milliseconds. " +
-                    "This can happen if the Kafka cluster is temporarily not available."));
-        }
+        final TimeoutException exception = assertThrows(TimeoutException.class,
+            () -> topicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig)),
+            "Should have thrown TimeoutException.");
+        assertEquals(
+            "MakeReady timeout: Could not create topics within 50 milliseconds. " +
+                "This can happen if the Kafka cluster is temporarily not available.",
+            exception.getMessage());
     }
     @Test
     public void shouldLogWhenTopicNotFoundAndNotThrowException() {
@@ -892,11 +882,9 @@ public class InternalTopicManagerTest {
             appender.setClassLogger(InternalTopicManager.class, Level.DEBUG);
             internalTopicManager.makeReady(topicConfigMap);
 
-            assertThat(
-                appender.getMessages(),
-                hasItem("stream-thread [" + threadName + "] Topic internal-topic is unknown or not found, hence not existed yet.\n" +
-                    "Error message was: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: Topic internal-topic not found.")
-            );
+            assertTrue(appender.getMessages().contains(
+                "stream-thread [" + threadName + "] Topic internal-topic is unknown or not found, hence not existed yet.\n" +
+                    "Error message was: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: Topic internal-topic not found."));
         }
     }
 
@@ -994,11 +982,10 @@ public class InternalTopicManagerTest {
             () -> topicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig))
         );
         assertNull(exception.getCause());
-        assertThat(
-            exception.getMessage(),
-            equalTo("MakeReady timeout: Could not create topics within 50 milliseconds." +
-                " This can happen if the Kafka cluster is temporarily not available.")
-        );
+        assertEquals(
+            "MakeReady timeout: Could not create topics within 50 milliseconds." +
+                " This can happen if the Kafka cluster is temporarily not available.",
+            exception.getMessage());
     }
 
     @Test
@@ -1023,11 +1010,10 @@ public class InternalTopicManagerTest {
             () -> internalTopicManager.makeReady(Collections.singletonMap(topic1, internalTopicConfig))
         );
         assertNull(exception.getCause());
-        assertThat(
-            exception.getMessage(),
-            equalTo("MakeReady timeout: Could not create topics within 50 milliseconds." +
-                " This can happen if the Kafka cluster is temporarily not available.")
-        );
+        assertEquals(
+            "MakeReady timeout: Could not create topics within 50 milliseconds." +
+                " This can happen if the Kafka cluster is temporarily not available.",
+            exception.getMessage());
     }
 
     @Test
@@ -1042,8 +1028,8 @@ public class InternalTopicManagerTest {
             mkEntry(topic2, internalTopicConfig2)
         ));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1052,8 +1038,8 @@ public class InternalTopicManagerTest {
 
         final ValidationResult validationResult = internalTopicManager.validate(Collections.emptyMap());
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1072,10 +1058,10 @@ public class InternalTopicManagerTest {
         ));
 
         final Set<String> missingTopics = validationResult.missingTopics();
-        assertThat(missingTopics.size(), is(2));
-        assertThat(missingTopics, hasItem(missingTopic1));
-        assertThat(missingTopics, hasItem(missingTopic2));
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertEquals(2, missingTopics.size());
+        assertTrue(missingTopics.contains(missingTopic1));
+        assertTrue(missingTopics.contains(missingTopic2));
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1094,21 +1080,19 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(2));
-        assertThat(misconfigurationsForTopics, hasKey(topic1));
-        assertThat(misconfigurationsForTopics.get(topic1).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic1).get(0),
-            is("Internal topic " + topic1 + " requires 2 partitions, but the existing topic on the broker has 1 partitions.")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic2));
-        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic2).get(0),
-            is("Internal topic " + topic2 + " requires 3 partitions, but the existing topic on the broker has 1 partitions.")
-        );
-        assertThat(misconfigurationsForTopics, not(hasKey(topic3)));
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(2, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic1));
+        assertEquals(1, misconfigurationsForTopics.get(topic1).size());
+        assertEquals(
+            "Internal topic " + topic1 + " requires 2 partitions, but the existing topic on the broker has 1 partitions.",
+            misconfigurationsForTopics.get(topic1).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic2));
+        assertEquals(1, misconfigurationsForTopics.get(topic2).size());
+        assertEquals(
+            "Internal topic " + topic2 + " requires 3 partitions, but the existing topic on the broker has 1 partitions.",
+            misconfigurationsForTopics.get(topic2).get(0));
+        assertFalse(misconfigurationsForTopics.containsKey(topic3));
     }
 
     @Test
@@ -1137,23 +1121,21 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(2));
-        assertThat(misconfigurationsForTopics, hasKey(topic1));
-        assertThat(misconfigurationsForTopics.get(topic1).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic1).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic1 + " should not contain \""
-                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic2));
-        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic2).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic2 + " should not contain \""
-                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
-        );
-        assertThat(misconfigurationsForTopics, not(hasKey(topic3)));
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(2, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic1));
+        assertEquals(1, misconfigurationsForTopics.get(topic1).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic1 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".",
+            misconfigurationsForTopics.get(topic1).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic2));
+        assertEquals(1, misconfigurationsForTopics.get(topic2).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic2 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".",
+            misconfigurationsForTopics.get(topic2).get(0));
+        assertFalse(misconfigurationsForTopics.containsKey(topic3));
     }
 
     @Test
@@ -1186,31 +1168,28 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(3));
-        assertThat(misconfigurationsForTopics, hasKey(topic2));
-        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic2).get(0),
-            is("Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
-                topic2 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic4));
-        assertThat(misconfigurationsForTopics.get(topic4).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic4).get(0),
-            is("Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
-                topic4 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic5));
-        assertThat(misconfigurationsForTopics.get(topic5).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic5).get(0),
-            is("Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic " +
-                topic5 + " is set but it should be unset.")
-        );
-        assertThat(misconfigurationsForTopics, not(hasKey(topic1)));
-        assertThat(misconfigurationsForTopics, not(hasKey(topic3)));
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(3, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic2));
+        assertEquals(1, misconfigurationsForTopics.get(topic2).size());
+        assertEquals(
+            "Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
+                topic2 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.",
+            misconfigurationsForTopics.get(topic2).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic4));
+        assertEquals(1, misconfigurationsForTopics.get(topic4).size());
+        assertEquals(
+            "Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
+                topic4 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.",
+            misconfigurationsForTopics.get(topic4).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic5));
+        assertEquals(1, misconfigurationsForTopics.get(topic5).size());
+        assertEquals(
+            "Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic " +
+                topic5 + " is set but it should be unset.",
+            misconfigurationsForTopics.get(topic5).get(0));
+        assertFalse(misconfigurationsForTopics.containsKey(topic1));
+        assertFalse(misconfigurationsForTopics.containsKey(topic3));
     }
 
     @Test
@@ -1238,30 +1217,27 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(3));
-        assertThat(misconfigurationsForTopics, hasKey(topic2));
-        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic2).get(0),
-            is("Min compaction lag (" + TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG + ") of existing internal topic " +
-                topic2 + " is " + shorterCompactionLagMs + " but should be " + compactionLagMs + " or larger.")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic3));
-        assertThat(misconfigurationsForTopics.get(topic3).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic3).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic3 + " should not contain \""
-                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic4));
-        assertThat(misconfigurationsForTopics.get(topic4).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic4).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic4 + " should not contain \""
-                + TopicConfig.CLEANUP_POLICY_DELETE + "\".")
-        );
-        assertThat(misconfigurationsForTopics, not(hasKey(topic1)));
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(3, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic2));
+        assertEquals(1, misconfigurationsForTopics.get(topic2).size());
+        assertEquals(
+            "Min compaction lag (" + TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG + ") of existing internal topic " +
+                topic2 + " is " + shorterCompactionLagMs + " but should be " + compactionLagMs + " or larger.",
+            misconfigurationsForTopics.get(topic2).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic3));
+        assertEquals(1, misconfigurationsForTopics.get(topic3).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic3 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".",
+            misconfigurationsForTopics.get(topic3).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic4));
+        assertEquals(1, misconfigurationsForTopics.get(topic4).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic " + topic4 + " should not contain \""
+                + TopicConfig.CLEANUP_POLICY_DELETE + "\".",
+            misconfigurationsForTopics.get(topic4).get(0));
+        assertFalse(misconfigurationsForTopics.containsKey(topic1));
     }
 
     @Test
@@ -1298,36 +1274,32 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(4));
-        assertThat(misconfigurationsForTopics, hasKey(topic2));
-        assertThat(misconfigurationsForTopics.get(topic2).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic2).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic "
-                + topic2 + " should not contain \"" + TopicConfig.CLEANUP_POLICY_COMPACT + "\".")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic3));
-        assertThat(misconfigurationsForTopics.get(topic3).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic3).get(0),
-            is("Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic "
-                + topic3 + " should not contain \"" + TopicConfig.CLEANUP_POLICY_COMPACT + "\".")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic4));
-        assertThat(misconfigurationsForTopics.get(topic4).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic4).get(0),
-            is("Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic "
-                + topic4 + " is " + retentionMs + " but should be -1.")
-        );
-        assertThat(misconfigurationsForTopics, hasKey(topic5));
-        assertThat(misconfigurationsForTopics.get(topic5).size(), is(1));
-        assertThat(
-            misconfigurationsForTopics.get(topic5).get(0),
-            is("Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic "
-                + topic5 + " is set but it should be unset.")
-        );
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(4, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic2));
+        assertEquals(1, misconfigurationsForTopics.get(topic2).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic "
+                + topic2 + " should not contain \"" + TopicConfig.CLEANUP_POLICY_COMPACT + "\".",
+            misconfigurationsForTopics.get(topic2).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic3));
+        assertEquals(1, misconfigurationsForTopics.get(topic3).size());
+        assertEquals(
+            "Cleanup policy (" + TopicConfig.CLEANUP_POLICY_CONFIG + ") of existing internal topic "
+                + topic3 + " should not contain \"" + TopicConfig.CLEANUP_POLICY_COMPACT + "\".",
+            misconfigurationsForTopics.get(topic3).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic4));
+        assertEquals(1, misconfigurationsForTopics.get(topic4).size());
+        assertEquals(
+            "Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic "
+                + topic4 + " is " + retentionMs + " but should be -1.",
+            misconfigurationsForTopics.get(topic4).get(0));
+        assertTrue(misconfigurationsForTopics.containsKey(topic5));
+        assertEquals(1, misconfigurationsForTopics.get(topic5).size());
+        assertEquals(
+            "Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic "
+                + topic5 + " is set but it should be unset.",
+            misconfigurationsForTopics.get(topic5).get(0));
     }
 
     @Test
@@ -1344,20 +1316,18 @@ public class InternalTopicManagerTest {
         ));
 
         final Map<String, List<String>> misconfigurationsForTopics = validationResult.misconfigurationsForTopics();
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(misconfigurationsForTopics.size(), is(1));
-        assertThat(misconfigurationsForTopics, hasKey(topic1));
-        assertThat(misconfigurationsForTopics.get(topic1).size(), is(2));
-        assertThat(
-            misconfigurationsForTopics.get(topic1).get(0),
-            is("Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
-                topic1 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.")
-        );
-        assertThat(
-            misconfigurationsForTopics.get(topic1).get(1),
-            is("Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic " +
-                topic1 + " is set but it should be unset.")
-        );
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertEquals(1, misconfigurationsForTopics.size());
+        assertTrue(misconfigurationsForTopics.containsKey(topic1));
+        assertEquals(2, misconfigurationsForTopics.get(topic1).size());
+        assertEquals(
+            "Retention time (" + TopicConfig.RETENTION_MS_CONFIG + ") of existing internal topic " +
+                topic1 + " is " + shorterRetentionMs + " but should be " + retentionMs + " or larger.",
+            misconfigurationsForTopics.get(topic1).get(0));
+        assertEquals(
+            "Retention byte (" + TopicConfig.RETENTION_BYTES_CONFIG + ") of existing internal topic " +
+                topic1 + " is set but it should be unset.",
+            misconfigurationsForTopics.get(topic1).get(1));
     }
 
     @Test
@@ -1385,8 +1355,8 @@ public class InternalTopicManagerTest {
         final ValidationResult validationResult =
             internalTopicManager2.validate(Collections.singletonMap(topic1, internalTopicConfig));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1397,8 +1367,8 @@ public class InternalTopicManagerTest {
 
         final ValidationResult validationResult = internalTopicManager.validate(Collections.singletonMap(topic1, internalTopicConfig));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1432,8 +1402,8 @@ public class InternalTopicManagerTest {
 
         final ValidationResult validationResult = topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1467,8 +1437,8 @@ public class InternalTopicManagerTest {
 
         final ValidationResult validationResult = topicManager.validate(Collections.singletonMap(topic1, internalTopicConfig));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test
@@ -1522,8 +1492,8 @@ public class InternalTopicManagerTest {
             mkEntry(topic2, internalTopicConfig2)
         ));
 
-        assertThat(validationResult.missingTopics(), empty());
-        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        assertTrue(validationResult.missingTopics().isEmpty());
+        assertTrue(validationResult.misconfigurationsForTopics().isEmpty());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -77,20 +77,13 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_2;
 import static org.apache.kafka.streams.utils.TestUtils.dummyStreamsConfigMap;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class InternalTopologyBuilderTest {
 
@@ -112,11 +105,11 @@ public class InternalTopologyBuilderTest {
         builder.addSource(new AutoOffsetResetInternal(AutoOffsetReset.byDuration(Duration.ofSeconds(42))), "source3", null, null, null, durationTopic);
         builder.initializeSubscription();
 
-        assertThat(builder.offsetResetStrategy(noneTopic), equalTo(AutoOffsetResetStrategy.NONE));
-        assertThat(builder.offsetResetStrategy(earliestTopic), equalTo(AutoOffsetResetStrategy.EARLIEST));
-        assertThat(builder.offsetResetStrategy(latestTopic), equalTo(AutoOffsetResetStrategy.LATEST));
-        assertThat(builder.offsetResetStrategy(durationTopic).type(), equalTo(AutoOffsetResetStrategy.StrategyType.BY_DURATION));
-        assertThat(builder.offsetResetStrategy(durationTopic).duration().orElseThrow().toSeconds(), equalTo(42L));
+        assertEquals(AutoOffsetResetStrategy.NONE, builder.offsetResetStrategy(noneTopic));
+        assertEquals(AutoOffsetResetStrategy.EARLIEST, builder.offsetResetStrategy(earliestTopic));
+        assertEquals(AutoOffsetResetStrategy.LATEST, builder.offsetResetStrategy(latestTopic));
+        assertEquals(AutoOffsetResetStrategy.StrategyType.BY_DURATION, builder.offsetResetStrategy(durationTopic).type());
+        assertEquals(42L, builder.offsetResetStrategy(durationTopic).duration().orElseThrow().toSeconds());
     }
 
     @Test
@@ -133,11 +126,11 @@ public class InternalTopologyBuilderTest {
 
         builder.initializeSubscription();
 
-        assertThat(builder.offsetResetStrategy("noneTestTopic"), equalTo(AutoOffsetResetStrategy.NONE));
-        assertThat(builder.offsetResetStrategy("earliestTestTopic"), equalTo(AutoOffsetResetStrategy.EARLIEST));
-        assertThat(builder.offsetResetStrategy("latestTestTopic"), equalTo(AutoOffsetResetStrategy.LATEST));
-        assertThat(builder.offsetResetStrategy("durationTestTopic").type(), equalTo(AutoOffsetResetStrategy.StrategyType.BY_DURATION));
-        assertThat(builder.offsetResetStrategy("durationTestTopic").duration().orElseThrow().toSeconds(), equalTo(42L));
+        assertEquals(AutoOffsetResetStrategy.NONE, builder.offsetResetStrategy("noneTestTopic"));
+        assertEquals(AutoOffsetResetStrategy.EARLIEST, builder.offsetResetStrategy("earliestTestTopic"));
+        assertEquals(AutoOffsetResetStrategy.LATEST, builder.offsetResetStrategy("latestTestTopic"));
+        assertEquals(AutoOffsetResetStrategy.StrategyType.BY_DURATION, builder.offsetResetStrategy("durationTestTopic").type());
+        assertEquals(42L, builder.offsetResetStrategy("durationTestTopic").duration().orElseThrow().toSeconds());
     }
 
     @Test
@@ -147,7 +140,7 @@ public class InternalTopologyBuilderTest {
 
         assertEquals(Collections.singletonList("test-topic"), builder.fullSourceTopicNames());
 
-        assertThat(builder.offsetResetStrategy("test-topic"), equalTo(null));
+        assertNull(builder.offsetResetStrategy("test-topic"));
     }
 
     @Test
@@ -157,9 +150,9 @@ public class InternalTopologyBuilderTest {
         builder.addSource(null, "source", null, stringSerde.deserializer(), stringSerde.deserializer(), Pattern.compile("test-.*"));
         builder.initializeSubscription();
 
-        assertThat(expectedPattern.pattern(), builder.sourceTopicPatternString(), equalTo("test-.*"));
+        assertEquals("test-.*", builder.sourceTopicPatternString(), expectedPattern.pattern());
 
-        assertThat(builder.offsetResetStrategy("test-topic"), equalTo(null));
+        assertNull(builder.offsetResetStrategy("test-topic"));
     }
 
     @Test
@@ -171,38 +164,34 @@ public class InternalTopologyBuilderTest {
     @Test
     public void shouldNotAllowOffsetResetSourceWithDuplicateSourceName() {
         builder.addSource(new AutoOffsetResetInternal(AutoOffsetReset.earliest()), "source", null, stringSerde.deserializer(), stringSerde.deserializer(), "topic-1");
-        try {
-            builder.addSource(new AutoOffsetResetInternal(AutoOffsetReset.latest()), "source", null, stringSerde.deserializer(), stringSerde.deserializer(), "topic-2");
-            fail("Should throw TopologyException for duplicate source name");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSource(new AutoOffsetResetInternal(AutoOffsetReset.latest()), "source", null, stringSerde.deserializer(), stringSerde.deserializer(), "topic-2"),
+            "Should throw TopologyException for duplicate source name");
     }
 
     @Test
     public void testAddSourceWithSameName() {
         builder.addSource(null, "source", null, null, null, "topic-1");
-        try {
-            builder.addSource(null, "source", null, null, null, "topic-2");
-            fail("Should throw TopologyException with source name conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSource(null, "source", null, null, null, "topic-2"),
+            "Should throw TopologyException with source name conflict");
     }
 
     @Test
     public void testAddSourceWithSameTopic() {
         builder.addSource(null, "source", null, null, null, "topic-1");
-        try {
-            builder.addSource(null, "source-2", null, null, null, "topic-1");
-            fail("Should throw TopologyException with topic conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSource(null, "source-2", null, null, null, "topic-1"),
+            "Should throw TopologyException with topic conflict");
     }
 
     @Test
     public void testAddProcessorWithSameName() {
         builder.addSource(null, "source", null, null, null, "topic-1");
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-        try {
-            builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
-            fail("Should throw TopologyException with processor name conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source"),
+            "Should throw TopologyException with processor name conflict");
     }
 
     @Test
@@ -233,7 +222,7 @@ public class InternalTopologyBuilderTest {
                 IllegalArgumentException.class,
             () -> builder.addProcessor("processor", () -> processor, (String) null)
         );
-        assertThat(exception.getMessage(), containsString("#get() must return a new object each time it is called."));
+        assertTrue(exception.getMessage().contains("#get() must return a new object each time it is called."));
     }
 
     @Test
@@ -252,17 +241,16 @@ public class InternalTopologyBuilderTest {
                 false
             )
         );
-        assertThat(exception.getMessage(), containsString("#get() must return a new object each time it is called."));
+        assertTrue(exception.getMessage().contains("#get() must return a new object each time it is called."));
     }
 
     @Test
     public void testAddSinkWithSameName() {
         builder.addSource(null, "source", null, null, null, "topic-1");
         builder.addSink("sink", "topic-2", null, null, null, "source");
-        try {
-            builder.addSink("sink", "topic-3", null, null, null, "source");
-            fail("Should throw TopologyException with sink name conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSink("sink", "topic-3", null, null, null, "source"),
+            "Should throw TopologyException with sink name conflict");
     }
 
     @Test
@@ -392,7 +380,7 @@ public class InternalTopologyBuilderTest {
         );
         builder.initializeSubscription();
 
-        assertThat(builder.fullSourceTopicNames(), equalTo(asList("topic-1", "topic-2")));
+        assertEquals(List.of("topic-1", "topic-2"), builder.fullSourceTopicNames());
     }
 
     @Test
@@ -430,19 +418,17 @@ public class InternalTopologyBuilderTest {
     @Test
     public void testPatternMatchesAlreadyProvidedTopicSource() {
         builder.addSource(null, "source-1", null, null, null, "foo");
-        try {
-            builder.addSource(null, "source-2", null, null, null, Pattern.compile("f.*"));
-            fail("Should throw TopologyException with topic name/pattern conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSource(null, "source-2", null, null, null, Pattern.compile("f.*")),
+            "Should throw TopologyException with topic name/pattern conflict");
     }
 
     @Test
     public void testNamedTopicMatchesAlreadyProvidedPattern() {
         builder.addSource(null, "source-1", null, null, null, Pattern.compile("f.*"));
-        try {
-            builder.addSource(null, "source-2", null, null, null, "foo");
-            fail("Should throw TopologyException with topic name/pattern conflict");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addSource(null, "source-2", null, null, null, "foo"),
+            "Should throw TopologyException with topic name/pattern conflict");
     }
 
     @Test
@@ -453,20 +439,18 @@ public class InternalTopologyBuilderTest {
     @Test
     public void testAddStateStoreWithSource() {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
-        try {
-            builder.addStateStore(storeFactory, "source-1");
-            fail("Should throw TopologyException with store cannot be added to source");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addStateStore(storeFactory, "source-1"),
+            "Should throw TopologyException with store cannot be added to source");
     }
 
     @Test
     public void testAddStateStoreWithSink() {
         builder.addSource(null, "source-1", null, null, null, "topic-1");
         builder.addSink("sink-1", "topic-1", null, null, null, "source-1");
-        try {
-            builder.addStateStore(storeFactory, "sink-1");
-            fail("Should throw TopologyException with store cannot be added to sink");
-        } catch (final TopologyException expected) { /* ok */ }
+        assertThrows(TopologyException.class,
+            () -> builder.addStateStore(storeFactory, "sink-1"),
+            "Should throw TopologyException with store cannot be added to sink");
     }
 
     @Test
@@ -481,10 +465,7 @@ public class InternalTopologyBuilderTest {
             () -> builder.addStateStore(otherBuilder)
         );
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Invalid topology: A different StateStore has already been added with the name testStore")
-        );
+        assertEquals("Invalid topology: A different StateStore has already been added with the name testStore", exception.getMessage());
     }
 
     @Test
@@ -508,10 +489,7 @@ public class InternalTopologyBuilderTest {
             () -> builder.addStateStore(storeFactory)
         );
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Invalid topology: A different GlobalStateStore has already been added with the name testStore")
-        );
+        assertEquals("Invalid topology: A different GlobalStateStore has already been added with the name testStore", exception.getMessage());
     }
 
     @Test
@@ -535,10 +513,7 @@ public class InternalTopologyBuilderTest {
             )
         );
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Invalid topology: A different StateStore has already been added with the name testStore")
-        );
+        assertEquals("Invalid topology: A different StateStore has already been added with the name testStore", exception.getMessage());
     }
 
     @Test
@@ -573,10 +548,7 @@ public class InternalTopologyBuilderTest {
             )
         );
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Invalid topology: A different GlobalStateStore has already been added with the name testStore")
-        );
+        assertEquals("Invalid topology: A different GlobalStateStore has already been added with the name testStore", exception.getMessage());
     }
 
     @Test
@@ -609,13 +581,13 @@ public class InternalTopologyBuilderTest {
 
         builder.buildTopology();
         final Set<String> stateStoreNames = builder.stateStoreNamesForSubtopology(0);
-        assertThat(stateStoreNames, equalTo(Set.of(storeFactory.storeName())));
+        assertEquals(Set.of(storeFactory.storeName()), stateStoreNames);
 
         final Set<String> emptyStoreNames = builder.stateStoreNamesForSubtopology(1);
-        assertThat(emptyStoreNames, equalTo(Set.of()));
+        assertTrue(emptyStoreNames.isEmpty());
 
         final Set<String> stateStoreNamesUnknownSubtopology = builder.stateStoreNamesForSubtopology(13);
-        assertThat(stateStoreNamesUnknownSubtopology, nullValue());
+        assertNull(stateStoreNamesUnknownSubtopology);
     }
 
     @Test
@@ -1048,8 +1020,8 @@ public class InternalTopologyBuilderTest {
         globalProps.put(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 100L);
         final StreamsConfig globalStreamsConfig = new StreamsConfig(globalProps);
         final InternalTopologyBuilder topologyBuilder = builder.rewriteTopology(globalStreamsConfig);
-        assertThat(topologyBuilder.topologyConfigs(), equalTo(new TopologyConfig(null, globalStreamsConfig, new Properties())));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs, equalTo(100L));
+        assertEquals(new TopologyConfig(null, globalStreamsConfig, new Properties()), topologyBuilder.topologyConfigs());
+        assertEquals(100L, topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs);
     }
 
     @Test
@@ -1060,8 +1032,8 @@ public class InternalTopologyBuilderTest {
         globalProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 100L);
         final StreamsConfig globalStreamsConfig = new StreamsConfig(globalProps);
         final InternalTopologyBuilder topologyBuilder = builder.rewriteTopology(globalStreamsConfig);
-        assertThat(topologyBuilder.topologyConfigs(), equalTo(new TopologyConfig(null, globalStreamsConfig, new Properties())));
-        assertThat(topologyBuilder.topologyConfigs().cacheSize, equalTo(200L));
+        assertEquals(new TopologyConfig(null, globalStreamsConfig, new Properties()), topologyBuilder.topologyConfigs());
+        assertEquals(200L, topologyBuilder.topologyConfigs().cacheSize);
     }
 
     @SuppressWarnings("deprecation")
@@ -1084,13 +1056,13 @@ public class InternalTopologyBuilderTest {
                 topologyOverrides)
         );
 
-        assertThat(topologyBuilder.topologyConfigs().cacheSize, is(12345L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs, equalTo(500L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().taskTimeoutMs, equalTo(1000L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxBufferedSize, equalTo(15));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().timestampExtractor.getClass(), equalTo(MockTimestampExtractor.class));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass(), equalTo(LogAndContinueExceptionHandler.class));
-        assertThat(topologyBuilder.topologyConfigs().parseStoreType(), equalTo(Materialized.StoreType.IN_MEMORY));
+        assertEquals(12345L, topologyBuilder.topologyConfigs().cacheSize);
+        assertEquals(500L, topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs);
+        assertEquals(1000L, topologyBuilder.topologyConfigs().getTaskConfig().taskTimeoutMs);
+        assertEquals(15, topologyBuilder.topologyConfigs().getTaskConfig().maxBufferedSize);
+        assertEquals(MockTimestampExtractor.class, topologyBuilder.topologyConfigs().getTaskConfig().timestampExtractor.getClass());
+        assertEquals(LogAndContinueExceptionHandler.class, topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass());
+        assertEquals(Materialized.StoreType.IN_MEMORY, topologyBuilder.topologyConfigs().parseStoreType());
     }
 
     @SuppressWarnings("deprecation")
@@ -1108,7 +1080,7 @@ public class InternalTopologyBuilderTest {
                 topologyOverrides)
         );
 
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass(), equalTo(LogAndContinueExceptionHandler.class));
+        assertEquals(LogAndContinueExceptionHandler.class, topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass());
     }
 
     @SuppressWarnings("deprecation")
@@ -1129,19 +1101,19 @@ public class InternalTopologyBuilderTest {
                 config,
                 new Properties())
         );
-        assertThat(topologyBuilder.topologyConfigs().cacheSize, is(12345L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs, is(500L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().taskTimeoutMs, is(1000L));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().maxBufferedSize, is(15));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().timestampExtractor.getClass(), is(MockTimestampExtractor.class));
-        assertThat(topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass(), is(LogAndContinueExceptionHandler.class));
+        assertEquals(12345L, topologyBuilder.topologyConfigs().cacheSize);
+        assertEquals(500L, topologyBuilder.topologyConfigs().getTaskConfig().maxTaskIdleMs);
+        assertEquals(1000L, topologyBuilder.topologyConfigs().getTaskConfig().taskTimeoutMs);
+        assertEquals(15, topologyBuilder.topologyConfigs().getTaskConfig().maxBufferedSize);
+        assertEquals(MockTimestampExtractor.class, topologyBuilder.topologyConfigs().getTaskConfig().timestampExtractor.getClass());
+        assertEquals(LogAndContinueExceptionHandler.class, topologyBuilder.topologyConfigs().getTaskConfig().deserializationExceptionHandler.getClass());
     }
 
     @Test
     public void shouldAddTimestampExtractorPerSource() {
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, "topic");
         final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
-        assertThat(processorTopology.source("topic").timestampExtractor(), instanceOf(MockTimestampExtractor.class));
+        assertInstanceOf(MockTimestampExtractor.class, processorTopology.source("topic").timestampExtractor());
     }
 
     @Test
@@ -1149,7 +1121,7 @@ public class InternalTopologyBuilderTest {
         final Pattern pattern = Pattern.compile("t.*");
         builder.addSource(null, "source", new MockTimestampExtractor(), null, null, pattern);
         final ProcessorTopology processorTopology = builder.rewriteTopology(new StreamsConfig(StreamsTestUtils.getStreamsConfig())).buildTopology();
-        assertThat(processorTopology.source(pattern.pattern()).timestampExtractor(), instanceOf(MockTimestampExtractor.class));
+        assertInstanceOf(MockTimestampExtractor.class, processorTopology.source(pattern.pattern()).timestampExtractor());
     }
 
     @Test
@@ -1259,7 +1231,7 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source base = new InternalTopologyBuilder.Source("name", Collections.singleton("topic"), null);
         final InternalTopologyBuilder.Source sameAsBase = new InternalTopologyBuilder.Source("name", Collections.singleton("topic"), null);
 
-        assertThat(base, equalTo(sameAsBase));
+        assertEquals(sameAsBase, base);
     }
 
     @Test
@@ -1267,7 +1239,7 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source base = new InternalTopologyBuilder.Source("name", null, Pattern.compile("topic"));
         final InternalTopologyBuilder.Source sameAsBase = new InternalTopologyBuilder.Source("name", null, Pattern.compile("topic"));
 
-        assertThat(base, equalTo(sameAsBase));
+        assertEquals(sameAsBase, base);
     }
 
     @Test
@@ -1275,7 +1247,7 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source base = new InternalTopologyBuilder.Source("name", Collections.singleton("topic"), null);
         final InternalTopologyBuilder.Source differentName = new InternalTopologyBuilder.Source("name2", Collections.singleton("topic"), null);
 
-        assertThat(base, not(equalTo(differentName)));
+        assertNotEquals(differentName, base);
     }
 
     @Test
@@ -1283,7 +1255,7 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source base = new InternalTopologyBuilder.Source("name", null, Pattern.compile("topic"));
         final InternalTopologyBuilder.Source differentName = new InternalTopologyBuilder.Source("name2", null, Pattern.compile("topic"));
 
-        assertThat(base, not(equalTo(differentName)));
+        assertNotEquals(differentName, base);
     }
 
     @Test
@@ -1292,8 +1264,8 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source differentTopicList = new InternalTopologyBuilder.Source("name", Collections.emptySet(), null);
         final InternalTopologyBuilder.Source differentTopic = new InternalTopologyBuilder.Source("name", Collections.singleton("topic2"), null);
 
-        assertThat(base, not(equalTo(differentTopicList)));
-        assertThat(base, not(equalTo(differentTopic)));
+        assertNotEquals(differentTopicList, base);
+        assertNotEquals(differentTopic, base);
     }
 
     @Test
@@ -1302,8 +1274,8 @@ public class InternalTopologyBuilderTest {
         final InternalTopologyBuilder.Source differentPattern = new InternalTopologyBuilder.Source("name", null, Pattern.compile("topic2"));
         final InternalTopologyBuilder.Source overlappingPattern = new InternalTopologyBuilder.Source("name", null, Pattern.compile("top*"));
 
-        assertThat(base, not(equalTo(differentPattern)));
-        assertThat(base, not(equalTo(overlappingPattern)));
+        assertNotEquals(differentPattern, base);
+        assertNotEquals(overlappingPattern, base);
     }
 
     @Test
@@ -1387,7 +1359,7 @@ public class InternalTopologyBuilderTest {
             mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "asdf")
         ))));
 
-        assertThat(builder.buildGlobalStateTopology().storeToChangelogTopic().get(globalStoreName), is(globalTopic));
+        assertEquals(globalTopic, builder.buildGlobalStateTopology().storeToChangelogTopic().get(globalStoreName));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
@@ -54,10 +54,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
@@ -127,9 +126,9 @@ public class KeyValueStoreMaterializerTest {
 
         final WrappedStateStore<?, ?, ?> caching = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
         final StateStore logging = caching.wrapped();
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStore.class));
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(logging, instanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class));
+        assertInstanceOf(MeteredTimestampedKeyValueStore.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class, logging);
     }
 
     @Test
@@ -141,7 +140,7 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStore<String, String> store = getTimestampedStore(materialized);
 
         final WrappedStateStore<?, ?, ?> logging = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(logging, instanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class));
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStore.class, logging);
     }
 
     @Test
@@ -153,8 +152,8 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStore<String, String> store = getTimestampedStore(materialized);
 
         final WrappedStateStore<?, ?, ?> caching = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(caching.wrapped(), not(instanceOf(ChangeLoggingKeyValueBytesStore.class)));
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertFalse(caching.wrapped() instanceof ChangeLoggingKeyValueBytesStore);
     }
 
     @Test
@@ -166,8 +165,8 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStore<String, String> store = getTimestampedStore(materialized);
 
         final StateStore wrapped = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(wrapped, not(instanceOf(CachingKeyValueStore.class)));
-        assertThat(wrapped, not(instanceOf(ChangeLoggingKeyValueBytesStore.class)));
+        assertFalse(wrapped instanceof CachingKeyValueStore);
+        assertFalse(wrapped instanceof ChangeLoggingKeyValueBytesStore);
     }
 
     @Test
@@ -179,10 +178,10 @@ public class KeyValueStoreMaterializerTest {
 
         final WrappedStateStore<?, ?, ?> caching = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
         final StateStore logging = caching.wrapped();
-        assertThat(innerKeyValueStore.name(), equalTo(store.name()));
-        assertThat(store, instanceOf(MeteredTimestampedKeyValueStoreWithHeaders.class));
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(logging, instanceOf(ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders.class));
+        assertEquals(innerKeyValueStore.name(), store.name());
+        assertInstanceOf(MeteredTimestampedKeyValueStoreWithHeaders.class, store);
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertInstanceOf(ChangeLoggingTimestampedKeyValueBytesStoreWithHeaders.class, logging);
     }
 
     @Test
@@ -193,8 +192,8 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStoreWithHeaders<String, String> store = getHeadersStore(materialized);
 
         final WrappedStateStore<?, ?, ?> logging = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(innerKeyValueStore.name(), equalTo(store.name()));
-        assertThat(logging, instanceOf(ChangeLoggingKeyValueBytesStore.class));
+        assertEquals(innerKeyValueStore.name(), store.name());
+        assertInstanceOf(ChangeLoggingKeyValueBytesStore.class, logging);
     }
 
     @Test
@@ -205,9 +204,9 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStoreWithHeaders<String, String> store = getHeadersStore(materialized);
 
         final WrappedStateStore<?, ?, ?> caching = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(innerKeyValueStore.name(), equalTo(store.name()));
-        assertThat(caching, instanceOf(CachingKeyValueStore.class));
-        assertThat(caching.wrapped(), not(instanceOf(ChangeLoggingKeyValueBytesStore.class)));
+        assertEquals(innerKeyValueStore.name(), store.name());
+        assertInstanceOf(CachingKeyValueStore.class, caching);
+        assertFalse(caching.wrapped() instanceof ChangeLoggingKeyValueBytesStore);
     }
 
     @Test
@@ -218,9 +217,9 @@ public class KeyValueStoreMaterializerTest {
         final TimestampedKeyValueStoreWithHeaders<String, String> store = getHeadersStore(materialized);
 
         final StateStore wrapped = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(innerKeyValueStore.name(), equalTo(store.name()));
-        assertThat(wrapped, not(instanceOf(CachingKeyValueStore.class)));
-        assertThat(wrapped, not(instanceOf(ChangeLoggingKeyValueBytesStore.class)));
+        assertEquals(innerKeyValueStore.name(), store.name());
+        assertFalse(wrapped instanceof CachingKeyValueStore);
+        assertFalse(wrapped instanceof ChangeLoggingKeyValueBytesStore);
     }
 
     @Test
@@ -233,10 +232,10 @@ public class KeyValueStoreMaterializerTest {
 
         final WrappedStateStore<?, ?, ?> logging = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
         final StateStore inner = logging.wrapped();
-        assertThat(innerVersionedStore.name(), equalTo(store.name()));
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
-        assertThat(logging, instanceOf(ChangeLoggingVersionedKeyValueBytesStore.class));
-        assertThat(innerVersionedStore, equalTo(inner));
+        assertEquals(innerVersionedStore.name(), store.name());
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
+        assertInstanceOf(ChangeLoggingVersionedKeyValueBytesStore.class, logging);
+        assertEquals(innerVersionedStore, inner);
     }
 
     @Test
@@ -248,9 +247,9 @@ public class KeyValueStoreMaterializerTest {
         final VersionedKeyValueStore<String, String> store = getVersionedStore(materialized);
 
         final StateStore inner = ((WrappedStateStore<?, ?, ?>) store).wrapped();
-        assertThat(innerVersionedStore.name(), equalTo(store.name()));
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
-        assertThat(innerVersionedStore, equalTo(inner));
+        assertEquals(innerVersionedStore.name(), store.name());
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
+        assertEquals(innerVersionedStore, inner);
     }
 
     @Test
@@ -263,10 +262,10 @@ public class KeyValueStoreMaterializerTest {
 
         final WrappedStateStore<?, ?, ?> logging = (WrappedStateStore<?, ?, ?>) ((WrappedStateStore<?, ?, ?>) store).wrapped();
         final StateStore inner = logging.wrapped();
-        assertThat(innerVersionedStore.name(), equalTo(store.name()));
-        assertThat(store, instanceOf(MeteredVersionedKeyValueStore.class));
-        assertThat(logging, instanceOf(ChangeLoggingVersionedKeyValueBytesStore.class));
-        assertThat(innerVersionedStore, equalTo(inner));
+        assertEquals(innerVersionedStore.name(), store.name());
+        assertInstanceOf(MeteredVersionedKeyValueStore.class, store);
+        assertInstanceOf(ChangeLoggingVersionedKeyValueBytesStore.class, logging);
+        assertEquals(innerVersionedStore, inner);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/NamedTopologyTest.java
@@ -40,8 +40,8 @@ import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("deprecation")
@@ -107,15 +107,15 @@ public class NamedTopologyTest {
         final NamedTopology topology2 = builder2.build();
         final NamedTopology topology3 = builder3.build();
         streams.start(asList(topology1, topology2, topology3));
-        assertThat(streams.getTopologyByName("topology-1").orElseThrow(), equalTo(topology1));
-        assertThat(streams.getTopologyByName("topology-2").orElseThrow(), equalTo(topology2));
-        assertThat(streams.getTopologyByName("topology-3").orElseThrow(), equalTo(topology3));
+        assertEquals(topology1, streams.getTopologyByName("topology-1").orElseThrow());
+        assertEquals(topology2, streams.getTopologyByName("topology-2").orElseThrow());
+        assertEquals(topology3, streams.getTopologyByName("topology-3").orElseThrow());
     }
 
     @Test
     public void shouldReturnEmptyWhenLookingUpNonExistentTopologyByName() {
         streams.start(builder1.build());
-        assertThat(streams.getTopologyByName("non-existent-topology").isPresent(), equalTo(false));
+        assertFalse(streams.getTopologyByName("non-existent-topology").isPresent());
     }
 
     @Test
@@ -164,7 +164,7 @@ public class NamedTopologyTest {
             () -> streams.addNamedTopology(builder2.build()).all().get()
         );
 
-        assertThat(exception.getCause().getClass(), equalTo(TopologyException.class));
+        assertEquals(TopologyException.class, exception.getCause().getClass());
     }
 
     @Test
@@ -179,7 +179,7 @@ public class NamedTopologyTest {
             () -> streams.addNamedTopology(builder2.build()).all().get()
         );
 
-        assertThat(exception.getCause().getClass(), equalTo(TopologyException.class));
+        assertEquals(TopologyException.class, exception.getCause().getClass());
     }
 
     @Test
@@ -319,23 +319,21 @@ public class NamedTopologyTest {
         builder1.stream("input").filter((k, v) -> !k.equals(v)).to("output");
         streams.start(builder1.build());
 
-        assertThat(
-            streams.getFullTopologyDescription(),
-            equalTo(
-                "Topology: topology-1:\n"
-                    + "   Sub-topology: 0\n"
-                    + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-1])\n"
-                    + "      --> none\n"
-                    + "\n"
-                    + "  Sub-topology: 1\n"
-                    + "    Source: KSTREAM-SOURCE-0000000001 (topics: [input])\n"
-                    + "      --> KSTREAM-FILTER-0000000002\n"
-                    + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
-                    + "      --> KSTREAM-SINK-0000000003\n"
-                    + "      <-- KSTREAM-SOURCE-0000000001\n"
-                    + "    Sink: KSTREAM-SINK-0000000003 (topic: output)\n"
-                    + "      <-- KSTREAM-FILTER-0000000002\n\n")
-        );
+        assertEquals(
+            "Topology: topology-1:\n"
+                + "   Sub-topology: 0\n"
+                + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-1])\n"
+                + "      --> none\n"
+                + "\n"
+                + "  Sub-topology: 1\n"
+                + "    Source: KSTREAM-SOURCE-0000000001 (topics: [input])\n"
+                + "      --> KSTREAM-FILTER-0000000002\n"
+                + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
+                + "      --> KSTREAM-SINK-0000000003\n"
+                + "      <-- KSTREAM-SOURCE-0000000001\n"
+                + "    Sink: KSTREAM-SINK-0000000003 (topic: output)\n"
+                + "      <-- KSTREAM-FILTER-0000000002\n\n",
+            streams.getFullTopologyDescription());
     }
 
     @Test
@@ -351,55 +349,53 @@ public class NamedTopologyTest {
                 builder3.build())
         );
 
-        assertThat(
-            streams.getFullTopologyDescription(),
-            equalTo(
-                     "Topology: topology-1:\n"
-                    + "   Sub-topology: 0\n"
-                    + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-1])\n"
-                    + "      --> none\n"
-                    + "\n"
-                    + "  Sub-topology: 1\n"
-                    + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-1])\n"
-                    + "      --> KSTREAM-FILTER-0000000002\n"
-                    + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
-                    + "      --> KSTREAM-SINK-0000000003\n"
-                    + "      <-- KSTREAM-SOURCE-0000000001\n"
-                    + "    Sink: KSTREAM-SINK-0000000003 (topic: output-1)\n"
-                    + "      <-- KSTREAM-FILTER-0000000002\n"
-                    + "\n"
-                    + "Topology: topology-2:\n"
-                    + "   Sub-topology: 0\n"
-                    + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-2])\n"
-                    + "      --> none\n"
-                    + "\n"
-                    + "  Sub-topology: 1\n"
-                    + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-2])\n"
-                    + "      --> KSTREAM-FILTER-0000000002\n"
-                    + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
-                    + "      --> KSTREAM-SINK-0000000003\n"
-                    + "      <-- KSTREAM-SOURCE-0000000001\n"
-                    + "    Sink: KSTREAM-SINK-0000000003 (topic: output-2)\n"
-                    + "      <-- KSTREAM-FILTER-0000000002\n"
-                    + "\n"
-                    + "Topology: topology-3:\n"
-                    + "   Sub-topology: 0\n"
-                    + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-3])\n"
-                    + "      --> none\n"
-                    + "\n"
-                    + "  Sub-topology: 1\n"
-                    + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-3])\n"
-                    + "      --> KSTREAM-FILTER-0000000002\n"
-                    + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
-                    + "      --> KSTREAM-SINK-0000000003\n"
-                    + "      <-- KSTREAM-SOURCE-0000000001\n"
-                    + "    Sink: KSTREAM-SINK-0000000003 (topic: output-3)\n"
-                    + "      <-- KSTREAM-FILTER-0000000002\n\n")
-        );
+        assertEquals(
+            "Topology: topology-1:\n"
+                + "   Sub-topology: 0\n"
+                + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-1])\n"
+                + "      --> none\n"
+                + "\n"
+                + "  Sub-topology: 1\n"
+                + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-1])\n"
+                + "      --> KSTREAM-FILTER-0000000002\n"
+                + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
+                + "      --> KSTREAM-SINK-0000000003\n"
+                + "      <-- KSTREAM-SOURCE-0000000001\n"
+                + "    Sink: KSTREAM-SINK-0000000003 (topic: output-1)\n"
+                + "      <-- KSTREAM-FILTER-0000000002\n"
+                + "\n"
+                + "Topology: topology-2:\n"
+                + "   Sub-topology: 0\n"
+                + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-2])\n"
+                + "      --> none\n"
+                + "\n"
+                + "  Sub-topology: 1\n"
+                + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-2])\n"
+                + "      --> KSTREAM-FILTER-0000000002\n"
+                + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
+                + "      --> KSTREAM-SINK-0000000003\n"
+                + "      <-- KSTREAM-SOURCE-0000000001\n"
+                + "    Sink: KSTREAM-SINK-0000000003 (topic: output-2)\n"
+                + "      <-- KSTREAM-FILTER-0000000002\n"
+                + "\n"
+                + "Topology: topology-3:\n"
+                + "   Sub-topology: 0\n"
+                + "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-3])\n"
+                + "      --> none\n"
+                + "\n"
+                + "  Sub-topology: 1\n"
+                + "    Source: KSTREAM-SOURCE-0000000001 (topics: [stream-3])\n"
+                + "      --> KSTREAM-FILTER-0000000002\n"
+                + "    Processor: KSTREAM-FILTER-0000000002 (stores: [])\n"
+                + "      --> KSTREAM-SINK-0000000003\n"
+                + "      <-- KSTREAM-SOURCE-0000000001\n"
+                + "    Sink: KSTREAM-SINK-0000000003 (topic: output-3)\n"
+                + "      <-- KSTREAM-FILTER-0000000002\n\n",
+            streams.getFullTopologyDescription());
     }
 
     @Test
     public void shouldDescribeWithEmptyNamedTopology() {
-        assertThat(streams.getFullTopologyDescription(), equalTo(""));
+        assertEquals("", streams.getFullTopologyDescription());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.MockTimestampExtractor;
 
 import org.apache.logging.log4j.Level;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -54,14 +53,9 @@ import java.util.UUID;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -150,7 +144,7 @@ public class PartitionGroupTest {
     private void testFirstBatch(final PartitionGroup group) {
         StampedRecord record;
         final PartitionGroup.RecordInfo info = new RecordInfo();
-        assertThat(group.numBuffered(), is(0));
+        assertEquals(0, group.numBuffered());
         assertNull(group.headRecordLeaderEpoch(partition1));
         assertNull(group.headRecordLeaderEpoch(partition2));
 
@@ -174,42 +168,42 @@ public class PartitionGroupTest {
         // st: -1 since no records was being processed yet
 
         verifyBuffered(6, 3, 3, group);
-        assertThat(group.partitionTimestamp(partition1), is(RecordQueue.UNKNOWN));
-        assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
-        assertThat(group.headRecordOffset(partition1), is(1L));
-        assertThat(group.headRecordOffset(partition2), is(2L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(0)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(1)));
-        assertThat(group.streamTime(), is(RecordQueue.UNKNOWN));
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition1));
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition2));
+        assertEquals(1L, group.headRecordOffset(partition1));
+        assertEquals(2L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(0), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(1), group.headRecordLeaderEpoch(partition2));
+        assertEquals(RecordQueue.UNKNOWN, group.streamTime());
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one record, now the time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[3, 5]
         // 2:[2, 4, 6]
         // st: 1
-        assertThat(info.partition(), equalTo(partition1));
-        assertThat(group.partitionTimestamp(partition1), is(1L));
-        assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
-        assertThat(group.headRecordOffset(partition1), is(3L));
-        assertThat(group.headRecordOffset(partition2), is(2L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(0)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(1)));
+        assertEquals(partition1, info.partition());
+        assertEquals(1L, group.partitionTimestamp(partition1));
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition2));
+        assertEquals(3L, group.headRecordOffset(partition1));
+        assertEquals(2L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(0), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(1), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 1L, 1L, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one record, now the time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[3, 5]
         // 2:[4, 6]
         // st: 2
-        assertThat(info.partition(), equalTo(partition2));
-        assertThat(group.partitionTimestamp(partition1), is(1L));
-        assertThat(group.partitionTimestamp(partition2), is(2L));
-        assertThat(group.headRecordOffset(partition1), is(3L));
-        assertThat(group.headRecordOffset(partition2), is(4L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(0)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(partition2, info.partition());
+        assertEquals(1L, group.partitionTimestamp(partition1));
+        assertEquals(2L, group.partitionTimestamp(partition2));
+        assertEquals(3L, group.headRecordOffset(partition1));
+        assertEquals(4L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(0), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 2L, 2L, group);
         verifyBuffered(4, 2, 2, group);
         assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
@@ -229,110 +223,110 @@ public class PartitionGroupTest {
         // 2:[4, 6]
         // st: 2 (just adding records shouldn't change it)
         verifyBuffered(6, 4, 2, group);
-        assertThat(group.partitionTimestamp(partition1), is(1L));
-        assertThat(group.partitionTimestamp(partition2), is(2L));
-        assertThat(group.headRecordOffset(partition1), is(3L));
-        assertThat(group.headRecordOffset(partition2), is(4L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(0)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
-        assertThat(group.streamTime(), is(2L));
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(1L, group.partitionTimestamp(partition1));
+        assertEquals(2L, group.partitionTimestamp(partition2));
+        assertEquals(3L, group.headRecordOffset(partition1));
+        assertEquals(4L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(0), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
+        assertEquals(2L, group.streamTime());
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one record, time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[5, 2, 4]
         // 2:[4, 6]
         // st: 3
-        assertThat(info.partition(), equalTo(partition1));
-        assertThat(group.partitionTimestamp(partition1), is(3L));
-        assertThat(group.partitionTimestamp(partition2), is(2L));
-        assertThat(group.headRecordOffset(partition1), is(5L));
-        assertThat(group.headRecordOffset(partition2), is(4L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(2)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(partition1, info.partition());
+        assertEquals(3L, group.partitionTimestamp(partition1));
+        assertEquals(2L, group.partitionTimestamp(partition2));
+        assertEquals(5L, group.headRecordOffset(partition1));
+        assertEquals(4L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(2), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 3L, 3L, group);
         verifyBuffered(5, 3, 2, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one record, time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[5, 2, 4]
         // 2:[6]
         // st: 4
-        assertThat(info.partition(), equalTo(partition2));
-        assertThat(group.partitionTimestamp(partition1), is(3L));
-        assertThat(group.partitionTimestamp(partition2), is(4L));
-        assertThat(group.headRecordOffset(partition1), is(5L));
-        assertThat(group.headRecordOffset(partition2), is(6L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(2)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(partition2, info.partition());
+        assertEquals(3L, group.partitionTimestamp(partition1));
+        assertEquals(4L, group.partitionTimestamp(partition2));
+        assertEquals(5L, group.headRecordOffset(partition1));
+        assertEquals(6L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(2), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 4L, 4L, group);
         verifyBuffered(4, 3, 1, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one more record, time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[2, 4]
         // 2:[6]
         // st: 5
-        assertThat(info.partition(), equalTo(partition1));
-        assertThat(group.partitionTimestamp(partition1), is(5L));
-        assertThat(group.partitionTimestamp(partition2), is(4L));
-        assertThat(group.headRecordOffset(partition1), is(2L));
-        assertThat(group.headRecordOffset(partition2), is(6L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(5)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(partition1, info.partition());
+        assertEquals(5L, group.partitionTimestamp(partition1));
+        assertEquals(4L, group.partitionTimestamp(partition2));
+        assertEquals(2L, group.headRecordOffset(partition1));
+        assertEquals(6L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(5), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 5L, 5L, group);
         verifyBuffered(3, 2, 1, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one more record, time should not be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[4]
         // 2:[6]
         // st: 5
-        assertThat(info.partition(), equalTo(partition1));
-        assertThat(group.partitionTimestamp(partition1), is(5L));
-        assertThat(group.partitionTimestamp(partition2), is(4L));
-        assertThat(group.headRecordOffset(partition1), is(4L));
-        assertThat(group.headRecordOffset(partition2), is(6L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(Optional.of(6)));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(partition1, info.partition());
+        assertEquals(5L, group.partitionTimestamp(partition1));
+        assertEquals(4L, group.partitionTimestamp(partition2));
+        assertEquals(4L, group.headRecordOffset(partition1));
+        assertEquals(6L, group.headRecordOffset(partition2));
+        assertEquals(Optional.of(6), group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 2L, 5L, group);
         verifyBuffered(2, 1, 1, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(3.0));
+        assertEquals(3.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one more record, time should not be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[]
         // 2:[6]
         // st: 5
-        assertThat(info.partition(), equalTo(partition1));
-        assertThat(group.partitionTimestamp(partition1), is(5L));
-        assertThat(group.partitionTimestamp(partition2), is(4L));
+        assertEquals(partition1, info.partition());
+        assertEquals(5L, group.partitionTimestamp(partition1));
+        assertEquals(4L, group.partitionTimestamp(partition2));
         assertNull(group.headRecordOffset(partition1));
-        assertThat(group.headRecordOffset(partition2), is(6L));
-        assertThat(group.headRecordLeaderEpoch(partition1), is(nullValue()));
-        assertThat(group.headRecordLeaderEpoch(partition2), is(Optional.of(4)));
+        assertEquals(6L, group.headRecordOffset(partition2));
+        assertNull(group.headRecordLeaderEpoch(partition1));
+        assertEquals(Optional.of(4), group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 4L, 5L, group);
         verifyBuffered(1, 0, 1, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(1.0));
+        assertEquals(1.0, metrics.metric(lastLatenessValue).metricValue());
 
         // get one more record, time should be advanced
         record = group.nextRecord(info, time.milliseconds());
         // 1:[]
         // 2:[]
         // st: 6
-        assertThat(info.partition(), equalTo(partition2));
-        assertThat(group.partitionTimestamp(partition1), is(5L));
-        assertThat(group.partitionTimestamp(partition2), is(6L));
+        assertEquals(partition2, info.partition());
+        assertEquals(5L, group.partitionTimestamp(partition1));
+        assertEquals(6L, group.partitionTimestamp(partition2));
         assertNull(group.headRecordOffset(partition1));
         assertNull(group.headRecordOffset(partition2));
         assertNull(group.headRecordLeaderEpoch(partition1));
         assertNull(group.headRecordLeaderEpoch(partition2));
         verifyTimes(record, 6L, 6L, group);
         verifyBuffered(0, 0, 0, group);
-        assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
+        assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
     }
 
     @Test
@@ -389,8 +383,8 @@ public class PartitionGroupTest {
                              final long recordTime,
                              final long streamTime,
                              final PartitionGroup group) {
-        assertThat(record.timestamp, is(recordTime));
-        assertThat(group.streamTime(), is(streamTime));
+        assertEquals(recordTime, record.timestamp);
+        assertEquals(streamTime, group.streamTime());
     }
 
     private void verifyBuffered(final int totalBuffered,
@@ -421,7 +415,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.addRawRecords(unknownPartition, null));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -431,7 +425,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.numBuffered(unknownPartition));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -441,7 +435,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.setPartitionTime(unknownPartition, 0L));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -451,7 +445,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.partitionTimestamp(unknownPartition));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -461,7 +455,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.headRecordOffset(unknownPartition));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -471,7 +465,7 @@ public class PartitionGroupTest {
         final IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
                 () -> group.headRecordLeaderEpoch(unknownPartition));
-        assertThat(errMessage, equalTo(exception.getMessage()));
+        assertEquals(errMessage, exception.getMessage());
     }
 
     @Test
@@ -500,10 +494,10 @@ public class PartitionGroupTest {
 
         group.clear();
 
-        assertThat(group.numBuffered(), equalTo(0));
-        assertThat(group.streamTime(), equalTo(RecordQueue.UNKNOWN));
-        assertThat(group.nextRecord(new RecordInfo(), time.milliseconds()), equalTo(null));
-        assertThat(group.partitionTimestamp(partition1), equalTo(RecordQueue.UNKNOWN));
+        assertEquals(0, group.numBuffered());
+        assertEquals(RecordQueue.UNKNOWN, group.streamTime());
+        assertNull(group.nextRecord(new RecordInfo(), time.milliseconds()));
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition1));
         hasNoFetchedLag(group, partition1);
 
         group.addRawRecords(partition1, list);
@@ -536,8 +530,8 @@ public class PartitionGroupTest {
         assertEquals(list2.size(), group.numBuffered());
         assertEquals(1, group.streamTime());
         assertThrows(IllegalStateException.class, () -> group.partitionTimestamp(partition1));
-        assertThat(group.nextRecord(new RecordInfo(), time.milliseconds()), notNullValue());  // can access buffered records
-        assertThat(group.partitionTimestamp(partition2), equalTo(2L));
+        assertNotNull(group.nextRecord(new RecordInfo(), time.milliseconds()));  // can access buffered records
+        assertEquals(2L, group.partitionTimestamp(partition2));
     }
 
     @Test
@@ -568,9 +562,9 @@ public class PartitionGroupTest {
         assertFalse(group.allPartitionsBufferedLocally());  // because added new partition
         assertEquals(1, group.numBuffered());
         assertEquals(1, group.streamTime());
-        assertThat(group.partitionTimestamp(partition1), equalTo(1L));
-        assertThat(group.partitionTimestamp(partition2), equalTo(RecordQueue.UNKNOWN));
-        assertThat(group.nextRecord(new RecordInfo(), time.milliseconds()), notNullValue());  // can access buffered records
+        assertEquals(1L, group.partitionTimestamp(partition1));
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition2));
+        assertNotNull(group.nextRecord(new RecordInfo(), time.milliseconds()));  // can access buffered records
     }
 
     @Test
@@ -601,8 +595,8 @@ public class PartitionGroupTest {
         assertEquals(0, group.numBuffered());
         assertEquals(1, group.streamTime());
         assertThrows(IllegalStateException.class, () -> group.partitionTimestamp(partition1));
-        assertThat(group.partitionTimestamp(partition2), equalTo(RecordQueue.UNKNOWN));
-        assertThat(group.nextRecord(new RecordInfo(), time.milliseconds()), nullValue());  // all available records removed
+        assertEquals(RecordQueue.UNKNOWN, group.partitionTimestamp(partition2));
+        assertNull(group.nextRecord(new RecordInfo(), time.milliseconds()));  // all available records removed
     }
 
     @Test
@@ -706,24 +700,17 @@ public class PartitionGroupTest {
             new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
 
-        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        assertFalse(group.allPartitionsBufferedLocally());
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
             appender.setClassLogger(PartitionGroup.class, Level.TRACE);
             final AbstractPartitionGroup.ReadyToProcessResult result = group.readyToProcess(0L);
             assertTrue(result.isReady());
             assertTrue(result.getLogMessage().isEmpty());
-            assertThat(
-                appender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("TRACE")),
-                    Matchers.hasProperty("message", equalTo(
-                        "[test] Ready for processing because max.task.idle.ms is disabled.\n" +
-                            "\tThere may be out-of-order processing for this task as a result.\n" +
-                            "\tBuffered partitions: [topic-1]\n" +
-                            "\tNon-buffered partitions: [topic-2]"
-                    ))
-                ))
-            );
+            assertTrue(appender.getMessages("TRACE").contains(
+                "[test] Ready for processing because max.task.idle.ms is disabled.\n" +
+                    "\tThere may be out-of-order processing for this task as a result.\n" +
+                    "\tBuffered partitions: [topic-1]\n" +
+                    "\tNon-buffered partitions: [topic-2]"));
         }
     }
 
@@ -751,20 +738,15 @@ public class PartitionGroupTest {
             new ConsumerRecord<>("topic", 2, 5L, recordKey, recordValue));
         group.addRawRecords(partition2, list2);
 
-        assertThat(group.allPartitionsBufferedLocally(), is(true));
+        assertTrue(group.allPartitionsBufferedLocally());
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
             appender.setClassLogger(PartitionGroup.class, Level.TRACE);
             final AbstractPartitionGroup.ReadyToProcessResult result = group.readyToProcess(0L);
             assertTrue(result.isReady());
             assertTrue(result.getLogMessage().isEmpty());
-            assertThat(
-                appender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("TRACE")),
-                    Matchers.hasProperty("message", equalTo("[test] All partitions were buffered locally, so this task is ready for processing."))
-                ))
-            );
+            assertTrue(appender.getMessages("TRACE").contains(
+                "[test] All partitions were buffered locally, so this task is ready for processing."));
         }
     }
 
@@ -788,7 +770,7 @@ public class PartitionGroupTest {
             new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
 
-        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        assertFalse(group.allPartitionsBufferedLocally());
         final AbstractPartitionGroup.ReadyToProcessResult result = group.readyToProcess(0L);
         assertFalse(result.isReady());
         assertTrue(result.getLogMessage().isPresent() &&
@@ -821,7 +803,7 @@ public class PartitionGroupTest {
         lags.put(partition2, OptionalLong.of(1L));
         group.updateLags();
 
-        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        assertFalse(group.allPartitionsBufferedLocally());
 
         final AbstractPartitionGroup.ReadyToProcessResult result = group.readyToProcess(0L);
         assertFalse(result.isReady());
@@ -849,7 +831,7 @@ public class PartitionGroupTest {
             new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
 
-        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        assertFalse(group.allPartitionsBufferedLocally());
 
         final AbstractPartitionGroup.ReadyToProcessResult result1 = group.readyToProcess(0L);
         assertFalse(result1.isReady());
@@ -861,20 +843,13 @@ public class PartitionGroupTest {
             final AbstractPartitionGroup.ReadyToProcessResult result2 = group.readyToProcess(1L);
             assertTrue(result2.isReady());
             assertTrue(result2.getLogMessage().isEmpty());
-            assertThat(
-                appender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("TRACE")),
-                    Matchers.hasProperty("message", equalTo(
-                        "[test] Continuing to process although some partitions are empty on the broker.\n" +
-                            "\tThere may be out-of-order processing for this task as a result.\n" +
-                            "\tPartitions with local data: [topic-1].\n" +
-                            "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
-                            "\tConfigured max.task.idle.ms: 1.\n" +
-                            "\tCurrent wall-clock time: 1."
-                    ))
-                ))
-            );
+            assertTrue(appender.getMessages("TRACE").contains(
+                "[test] Continuing to process although some partitions are empty on the broker.\n" +
+                    "\tThere may be out-of-order processing for this task as a result.\n" +
+                    "\tPartitions with local data: [topic-1].\n" +
+                    "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
+                    "\tConfigured max.task.idle.ms: 1.\n" +
+                    "\tCurrent wall-clock time: 1."));
         }
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
@@ -882,20 +857,13 @@ public class PartitionGroupTest {
             final AbstractPartitionGroup.ReadyToProcessResult result3 = group.readyToProcess(2L);
             assertTrue(result3.isReady());
             assertTrue(result3.getLogMessage().isEmpty());
-            assertThat(
-                appender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("TRACE")),
-                    Matchers.hasProperty("message", equalTo(
-                        "[test] Continuing to process although some partitions are empty on the broker.\n" +
-                            "\tThere may be out-of-order processing for this task as a result.\n" +
-                            "\tPartitions with local data: [topic-1].\n" +
-                            "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
-                            "\tConfigured max.task.idle.ms: 1.\n" +
-                            "\tCurrent wall-clock time: 2."
-                    ))
-                ))
-            );
+            assertTrue(appender.getMessages("TRACE").contains(
+                "[test] Continuing to process although some partitions are empty on the broker.\n" +
+                    "\tThere may be out-of-order processing for this task as a result.\n" +
+                    "\tPartitions with local data: [topic-1].\n" +
+                    "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
+                    "\tConfigured max.task.idle.ms: 1.\n" +
+                    "\tCurrent wall-clock time: 2."));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextTest.java
@@ -29,9 +29,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -60,21 +59,17 @@ public class ProcessorContextTest {
 
     @Test
     public void shouldNotAllowToScheduleZeroMillisecondPunctuation() {
-        try {
-            context.schedule(Duration.ofMillis(0L), null, null);
-            fail("Should have thrown IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            assertThat(expected.getMessage(), equalTo("The minimum supported scheduling interval is 1 millisecond."));
-        }
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> context.schedule(Duration.ofMillis(0L), null, null),
+            "Should have thrown IllegalArgumentException");
+        assertEquals("The minimum supported scheduling interval is 1 millisecond.", exception.getMessage());
     }
 
     @Test
     public void shouldNotAllowToScheduleSubMillisecondPunctuation() {
-        try {
-            context.schedule(Duration.ofNanos(999_999L), null, null);
-            fail("Should have thrown IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            assertThat(expected.getMessage(), equalTo("The minimum supported scheduling interval is 1 millisecond."));
-        }
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> context.schedule(Duration.ofNanos(999_999L), null, null),
+            "Should have thrown IllegalArgumentException");
+        assertEquals("The minimum supported scheduling interval is 1 millisecond.", exception.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorMetadataTest.java
@@ -25,11 +25,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,10 +42,10 @@ public class ProcessorMetadataTest {
         metadata.put(key, value);
         final Long actualValue =  metadata.get(key);
 
-        assertThat(actualValue, is(value));
+        assertEquals(value, actualValue);
 
         final Long noValue = metadata.get("no_key");
-        assertThat(noValue, is(nullValue()));
+        assertNull(noValue);
     }
 
     @Test
@@ -59,17 +57,17 @@ public class ProcessorMetadataTest {
         final ProcessorMetadata metadata = new ProcessorMetadata(map);
 
         final long value1 = metadata.get("key1");
-        assertThat(value1, is(1L));
+        assertEquals(1L, value1);
 
         final long value2 = metadata.get("key2");
-        assertThat(value2, is(2L));
+        assertEquals(2L, value2);
 
         final Long noValue = metadata.get("key3");
-        assertThat(noValue, is(nullValue()));
+        assertNull(noValue);
 
         metadata.put("key3", 3L);
         final long value3 = metadata.get("key3");
-        assertThat(value3, is(3L));
+        assertEquals(3L, value3);
     }
 
     @Test
@@ -85,15 +83,15 @@ public class ProcessorMetadataTest {
         final byte[] serialized = metadata.serialize();
         final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(serialized);
 
-        assertThat(deserialized.get(key1), is(value1));
-        assertThat(deserialized.get(key2), is(value2));
-        assertThat(deserialized.get(key3), is(value3));
+        assertEquals(value1, deserialized.get(key1));
+        assertEquals(value2, deserialized.get(key2));
+        assertEquals(value3, deserialized.get(key3));
     }
 
     @Test
     public void shouldDeserializeNull() {
         final ProcessorMetadata deserialized = ProcessorMetadata.deserialize(null);
-        assertThat(deserialized, is(new ProcessorMetadata()));
+        assertEquals(new ProcessorMetadata(), deserialized);
     }
 
     @Test
@@ -101,7 +99,7 @@ public class ProcessorMetadataTest {
         final ProcessorMetadata emptyMeta = new ProcessorMetadata();
         emptyMeta.update(null);
 
-        assertThat(emptyMeta, is(new ProcessorMetadata()));
+        assertEquals(new ProcessorMetadata(), emptyMeta);
 
         {
             final Map<String, Long> map1 = new HashMap<>();
@@ -109,8 +107,8 @@ public class ProcessorMetadataTest {
             map1.put("key2", 2L);
             final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.get("key1"), is(1L));
-            assertThat(emptyMeta.get("key2"), is(2L));
+            assertEquals(1L, emptyMeta.get("key1"));
+            assertEquals(2L, emptyMeta.get("key2"));
         }
 
         {
@@ -119,8 +117,8 @@ public class ProcessorMetadataTest {
             map1.put("key2", 1L);
             final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.get("key1"), is(1L));
-            assertThat(emptyMeta.get("key2"), is(2L));
+            assertEquals(1L, emptyMeta.get("key1"));
+            assertEquals(2L, emptyMeta.get("key2"));
         }
 
         {
@@ -129,8 +127,8 @@ public class ProcessorMetadataTest {
             map1.put("key2", 3L);
             final ProcessorMetadata metadata1 = new ProcessorMetadata(map1);
             emptyMeta.update(metadata1);
-            assertThat(emptyMeta.get("key1"), is(2L));
-            assertThat(emptyMeta.get("key2"), is(3L));
+            assertEquals(2L, emptyMeta.get("key1"));
+            assertEquals(3L, emptyMeta.get("key2"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -76,19 +76,13 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -163,10 +157,7 @@ public class ProcessorStateManagerTest {
         final String applicationId = "appId";
         final String storeName = "store";
 
-        assertThat(
-            ProcessorStateManager.storeChangelogTopic(applicationId, storeName, null),
-            is(applicationId + "-" + storeName + "-changelog")
-        );
+        assertEquals(applicationId + "-" + storeName + "-changelog", ProcessorStateManager.storeChangelogTopic(applicationId, storeName, null));
     }
 
     @Test
@@ -175,10 +166,9 @@ public class ProcessorStateManagerTest {
         final String namedTopology = "namedTopology";
         final String storeName = "store";
 
-        assertThat(
-            ProcessorStateManager.storeChangelogTopic(applicationId, storeName, namedTopology),
-            is(applicationId + "-" + namedTopology + "-" + storeName + "-changelog")
-        );
+        assertEquals(
+            applicationId + "-" + namedTopology + "-" + storeName + "-changelog",
+            ProcessorStateManager.storeChangelogTopic(applicationId, storeName, namedTopology));
     }
 
     @Test
@@ -256,11 +246,11 @@ public class ProcessorStateManagerTest {
         try {
             stateMgr.registerStore(persistentStore, restoreCallback, null);
             final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
-            assertThat(storeMetadata, notNullValue());
+            assertNotNull(storeMetadata);
 
             stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
 
-            assertThat(restoreCallback.restored.size(), is(1));
+            assertEquals(1, restoreCallback.restored.size());
             assertTrue(restoreCallback.restored.contains(expectedKeyValue));
 
             assertEquals(Collections.singletonMap(persistentStorePartition, 101L), stateMgr.changelogOffsets());
@@ -276,11 +266,11 @@ public class ProcessorStateManagerTest {
         try {
             stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback, null);
             final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
-            assertThat(storeMetadata, notNullValue());
+            assertNotNull(storeMetadata);
 
             stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
 
-            assertThat(persistentStore.keys.size(), is(1));
+            assertEquals(1, persistentStore.keys.size());
             assertTrue(persistentStore.keys.contains(key));
             // we just check non timestamped value length
             assertEquals(9, persistentStore.values.get(0).length);
@@ -297,11 +287,11 @@ public class ProcessorStateManagerTest {
         try {
             stateMgr.registerStore(store, store.stateRestoreCallback, null);
             final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
-            assertThat(storeMetadata, notNullValue());
+            assertNotNull(storeMetadata);
 
             stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
 
-            assertThat(store.keys.size(), is(1));
+            assertEquals(1, store.keys.size());
             assertTrue(store.keys.contains(key));
             // we just check timestamped value length
             assertEquals(17, store.values.get(0).length);
@@ -339,11 +329,11 @@ public class ProcessorStateManagerTest {
         final File taskDir = stateDirectory.getOrCreateDirectoryForTask(taskId);
         final long staleTime = time.milliseconds() - 60_000L;
         assertTrue(taskDir.setLastModified(staleTime));
-        assertThat(taskDir.lastModified(), is(staleTime));
+        assertEquals(staleTime, taskDir.lastModified());
 
         stateMgr.close();
 
-        assertThat(taskDir.lastModified(), is(time.milliseconds()));
+        assertEquals(time.milliseconds(), taskDir.lastModified());
     }
 
     @Test
@@ -368,7 +358,7 @@ public class ProcessorStateManagerTest {
 
         stateMgr.close();
 
-        assertThat(taskDir.lastModified(), is(staleTime));
+        assertEquals(staleTime, taskDir.lastModified());
     }
 
     @Test
@@ -384,7 +374,7 @@ public class ProcessorStateManagerTest {
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
 
         stateMgr.recycle();
-        assertThat(stateMgr.store(persistentStoreName), equalTo(store));
+        assertEquals(store, stateMgr.store(persistentStoreName));
 
         stateMgr.registerStateStores(singletonList(store), context);
 
@@ -403,10 +393,10 @@ public class ProcessorStateManagerTest {
         verify(store).init(context, store);
 
         stateMgr.registerStore(store, noopStateRestoreCallback, null);
-        assertThat(stateMgr.store(persistentStoreName), equalTo(store));
+        assertEquals(store, stateMgr.store(persistentStoreName));
 
         stateMgr.recycle();
-        assertThat(stateMgr.store(persistentStoreName), equalTo(store));
+        assertEquals(store, stateMgr.store(persistentStoreName));
 
         verify(store).clearCache();
     }
@@ -460,7 +450,7 @@ public class ProcessorStateManagerTest {
             stateMgr.registerStateStores(singletonList(unloggedStore), context);
 
             assertTrue(unloggedStore.initialized);
-            assertThat(stateMgr.store(unloggedStoreName), is(unloggedStore));
+            assertEquals(unloggedStore, stateMgr.store(unloggedStoreName));
             assertTrue(stateMgr.changelogPartitions().isEmpty());
         } finally {
             stateMgr.close();
@@ -499,7 +489,7 @@ public class ProcessorStateManagerTest {
 
             assertNull(stateMgr.storeMetadata(irrelevantPartition));
             assertNull(stateMgr.storeMetadata(persistentStoreTwoPartition).offset());
-            assertThat(stateMgr.storeMetadata(persistentStorePartition).offset(), equalTo(checkpointOffset));
+            assertEquals(checkpointOffset, stateMgr.storeMetadata(persistentStorePartition).offset());
             assertNull(stateMgr.storeMetadata(nonPersistentStorePartition).offset());
         } finally {
             stateMgr.close();
@@ -539,7 +529,7 @@ public class ProcessorStateManagerTest {
 
             assertNull(stateMgr.storeMetadata(irrelevantPartition));
             assertNull(stateMgr.storeMetadata(persistentStoreTwoPartition).offset());
-            assertThat(stateMgr.storeMetadata(persistentStorePartition).offset(), equalTo(checkpointOffset));
+            assertEquals(checkpointOffset, stateMgr.storeMetadata(persistentStorePartition).offset());
             assertNull(stateMgr.storeMetadata(nonPersistentStorePartition).offset());
         } finally {
             stateMgr.close();
@@ -560,15 +550,17 @@ public class ProcessorStateManagerTest {
 
             // the shared sums outlive this task, so they must only count state that outlives it too (KAFKA-20893);
             // the in-memory store's 201 is reported from the live task by TaskManager instead
-            assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 101L))));
-            assertThat(stateMgr.changelogOffsets(), is(mkMap(
-                mkEntry(persistentStorePartition, 101L),
-                mkEntry(nonPersistentStorePartition, 201L))));
+            assertEquals(Map.of(taskId, 101L), stateDirectory.taskOffsetSums());
+            assertEquals(
+                Map.of(
+                    persistentStorePartition, 101L,
+                    nonPersistentStorePartition, 201L),
+                stateMgr.changelogOffsets());
         } finally {
             stateMgr.close();
         }
 
-        assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 101L))));
+        assertEquals(Map.of(taskId, 101L), stateDirectory.taskOffsetSums());
     }
 
     @Test
@@ -581,12 +573,12 @@ public class ProcessorStateManagerTest {
             stateMgr.initializeStoreOffsets(true);
             stateMgr.updateChangelogOffsets(Collections.singletonMap(nonPersistentStorePartition, 200L));
 
-            assertThat(stateDirectory.taskOffsetSums(), is(Collections.emptyMap()));
+            assertTrue(stateDirectory.taskOffsetSums().isEmpty());
         } finally {
             stateMgr.close();
         }
 
-        assertThat(stateDirectory.taskOffsetSums(), is(Collections.emptyMap()));
+        assertTrue(stateDirectory.taskOffsetSums().isEmpty());
     }
 
     @Test
@@ -601,12 +593,12 @@ public class ProcessorStateManagerTest {
                 mkEntry(persistentStorePartition, 100L),
                 mkEntry(persistentStoreTwoPartition, 200L)));
 
-            assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 302L))));
+            assertEquals(Map.of(taskId, 302L), stateDirectory.taskOffsetSums());
         } finally {
             stateMgr.close();
         }
 
-        assertThat(stateDirectory.taskOffsetSums(), is(mkMap(mkEntry(taskId, 302L))));
+        assertEquals(Map.of(taskId, 302L), stateDirectory.taskOffsetSums());
     }
 
     @Test
@@ -631,8 +623,8 @@ public class ProcessorStateManagerTest {
 
         final TopicPartition changelogPartition = stateMgr.registeredChangelogPartitionFor(persistentStoreName);
 
-        assertThat(changelogPartition.topic(), is(persistentStoreTopicName));
-        assertThat(changelogPartition.partition(), is(taskId.partition()));
+        assertEquals(persistentStoreTopicName, changelogPartition.topic());
+        assertEquals(taskId.partition(), changelogPartition.partition());
     }
 
     @Test
@@ -688,7 +680,7 @@ public class ProcessorStateManagerTest {
             assertTrue(nonPersistentStore.committed);
 
             // make sure that flush is called in the proper order
-            assertThat(persistentStore.getLastCommitCount(), lessThan(nonPersistentStore.getLastCommitCount()));
+            assertTrue(persistentStore.getLastCommitCount() < nonPersistentStore.getLastCommitCount());
 
             stateMgr.updateChangelogOffsets(ackedOffsets);
             stateMgr.commit();
@@ -698,7 +690,7 @@ public class ProcessorStateManagerTest {
             // the checkpoint file should contain an offset from the persistent store only.
             final OffsetCheckpoint storeCheckpoint = new OffsetCheckpoint(storeCheckpointFile);
             final Map<TopicPartition, Long> checkpointedOffsets = storeCheckpoint.read();
-            assertThat(checkpointedOffsets, is(singletonMap(new TopicPartition(persistentStoreTopicName, 1), 25_000L)));
+            assertEquals(Map.of(new TopicPartition(persistentStoreTopicName, 1), 25_000L), checkpointedOffsets);
 
             stateMgr.close();
 
@@ -733,7 +725,7 @@ public class ProcessorStateManagerTest {
             assertTrue(nonPersistentStore.committed);
 
             // make sure that flush is called in the proper order
-            assertThat(persistentStore.getLastCommitCount(), lessThan(nonPersistentStore.getLastCommitCount()));
+            assertTrue(persistentStore.getLastCommitCount() < nonPersistentStore.getLastCommitCount());
 
             stateMgr.updateChangelogOffsets(ackedOffsets);
             stateMgr.commit();
@@ -746,7 +738,7 @@ public class ProcessorStateManagerTest {
             // the checkpoint file should contain an offset from the persistent store only.
             final OffsetCheckpoint storeCheckpoint = new OffsetCheckpoint(storeCheckpointFile);
             final Map<TopicPartition, Long> checkpointedOffsets = storeCheckpoint.read();
-            assertThat(checkpointedOffsets, is(singletonMap(new TopicPartition(persistentStoreTopicName, 1), -4L)));
+            assertEquals(Map.of(new TopicPartition(persistentStoreTopicName, 1), -4L), checkpointedOffsets);
 
             try {
                 // Reopen to verify null committed offset
@@ -770,12 +762,12 @@ public class ProcessorStateManagerTest {
             stateMgr.initializeStoreOffsets(true);
 
             final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
-            assertThat(storeMetadata, notNullValue());
-            assertThat(storeMetadata.offset(), equalTo(99L));
+            assertNotNull(storeMetadata);
+            assertEquals(99L, storeMetadata.offset());
 
             stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
 
-            assertThat(storeMetadata.offset(), equalTo(100L));
+            assertEquals(100L, storeMetadata.offset());
 
             // should ignore irrelevant topic partitions
             stateMgr.updateChangelogOffsets(mkMap(
@@ -784,8 +776,8 @@ public class ProcessorStateManagerTest {
             ));
             stateMgr.commit();
 
-            assertThat(stateMgr.storeMetadata(irrelevantPartition), equalTo(null));
-            assertThat(storeMetadata.offset(), equalTo(220L));
+            assertNull(stateMgr.storeMetadata(irrelevantPartition));
+            assertEquals(220L, storeMetadata.offset());
         } finally {
             stateMgr.close();
         }
@@ -811,7 +803,7 @@ public class ProcessorStateManagerTest {
             stateMgr.commit();
 
             final Map<TopicPartition, Long> read = checkpoint.read();
-            assertThat(read, equalTo(emptyMap()));
+            assertTrue(read.isEmpty());
         } finally {
             stateMgr.close();
         }
@@ -1004,13 +996,10 @@ public class ProcessorStateManagerTest {
         writer.write("abcdefg");
         writer.close();
 
-        try {
+        assertThrows(ProcessorStateException.class, () -> {
             stateMgr.registerStateStores(Collections.singletonList(persistentStore), context);
             stateMgr.initializeStoreOffsets(true);
-            fail("should have thrown processor state exception when IO exception happens");
-        } catch (final ProcessorStateException e) {
-            // pass
-        }
+        }, "should have thrown processor state exception when IO exception happens");
     }
 
     @Test
@@ -1027,12 +1016,9 @@ public class ProcessorStateManagerTest {
 
         final StateStoreMetadata storeMetadata = stateMgr.storeMetadata(persistentStorePartition);
 
-        try {
-            stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L));
-            fail("should have thrown processor state exception when IO exception happens");
-        } catch (final ProcessorStateException e) {
-            // pass
-        }
+        assertThrows(ProcessorStateException.class,
+            () -> stateMgr.restore(storeMetadata, singletonList(consumerRecord), OptionalLong.of(2L)),
+            "should have thrown processor state exception when IO exception happens");
     }
 
     @Test
@@ -1152,8 +1138,8 @@ public class ProcessorStateManagerTest {
             stateMgr.registerStateStores(Arrays.asList(persistentStore, nonPersistentStore), context);
             stateMgr.initializeStoreOffsets(true);
 
-            assertThat(stateMgr.storeMetadata(nonPersistentStorePartition), notNullValue());
-            assertThat(stateMgr.storeMetadata(persistentStorePartition), notNullValue());
+            assertNotNull(stateMgr.storeMetadata(nonPersistentStorePartition));
+            assertNotNull(stateMgr.storeMetadata(persistentStorePartition));
 
             stateMgr.updateChangelogOffsets(mkMap(
                 mkEntry(nonPersistentStorePartition, 876L),
@@ -1171,8 +1157,8 @@ public class ProcessorStateManagerTest {
 
             // This should not throw a TaskCorruptedException!
             stateMgr.initializeStoreOffsets(false);
-            assertThat(stateMgr.storeMetadata(nonPersistentStorePartition), notNullValue());
-            assertThat(stateMgr.storeMetadata(persistentStorePartition), notNullValue());
+            assertNotNull(stateMgr.storeMetadata(nonPersistentStorePartition));
+            assertNotNull(stateMgr.storeMetadata(persistentStorePartition));
         } finally {
             stateMgr.close();
         }
@@ -1225,10 +1211,7 @@ public class ProcessorStateManagerTest {
         // the checkpoint file should contain an offset from the persistent store only.
         final Map<TopicPartition, Long> persistentOffsets = persistentCheckpoint.getOffsetCheckpoint()
                                                                                 .read();
-        assertThat(
-            persistentOffsets,
-            is(singletonMap(new TopicPartition(persistentStoreTopicName, 1), 123L))
-        );
+        assertEquals(Map.of(new TopicPartition(persistentStoreTopicName, 1), 123L), persistentOffsets);
 
         assertEquals(
             persistentCheckpoint.getCheckpointedPosition(),
@@ -1257,14 +1240,10 @@ public class ProcessorStateManagerTest {
             stateMgr::commit
         );
 
-        assertThat(
-            processorStateException.getMessage(),
-            containsString(
-                "process-state-manager-test Exception caught while trying to checkpoint store,"
-                    + " changelog partition test-application-My-Topology-persistentStore-changelog-1"
-            )
-        );
-        assertThat(processorStateException.getCause(), is(ioException));
+        assertTrue(processorStateException.getMessage().contains(
+            "process-state-manager-test Exception caught while trying to checkpoint store,"
+                + " changelog partition test-application-My-Topology-persistentStore-changelog-1"));
+        assertEquals(ioException, processorStateException.getCause());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -71,12 +71,6 @@ import java.util.function.Supplier;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -174,7 +168,7 @@ public class ProcessorTopologyTest {
 
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
 
-        assertThat(processorTopology.terminalNodes(), equalTo(Set.of("processor-2", "sink-1")));
+        assertEquals(Set.of("processor-2", "sink-1"), processorTopology.terminalNodes());
     }
 
     @Test
@@ -184,11 +178,11 @@ public class ProcessorTopologyTest {
         final String newTopic = "topic-2";
         topology.addSource(sourceNode, topic);
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
-        assertThat(processorTopology.source(newTopic), is(nullValue()));
+        assertNull(processorTopology.source(newTopic));
 
         processorTopology.updateSourceTopics(Collections.singletonMap(sourceNode, asList(topic, newTopic)));
 
-        assertThat(processorTopology.source(newTopic).name(), equalTo(sourceNode));
+        assertEquals(sourceNode, processorTopology.source(newTopic).name());
     }
 
     @Test
@@ -198,11 +192,11 @@ public class ProcessorTopologyTest {
         final String topicToRemove = "topic-2";
         topology.addSource(sourceNode, topic, topicToRemove);
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
-        assertThat(processorTopology.source(topicToRemove).name(), equalTo(sourceNode));
+        assertEquals(sourceNode, processorTopology.source(topicToRemove).name());
 
         processorTopology.updateSourceTopics(Collections.singletonMap(sourceNode, Collections.singletonList(topic)));
 
-        assertThat(processorTopology.source(topicToRemove), is(nullValue()));
+        assertNull(processorTopology.source(topicToRemove));
     }
 
     @Test
@@ -211,11 +205,11 @@ public class ProcessorTopologyTest {
         final String topic = "topic-1";
         topology.addSource(sourceNode, topic);
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
-        assertThat(processorTopology.source(topic).name(), equalTo(sourceNode));
+        assertEquals(sourceNode, processorTopology.source(topic).name());
 
         processorTopology.updateSourceTopics(Collections.singletonMap(sourceNode, Collections.emptyList()));
 
-        assertThat(processorTopology.source(topic), is(nullValue()));
+        assertNull(processorTopology.source(topic));
     }
 
     @Test
@@ -233,8 +227,8 @@ public class ProcessorTopologyTest {
             )
         );
 
-        assertThat(processorTopology.source(topicOutsideSubtopology), is(nullValue()));
-        assertThat(processorTopology.sources().size(), equalTo(1));
+        assertNull(processorTopology.source(topicOutsideSubtopology));
+        assertEquals(1, processorTopology.sources().size());
     }
 
     @Test
@@ -252,7 +246,7 @@ public class ProcessorTopologyTest {
                 existingSourceNode, Collections.singletonList(topicOfExistingSourceNode)
             ))
         );
-        assertThat(exception.getMessage(), is("Node " + nonExistingSourceNode + " not found in full topology"));
+        assertEquals("Node " + nonExistingSourceNode + " not found in full topology", exception.getMessage());
     }
 
     @Test
@@ -272,10 +266,7 @@ public class ProcessorTopologyTest {
                 mkEntry(updatedSourceNode, Arrays.asList(topic, doublySubscribedTopic))
             ))
         );
-        assertThat(
-            exception.getMessage(),
-            startsWith("Topic " + doublySubscribedTopic + " was already registered to source node")
-        );
+        assertTrue(exception.getMessage().startsWith("Topic " + doublySubscribedTopic + " was already registered to source node"));
     }
 
     @Test
@@ -861,12 +852,9 @@ public class ProcessorTopologyTest {
         inputTopic.pipeInput("key2", "value2@2000");
         inputTopic.pipeInput("key3", "value3@3000");
         final TestOutputTopic<String, String> outputTopic = driver.createOutputTopic(OUTPUT_TOPIC_1, STRING_DESERIALIZER, STRING_DESERIALIZER);
-        assertThat(outputTopic.readRecord(),
-                equalTo(new TestRecord<>("key1", "value1", null, 1000L)));
-        assertThat(outputTopic.readRecord(),
-                equalTo(new TestRecord<>("key2", "value2", null, 2000L)));
-        assertThat(outputTopic.readRecord(),
-                equalTo(new TestRecord<>("key3", "value3", null, 3000L)));
+        assertEquals(new TestRecord<>("key1", "value1", null, 1000L), outputTopic.readRecord());
+        assertEquals(new TestRecord<>("key2", "value2", null, 2000L), outputTopic.readRecord());
+        assertEquals(new TestRecord<>("key3", "value3", null, 3000L), outputTopic.readRecord());
     }
 
 
@@ -891,7 +879,7 @@ public class ProcessorTopologyTest {
         topology.addSource("source", "topic1", "topic2");
         final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
-        assertThat(result, containsString("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
+        assertTrue(result.contains("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
     }
 
     @Test
@@ -900,8 +888,8 @@ public class ProcessorTopologyTest {
         topology.addSource("source2", "t", "t1", "t2");
         final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
-        assertThat(result, containsString("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
-        assertThat(result, containsString("source2:\n\t\ttopics:\t\t[t, t1, t2]\n"));
+        assertTrue(result.contains("source:\n\t\ttopics:\t\t[topic1, topic2]\n"));
+        assertTrue(result.contains("source2:\n\t\ttopics:\t\t[t, t1, t2]\n"));
     }
 
     @Test
@@ -911,9 +899,9 @@ public class ProcessorTopologyTest {
                 .addProcessor("other", mockProcessorSupplier, "source");
         final ProcessorTopology processorTopology = topology.getInternalBuilder().buildTopology();
         final String result = processorTopology.toString();
-        assertThat(result, containsString("\t\tchildren:\t[processor, other]"));
-        assertThat(result, containsString("processor:\n"));
-        assertThat(result, containsString("other:\n"));
+        assertTrue(result.contains("\t\tchildren:\t[processor, other]"));
+        assertTrue(result.contains("processor:\n"));
+        assertTrue(result.contains("other:\n"));
     }
 
     @Test
@@ -926,8 +914,8 @@ public class ProcessorTopologyTest {
                 .addProcessor("child-two-one", mockProcessorSupplier, "child-two");
 
         final String result = topology.getInternalBuilder().buildTopology().toString();
-        assertThat(result, containsString("child-one:\n\t\tchildren:\t[child-one-one]"));
-        assertThat(result, containsString("child-two:\n\t\tchildren:\t[child-two-one]"));
+        assertTrue(result.contains("child-one:\n\t\tchildren:\t[child-one-one]"));
+        assertTrue(result.contains("child-two:\n\t\tchildren:\t[child-two-one]"));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -95,9 +95,6 @@ import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMo
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
 import static org.apache.kafka.streams.processor.internals.ClientUtils.producerRecordSizeInBytes;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_LEVEL_GROUP;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -222,38 +219,38 @@ public class RecordCollectorTest {
         double totalRecords = 0D;
         double totalBytes = 0D;
 
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
 
         collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, sinkNodeName, context);
         ++totalRecords;
         totalBytes += producerRecordSizeInBytes(mockProducer.history().get(0));
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
 
         collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, sinkNodeName, context);
         ++totalRecords;
         totalBytes += producerRecordSizeInBytes(mockProducer.history().get(1));
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
 
         collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, sinkNodeName, context);
         ++totalRecords;
         totalBytes += producerRecordSizeInBytes(mockProducer.history().get(2));
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
 
         collector.send(topic, "999", "0", headers, 1, null, stringSerializer, stringSerializer, sinkNodeName, context);
         ++totalRecords;
         totalBytes += producerRecordSizeInBytes(mockProducer.history().get(3));
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
 
         collector.send(topic, "999", "0", null, 0, null, stringSerializer, stringSerializer, sinkNodeName, context);
         ++totalRecords;
         totalBytes += producerRecordSizeInBytes(mockProducer.history().get(4));
-        assertThat(recordsProduced.metricValue(), equalTo(totalRecords));
-        assertThat(bytesProduced.metricValue(), equalTo(totalBytes));
+        assertEquals(totalRecords, recordsProduced.metricValue());
+        assertEquals(totalBytes, bytesProduced.metricValue());
     }
 
     @Test
@@ -521,7 +518,7 @@ public class RecordCollectorTest {
         assertTrue(offsets.isEmpty());
 
         assertEquals(0, mockProducer.history().size());
-        assertThat(recordsDropped.metricValue(), equalTo(9.0));
+        assertEquals(9.0, recordsDropped.metricValue());
 
         // returned offsets should not be modified
         final TopicPartition topicPartition = new TopicPartition(topic, 0);
@@ -932,16 +929,14 @@ public class RecordCollectorTest {
                 new StringSerializer(), null, null)
         );
 
-        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
-        assertThat(
-            expected.getMessage(),
-            equalTo(
-                "ClassCastException while producing data to topic topic. " +
-                    "The key serializer org.apache.kafka.common.serialization.LongSerializer " +
-                    "is not compatible to the actual key type: java.lang.String. " +
-                    "Change the default key serde in StreamConfig or provide the correct key serde via method parameters " +
-                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
-        );
+        assertInstanceOf(ClassCastException.class, expected.getCause());
+        assertEquals(
+            "ClassCastException while producing data to topic topic. " +
+                "The key serializer org.apache.kafka.common.serialization.LongSerializer " +
+                "is not compatible to the actual key type: java.lang.String. " +
+                "Change the default key serde in StreamConfig or provide the correct key serde via method parameters " +
+                "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+            expected.getMessage());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -960,16 +955,14 @@ public class RecordCollectorTest {
                 new StringSerializer(), null, null)
         );
 
-        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
-        assertThat(
-            expected.getMessage(),
-            equalTo(
-                "ClassCastException while producing data to topic topic. " +
-                    "The key serializer org.apache.kafka.common.serialization.LongSerializer " +
-                    "is not compatible to the actual key type: java.lang.String. " +
-                    "Change the default key serde in StreamConfig or provide the correct key serde via method parameters " +
-                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
-        );
+        assertInstanceOf(ClassCastException.class, expected.getCause());
+        assertEquals(
+            "ClassCastException while producing data to topic topic. " +
+                "The key serializer org.apache.kafka.common.serialization.LongSerializer " +
+                "is not compatible to the actual key type: java.lang.String. " +
+                "Change the default key serde in StreamConfig or provide the correct key serde via method parameters " +
+                "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.keySerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+            expected.getMessage());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -988,16 +981,14 @@ public class RecordCollectorTest {
                 (Serializer) new LongSerializer(), null, null) // need to add cast to trigger `ClassCastException`
         );
 
-        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
-        assertThat(
-            expected.getMessage(),
-            equalTo(
-                "ClassCastException while producing data to topic topic. " +
-                    "The value serializer org.apache.kafka.common.serialization.LongSerializer " +
-                    "is not compatible to the actual value type: java.lang.String. " +
-                    "Change the default value serde in StreamConfig or provide the correct value serde via method parameters " +
-                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.valueSerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
-        );
+        assertInstanceOf(ClassCastException.class, expected.getCause());
+        assertEquals(
+            "ClassCastException while producing data to topic topic. " +
+                "The value serializer org.apache.kafka.common.serialization.LongSerializer " +
+                "is not compatible to the actual value type: java.lang.String. " +
+                "Change the default value serde in StreamConfig or provide the correct value serde via method parameters " +
+                "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.valueSerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+            expected.getMessage());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -1016,16 +1007,14 @@ public class RecordCollectorTest {
                 (Serializer) new LongSerializer(), null, null) // need to add cast to trigger `ClassCastException`
         );
 
-        assertThat(expected.getCause(), instanceOf(ClassCastException.class));
-        assertThat(
-            expected.getMessage(),
-            equalTo(
-                "ClassCastException while producing data to topic topic. " +
-                    "The value serializer org.apache.kafka.common.serialization.LongSerializer " +
-                    "is not compatible to the actual value type: java.lang.String. " +
-                    "Change the default value serde in StreamConfig or provide the correct value serde via method parameters " +
-                    "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.valueSerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).")
-        );
+        assertInstanceOf(ClassCastException.class, expected.getCause());
+        assertEquals(
+            "ClassCastException while producing data to topic topic. " +
+                "The value serializer org.apache.kafka.common.serialization.LongSerializer " +
+                "is not compatible to the actual value type: java.lang.String. " +
+                "Change the default value serde in StreamConfig or provide the correct value serde via method parameters " +
+                "(for example if using the DSL, `#to(String topic, Produced<K, V> produced)` with `Produced.valueSerde(WindowedSerdes.timeWindowedSerdeFrom(String.class))`).",
+            expected.getMessage());
     }
 
     @Test
@@ -1044,11 +1033,10 @@ public class RecordCollectorTest {
             StreamsException.class,
             () -> collector.send(topic, "0", "0", null, null, stringSerializer, stringSerializer, null, context, streamPartitioner)
         );
-        assertThat(
-            exception.getMessage(),
-            equalTo("Could not determine the number of partitions for topic '" + topic + "' for task " +
-                taskId + " due to org.apache.kafka.common.KafkaException: Kaboom!")
-        );
+        assertEquals(
+            "Could not determine the number of partitions for topic '" + topic + "' for task " +
+                taskId + " due to org.apache.kafka.common.KafkaException: Kaboom!",
+            exception.getMessage());
     }
 
     @Test
@@ -1076,7 +1064,7 @@ public class RecordCollectorTest {
             runtimeException.getClass(),
             () -> collector.send(topic, "0", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner)
         );
-        assertThat(exception.getMessage(), equalTo("Kaboom!"));
+        assertEquals("Kaboom!", exception.getMessage());
     }
 
     @Test
@@ -1197,12 +1185,11 @@ public class RecordCollectorTest {
             () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, sinkNodeName, context, streamPartitioner)
         );
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
                 "\norg.apache.kafka.common.KafkaException: KABOOM!" +
-                "\nException handler choose to FAIL the processing, no more records would be sent.")
-        );
+                "\nException handler choose to FAIL the processing, no more records would be sent.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1221,12 +1208,11 @@ public class RecordCollectorTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
-                        "\norg.apache.kafka.common.KafkaException: KABOOM!" +
-                        "\nException handler choose to FAIL the processing, no more records would be sent.")
-        );
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
+                "\norg.apache.kafka.common.KafkaException: KABOOM!" +
+                "\nException handler choose to FAIL the processing, no more records would be sent.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1245,12 +1231,11 @@ public class RecordCollectorTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, collector::closeClean);
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
-                        "\norg.apache.kafka.common.KafkaException: KABOOM!" +
-                        "\nException handler choose to FAIL the processing, no more records would be sent.")
-        );
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
+                "\norg.apache.kafka.common.KafkaException: KABOOM!" +
+                "\nException handler choose to FAIL the processing, no more records would be sent.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1272,12 +1257,11 @@ public class RecordCollectorTest {
             () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner)
         );
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
-                        "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
-                        "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.")
-        );
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
+                "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
+                "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1296,12 +1280,11 @@ public class RecordCollectorTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
-                        "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
-                        "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.")
-        );
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
+                "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
+                "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1320,12 +1303,11 @@ public class RecordCollectorTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, collector::closeClean);
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
-                        "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
-                        "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.")
-        );
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
+                "\norg.apache.kafka.common.errors.AuthenticationException: KABOOM!" +
+                "\nWritten offsets would not be recorded and no more records would be sent since this is a fatal error.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1392,10 +1374,7 @@ public class RecordCollectorTest {
         collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, sinkNodeName, context, streamPartitioner);
 
         final TaskCorruptedException thrown = assertThrows(TaskCorruptedException.class, collector::flush);
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Tasks [0_0] are corrupted and hence need to be re-initialized")
-        );
+        assertEquals("Tasks [0_0] are corrupted and hence need to be re-initialized", thrown.getMessage());
     }
 
     @Test
@@ -1420,12 +1399,11 @@ public class RecordCollectorTest {
         // With custom handler which returns FAIL, flush() throws StreamsException with TimeoutException cause
         final StreamsException thrown = assertThrows(StreamsException.class, collector::flush);
         assertEquals(exception, thrown.getCause());
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
+        assertEquals(
+            "Error encountered sending record to topic topic for task 0_0 due to:" +
                 "\norg.apache.kafka.common.errors.TimeoutException: KABOOM!" +
-                "\nException handler choose to FAIL the processing, no more records would be sent.")
-        );
+                "\nException handler choose to FAIL the processing, no more records would be sent.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1472,17 +1450,15 @@ public class RecordCollectorTest {
 
             final StreamsException thrown = assertThrows(StreamsException.class, collector::flush);
             assertEquals(exception, thrown.getCause());
-            assertThat(
-                thrown.getMessage(),
-                equalTo("Error encountered sending record to topic topic for task 0_0 due to:" +
+            assertEquals(
+                "Error encountered sending record to topic topic for task 0_0 due to:" +
                     "\njava.lang.RuntimeException: KABOOM!" +
-                    "\nException handler choose to FAIL the processing, no more records would be sent.")
-            );
+                    "\nException handler choose to FAIL the processing, no more records would be sent.",
+                thrown.getMessage());
 
-            assertThat(
-                logCaptureAppender.getMessages().get(0),
-                equalTo("test ProductionExceptionHandler returned RETRY for a non-retriable exception. Will treat it as FAIL.")
-            );
+            assertEquals(
+                "test ProductionExceptionHandler returned RETRY for a non-retriable exception. Will treat it as FAIL.",
+                logCaptureAppender.getMessages().get(0));
         }
     }
 
@@ -1538,11 +1514,10 @@ public class RecordCollectorTest {
             StreamsException.class,
             () -> collector.send(topic, "3", "0", null, null, stringSerializer, stringSerializer, null, null, streamPartitioner)
         );
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Could not get partition information for topic topic for task 0_0." +
-                " This can happen if the topic does not exist.")
-        );
+        assertEquals(
+            "Could not get partition information for topic topic for task 0_0." +
+                " This can happen if the topic does not exist.",
+            thrown.getMessage());
     }
 
     @Test
@@ -1586,7 +1561,7 @@ public class RecordCollectorTest {
                 () -> collector.send(topic, "key", "val", null, 0, null, stringSerializer, errorSerializer, sinkNodeName, context)
             );
 
-            assertThat(error.getCause(), instanceOf(SerializationException.class));
+            assertInstanceOf(SerializationException.class, error.getCause());
         }
     }
 
@@ -1604,8 +1579,9 @@ public class RecordCollectorTest {
 
             collector.send(topic, "key", "val", null, 0, null, errorSerializer, stringSerializer, sinkNodeName, context);
 
-            assertThat(mockProducer.history().isEmpty(), equalTo(true));
-            assertThat(
+            assertTrue(mockProducer.history().isEmpty());
+            assertEquals(
+                1.0,
                 streamsMetrics.metrics().get(new MetricName(
                     "dropped-records-total",
                     "stream-task-metrics",
@@ -1613,9 +1589,7 @@ public class RecordCollectorTest {
                     mkMap(
                         mkEntry("thread-id", Thread.currentThread().getName()),
                         mkEntry("task-id", taskId.toString())
-                    ))).metricValue(),
-                equalTo(1.0)
-            );
+                    ))).metricValue());
         }
     }
 
@@ -1858,13 +1832,13 @@ public class RecordCollectorTest {
             );
             collector.initialize();
 
-            assertThat(mockProducer.history().isEmpty(), equalTo(true));
+            assertTrue(mockProducer.history().isEmpty());
             final StreamsException error = assertThrows(
                 StreamsException.class,
                 () -> collector.send(topic, true, "val", null, 0, null, (Serializer) errorSerializer, stringSerializer, sinkNodeName, context)
             );
 
-            assertThat(error.getCause(), instanceOf(ClassCastException.class));
+            assertInstanceOf(ClassCastException.class, error.getCause());
         }
     }
 
@@ -1904,7 +1878,7 @@ public class RecordCollectorTest {
             final RecordCollector collector = newRecordCollector(productionExceptionHandler);
             collector.initialize();
 
-            assertThat(mockProducer.history().isEmpty(), equalTo(true));
+            assertTrue(mockProducer.history().isEmpty());
             assertThrows(
                 StreamsException.class,
                 () ->

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -56,11 +56,8 @@ import java.util.Optional;
 
 import static org.apache.kafka.streams.processor.internals.ClientUtils.consumerRecordSizeInBytes;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_LEVEL_GROUP;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -152,22 +149,22 @@ public class RecordQueueTest {
         ++totalRecords;
         totalBytes += consumerRecordSizeInBytes(records.get(0));
 
-        assertThat(bytesConsumed.metricValue(), equalTo(totalBytes));
-        assertThat(recordsConsumed.metricValue(), equalTo(totalRecords));
+        assertEquals(totalBytes, bytesConsumed.metricValue());
+        assertEquals(totalRecords, recordsConsumed.metricValue());
 
         queue.poll(6L);
         ++totalRecords;
         totalBytes += consumerRecordSizeInBytes(records.get(1));
 
-        assertThat(bytesConsumed.metricValue(), equalTo(totalBytes));
-        assertThat(recordsConsumed.metricValue(), equalTo(totalRecords));
+        assertEquals(totalBytes, bytesConsumed.metricValue());
+        assertEquals(totalRecords, recordsConsumed.metricValue());
 
         queue.poll(7L);
         ++totalRecords;
         totalBytes += consumerRecordSizeInBytes(records.get(2));
 
-        assertThat(bytesConsumed.metricValue(), equalTo(totalBytes));
-        assertThat(recordsConsumed.metricValue(), equalTo(totalRecords));
+        assertEquals(totalBytes, bytesConsumed.metricValue());
+        assertEquals(totalRecords, recordsConsumed.metricValue());
     }
 
     @Test
@@ -285,9 +282,9 @@ public class RecordQueueTest {
     @Test
     public void shouldTrackPartitionTimeAsMaxProcessedTimestamp() {
         assertTrue(queue.isEmpty());
-        assertThat(queue.size(), is(0));
-        assertThat(queue.headRecordTimestamp(), is(RecordQueue.UNKNOWN));
-        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
+        assertEquals(0, queue.size());
+        assertEquals(RecordQueue.UNKNOWN, queue.headRecordTimestamp());
+        assertEquals(RecordQueue.UNKNOWN, queue.partitionTime());
 
         // add three 3 out-of-order records with timestamp 2, 1, 3, 4
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
@@ -301,27 +298,27 @@ public class RecordQueueTest {
                 new RecordHeaders(), Optional.empty()));
 
         queue.addRawRecords(list1);
-        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
+        assertEquals(RecordQueue.UNKNOWN, queue.partitionTime());
 
         queue.poll(0);
-        assertThat(queue.partitionTime(), is(2L));
+        assertEquals(2L, queue.partitionTime());
 
         queue.poll(0);
-        assertThat(queue.partitionTime(), is(2L));
+        assertEquals(2L, queue.partitionTime());
 
         queue.poll(0);
-        assertThat(queue.partitionTime(), is(3L));
+        assertEquals(3L, queue.partitionTime());
     }
 
     @Test
     public void shouldSetTimestampAndRespectMaxTimestampPolicy() {
         assertTrue(queue.isEmpty());
-        assertThat(queue.size(), is(0));
-        assertThat(queue.headRecordTimestamp(), is(RecordQueue.UNKNOWN));
-        assertThat(queue.partitionTime(), is(RecordQueue.UNKNOWN));
+        assertEquals(0, queue.size());
+        assertEquals(RecordQueue.UNKNOWN, queue.headRecordTimestamp());
+        assertEquals(RecordQueue.UNKNOWN, queue.partitionTime());
 
         queue.setPartitionTime(150L);
-        assertThat(queue.partitionTime(), is(150L));
+        assertEquals(150L, queue.partitionTime());
 
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
             new ConsumerRecord<>("topic", 1, 200, 0L, TimestampType.CREATE_TIME, 0, 0, recordKey, recordValue,
@@ -334,16 +331,16 @@ public class RecordQueueTest {
                 new RecordHeaders(), Optional.empty()));
 
         queue.addRawRecords(list1);
-        assertThat(queue.partitionTime(), is(150L));
+        assertEquals(150L, queue.partitionTime());
 
         queue.poll(0);
-        assertThat(queue.partitionTime(), is(200L));
+        assertEquals(200L, queue.partitionTime());
 
         queue.setPartitionTime(500L);
-        assertThat(queue.partitionTime(), is(500L));
+        assertEquals(500L, queue.partitionTime());
 
         queue.poll(0);
-        assertThat(queue.partitionTime(), is(500L));
+        assertEquals(500L, queue.partitionTime());
     }
 
     @Test
@@ -357,7 +354,7 @@ public class RecordQueueTest {
             StreamsException.class,
             () -> queue.addRawRecords(records)
         );
-        assertThat(exception.getCause(), instanceOf(SerializationException.class));
+        assertInstanceOf(SerializationException.class, exception.getCause());
     }
 
     @Test
@@ -371,7 +368,7 @@ public class RecordQueueTest {
             StreamsException.class,
             () -> queue.addRawRecords(records)
         );
-        assertThat(exception.getCause(), instanceOf(SerializationException.class));
+        assertInstanceOf(SerializationException.class, exception.getCause());
     }
 
     @Test
@@ -419,12 +416,14 @@ public class RecordQueueTest {
             StreamsException.class,
             () -> queue.addRawRecords(records)
         );
-        assertThat(exception.getMessage(), equalTo("Input record ConsumerRecord(topic = topic, partition = 1, " +
-            "leaderEpoch = null, offset = 1, CreateTime = -1, deliveryCount = null, serialized key size = 0, " +
-            "serialized value size = 0, headers = RecordHeaders(headers = [], isReadOnly = false), key = 1, value = 10) " +
-            "has invalid (negative) timestamp. Possibly because a pre-0.10 producer client was used to write this record " +
-            "to Kafka without embedding a timestamp, or because the input topic was created before upgrading the Kafka " +
-            "cluster to 0.10+. Use a different TimestampExtractor to process this data."));
+        assertEquals(
+            "Input record ConsumerRecord(topic = topic, partition = 1, " +
+                "leaderEpoch = null, offset = 1, CreateTime = -1, deliveryCount = null, serialized key size = 0, " +
+                "serialized value size = 0, headers = RecordHeaders(headers = [], isReadOnly = false), key = 1, value = 10) " +
+                "has invalid (negative) timestamp. Possibly because a pre-0.10 producer client was used to write this record " +
+                "to Kafka without embedding a timestamp, or because the input topic was created before upgrading the Kafka " +
+                "cluster to 0.10+. Use a different TimestampExtractor to process this data.",
+            exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Remove hamcrest from a subset of tests in the
`org.apache.kafka.streams.processor.internals` package by migrating to
JUnit assertions.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
