### PR TITLE
KAFKA-20998: Add balanced task assignor for streams groups

### DIFF
--- a/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StreamsGroupHeartbeatRequestTest.scala
@@ -960,6 +960,22 @@ class StreamsGroupHeartbeatRequestTest(cluster: ClusterInstance) extends GroupCo
         s"Expected InvalidConfigurationException but got ${executionException.getCause}")
       assertTrue(executionException.getCause.getMessage.contains("'does-not-exist' is not a registered task assignor"),
         s"Unexpected error message: ${executionException.getCause.getMessage}")
+
+      // Every built-in assignor is registered by default, so a group can select the balanced assignor without
+      // any broker configuration. Group config propagation is asynchronous, so wait for it.
+      val balancedAlterOp = new AlterConfigOp(
+        new ConfigEntry(GroupConfig.STREAMS_ASSIGNOR_NAME_CONFIG, "balanced"),
+        AlterConfigOp.OpType.SET
+      )
+      admin.incrementalAlterConfigs(
+        Map(groupConfigResource -> List(balancedAlterOp).asJavaCollection).asJava
+      ).all().get()
+
+      TestUtils.waitUntilTrue(() => {
+        val describedConfigs = admin.describeConfigs(List(groupConfigResource).asJava).all().get()
+        val assignorName = describedConfigs.get(groupConfigResource).get(GroupConfig.STREAMS_ASSIGNOR_NAME_CONFIG)
+        assignorName != null && assignorName.value() == "balanced"
+      }, s"${GroupConfig.STREAMS_ASSIGNOR_NAME_CONFIG} was not updated to the expected value within the timeout period.")
     } finally {
       admin.close()
     }

--- a/docs/streams/developer-guide/streams-rebalance-protocol.md
+++ b/docs/streams/developer-guide/streams-rebalance-protocol.md
@@ -39,7 +39,7 @@ The following features are available in the current release:
 
 * **Core Streams Group Rebalance Protocol**: The `group.protocol=streams` configuration enables the dedicated streams rebalance protocol. This separates streams groups from consumer groups and provides a streams-specific group membership lifecycle and metadata management on the broker.
 
-* **Sticky Task Assignor**: A basic task assignment strategy that minimizes task movement during rebalances is included. It is registered under the name `sticky` and is the default assignor.
+* **Built-in Task Assignors**: Two task assignment strategies are included. The `sticky` assignor minimizes task movement during rebalances and is the default assignor. The `balanced` assignor spreads the tasks of each subtopology across processes and evens out the per-thread task load, at the price of moving more tasks when the group membership changes; it is the counterpart of the `HighAvailabilityTaskAssignor` of the classic protocol, without the warmup task and rack-aware placement features, which are not assignor features in the streams protocol. A group selects an assignor with the group configuration `streams.assignor.name`.
 
 * **Custom Task Assignors**: Brokers can be configured with custom task assignors via `group.streams.assignors`, which takes a list of built-in assignor names and fully qualified class names of custom `TaskAssignor` implementations. The first entry is the default assignor. An individual group selects one of the registered assignors by name with the group configuration `streams.assignor.name`; when unset, the group uses the first entry of `group.streams.assignors`. Custom implementations must be thread-safe, since a single instance is shared across all groups on a broker.
 
@@ -61,7 +61,7 @@ The following features are not yet available and should be avoided when using th
 
 * **Topology Updates**: If a topology is changed significantly (e.g., by adding new source topics or changing the number of subtopologies), a new streams group must be created.
 
-* **High Availability Assignor**: The sticky assignor is the only built-in assignor and it does not support rack aware assignment, but a custom assignor registered via `group.streams.assignors` can implement it.
+* **Rack-Aware Assignment**: Neither built-in assignor supports rack aware standby task assignment yet, but a custom assignor registered via `group.streams.assignors` can implement it.
 
 * **Warmup Tasks**: In contrast to the "classic" rebalance protocol, warmup tasks are not an assignor feature, but the group coordinator would inject warmup tasks into an assignment. The benefit is, that warmup tasks can be used independent of the configured assignor. However, warmup task support is not implemented yet.
 

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfig.java
@@ -33,6 +33,7 @@ import org.apache.kafka.coordinator.group.assignor.SimpleAssignor;
 import org.apache.kafka.coordinator.group.assignor.UniformAssignor;
 import org.apache.kafka.coordinator.group.streams.AssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
+import org.apache.kafka.coordinator.group.streams.assignor.BalancedTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 
 import org.slf4j.Logger;
@@ -395,7 +396,8 @@ public class GroupCoordinatorConfig {
     // The first entry is the default assignor for groups that do not select one. New built-in
     // assignors must be appended so that the default does not change for existing groups.
     private static final List<TaskAssignor> STREAMS_GROUP_BUILTIN_ASSIGNORS = List.of(
-        new StickyTaskAssignor()
+        new StickyTaskAssignor(),
+        new BalancedTaskAssignor()
     );
     public static final String STREAMS_GROUP_ASSIGNORS_CONFIG = "group.streams.assignors";
     public static final String STREAMS_GROUP_ASSIGNORS_DOC = "The server side task assignors for streams groups as a list of either names for built-in assignors or fully qualified class names for custom assignors. " +

--- a/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignor.java
+++ b/group-coordinator/src/main/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignor.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.assignor;
+
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupSpec;
+import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignmentState;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignorException;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A task assignor that computes a <em>balanced</em> assignment: tasks of the same subtopology are spread over as
+ * many processes as possible, and the per-member task load is evened out across processes.
+ * <p>
+ * The assignment is the placement half of the "classic" protocol's {@code HighAvailabilityTaskAssignor}, translated
+ * to the streams rebalance protocol:
+ * <ol>
+ *     <li>Stateful active tasks are dealt round-robin over the processes, in sorted order of task and process ID,
+ *     and then moved between processes as long as a move reduces the skew of the per-member task load.</li>
+ *     <li>Standby tasks are placed on the least loaded process that does not hold the task yet, and evened out the
+ *     same way.</li>
+ *     <li>Stateless active tasks fill in the gaps, going to the process with the lowest active task load.</li>
+ *     <li>Within a process, the tasks are spread evenly over its members, keeping a task on the member that currently
+ *     owns it where the quota allows.</li>
+ * </ol>
+ * In contrast to the {@link StickyTaskAssignor}, the placement across processes does not depend on the previous
+ * assignment, so the assignment stays orderly across many membership changes at the price of moving more tasks.
+ * <p>
+ * The parts of the classic assignor that this assignor deliberately does <em>not</em> implement are not assignor
+ * concerns in the streams rebalance protocol: warm-up tasks are inserted by the group coordinator when it applies the
+ * target assignment (so the member's {@link MemberAssignmentState#warmupTasks()}, {@link MemberAssignmentState#taskOffsets()}
+ * and {@link MemberAssignmentState#taskEndOffsets()} are not read here), and rack-aware placement is tracked
+ * separately.
+ */
+public class BalancedTaskAssignor implements TaskAssignor {
+
+    private static final String BALANCED_ASSIGNOR_NAME = "balanced";
+    private static final Logger log = LoggerFactory.getLogger(BalancedTaskAssignor.class);
+
+    private static final Comparator<ProcessTasks> BY_ASSIGNED_LOAD =
+        Comparator.comparingDouble(ProcessTasks::assignedTaskLoad).thenComparing(ProcessTasks::processId);
+    private static final Comparator<ProcessTasks> BY_ACTIVE_LOAD =
+        Comparator.comparingDouble(ProcessTasks::activeTaskLoad).thenComparing(ProcessTasks::processId);
+
+    @Override
+    public String name() {
+        return BALANCED_ASSIGNOR_NAME;
+    }
+
+    @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
+    public GroupAssignment assign(final GroupSpec groupSpec, final TopologyDescriber topologyDescriber) throws TaskAssignorException {
+        final TreeMap<String, ProcessTasks> processes = initializeProcesses(groupSpec);
+
+        final SortedSet<TaskId> statefulTasks = new TreeSet<>();
+        final SortedSet<TaskId> statelessTasks = new TreeSet<>();
+        for (final String subtopology : topologyDescriber.subtopologies()) {
+            final SortedSet<TaskId> tasks = topologyDescriber.isStateful(subtopology) ? statefulTasks : statelessTasks;
+            final int numberOfPartitions = topologyDescriber.maxNumInputPartitions(subtopology);
+            for (int partition = 0; partition < numberOfPartitions; partition++) {
+                tasks.add(new TaskId(subtopology, partition));
+            }
+        }
+
+        if (processes.isEmpty()) {
+            if (!statefulTasks.isEmpty() || !statelessTasks.isEmpty()) {
+                throw new TaskAssignorException("No process available to assign active tasks.");
+            }
+            return new GroupAssignment(Map.of());
+        }
+
+        assignActiveStatefulTasks(processes.values(), statefulTasks);
+
+        final int numStandbyReplicas = groupSpec.configs().numStandbyReplicas();
+        if (numStandbyReplicas > 0) {
+            assignStandbyReplicaTasks(processes.values(), statefulTasks, numStandbyReplicas);
+        }
+
+        assignStatelessActiveTasks(processes.values(), statelessTasks);
+
+        return buildGroupAssignment(processes.values());
+    }
+
+    /**
+     * Groups the members by process. The processes are kept in sorted order of their ID, which makes the
+     * assignment deterministic for a given group.
+     */
+    private static TreeMap<String, ProcessTasks> initializeProcesses(final GroupSpec groupSpec) {
+        final TreeMap<String, ProcessTasks> processes = new TreeMap<>();
+        for (final String memberId : groupSpec.memberIds()) {
+            final String processId = groupSpec.memberMetadata(memberId).processId();
+            processes.computeIfAbsent(processId, ProcessTasks::new)
+                .addMember(memberId, groupSpec.memberAssignmentState(memberId));
+        }
+        return processes;
+    }
+
+    /**
+     * Deals the stateful tasks round-robin over the processes and then evens out the load. Iterating the tasks in
+     * subtopology order spreads the tasks of each subtopology over the processes, which is what makes the assignment
+     * balanced rather than merely even.
+     */
+    private static void assignActiveStatefulTasks(final Collection<ProcessTasks> processes,
+                                                  final SortedSet<TaskId> statefulTasks) {
+        Iterator<ProcessTasks> processIterator = null;
+        for (final TaskId task : statefulTasks) {
+            if (processIterator == null || !processIterator.hasNext()) {
+                processIterator = processes.iterator();
+            }
+            processIterator.next().activeTasks.add(task);
+        }
+
+        balanceTasksOverProcesses(processes, process -> process.activeTasks);
+    }
+
+    private static void assignStandbyReplicaTasks(final Collection<ProcessTasks> processes,
+                                                  final SortedSet<TaskId> statefulTasks,
+                                                  final int numStandbyReplicas) {
+        // The queue orders the processes by their load as of the time they were offered. A polled process is offered
+        // again after its load changed, so the order stays valid.
+        final PriorityQueue<ProcessTasks> processesByLoad = new PriorityQueue<>(BY_ASSIGNED_LOAD);
+        processesByLoad.addAll(processes);
+
+        for (final TaskId task : statefulTasks) {
+            int remainingReplicas = numStandbyReplicas;
+            while (remainingReplicas > 0) {
+                final ProcessTasks process = pollLeastLoadedProcessWithoutTask(processesByLoad, task);
+                if (process == null) {
+                    break;
+                }
+                process.standbyTasks.add(task);
+                processesByLoad.add(process);
+                remainingReplicas--;
+            }
+
+            if (remainingReplicas > 0) {
+                log.warn("Unable to assign {} of {} standby tasks for task [{}]. " +
+                        "There is not enough available capacity. You should increase the number of " +
+                        "application instances to maintain the requested number of standby replicas.",
+                    remainingReplicas, numStandbyReplicas, task);
+            }
+        }
+
+        balanceTasksOverProcesses(processes, process -> process.standbyTasks);
+    }
+
+    /**
+     * Polls the least loaded process that does not hold the task yet, or {@code null} if every process holds it.
+     * Processes that were skipped are offered back to the queue; the returned process is not, since the caller
+     * changes its load.
+     */
+    private static ProcessTasks pollLeastLoadedProcessWithoutTask(final PriorityQueue<ProcessTasks> processesByLoad,
+                                                                  final TaskId task) {
+        final List<ProcessTasks> skipped = new ArrayList<>();
+        ProcessTasks found = null;
+        while (!processesByLoad.isEmpty()) {
+            final ProcessTasks candidate = processesByLoad.poll();
+            if (candidate.hasTask(task)) {
+                skipped.add(candidate);
+            } else {
+                found = candidate;
+                break;
+            }
+        }
+        processesByLoad.addAll(skipped);
+        return found;
+    }
+
+    /**
+     * Stateless tasks carry no state to restore, so they are simply placed on the process with the lowest active task
+     * load, which fills in any imbalance the stateful placement left behind.
+     */
+    private static void assignStatelessActiveTasks(final Collection<ProcessTasks> processes,
+                                                   final SortedSet<TaskId> statelessTasks) {
+        final PriorityQueue<ProcessTasks> processesByActiveLoad = new PriorityQueue<>(BY_ACTIVE_LOAD);
+        processesByActiveLoad.addAll(processes);
+
+        for (final TaskId task : statelessTasks) {
+            final ProcessTasks process = processesByActiveLoad.poll();
+            process.activeTasks.add(task);
+            processesByActiveLoad.add(process);
+        }
+    }
+
+    /**
+     * Moves tasks from more loaded to less loaded processes until no single move reduces the skew of the per-member
+     * task load any further. A task is never moved to a process that already holds it as active or standby task.
+     */
+    private static void balanceTasksOverProcesses(final Collection<ProcessTasks> processes,
+                                                  final Function<ProcessTasks, SortedSet<TaskId>> tasksToBalance) {
+        boolean keepBalancing = true;
+        while (keepBalancing) {
+            keepBalancing = false;
+            for (final ProcessTasks source : processes) {
+                for (final ProcessTasks destination : processes) {
+                    if (source == destination || !shouldMoveATask(source, destination)) {
+                        continue;
+                    }
+
+                    final SortedSet<TaskId> sourceTasks = tasksToBalance.apply(source);
+                    final SortedSet<TaskId> destinationTasks = tasksToBalance.apply(destination);
+                    // Iterate over a copy, since the moves below modify the source's tasks.
+                    final Iterator<TaskId> sourceIterator = new ArrayList<>(sourceTasks).iterator();
+                    while (shouldMoveATask(source, destination) && sourceIterator.hasNext()) {
+                        final TaskId taskToMove = sourceIterator.next();
+                        if (!destination.hasTask(taskToMove)) {
+                            sourceTasks.remove(taskToMove);
+                            destinationTasks.add(taskToMove);
+                            keepBalancing = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * A task should move from the source to the destination only if the destination is less loaded per member, and
+     * the move would reduce that skew without tipping the imbalance over to the other side.
+     */
+    private static boolean shouldMoveATask(final ProcessTasks source, final ProcessTasks destination) {
+        final double skew = source.assignedTaskLoad() - destination.assignedTaskLoad();
+
+        if (skew <= 0) {
+            return false;
+        }
+
+        final double proposedAssignedTasksPerMemberAtDestination =
+            (destination.assignedTaskCount() + 1.0) / destination.capacity();
+        final double proposedAssignedTasksPerMemberAtSource =
+            (source.assignedTaskCount() - 1.0) / source.capacity();
+        final double proposedSkew = proposedAssignedTasksPerMemberAtSource - proposedAssignedTasksPerMemberAtDestination;
+
+        if (proposedSkew < 0) {
+            // then the move would only create an imbalance in the other direction.
+            return false;
+        }
+        // we should only move a task if doing so would actually improve the skew.
+        return proposedSkew < skew;
+    }
+
+    /**
+     * Every member belongs to exactly one process and each process reports an assignment for each of its members,
+     * so the per-process assignments cover the whole group and never overlap.
+     */
+    private static GroupAssignment buildGroupAssignment(final Collection<ProcessTasks> processes) {
+        return new GroupAssignment(processes.stream()
+            .flatMap(process -> process.distributeTasksOverMembers().entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private static Map<String, Set<Integer>> toCompactedTaskIds(final Set<TaskId> taskIds) {
+        final Map<String, Set<Integer>> ret = new HashMap<>();
+        for (final TaskId taskId : taskIds) {
+            ret.computeIfAbsent(taskId.subtopologyId(), subtopologyId -> new HashSet<>())
+                .add(taskId.partition());
+        }
+        return ret;
+    }
+
+    private static int computeTasksPerMember(final int numberOfTasks, final int numberOfMembers) {
+        int tasksPerMember = numberOfTasks / numberOfMembers;
+        if (numberOfTasks % numberOfMembers > 0) {
+            tasksPerMember++;
+        }
+        return tasksPerMember;
+    }
+
+    /**
+     * The tasks placed on one process, and the members the process contributes. The assignment across processes
+     * works on this level; the tasks are spread over the members only once the placement is final.
+     */
+    private static final class ProcessTasks {
+        private final String processId;
+        private final TreeSet<String> memberIds = new TreeSet<>();
+        private final SortedSet<TaskId> activeTasks = new TreeSet<>();
+        private final SortedSet<TaskId> standbyTasks = new TreeSet<>();
+        // The member of this process that currently owns a task, used to keep the task on that member if possible.
+        private final Map<TaskId, String> currentActiveOwner = new HashMap<>();
+        private final Map<TaskId, String> currentStandbyOwner = new HashMap<>();
+
+        private ProcessTasks(final String processId) {
+            this.processId = processId;
+        }
+
+        private String processId() {
+            return processId;
+        }
+
+        private void addMember(final String memberId, final MemberAssignmentState currentAssignment) {
+            memberIds.add(memberId);
+            recordCurrentOwner(currentActiveOwner, memberId, currentAssignment.activeTasks());
+            recordCurrentOwner(currentStandbyOwner, memberId, currentAssignment.standbyTasks());
+        }
+
+        private static void recordCurrentOwner(final Map<TaskId, String> currentOwner,
+                                               final String memberId,
+                                               final Map<String, Set<Integer>> tasks) {
+            for (final Map.Entry<String, Set<Integer>> entry : tasks.entrySet()) {
+                for (final int partition : entry.getValue()) {
+                    // Two members of one process cannot own the same task; the smaller member ID wins if they do.
+                    currentOwner.merge(new TaskId(entry.getKey(), partition), memberId,
+                        (existing, candidate) -> existing.compareTo(candidate) <= 0 ? existing : candidate);
+                }
+            }
+        }
+
+        private int capacity() {
+            return memberIds.size();
+        }
+
+        private int assignedTaskCount() {
+            return activeTasks.size() + standbyTasks.size();
+        }
+
+        private double assignedTaskLoad() {
+            return ((double) assignedTaskCount()) / capacity();
+        }
+
+        private double activeTaskLoad() {
+            return ((double) activeTasks.size()) / capacity();
+        }
+
+        private boolean hasTask(final TaskId task) {
+            return activeTasks.contains(task) || standbyTasks.contains(task);
+        }
+
+        /**
+         * Spreads the process's tasks evenly over its members: first the active tasks, then the standby tasks on
+         * top of them. A task stays on the member that currently owns it as long as that member is below its quota;
+         * the remaining tasks go to the least loaded member.
+         *
+         * @return The assignment of every member of this process, including members that received no task.
+         */
+        private Map<String, MemberAssignment> distributeTasksOverMembers() {
+            final Map<String, Integer> totalTaskCountByMember = new HashMap<>(capacity());
+            final Map<String, Set<TaskId>> activeTasksByMember = new HashMap<>(capacity());
+            final Map<String, Set<TaskId>> standbyTasksByMember = new HashMap<>(capacity());
+            for (final String memberId : memberIds) {
+                totalTaskCountByMember.put(memberId, 0);
+                activeTasksByMember.put(memberId, new HashSet<>());
+                standbyTasksByMember.put(memberId, new HashSet<>());
+            }
+
+            distributeTasksOverMembers(activeTasks, currentActiveOwner, totalTaskCountByMember,
+                computeTasksPerMember(activeTasks.size(), capacity()), activeTasksByMember);
+            distributeTasksOverMembers(standbyTasks, currentStandbyOwner, totalTaskCountByMember,
+                computeTasksPerMember(assignedTaskCount(), capacity()), standbyTasksByMember);
+
+            return memberIds.stream().collect(Collectors.toMap(
+                Function.identity(),
+                memberId -> new MemberAssignment(
+                    toCompactedTaskIds(activeTasksByMember.get(memberId)),
+                    toCompactedTaskIds(standbyTasksByMember.get(memberId))
+                )
+            ));
+        }
+
+        /**
+         * Distributes the tasks of one role (active or standby) over the members.
+         *
+         * @param tasksToDistribute        The tasks of this role placed on the process.
+         * @param currentOwner             The member of this process that currently owns a task, if any.
+         * @param totalTaskCountByMember   The number of tasks of <em>both</em> roles each member holds so far; the
+         *                                 quota and the least-loaded choice are based on this total, and it is
+         *                                 updated as tasks are distributed.
+         * @param quota                    The number of tasks a member may hold in total before it stops keeping
+         *                                 its current tasks.
+         * @param distributedTasksByMember The tasks of this role each member receives; the output of this method.
+         */
+        private void distributeTasksOverMembers(final SortedSet<TaskId> tasksToDistribute,
+                                                final Map<TaskId, String> currentOwner,
+                                                final Map<String, Integer> totalTaskCountByMember,
+                                                final int quota,
+                                                final Map<String, Set<TaskId>> distributedTasksByMember) {
+            final List<TaskId> unassignedTasks = new ArrayList<>();
+            for (final TaskId task : tasksToDistribute) {
+                final String owner = currentOwner.get(task);
+                if (owner != null && totalTaskCountByMember.get(owner) < quota) {
+                    distributedTasksByMember.get(owner).add(task);
+                    totalTaskCountByMember.merge(owner, 1, Integer::sum);
+                } else {
+                    unassignedTasks.add(task);
+                }
+            }
+
+            final PriorityQueue<String> membersByLoad = new PriorityQueue<>(
+                Comparator.<String>comparingInt(totalTaskCountByMember::get).thenComparing(Comparator.naturalOrder())
+            );
+            membersByLoad.addAll(memberIds);
+            for (final TaskId task : unassignedTasks) {
+                final String member = membersByLoad.poll();
+                distributedTasksByMember.get(member).add(task);
+                totalTaskCountByMember.merge(member, 1, Integer::sum);
+                membersByLoad.add(member);
+            }
+        }
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/GroupCoordinatorConfigTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.coordinator.group.streams.MemberTaskOffsets;
 import org.apache.kafka.coordinator.group.streams.NoOpAssignmentRefiner;
 import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
 import org.apache.kafka.coordinator.group.streams.TasksTuple;
+import org.apache.kafka.coordinator.group.streams.assignor.BalancedTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.assignor.StickyTaskAssignor;
 import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
 
@@ -387,13 +388,15 @@ public class GroupCoordinatorConfigTest {
         GroupCoordinatorConfig config;
         List<TaskAssignor> assignors;
 
-        // Test default config. The default is every built-in assignor, in declaration order.
-        assertEquals(List.of("sticky"), GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNORS_DEFAULT);
+        // Test default config. The default is every built-in assignor, in declaration order, so that the
+        // first entry -- the default assignor of groups that do not select one -- stays the sticky assignor.
+        assertEquals(List.of("sticky", "balanced"), GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNORS_DEFAULT);
         config = createConfig(configs);
         assignors = config.streamsGroupAssignors();
-        assertEquals(1, assignors.size());
+        assertEquals(2, assignors.size());
         assertInstanceOf(StickyTaskAssignor.class, assignors.get(0));
-        assertEquals(List.of("sticky"), config.streamsGroupAssignorNames());
+        assertInstanceOf(BalancedTaskAssignor.class, assignors.get(1));
+        assertEquals(List.of("sticky", "balanced"), config.streamsGroupAssignorNames());
 
         // Test custom assignor.
         configs.put(GroupCoordinatorConfig.STREAMS_GROUP_ASSIGNORS_CONFIG, CustomTaskAssignor.class.getName());

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignorTest.java
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.coordinator.group.streams.assignor;
+
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignorException;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BalancedTaskAssignorTest {
+
+    private static final String SUBTOPOLOGY_1 = "test-subtopology1";
+    private static final String SUBTOPOLOGY_2 = "test-subtopology2";
+
+    private final BalancedTaskAssignor assignor = new BalancedTaskAssignor();
+
+    @Test
+    public void testToStringReturnsName() {
+        assertEquals("balanced", assignor.name());
+        assertEquals(assignor.name(), assignor.toString());
+    }
+
+    @Test
+    public void shouldThrowWhenThereAreTasksButNoMembers() {
+        assertThrows(TaskAssignorException.class, () -> assignor.assign(
+            new GroupSpecImpl(Map.of(), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(3, SUBTOPOLOGY_1)
+        ));
+    }
+
+    @Test
+    public void shouldAssignNothingWhenThereAreNoTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1", "process1", "member2", "process2"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(0, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, result.members().size());
+        assertEquals(new MemberAssignment(Map.of(), Map.of()), result.members().get("member1"));
+        assertEquals(new MemberAssignment(Map.of(), Map.of()), result.members().get("member2"));
+    }
+
+    @Test
+    public void shouldAssignActiveStatefulTasksEvenlyOverProcessesWhereNumberOfProcessesIntegralDivisorOfNumberOfTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1", "process1", "member2", "process2", "member3", "process3"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(6, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1"));
+        assertEquals(2, activeTaskCount(result, "member2"));
+        assertEquals(2, activeTaskCount(result, "member3"));
+        assertAllTasksAssignedOnce(result, statefulTopology(6, SUBTOPOLOGY_1));
+        assertNoStandbyTasks(result);
+    }
+
+    @Test
+    public void shouldAssignActiveStatefulTasksEvenlyOverMembersWhereNumberOfMembersIntegralDivisorOfNumberOfTasks() {
+        // process1 has two members, process2 one; so process1 gets twice as many tasks.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1_1", "process1", "member1_2", "process1", "member2_1", "process2"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(6, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1_1"));
+        assertEquals(2, activeTaskCount(result, "member1_2"));
+        assertEquals(2, activeTaskCount(result, "member2_1"));
+        assertAllTasksAssignedOnce(result, statefulTopology(6, SUBTOPOLOGY_1));
+    }
+
+    @Test
+    public void shouldAssignActiveStatefulTasksEvenlyOverProcessesWhereNumberOfProcessesNotIntegralDivisorOfNumberOfTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1", "process1", "member2", "process2"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(5, SUBTOPOLOGY_1)
+        );
+
+        final int count1 = activeTaskCount(result, "member1");
+        final int count2 = activeTaskCount(result, "member2");
+        assertEquals(5, count1 + count2);
+        assertTrue(Math.abs(count1 - count2) <= 1, "Expected an even split, got " + count1 + " and " + count2);
+        assertAllTasksAssignedOnce(result, statefulTopology(5, SUBTOPOLOGY_1));
+    }
+
+    @Test
+    public void shouldAssignActiveStatefulTasksEvenlyOverUnevenlyDistributedMembers() {
+        // process1 has three members, process2 has one. Round-robin would give each process four tasks, so the
+        // balancing step has to move two tasks to process1 to even out the per-member load.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members(
+                "member1_1", "process1", "member1_2", "process1", "member1_3", "process1",
+                "member2_1", "process2"
+            ), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(8, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1_1"));
+        assertEquals(2, activeTaskCount(result, "member1_2"));
+        assertEquals(2, activeTaskCount(result, "member1_3"));
+        assertEquals(2, activeTaskCount(result, "member2_1"));
+        assertAllTasksAssignedOnce(result, statefulTopology(8, SUBTOPOLOGY_1));
+    }
+
+    @Test
+    public void shouldAssignActiveStatefulTasksEvenlyOverProcessesWithMoreProcessesThanTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1", "process1", "member2", "process2", "member3", "process3", "member4", "process4"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(2, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(1, activeTaskCount(result, "member1"));
+        assertEquals(1, activeTaskCount(result, "member2"));
+        assertEquals(0, activeTaskCount(result, "member3"));
+        assertEquals(0, activeTaskCount(result, "member4"));
+        assertAllTasksAssignedOnce(result, statefulTopology(2, SUBTOPOLOGY_1));
+    }
+
+    @Test
+    public void shouldSpreadTasksOfEachSubtopologyOverProcesses() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1", "process1", "member2", "process2"), AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(2, SUBTOPOLOGY_1, SUBTOPOLOGY_2)
+        );
+
+        // Each process gets one partition of each subtopology, never both partitions of the same subtopology.
+        assertEquals(
+            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0)), mkEntry(SUBTOPOLOGY_2, Set.of(0))),
+            result.members().get("member1").activeTasks()
+        );
+        assertEquals(
+            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1)), mkEntry(SUBTOPOLOGY_2, Set.of(1))),
+            result.members().get("member2").activeTasks()
+        );
+    }
+
+    @Test
+    public void shouldNotDependOnPreviousAssignmentAcrossProcessesUnlikeStickyAssignor() {
+        // The previous assignment groups the tasks by subtopology. The sticky assignor keeps that layout, because
+        // both members are below quota; the balanced assignor recomputes the interleaved layout regardless.
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberWithTasks("process1", mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 1))), Map.of())),
+            mkEntry("member2", memberWithTasks("process2", mkMap(mkEntry(SUBTOPOLOGY_2, Set.of(0, 1))), Map.of()))
+        );
+        final TopologyDescriber topology = statefulTopology(2, SUBTOPOLOGY_1, SUBTOPOLOGY_2);
+
+        final GroupAssignment sticky = new StickyTaskAssignor().assign(new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT), topology);
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 1))), sticky.members().get("member1").activeTasks());
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_2, Set.of(0, 1))), sticky.members().get("member2").activeTasks());
+
+        final GroupAssignment balanced = assignor.assign(new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT), topology);
+        assertEquals(
+            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0)), mkEntry(SUBTOPOLOGY_2, Set.of(0))),
+            balanced.members().get("member1").activeTasks()
+        );
+        assertEquals(
+            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1)), mkEntry(SUBTOPOLOGY_2, Set.of(1))),
+            balanced.members().get("member2").activeTasks()
+        );
+    }
+
+    @Test
+    public void shouldKeepTasksOnTheirCurrentMemberWithinAProcess() {
+        // Both members of the process are at quota with their current tasks, so nothing needs to move within the
+        // process even though the tasks were dealt to the process in a different order.
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberWithTasks("process1", mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1, 3))), Map.of())),
+            mkEntry("member2", memberWithTasks("process1", mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 2))), Map.of()))
+        );
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(4, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1, 3))), result.members().get("member1").activeTasks());
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 2))), result.members().get("member2").activeTasks());
+    }
+
+    @Test
+    public void shouldMoveTasksOffAnOverloadedMemberWithinAProcess() {
+        // member1 currently owns every task; it keeps two (its quota) and the other two move to member2.
+        final Map<String, MemberMetadataAndStateImpl> members = mkMap(
+            mkEntry("member1", memberWithTasks("process1", mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 1, 2, 3))), Map.of())),
+            mkEntry("member2", memberWithTasks("process1", Map.of(), Map.of()))
+        );
+
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT),
+            statefulTopology(4, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 1))), result.members().get("member1").activeTasks());
+        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(2, 3))), result.members().get("member2").activeTasks());
+    }
+
+    @Test
+    public void shouldAssignStandbysForStatefulTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(
+                members("member1", "process1", "member2", "process2", "member3", "process3"),
+                AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)
+            ),
+            statefulTopology(3, SUBTOPOLOGY_1)
+        );
+
+        for (final String memberId : List.of("member1", "member2", "member3")) {
+            assertEquals(1, activeTaskCount(result, memberId));
+            assertEquals(1, standbyTaskCount(result, memberId));
+        }
+        assertAllTasksAssignedOnce(result, statefulTopology(3, SUBTOPOLOGY_1));
+        assertStandbysAssigned(result, statefulTopology(3, SUBTOPOLOGY_1), 1);
+    }
+
+    @Test
+    public void shouldNotAssignStandbysForStatelessTasks() {
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(
+                members("member1", "process1", "member2", "process2"),
+                AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)
+            ),
+            statelessTopology(4, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1"));
+        assertEquals(2, activeTaskCount(result, "member2"));
+        assertNoStandbyTasks(result);
+    }
+
+    @Test
+    public void shouldNotAssignStandbyToTheProcessThatOwnsTheActiveTask() {
+        // Two members per process: a standby must still land on the other process, not on the sibling member.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(
+                members("member1_1", "process1", "member1_2", "process1", "member2_1", "process2", "member2_2", "process2"),
+                AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)
+            ),
+            statefulTopology(4, SUBTOPOLOGY_1)
+        );
+
+        final Set<Integer> process1Actives = mergeTasks(result, true, "member1_1", "member1_2").getOrDefault(SUBTOPOLOGY_1, Set.of());
+        final Set<Integer> process1Standbys = mergeTasks(result, false, "member1_1", "member1_2").getOrDefault(SUBTOPOLOGY_1, Set.of());
+        assertEquals(2, process1Actives.size());
+        assertEquals(2, process1Standbys.size());
+        assertTrue(process1Actives.stream().noneMatch(process1Standbys::contains),
+            "process1 holds " + process1Actives + " as active and " + process1Standbys + " as standby");
+        assertStandbysAssigned(result, statefulTopology(4, SUBTOPOLOGY_1), 1);
+    }
+
+    @Test
+    public void shouldNotAssignAnyStandbysWithInsufficientCapacity() {
+        // A single process cannot hold a standby of its own active tasks; the assignor warns and carries on.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(
+                members("member1", "process1", "member2", "process1"),
+                AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)
+            ),
+            statefulTopology(4, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1"));
+        assertEquals(2, activeTaskCount(result, "member2"));
+        assertNoStandbyTasks(result);
+    }
+
+    @Test
+    public void shouldAssignAsManyStandbysAsCapacityAllows() {
+        // Two processes, two standby replicas requested: only one standby per task fits.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(
+                members("member1", "process1", "member2", "process2"),
+                AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(2)
+            ),
+            statefulTopology(2, SUBTOPOLOGY_1)
+        );
+
+        assertEquals(1, activeTaskCount(result, "member1"));
+        assertEquals(1, activeTaskCount(result, "member2"));
+        assertStandbysAssigned(result, statefulTopology(2, SUBTOPOLOGY_1), 1);
+    }
+
+    @Test
+    public void shouldDistributeStatelessTasksToBalanceTotalTaskLoad() {
+        // Stateful placement leaves process1 (two members) and process2 (one member) at a load of one task per
+        // member. The stateless tasks are then dealt by active load, so process1 gets two of them and process2 one.
+        final GroupAssignment result = assignor.assign(
+            new GroupSpecImpl(members("member1_1", "process1", "member1_2", "process1", "member2_1", "process2"), AssignmentConfigsImpl.DEFAULT),
+            new MixedTopologyDescriber(3, 3)
+        );
+
+        assertEquals(2, activeTaskCount(result, "member1_1"));
+        assertEquals(2, activeTaskCount(result, "member1_2"));
+        assertEquals(2, activeTaskCount(result, "member2_1"));
+        assertAllTasksAssignedOnce(result, new MixedTopologyDescriber(3, 3));
+        assertNoStandbyTasks(result);
+    }
+
+    @Test
+    public void shouldIgnoreWarmupTasksAndReportedOffsets() {
+        // The balanced strategy does not use lag or warm-up information; the result must match the plain spec.
+        final Map<String, MemberMetadataAndStateImpl> plainMembers = members("member1", "process1", "member2", "process2");
+        final Map<String, MemberMetadataAndStateImpl> membersWithHints = mkMap(
+            mkEntry("member1", new MemberMetadataAndStateImpl(
+                Optional.of("instance1"),
+                Optional.of("rack1"),
+                "process1",
+                Map.of("zone", "a"),
+                Map.of(),
+                Map.of(),
+                mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1, 3))),
+                mkMap(mkEntry(SUBTOPOLOGY_1, mkMap(mkEntry(1, 100L), mkEntry(3, 100L)))),
+                mkMap(mkEntry(SUBTOPOLOGY_1, mkMap(mkEntry(1, 100L), mkEntry(3, 100L))))
+            )),
+            mkEntry("member2", new MemberMetadataAndStateImpl(
+                Optional.of("instance2"),
+                Optional.of("rack2"),
+                "process2",
+                Map.of("zone", "b"),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                mkMap(mkEntry(SUBTOPOLOGY_1, mkMap(mkEntry(0, 5L), mkEntry(2, 5L)))),
+                mkMap(mkEntry(SUBTOPOLOGY_1, mkMap(mkEntry(0, 500L), mkEntry(2, 500L))))
+            ))
+        );
+        final TopologyDescriber topology = statefulTopology(4, SUBTOPOLOGY_1);
+
+        final GroupAssignment plain = assignor.assign(new GroupSpecImpl(plainMembers, AssignmentConfigsImpl.DEFAULT), topology);
+        final GroupAssignment withHints = assignor.assign(new GroupSpecImpl(membersWithHints, AssignmentConfigsImpl.DEFAULT), topology);
+
+        assertEquals(plain, withHints);
+    }
+
+    @Test
+    public void shouldBeDeterministicRegardlessOfMemberOrder() {
+        final Map<String, MemberMetadataAndStateImpl> ordered = new TreeMap<>(members(
+            "member1", "process2", "member2", "process1", "member3", "process3", "member4", "process1"
+        ));
+        final Map<String, MemberMetadataAndStateImpl> reversed = new TreeMap<>((a, b) -> b.compareTo(a));
+        reversed.putAll(ordered);
+        final TopologyDescriber topology = new MixedTopologyDescriber(5, 3);
+
+        assertEquals(
+            assignor.assign(new GroupSpecImpl(ordered, AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)), topology),
+            assignor.assign(new GroupSpecImpl(reversed, AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(1)), topology)
+        );
+    }
+
+    @Test
+    public void shouldProduceValidAndEvenAssignmentsForRandomInput() {
+        final long seed = System.nanoTime();
+        final Random random = new Random(seed);
+
+        for (int iteration = 0; iteration < 50; iteration++) {
+            final int numProcesses = 1 + random.nextInt(8);
+            final int membersPerProcess = 1 + random.nextInt(4);
+            final int numStatefulTasks = random.nextInt(20);
+            final int numStatelessTasks = random.nextInt(20);
+            final int numStandbyReplicas = random.nextInt(3);
+
+            final Map<String, MemberMetadataAndStateImpl> members = new HashMap<>();
+            for (int p = 0; p < numProcesses; p++) {
+                for (int m = 0; m < membersPerProcess; m++) {
+                    members.put("member" + p + "_" + m, member("process" + p));
+                }
+            }
+            final TopologyDescriber topology = new MixedTopologyDescriber(numStatefulTasks, numStatelessTasks);
+            final String context = String.format("seed=%d processes=%d membersPerProcess=%d stateful=%d stateless=%d standbys=%d",
+                seed, numProcesses, membersPerProcess, numStatefulTasks, numStatelessTasks, numStandbyReplicas);
+
+            final GroupAssignment result = assignor.assign(
+                new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(numStandbyReplicas)),
+                topology
+            );
+
+            assertAllTasksAssignedOnce(result, topology);
+            // Every process has the same capacity, so the number of active tasks per member may differ by at most one.
+            final List<Integer> activeCounts = members.keySet().stream().map(memberId -> activeTaskCount(result, memberId)).toList();
+            final int maxActive = activeCounts.stream().mapToInt(Integer::intValue).max().orElse(0);
+            final int minActive = activeCounts.stream().mapToInt(Integer::intValue).min().orElse(0);
+            assertTrue(maxActive - minActive <= 1, "Active tasks per member not even (" + context + "): " + activeCounts);
+
+            // Standbys are bounded by the replicas requested and the number of other processes, and never share a
+            // process with the active task or another standby of the same task.
+            final int expectedStandbys = Math.min(numStandbyReplicas, numProcesses - 1);
+            assertStandbysAssigned(result, topology, expectedStandbys);
+            for (int p = 0; p < numProcesses; p++) {
+                final String[] memberIds = new String[membersPerProcess];
+                for (int m = 0; m < membersPerProcess; m++) {
+                    memberIds[m] = "member" + p + "_" + m;
+                }
+                final Map<String, Set<Integer>> actives = mergeTasks(result, true, memberIds);
+                final Map<String, Set<Integer>> standbys = mergeTasks(result, false, memberIds);
+                for (final Map.Entry<String, Set<Integer>> entry : standbys.entrySet()) {
+                    final Set<Integer> activePartitions = actives.getOrDefault(entry.getKey(), Set.of());
+                    assertTrue(entry.getValue().stream().noneMatch(activePartitions::contains),
+                        "process" + p + " holds a task as active and standby (" + context + ")");
+                }
+            }
+        }
+    }
+
+    private static Map<String, MemberMetadataAndStateImpl> members(final String... memberIdsAndProcessIds) {
+        final Map<String, MemberMetadataAndStateImpl> members = new HashMap<>();
+        for (int i = 0; i < memberIdsAndProcessIds.length; i += 2) {
+            members.put(memberIdsAndProcessIds[i], member(memberIdsAndProcessIds[i + 1]));
+        }
+        return members;
+    }
+
+    private static MemberMetadataAndStateImpl member(final String processId) {
+        return memberWithTasks(processId, Map.of(), Map.of());
+    }
+
+    private static MemberMetadataAndStateImpl memberWithTasks(final String processId,
+                                                              final Map<String, Set<Integer>> activeTasks,
+                                                              final Map<String, Set<Integer>> standbyTasks) {
+        return new MemberMetadataAndStateImpl(
+            Optional.empty(),
+            Optional.empty(),
+            processId,
+            Map.of(),
+            activeTasks,
+            standbyTasks,
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+    }
+
+    private static TopologyDescriber statefulTopology(final int numTasks, final String... subtopologies) {
+        return new UniformTopologyDescriber(numTasks, true, List.of(subtopologies));
+    }
+
+    private static TopologyDescriber statelessTopology(final int numTasks, final String... subtopologies) {
+        return new UniformTopologyDescriber(numTasks, false, List.of(subtopologies));
+    }
+
+    private static int activeTaskCount(final GroupAssignment result, final String memberId) {
+        final MemberAssignment member = result.members().get(memberId);
+        assertNotNull(member);
+        return member.activeTasks().values().stream().mapToInt(Set::size).sum();
+    }
+
+    private static int standbyTaskCount(final GroupAssignment result, final String memberId) {
+        final MemberAssignment member = result.members().get(memberId);
+        assertNotNull(member);
+        return member.standbyTasks().values().stream().mapToInt(Set::size).sum();
+    }
+
+    private static Map<String, Set<Integer>> mergeTasks(final GroupAssignment result, final boolean active, final String... memberIds) {
+        final Map<String, Set<Integer>> merged = new HashMap<>();
+        for (final String memberId : memberIds) {
+            final MemberAssignment member = result.members().get(memberId);
+            assertNotNull(member);
+            final Map<String, Set<Integer>> tasks = active ? member.activeTasks() : member.standbyTasks();
+            tasks.forEach((subtopology, partitions) -> merged.computeIfAbsent(subtopology, s -> new HashSet<>()).addAll(partitions));
+        }
+        return merged;
+    }
+
+    private static void assertNoStandbyTasks(final GroupAssignment result) {
+        for (final Map.Entry<String, MemberAssignment> entry : result.members().entrySet()) {
+            assertTrue(entry.getValue().standbyTasks().isEmpty(), entry.getKey() + " has standby tasks " + entry.getValue().standbyTasks());
+        }
+    }
+
+    /** Every task of the topology is assigned as active task to exactly one member. */
+    private static void assertAllTasksAssignedOnce(final GroupAssignment result, final TopologyDescriber topology) {
+        final Map<TaskId, Integer> owners = new HashMap<>();
+        for (final MemberAssignment member : result.members().values()) {
+            member.activeTasks().forEach((subtopology, partitions) ->
+                partitions.forEach(partition -> owners.merge(new TaskId(subtopology, partition), 1, Integer::sum)));
+        }
+        final Set<TaskId> expected = new HashSet<>();
+        for (final String subtopology : topology.subtopologies()) {
+            for (int partition = 0; partition < topology.maxNumInputPartitions(subtopology); partition++) {
+                expected.add(new TaskId(subtopology, partition));
+            }
+        }
+        assertEquals(expected, owners.keySet());
+        owners.forEach((task, count) -> assertEquals(1, count, task + " is active on " + count + " members"));
+    }
+
+    /** Every stateful task has exactly the given number of standbys and no stateless task has any. */
+    private static void assertStandbysAssigned(final GroupAssignment result, final TopologyDescriber topology, final int expectedStandbys) {
+        final Map<TaskId, Integer> standbyCounts = new HashMap<>();
+        for (final MemberAssignment member : result.members().values()) {
+            member.standbyTasks().forEach((subtopology, partitions) ->
+                partitions.forEach(partition -> standbyCounts.merge(new TaskId(subtopology, partition), 1, Integer::sum)));
+        }
+        final Map<TaskId, Integer> expected = new HashMap<>();
+        if (expectedStandbys > 0) {
+            for (final String subtopology : topology.subtopologies()) {
+                if (topology.isStateful(subtopology)) {
+                    for (int partition = 0; partition < topology.maxNumInputPartitions(subtopology); partition++) {
+                        expected.put(new TaskId(subtopology, partition), expectedStandbys);
+                    }
+                }
+            }
+        }
+        assertEquals(expected, standbyCounts);
+        standbyCounts.keySet().forEach(task -> assertTrue(
+            topology.isStateful(task.subtopologyId()), task + " is stateless but has standbys"));
+    }
+
+    private record UniformTopologyDescriber(int numTasks, boolean isStateful, List<String> subtopologies) implements TopologyDescriber {
+
+        @Override
+        public int maxNumInputPartitions(final String subtopologyId) throws NoSuchElementException {
+            return numTasks;
+        }
+
+        @Override
+        public boolean isStateful(final String subtopologyId) {
+            return isStateful;
+        }
+    }
+
+    /** One stateful subtopology followed by one stateless subtopology. */
+    private record MixedTopologyDescriber(int numStatefulTasks, int numStatelessTasks) implements TopologyDescriber {
+
+        @Override
+        public List<String> subtopologies() {
+            final List<String> subtopologies = new ArrayList<>();
+            if (numStatefulTasks > 0) {
+                subtopologies.add(SUBTOPOLOGY_1);
+            }
+            if (numStatelessTasks > 0) {
+                subtopologies.add(SUBTOPOLOGY_2);
+            }
+            return subtopologies;
+        }
+
+        @Override
+        public int maxNumInputPartitions(final String subtopologyId) throws NoSuchElementException {
+            return subtopologyId.equals(SUBTOPOLOGY_1) ? numStatefulTasks : numStatelessTasks;
+        }
+
+        @Override
+        public boolean isStateful(final String subtopologyId) {
+            return subtopologyId.equals(SUBTOPOLOGY_1);
+        }
+    }
+}

--- a/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignorTest.java
+++ b/group-coordinator/src/test/java/org/apache/kafka/coordinator/group/streams/assignor/BalancedTaskAssignorTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -142,10 +143,8 @@ public class BalancedTaskAssignorTest {
             statefulTopology(2, SUBTOPOLOGY_1)
         );
 
-        assertEquals(1, activeTaskCount(result, "member1"));
-        assertEquals(1, activeTaskCount(result, "member2"));
-        assertEquals(0, activeTaskCount(result, "member3"));
-        assertEquals(0, activeTaskCount(result, "member4"));
+        // Which two of the four interchangeable processes receive a task is a tie-break, not a property.
+        assertEquals(List.of(0, 0, 1, 1), sortedActiveTaskCounts(result, "member1", "member2", "member3", "member4"));
         assertAllTasksAssignedOnce(result, statefulTopology(2, SUBTOPOLOGY_1));
     }
 
@@ -157,14 +156,9 @@ public class BalancedTaskAssignorTest {
         );
 
         // Each process gets one partition of each subtopology, never both partitions of the same subtopology.
-        assertEquals(
-            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0)), mkEntry(SUBTOPOLOGY_2, Set.of(0))),
-            result.members().get("member1").activeTasks()
-        );
-        assertEquals(
-            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1)), mkEntry(SUBTOPOLOGY_2, Set.of(1))),
-            result.members().get("member2").activeTasks()
-        );
+        assertOnePartitionOfEachSubtopology(result, "member1", SUBTOPOLOGY_1, SUBTOPOLOGY_2);
+        assertOnePartitionOfEachSubtopology(result, "member2", SUBTOPOLOGY_1, SUBTOPOLOGY_2);
+        assertAllTasksAssignedOnce(result, statefulTopology(2, SUBTOPOLOGY_1, SUBTOPOLOGY_2));
     }
 
     @Test
@@ -182,14 +176,9 @@ public class BalancedTaskAssignorTest {
         assertEquals(mkMap(mkEntry(SUBTOPOLOGY_2, Set.of(0, 1))), sticky.members().get("member2").activeTasks());
 
         final GroupAssignment balanced = assignor.assign(new GroupSpecImpl(members, AssignmentConfigsImpl.DEFAULT), topology);
-        assertEquals(
-            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0)), mkEntry(SUBTOPOLOGY_2, Set.of(0))),
-            balanced.members().get("member1").activeTasks()
-        );
-        assertEquals(
-            mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(1)), mkEntry(SUBTOPOLOGY_2, Set.of(1))),
-            balanced.members().get("member2").activeTasks()
-        );
+        assertOnePartitionOfEachSubtopology(balanced, "member1", SUBTOPOLOGY_1, SUBTOPOLOGY_2);
+        assertOnePartitionOfEachSubtopology(balanced, "member2", SUBTOPOLOGY_1, SUBTOPOLOGY_2);
+        assertAllTasksAssignedOnce(balanced, topology);
     }
 
     @Test
@@ -223,8 +212,12 @@ public class BalancedTaskAssignorTest {
             statefulTopology(4, SUBTOPOLOGY_1)
         );
 
-        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(0, 1))), result.members().get("member1").activeTasks());
-        assertEquals(mkMap(mkEntry(SUBTOPOLOGY_1, Set.of(2, 3))), result.members().get("member2").activeTasks());
+        // member1 keeps two of its current tasks -- which two is a tie-break -- and member2 receives the other two.
+        final Set<Integer> keptByMember1 = result.members().get("member1").activeTasks().get(SUBTOPOLOGY_1);
+        final Set<Integer> movedToMember2 = result.members().get("member2").activeTasks().get(SUBTOPOLOGY_1);
+        assertEquals(2, keptByMember1.size());
+        assertEquals(2, movedToMember2.size());
+        assertAllTasksAssignedOnce(result, statefulTopology(4, SUBTOPOLOGY_1));
     }
 
     @Test
@@ -473,6 +466,20 @@ public class BalancedTaskAssignorTest {
         final MemberAssignment member = result.members().get(memberId);
         assertNotNull(member);
         return member.activeTasks().values().stream().mapToInt(Set::size).sum();
+    }
+
+    private static List<Integer> sortedActiveTaskCounts(final GroupAssignment result, final String... memberIds) {
+        return Stream.of(memberIds).map(memberId -> activeTaskCount(result, memberId)).sorted().toList();
+    }
+
+    /** The member holds exactly one partition of each of the given subtopologies and nothing else. */
+    private static void assertOnePartitionOfEachSubtopology(final GroupAssignment result,
+                                                            final String memberId,
+                                                            final String... subtopologies) {
+        final Map<String, Set<Integer>> activeTasks = result.members().get(memberId).activeTasks();
+        assertEquals(Set.of(subtopologies), activeTasks.keySet(), memberId + " holds " + activeTasks);
+        activeTasks.forEach((subtopology, partitions) ->
+            assertEquals(1, partitions.size(), memberId + " holds " + partitions + " of " + subtopology));
     }
 
     private static int standbyTaskCount(final GroupAssignment result, final String memberId) {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsBalancedAssignorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/assignor/StreamsBalancedAssignorBenchmark.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.assignor;
+
+import org.apache.kafka.coordinator.common.runtime.CoordinatorMetadataImage;
+import org.apache.kafka.coordinator.group.api.streams.assignor.AssignmentConfigs;
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.GroupSpec;
+import org.apache.kafka.coordinator.group.api.streams.assignor.MemberAssignment;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TaskAssignor;
+import org.apache.kafka.coordinator.group.api.streams.assignor.TopologyDescriber;
+import org.apache.kafka.coordinator.group.streams.StreamsGroupMember;
+import org.apache.kafka.coordinator.group.streams.TopologyMetadata;
+import org.apache.kafka.coordinator.group.streams.assignor.AssignmentConfigsImpl;
+import org.apache.kafka.coordinator.group.streams.assignor.BalancedTaskAssignor;
+import org.apache.kafka.coordinator.group.streams.assignor.GroupSpecImpl;
+import org.apache.kafka.coordinator.group.streams.assignor.MemberMetadataAndStateImpl;
+import org.apache.kafka.coordinator.group.streams.topics.ConfiguredSubtopology;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class StreamsBalancedAssignorBenchmark {
+
+    /**
+     * The assignment type is decided based on whether all the members are assigned partitions
+     * for the first time (full), or incrementally when a rebalance is triggered.
+     */
+    public enum AssignmentType {
+        FULL, INCREMENTAL
+    }
+
+    /**
+     * Whether the members report offset sums for the state they hold on local disk. NONE is the behaviour of a
+     * group whose clients do not report offsets, OWNED_AND_DORMANT also reports state left behind by earlier
+     * assignments. The balanced assignor does not read reported offsets; the parameter is kept so that the results
+     * can be compared side by side with {@link StreamsStickyAssignorBenchmark}.
+     */
+    public enum ReportedOffsets {
+        NONE, OWNED_AND_DORMANT
+    }
+
+    /**
+     * The number of members reporting a task on top of the one owning it, under OWNED_AND_DORMANT.
+     */
+    private static final int DORMANT_REPLICAS = 1;
+
+    @Param({"100", "1000"})
+    private int memberCount;
+
+    @Param({"10", "100"})
+    private int partitionCount;
+
+    @Param({"10", "100"})
+    private int subtopologyCount;
+
+    @Param({"0", "1"})
+    private int standbyReplicas;
+
+    @Param({"1", "50"})
+    private int membersPerProcess;
+
+    @Param({"FULL", "INCREMENTAL"})
+    private AssignmentType assignmentType;
+
+    @Param({"NONE", "OWNED_AND_DORMANT"})
+    private ReportedOffsets reportedOffsets;
+
+    private TaskAssignor taskAssignor;
+
+    private GroupSpec groupSpec;
+
+    private TopologyDescriber topologyDescriber;
+
+    private AssignmentConfigs assignmentConfigs;
+
+    private Map<String, Map<String, Map<Integer, Long>>> taskOffsets;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        List<String> allTopicNames = AssignorBenchmarkUtils.createTopicNames(subtopologyCount);
+
+        SortedMap<String, ConfiguredSubtopology> subtopologyMap = StreamsAssignorBenchmarkUtils.createSubtopologyMap(partitionCount, allTopicNames);
+
+        CoordinatorMetadataImage metadataImage = AssignorBenchmarkUtils.createMetadataImage(allTopicNames, partitionCount);
+
+        topologyDescriber = new TopologyMetadata(metadataImage, subtopologyMap);
+
+        taskAssignor = new BalancedTaskAssignor();
+
+        Map<String, StreamsGroupMember> members = createMembers();
+        this.assignmentConfigs = AssignmentConfigsImpl.DEFAULT.withNumStandbyReplicas(standbyReplicas);
+
+        List<String> memberIds = new ArrayList<>(members.keySet());
+        Collections.sort(memberIds);
+        this.taskOffsets = reportedOffsets == ReportedOffsets.NONE
+            ? Map.of()
+            : StreamsAssignorBenchmarkUtils.createTaskOffsets(memberIds, subtopologyMap, DORMANT_REPLICAS);
+
+        if (assignmentType == AssignmentType.INCREMENTAL) {
+            // The setup assignment is only fixture for the measured one, so it is left offset-free. The offsets
+            // go into the member spec it produces, which is what the measured assignment sees.
+            this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs, Map.of());
+            simulateIncrementalRebalance();
+        } else {
+            this.groupSpec = StreamsAssignorBenchmarkUtils.createGroupSpec(members, assignmentConfigs, taskOffsets);
+        }
+    }
+
+    private Map<String, StreamsGroupMember> createMembers() {
+        // In the rebalance case, we will add the last member as a trigger.
+        // This is done to keep the total members count consistent with the input.
+        int numberOfMembers = assignmentType.equals(AssignmentType.INCREMENTAL) ? memberCount - 1 : memberCount;
+
+        return StreamsAssignorBenchmarkUtils.createStreamsMembers(
+            numberOfMembers,
+            membersPerProcess
+        );
+    }
+
+    private void simulateIncrementalRebalance() {
+        GroupAssignment initialAssignment = new BalancedTaskAssignor().assign(groupSpec, topologyDescriber);
+        Map<String, MemberAssignment> members = initialAssignment.members();
+
+        Map<String, MemberMetadataAndStateImpl> updatedMemberSpec = new HashMap<>();
+
+        for (String memberId : groupSpec.memberIds()) {
+            MemberAssignment memberAssignment = members.getOrDefault(
+                memberId,
+                new MemberAssignment(Map.of(), Map.of())
+            );
+
+            updatedMemberSpec.put(memberId, new MemberMetadataAndStateImpl(
+                Optional.empty(),
+                Optional.empty(),
+                groupSpec.memberMetadata(memberId).processId(),
+                Map.of(),
+                memberAssignment.activeTasks(),
+                memberAssignment.standbyTasks(),
+                // Warm-up tasks are not assigned by the assignor; they are decided during reconciliation.
+                Map.of(),
+                taskOffsets.getOrDefault(memberId, Map.of()),
+                Map.of()
+            ));
+        }
+
+        updatedMemberSpec.put("newMember", new MemberMetadataAndStateImpl(
+            Optional.empty(),
+            Optional.empty(),
+            "process-newMember",
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        ));
+
+        groupSpec = new GroupSpecImpl(
+            updatedMemberSpec,
+            assignmentConfigs
+        );
+    }
+
+    @Benchmark
+    @Threads(1)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void doAssignment(Blackhole blackhole) {
+        blackhole.consume(taskAssignor.assign(groupSpec, topologyDescriber));
+    }
+}


### PR DESCRIPTION
The streams rebalance protocol (KIP-1071) ships a single built-in task assignor, "sticky". This adds a second one, "balanced", which is a translation of the placement half of the classic `HighAvailabilityTaskAssignor`: stateful active tasks are dealt round-robin over the processes and then moved between processes while a move reduces the per-member load skew, standby tasks go to the least loaded process that does not hold the task, and stateless tasks fill in the gaps by active task load. Because the broker assigns to members rather than processes, each process's tasks are then spread over its members, keeping a task on the member that currently owns it where the quota allows, as the classic client does across its stream threads. Warm-up tasks (handled by the assignment refiner, KAFKA-20665) and rack-aware standby placement (KAFKA-20999) are not assignor concerns in this protocol and are left out, so the assignor does not read warm-up tasks or reported offsets. The assignor is appended to the built-in list, so `group.streams.assignors` defaults to `sticky,balanced` and a group selects it with `streams.assignor.name=balanced`; "sticky" stays the default. KIP-1071 calls this assignor `highly_available`; the KIP is to be amended to `balanced`, since high availability comes from the refiner rather than the assignor.

Testing: `BalancedTaskAssignorTest` covers even distribution across processes and members, subtopology interleaving, the contrast with the sticky assignor on the same previous assignment, member stickiness within a process, standby placement and capacity shortfall, stateless placement, independence from warm-up and offset inputs, determinism, and a randomized validity check; `GroupCoordinatorConfigTest` and `StreamsGroupHeartbeatRequestTest` are updated for the new built-in. `StreamsBalancedAssignorBenchmark` mirrors the sticky benchmark: the balanced assignor takes 1-5x the sticky assignor's time, except for groups of 1000 single-member processes where the all-pairs skew loop dominates (6-18 ms per assignment); optimizing that loop is left for a follow-up.
