### PR TITLE
KAFKA-21022: Treat logs missing topic ID as stray replicas in findStr…

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -1665,21 +1665,23 @@ object LogManager {
       })
     })
     logs.flatMap { log =>
-      val topicId = log.topicId.getOrElse {
-        throw new RuntimeException(s"The log dir $log does not have a topic ID, " +
-          "which is not allowed when running in KRaft mode.")
-      }
-      Option(partitions.get(log.topicPartition)) match {
-        case Some(id) =>
-          if (id.equals(topicId)) {
-            None
-          } else {
-            info(s"Found stray log dir $log: this partition now exists with topic ID $id not $topicId.")
+      if (log.topicId.isEmpty) {
+        info(s"The topicId does not exist in $log, treat it as a stray log")
+        Some(log.topicPartition)
+      } else {
+        val topicId = log.topicId.get
+        Option(partitions.get(log.topicPartition)) match {
+          case Some(id) =>
+            if (id.equals(topicId)) {
+              None
+            } else {
+              info(s"Found stray log dir $log: this partition now exists with topic ID $id not $topicId.")
+              Some(log.topicPartition)
+            }
+          case None =>
+            info(s"Found stray log dir $log: this partition does not exist in the new full LeaderAndIsrRequest.")
             Some(log.topicPartition)
-          }
-        case None =>
-          info(s"Found stray log dir $log: this partition does not exist in the new full LeaderAndIsrRequest.")
-          Some(log.topicPartition)
+        }
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.message.LeaderAndIsrRequestData
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrTopicState
+import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{AbstractControlRequest, LeaderAndIsrRequest}
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{DirectoryId, KafkaException, TopicIdPartition, TopicPartition, Uuid}
@@ -1301,6 +1302,25 @@ class LogManagerTest {
       LogManager.findStrayReplicas(0,
         createLeaderAndIsrRequestForStrayDetection(Seq()),
           onDisk.map(mockLog)).toSet)
+  }
+
+  @Test
+  def testFindStrayReplicasMissingTopicId(): Unit = {
+    val topicPartition = new TopicPartition("foo", 0)
+    val log = Mockito.mock(classOf[UnifiedLog])
+    Mockito.when(log.topicId).thenReturn(Option.empty)
+    Mockito.when(log.topicPartition).thenReturn(topicPartition)
+
+    val reqData = new LeaderAndIsrRequestData()
+      .setType(AbstractControlRequest.Type.FULL.toByte)
+
+    val request = new LeaderAndIsrRequest(
+      reqData,
+      ApiKeys.LEADER_AND_ISR.latestVersion()
+    )
+
+    val strays = LogManager.findStrayReplicas(0, request, Seq(log))
+    assertEquals(Seq(topicPartition), strays.toSeq)
   }
 
   @Test


### PR DESCRIPTION
When processing a full `LeaderAndIsrRequest` via `LogManager.findStrayReplicas` (e.g., during ZooKeeper-to-KRaft migration), encountering a local log directory that lacks a topic ID caused a `RuntimeException` via an unsafe `getOrElse` call. 

This change updates `findStrayReplicas` to check for `log.topicId.isEmpty` and safely treat these logs as stray replicas rather than crashing the broker, aligning the behavior with standard KRaft migration expectations.

Summary of testing strategy:

- Added a regression unit test `testFindStrayReplicasMissingTopicId` in `LogManagerTest.scala` to verify that logs missing topic IDs are correctly marked as stray replicas.
- Executed `./gradlew :core:compileScala :core:compileTestScala` and verified the core module test suite passes cleanly.
