### PR TITLE
MINOR: Preserve changelogs during Streams application upgrade tests

### DIFF
--- a/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_application_upgrade_test.py
@@ -118,6 +118,11 @@ class StreamsUpgradeTest(Test):
         if from_version == to_version:
             return
 
+        # The driver produces records two days in the past. Older smoke-test clients
+        # use the one-day default, which can expire changelogs before state restoration.
+        extra_configs = dict(extra_configs or {})
+        extra_configs.setdefault("windowstore.changelog.additional.retention.ms", 3 * 24 * 60 * 60 * 1000)
+
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=None, topics={
             'echo' : { 'partitions': 5, 'replication-factor': 1 },
             'data' : { 'partitions': 5, 'replication-factor': 1 },


### PR DESCRIPTION
The Streams upgrade test uses a driver that timestamps records two days
in the past. Older smoke-test clients use the default one-day additional
changelog retention, while the current client already uses three days.
Consequently, changelog records can expire during the old-version phase,
before the upgraded application restores its state.

Pass a three-day `windowstore.changelog.additional.retention.ms` default
to every processor from the start of the application transition.
Preserve explicit caller overrides. This matches the current smoke-test
client and leaves the startup deadline and restoration checks unchanged.

In [Jenkins kafka-e2e
#928](https://jenkins.opensource4you.tw/job/kafka-e2e/928/), the 4.1.2
upgrade case created the small-window changelog with
`retention.ms=86432000`. The broker advanced its start offset to 111
through retention deletion, while the upgraded processor attempted
restoration from offset 52. Both the 4.1.2 and 3.9.2 cases failed while
restoring state and waiting for startup.

Validation performed on Kafka commit
`9ec73ca7b08b0c7205a19831acfbad146520823f`, with JDK 17:
- Full `StreamsUpgradeTest.test_app_upgrade`, `COMBINED_KRAFT`: both
4.1.2 and 3.9.2 to DEV PASS with the patch.
- Broker logs confirm `retention.ms=259232000` from initial topic
creation. Neither run's current or rotated Streams logs contains
`OffsetOutOfRangeException` or `TaskCorruptedException`.
- Python syntax and `git diff --check` pass. The target file was
unchanged between the tested base and current trunk. E2E was not rerun
on the rebased head; the unmodified Streams failure evidence comes from
#928, not a separate local baseline run.

Generated-by: OpenAI Codex (GPT-6)
