### PR TITLE
KAFKA-21053: Fix missing record context offset assertion

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -118,13 +118,9 @@ public class AbstractProcessorContextTest {
     }
 
     @Test
-    public void shouldThrowIllegalStateExceptionOnOffsetIfNoRecordContext() {
+    public void shouldReturnDummyOffsetIfNoRecordContext() {
         context.setRecordContext(null);
-        try {
-            context.offset();
-        } catch (final IllegalStateException e) {
-            // pass
-        }
+        assertEquals(-1L, context.offset());
     }
 
     @Test


### PR DESCRIPTION
The test `shouldThrowIllegalStateExceptionOnOffsetIfNoRecordContext`
still expects an exception, while `AbstractProcessorContext.offset()`
returns `-1L` when the record context is null. Its try/catch block
neither fails when no exception is thrown nor checks the returned value,
so it does not detect this mismatch.

The test was introduced in commit d95f22c12c (KAFKA-4646) in 2017, when
the implementation did throw `IllegalStateException`. In 2020, commit
69790a1463 (KAFKA-10535, #9361) changed the behavior to return `-1L`.
That commit updated the corresponding topic, partition, and timestamp
tests, but left the offset test unchanged.

This change renames the test to
`shouldReturnDummyOffsetIfNoRecordContext` and replaces the ineffective
try/catch with `assertEquals(-1L, context.offset())`. This verifies the
current behavior and follows the naming pattern of the neighboring
dummy-value tests.

Test plan: Run AbstractProcessorContextTest.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>
