### PR TITLE
MINOR: Allow Connect exactly-once validation consumers time to start

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -831,7 +831,10 @@ class ConnectDistributedTest(Test):
         self.source.stop()
         self.cc.stop()
 
-        consumer = ConsoleConsumer(self.test_context, 1, self.kafka, self.source.topic, message_validator=json.loads, consumer_timeout_ms=1000, isolation_level="read_committed")
+        # The timeout also covers joining the group and fetching the first batch. A short
+        # timeout can report no source records before the consumer has started reading.
+        consumer_timeout_ms = 10000
+        consumer = ConsoleConsumer(self.test_context, 1, self.kafka, self.source.topic, message_validator=json.loads, consumer_timeout_ms=consumer_timeout_ms, isolation_level="read_committed")
         consumer.run()
         src_messages = consumer.messages_consumed[1]
 
@@ -865,7 +868,7 @@ class ConnectDistributedTest(Test):
         if not success:
             self.mark_for_collect(self.cc)
             # Also collect the data in the topic to aid in debugging
-            consumer_validator = ConsoleConsumer(self.test_context, 1, self.kafka, self.source.topic, consumer_timeout_ms=1000, print_key=True)
+            consumer_validator = ConsoleConsumer(self.test_context, 1, self.kafka, self.source.topic, consumer_timeout_ms=consumer_timeout_ms, print_key=True)
             consumer_validator.run()
             self.mark_for_collect(consumer_validator, "consumer_stdout")
 


### PR DESCRIPTION
The exactly-once source system test can report that all source tasks
produced no records because its validation consumer times out before
receiving the first fetch response. The console consumer timeout also
covers group initialization and the first fetch.

Increase the timeout from one second to ten seconds for both the
read-committed validation consumer and the diagnostic consumer. Keep the
existing missing-sequence and duplicate-sequence checks unchanged.

Validation performed on Kafka commit
`9ec73ca7b08b0c7205a19831acfbad146520823f`, the revision tested by
[Jenkins kafka-e2e
#928](https://jenkins.opensource4you.tw/job/kafka-e2e/928/):
- Full `ConnectDistributedTest.test_exactly_once_source` with
`clean=False`, `connect_protocol=eager`, and
`metadata_quorum=ISOLATED_KRAFT`: unmodified test FAIL, modified test
PASS with JDK 17. The three tasks reached sequence numbers 9559, 9638,
and 9042 without missing or duplicate sequences.
- A separate real-broker startup reproduction with a fresh classic
consumer group and a three-second initial rebalance delay returned zero
records with the one-second timeout and all 300 records with the
ten-second timeout, in all three paired runs.
- Python syntax and `git diff --check` pass. The patch was rebased onto
current trunk; the target file was unchanged between the tested base and
trunk. E2E was not rerun on the rebased head, and the other parameter
combinations were not rerun.

Generated-by: OpenAI Codex (GPT-6)
