### PR TITLE
MINOR: Warn when Connect sink tasks use the consumer group protocol

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -1920,6 +1921,10 @@ public final class Worker {
             Map<String, Object> consumerProps = baseConsumerConfigs(
                     id.connector(),  "connector-consumer-" + id, config, connectorConfig, connectorClass,
                     connectorClientConfigOverridePolicy, kafkaClusterId, ConnectorType.SINK);
+            Object groupProtocol = consumerProps.get(ConsumerConfig.GROUP_PROTOCOL_CONFIG);
+            if (groupProtocol != null && GroupProtocol.CONSUMER.name().equalsIgnoreCase(groupProtocol.toString())) {
+                log.warn("Sink task {} uses group.protocol=CONSUMER, which has not been fully tested for production use with Kafka Connect.", id);
+            }
             KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps);
 
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, configState, metrics, keyConverterPlugin,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -93,6 +93,7 @@ import org.apache.kafka.connect.util.TopicAdmin;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
@@ -709,6 +710,80 @@ public class WorkerTest {
         verifyVersionedTaskConverterFromConnector(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG);
         verifyVersionedTaskHeaderConverterFromConnector();
         verifyExecutorSubmit();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, consumer, true",
+        "false, consumer, true",
+        "true, classic, false",
+        "false, classic, false"
+    })
+    public void testWarnWhenStartingSinkTaskWithConsumerGroupProtocol(
+            boolean enableTopicCreation,
+            String groupProtocol,
+            boolean expectWarning) {
+        setup(enableTopicCreation);
+        workerProps.put("consumer." + ConsumerConfig.GROUP_PROTOCOL_CONFIG, groupProtocol);
+        config = new StandaloneConfig(workerProps);
+        // Most of the other cases use source tasks; we make sure to get code coverage for sink tasks here as well
+        SinkTask task = mock(TestSinkTask.class);
+        mockKafkaClusterId();
+        mockVersionedTaskIsolation(SampleSinkConnector.class, TestSinkTask.class, null, sinkConnector, task);
+        mockVersionedTaskConverterFromConnector(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG, taskKeyConverter);
+        mockVersionedTaskConverterFromConnector(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG, taskValueConverter);
+        mockVersionedTaskHeaderConverterFromConnector(taskHeaderConverter);
+        mockExecutorFakeSubmit(WorkerTask.class);
+
+        Map<String, String> origProps = Map.of(TaskConfig.TASK_CLASS_CONFIG, TestSinkTask.class.getName());
+
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore, executorService,
+                noneConnectorClientConfigOverridePolicy, null);
+        worker.herder = herder;
+        worker.start();
+
+        assertStatistics(worker, 0, 0);
+        assertEquals(Set.of(), worker.taskIds());
+        Map<String, String> connectorConfigs = anyConnectorConfigMap();
+        connectorConfigs.put(TOPICS_CONFIG, "t1");
+        connectorConfigs.put(CONNECTOR_CLASS_CONFIG, SampleSinkConnector.class.getName());
+
+        ClusterConfigState configState = new ClusterConfigState(
+                0,
+                null,
+                Map.of(CONNECTOR_ID, 1),
+                Map.of(CONNECTOR_ID, connectorConfigs),
+                Map.of(CONNECTOR_ID, TargetState.STARTED),
+                Map.of(TASK_ID, origProps),
+                Map.of(),
+                Map.of(),
+                Map.of(CONNECTOR_ID, new AppliedConnectorConfig(connectorConfigs)),
+                Set.of(),
+                Set.of()
+        );
+        boolean warningLogged;
+        try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(Worker.class)) {
+            assertTrue(worker.startSinkTask(TASK_ID, configState, connectorConfigs, origProps, taskStatusListener, TargetState.STARTED));
+            warningLogged = appender.getMessages("WARN").stream().anyMatch(message -> message.contains("group.protocol=CONSUMER")
+                    && message.contains("not been fully tested for production")
+                    && message.contains(TASK_ID.toString()));
+        }
+        assertStatistics(worker, 0, 1);
+        assertEquals(Set.of(TASK_ID), worker.taskIds());
+        worker.stopAndAwaitTask(TASK_ID);
+        assertStatistics(worker, 0, 0);
+        assertEquals(Set.of(), worker.taskIds());
+        // Nothing should be left, so this should effectively be a nop
+        worker.stop();
+        assertStatistics(worker, 0, 0);
+
+        verifyKafkaClusterId();
+        verifyVersionedTaskIsolation(SampleSinkConnector.class, TestSinkTask.class, null, task);
+        verifyVersionedTaskConverterFromConnector(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, ConnectorConfig.KEY_CONVERTER_VERSION_CONFIG);
+        verifyVersionedTaskConverterFromConnector(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, ConnectorConfig.VALUE_CONVERTER_VERSION_CONFIG);
+        verifyVersionedTaskHeaderConverterFromConnector();
+        verifyExecutorSubmit();
+        assertEquals(expectWarning, warningLogged, "Production-readiness warning should only be logged for group.protocol=CONSUMER");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Warn when a Kafka Connect sink task uses `group.protocol=CONSUMER`, since this combination has not been fully tested for production use.

This follows the [review discussion in PR #23364](https://github.com/apache/kafka/pull/23364#discussion_r3976326919), which recommends warning users while preserving the existing ability to select the consumer group protocol.

Check the effective consumer configuration in `SinkTaskBuilder.doBuild()` after worker settings and connector overrides are merged. Preserve the configured protocol and include the task ID in the warning.

Test plan:
- Passed 4 parameterized cases covering warnings for `CONSUMER` and no warnings for `CLASSIC`, with topic creation enabled and disabled.