### PR TITLE
MINOR: Add cross-version compatibility tests for the KIP-1331 topology description plugin

### DIFF
--- a/tests/kafkatest/tests/streams/streams_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_smoke_test.py
@@ -16,9 +16,10 @@
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 
-from kafkatest.services.kafka import quorum
+from kafkatest.services.kafka import KafkaService, quorum
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService
 from kafkatest.tests.streams.base_streams_test import BaseStreamsTest
+from kafkatest.version import LATEST_4_3
 
 class StreamsSmokeTest(BaseStreamsTest):
     """
@@ -122,3 +123,45 @@ class StreamsSmokeTest(BaseStreamsTest):
         processor3.stop()
 
         self.driver.node.account.ssh("grep SUCCESS %s" % self.driver.STDOUT_FILE, allow_fail=False)
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_old_client_not_solicited_for_topology_push(self, metadata_quorum):
+        """
+        Test the situation when a pre-KIP-1331 Kafka Streams client uses the streams group
+        protocol against a broker on this branch with the topology description plugin configured
+        (the default broker setup from BaseStreamsTest). StreamsGroupHeartbeat negotiates down to
+        version 0 for this client, so the broker must never solicit a topology description push
+        for it.
+        """
+        processor = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, 'at_least_once', 'streams')
+        processor.set_version(str(LATEST_4_3))
+
+        broker_node = self.kafka.nodes[0]
+        broker_log = "%s/server.log" % KafkaService.OPERATIONAL_LOG_INFO_DIR
+
+        with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+            processor.start()
+            monitor.wait_until('REBALANCING -> RUNNING',
+                               timeout_sec=60,
+                               err_msg="Never saw 'REBALANCING -> RUNNING' message " + str(processor.node.account)
+                               )
+
+            self.driver.start()
+
+            monitor.wait_until('processed',
+                                timeout_sec=30,
+                                err_msg="Didn't see any processing messages " + str(processor.node.account)
+                                )
+
+        self.driver.wait()
+        self.driver.stop()
+        processor.stop()
+
+        self.driver.node.account.ssh("grep SUCCESS %s" % self.driver.STDOUT_FILE, allow_fail=False)
+
+        solicited = broker_node.account.ssh_capture(
+            "grep -c 'Requested topology description push at topology epoch' %s || true" % broker_log,
+            allow_fail=False)
+        assert int(next(solicited).strip()) == 0, \
+            "Broker solicited a topology description push for a pre-KIP-1331 streams client"

--- a/tests/kafkatest/tests/streams/streams_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_smoke_test.py
@@ -137,7 +137,6 @@ class StreamsSmokeTest(BaseStreamsTest):
         processor = StreamsSmokeTestJobRunnerService(self.test_context, self.kafka, 'at_least_once', 'streams')
         processor.set_version(str(LATEST_4_3))
 
-        broker_node = self.kafka.nodes[0]
         broker_log = "%s/server.log" % KafkaService.OPERATIONAL_LOG_INFO_DIR
 
         with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor:
@@ -160,8 +159,13 @@ class StreamsSmokeTest(BaseStreamsTest):
 
         self.driver.node.account.ssh("grep SUCCESS %s" % self.driver.STDOUT_FILE, allow_fail=False)
 
-        solicited = broker_node.account.ssh_capture(
-            "grep -c 'Requested topology description push at topology epoch' %s || true" % broker_log,
-            allow_fail=False)
-        assert int(next(solicited).strip()) == 0, \
-            "Broker solicited a topology description push for a pre-KIP-1331 streams client"
+        # BaseStreamsTest runs 3 brokers and the group coordinator for this group can land on
+        # any of them, so every broker's log needs to be checked, not just one.
+        solicited = 0
+        for broker_node in self.kafka.nodes:
+            count = broker_node.account.ssh_capture(
+                "grep -c 'Requested topology description push at topology epoch' %s || true" % broker_log,
+                allow_fail=False)
+            solicited += int(next(count).strip())
+        assert solicited == 0, \
+            "A broker solicited a topology description push for a pre-KIP-1331 streams client"

--- a/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
+++ b/tests/kafkatest/tests/streams/streams_topology_description_plugin_test.py
@@ -24,6 +24,7 @@ from kafkatest.services.streams import (
     INMEMORY_TOPOLOGY_DESCRIPTION_PLUGIN_CLASS,
     StreamsTopologyDescriptionPluginService,
 )
+from kafkatest.version import DEV_BRANCH, LATEST_4_3, KafkaVersion
 
 
 class StreamsTopologyDescriptionPluginTest(Test):
@@ -45,7 +46,7 @@ class StreamsTopologyDescriptionPluginTest(Test):
             self.SINK_TOPIC: {"partitions": 1, "replication-factor": 1},
         }
 
-    def setup_kafka(self, plugin_enabled):
+    def setup_kafka(self, plugin_enabled, broker_version=None):
         server_prop_overrides = [
             ["group.streams.min.session.timeout.ms", "10000"],
             ["group.streams.session.timeout.ms", "10000"],
@@ -61,6 +62,8 @@ class StreamsTopologyDescriptionPluginTest(Test):
             use_streams_groups=True,
             server_prop_overrides=server_prop_overrides,
         )
+        if broker_version is not None:
+            self.kafka.set_version(KafkaVersion(broker_version))
         self.kafka.start()
         self.kafka.run_features_command("upgrade", "streams.version", 1)
 
@@ -164,6 +167,67 @@ class StreamsTopologyDescriptionPluginTest(Test):
         assert int(next(pushed).strip()) == 0, \
             "Client logged a successful push despite no plugin being configured on the broker"
         processor.stop()
+
+    @cluster(num_nodes=2)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_topology_description_not_stored_with_pre_kip_1331_broker(self, metadata_quorum):
+        """
+        Test the situation when a streams client built from this branch (topology description
+        push enabled by default) talks to a broker that predates KIP-1331. Such a broker only
+        negotiates StreamsGroupHeartbeat down to version 0, which carries no
+        topologyDescriptionRequired field, so it can never solicit a push and the client must
+        never attempt one.
+        """
+        self.setup_kafka(plugin_enabled=False, broker_version=str(LATEST_4_3))
+
+        processor = StreamsTopologyDescriptionPluginService(self.test_context, self.kafka)
+        with processor.node.account.monitor_log(processor.LOG_FILE) as monitor:
+            processor.start()
+            monitor.wait_until(self.STREAMS_RUNNING_LOG,
+                               timeout_sec=60,
+                               err_msg="Never saw 'REBALANCING -> RUNNING' message " + str(processor.node.account))
+
+        solicited = processor.node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.PUSH_REQUESTED_LOG, processor.LOG_FILE),
+            allow_fail=False)
+        assert int(next(solicited).strip()) == 0, \
+            "Client saw a topology push solicitation from a broker that predates KIP-1331"
+
+        sent = processor.node.account.ssh_capture(
+            "grep -c '%s' %s || true" % (self.PUSH_SENDING_LOG, processor.LOG_FILE),
+            allow_fail=False)
+        assert int(next(sent).strip()) == 0, \
+            "Client sent a topology description to a broker that predates KIP-1331"
+        processor.stop()
+
+    @cluster(num_nodes=1)
+    @matrix(metadata_quorum=[quorum.combined_kraft])
+    def test_describe_topology_fails_against_pre_kip_1331_broker(self, metadata_quorum):
+        """
+        Test the situation when kafka-streams-groups.sh --describe --topology (built from this
+        branch) is pointed at a broker that predates KIP-1331. StreamsGroupDescribe only
+        negotiates to version 0 against such a broker, and IncludeTopologyDescription is not a
+        version-0 field, so the admin client must refuse to send the request with
+        UnsupportedVersionException instead of silently describing the group without the
+        topology.
+        """
+        self.setup_kafka(plugin_enabled=False, broker_version=str(LATEST_4_3))
+
+        node = self.kafka.nodes[0]
+        # Always run the CLI tool from this branch, not the old broker's bundled version, since
+        # the --topology flag and the client-side version-gating it relies on postdate KIP-1331.
+        streams_group_script = self.kafka.path.script("kafka-streams-groups.sh", DEV_BRANCH)
+        cmd = "%s --bootstrap-server %s --describe --topology --group nonexistent-group" % (
+            streams_group_script, self.kafka.bootstrap_servers())
+
+        exit_code = node.account.ssh(cmd, allow_fail=True)
+        assert exit_code != 0, \
+            "kafka-streams-groups.sh --describe --topology unexpectedly succeeded against a broker that predates KIP-1331"
+
+        output = node.account.ssh_output(cmd, allow_fail=True).decode("utf-8")
+        assert "UnsupportedVersionException" in output, \
+            "Expected an UnsupportedVersionException when requesting a topology description from a broker " \
+            "that predates KIP-1331, got: " + output
 
     @cluster(num_nodes=2)
     @matrix(metadata_quorum=[quorum.combined_kraft])


### PR DESCRIPTION
The heartbeat- and describe-based topology push protocol added by
KIP-1331 relies on StreamsGroupHeartbeat and StreamsGroupDescribe
negotiating down to earlier versions when talking to a broker or client
that predates the feature, and on the admin client refusing to send a
topology description request a broker cannot understand. This was
previously only checked by unit tests exercising the version-gating
logic directly; nothing ran an actual pre-4.4 Kafka broker or Streams
client against the feature to prove the real wire negotiation degrades
gracefully in both directions.

This adds three system tests covering the missing directions: a Streams
client built from this branch (topology push enabled by default) talking
to a genuine 4.3.1 broker, a genuine 4.3.1 Streams client talking to a
broker on this branch with the plugin configured, and the admin
client/CLI on this branch requesting a topology description from a 4.3.1
broker, which must fail client-side with UnsupportedVersionException
rather than silently describing the group without it.

## Test plan

All three tests were run against real ducker containers (docker-based
ducktape harness) to confirm they exercise the intended code paths
rather than passing vacuously:
- Confirmed via broker/client logs that the pinned old-version processes
actually ran Kafka 4.3.1, not the dev-branch build.
- Confirmed the admin-client test's failure text matches
`UnsupportedVersionException: Attempted to write a non-default
includeTopologyDescription at version 0` with exit code 1.
- Re-ran the full `streams_topology_description_plugin_test.py` suite (9
tests) plus the new smoke test together; all pass.

Reviewers: TengYao Chi <frankvicky@apache.org>
