### PR TITLE
KAFKA-21019: Add consumer and share group protocol test cases to Docker sanity tests

### DIFF
--- a/docker/test/constants.py
+++ b/docker/test/constants.py
@@ -16,12 +16,23 @@
 KAFKA_TOPICS="fixtures/kafka/bin/kafka-topics.sh"
 KAFKA_CONSOLE_PRODUCER="fixtures/kafka/bin/kafka-console-producer.sh"
 KAFKA_CONSOLE_CONSUMER="fixtures/kafka/bin/kafka-console-consumer.sh"
+KAFKA_CONSOLE_SHARE_CONSUMER="fixtures/kafka/bin/kafka-console-share-consumer.sh"
+KAFKA_CONFIGS="fixtures/kafka/bin/kafka-configs.sh"
 KAFKA_RUN_CLASS="fixtures/kafka/bin/kafka-run-class.sh"
 
 COMBINED_MODE_COMPOSE="fixtures/mode/combined/docker-compose.yml"
 ISOLATED_MODE_COMPOSE="fixtures/mode/isolated/docker-compose.yml"
 
 CLIENT_TIMEOUT=40000
+
+CONSUMER_GROUP_PROTOCOL_TESTS="Consumer Group Protocol Tests"
+CONSUMER_GROUP_PROTOCOL_TOPIC="test-topic-consumer-group-protocol"
+CONSUMER_GROUP_PROTOCOL_GROUP_ID="docker-sanity-consumer-group"
+
+SHARE_GROUP_PROTOCOL_TESTS="Share Group Protocol Tests"
+SHARE_GROUP_PROTOCOL_TOPIC="test-topic-share-group-protocol"
+SHARE_GROUP_PROTOCOL_GROUP_ID="docker-sanity-share-group"
+SHARE_GROUP_CONFIG_TIMEOUT_SECONDS=20
 
 SSL_FLOW_TESTS="SSL Flow Tests"
 SSL_CLIENT_CONFIG="fixtures/secrets/client-ssl.properties"
@@ -48,3 +59,5 @@ SASL_ERROR_PREFIX="SASL_ERR"
 BROKER_RESTART_ERROR_PREFIX="BROKER_RESTART_ERR"
 FILE_INPUT_ERROR_PREFIX="FILE_INPUT_ERR"
 BROKER_METRICS_ERROR_PREFIX="BROKER_METRICS_ERR"
+CONSUMER_GROUP_PROTOCOL_ERROR_PREFIX="CONSUMER_GROUP_PROTOCOL_ERR"
+SHARE_GROUP_PROTOCOL_ERROR_PREFIX="SHARE_GROUP_PROTOCOL_ERR"

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -17,6 +17,7 @@
 
 import os
 import subprocess
+import time
 import unittest
 
 import pytest
@@ -76,6 +77,40 @@ class DockerSanityTest(unittest.TestCase):
         message = subprocess.check_output(["bash", "-c", " ".join(command)])
         return message.decode("utf-8").strip()
     
+    def consume_share_message(self, topic, consumer_config):
+        command = [f"{self.FIXTURES_DIR}/{constants.KAFKA_CONSOLE_SHARE_CONSUMER}", "--topic", topic, "--formatter-property", "'print.key=true'", "--formatter-property", "'key.separator=:'", "--max-messages", "1", "--timeout-ms", f"{constants.CLIENT_TIMEOUT}"]
+        command.extend(consumer_config)
+        message = subprocess.check_output(["bash", "-c", " ".join(command)])
+        return message.decode("utf-8").strip()
+
+    def set_share_group_offset_reset_strategy(self, group_id, strategy, command_config):
+        # Set the offset reset strategy for the share group.
+        offset_reset_config = f"share.auto.offset.reset={strategy}"
+        command = [f"{self.FIXTURES_DIR}/{constants.KAFKA_CONFIGS}", "--group", group_id, "--alter", "--add-config", offset_reset_config]
+        command.extend(command_config)
+        subprocess.run(["bash", "-c", " ".join(command)], check=True)
+
+        # Wait for a broker to report the updated strategy.
+        describe = [f"{self.FIXTURES_DIR}/{constants.KAFKA_CONFIGS}", "--group", group_id, "--describe", "--all"]
+        describe.extend(command_config)
+        deadline = time.monotonic() + constants.SHARE_GROUP_CONFIG_TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                configs = subprocess.check_output(["bash", "-c", " ".join(describe)], timeout=remaining).decode("utf-8")
+            except subprocess.TimeoutExpired:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            # Match the actual config value, ignoring synonyms.
+            if any(line.strip().startswith(f"{offset_reset_config} ") for line in configs.splitlines()):
+                return
+            time.sleep(min(1, remaining))
+        raise AssertionError(f"Timed out waiting for {offset_reset_config} to become visible for group {group_id}")
+
     def get_metrics(self, jmx_tool_config):
         command = [f"{self.FIXTURES_DIR}/{constants.KAFKA_RUN_CLASS}", constants.JMX_TOOL]
         command.extend(jmx_tool_config)
@@ -122,6 +157,48 @@ class DockerSanityTest(unittest.TestCase):
                     self.assertEqual(after_metrics_data[i], before_metrics_data[i])
         except AssertionError as e:
             errors.append(constants.BROKER_METRICS_ERROR_PREFIX + str(e))
+
+        return errors
+
+    def consumer_group_protocol_flow(self):
+        print(f"Running {constants.CONSUMER_GROUP_PROTOCOL_TESTS}")
+        errors = []
+        try:
+            self.assertTrue(self.create_topic(constants.CONSUMER_GROUP_PROTOCOL_TOPIC, ["--bootstrap-server", "localhost:9092"]))
+        except AssertionError as e:
+            errors.append(constants.CONSUMER_GROUP_PROTOCOL_ERROR_PREFIX + str(e))
+            return errors
+
+        producer_config = ["--bootstrap-server", "localhost:9092", "--command-property", "client.id=host"]
+        self.produce_message(constants.CONSUMER_GROUP_PROTOCOL_TOPIC, producer_config, "key", "message")
+        consumer_config = ["--bootstrap-server", "localhost:9092", "--group", constants.CONSUMER_GROUP_PROTOCOL_GROUP_ID, "--command-property", "group.protocol=consumer"]
+        message = self.consume_message(constants.CONSUMER_GROUP_PROTOCOL_TOPIC, consumer_config)
+        try:
+            self.assertEqual(message, "key:message")
+        except AssertionError as e:
+            errors.append(constants.CONSUMER_GROUP_PROTOCOL_ERROR_PREFIX + str(e))
+
+        return errors
+
+    def share_group_protocol_flow(self):
+        print(f"Running {constants.SHARE_GROUP_PROTOCOL_TESTS}")
+        errors = []
+        try:
+            self.assertTrue(self.create_topic(constants.SHARE_GROUP_PROTOCOL_TOPIC, ["--bootstrap-server", "localhost:9092"]))
+            # Configure earliest before the first share fetch initializes the share partition.
+            self.set_share_group_offset_reset_strategy(constants.SHARE_GROUP_PROTOCOL_GROUP_ID, "earliest", ["--bootstrap-server", "localhost:9092"])
+        except AssertionError as e:
+            errors.append(constants.SHARE_GROUP_PROTOCOL_ERROR_PREFIX + str(e))
+            return errors
+
+        producer_config = ["--bootstrap-server", "localhost:9092", "--command-property", "client.id=host"]
+        self.produce_message(constants.SHARE_GROUP_PROTOCOL_TOPIC, producer_config, "key", "message")
+        consumer_config = ["--bootstrap-server", "localhost:9092", "--group", constants.SHARE_GROUP_PROTOCOL_GROUP_ID]
+        message = self.consume_share_message(constants.SHARE_GROUP_PROTOCOL_TOPIC, consumer_config)
+        try:
+            self.assertEqual(message, "key:message")
+        except AssertionError as e:
+            errors.append(constants.SHARE_GROUP_PROTOCOL_ERROR_PREFIX + str(e))
 
         return errors
 
@@ -184,6 +261,16 @@ class DockerSanityTest(unittest.TestCase):
             total_errors.extend(self.broker_metrics_flow())
         except Exception as e:
             print(constants.BROKER_METRICS_ERROR_PREFIX, str(e))
+            total_errors.append(str(e))
+        try:
+            total_errors.extend(self.consumer_group_protocol_flow())
+        except Exception as e:
+            print(constants.CONSUMER_GROUP_PROTOCOL_ERROR_PREFIX, str(e))
+            total_errors.append(str(e))
+        try:
+            total_errors.extend(self.share_group_protocol_flow())
+        except Exception as e:
+            print(constants.SHARE_GROUP_PROTOCOL_ERROR_PREFIX, str(e))
             total_errors.append(str(e))
         try:
             total_errors.extend(self.secure_flow('localhost:9093', constants.SSL_CLIENT_CONFIG, constants.SSL_FLOW_TESTS, constants.SSL_ERROR_PREFIX, constants.SSL_TOPIC))


### PR DESCRIPTION
Add consumer and share group protocol test cases to Docker sanity tests
for JVM and native images in both combined and isolated modes.
