### PR TITLE
MINOR: Remove unused consumer argument in EndToEndLatency and EndToEndLatencyTest

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
+++ b/tools/src/main/java/org/apache/kafka/tools/EndToEndLatency.java
@@ -126,7 +126,7 @@ public class EndToEndLatency {
                 ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(POLL_TIMEOUT_MS));
                 long elapsed = System.nanoTime() - begin;
 
-                validate(consumer, recordValue, records, recordKey, headers);
+                validate(recordValue, records, recordKey, headers);
 
                 //Report progress
                 if (i % 1000 == 0)
@@ -140,7 +140,7 @@ public class EndToEndLatency {
     }
 
     // Visible for testing
-    static void validate(KafkaConsumer<byte[], byte[]> consumer, byte[] sentRecordValue, ConsumerRecords<byte[], byte[]> records, byte[] sentRecordKey, Iterable<Header> sentHeaders) {
+    static void validate(byte[] sentRecordValue, ConsumerRecords<byte[], byte[]> records, byte[] sentRecordKey, Iterable<Header> sentHeaders) {
         if (records.isEmpty()) {
             throw new RuntimeException("poll() timed out before finding a result (timeout:[" + POLL_TIMEOUT_MS + "ms])");
         }
@@ -166,7 +166,7 @@ public class EndToEndLatency {
             throw new RuntimeException("Expected null message key but received [" + new String(record.key(), StandardCharsets.UTF_8) + "]");
         }
 
-        validateHeaders(consumer, sentHeaders, record);
+        validateHeaders(sentHeaders, record);
 
         //Check we only got the one message
         if (records.count() != 1) {
@@ -174,7 +174,7 @@ public class EndToEndLatency {
         }
     }
 
-    private static void validateHeaders(KafkaConsumer<byte[], byte[]> consumer, Iterable<Header> sentHeaders, ConsumerRecord<byte[], byte[]> record) {
+    private static void validateHeaders(Iterable<Header> sentHeaders, ConsumerRecord<byte[], byte[]> record) {
         if (sentHeaders != null && sentHeaders.iterator().hasNext()) {
             if (!record.headers().iterator().hasNext()) {
                 throw new RuntimeException("Expected message headers but received none");

--- a/tools/src/test/java/org/apache/kafka/tools/EndToEndLatencyTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/EndToEndLatencyTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.tools;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -100,9 +99,6 @@ public class EndToEndLatencyTest {
             return with(param, "0");
         }
     }
-
-    @Mock
-    KafkaConsumer<byte[], byte[]> consumer;
 
     @Mock
     ConsumerRecords<byte[], byte[]> records;
@@ -204,7 +200,7 @@ public class EndToEndLatencyTest {
     @Test
     public void shouldFailWhenConsumerRecordsIsEmpty() {
         when(records.isEmpty()).thenReturn(true);
-        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(consumer, new byte[0], records, null, null));
+        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(new byte[0], records, null, null));
     }
 
     @Test
@@ -216,7 +212,7 @@ public class EndToEndLatencyTest {
         when(records.iterator()).thenReturn(iterator);
         when(iterator.next()).thenReturn(record);
         when(record.value()).thenReturn(RECORD_VALUE_DIFFERENT);
-        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(consumer, RECORD_VALUE, records, null, null));
+        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(RECORD_VALUE, records, null, null));
     }
 
     @Test
@@ -231,7 +227,7 @@ public class EndToEndLatencyTest {
         when(record.key()).thenReturn(RECORD_KEY_DIFFERENT);
 
         assertThrows(RuntimeException.class, () ->
-                EndToEndLatency.validate(consumer, RECORD_VALUE, records,
+                EndToEndLatency.validate(RECORD_VALUE, records,
                         RECORD_KEY, null));
     }
 
@@ -258,7 +254,7 @@ public class EndToEndLatencyTest {
         List<Header> sentHeaders = List.of(sentHeader);
 
         assertThrows(RuntimeException.class, () ->
-                EndToEndLatency.validate(consumer, RECORD_VALUE, records, null, sentHeaders));
+                EndToEndLatency.validate(RECORD_VALUE, records, null, sentHeaders));
     }
 
     @Test
@@ -283,7 +279,7 @@ public class EndToEndLatencyTest {
         when(headerIterator.next()).thenReturn(receivedHeader);
 
         assertThrows(RuntimeException.class, () ->
-                EndToEndLatency.validate(consumer, RECORD_VALUE, records, null, sentHeaders));
+                EndToEndLatency.validate(RECORD_VALUE, records, null, sentHeaders));
     }
 
     @Test
@@ -296,7 +292,7 @@ public class EndToEndLatencyTest {
         when(iterator.next()).thenReturn(record);
         when(record.value()).thenReturn(RECORD_VALUE);
         when(records.count()).thenReturn(2);
-        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(consumer, RECORD_VALUE, records, null, null));
+        assertThrows(RuntimeException.class, () -> EndToEndLatency.validate(RECORD_VALUE, records, null, null));
     }
 
     @Test
@@ -322,7 +318,7 @@ public class EndToEndLatencyTest {
         when(headerIterator.hasNext()).thenReturn(true, true, false);
         when(headerIterator.next()).thenReturn(receivedHeader);
 
-        assertDoesNotThrow(() -> EndToEndLatency.validate(consumer, RECORD_VALUE, records, recordKey, sentHeaders));
+        assertDoesNotThrow(() -> EndToEndLatency.validate(RECORD_VALUE, records, recordKey, sentHeaders));
     }
 
     @Test


### PR DESCRIPTION
Follow-up cleanup for #23402.  Removed the unused `consumer` in
`EndToEndLatency#validate` and `validateHeaders`.

**test**
`./gradlew tools:test --tests EndToEndLatencyTest`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
