### PR TITLE
MINOR: Propagate exceptions in TaskMetadataIntegrationTest

### DIFF
--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -111,7 +111,7 @@ public class TaskMetadataIntegrationTest {
     }
 
     @Test
-    public void shouldReportCorrectCommittedOffsetInformation() {
+    public void shouldReportCorrectCommittedOffsetInformation() throws Exception {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
@@ -131,13 +131,11 @@ public class TaskMetadataIntegrationTest {
             produceMessages(0L, inputTopic, "test1");
             TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
             TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 3L, "the record was processed");
-        } catch (final Exception e) {
-            e.printStackTrace();
         }
     }
 
     @Test
-    public void shouldReportCorrectEndOffsetInformation() {
+    public void shouldReportCorrectEndOffsetInformation() throws Exception {
         try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
             IntegrationTestUtils.startApplicationAndWaitUntilRunning(kafkaStreams);
             final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
@@ -151,9 +149,6 @@ public class TaskMetadataIntegrationTest {
                 process.set(true);
             }
             assertEquals(9L, taskMetadata.endOffsets().get(topicPartition));
-
-        } catch (final Exception e) {
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
This PR follows up on the review feedback from
https://github.com/apache/kafka/pull/23386#discussion_r3964011664.

Two test methods in `TaskMetadataIntegrationTest` caught unexpected
exceptions  and only printed their stack traces. This prevented those
exceptions from  reaching JUnit and could allow the tests to be reported
as successful.

This change removes the catch blocks from
`shouldReportCorrectCommittedOffsetInformation` and
`shouldReportCorrectEndOffsetInformation`. Both methods now declare
`throws Exception`, allowing the original exceptions to propagate to
JUnit  while retaining the existing try-with-resources cleanup.

### Testing

`./gradlew :streams:integration-tests:test --tests
org.apache.kafka.streams.integration.TaskMetadataIntegrationTest`

Reviewers: Ming-Yen Chung <mingyen066@gmail.com>, Ken Huang
 <s7133700@gmail.com>
