### PR TITLE
KAFKA-21054: Fix vacuous timeout tests in InternalTopicManagerTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -74,6 +74,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -313,57 +314,33 @@ public class InternalTopicManagerTest {
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionIfGetPartitionInfoHasTopicDescriptionTimeout() {
-        mockAdminClient.timeoutNextRequest(1);
-
+    public void shouldNotThrowExceptionIfGetPartitionInfoHasTopicDescriptionTimeout() {
         final InternalTopicManager internalTopicManager =
                 new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
-        try {
-            final Set<String> topic1set = Set.of(topic1);
-            internalTopicManager.getTopicPartitionInfo(topic1set, null);
-
-        } catch (final TimeoutException expected) {
-            assertEquals(TimeoutException.class, expected.getCause().getClass());
-        }
 
         mockAdminClient.timeoutNextRequest(1);
+        final Set<String> topic1set = Set.of(topic1);
+        assertDoesNotThrow(
+                () -> internalTopicManager.getTopicPartitionInfo(topic1set, null)
+        );
 
-        try {
-            final Set<String> topic2set = Set.of(topic2);
-            internalTopicManager.getTopicPartitionInfo(topic2set, null);
-
-        } catch (final TimeoutException expected) {
-            assertEquals(TimeoutException.class, expected.getCause().getClass());
-        }
+        mockAdminClient.timeoutNextRequest(1);
+        final Set<String> topic2set = Set.of(topic2);
+        assertDoesNotThrow(
+                () -> internalTopicManager.getTopicPartitionInfo(topic2set, null)
+        );
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionIfGetNumPartitionsHasTopicDescriptionTimeout() {
+    public void shouldNotThrowExceptionIfGetNumPartitionsHasTopicDescriptionTimeout() {
         mockAdminClient.timeoutNextRequest(1);
 
-        final InternalTopicManager internalTopicManager =
-                new InternalTopicManager(time, mockAdminClient, new StreamsConfig(config));
-        try {
-            final Set<String> topic1set = Set.of(topic1);
-            final Set<String> topic2set = new HashSet<>(Collections.singletonList(topic2));
+        final Set<String> topic1set = Set.of(topic1);
+        final Set<String> topic2set = new HashSet<>(Collections.singletonList(topic2));
 
-            internalTopicManager.getNumPartitions(topic1set, topic2set);
-
-        } catch (final TimeoutException expected) {
-            assertEquals(TimeoutException.class, expected.getCause().getClass());
-        }
-
-        mockAdminClient.timeoutNextRequest(1);
-
-        try {
-            final Set<String> topic1set = Set.of(topic1);
-            final Set<String> topic2set = new HashSet<>(Collections.singletonList(topic2));
-
-            internalTopicManager.getNumPartitions(topic1set, topic2set);
-
-        } catch (final TimeoutException expected) {
-            assertEquals(TimeoutException.class, expected.getCause().getClass());
-        }
+        assertDoesNotThrow(
+                () -> internalTopicManager.getNumPartitions(topic1set, topic2set)
+        );
     }
 
     @Test


### PR DESCRIPTION
  The two shouldThrowTimeoutException...HasTopicDescriptionTimeout tests                                         
  wrapped the call under test in try/catch without fail(), so they passed                                        
  whether or not an exception was thrown. Since KAFKA-14128 the code under                                       
  test swallows the TimeoutException from describeTopics and never throws,                                       
  so the catch block and its assertion have never executed.

  Rename both tests to shouldNotThrowExceptionIf... and replace the                                              
  try/catch with assertDoesNotThrow so they fail if the behavior regresses                                       
  to throwing. Also collapse the duplicated identical call in the                                                
  getNumPartitions test, which was introduced by a rebase conflict                                               
  resolution in PR #13161.
  
  Testing: test-only change. Ran InternalTopicManagerTest locally, all passing. 
  No production code is affected.