### PR TITLE
MINOR: Fix typos in Kafka Streams test method names

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/ApiUtilsTest.java
@@ -98,7 +98,7 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void shouldContainsNameAndValueInFailMsgPrefix() {
+    public void shouldContainNameAndValueInFailMsgPrefix() {
         final String failMsgPrefix = prepareMillisCheckFailMsgPrefix("someValue", "variableName");
 
         assertTrue(failMsgPrefix.contains("variableName"));

--- a/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/internals/metrics/ClientMetricsTest.java
@@ -199,19 +199,4 @@ public class ClientMetricsTest {
                 eq(value)
         );
     }
-
-    private void setUpAndVerifyImmutableMetric(final String name,
-                                               final String description,
-                                               final int value,
-                                               final Runnable metricAdder) {
-
-        metricAdder.run();
-
-        verify(streamsMetrics).addClientLevelImmutableMetric(
-                eq(name),
-                eq(description),
-                eq(RecordingLevel.INFO),
-                eq(value)
-        );
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
@@ -149,7 +149,7 @@ public class CogroupedKStreamImplTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void shouldNotHaveNullNamedOnAggregateWithMateriazlied(final boolean withHeaders) {
+    public void shouldNotHaveNullNamedOnAggregateWithMaterialized(final boolean withHeaders) {
         setup(withHeaders);
         assertThrows(NullPointerException.class, () -> cogroupedStream.aggregate(STRING_INITIALIZER,  null,  Materialized.as("store")));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -159,7 +159,7 @@ public class InternalStreamsBuilderTest {
     }
 
     @Test
-    public void shouldBuildGlobalTableWithQueryaIbleStoreName() {
+    public void shouldBuildGlobalTableWithQueryableStoreName() {
         final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materializedInternal =
             new MaterializedInternal<>(Materialized.as("globalTable"), builder, storePrefix);
         final GlobalKTable<String, String> table1 = builder.globalTable("topic2", consumed, materializedInternal);
@@ -572,7 +572,7 @@ public class InternalStreamsBuilderTest {
     }
 
     @Test
-    public void shouldMarkFirstStreamStreamJoinAsSelfJoinNwaySameSource() {
+    public void shouldMarkFirstStreamStreamJoinAsSelfJoinNWaySameSource() {
         // Given:
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         final KStream<String, String> stream1 = builder.stream(Collections.singleton("t1"), consumed);
@@ -598,7 +598,7 @@ public class InternalStreamsBuilderTest {
     }
 
     @Test
-    public void shouldMarkFirstStreamStreamJoinAsSelfJoinNway() {
+    public void shouldMarkFirstStreamStreamJoinAsSelfJoinNWay() {
         // Given:
         props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
         final KStream<String, String> stream1 = builder.stream(Collections.singleton("t1"), consumed);


### PR DESCRIPTION
### Summary

Fix typos in test method names across several Kafka Streams unit tests
- `shouldContainsNameAndValueInFailMsgPrefix` →
`shouldContainNameAndValueInFailMsgPrefix`
- `shouldNotHaveNullNamedOnAggregateWithMateriazlied` →
`...WithMaterialized`
- `shouldBuildGlobalTableWithQueryaIbleStoreName` →
`...QueryableStoreName`,
- `shouldMarkFirstStreamStreamJoinAsSelfJoinNwaySameSource/Nway` →
`NWaySameSource/NWay`

Remove an unused private helper method `setUpAndVerifyImmutableMetric`
from `ClientMetricsTest`

Reviewers: Andrew Schofield <aschofield@confluent.io>
