### PR TITLE
KAFKA-21028: [2/2] Remove hamcrest from org.apache.kafka.streams.processor.internals package

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionOptimizingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionOptimizingTest.java
@@ -67,8 +67,6 @@ import java.util.regex.Pattern;
 
 import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("deprecation")
@@ -97,12 +95,9 @@ public class RepartitionOptimizingTest {
 
     private final List<String> processorValueCollector = new ArrayList<>();
 
-    private final List<KeyValue<String, Long>> expectedCountKeyValues =
-        Arrays.asList(KeyValue.pair("A", 3L), KeyValue.pair("B", 3L), KeyValue.pair("C", 3L));
-    private final List<KeyValue<String, Integer>> expectedAggKeyValues =
-        Arrays.asList(KeyValue.pair("A", 9), KeyValue.pair("B", 9), KeyValue.pair("C", 9));
-    private final List<KeyValue<String, String>> expectedReduceKeyValues =
-        Arrays.asList(KeyValue.pair("A", "foo:bar:baz"), KeyValue.pair("B", "foo:bar:baz"), KeyValue.pair("C", "foo:bar:baz"));
+    private final Map<String, Long> expectedCountKeyValues = Map.of("A", 3L, "B", 3L, "C", 3L);
+    private final Map<String, Integer> expectedAggKeyValues = Map.of("A", 9, "B", 9, "C", 9);
+    private final Map<String, String> expectedReduceKeyValues = Map.of("A", "foo:bar:baz", "B", "foo:bar:baz", "C", "foo:bar:baz");
     private final List<KeyValue<String, String>> expectedJoinKeyValues =
         Arrays.asList(KeyValue.pair("A", "foo:3"), KeyValue.pair("A", "bar:3"), KeyValue.pair("A", "baz:3"));
     private final List<String> expectedCollectedProcessorValues =
@@ -214,14 +209,14 @@ public class RepartitionOptimizingTest {
         assertEquals(expectedNumberRepartitionTopics, getCountOfRepartitionTopicsFound(topologyString));
 
         // Verify the values collected by the processor
-        assertThat(3, equalTo(processorValueCollector.size()));
-        assertThat(processorValueCollector, equalTo(expectedCollectedProcessorValues));
+        assertEquals(3, processorValueCollector.size());
+        assertEquals(expectedCollectedProcessorValues, processorValueCollector);
 
         // Verify the expected output
-        assertThat(countOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedCountKeyValues)));
-        assertThat(aggregationOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedAggKeyValues)));
-        assertThat(reduceOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedReduceKeyValues)));
-        assertThat(joinedOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedJoinKeyValues)));
+        assertEquals(expectedCountKeyValues, countOutputTopic.readKeyValuesToMap());
+        assertEquals(expectedAggKeyValues, aggregationOutputTopic.readKeyValuesToMap());
+        assertEquals(expectedReduceKeyValues, reduceOutputTopic.readKeyValuesToMap());
+        assertEquals(keyValueListToMap(expectedJoinKeyValues), joinedOutputTopic.readKeyValuesToMap());
     }
 
     @Test
@@ -253,7 +248,7 @@ public class RepartitionOptimizingTest {
 
         inputTopic.pipeKeyValueList(getKeyValues());
 
-        assertThat(outputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedAggKeyValues)));
+        assertEquals(expectedAggKeyValues, outputTopic.readKeyValuesToMap());
     }
 
     private <K, V> Map<K, V> keyValueListToMap(final List<KeyValue<K, V>> keyValuePairs) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
@@ -48,12 +48,12 @@ import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNAMED_TOPOLOGY;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_1;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -139,7 +139,7 @@ public class RepartitionTopicsTest {
         repartitionTopics.setup();
 
         final Map<TopicPartition, PartitionInfo> topicPartitionsInfo = repartitionTopics.topicPartitionsInfo();
-        assertThat(topicPartitionsInfo.size(), is(6));
+        assertEquals(6, topicPartitionsInfo.size());
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 0);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 1);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 2);
@@ -147,8 +147,8 @@ public class RepartitionTopicsTest {
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME2, 0);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME2, 1);
 
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
 
         verify(copartitionedTopicsEnforcer).enforce(eq(coPartitionGroup1), any(), eq(clusterMetadata));
         verify(copartitionedTopicsEnforcer).enforce(eq(coPartitionGroup2), any(), eq(clusterMetadata));
@@ -169,14 +169,11 @@ public class RepartitionTopicsTest {
         );
         repartitionTopics.setup();
 
-        assertThat(
-            repartitionTopics.topologiesWithMissingInputTopics(),
-            equalTo(Collections.singleton(UNNAMED_TOPOLOGY))
-        );
+        assertEquals(Set.of(UNNAMED_TOPOLOGY), repartitionTopics.topologiesWithMissingInputTopics());
         final StreamsException exception = repartitionTopics.missingSourceTopicExceptions().poll();
-        assertThat(exception, notNullValue());
-        assertThat(exception.taskId().isPresent(), is(true));
-        assertThat(exception.taskId().get(), equalTo(new TaskId(0, 0)));
+        assertNotNull(exception);
+        assertTrue(exception.taskId().isPresent());
+        assertEquals(new TaskId(0, 0), exception.taskId().get());
     }
 
     @Test
@@ -198,9 +195,11 @@ public class RepartitionTopicsTest {
         );
 
         final TaskAssignmentException exception = assertThrows(TaskAssignmentException.class, repartitionTopics::setup);
-        assertThat(exception.getMessage(), is("Failed to compute number of partitions for all repartition topics, make sure all user input topics are created and all Pattern subscriptions match at least one topic in the cluster"));
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertEquals(
+            "Failed to compute number of partitions for all repartition topics, make sure all user input topics are created and all Pattern subscriptions match at least one topic in the cluster",
+            exception.getMessage());
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
     }
 
     @Test
@@ -230,12 +229,9 @@ public class RepartitionTopicsTest {
         );
 
         final TaskAssignmentException exception = assertThrows(TaskAssignmentException.class, repartitionTopics::setup);
-        assertThat(
-            exception.getMessage(),
-            is("No partition count found for source topic " + SOURCE_TOPIC_NAME1 + ", but it should have been.")
-        );
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertEquals("No partition count found for source topic " + SOURCE_TOPIC_NAME1 + ", but it should have been.", exception.getMessage());
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
     }
 
     @Test
@@ -277,7 +273,7 @@ public class RepartitionTopicsTest {
         repartitionTopics.setup();
 
         final Map<TopicPartition, PartitionInfo> topicPartitionsInfo = repartitionTopics.topicPartitionsInfo();
-        assertThat(topicPartitionsInfo.size(), is(9));
+        assertEquals(9, topicPartitionsInfo.size());
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 0);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 1);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 2);
@@ -288,8 +284,8 @@ public class RepartitionTopicsTest {
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_WITHOUT_PARTITION_COUNT, 1);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_WITHOUT_PARTITION_COUNT, 2);
 
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
     }
 
     @Test
@@ -331,7 +327,7 @@ public class RepartitionTopicsTest {
         repartitionTopics.setup();
 
         final Map<TopicPartition, PartitionInfo> topicPartitionsInfo = repartitionTopics.topicPartitionsInfo();
-        assertThat(topicPartitionsInfo.size(), is(10));
+        assertEquals(10, topicPartitionsInfo.size());
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 0);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 1);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_TOPIC_NAME1, 2);
@@ -343,8 +339,8 @@ public class RepartitionTopicsTest {
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_WITHOUT_PARTITION_COUNT, 2);
         verifyRepartitionTopicPartitionInfo(topicPartitionsInfo, REPARTITION_WITHOUT_PARTITION_COUNT, 3);
 
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
     }
 
     @Test
@@ -369,24 +365,24 @@ public class RepartitionTopicsTest {
         repartitionTopics.setup();
 
         final Map<TopicPartition, PartitionInfo> topicPartitionsInfo = repartitionTopics.topicPartitionsInfo();
-        assertThat(topicPartitionsInfo, is(Collections.emptyMap()));
+        assertTrue(topicPartitionsInfo.isEmpty());
 
-        assertThat(repartitionTopics.topologiesWithMissingInputTopics().isEmpty(), is(true));
-        assertThat(repartitionTopics.missingSourceTopicExceptions().isEmpty(), is(true));
+        assertTrue(repartitionTopics.topologiesWithMissingInputTopics().isEmpty());
+        assertTrue(repartitionTopics.missingSourceTopicExceptions().isEmpty());
     }
 
     private void verifyRepartitionTopicPartitionInfo(final Map<TopicPartition, PartitionInfo> topicPartitionsInfo,
                                                      final String topic,
                                                      final int partition) {
         final TopicPartition repartitionTopicPartition = new TopicPartition(topic, partition);
-        assertThat(topicPartitionsInfo.containsKey(repartitionTopicPartition), is(true));
+        assertTrue(topicPartitionsInfo.containsKey(repartitionTopicPartition));
         final PartitionInfo repartitionTopicInfo = topicPartitionsInfo.get(repartitionTopicPartition);
-        assertThat(repartitionTopicInfo.topic(), is(topic));
-        assertThat(repartitionTopicInfo.partition(), is(partition));
-        assertThat(repartitionTopicInfo.inSyncReplicas(), is(new Node[0]));
-        assertThat(repartitionTopicInfo.leader(), nullValue());
-        assertThat(repartitionTopicInfo.offlineReplicas(), is(new Node[0]));
-        assertThat(repartitionTopicInfo.replicas(), is(new Node[0]));
+        assertEquals(topic, repartitionTopicInfo.topic());
+        assertEquals(partition, repartitionTopicInfo.partition());
+        assertArrayEquals(new Node[0], repartitionTopicInfo.inSyncReplicas());
+        assertNull(repartitionTopicInfo.leader());
+        assertArrayEquals(new Node[0], repartitionTopicInfo.offlineReplicas());
+        assertArrayEquals(new Node[0], repartitionTopicInfo.replicas());
     }
 
     private void setupCluster(final boolean mockPartitionCount) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionWithMergeOptimizingTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionWithMergeOptimizingTest.java
@@ -45,16 +45,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RepartitionWithMergeOptimizingTest {
@@ -75,10 +71,8 @@ public class RepartitionWithMergeOptimizingTest {
     private Properties streamsConfiguration;
     private TopologyTestDriver topologyTestDriver;
 
-    private final List<KeyValue<String, Long>> expectedCountKeyValues =
-        Arrays.asList(KeyValue.pair("A", 6L), KeyValue.pair("B", 6L), KeyValue.pair("C", 6L));
-    private final List<KeyValue<String, String>> expectedStringCountKeyValues =
-        Arrays.asList(KeyValue.pair("A", "6"), KeyValue.pair("B", "6"), KeyValue.pair("C", "6"));
+    private final Map<String, Long> expectedCountKeyValues = Map.of("A", 6L, "B", 6L, "C", 6L);
+    private final Map<String, String> expectedStringCountKeyValues = Map.of("A", "6", "B", "6", "C", "6");
 
     @BeforeEach
     public void setUp() {
@@ -161,16 +155,8 @@ public class RepartitionWithMergeOptimizingTest {
         assertEquals(expectedNumberRepartitionTopics, getCountOfRepartitionTopicsFound(topologyString));
 
         // Verify the expected output
-        assertThat(countOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedCountKeyValues)));
-        assertThat(stringCountOutputTopic.readKeyValuesToMap(), equalTo(keyValueListToMap(expectedStringCountKeyValues)));
-    }
-
-    private <K, V> Map<K, V> keyValueListToMap(final List<KeyValue<K, V>> keyValuePairs) {
-        final Map<K, V> map = new HashMap<>();
-        for (final KeyValue<K, V> pair : keyValuePairs) {
-            map.put(pair.key, pair.value);
-        }
-        return map;
+        assertEquals(expectedCountKeyValues, countOutputTopic.readKeyValuesToMap());
+        assertEquals(expectedStringCountKeyValues, stringCountOutputTopic.readKeyValuesToMap());
     }
 
     private int getCountOfRepartitionTopicsFound(final String topologyString) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -33,10 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 public class SinkNodeTest {
@@ -67,12 +65,9 @@ public class SinkNodeTest {
         sink.init(context);
         // When/Then
         context.setTime(-1); // ensures a negative timestamp is set for the record we send next
-        try {
-            illTypedSink.process(new Record<>("any key".getBytes(), "any value".getBytes(), -1));
-            fail("Should have thrown StreamsException");
-        } catch (final StreamsException ignored) {
-            // expected
-        }
+        assertThrows(StreamsException.class,
+            () -> illTypedSink.process(new Record<>("any key".getBytes(), "any value".getBytes(), -1)),
+            "Should have thrown StreamsException");
     }
 
     @Test
@@ -82,14 +77,8 @@ public class SinkNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Failed to initialize key serdes for sink node anyNodeName")
-        );
-        assertThat(
-            exception.getCause().getMessage(),
-            equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
-        );
+        assertEquals("Failed to initialize key serdes for sink node anyNodeName", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -99,14 +88,8 @@ public class SinkNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Failed to initialize value serdes for sink node anyNodeName")
-        );
-        assertThat(
-            exception.getCause().getMessage(),
-            equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
-        );
+        assertEquals("Failed to initialize value serdes for sink node anyNodeName", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -115,6 +98,6 @@ public class SinkNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> sink.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for sink node anyNodeName"));
+        assertEquals("Failed to initialize key serdes for sink node anyNodeName", exception.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -38,15 +38,13 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +68,7 @@ public class SourceNodeTest {
         final SourceNode<String, String> sourceNode = new MockSourceNode<>(new TheDeserializer(), new TheDeserializer());
         final RecordHeaders headers = new RecordHeaders();
         final String deserializeKey = sourceNode.deserializeKey("topic", headers, "data".getBytes(StandardCharsets.UTF_8));
-        assertThat(deserializeKey, is("topic" + headers + "data"));
+        assertEquals("topic" + headers + "data", deserializeKey);
     }
 
     @Test
@@ -78,7 +76,7 @@ public class SourceNodeTest {
         final SourceNode<String, String> sourceNode = new MockSourceNode<>(new TheDeserializer(), new TheDeserializer());
         final RecordHeaders headers = new RecordHeaders();
         final String deserializedValue = sourceNode.deserializeValue("topic", headers, "data".getBytes(StandardCharsets.UTF_8));
-        assertThat(deserializedValue, is("topic" + headers + "data"));
+        assertEquals("topic" + headers + "data", deserializedValue);
     }
 
     public static class TheDeserializer implements Deserializer<String> {
@@ -124,10 +122,9 @@ public class SourceNodeTest {
         final Sensor processSensor =
             metrics.getSensor(sensorNamePrefix + ".node." + context.currentNode().name() + ".s.process");
         final SensorAccessor sensorAccessor = new SensorAccessor(processSensor);
-        assertThat(
-            sensorAccessor.parents().stream().map(Sensor::name).collect(Collectors.toList()),
-            contains(sensorNamePrefix + ".s.process")
-        );
+        assertEquals(
+            List.of(sensorNamePrefix + ".s.process"),
+            sensorAccessor.parents().stream().map(Sensor::name).collect(Collectors.toList()));
     }
 
     @Test
@@ -142,14 +139,8 @@ public class SourceNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Failed to initialize key serdes for source node TESTING_NODE")
-        );
-        assertThat(
-            exception.getCause().getMessage(),
-            equalTo("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG")
-        );
+        assertEquals("Failed to initialize key serdes for source node TESTING_NODE", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_KEY_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -164,14 +155,8 @@ public class SourceNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
 
-        assertThat(
-            exception.getMessage(),
-            equalTo("Failed to initialize value serdes for source node TESTING_NODE")
-        );
-        assertThat(
-            exception.getCause().getMessage(),
-            equalTo("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG")
-        );
+        assertEquals("Failed to initialize value serdes for source node TESTING_NODE", exception.getMessage());
+        assertEquals("Please set StreamsConfig#DEFAULT_VALUE_SERDE_CLASS_CONFIG", exception.getCause().getMessage());
     }
 
     @Test
@@ -185,6 +170,6 @@ public class SourceNodeTest {
 
         final Throwable exception = assertThrows(StreamsException.class, () -> node.init(context));
 
-        assertThat(exception.getMessage(), equalTo("Failed to initialize key serdes for source node TESTING_NODE"));
+        assertEquals("Failed to initialize key serdes for source node TESTING_NODE", exception.getMessage());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -70,13 +70,10 @@ import static org.apache.kafka.streams.processor.internals.Task.State.CREATED;
 import static org.apache.kafka.streams.processor.internals.Task.State.RUNNING;
 import static org.apache.kafka.streams.processor.internals.Task.State.SUSPENDED;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -283,7 +280,7 @@ public class StandbyTaskTest {
     @Test
     public void shouldRequireSuspendingCreatedTasksBeforeClose() {
         task = createStandbyTask();
-        assertThat(task.state(), equalTo(CREATED));
+        assertEquals(CREATED, task.state());
         assertThrows(IllegalStateException.class, () -> task.closeClean());
 
         task.suspend();
@@ -331,7 +328,7 @@ public class StandbyTaskTest {
         task.closeClean();
         // Currently, there are no metrics registered for standby tasks.
         // This is a regression test so that, if we add some, we will be sure to deregister them.
-        assertThat(getTaskMetrics(), empty());
+        assertTrue(getTaskMetrics().isEmpty());
     }
 
     @Test
@@ -344,7 +341,7 @@ public class StandbyTaskTest {
 
         // Currently, there are no metrics registered for standby tasks.
         // This is a regression test so that, if we add some, we will be sure to deregister them.
-        assertThat(getTaskMetrics(), empty());
+        assertTrue(getTaskMetrics().isEmpty());
     }
 
     @Test
@@ -422,11 +419,11 @@ public class StandbyTaskTest {
 
         task.suspend();
         task.prepareRecycle(); // SUSPENDED
-        assertThat(task.state(), is(Task.State.CLOSED));
+        assertEquals(Task.State.CLOSED, task.state());
 
         // Currently, there are no metrics registered for standby tasks.
         // This is a regression test so that, if we add some, we will be sure to deregister them.
-        assertThat(getTaskMetrics(), empty());
+        assertTrue(getTaskMetrics().isEmpty());
 
         verify(stateManager).recycle();
     }
@@ -434,18 +431,18 @@ public class StandbyTaskTest {
     @Test
     public void shouldAlwaysSuspendCreatedTasks() {
         task = createStandbyTask();
-        assertThat(task.state(), equalTo(CREATED));
+        assertEquals(CREATED, task.state());
         task.suspend();
-        assertThat(task.state(), equalTo(SUSPENDED));
+        assertEquals(SUSPENDED, task.state());
     }
 
     @Test
     public void shouldAlwaysSuspendRunningTasks() {
         task = createStandbyTask();
         task.initializeIfNeeded();
-        assertThat(task.state(), equalTo(RUNNING));
+        assertEquals(RUNNING, task.state());
         task.suspend();
-        assertThat(task.state(), equalTo(SUSPENDED));
+        assertEquals(SUSPENDED, task.state());
     }
 
     @Test
@@ -460,7 +457,7 @@ public class StandbyTaskTest {
             () -> task.maybeInitTaskTimeoutOrThrow(Duration.ofMinutes(5).plus(Duration.ofMillis(1L)).toMillis(), null)
         );
 
-        assertThat(thrown.getCause(), isA(TimeoutException.class));
+        assertInstanceOf(TimeoutException.class, thrown.getCause());
 
     }
 
@@ -480,13 +477,13 @@ public class StandbyTaskTest {
         final KafkaMetric totalMetric = getMetric("update", "%s-total", task.id().toString());
         final KafkaMetric rateMetric = getMetric("update", "%s-rate", task.id().toString());
 
-        assertThat(totalMetric.metricValue(), equalTo(0.0));
-        assertThat(rateMetric.metricValue(), equalTo(0.0));
+        assertEquals(0.0, totalMetric.metricValue());
+        assertEquals(0.0, rateMetric.metricValue());
 
         // standby tasks have no remaining-records metric, so the offset-slot argument is ignored
         task.recordRestoration(time, 25L, 30L, false);
 
-        assertThat(totalMetric.metricValue(), equalTo(25.0));
+        assertEquals(25.0, totalMetric.metricValue());
         // the rate measures updated records per second, not update batches per second; with no time
         // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
         assertEquals(
@@ -499,7 +496,7 @@ public class StandbyTaskTest {
 
         task.recordRestoration(time, 50L, 55L, false);
 
-        assertThat(totalMetric.metricValue(), equalTo(75.0));
+        assertEquals(75.0, totalMetric.metricValue());
         assertEquals(
             75.0 / 30.0,
             ((Number) rateMetric.metricValue()).doubleValue(),
@@ -562,7 +559,7 @@ public class StandbyTaskTest {
     private void verifyCloseTaskMetric(final double expected, final StreamsMetricsImpl streamsMetrics, final MetricName metricName) {
         final KafkaMetric metric = (KafkaMetric) streamsMetrics.metrics().get(metricName);
         final double totalCloses = metric.measurable().measure(metric.config(), System.currentTimeMillis());
-        assertThat(totalCloses, equalTo(expected));
+        assertEquals(expected, totalCloses);
     }
 
     private List<MetricName> getTaskMetrics() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -67,24 +67,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.processor.internals.StateDirectory.LOCK_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateDirectory.PROCESS_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.toTaskDirString;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -183,27 +174,27 @@ public class StateDirectoryTest {
             }
             try {
                 final Set<PosixFilePermission> filePermissions = Files.getPosixFilePermissions(path);
-                assertThat(filePermissions, equalTo(expectedPermissions));
+                assertEquals(expectedPermissions, filePermissions);
             } catch (final IOException e) {
                 fail("Should create correct files and set correct permissions");
             }
         } else {
-            assertThat(file.canRead(), is(true));
-            assertThat(file.canWrite(), is(true));
-            assertThat(file.canExecute(), is(true));
+            assertTrue(file.canRead());
+            assertTrue(file.canWrite());
+            assertTrue(file.canExecute());
         }
     }
 
     @Test
     public void shouldParseUnnamedTaskId() {
         final TaskId task = new TaskId(1, 0);
-        assertThat(TaskId.parse(task.toString()), equalTo(task));
+        assertEquals(task, TaskId.parse(task.toString()));
     }
 
     @Test
     public void shouldParseNamedTaskId() {
         final TaskId task = new TaskId(1, 0, "namedTopology");
-        assertThat(TaskId.parse(task.toString()), equalTo(task));
+        assertEquals(task, TaskId.parse(task.toString()));
     }
 
     @Test
@@ -312,8 +303,8 @@ public class StateDirectoryTest {
         final TaskId taskId = new TaskId(0, 0);
         final TaskId taskId2 = new TaskId(1, 0);
 
-        assertThat(directory.lock(taskId), is(true));
-        assertThat(directory.lock(taskId2), is(true));
+        assertTrue(directory.lock(taskId));
+        assertTrue(directory.lock(taskId2));
         directory.unlock(taskId);
         directory.unlock(taskId2);
     }
@@ -386,10 +377,7 @@ public class StateDirectoryTest {
             assertFalse(dir.exists());
             assertEquals(0, directory.listAllTaskDirectories().size());
             assertEquals(0, directory.listNonEmptyTaskDirectories().size());
-            assertThat(
-                appender.getMessages(),
-                hasItem(containsString("Deleting obsolete state directory"))
-            );
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("Deleting obsolete state directory")));
         }
     }
 
@@ -446,13 +434,13 @@ public class StateDirectoryTest {
         final File storeDir = new File(taskDir1.file(), "store");
         assertTrue(storeDir.mkdir());
 
-        assertThat(Set.of(taskDir1, taskDir2), equalTo(new HashSet<>(directory.listAllTaskDirectories())));
-        assertThat(singletonList(taskDir1), equalTo(directory.listNonEmptyTaskDirectories()));
+        assertEquals(Set.of(taskDir1, taskDir2), new HashSet<>(directory.listAllTaskDirectories()));
+        assertEquals(List.of(taskDir1), directory.listNonEmptyTaskDirectories());
 
         Utils.delete(taskDir1.file());
 
-        assertThat(singleton(taskDir2), equalTo(new HashSet<>(directory.listAllTaskDirectories())));
-        assertThat(emptyList(), equalTo(directory.listNonEmptyTaskDirectories()));
+        assertEquals(Set.of(taskDir2), new HashSet<>(directory.listAllTaskDirectories()));
+        assertTrue(directory.listNonEmptyTaskDirectories().isEmpty());
     }
 
     @Test
@@ -535,10 +523,10 @@ public class StateDirectoryTest {
     public void shouldNotCreateBaseDirectory() throws IOException {
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             initializeStateDirectory(false, false);
-            assertThat(stateDir.exists(), is(false));
-            assertThat(appDir.exists(), is(false));
-            assertThat(appender.getMessages(),
-                not(hasItem(containsString("Error changing permissions for the state or base directory"))));
+            assertFalse(stateDir.exists());
+            assertFalse(appDir.exists());
+            assertFalse(appender.getMessages().stream().anyMatch(message ->
+                message.contains("Error changing permissions for the state or base directory")));
         }
     }
 
@@ -591,8 +579,8 @@ public class StateDirectoryTest {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
-        assertThat(testFile.mkdir(), is(true));
-        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+        assertTrue(testFile.mkdir());
+        assertFalse(directory.directoryForTaskIsEmpty(taskId));
 
         // call StateDirectory#clean
         directory.clean();
@@ -606,8 +594,8 @@ public class StateDirectoryTest {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
-        assertThat(testFile.mkdir(), is(true));
-        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+        assertTrue(testFile.mkdir());
+        assertFalse(directory.directoryForTaskIsEmpty(taskId));
 
         // Create a dummy file in appDir; for this, appDir will not be empty after cleanup.
         final File dummyFile = new File(appDir, "dummy");
@@ -617,10 +605,7 @@ public class StateDirectoryTest {
             // call StateDirectory#clean
             directory.clean();
             assertTrue(appDir.exists());
-            assertThat(
-                appender.getMessages(),
-                hasItem(containsString("unexpected files remain"))
-            );
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("unexpected files remain")));
         }
     }
 
@@ -629,15 +614,12 @@ public class StateDirectoryTest {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
-        assertThat(testFile.mkdir(), is(true));
-        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+        assertTrue(testFile.mkdir());
+        assertFalse(directory.directoryForTaskIsEmpty(taskId));
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             directory.clean();
-            assertThat(
-                appender.getMessages(),
-                hasItem(endsWith("as user calling cleanup."))
-            );
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.endsWith("as user calling cleanup.")));
         }
     }
 
@@ -646,14 +628,15 @@ public class StateDirectoryTest {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
-        assertThat(testFile.mkdir(), is(true));
-        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+        assertTrue(testFile.mkdir());
+        assertFalse(directory.directoryForTaskIsEmpty(taskId));
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             final long cleanupDelayMs = 0;
             time.sleep(5000);
             directory.cleanRemovedTasks(cleanupDelayMs);
-            assertThat(appender.getMessages(), hasItem(endsWith("ms has elapsed (cleanup delay is " + cleanupDelayMs + "ms).")));
+            assertTrue(appender.getMessages().stream().anyMatch(message ->
+                message.endsWith("ms has elapsed (cleanup delay is " + cleanupDelayMs + "ms).")));
         }
     }
 
@@ -671,12 +654,10 @@ public class StateDirectoryTest {
                 true,
                 false
             );
-            assertThat(
-                appender.getMessages(),
-                hasItem("Using an OS temp directory in the state.dir property can cause failures with writing the" +
-                            " checkpoint file due to the fact that this directory can be cleared by the OS." +
-                            " Resolved state.dir: [" + System.getProperty("java.io.tmpdir") + "/kafka-streams]")
-            );
+            assertTrue(appender.getMessages().contains(
+                "Using an OS temp directory in the state.dir property can cause failures with writing the" +
+                    " checkpoint file due to the fact that this directory can be cleared by the OS." +
+                    " Resolved state.dir: [" + System.getProperty("java.io.tmpdir") + "/kafka-streams]"));
         }
     }
 
@@ -690,17 +671,17 @@ public class StateDirectoryTest {
         directory.getOrCreateDirectoryForTask(new TaskId(0, 1, "topology1"));
         directory.getOrCreateDirectoryForTask(new TaskId(0, 0, "topology2"));
 
-        assertThat(new File(appDir, "__topology1__").exists(), is(true));
-        assertThat(new File(appDir, "__topology1__").isDirectory(), is(true));
-        assertThat(new File(appDir, "__topology2__").exists(), is(true));
-        assertThat(new File(appDir, "__topology2__").isDirectory(), is(true));
+        assertTrue(new File(appDir, "__topology1__").exists());
+        assertTrue(new File(appDir, "__topology1__").isDirectory());
+        assertTrue(new File(appDir, "__topology2__").exists());
+        assertTrue(new File(appDir, "__topology2__").isDirectory());
 
-        assertThat(new File(new File(appDir, "__topology1__"), "0_0").exists(), is(true));
-        assertThat(new File(new File(appDir, "__topology1__"), "0_0").isDirectory(), is(true));
-        assertThat(new File(new File(appDir, "__topology1__"), "0_1").exists(), is(true));
-        assertThat(new File(new File(appDir, "__topology1__"), "0_1").isDirectory(), is(true));
-        assertThat(new File(new File(appDir, "__topology2__"), "0_0").exists(), is(true));
-        assertThat(new File(new File(appDir, "__topology2__"), "0_0").isDirectory(), is(true));
+        assertTrue(new File(new File(appDir, "__topology1__"), "0_0").exists());
+        assertTrue(new File(new File(appDir, "__topology1__"), "0_0").isDirectory());
+        assertTrue(new File(new File(appDir, "__topology1__"), "0_1").exists());
+        assertTrue(new File(new File(appDir, "__topology1__"), "0_1").isDirectory());
+        assertTrue(new File(new File(appDir, "__topology2__"), "0_0").exists());
+        assertTrue(new File(new File(appDir, "__topology2__"), "0_0").isDirectory());
     }
 
     @Test
@@ -715,13 +696,13 @@ public class StateDirectoryTest {
         final File storeDir = new File(taskDir1.file(), "store");
         assertTrue(storeDir.mkdir());
 
-        assertThat(new HashSet<>(directory.listAllTaskDirectories()), equalTo(Set.of(taskDir1, taskDir2, taskDir3)));
-        assertThat(directory.listNonEmptyTaskDirectories(), equalTo(singletonList(taskDir1)));
+        assertEquals(Set.of(taskDir1, taskDir2, taskDir3), new HashSet<>(directory.listAllTaskDirectories()));
+        assertEquals(List.of(taskDir1), directory.listNonEmptyTaskDirectories());
 
         Utils.delete(taskDir1.file());
 
-        assertThat(new HashSet<>(directory.listAllTaskDirectories()), equalTo(Set.of(taskDir2, taskDir3)));
-        assertThat(directory.listNonEmptyTaskDirectories(), equalTo(emptyList()));
+        assertEquals(Set.of(taskDir2, taskDir3), new HashSet<>(directory.listAllTaskDirectories()));
+        assertTrue(directory.listNonEmptyTaskDirectories().isEmpty());
     }
 
     @Test
@@ -730,21 +711,21 @@ public class StateDirectoryTest {
         final File taskDir = directory.getOrCreateDirectoryForTask(new TaskId(2, 0, "topology1"));
         final File namedTopologyDir = new File(appDir, "__topology1__");
 
-        assertThat(taskDir.exists(), is(true));
-        assertThat(namedTopologyDir.exists(), is(true));
+        assertTrue(taskDir.exists());
+        assertTrue(namedTopologyDir.exists());
         directory.clean();
-        assertThat(taskDir.exists(), is(false));
-        assertThat(namedTopologyDir.exists(), is(false));
+        assertFalse(taskDir.exists());
+        assertFalse(namedTopologyDir.exists());
     }
 
     @Test
     public void shouldRemoveEmptyNamedTopologyDirsWhenCallingClean() throws IOException {
         initializeStateDirectory(true, true);
         final File namedTopologyDir = new File(appDir, "__topology1__");
-        assertThat(namedTopologyDir.mkdir(), is(true));
-        assertThat(namedTopologyDir.exists(), is(true));
+        assertTrue(namedTopologyDir.mkdir());
+        assertTrue(namedTopologyDir.exists());
         directory.clean();
-        assertThat(namedTopologyDir.exists(), is(false));
+        assertFalse(namedTopologyDir.exists());
     }
 
     @Test
@@ -754,11 +735,11 @@ public class StateDirectoryTest {
         final File taskDir = directory.getOrCreateDirectoryForTask(new TaskId(2, 0, topologyName));
         final File namedTopologyDir = new File(appDir, "__" + topologyName + "__");
 
-        assertThat(taskDir.exists(), is(true));
-        assertThat(namedTopologyDir.exists(), is(true));
+        assertTrue(taskDir.exists());
+        assertTrue(namedTopologyDir.exists());
         directory.clearLocalStateForNamedTopology(topologyName);
-        assertThat(taskDir.exists(), is(false));
-        assertThat(namedTopologyDir.exists(), is(false));
+        assertFalse(taskDir.exists());
+        assertFalse(namedTopologyDir.exists());
     }
 
     @Test
@@ -766,20 +747,20 @@ public class StateDirectoryTest {
         initializeStateDirectory(true, true);
         final String topologyName = "topology1";
         final File namedTopologyDir = new File(appDir, "__" + topologyName + "__");
-        assertThat(namedTopologyDir.mkdir(), is(true));
-        assertThat(namedTopologyDir.exists(), is(true));
+        assertTrue(namedTopologyDir.mkdir());
+        assertTrue(namedTopologyDir.exists());
         directory.clearLocalStateForNamedTopology(topologyName);
-        assertThat(namedTopologyDir.exists(), is(false));
+        assertFalse(namedTopologyDir.exists());
     }
 
     @Test
     public void shouldNotRemoveDirsThatDoNotMatchNamedTopologyDirsWhenCallingClean() throws IOException {
         initializeStateDirectory(true, true);
         final File someDir = new File(appDir, "_not-a-valid-named-topology_dir_name_");
-        assertThat(someDir.mkdir(), is(true));
-        assertThat(someDir.exists(), is(true));
+        assertTrue(someDir.mkdir());
+        assertTrue(someDir.exists());
         directory.clean();
-        assertThat(someDir.exists(), is(true));
+        assertTrue(someDir.exists());
     }
 
     @Test
@@ -788,23 +769,20 @@ public class StateDirectoryTest {
 
         final File taskDir = directory.getOrCreateDirectoryForTask(new TaskId(2, 0, "topology1"));
         final File namedTopologyDir = new File(appDir, "__topology1__");
-        assertThat(namedTopologyDir.exists(), is(true));
-        assertThat(taskDir.exists(), is(true));
+        assertTrue(namedTopologyDir.exists());
+        assertTrue(taskDir.exists());
         assertTrue(new File(taskDir, "store").mkdir());
-        assertThat(directory.listAllTaskDirectories().size(), is(1));
-        assertThat(directory.listNonEmptyTaskDirectories().size(), is(1));
+        assertEquals(1, directory.listAllTaskDirectories().size());
+        assertEquals(1, directory.listNonEmptyTaskDirectories().size());
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
             time.sleep(5000);
             directory.cleanRemovedTasks(0);
-            assertThat(taskDir.exists(), is(false));
-            assertThat(namedTopologyDir.exists(), is(false));
-            assertThat(directory.listAllTaskDirectories().size(), is(0));
-            assertThat(directory.listNonEmptyTaskDirectories().size(), is(0));
-            assertThat(
-                appender.getMessages(),
-                hasItem(containsString("Deleting obsolete state directory"))
-            );
+            assertFalse(taskDir.exists());
+            assertFalse(namedTopologyDir.exists());
+            assertEquals(0, directory.listAllTaskDirectories().size());
+            assertEquals(0, directory.listNonEmptyTaskDirectories().size());
+            assertTrue(appender.getMessages().stream().anyMatch(message -> message.contains("Deleting obsolete state directory")));
         }
     }
 
@@ -812,7 +790,7 @@ public class StateDirectoryTest {
     public void shouldPersistProcessIdAcrossRestart() {
         final UUID processId = directory.initializeProcessId();
         directory.close();
-        assertThat(directory.initializeProcessId(), equalTo(processId));
+        assertEquals(processId, directory.initializeProcessId());
     }
 
     @Test
@@ -821,10 +799,10 @@ public class StateDirectoryTest {
         directory.close();
 
         final File processFile = new File(appDir, PROCESS_FILE_NAME);
-        assertThat(processFile.exists(), is(true));
-        assertThat(processFile.delete(), is(true));
+        assertTrue(processFile.exists());
+        assertTrue(processFile.delete());
 
-        assertThat(directory.initializeProcessId(), not(processId));
+        assertNotEquals(processId, directory.initializeProcessId());
     }
 
     @Test
@@ -841,7 +819,7 @@ public class StateDirectoryTest {
             fileOutputStream.getFD().sync();
         }
 
-        assertThat(directory.initializeProcessId(), not(processId));
+        assertNotEquals(processId, directory.initializeProcessId());
     }
 
     @Test
@@ -851,7 +829,7 @@ public class StateDirectoryTest {
         final UUID processId = UUID.randomUUID();
         mapper.writeValue(processFile, new FutureStateDirectoryProcessFile(processId, "some random junk"));
 
-        assertThat(directory.initializeProcessId(), equalTo(processId));
+        assertEquals(processId, directory.initializeProcessId());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
@@ -35,8 +35,8 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.processor.internals.StateRestoreCallbackAdapter.adapt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -101,12 +101,12 @@ public class StateRestoreCallbackAdapterTest {
             new ConsumerRecord<>("topic2", 1, 1L, key2, value2)
         ));
 
-        assertThat(
-            actual,
-            is(asList(
+        assertEquals(
+            List.of(
                 new KeyValue<>(key1, value1),
                 new KeyValue<>(key2, value2)
-            ))
+            ),
+            actual
         );
     }
 
@@ -126,28 +126,28 @@ public class StateRestoreCallbackAdapterTest {
             new ConsumerRecord<>("topic2", 1, 1L, key2, value2)
         ));
 
-        assertThat(
-            actual,
-            is(asList(
+        assertEquals(
+            List.of(
                 new KeyValue<>(key1, value1),
                 new KeyValue<>(key2, value2)
-            ))
+            ),
+            actual
         );
     }
 
     private void validate(final List<ConsumerRecord<byte[], byte[]>> actual,
                           final List<ConsumerRecord<byte[], byte[]>> expected) {
-        assertThat(actual.size(), is(expected.size()));
+        assertEquals(expected.size(), actual.size());
         for (int i = 0; i < actual.size(); i++) {
             final ConsumerRecord<byte[], byte[]> actual1 = actual.get(i);
             final ConsumerRecord<byte[], byte[]> expected1 = expected.get(i);
-            assertThat(actual1.topic(), is(expected1.topic()));
-            assertThat(actual1.partition(), is(expected1.partition()));
-            assertThat(actual1.offset(), is(expected1.offset()));
-            assertThat(actual1.key(), is(expected1.key()));
-            assertThat(actual1.value(), is(expected1.value()));
-            assertThat(actual1.timestamp(), is(expected1.timestamp()));
-            assertThat(actual1.headers(), is(expected1.headers()));
+            assertEquals(expected1.topic(), actual1.topic());
+            assertEquals(expected1.partition(), actual1.partition());
+            assertEquals(expected1.offset(), actual1.offset());
+            assertArrayEquals(expected1.key(), actual1.key());
+            assertArrayEquals(expected1.value(), actual1.value());
+            assertEquals(expected1.timestamp(), actual1.timestamp());
+            assertEquals(expected1.headers(), actual1.headers());
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -88,9 +88,6 @@ import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_BATCH;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_SUSPENDED;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -450,7 +447,7 @@ public class StoreChangelogReaderTest {
             changelogReader.register(tp, stateManager);
             changelogReader.restore(mockTasks);
 
-            assertThat(callback.restoreStartOffset, equalTo(0L));
+            assertEquals(0L, callback.restoreStartOffset);
         }
     }
 
@@ -1461,11 +1458,8 @@ public class StoreChangelogReaderTest {
             appender.setClassLogger(StoreChangelogReader.class, Level.DEBUG);
             changelogReader.unregister(Collections.singletonList(new TopicPartition("unknown", 0)));
 
-            assertThat(
-                appender.getMessages(),
-                hasItem("test-reader Changelog partition unknown-0 could not be found," +
-                    " it could be already cleaned up during the handling of task corruption and never restore again")
-            );
+            assertTrue(appender.getMessages().contains("test-reader Changelog partition unknown-0 could not be found," +
+                " it could be already cleaned up during the handling of task corruption and never restore again"));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -79,7 +79,6 @@ import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 
 import org.apache.logging.log4j.Level;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,16 +124,6 @@ import static org.apache.kafka.streams.processor.internals.Task.State.RUNNING;
 import static org.apache.kafka.streams.processor.internals.Task.State.SUSPENDED;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByNameFilterByTags;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -143,7 +132,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -478,8 +466,8 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(resetter);
 
-        assertThat(consumer.position(partition1), equalTo(5L));
-        assertThat(consumer.position(partition2), equalTo(15L));
+        assertEquals(5L, consumer.position(partition1));
+        assertEquals(15L, consumer.position(partition2));
         verify(resetter).accept(Collections.emptySet());
     }
 
@@ -519,9 +507,9 @@ public class StreamTaskTest {
             task.completeRestoration(partitionsAtCall::addAll);
 
             // because we mocked the `resetter` positions don't change
-            assertThat(consumer.position(partition1), equalTo(5L));
-            assertThat(consumer.position(partition2), equalTo(15L));
-            assertThat(partitionsAtCall, equalTo(Collections.singleton(partition1)));
+            assertEquals(5L, consumer.position(partition1));
+            assertEquals(15L, consumer.position(partition2));
+            assertEquals(Set.of(partition1), partitionsAtCall);
         }
     }
 
@@ -766,7 +754,7 @@ public class StreamTaskTest {
 
         final KafkaMetric metric = getMetric("active-buffer", "%s-count", task.id().toString());
 
-        assertThat(metric.metricValue(), equalTo(0.0));
+        assertEquals(0.0, metric.metricValue());
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 10),
@@ -774,12 +762,12 @@ public class StreamTaskTest {
         ));
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(2.0));
+        assertEquals(2.0, metric.metricValue());
 
         assertTrue(task.process(0L));
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(1.0));
+        assertEquals(1.0, metric.metricValue());
     }
 
     @Test
@@ -790,22 +778,22 @@ public class StreamTaskTest {
 
         final KafkaMetric metric = getMetric("active-process", "%s-ratio", task.id().toString());
 
-        assertThat(metric.metricValue(), equalTo(0.0));
+        assertEquals(0.0, metric.metricValue());
 
         task.recordProcessBatchTime(10L);
         task.recordProcessBatchTime(15L);
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(0.25));
+        assertEquals(0.25, metric.metricValue());
 
         task.recordProcessBatchTime(10L);
 
-        assertThat(metric.metricValue(), equalTo(0.25));
+        assertEquals(0.25, metric.metricValue());
 
         task.recordProcessBatchTime(10L);
         task.recordProcessTimeRatioAndBufferSize(20L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(1.0));
+        assertEquals(1.0, metric.metricValue());
     }
 
     @Test
@@ -854,14 +842,14 @@ public class StreamTaskTest {
         // flush terminal e2e for the batch, as TaskExecutor.processTask does
         task.maybeFlushTerminalE2ELatency(10L);
 
-        assertThat(sourceAvg.metricValue(), equalTo(10.0));
-        assertThat(sourceMin.metricValue(), equalTo(10.0));
-        assertThat(sourceMax.metricValue(), equalTo(10.0));
+        assertEquals(10.0, sourceAvg.metricValue());
+        assertEquals(10.0, sourceMin.metricValue());
+        assertEquals(10.0, sourceMax.metricValue());
 
         // key 0: reaches terminal node
-        assertThat(terminalAvg.metricValue(), equalTo(10.0));
-        assertThat(terminalMin.metricValue(), equalTo(10.0));
-        assertThat(terminalMax.metricValue(), equalTo(10.0));
+        assertEquals(10.0, terminalAvg.metricValue());
+        assertEquals(10.0, terminalMin.metricValue());
+        assertEquals(10.0, terminalMax.metricValue());
 
 
         // e2e latency = 15
@@ -869,14 +857,14 @@ public class StreamTaskTest {
         task.process(15L);
         task.maybeFlushTerminalE2ELatency(15L);
 
-        assertThat(sourceAvg.metricValue(), equalTo(12.5));
-        assertThat(sourceMin.metricValue(), equalTo(10.0));
-        assertThat(sourceMax.metricValue(), equalTo(15.0));
+        assertEquals(12.5, sourceAvg.metricValue());
+        assertEquals(10.0, sourceMin.metricValue());
+        assertEquals(15.0, sourceMax.metricValue());
 
         // key 1: stops at source, doesn't affect terminal node metrics
-        assertThat(terminalAvg.metricValue(), equalTo(10.0));
-        assertThat(terminalMin.metricValue(), equalTo(10.0));
-        assertThat(terminalMax.metricValue(), equalTo(10.0));
+        assertEquals(10.0, terminalAvg.metricValue());
+        assertEquals(10.0, terminalMin.metricValue());
+        assertEquals(10.0, terminalMax.metricValue());
 
 
         // e2e latency = 23
@@ -884,14 +872,14 @@ public class StreamTaskTest {
         task.process(23L);
         task.maybeFlushTerminalE2ELatency(23L);
 
-        assertThat(sourceAvg.metricValue(), equalTo(16.0));
-        assertThat(sourceMin.metricValue(), equalTo(10.0));
-        assertThat(sourceMax.metricValue(), equalTo(23.0));
+        assertEquals(16.0, sourceAvg.metricValue());
+        assertEquals(10.0, sourceMin.metricValue());
+        assertEquals(23.0, sourceMax.metricValue());
 
         // key 2: reaches terminal node
-        assertThat(terminalAvg.metricValue(), equalTo(16.5));
-        assertThat(terminalMin.metricValue(), equalTo(10.0));
-        assertThat(terminalMax.metricValue(), equalTo(23.0));
+        assertEquals(16.5, terminalAvg.metricValue());
+        assertEquals(10.0, terminalMin.metricValue());
+        assertEquals(23.0, terminalMax.metricValue());
 
 
         // e2e latency = 5
@@ -899,14 +887,14 @@ public class StreamTaskTest {
         task.process(5L);
         task.maybeFlushTerminalE2ELatency(5L);
 
-        assertThat(sourceAvg.metricValue(), equalTo(13.25));
-        assertThat(sourceMin.metricValue(), equalTo(5.0));
-        assertThat(sourceMax.metricValue(), equalTo(23.0));
+        assertEquals(13.25, sourceAvg.metricValue());
+        assertEquals(5.0, sourceMin.metricValue());
+        assertEquals(23.0, sourceMax.metricValue());
 
         // key 3: stops at source, doesn't affect terminal node metrics
-        assertThat(terminalAvg.metricValue(), equalTo(16.5));
-        assertThat(terminalMin.metricValue(), equalTo(10.0));
-        assertThat(terminalMax.metricValue(), equalTo(23.0));
+        assertEquals(16.5, terminalAvg.metricValue());
+        assertEquals(10.0, terminalMin.metricValue());
+        assertEquals(23.0, terminalMax.metricValue());
     }
 
     @Test
@@ -953,9 +941,9 @@ public class StreamTaskTest {
         task.maybeFlushTerminalE2ELatency(time.milliseconds());
 
         // source node measures only consumption latency (record timestamp -> source observed it)
-        assertThat(sourceMax.metricValue(), equalTo(10.0));
+        assertEquals(10.0, sourceMax.metricValue());
         // terminal node measures full end-to-end latency, including the processing delay
-        assertThat(terminalMax.metricValue(), equalTo(10.0 + processingDelay));
+        assertEquals(10.0 + processingDelay, terminalMax.metricValue());
     }
 
     @Test
@@ -1000,9 +988,9 @@ public class StreamTaskTest {
         // batch completes at 1000; true latencies [900,550,520,510,500] -> max 900, min 500, avg 596
         task.maybeFlushTerminalE2ELatency(1000L);
 
-        assertThat(terminalMax.metricValue(), equalTo(900.0));
-        assertThat(terminalMin.metricValue(), equalTo(500.0));
-        assertThat((double) terminalAvg.metricValue(), closeTo(596.0, 1e-9));
+        assertEquals(900.0, terminalMax.metricValue());
+        assertEquals(500.0, terminalMin.metricValue());
+        assertEquals(596.0, (double) terminalAvg.metricValue(), 1e-9);
     }
 
     @Test
@@ -1047,9 +1035,9 @@ public class StreamTaskTest {
         // batch completes at 1000; true latencies [900,600] -> max 900, min 600, avg 750
         task.maybeFlushTerminalE2ELatency(1000L);
 
-        assertThat(terminalMax.metricValue(), equalTo(900.0));
-        assertThat(terminalMin.metricValue(), equalTo(600.0));
-        assertThat((double) terminalAvg.metricValue(), closeTo(750.0, 1e-9));
+        assertEquals(900.0, terminalMax.metricValue());
+        assertEquals(600.0, terminalMin.metricValue());
+        assertEquals(750.0, (double) terminalAvg.metricValue(), 1e-9);
     }
 
     @Test
@@ -1085,7 +1073,7 @@ public class StreamTaskTest {
         });
 
         // the latency must include the time the punctuator itself spent before forwarding
-        assertThat(terminalMax.metricValue(), equalTo(20.0 + punctuatorDelay));
+        assertEquals(20.0 + punctuatorDelay, terminalMax.metricValue());
     }
 
     @Test
@@ -1125,7 +1113,7 @@ public class StreamTaskTest {
         time.sleep(5L);
         task.flush();
 
-        assertThat(terminalMax.metricValue(), equalTo(15.0));
+        assertEquals(15.0, terminalMax.metricValue());
     }
 
     @Test
@@ -1138,19 +1126,19 @@ public class StreamTaskTest {
         final KafkaMetric rateMetric = getMetric("restore", "%s-rate", task.id().toString());
         final KafkaMetric remainMetric = getMetric("restore", "%s-remaining-records-total", task.id().toString());
 
-        assertThat(totalMetric.metricValue(), equalTo(0.0));
-        assertThat(rateMetric.metricValue(), equalTo(0.0));
-        assertThat(remainMetric.metricValue(), equalTo(0.0));
+        assertEquals(0.0, totalMetric.metricValue());
+        assertEquals(0.0, rateMetric.metricValue());
+        assertEquals(0.0, remainMetric.metricValue());
 
         // remaining-records is initialized from the offset range
         task.recordRestoration(time, 0L, 100L, true);
 
-        assertThat(remainMetric.metricValue(), equalTo(100.0));
+        assertEquals(100.0, remainMetric.metricValue());
 
         // restore-total counts records; remaining-records is decremented by offset slots (which may differ)
         task.recordRestoration(time, 25L, 30L, false);
 
-        assertThat(totalMetric.metricValue(), equalTo(25.0));
+        assertEquals(25.0, totalMetric.metricValue());
         // the rate measures restored records per second, not restore batches per second; with no time
         // elapsed the rate window is (metrics.num.samples - 1) * metrics.sample.window.ms == 30s
         assertEquals(
@@ -1160,11 +1148,11 @@ public class StreamTaskTest {
             "restore-rate must measure restored records per second, not restore batches per second; "
                 + "counting batches would give 1/30 == 0.03333 (KAFKA-20877)"
         );
-        assertThat(remainMetric.metricValue(), equalTo(70.0));
+        assertEquals(70.0, remainMetric.metricValue());
 
         task.recordRestoration(time, 50L, 55L, false);
 
-        assertThat(totalMetric.metricValue(), equalTo(75.0));
+        assertEquals(75.0, totalMetric.metricValue());
         assertEquals(
             75.0 / 30.0,
             ((Number) rateMetric.metricValue()).doubleValue(),
@@ -1172,7 +1160,7 @@ public class StreamTaskTest {
             "restore-rate must measure restored records per second, not restore batches per second; "
                 + "counting batches would give 2/30 == 0.06666 (KAFKA-20877)"
         );
-        assertThat(remainMetric.metricValue(), equalTo(15.0));
+        assertEquals(15.0, remainMetric.metricValue());
     }
 
     @Test
@@ -1187,19 +1175,19 @@ public class StreamTaskTest {
             TimeoutException.class,
             () -> task.process(0)
         );
-        assertThat(exception.getMessage(), equalTo("Kaboom!"));
+        assertEquals("Kaboom!", exception.getMessage());
 
         // we have only a single record that was not successfully processed
         // however, the record should not be in the record buffer any longer, but should be cached within the task itself
-        assertThat(task.commitNeeded(), equalTo(false));
-        assertThat(task.hasRecordsQueued(), equalTo(false));
+        assertFalse(task.commitNeeded());
+        assertFalse(task.hasRecordsQueued());
 
         // -> thus the task should try process the cached record now (that thus throw again)
         final TimeoutException nextException = assertThrows(
             TimeoutException.class,
             () -> task.process(0)
         );
-        assertThat(nextException.getMessage(), equalTo("Kaboom!"));
+        assertEquals("Kaboom!", nextException.getMessage());
     }
 
     @Test
@@ -1754,7 +1742,7 @@ public class StreamTaskTest {
             )
         );
 
-        assertThat(offsetsAndMetadata, equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(5L, Optional.of(2), expected.encode())))));
+        assertEquals(Map.of(partition1, new OffsetAndMetadata(5L, Optional.of(2), expected.encode())), offsetsAndMetadata);
     }
 
     @Test
@@ -1783,11 +1771,7 @@ public class StreamTaskTest {
         final TopicPartitionMetadata metadata = new TopicPartitionMetadata(0, new ProcessorMetadata());
 
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(true), equalTo(
-                mkMap(
-                        mkEntry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode()))
-                )
-        ));
+        assertEquals(Map.of(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode())), task.prepareCommit(true));
 
         task.postCommit(false);
 
@@ -1800,12 +1784,13 @@ public class StreamTaskTest {
         task.process(0L);
 
         assertTrue(task.commitNeeded());
-        assertThat(task.prepareCommit(true), equalTo(
-            mkMap(
-                mkEntry(partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode())),
-                mkEntry(partition2, new OffsetAndMetadata(1L, Optional.of(0), metadata.encode()))
-            )
-        ));
+        assertEquals(
+            Map.of(
+                partition1, new OffsetAndMetadata(3L, Optional.of(2), metadata.encode()),
+                partition2, new OffsetAndMetadata(1L, Optional.of(0), metadata.encode())
+            ),
+            task.prepareCommit(true)
+        );
         task.postCommit(false);
 
         assertFalse(task.commitNeeded());
@@ -1856,11 +1841,13 @@ public class StreamTaskTest {
 
         assertTrue(task.commitNeeded());
 
-        assertThat(task.prepareCommit(true), equalTo(
-            mkMap(
-                mkEntry(partition1, new OffsetAndMetadata(1L,  Optional.of(1), expectedMetadata1.encode())),
-                mkEntry(partition2, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata2.encode()))
-            )));
+        assertEquals(
+            Map.of(
+                partition1, new OffsetAndMetadata(1L, Optional.of(1), expectedMetadata1.encode()),
+                partition2, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata2.encode())
+            ),
+            task.prepareCommit(true)
+        );
         task.postCommit(false);
 
         // the task should still be committed since the processed records have not reached the consumer position
@@ -1879,9 +1866,7 @@ public class StreamTaskTest {
         assertTrue(task.commitNeeded());
 
         // Processor metadata not updated, we just need to commit to partition1 again with new offset
-        assertThat(task.prepareCommit(true), equalTo(
-                mkMap(mkEntry(partition1, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata3.encode())))
-        ));
+        assertEquals(Map.of(partition1, new OffsetAndMetadata(2L, Optional.of(1), expectedMetadata3.encode())), task.prepareCommit(true));
         task.postCommit(false);
 
         assertFalse(task.commitNeeded());
@@ -1899,7 +1884,7 @@ public class StreamTaskTest {
             () -> task.prepareCommit(true)
         );
 
-        assertThat(thrown.getMessage(), is("Illegal state CLOSED while preparing active task 0_0 for committing"));
+        assertEquals("Illegal state CLOSED while preparing active task 0_0 for committing", thrown.getMessage());
     }
 
     @Test
@@ -1922,19 +1907,19 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
-        assertThat("task is not idling", task.timeCurrentIdlingStarted().isEmpty());
+        assertTrue(task.timeCurrentIdlingStarted().isEmpty(), "task is not idling");
 
         assertFalse(task.process(0L));
 
         task.addRecords(partition1, singleton(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)));
 
         assertFalse(task.process(0L));
-        assertThat("task is idling", task.timeCurrentIdlingStarted().isPresent());
+        assertTrue(task.timeCurrentIdlingStarted().isPresent(), "task is idling");
 
         task.addRecords(partition2, singleton(getConsumerRecordWithOffsetAsTimestamp(partition2, 0)));
 
         assertTrue(task.process(0L));
-        assertThat("task is not idling", task.timeCurrentIdlingStarted().isEmpty());
+        assertTrue(task.timeCurrentIdlingStarted().isEmpty(), "task is not idling");
     }
 
     @Test
@@ -1946,11 +1931,11 @@ public class StreamTaskTest {
         task.completeRestoration(noOpResetter -> { });
         task.suspend();
 
-        assertThat("task is idling", task.timeCurrentIdlingStarted().isPresent());
+        assertTrue(task.timeCurrentIdlingStarted().isPresent(), "task is idling");
 
         task.resume();
 
-        assertThat("task is not idling", task.timeCurrentIdlingStarted().isEmpty());
+        assertTrue(task.timeCurrentIdlingStarted().isEmpty(), "task is not idling");
     }
 
     @Test
@@ -1992,24 +1977,12 @@ public class StreamTaskTest {
             messages = streamTaskAppender.getMessages();
             final String expectedNotReadyMessage = "stream-thread [Test worker] task [0_0] Partition topic2-0 has fetched lag of -1\n\tWaiting to fetch data for topic2-0";
             final String expectedReadyMessage = "Partition topic1-0 has buffered data, ready for processing";
-            assertThat("Should have logged not ready message", messages.size(), is(1));
-            assertThat(
-                streamTaskAppender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("INFO")),
-                    Matchers.hasProperty("message", equalTo(expectedNotReadyMessage))
-                ))
-            );
-            assertThat(messages.get(0), equalTo(expectedNotReadyMessage));
+            assertEquals(1, messages.size(), "Should have logged not ready message");
+            assertTrue(streamTaskAppender.getMessages("INFO").contains(expectedNotReadyMessage));
+            assertEquals(expectedNotReadyMessage, messages.get(0));
             
             // Validate TRACE log from PartitionGroup about partition1 being ready
-            assertThat(
-                partitionGroupAppender.getEvents(),
-                hasItem(Matchers.allOf(
-                    Matchers.hasProperty("level", equalTo("TRACE")),
-                    Matchers.hasProperty("message", containsString(expectedReadyMessage))
-                ))
-            );
+            assertTrue(partitionGroupAppender.getMessages("TRACE").stream().anyMatch(message -> message.contains(expectedReadyMessage)));
         }
     }
 
@@ -2132,16 +2105,16 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
-        try {
-            task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, timestamp -> {
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            () -> task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, timestamp -> {
                 throw new KafkaException("KABOOM!");
-            });
-            fail("Should've thrown StreamsException");
-        } catch (final StreamsException e) {
-            final String message = e.getMessage();
-            assertTrue(message.contains("processor '" + processorStreamTime.name() + "'"), "message=" + message + " should contain processor");
-            assertThat(task.processorContext().currentNode(), nullValue());
-        }
+            }),
+            "Should've thrown StreamsException"
+        );
+        final String message = exception.getMessage();
+        assertTrue(message.contains("processor '" + processorStreamTime.name() + "'"), "message=" + message + " should contain processor");
+        assertNull(task.processorContext().currentNode());
     }
 
     @Test
@@ -2152,16 +2125,16 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
 
-        try {
-            task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            () -> task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
                 throw new KafkaException("KABOOM!");
-            });
-            fail("Should've thrown StreamsException");
-        } catch (final StreamsException e) {
-            final String message = e.getMessage();
-            assertTrue(message.contains("processor '" + processorSystemTime.name() + "'"), "message=" + message + " should contain processor");
-            assertThat(task.processorContext().currentNode(), nullValue());
-        }
+            }),
+            "Should've thrown StreamsException"
+        );
+        final String message = exception.getMessage();
+        assertTrue(message.contains("processor '" + processorSystemTime.name() + "'"), "message=" + message + " should contain processor");
+        assertNull(task.processorContext().currentNode());
     }
 
     @Test
@@ -2206,8 +2179,8 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition2, 45)
         ));
 
-        assertThat("Map did not contain the partitions", task.highWaterMark().containsKey(partition1)
-                && task.highWaterMark().containsKey(partition2));
+        assertTrue(task.highWaterMark().containsKey(partition1) && task.highWaterMark().containsKey(partition2),
+            "Map did not contain the partitions");
         assertThrows(StreamsException.class, () -> task.process(0L));
     }
 
@@ -2258,7 +2231,7 @@ public class StreamTaskTest {
         assertTrue(source1.initialized);
         assertTrue(source2.initialized);
 
-        assertThat("Map did not contain the partition", task.highWaterMark().containsKey(partition1));
+        assertTrue(task.highWaterMark().containsKey(partition1), "Map did not contain the partition");
 
         verify(recordCollector).offsets();
     }
@@ -2272,12 +2245,9 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
         task.processorContext().setCurrentNode(processorStreamTime);
-        try {
-            task.punctuate(processorStreamTime, 10, PunctuationType.STREAM_TIME, punctuator);
-            fail("Should throw illegal state exception as current node is not null");
-        } catch (final IllegalStateException e) {
-            // pass
-        }
+        assertThrows(IllegalStateException.class,
+            () -> task.punctuate(processorStreamTime, 10, PunctuationType.STREAM_TIME, punctuator),
+            "Should throw illegal state exception as current node is not null");
     }
 
     @Test
@@ -2288,9 +2258,9 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
-        assertThat(punctuatedAt, equalTo(5L));
+        assertEquals(5L, punctuatedAt);
         task.punctuate(processorStreamTime, 10, PunctuationType.STREAM_TIME, punctuator);
-        assertThat(punctuatedAt, equalTo(10L));
+        assertEquals(10L, punctuatedAt);
     }
 
     @Test
@@ -2301,7 +2271,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
-        assertThat(task.processorContext().currentNode(), nullValue());
+        assertNull(task.processorContext().currentNode());
     }
 
     @Test
@@ -2415,9 +2385,9 @@ public class StreamTaskTest {
         final Map<TopicPartition, Long> map = task.purgeableOffsets();
 
         if (doCommit) {
-            assertThat(map, equalTo(singletonMap(repartition, 10L)));
+            assertEquals(Map.of(repartition, 10L), map);
         } else {
-            assertThat(map, equalTo(Collections.emptyMap()));
+            assertTrue(map.isEmpty());
         }
     }
 
@@ -2723,9 +2693,9 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
         task.suspend();
-        assertThat(getTaskMetrics(), not(empty()));
+        assertFalse(getTaskMetrics().isEmpty());
         task.closeClean();
-        assertThat(getTaskMetrics(), empty());
+        assertTrue(getTaskMetrics().isEmpty());
     }
 
     @Test
@@ -2735,9 +2705,9 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
         task.suspend();
-        assertThat(getTaskMetrics(), not(empty()));
+        assertFalse(getTaskMetrics().isEmpty());
         task.closeDirty();
-        assertThat(getTaskMetrics(), empty());
+        assertTrue(getTaskMetrics().isEmpty());
     }
 
     @Test
@@ -2746,10 +2716,10 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
         task.suspend();
-        assertThat(getTaskMetrics(), not(empty()));
+        assertFalse(getTaskMetrics().isEmpty());
         task.prepareRecycle();
-        assertThat(getTaskMetrics(), empty());
-        assertThat(task.state(), is(Task.State.CLOSED));
+        assertTrue(getTaskMetrics().isEmpty());
+        assertEquals(Task.State.CLOSED, task.state());
 
         verify(stateManager).recycle();
     }
@@ -2779,11 +2749,11 @@ public class StreamTaskTest {
         task.requestCommit();
 
         task.suspend();
-        assertThat(task.commitNeeded(), is(true));
-        assertThat(task.commitRequested(), is(true));
+        assertTrue(task.commitNeeded());
+        assertTrue(task.commitRequested());
         task.closeDirty();
-        assertThat(task.commitNeeded(), is(false));
-        assertThat(task.commitRequested(), is(false));
+        assertFalse(task.commitNeeded());
+        assertFalse(task.commitRequested());
     }
 
     @Test
@@ -2813,7 +2783,7 @@ public class StreamTaskTest {
             mkEntry(source2.name(), singletonList(topic2)))
         );
 
-        assertThat(task.inputPartitions(), equalTo(newPartitions));
+        assertEquals(newPartitions, task.inputPartitions());
     }
 
     @Test
@@ -2862,7 +2832,7 @@ public class StreamTaskTest {
 
         task.suspend();
         task.prepareRecycle(); // SUSPENDED
-        assertThat(task.state(), is(Task.State.CLOSED));
+        assertEquals(Task.State.CLOSED, task.state());
 
         verify(stateManager).recycle();
         verify(recordCollector).closeClean();
@@ -2873,9 +2843,9 @@ public class StreamTaskTest {
         when(stateManager.taskId()).thenReturn(taskId);
         when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);
         task = createStatefulTask(createConfig("100"), true);
-        assertThat(task.state(), equalTo(CREATED));
+        assertEquals(CREATED, task.state());
         task.suspend();
-        assertThat(task.state(), equalTo(SUSPENDED));
+        assertEquals(SUSPENDED, task.state());
     }
 
     @Test
@@ -2884,9 +2854,9 @@ public class StreamTaskTest {
         when(stateManager.taskType()).thenReturn(TaskType.ACTIVE);
         task = createStatefulTask(createConfig("100"), true);
         task.initializeIfNeeded();
-        assertThat(task.state(), equalTo(RESTORING));
+        assertEquals(RESTORING, task.state());
         task.suspend();
-        assertThat(task.state(), equalTo(SUSPENDED));
+        assertEquals(SUSPENDED, task.state());
     }
 
     @Test
@@ -2896,9 +2866,9 @@ public class StreamTaskTest {
         task = createFaultyStatefulTask(createConfig("100"));
         task.initializeIfNeeded();
         task.completeRestoration(noOpResetter -> { });
-        assertThat(task.state(), equalTo(RUNNING));
+        assertEquals(RUNNING, task.state());
         assertThrows(RuntimeException.class, () -> task.suspend());
-        assertThat(task.state(), equalTo(SUSPENDED));
+        assertEquals(SUSPENDED, task.state());
     }
 
     @Test
@@ -2936,10 +2906,11 @@ public class StreamTaskTest {
             )
         );
 
-        assertThat(exception.getMessage(), equalTo("Invalid topology: " +
+        assertEquals("Invalid topology: " +
                 "Topic " + topic1 + " is unknown to the topology. This may happen if different KafkaStreams instances of the same " +
                 "application execute different Topologies. Note that Topologies are only identical if all operators " +
-                "are added in the same order."));
+                "are added in the same order.",
+            exception.getMessage());
     }
 
     @Test
@@ -2956,7 +2927,7 @@ public class StreamTaskTest {
             () -> task.maybeInitTaskTimeoutOrThrow(Duration.ofMinutes(5).plus(Duration.ofMillis(1L)).toMillis(), null)
         );
 
-        assertThat(thrown.getCause(), isA(TimeoutException.class));
+        assertInstanceOf(TimeoutException.class, thrown.getCause());
     }
 
     @Test
@@ -2994,11 +2965,11 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1,
+        assertEquals(
+            Map.of(partition1,
                 new OffsetAndMetadata(offset + 1,
-                    new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode()))))
+                    new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3026,9 +2997,9 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3056,16 +3027,16 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3093,11 +3064,11 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1,
+        assertEquals(
+            Map.of(partition1,
                 new OffsetAndMetadata(offset + 1,
-                    new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode()))))
+                    new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3125,9 +3096,9 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(offset + 1, new TopicPartitionMetadata(offset, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3156,16 +3127,16 @@ public class StreamTaskTest {
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(1, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
 
         assertTrue(task.process(offset));
         assertTrue(task.commitNeeded());
-        assertThat(
-            task.prepareCommit(true),
-            equalTo(mkMap(mkEntry(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode()))))
+        assertEquals(
+            Map.of(partition1, new OffsetAndMetadata(2, new TopicPartitionMetadata(0, new ProcessorMetadata()).encode())),
+            task.prepareCommit(true)
         );
     }
 
@@ -3884,6 +3855,6 @@ public class StreamTaskTest {
     private void verifyCloseTaskMetric(final double expected, final StreamsMetricsImpl streamsMetrics, final MetricName metricName) {
         final KafkaMetric metric = (KafkaMetric) streamsMetrics.metrics().get(metricName);
         final double totalCloses = metric.measurable().measure(metric.config(), System.currentTimeMillis());
-        assertThat(totalCloses, equalTo(expected));
+        assertEquals(expected, totalCloses);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -150,18 +150,11 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.adminClie
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
 import static org.apache.kafka.test.TestUtils.DEFAULT_MAX_WAIT_MS;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -897,7 +890,7 @@ public class StreamThreadTest {
         // Validate that the scheduled rebalance wasn't reset then set to MAX_VALUE so we
         // don't trigger one before we can shut down, since the rebalance must be ended
         // for the thread to fully shut down
-        assertThat(mockClientSupplier.nextRebalanceMs().get(), not(0L));
+        assertNotEquals(0L, mockClientSupplier.nextRebalanceMs().get());
 
         thread.taskManager().handleRebalanceComplete();
 
@@ -980,43 +973,43 @@ public class StreamThreadTest {
         addRecord(mockConsumer, ++offset, 0L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertEquals(1, thread.currentNumIterations());
 
         // processed one more record without punctuation, and bump num.iterations to 2
         addRecord(mockConsumer, ++offset, 1L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(2));
+        assertEquals(2, thread.currentNumIterations());
 
         // processed zero records, early exit and iterations stays as 2
         runOnce(false);
-        assertThat(thread.currentNumIterations(), equalTo(2));
+        assertEquals(2, thread.currentNumIterations());
 
         // system time based punctuation without processing any record, iteration stays as 2
         mockTime.sleep(11L);
 
         runOnce(false);
-        assertThat(thread.currentNumIterations(), equalTo(2));
+        assertEquals(2, thread.currentNumIterations());
 
         // system time based punctuation after processing a record, half iteration to 1
         mockTime.sleep(11L);
         addRecord(mockConsumer, ++offset, 5L);
 
         runOnce(false);
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertEquals(1, thread.currentNumIterations());
 
         // processed two records, bumping up iterations to 3 (1 + 2)
         addRecord(mockConsumer, ++offset, 5L);
         addRecord(mockConsumer, ++offset, 6L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(3));
+        assertEquals(3, thread.currentNumIterations());
 
         // stream time based punctuation halves to 1
         addRecord(mockConsumer, ++offset, 11L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertEquals(1, thread.currentNumIterations());
 
         // processed three records, bumping up iterations to 3 (1 + 2)
         addRecord(mockConsumer, ++offset, 12L);
@@ -1024,14 +1017,14 @@ public class StreamThreadTest {
         addRecord(mockConsumer, ++offset, 14L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(3));
+        assertEquals(3, thread.currentNumIterations());
 
         mockProcessors.forEach(MockApiProcessor::requestCommit);
         addRecord(mockConsumer, ++offset, 15L);
         runOnce(false);
 
         // user requested commit should half iteration to 1
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertEquals(1, thread.currentNumIterations());
 
         // processed three records, bumping up iterations to 3 (1 + 2)
         addRecord(mockConsumer, ++offset, 15L);
@@ -1039,20 +1032,20 @@ public class StreamThreadTest {
         addRecord(mockConsumer, ++offset, 17L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(3));
+        assertEquals(3, thread.currentNumIterations());
 
         // time based commit without processing, should keep the iteration as 3
         mockTime.sleep(90L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(3));
+        assertEquals(3, thread.currentNumIterations());
 
         // time based commit without processing, should half the iteration to 1
         mockTime.sleep(90L);
         addRecord(mockConsumer, ++offset, 18L);
         runOnce(false);
 
-        assertThat(thread.currentNumIterations(), equalTo(1));
+        assertEquals(1, thread.currentNumIterations());
     }
 
     @ParameterizedTest
@@ -1423,28 +1416,26 @@ public class StreamThreadTest {
 
         runOnce(processingThreadsEnabled);
 
-        assertThat(
+        assertEquals(
+            10.0,
             streamsMetrics.metrics().get(
                 new MetricName(
                     "commit-latency-max",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID)
+                    Map.of("thread-id", CLIENT_ID)
                 )
-            ).metricValue(),
-            equalTo(10.0)
-        );
-        assertThat(
+            ).metricValue());
+        assertEquals(
+            10.0,
             streamsMetrics.metrics().get(
                 new MetricName(
                     "commit-latency-avg",
                     "stream-thread-metrics",
                     "",
-                    Collections.singletonMap("thread-id", CLIENT_ID)
+                    Map.of("thread-id", CLIENT_ID)
                 )
-            ).metricValue(),
-            equalTo(10.0)
-        );
+            ).metricValue());
     }
 
     @ParameterizedTest
@@ -1520,7 +1511,7 @@ public class StreamThreadTest {
 
         runOnce(processingThreadsEnabled);
 
-        assertThat(clientSupplier.producers.size(), is(1));
+        assertEquals(1, clientSupplier.producers.size());
         assertSame(clientSupplier.consumer, thread.mainConsumer());
         assertSame(clientSupplier.restoreConsumer, thread.restoreConsumer());
     }
@@ -1664,7 +1655,7 @@ public class StreamThreadTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, thread::run);
 
-        assertThat(thrown.getCause(), isA(IllegalStateException.class));
+        assertInstanceOf(IllegalStateException.class, thrown.getCause());
         // The Mock consumer shall throw as the assignment has been wiped out, but records are assigned.
         assertEquals("Cannot add records for a partition that is not assigned to the consumer", thrown.getCause().getMessage());
         assertFalse(consumer.shouldRebalance());
@@ -1856,7 +1847,7 @@ public class StreamThreadTest {
         thread.rebalanceListener().onPartitionsAssigned(assignedPartitions);
 
         runOnce(processingThreadsEnabled);
-        assertThat(thread.readOnlyActiveTasks().size(), equalTo(1));
+        assertEquals(1, thread.readOnlyActiveTasks().size());
         final MockProducer<byte[], byte[]> producer = clientSupplier.producers.get(0);
 
         // change consumer subscription from "pattern" to "manual" to be able to call .addRecords()
@@ -1870,7 +1861,7 @@ public class StreamThreadTest {
         } else {
             mockTime.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) + 1L);
             runOnce(processingThreadsEnabled);
-            assertThat(producer.history().size(), equalTo(1));
+            assertEquals(1, producer.history().size());
         }
 
         mockTime.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG) + 1L);
@@ -1893,7 +1884,7 @@ public class StreamThreadTest {
         assertTrue(thread.readOnlyActiveTasks().stream().anyMatch(task -> task.id().equals(task1)),
             "StreamsThread removed the fenced zombie task already, should wait for rebalance to close all zombies together.");
 
-        assertThat(producer.commitCount(), equalTo(1L));
+        assertEquals(1L, producer.commitCount());
     }
 
     private void testThrowingDuringCommitTransactionException(final RuntimeException e, final boolean processingThreadsEnabled) throws InterruptedException {
@@ -1923,7 +1914,7 @@ public class StreamThreadTest {
 
         runOnce(processingThreadsEnabled);
 
-        assertThat(thread.readOnlyActiveTasks().size(), equalTo(1));
+        assertEquals(1, thread.readOnlyActiveTasks().size());
 
         // need to process a record to enable committing
         addRecord(mockConsumer, 0L);
@@ -2017,7 +2008,7 @@ public class StreamThreadTest {
 
         // the first iteration completes the restoration
         runOnce(processingThreadsEnabled);
-        assertThat(thread.readOnlyActiveTasks().size(), equalTo(1));
+        assertEquals(1, thread.readOnlyActiveTasks().size());
 
         // the second transits to running and unpause the input
         runOnce(processingThreadsEnabled);
@@ -2055,13 +2046,13 @@ public class StreamThreadTest {
         // process the record
         addRecord(mockConsumer, 0L);
         shouldThrow.set(false);
-        assertThat(processed.get(), is(false));
+        assertFalse(processed.get());
         if (processingThreadsEnabled) {
             assertTrue(runUntilTimeoutOrCondition(() -> runOnce(processingThreadsEnabled), processed::get));
         } else {
             runOnce(processingThreadsEnabled);
             runOnce(processingThreadsEnabled);
-            assertThat(processed.get(), is(true));
+            assertTrue(processed.get());
         }
     }
 
@@ -2095,7 +2086,7 @@ public class StreamThreadTest {
         thread.rebalanceListener().onPartitionsAssigned(assignedPartitions);
 
         runOnce(processingThreadsEnabled);
-        assertThat(thread.readOnlyActiveTasks().size(), equalTo(1));
+        assertEquals(1, thread.readOnlyActiveTasks().size());
         final MockProducer<byte[], byte[]> producer = clientSupplier.producers.get(0);
 
         producer.commitTransactionException = e;
@@ -2112,7 +2103,7 @@ public class StreamThreadTest {
         assertTrue(thread.readOnlyActiveTasks().stream().anyMatch(task -> task.id().equals(task1)),
             "StreamsThread removed the fenced zombie task already, should wait for rebalance to close all zombies together.");
 
-        assertThat(producer.commitCount(), equalTo(0L));
+        assertEquals(0L, producer.commitCount());
 
         assertTrue(clientSupplier.producers.get(0).transactionInFlight());
         assertFalse(clientSupplier.producers.get(0).transactionCommitted());
@@ -2161,7 +2152,7 @@ public class StreamThreadTest {
 
         runOnce(processingThreadsEnabled);
 
-        assertThat(thread.readOnlyActiveTasks().size(), equalTo(1));
+        assertEquals(1, thread.readOnlyActiveTasks().size());
 
         // need to process a record to enable committing
         addRecord(mockConsumer, 0L);
@@ -2251,7 +2242,7 @@ public class StreamThreadTest {
         assertTrue(Arrays.asList("RUNNING", "STARTING", "PARTITIONS_REVOKED", "PARTITIONS_ASSIGNED", "CREATED").contains(metadata.threadState()),
             "#threadState() was: " + metadata.threadState() + "; expected either RUNNING, STARTING, PARTITIONS_REVOKED, PARTITIONS_ASSIGNED, or CREATED");
         final String threadName = metadata.threadName();
-        assertThat(threadName, startsWith(CLIENT_ID + "-StreamThread-" + threadIdx));
+        assertTrue(threadName.startsWith(CLIENT_ID + "-StreamThread-" + threadIdx));
         assertEquals(threadName + "-consumer", metadata.consumerClientId());
         assertEquals(threadName + "-restore-consumer", metadata.restoreConsumerClientId());
         assertEquals(Collections.singleton(threadName + "-producer"), metadata.producerClientIds());
@@ -2312,7 +2303,7 @@ public class StreamThreadTest {
         setupInternalTopologyWithoutState(config);
         internalTopologyBuilder.addStateStore(new MockKeyValueStoreBuilder("myStore", true), "processor1");
 
-        assertThat(createStandbyTask(config), not(empty()));
+        assertFalse(createStandbyTask(config).isEmpty());
     }
 
     @ParameterizedTest
@@ -2321,7 +2312,7 @@ public class StreamThreadTest {
         final StreamsConfig config = new StreamsConfig(configProps(false, processingThreadsEnabled));
         setupInternalTopologyWithoutState(config);
 
-        assertThat(createStandbyTask(config), empty());
+        assertTrue(createStandbyTask(config).isEmpty());
     }
 
     @ParameterizedTest
@@ -2334,7 +2325,7 @@ public class StreamThreadTest {
         storeBuilder.withLoggingDisabled();
         internalTopologyBuilder.addStateStore(storeBuilder, "processor1");
 
-        assertThat(createStandbyTask(config), empty());
+        assertTrue(createStandbyTask(config).isEmpty());
     }
 
     @Test
@@ -2861,7 +2852,7 @@ public class StreamThreadTest {
         thread.setStreamsUncaughtExceptionHandler((e, b) -> exceptionHandlerInvoked.set(true));
         thread.run();
 
-        assertThat(exceptionHandlerInvoked.get(), is(true));
+        assertTrue(exceptionHandlerInvoked.get());
 
         verify(consumer).subscribe((Collection<String>) any(), any());
     }
@@ -3311,7 +3302,7 @@ public class StreamThreadTest {
         topologyMetadata.buildAndRewriteTopology();
         thread = buildStreamThread(consumer, taskManager, config, topologyMetadata);
 
-        assertThat(dummyProducerMetrics, is(thread.producerMetrics()));
+        assertEquals(dummyProducerMetrics, thread.producerMetrics());
     }
 
     @ParameterizedTest
@@ -3441,7 +3432,7 @@ public class StreamThreadTest {
         thread.run();
 
         final Metric failedThreads = StreamsTestUtils.getMetricByName(metrics.metrics(), "failed-stream-threads", "stream-metrics");
-        assertThat(failedThreads.metricValue(), is(shouldFail ? 1.0 : 0.0));
+        assertEquals(shouldFail ? 1.0 : 0.0, failedThreads.metricValue());
     }
 
     @ParameterizedTest
@@ -3568,15 +3559,15 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> mainConsumerFuture = clientInstanceIdFutures.get("clientId-StreamThread-1-consumer");
         final Uuid mainConsumerUuid = mainConsumerFuture.get();
-        assertThat(mainConsumerUuid, equalTo(consumerInstanceId));
+        assertEquals(consumerInstanceId, mainConsumerUuid);
 
         final KafkaFuture<Uuid> restoreConsumerFuture = clientInstanceIdFutures.get("clientId-StreamThread-1-restore-consumer");
         final Uuid restoreConsumerUuid = restoreConsumerFuture.get();
-        assertThat(restoreConsumerUuid, equalTo(restoreInstanceId));
+        assertEquals(restoreInstanceId, restoreConsumerUuid);
 
         final KafkaFuture<Uuid> producerFuture = clientInstanceIdFutures.get("clientId-StreamThread-1-producer");
         final Uuid producerUuid = producerFuture.get();
-        assertThat(producerUuid, equalTo(producerInstanceId));
+        assertEquals(producerInstanceId, producerUuid);
     }
 
     @ParameterizedTest
@@ -3592,8 +3583,8 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-consumer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
-        assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+        assertInstanceOf(UnsupportedOperationException.class, error.getCause());
+        assertEquals("clientInstanceId not set", error.getCause().getMessage());
     }
 
     @ParameterizedTest
@@ -3609,8 +3600,8 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-restore-consumer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
-        assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+        assertInstanceOf(UnsupportedOperationException.class, error.getCause());
+        assertEquals("clientInstanceId not set", error.getCause().getMessage());
     }
 
     @ParameterizedTest
@@ -3626,8 +3617,8 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(UnsupportedOperationException.class));
-        assertThat(error.getCause().getMessage(), equalTo("clientInstanceId not set"));
+        assertInstanceOf(UnsupportedOperationException.class, error.getCause());
+        assertEquals("clientInstanceId not set", error.getCause().getMessage());
     }
 
     @ParameterizedTest
@@ -3644,7 +3635,7 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-consumer");
         final Uuid clientInstanceId = future.get();
-        assertThat(clientInstanceId, equalTo(null));
+        assertNull(clientInstanceId);
     }
 
     @ParameterizedTest
@@ -3662,7 +3653,7 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-restore-consumer");
         final Uuid clientInstanceId = future.get();
-        assertThat(clientInstanceId, equalTo(null));
+        assertNull(clientInstanceId);
     }
 
     @ParameterizedTest
@@ -3682,7 +3673,7 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
         final Uuid clientInstanceId = future.get();
-        assertThat(clientInstanceId, equalTo(null));
+        assertNull(clientInstanceId);
     }
 
     @ParameterizedTest
@@ -3702,11 +3693,8 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-consumer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(TimeoutException.class));
-        assertThat(
-            error.getCause().getMessage(),
-            equalTo("Could not retrieve main consumer client instance id.")
-        );
+        assertInstanceOf(TimeoutException.class, error.getCause());
+        assertEquals("Could not retrieve main consumer client instance id.", error.getCause().getMessage());
     }
 
 
@@ -3728,11 +3716,8 @@ public class StreamThreadTest {
         final KafkaFuture<Uuid> future = consumerFutures.get("clientId-StreamThread-1-restore-consumer");
 
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(TimeoutException.class));
-        assertThat(
-            error.getCause().getMessage(),
-            equalTo("Could not retrieve restore consumer client instance id.")
-        );
+        assertInstanceOf(TimeoutException.class, error.getCause());
+        assertEquals("Could not retrieve restore consumer client instance id.", error.getCause().getMessage());
     }
 
     @ParameterizedTest
@@ -3755,11 +3740,8 @@ public class StreamThreadTest {
 
         final KafkaFuture<Uuid> future = producerFutures.get("clientId-StreamThread-1-producer");
         final ExecutionException error = assertThrows(ExecutionException.class, future::get);
-        assertThat(error.getCause(), instanceOf(TimeoutException.class));
-        assertThat(
-            error.getCause().getMessage(),
-            equalTo("Could not retrieve thread producer client instance id.")
-        );
+        assertInstanceOf(TimeoutException.class, error.getCause());
+        assertEquals("Could not retrieve thread producer client instance id.", error.getCause().getMessage());
     }
 
     @Test
@@ -4587,12 +4569,11 @@ public class StreamThreadTest {
         thread = createStreamThread(CLIENT_ID, false);
 
         final List<MetricsReporter> reportersAfterCreate = thread.streamsMetrics().metricsRegistry().reporters();
-        assertThat(
-                reportersAfterCreate.stream()
-                        .filter(r -> r instanceof StreamsThreadMetricsDelegatingReporter)
-                        .count(),
-                equalTo(1L)
-        );
+        assertEquals(
+            1L,
+            reportersAfterCreate.stream()
+                .filter(r -> r instanceof StreamsThreadMetricsDelegatingReporter)
+                .count());
 
         thread.shutdown(CloseOptions.GroupMembershipOperation.LEAVE_GROUP);
         TestUtils.waitForCondition(
@@ -4602,12 +4583,11 @@ public class StreamThreadTest {
         );
 
         final List<MetricsReporter> reportersAfterShutdown = thread.streamsMetrics().metricsRegistry().reporters();
-        assertThat(
-                reportersAfterShutdown.stream()
-                        .filter(r -> r instanceof StreamsThreadMetricsDelegatingReporter)
-                        .count(),
-                equalTo(0L)
-        );
+        assertEquals(
+            0L,
+            reportersAfterShutdown.stream()
+                .filter(r -> r instanceof StreamsThreadMetricsDelegatingReporter)
+                .count());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTotalBlockedTimeTest.java
@@ -34,8 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -78,11 +77,11 @@ public class StreamThreadTotalBlockedTimeTest {
 
     @Test
     public void shouldComputeTotalBlockedTime() {
-        assertThat(
-            blockedTime.compute(),
-            equalTo(IO_TIME_TOTAL + IO_WAIT_TIME_TOTAL + COMMITTED_TIME_TOTAL
+        assertEquals(
+            IO_TIME_TOTAL + IO_WAIT_TIME_TOTAL + COMMITTED_TIME_TOTAL
                 + COMMIT_SYNC_TIME_TOTAL + RESTORE_IOTIME_TOTAL + RESTORE_IO_WAITTIME_TOTAL
-                + PRODUCER_BLOCKED_TIME)
+                + PRODUCER_BLOCKED_TIME,
+            blockedTime.compute()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsAssignmentScaleTest.java
@@ -67,8 +67,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getInfo;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.processIdForInt;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -302,7 +301,7 @@ public class StreamsAssignmentScaleTest {
             log.info("Second assignment took {}ms.", secondAssignmentDuration);
         }
 
-        assertThat(secondAssignments.size(), is(numClients * numThreadsPerClient));
+        assertEquals(numClients * numThreadsPerClient, secondAssignments.size());
     }
 
     private String getConsumerName(final int consumerIndex, final int clientIndex) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -151,17 +151,10 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.createMockAdminClientForAssignor;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.getInfo;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
@@ -486,8 +479,8 @@ public class StreamsPartitionAssignorTest {
         assertTrue(assignment.get(CONSUMER_1).containsAll(previousAssignment.get(CONSUMER_1)));
         assertTrue(assignment.get(CONSUMER_2).containsAll(previousAssignment.get(CONSUMER_2)));
 
-        assertThat(assignment.get(CONSUMER_1).size(), equalTo(4));
-        assertThat(assignment.get(CONSUMER_2).size(), equalTo(4));
+        assertEquals(4, assignment.get(CONSUMER_1).size());
+        assertEquals(4, assignment.get(CONSUMER_2).size());
     }
 
     @ParameterizedTest
@@ -531,10 +524,10 @@ public class StreamsPartitionAssignorTest {
         assertTrue(assignment.get(CONSUMER_2).containsAll(previousAssignment.get(CONSUMER_2)));
 
 
-        assertThat(assignment.get(CONSUMER_1).size(), equalTo(2));
-        assertThat(assignment.get(CONSUMER_2).size(), equalTo(2));
-        assertThat(assignment.get(CONSUMER_3).size(), equalTo(2));
-        assertThat(assignment.get(CONSUMER_4).size(), equalTo(2));
+        assertEquals(2, assignment.get(CONSUMER_1).size());
+        assertEquals(2, assignment.get(CONSUMER_2).size());
+        assertEquals(2, assignment.get(CONSUMER_3).size());
+        assertEquals(2, assignment.get(CONSUMER_4).size());
     }
 
     @ParameterizedTest
@@ -567,7 +560,7 @@ public class StreamsPartitionAssignorTest {
                 new HashMap<>()
             );
 
-        assertThat(interleavedTaskIds, equalTo(assignment));
+        assertEquals(assignment, interleavedTaskIds);
     }
 
     @ParameterizedTest
@@ -1615,9 +1608,9 @@ public class StreamsPartitionAssignorTest {
         expectedCreatedInternalTopics.put(APPLICATION_ID + "-KSTREAM-MAP-0000000001-repartition", 4);
 
         // check if all internal topics were created as expected
-        assertThat(mockInternalTopicManager.readyTopics, equalTo(expectedCreatedInternalTopics));
+        assertEquals(expectedCreatedInternalTopics, mockInternalTopicManager.readyTopics);
 
-        final List<TopicPartition> expectedAssignment = asList(
+        final Set<TopicPartition> expectedAssignment = Set.of(
             new TopicPartition("topic1", 0),
             new TopicPartition("topic1", 1),
             new TopicPartition("topic1", 2),
@@ -1636,7 +1629,7 @@ public class StreamsPartitionAssignorTest {
         );
 
         // check if we created a task for all expected topicPartitions.
-        assertThat(new HashSet<>(assignment.get(client).partitions()), equalTo(new HashSet<>(expectedAssignment)));
+        assertEquals(expectedAssignment, new HashSet<>(assignment.get(client).partitions()));
     }
 
     @ParameterizedTest
@@ -1777,12 +1770,10 @@ public class StreamsPartitionAssignorTest {
     public void shouldThrowExceptionIfApplicationServerConfigIsNotHostPortPair(final Map<String, Object> parameterizedConfig) {
         setUp(parameterizedConfig, false);
         createDefaultMockTaskManager();
-        try {
-            configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost"), parameterizedConfig);
-            fail("expected to an exception due to invalid config");
-        } catch (final ConfigException e) {
-            // pass
-        }
+        assertThrows(
+            ConfigException.class,
+            () -> configurePartitionAssignorWith(Collections.singletonMap(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost"), parameterizedConfig),
+            "expected to an exception due to invalid config");
     }
 
     @ParameterizedTest
@@ -1850,9 +1841,9 @@ public class StreamsPartitionAssignorTest {
         );
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
-        assertThat(mockInternalTopicManager.readyTopics.isEmpty(), equalTo(true));
+        assertTrue(mockInternalTopicManager.readyTopics.isEmpty());
 
-        assertThat(assignment.get(client).partitions().isEmpty(), equalTo(true));
+        assertTrue(assignment.get(client).partitions().isEmpty());
     }
 
     @ParameterizedTest
@@ -1900,11 +1891,11 @@ public class StreamsPartitionAssignorTest {
 
         partitionAssignor.onAssignment(createAssignment(oldHostState), null);
 
-        assertThat(referenceContainer.nextScheduledRebalanceMs.get(), is(0L));
+        assertEquals(0L, referenceContainer.nextScheduledRebalanceMs.get());
 
         partitionAssignor.onAssignment(createAssignment(newHostState), null);
 
-        assertThat(referenceContainer.nextScheduledRebalanceMs.get(), is(Long.MAX_VALUE));
+        assertEquals(Long.MAX_VALUE, referenceContainer.nextScheduledRebalanceMs.get());
     }
 
     @ParameterizedTest
@@ -1939,16 +1930,16 @@ public class StreamsPartitionAssignorTest {
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
         // Verify at least one partition was revoked
-        assertThat(assignment.get(CONSUMER_1).partitions(), not(allPartitions));
-        assertThat(assignment.get(CONSUMER_2).partitions(), equalTo(emptyList()));
+        assertNotEquals(allPartitions, assignment.get(CONSUMER_1).partitions());
+        assertTrue(assignment.get(CONSUMER_2).partitions().isEmpty());
 
         // Verify that stateless revoked tasks would not be assigned as standbys
-        assertThat(AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()).activeTasks(), equalTo(emptyList()));
-        assertThat(AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()).standbyTasks(), equalTo(emptyMap()));
+        assertTrue(AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()).activeTasks().isEmpty());
+        assertTrue(AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()).standbyTasks().isEmpty());
 
         partitionAssignor.onAssignment(assignment.get(CONSUMER_2), null);
 
-        assertThat(referenceContainer.nextScheduledRebalanceMs.get(), is(0L));
+        assertEquals(0L, referenceContainer.nextScheduledRebalanceMs.get());
     }
 
     @ParameterizedTest
@@ -2002,11 +1993,11 @@ public class StreamsPartitionAssignorTest {
         final Set<TopicPartition> consumer2StandbyPartitions = assignmentInfo.standbyPartitionByHost().get(new HostInfo("other", 9090));
         final HashSet<TopicPartition> allAssignedPartitions = new HashSet<>(consumer1ActivePartitions);
         allAssignedPartitions.addAll(consumer2ActivePartitions);
-        assertThat(consumer1ActivePartitions, not(allPartitions));
-        assertThat(consumer2ActivePartitions, not(allPartitions));
-        assertThat(consumer1ActivePartitions, equalTo(consumer2StandbyPartitions));
-        assertThat(consumer2ActivePartitions, equalTo(consumer1StandbyPartitions));
-        assertThat(allAssignedPartitions, equalTo(allPartitions));
+        assertNotEquals(allPartitions, consumer1ActivePartitions);
+        assertNotEquals(allPartitions, consumer2ActivePartitions);
+        assertEquals(consumer2StandbyPartitions, consumer1ActivePartitions);
+        assertEquals(consumer1StandbyPartitions, consumer2ActivePartitions);
+        assertEquals(allPartitions, allAssignedPartitions);
     }
 
     @ParameterizedTest
@@ -2020,7 +2011,7 @@ public class StreamsPartitionAssignorTest {
             KafkaException.class,
             () -> partitionAssignor.configure(config)
         );
-        assertThat(expected.getMessage(), equalTo("ReferenceContainer is not specified"));
+        assertEquals("ReferenceContainer is not specified", expected.getMessage());
     }
 
     @ParameterizedTest
@@ -2034,10 +2025,9 @@ public class StreamsPartitionAssignorTest {
             KafkaException.class,
             () -> partitionAssignor.configure(config)
         );
-        assertThat(
-            expected.getMessage(),
-            equalTo("java.lang.String is not an instance of org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer")
-        );
+        assertEquals(
+            "java.lang.String is not an instance of org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer",
+            expected.getMessage());
     }
 
     @ParameterizedTest
@@ -2087,9 +2077,9 @@ public class StreamsPartitionAssignorTest {
 
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
-        assertThat(assignment.size(), equalTo(2));
-        assertThat(AssignmentInfo.decode(assignment.get("consumer1").userData()).version(), equalTo(smallestVersion));
-        assertThat(AssignmentInfo.decode(assignment.get("consumer2").userData()).version(), equalTo(smallestVersion));
+        assertEquals(2, assignment.size());
+        assertEquals(smallestVersion, AssignmentInfo.decode(assignment.get("consumer1").userData()).version());
+        assertEquals(smallestVersion, AssignmentInfo.decode(assignment.get("consumer2").userData()).version());
     }
 
     @ParameterizedTest
@@ -2126,19 +2116,19 @@ public class StreamsPartitionAssignorTest {
 
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
-        assertThat(assignment.size(), equalTo(2));
+        assertEquals(2, assignment.size());
 
         // The new consumer's assignment should be empty until c1 has the chance to revoke its partitions/tasks
-        assertThat(assignment.get(CONSUMER_2).partitions(), equalTo(emptyList()));
+        assertTrue(assignment.get(CONSUMER_2).partitions().isEmpty());
 
         final AssignmentInfo actualAssignment = AssignmentInfo.decode(assignment.get(CONSUMER_2).userData());
-        assertThat(actualAssignment.version(), is(LATEST_SUPPORTED_VERSION));
-        assertThat(actualAssignment.activeTasks(), empty());
+        assertEquals(LATEST_SUPPORTED_VERSION, actualAssignment.version());
+        assertTrue(actualAssignment.activeTasks().isEmpty());
         // Note we're not asserting anything about standbys. If the assignor gave an active task to CONSUMER_2, it would
         // be converted to a standby, but we don't know whether the assignor will do that.
-        assertThat(actualAssignment.partitionsByHost(), anEmptyMap());
-        assertThat(actualAssignment.standbyPartitionByHost(), anEmptyMap());
-        assertThat(actualAssignment.errCode(), is(0));
+        assertTrue(actualAssignment.partitionsByHost().isEmpty());
+        assertTrue(actualAssignment.standbyPartitionByHost().isEmpty());
+        assertEquals(0, actualAssignment.errCode());
     }
 
     @ParameterizedTest
@@ -2174,18 +2164,18 @@ public class StreamsPartitionAssignorTest {
         final Map<String, Assignment> assignment =
             partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
-        assertThat(assignment.size(), equalTo(2));
+        assertEquals(2, assignment.size());
 
-        assertThat(assignment.get(CONSUMER_1).partitions(), equalTo(asList(t1p0, t1p2)));
-        assertThat(
-            AssignmentInfo.decode(assignment.get(CONSUMER_1).userData()),
-            equalTo(new AssignmentInfo(LATEST_SUPPORTED_VERSION, asList(TASK_0_0, TASK_0_2), emptyMap(), emptyMap(), emptyMap(), 0)));
+        assertEquals(List.of(t1p0, t1p2), assignment.get(CONSUMER_1).partitions());
+        assertEquals(
+            new AssignmentInfo(LATEST_SUPPORTED_VERSION, List.of(TASK_0_0, TASK_0_2), Map.of(), Map.of(), Map.of(), 0),
+            AssignmentInfo.decode(assignment.get(CONSUMER_1).userData()));
 
 
-        assertThat(assignment.get(CONSUMER_2).partitions(), equalTo(Collections.singletonList(t1p1)));
-        assertThat(
-            AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()),
-            equalTo(new AssignmentInfo(LATEST_SUPPORTED_VERSION, Collections.singletonList(TASK_0_1), emptyMap(), emptyMap(), emptyMap(), 0)));
+        assertEquals(List.of(t1p1), assignment.get(CONSUMER_2).partitions());
+        assertEquals(
+            new AssignmentInfo(LATEST_SUPPORTED_VERSION, List.of(TASK_0_1), Map.of(), Map.of(), Map.of(), 0),
+            AssignmentInfo.decode(assignment.get(CONSUMER_2).userData()));
     }
 
     @ParameterizedTest
@@ -2310,10 +2300,10 @@ public class StreamsPartitionAssignorTest {
 
         partitionAssignor.configure(props);
 
-        assertThat(partitionAssignor.acceptableRecoveryLag(), equalTo(11L));
-        assertThat(partitionAssignor.maxWarmupReplicas(), equalTo(33));
-        assertThat(partitionAssignor.numStandbyReplicas(), equalTo(44));
-        assertThat(partitionAssignor.probingRebalanceIntervalMs(), equalTo(55 * 60 * 1000L));
+        assertEquals(11L, partitionAssignor.acceptableRecoveryLag());
+        assertEquals(33, partitionAssignor.maxWarmupReplicas());
+        assertEquals(44, partitionAssignor.numStandbyReplicas());
+        assertEquals(55 * 60 * 1000L, partitionAssignor.probingRebalanceIntervalMs());
     }
 
     @ParameterizedTest
@@ -2326,7 +2316,7 @@ public class StreamsPartitionAssignorTest {
         final Map<String, Object> props = configProps(parameterizedConfig);
         final AssignorConfiguration assignorConfiguration = new AssignorConfiguration(props);
 
-        assertThat(assignorConfiguration.referenceContainer().time.milliseconds(), equalTo(Long.MAX_VALUE));
+        assertEquals(Long.MAX_VALUE, assignorConfiguration.referenceContainer().time.milliseconds());
     }
 
     @ParameterizedTest
@@ -2489,10 +2479,7 @@ public class StreamsPartitionAssignorTest {
 
         partitionAssignor.assign(metadata, new GroupSubscription(subscriptions));
 
-        assertThat(
-            capturedChangelogs.getValue().keySet(),
-            equalTo(changelogs)
-        );
+        assertEquals(changelogs, capturedChangelogs.getValue().keySet());
     }
 
     @ParameterizedTest
@@ -2558,8 +2545,7 @@ public class StreamsPartitionAssignorTest {
                               Optional.of(RACK_0)
                           ));
         final Map<String, Assignment> assignments = partitionAssignor.assign(emptyClusterMetadata, new GroupSubscription(subscriptions)).groupAssignment();
-        assertThat(AssignmentInfo.decode(assignments.get("consumer").userData()).errCode(),
-                   equalTo(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code()));
+        assertEquals(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code(), AssignmentInfo.decode(assignments.get("consumer").userData()).errCode());
     }
 
     @ParameterizedTest
@@ -2631,8 +2617,7 @@ public class StreamsPartitionAssignorTest {
                               Optional.of(RACK_1)
                           ));
         final Map<String, Assignment> assignments = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
-        assertThat(AssignmentInfo.decode(assignments.get("consumer").userData()).errCode(),
-                   equalTo(AssignorError.ASSIGNMENT_ERROR.code()));
+        assertEquals(AssignorError.ASSIGNMENT_ERROR.code(), AssignmentInfo.decode(assignments.get("consumer").userData()).errCode());
     }
 
     @ParameterizedTest
@@ -2704,8 +2689,8 @@ public class StreamsPartitionAssignorTest {
 
         final Map<String, Assignment> assignment = partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
 
-        assertThat(AssignmentInfo.decode(assignment.get("consumer1").userData()).errCode(), equalTo(AssignorError.ASSIGNMENT_ERROR.code()));
-        assertThat(AssignmentInfo.decode(assignment.get("future-consumer").userData()).errCode(), equalTo(AssignorError.ASSIGNMENT_ERROR.code()));
+        assertEquals(AssignorError.ASSIGNMENT_ERROR.code(), AssignmentInfo.decode(assignment.get("consumer1").userData()).errCode());
+        assertEquals(AssignorError.ASSIGNMENT_ERROR.code(), AssignmentInfo.decode(assignment.get("future-consumer").userData()).errCode());
     }
 
     private static Assignment createAssignment(final Map<HostInfo, Set<TopicPartition>> firstHostState) {
@@ -2769,7 +2754,7 @@ public class StreamsPartitionAssignorTest {
             final List<TaskId> otherTaskList = otherAssignment.get(consumer);
             Collections.sort(otherTaskList);
 
-            assertThat(thisTaskList, equalTo(otherTaskList));
+            assertEquals(thisTaskList, otherTaskList);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -56,11 +56,8 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE;
 import static org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -157,26 +154,26 @@ public class StreamsProducerTest {
         // given:
         eosStreamsProducer.send(
             new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
-        assertThat(eosStreamsProducer.transactionInFlight(), is(true));
+        assertTrue(eosStreamsProducer.transactionInFlight());
 
         // when:
         eosStreamsProducer.close();
 
         // then:
-        assertThat(eosStreamsProducer.transactionInFlight(), is(false));
+        assertFalse(eosStreamsProducer.transactionInFlight());
     }
 
     @Test
     public void shouldResetTransactionInFlightOnReset() {
         // given:
         eosStreamsProducer.send(new ProducerRecord<>("topic", new byte[1]), (metadata, error) -> { });
-        assertThat(eosStreamsProducer.transactionInFlight(), is(true));
+        assertTrue(eosStreamsProducer.transactionInFlight());
 
         // when:
         eosStreamsProducer.resetProducer(null);
 
         // then:
-        assertThat(eosStreamsProducer.transactionInFlight(), is(false));
+        assertFalse(eosStreamsProducer.transactionInFlight());
     }
 
     @Test
@@ -186,7 +183,7 @@ public class StreamsProducerTest {
 
         final List<PartitionInfo> partitionInfo = streamsProducerWithMock.partitionsFor(topic);
 
-        assertThat(partitionInfo, sameInstance(expectedPartitionInfo));
+        assertSame(expectedPartitionInfo, partitionInfo);
     }
 
     @Test
@@ -224,7 +221,7 @@ public class StreamsProducerTest {
             )
         );
 
-        assertThat(thrown.getMessage(), is("processingMode cannot be null"));
+        assertEquals("processingMode cannot be null", thrown.getMessage());
     }
 
     @Test
@@ -239,7 +236,7 @@ public class StreamsProducerTest {
             )
         );
 
-        assertThat(thrown.getMessage(), is("producer cannot be null"));
+        assertEquals("producer cannot be null", thrown.getMessage());
     }
 
     @Test
@@ -254,7 +251,7 @@ public class StreamsProducerTest {
             )
         );
 
-        assertThat(thrown.getMessage(), is("time cannot be null"));
+        assertEquals("time cannot be null", thrown.getMessage());
     }
 
     @Test
@@ -269,7 +266,7 @@ public class StreamsProducerTest {
             )
         );
 
-        assertThat(thrown.getMessage(), is("logContext cannot be null"));
+        assertEquals("logContext cannot be null", thrown.getMessage());
     }
 
     @Test
@@ -279,7 +276,7 @@ public class StreamsProducerTest {
             () -> nonEosStreamsProducer.resetProducer(null)
         );
 
-        assertThat(thrown.getMessage(), is("Expected EOS to be enabled, but processing mode is at_least_once"));
+        assertEquals("Expected EOS to be enabled, but processing mode is at_least_once", thrown.getMessage());
     }
 
 
@@ -289,20 +286,20 @@ public class StreamsProducerTest {
 
     @Test
     public void shouldNotInitTxIfEosDisable() {
-        assertThat(nonEosMockProducer.transactionInitialized(), is(false));
+        assertFalse(nonEosMockProducer.transactionInitialized());
     }
 
     @Test
     public void shouldNotBeginTxOnSendIfEosDisable() {
         nonEosStreamsProducer.send(record, null);
-        assertThat(nonEosMockProducer.transactionInFlight(), is(false));
+        assertFalse(nonEosMockProducer.transactionInFlight());
     }
 
     @Test
     public void shouldForwardRecordOnSend() {
         nonEosStreamsProducer.send(record, null);
-        assertThat(nonEosMockProducer.history().size(), is(1));
-        assertThat(nonEosMockProducer.history().get(0), is(record));
+        assertEquals(1, nonEosMockProducer.history().size());
+        assertEquals(record, nonEosMockProducer.history().get(0));
     }
 
     // error handling tests
@@ -314,7 +311,7 @@ public class StreamsProducerTest {
             nonEosStreamsProducer::initTransaction
         );
 
-        assertThat(thrown.getMessage(), is("Exactly-once is not enabled [test]"));
+        assertEquals("Exactly-once is not enabled [test]", thrown.getMessage());
     }
 
     @Test
@@ -326,8 +323,8 @@ public class StreamsProducerTest {
             () -> nonEosStreamsProducer.send(record, null)
         );
 
-        assertThat(thrown.getCause(), is(nonEosMockProducer.sendException));
-        assertThat(thrown.getMessage(), is("Error encountered trying to send record to topic topic [test]"));
+        assertEquals(nonEosMockProducer.sendException, thrown.getCause());
+        assertEquals("Error encountered trying to send record to topic topic [test]", thrown.getMessage());
     }
 
     @Test
@@ -339,7 +336,7 @@ public class StreamsProducerTest {
             () -> nonEosStreamsProducer.send(record, null)
         );
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @SuppressWarnings("removal")
@@ -350,7 +347,7 @@ public class StreamsProducerTest {
             () -> nonEosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(thrown.getMessage(), is("Exactly-once is not enabled [test]"));
+        assertEquals("Exactly-once is not enabled [test]", thrown.getMessage());
     }
 
     @Test
@@ -360,7 +357,7 @@ public class StreamsProducerTest {
             nonEosStreamsProducer::abortTransaction
         );
 
-        assertThat(thrown.getMessage(), is("Exactly-once is not enabled [test]"));
+        assertEquals("Exactly-once is not enabled [test]", thrown.getMessage());
     }
 
 
@@ -370,30 +367,30 @@ public class StreamsProducerTest {
 
     @Test
     public void shouldInitTxOnEos() {
-        assertThat(eosMockProducer.transactionInitialized(), is(true));
+        assertTrue(eosMockProducer.transactionInitialized());
     }
 
     @Test
     public void shouldBeginTxOnEosSend() {
         eosStreamsProducer.send(record, null);
-        assertThat(eosMockProducer.transactionInFlight(), is(true));
+        assertTrue(eosMockProducer.transactionInFlight());
     }
 
     @Test
     public void shouldContinueTxnSecondEosSend() {
         eosStreamsProducer.send(record, null);
         eosStreamsProducer.send(record, null);
-        assertThat(eosMockProducer.transactionInFlight(), is(true));
-        assertThat(eosMockProducer.uncommittedRecords().size(), is(2));
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertEquals(2, eosMockProducer.uncommittedRecords().size());
     }
 
     @Test
     public void shouldForwardRecordButNotCommitOnEosSend() {
         eosStreamsProducer.send(record, null);
-        assertThat(eosMockProducer.transactionInFlight(), is(true));
-        assertThat(eosMockProducer.history().isEmpty(), is(true));
-        assertThat(eosMockProducer.uncommittedRecords().size(), is(1));
-        assertThat(eosMockProducer.uncommittedRecords().get(0), is(record));
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.history().isEmpty());
+        assertEquals(1, eosMockProducer.uncommittedRecords().size());
+        assertEquals(record, eosMockProducer.uncommittedRecords().get(0));
     }
 
     @SuppressWarnings("removal")
@@ -412,24 +409,24 @@ public class StreamsProducerTest {
     @Test
     public void shouldSendOffsetToTxOnEosCommit() {
         eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
-        assertThat(eosMockProducer.sentOffsets(), is(true));
+        assertTrue(eosMockProducer.sentOffsets());
     }
 
     @SuppressWarnings("removal")
     @Test
     public void shouldCommitTxOnEosCommit() {
         eosStreamsProducer.send(record, null);
-        assertThat(eosMockProducer.transactionInFlight(), is(true));
+        assertTrue(eosMockProducer.transactionInFlight());
 
         eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"));
 
-        assertThat(eosMockProducer.transactionInFlight(), is(false));
-        assertThat(eosMockProducer.uncommittedRecords().isEmpty(), is(true));
-        assertThat(eosMockProducer.uncommittedOffsets().isEmpty(), is(true));
-        assertThat(eosMockProducer.history().size(), is(1));
-        assertThat(eosMockProducer.history().get(0), is(record));
-        assertThat(eosMockProducer.consumerGroupOffsetsHistory().size(), is(1));
-        assertThat(eosMockProducer.consumerGroupOffsetsHistory().get(0).get("appId"), is(offsetsAndMetadata));
+        assertFalse(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.uncommittedRecords().isEmpty());
+        assertTrue(eosMockProducer.uncommittedOffsets().isEmpty());
+        assertEquals(1, eosMockProducer.history().size());
+        assertEquals(record, eosMockProducer.history().get(0));
+        assertEquals(1, eosMockProducer.consumerGroupOffsetsHistory().size());
+        assertEquals(offsetsAndMetadata, eosMockProducer.consumerGroupOffsetsHistory().get(0).get("appId"));
     }
 
     @SuppressWarnings("removal")
@@ -459,17 +456,17 @@ public class StreamsProducerTest {
     public void shouldAbortTxOnEosAbort() {
         // call `send()` to start a transaction
         eosStreamsProducer.send(record, null);
-        assertThat(eosMockProducer.transactionInFlight(), is(true));
-        assertThat(eosMockProducer.uncommittedRecords().size(), is(1));
-        assertThat(eosMockProducer.uncommittedRecords().get(0), is(record));
+        assertTrue(eosMockProducer.transactionInFlight());
+        assertEquals(1, eosMockProducer.uncommittedRecords().size());
+        assertEquals(record, eosMockProducer.uncommittedRecords().get(0));
 
         eosStreamsProducer.abortTransaction();
 
-        assertThat(eosMockProducer.transactionInFlight(), is(false));
-        assertThat(eosMockProducer.uncommittedRecords().isEmpty(), is(true));
-        assertThat(eosMockProducer.uncommittedOffsets().isEmpty(), is(true));
-        assertThat(eosMockProducer.history().isEmpty(), is(true));
-        assertThat(eosMockProducer.consumerGroupOffsetsHistory().isEmpty(), is(true));
+        assertFalse(eosMockProducer.transactionInFlight());
+        assertTrue(eosMockProducer.uncommittedRecords().isEmpty());
+        assertTrue(eosMockProducer.uncommittedOffsets().isEmpty());
+        assertTrue(eosMockProducer.history().isEmpty());
+        assertTrue(eosMockProducer.consumerGroupOffsetsHistory().isEmpty());
     }
 
     @Test
@@ -499,7 +496,7 @@ public class StreamsProducerTest {
             streamsProducer::initTransaction
         );
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @Test
@@ -518,7 +515,7 @@ public class StreamsProducerTest {
             () -> streamsProducer.send(record, null)
         );
 
-        assertThat(thrown.getMessage(), is("MockProducer hasn't been initialized for transactions."));
+        assertEquals("MockProducer hasn't been initialized for transactions.", thrown.getMessage());
     }
 
     @Test
@@ -538,8 +535,8 @@ public class StreamsProducerTest {
             streamsProducer::initTransaction
         );
 
-        assertThat(thrown.getCause(), is(nonEosMockProducer.initTransactionException));
-        assertThat(thrown.getMessage(), is("Error encountered trying to initialize transactions [test]"));
+        assertEquals(nonEosMockProducer.initTransactionException, thrown.getCause());
+        assertEquals("Error encountered trying to initialize transactions [test]", thrown.getMessage());
     }
 
     @Test
@@ -559,7 +556,7 @@ public class StreamsProducerTest {
             streamsProducer::initTransaction
         );
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @Test
@@ -571,11 +568,10 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.send(null, null)
         );
 
-        assertThat(
-            thrown.getMessage(),
-            is("Producer got fenced trying to begin a new transaction [test];" +
-                   " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertEquals(
+            "Producer got fenced trying to begin a new transaction [test];" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @Test
@@ -587,11 +583,8 @@ public class StreamsProducerTest {
             StreamsException.class,
             () -> eosStreamsProducer.send(null, null));
 
-        assertThat(thrown.getCause(), is(eosMockProducer.beginTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Error encountered trying to begin a new transaction [test]")
-        );
+        assertEquals(eosMockProducer.beginTransactionException, thrown.getCause());
+        assertEquals("Error encountered trying to begin a new transaction [test]", thrown.getMessage());
     }
 
     @Test
@@ -603,7 +596,7 @@ public class StreamsProducerTest {
             RuntimeException.class,
             () -> eosStreamsProducer.send(null, null));
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @Test
@@ -631,12 +624,11 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.send(record, null)
         );
 
-        assertThat(thrown.getCause(), is(exception));
-        assertThat(
-            thrown.getMessage(),
-            is("Producer got fenced trying to send a record [test];" +
-                   " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertEquals(exception, thrown.getCause());
+        assertEquals(
+            "Producer got fenced trying to send a record [test];" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @Test
@@ -650,12 +642,11 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.send(record, null)
         );
 
-        assertThat(thrown.getCause(), is(exception));
-        assertThat(
-            thrown.getMessage(),
-            is("Producer got fenced trying to send a record [test];" +
-                   " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertEquals(exception, thrown.getCause());
+        assertEquals(
+            "Producer got fenced trying to send a record [test];" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @Test
@@ -688,12 +679,11 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Producer got fenced trying to add offsets to a transaction [test];" +
-                   " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertEquals(eosMockProducer.sendOffsetsToTransactionException, thrown.getCause());
+        assertEquals(
+            "Producer got fenced trying to add offsets to a transaction [test];" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @SuppressWarnings("removal")
@@ -708,11 +698,8 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(thrown.getCause(), is(eosMockProducer.sendOffsetsToTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Error encountered trying to add offsets to a transaction [test]")
-        );
+        assertEquals(eosMockProducer.sendOffsetsToTransactionException, thrown.getCause());
+        assertEquals("Error encountered trying to add offsets to a transaction [test]", thrown.getMessage());
     }
 
     @SuppressWarnings("removal")
@@ -727,7 +714,7 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(null, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @Test
@@ -755,13 +742,12 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(eosMockProducer.sentOffsets(), is(true));
-        assertThat(thrown.getCause(), is(eosMockProducer.commitTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Producer got fenced trying to commit a transaction [test];" +
-                   " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals(eosMockProducer.commitTransactionException, thrown.getCause());
+        assertEquals(
+            "Producer got fenced trying to commit a transaction [test];" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @SuppressWarnings("removal")
@@ -774,12 +760,9 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(eosMockProducer.sentOffsets(), is(true));
-        assertThat(thrown.getCause(), is(eosMockProducer.commitTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Error encountered trying to commit a transaction [test]")
-        );
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals(eosMockProducer.commitTransactionException, thrown.getCause());
+        assertEquals("Error encountered trying to commit a transaction [test]", thrown.getMessage());
     }
 
     @SuppressWarnings("removal")
@@ -792,8 +775,8 @@ public class StreamsProducerTest {
             () -> eosStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
         );
 
-        assertThat(eosMockProducer.sentOffsets(), is(true));
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertTrue(eosMockProducer.sentOffsets());
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
     @Test
@@ -832,11 +815,8 @@ public class StreamsProducerTest {
 
         final StreamsException thrown = assertThrows(StreamsException.class, eosStreamsProducer::abortTransaction);
 
-        assertThat(thrown.getCause(), is(eosMockProducer.abortTransactionException));
-        assertThat(
-            thrown.getMessage(),
-            is("Error encounter trying to abort a transaction [test]")
-        );
+        assertEquals(eosMockProducer.abortTransactionException, thrown.getCause());
+        assertEquals("Error encounter trying to abort a transaction [test]", thrown.getMessage());
     }
 
     @Test
@@ -847,7 +827,7 @@ public class StreamsProducerTest {
 
         final RuntimeException thrown = assertThrows(RuntimeException.class, eosStreamsProducer::abortTransaction);
 
-        assertThat(thrown.getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getMessage());
     }
 
 
@@ -868,7 +848,7 @@ public class StreamsProducerTest {
         final Producer<byte[], byte[]> newProducer = mock(Producer.class);
         eosStreamsProducer.resetProducer(newProducer);
 
-        assertThat(eosStreamsProducer.kafkaProducer(), is(newProducer));
+        assertEquals(newProducer, eosStreamsProducer.kafkaProducer());
     }
 
     @Test
@@ -911,7 +891,7 @@ public class StreamsProducerTest {
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
             TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME +
             METADATA_WAIT_TIME;
-        assertThat(nonEosStreamsProducer.totalBlockedTime(), closeTo(expectedTotalBlocked, 0.01));
+        assertEquals(expectedTotalBlocked, nonEosStreamsProducer.totalBlockedTime(), 0.01);
     }
 
     @Test
@@ -930,7 +910,7 @@ public class StreamsProducerTest {
         final double expectedTotalBlocked = BUFFER_POOL_WAIT_TIME + FLUSH_TME + TXN_INIT_TIME +
             TXN_BEGIN_TIME + TXN_SEND_OFFSETS_TIME +  TXN_COMMIT_TIME + TXN_ABORT_TIME +
             METADATA_WAIT_TIME;
-        assertThat(eosStreamsProducer.totalBlockedTime(), equalTo(expectedTotalBlocked));
+        assertEquals(expectedTotalBlocked, eosStreamsProducer.totalBlockedTime());
         final long closeStart = 1L;
         final long closeDelay = 1L;
         when(mockTime.nanoseconds()).thenReturn(closeStart).thenReturn(closeStart + closeDelay);
@@ -947,10 +927,7 @@ public class StreamsProducerTest {
             METADATA_WAIT_TIME
         );
 
-        assertThat(
-            eosStreamsProducer.totalBlockedTime(),
-            closeTo(2 * expectedTotalBlocked + closeDelay, 0.01)
-        );
+        assertEquals(2 * expectedTotalBlocked + closeDelay, eosStreamsProducer.totalBlockedTime(), 0.01);
     }
 
     private MetricName metricName(final String name) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
@@ -36,8 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -74,7 +73,7 @@ public class StreamsRebalanceListenerTest {
             MissingSourceTopicException.class,
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
-        assertThat(exception.getMessage(), is("One or more source topics were missing during rebalance"));
+        assertEquals("One or more source topics were missing during rebalance", exception.getMessage());
         verify(taskManager).handleRebalanceComplete();
     }
 
@@ -103,7 +102,7 @@ public class StreamsRebalanceListenerTest {
             TaskAssignmentException.class,
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
-        assertThat(exception.getMessage(), is("Hit an unexpected exception during task assignment phase of rebalance"));
+        assertEquals("Hit an unexpected exception during task assignment phase of rebalance", exception.getMessage());
 
         verify(taskManager).handleRebalanceComplete();
     }
@@ -116,7 +115,7 @@ public class StreamsRebalanceListenerTest {
             TaskAssignmentException.class,
             () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
         );
-        assertThat(exception.getMessage(), is("Hit an unrecognized exception during rebalance"));
+        assertEquals("Hit an unrecognized exception during rebalance", exception.getMessage());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -55,7 +55,6 @@ import org.apache.kafka.streams.processor.internals.testutil.DummyStreamsConfig;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 
 import org.apache.logging.log4j.Level;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -98,11 +97,6 @@ import static org.apache.kafka.streams.processor.internals.TopologyMetadata.UNNA
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.standbyTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statefulTask;
 import static org.apache.kafka.test.StreamsTestUtils.TaskBuilder.statelessTask;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1807,7 +1801,7 @@ public class TaskManagerTest {
         );
         taskManager.handleRebalanceStart(singleton("topic"));
 
-        assertThat(taskManager.lockedTaskDirectories(), is(singleton(taskId01)));
+        assertEquals(Set.of(taskId01), taskManager.lockedTaskDirectories());
     }
 
     @Test
@@ -1820,7 +1814,7 @@ public class TaskManagerTest {
         taskManager.handleRebalanceStart(singleton("topic"));
 
         verify(stateDirectory).unlock(taskId10);
-        assertThat(taskManager.lockedTaskDirectories(), is(singleton(taskId01)));
+        assertEquals(Set.of(taskId01), taskManager.lockedTaskDirectories());
     }
 
     @Test
@@ -1882,7 +1876,7 @@ public class TaskManagerTest {
 
         verify(consumer).pause(Set.of(t1p1, t1p2));
         verify(stateDirectory).unlock(taskId03);
-        assertThat(taskManager.lockedTaskDirectories(), is(Set.of(taskId00, taskId01, taskId02)));
+        assertEquals(Set.of(taskId00, taskId01, taskId02), taskManager.lockedTaskDirectories());
     }
 
     @Test
@@ -1898,10 +1892,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
         when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatefulTask)));
 
-        assertThat(
-            taskManager.taskOffsetSums(),
-            is(mkMap(mkEntry(taskId00, changelogOffsetOfRunningTask)))
-        );
+        assertEquals(Map.of(taskId00, changelogOffsetOfRunningTask), taskManager.taskOffsetSums());
     }
 
     @Test
@@ -1911,10 +1902,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
         when(tasks.allInitializedTasksPerId()).thenReturn(mkMap(mkEntry(taskId00, runningStatelessTask)));
 
-        assertThat(
-                taskManager.taskOffsetSums(),
-                is(emptyMap())
-        );
+        assertTrue(taskManager.taskOffsetSums().isEmpty());
     }
 
     @Test
@@ -1935,7 +1923,7 @@ public class TaskManagerTest {
         when(stateUpdater.tasks()).thenReturn(Set.of(restoringStatefulTask));
         when(stateDirectory.taskOffsetSums(expectedOffsetSums.keySet())).thenReturn(expectedOffsetSums);
 
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @Test
@@ -1957,7 +1945,7 @@ public class TaskManagerTest {
         taskManager.handleRebalanceStart(singleton("topic"));
 
         when(stateDirectory.taskOffsetSums(expectedOffsetSums.keySet())).thenReturn(expectedOffsetSums);
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @Test
@@ -1974,7 +1962,7 @@ public class TaskManagerTest {
         taskManager.handleRebalanceStart(singleton("topic"));
         when(stateDirectory.taskOffsetSums(Collections.singleton(taskId00))).thenReturn(mkMap(mkEntry(taskId00, changelogOffset)));
 
-        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId00, changelogOffset))));
+        assertEquals(Map.of(taskId00, changelogOffset), taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2005,14 +1993,13 @@ public class TaskManagerTest {
                         mkEntry(taskId02, changelogOffsetOfRestoringStandbyTask)
                 ));
 
-        assertThat(
-            taskManager.taskOffsetSums(),
-            is(mkMap(
-                mkEntry(taskId00, changelogOffsetOfRunningTask),
-                mkEntry(taskId01, changelogOffsetOfRestoringStatefulTask),
-                mkEntry(taskId02, changelogOffsetOfRestoringStandbyTask)
-            ))
-        );
+        assertEquals(
+            Map.of(
+                taskId00, changelogOffsetOfRunningTask,
+                taskId01, changelogOffsetOfRestoringStatefulTask,
+                taskId02, changelogOffsetOfRestoringStandbyTask
+            ),
+            taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2020,7 +2007,7 @@ public class TaskManagerTest {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        assertThat(taskManager.taskOffsetSumSnapshot(), is(Collections.emptyMap()));
+        assertTrue(taskManager.taskOffsetSumSnapshot().isEmpty());
     }
 
     @Test
@@ -2032,7 +2019,7 @@ public class TaskManagerTest {
 
         // the classic protocol reports offset sums through taskOffsetSums() instead, so the state directory is
         // never consulted for the snapshot
-        assertThat(taskManager.taskOffsetSumSnapshot(), is(Collections.emptyMap()));
+        assertTrue(taskManager.taskOffsetSumSnapshot().isEmpty());
         verify(stateDirectory, never()).taskOffsetSums();
     }
 
@@ -2061,11 +2048,13 @@ public class TaskManagerTest {
 
         // running-active taskId00 is omitted; restoring-active taskId01 reports its live sum (25L) rather than the
         // stale 20L on disk; standby and dormant tasks are reported with their disk sums
-        assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
-            mkEntry(new StreamsRebalanceData.TaskId("0", 1), 25L),
-            mkEntry(new StreamsRebalanceData.TaskId("0", 2), 30L),
-            mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
-        )));
+        assertEquals(
+            Map.of(
+                new StreamsRebalanceData.TaskId("0", 1), 25L,
+                new StreamsRebalanceData.TaskId("0", 2), 30L,
+                new StreamsRebalanceData.TaskId("0", 3), 40L
+            ),
+            taskManager.taskOffsetSumSnapshot());
 
         // once restoration completes, taskId01 moves from the state updater to the stream thread, just like taskId00
         when(restoringActiveTask.state()).thenReturn(State.RUNNING);
@@ -2078,10 +2067,12 @@ public class TaskManagerTest {
         taskManager.maybeUpdateTaskOffsetSumSnapshot();
 
         // taskId01 is now dropped entirely, not merely left unrefreshed at its last restoring sum
-        assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
-            mkEntry(new StreamsRebalanceData.TaskId("0", 2), 30L),
-            mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
-        )));
+        assertEquals(
+            Map.of(
+                new StreamsRebalanceData.TaskId("0", 2), 30L,
+                new StreamsRebalanceData.TaskId("0", 3), 40L
+            ),
+            taskManager.taskOffsetSumSnapshot());
     }
 
     @Test
@@ -2102,10 +2093,12 @@ public class TaskManagerTest {
         taskManager.maybeUpdateTaskOffsetSumSnapshot();
 
         // our own task reports its live sum, while a task held elsewhere on the instance keeps the on-disk sum
-        assertThat(taskManager.taskOffsetSumSnapshot(), is(mkMap(
-            mkEntry(new StreamsRebalanceData.TaskId("0", 2), 90L),
-            mkEntry(new StreamsRebalanceData.TaskId("0", 3), 40L)
-        )));
+        assertEquals(
+            Map.of(
+                new StreamsRebalanceData.TaskId("0", 2), 90L,
+                new StreamsRebalanceData.TaskId("0", 3), 40L
+            ),
+            taskManager.taskOffsetSumSnapshot());
     }
 
     @Test
@@ -2120,7 +2113,7 @@ public class TaskManagerTest {
         when(stateDirectory.taskOffsetSums(Collections.singleton(taskId02)))
             .thenReturn(mkMap(mkEntry(taskId02, 30L)));
 
-        assertThat(taskManager.taskOffsetSums(), is(mkMap(mkEntry(taskId02, 90L))));
+        assertEquals(Map.of(taskId02, 90L), taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2143,7 +2136,7 @@ public class TaskManagerTest {
         );
 
         when(stateDirectory.taskOffsetSums(expectedOffsetSums.keySet())).thenReturn(expectedOffsetSums);
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2173,7 +2166,7 @@ public class TaskManagerTest {
         taskManager.handleAssignment(emptyMap(), taskId00Assignment);
 
         when(stateDirectory.taskOffsetSums(any())).thenReturn(expectedOffsetSums);
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2186,7 +2179,7 @@ public class TaskManagerTest {
 
         taskManager.handleRebalanceStart(singleton("topic"));
 
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @ParameterizedTest
@@ -2212,7 +2205,7 @@ public class TaskManagerTest {
         taskManager.handleRebalanceStart(singleton("topic"));
 
         when(stateDirectory.taskOffsetSums(Collections.singleton(taskId00))).thenReturn(expectedOffsetSums);
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
     
     @Test
@@ -2244,7 +2237,7 @@ public class TaskManagerTest {
         when(stateDirectory.taskOffsetSums(expectedOffsetSums.keySet())).thenReturn(expectedOffsetSums);
         taskManager.handleRebalanceStart(singleton("topic"));
 
-        assertThat(taskManager.taskOffsetSums(), is(expectedOffsetSums));
+        assertEquals(expectedOffsetSums, taskManager.taskOffsetSums());
     }
 
     @Test
@@ -2288,11 +2281,8 @@ public class TaskManagerTest {
         verify(task00).closeClean();
         verify(task00).closeDirty();
         verify(tasks).removeTask(task00);
-        assertThat(
-            thrown.getMessage(),
-            is("Encounter unexpected fatal error for task 0_0")
-        );
-        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+        assertEquals("Encounter unexpected fatal error for task 0_0", thrown.getMessage());
+        assertEquals("KABOOM!", thrown.getCause().getMessage());
     }
 
     @Test
@@ -2324,7 +2314,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         taskManager.handleRebalanceStart(emptySet());
-        assertThat(taskManager.lockedTaskDirectories(), is(Set.of(taskId00, taskId01)));
+        assertEquals(Set.of(taskId00, taskId01), taskManager.lockedTaskDirectories());
 
         // this should close only active tasks as zombies
         taskManager.handleLostAll();
@@ -2343,11 +2333,11 @@ public class TaskManagerTest {
         verify(tasks, never()).removeTask(task01);
 
         // The locked task map will not be cleared.
-        assertThat(taskManager.lockedTaskDirectories(), is(Set.of(taskId00, taskId01)));
+        assertEquals(Set.of(taskId00, taskId01), taskManager.lockedTaskDirectories());
 
         taskManager.handleRebalanceStart(emptySet());
 
-        assertThat(taskManager.lockedTaskDirectories(), is(emptySet()));
+        assertTrue(taskManager.lockedTaskDirectories().isEmpty());
     }
 
     @Test
@@ -2590,7 +2580,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         taskManager.handleRebalanceStart(singleton(topic1));
-        assertThat(taskManager.rebalanceInProgress(), is(true));
+        assertTrue(taskManager.rebalanceInProgress());
 
         taskManager.handleCorruption(singleton(taskId00));
 
@@ -3033,7 +3023,7 @@ public class TaskManagerTest {
 
         verify(task00).updateInputPartitions(eq(newPartitionsSet), any());
         assertTrue(taskManager.checkStateUpdater(time.milliseconds(), noOpResetter));
-        assertThat(task00.state(), is(Task.State.RUNNING));
+        assertEquals(Task.State.RUNNING, task00.state());
         verify(activeTaskCreator).createTasks(any(), eq(emptyMap()));
         verify(standbyTaskCreator).createTasks(emptyMap());
     }
@@ -3568,7 +3558,7 @@ public class TaskManagerTest {
             RuntimeException.class,
             () -> taskManager.shutdown(true)
         );
-        assertThat(exception.getCause().getMessage(), is("oops"));
+        assertEquals("oops", exception.getCause().getMessage());
 
         // Verify tasks that threw exceptions were closed dirty
         verify(task00).prepareCommit(true);
@@ -3581,8 +3571,8 @@ public class TaskManagerTest {
         verify(task02, times(2)).suspend();
         verify(task02).closeDirty();
 
-        assertThat(taskManager.activeTaskMap(), Matchers.anEmptyMap());
-        assertThat(taskManager.standbyTaskMap(), Matchers.anEmptyMap());
+        assertTrue(taskManager.activeTaskMap().isEmpty());
+        assertTrue(taskManager.standbyTaskMap().isEmpty());
         verify(activeTaskCreator).close();
         verify(stateUpdater).shutdown(Duration.ofMinutes(1L));
     }
@@ -3606,13 +3596,13 @@ public class TaskManagerTest {
             () -> taskManager.shutdown(true)
         );
 
-        assertThat(exception.getMessage(), is("whatever"));
+        assertEquals("whatever", exception.getMessage());
 
         verify(task00).prepareCommit(true);
         verify(task00).suspend();
         verify(task00).closeClean();
-        assertThat(taskManager.activeTaskMap(), Matchers.anEmptyMap());
-        assertThat(taskManager.standbyTaskMap(), Matchers.anEmptyMap());
+        assertTrue(taskManager.activeTaskMap().isEmpty());
+        assertTrue(taskManager.standbyTaskMap().isEmpty());
         verify(activeTaskCreator).close();
         verify(stateUpdater).shutdown(Duration.ofMinutes(1L));
     }
@@ -3695,7 +3685,7 @@ public class TaskManagerTest {
                 Collections.emptyMap(),
                 singletonMap(taskId00, taskId00Partitions)
             ));
-        assertThat(thrown.getCause().getMessage(), is("task 0_1 suspend boom!"));
+        assertEquals("task 0_1 suspend boom!", thrown.getCause().getMessage());
 
         verify(task01, times(2)).suspend();
         verify(task01).closeDirty();
@@ -3732,7 +3722,7 @@ public class TaskManagerTest {
         final RuntimeException thrown = assertThrows(RuntimeException.class,
             () -> taskManager.handleRevocation(union(HashSet::new, taskId01Partitions, taskId02Partitions)));
 
-        assertThat(thrown.getCause().getMessage(), is("task 0_1 suspend boom!"));
+        assertEquals("task 0_1 suspend boom!", thrown.getCause().getMessage());
 
         verify(task01).suspend();
         verify(task02).suspend();
@@ -3990,11 +3980,11 @@ public class TaskManagerTest {
     public void shouldHandleRebalanceEvents() {
         when(consumer.assignment()).thenReturn(assignment);
         when(stateDirectory.listNonEmptyTaskDirectories()).thenReturn(new ArrayList<>());
-        assertThat(taskManager.rebalanceInProgress(), is(false));
+        assertFalse(taskManager.rebalanceInProgress());
         taskManager.handleRebalanceStart(emptySet());
-        assertThat(taskManager.rebalanceInProgress(), is(true));
+        assertTrue(taskManager.rebalanceInProgress());
         taskManager.handleRebalanceComplete();
-        assertThat(taskManager.rebalanceInProgress(), is(false));
+        assertFalse(taskManager.rebalanceInProgress());
         verify(consumer).pause(assignment);
     }
 
@@ -4021,7 +4011,7 @@ public class TaskManagerTest {
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        assertThat(taskManager.commitAll(), equalTo(2));
+        assertEquals(2, taskManager.commitAll());
 
         verify(task00, times(2)).commitNeeded();
         verify(task00).prepareCommit(true);
@@ -4081,7 +4071,7 @@ public class TaskManagerTest {
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        assertThat(taskManager.commit(Set.of(task00, task02, task03, task05)), equalTo(2));
+        assertEquals(2, taskManager.commit(Set.of(task00, task02, task03, task05)));
 
         verify(task00, times(2)).commitNeeded();
         verify(task00).prepareCommit(true);
@@ -4117,7 +4107,7 @@ public class TaskManagerTest {
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        assertThat(taskManager.commitAll(), equalTo(1));
+        assertEquals(1, taskManager.commitAll());
 
         verify(task00, times(2)).commitNeeded();
         verify(task00).prepareCommit(true);
@@ -4147,15 +4137,13 @@ public class TaskManagerTest {
 
         taskManager.handleRebalanceStart(emptySet());
 
-        assertThat(
-            taskManager.commitAll(),
-            equalTo(-1) // sentinel indicating that nothing was done because a rebalance is in progress
-        );
+        assertEquals(
+            -1, // sentinel indicating that nothing was done because a rebalance is in progress
+            taskManager.commitAll());
 
-        assertThat(
-            taskManager.maybeCommitActiveTasksPerUserRequested(),
-            equalTo(-1) // sentinel indicating that nothing was done because a rebalance is in progress
-        );
+        assertEquals(
+            -1, // sentinel indicating that nothing was done because a rebalance is in progress
+            taskManager.maybeCommitActiveTasksPerUserRequested());
     }
 
     @Test
@@ -4174,7 +4162,7 @@ public class TaskManagerTest {
 
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
-        assertThat(taskManager.commitAll(), equalTo(1));
+        assertEquals(1, taskManager.commitAll());
 
         verify(task01, times(2)).commitNeeded();
         verify(task01).prepareCommit(true);
@@ -4248,7 +4236,7 @@ public class TaskManagerTest {
 
         final RuntimeException thrown =
             assertThrows(RuntimeException.class, taskManager::commitAll);
-        assertThat(thrown.getMessage(), equalTo("opsh."));
+        assertEquals("opsh.", thrown.getMessage());
 
         verify(task00).commitNeeded();
         verify(task00).prepareCommit(true);
@@ -4271,7 +4259,7 @@ public class TaskManagerTest {
 
         final RuntimeException thrown =
             assertThrows(RuntimeException.class, () -> taskManager.commitAll());
-        assertThat(thrown.getMessage(), equalTo("opsh."));
+        assertEquals("opsh.", thrown.getMessage());
 
         verify(task01).commitNeeded();
         verify(task01).prepareCommit(true);
@@ -4419,7 +4407,7 @@ public class TaskManagerTest {
         // maybeCommitActiveTasksPerUserRequested checks if any task has both commitRequested AND commitNeeded
         // If found, commits all active running tasks that have commitNeeded
         // Returns count of committed tasks: task00, task01, and task03 (3 tasks)
-        assertThat(taskManager.maybeCommitActiveTasksPerUserRequested(), equalTo(3));
+        assertEquals(3, taskManager.maybeCommitActiveTasksPerUserRequested());
 
         // Verify commit flow for tasks that needed commit
         verify(task00, atLeastOnce()).commitNeeded();
@@ -4477,11 +4465,11 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         // check that we should be processing at most max num records
-        assertThat(taskManager.process(3, time), is(6));
+        assertEquals(6, taskManager.process(3, time));
 
         // check that if there's no records processable, we would stop early
-        assertThat(taskManager.process(3, time), is(5));
-        assertThat(taskManager.process(3, time), is(0));
+        assertEquals(5, taskManager.process(3, time));
+        assertEquals(0, taskManager.process(3, time));
     }
 
     @Test
@@ -4522,15 +4510,15 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         // should only process 2 records, because task01 throws TimeoutException
-        assertThat(taskManager.process(1, time), is(2));
+        assertEquals(2, taskManager.process(1, time));
         verify(task01).maybeInitTaskTimeoutOrThrow(anyLong(), any(TimeoutException.class));
 
         //  retry without error
-        assertThat(taskManager.process(1, time), is(3));
+        assertEquals(3, taskManager.process(1, time));
         verify(task01).clearTaskTimeout();
 
         // there should still be one record for task01 to be processed
-        assertThat(taskManager.process(1, time), is(1));
+        assertEquals(1, taskManager.process(1, time));
     }
 
     @Test
@@ -4566,9 +4554,9 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         final StreamsException exception = assertThrows(StreamsException.class, () -> taskManager.process(1, time));
-        assertThat(exception.taskId().isPresent(), is(true));
-        assertThat(exception.taskId().get(), is(taskId00));
-        assertThat(exception.getCause().getMessage(), is("oops"));
+        assertTrue(exception.taskId().isPresent());
+        assertEquals(taskId00, exception.taskId().get());
+        assertEquals("oops", exception.getCause().getMessage());
     }
 
     @Test
@@ -4622,7 +4610,7 @@ public class TaskManagerTest {
         final TaskManager taskManager = setUpTaskManager(ProcessingMode.AT_LEAST_ONCE, tasks);
 
         // one for stream and one for system time
-        assertThat(taskManager.punctuate(), equalTo(2));
+        assertEquals(2, taskManager.punctuate());
 
         verify(task00).maybePunctuateStreamTime();
         verify(task00).maybePunctuateSystemTime();
@@ -4636,7 +4624,7 @@ public class TaskManagerTest {
         // mock that the state updater is still restoring active tasks
         when(stateUpdater.restoresActiveTasks()).thenReturn(true);
 
-        assertThat(taskManager.checkStateUpdater(time.milliseconds(), noOpResetter), is(false));
+        assertFalse(taskManager.checkStateUpdater(time.milliseconds(), noOpResetter));
 
         verifyNoInteractions(consumer);
     }
@@ -4663,13 +4651,11 @@ public class TaskManagerTest {
             verify(task00).suspend();
 
             final List<String> messages = appender.getMessages();
-            assertThat(
-                messages,
-                hasItem("taskManagerTestThe following revoked partitions [unknown-0] are missing " +
+            assertTrue(messages.contains(
+                "taskManagerTestThe following revoked partitions [unknown-0] are missing " +
                     "from the current task partitions. It could potentially be due to race " +
                     "condition of consumer detecting the heartbeat failure, or the " +
-                    "tasks have been cleaned up by the handleAssignment callback.")
-            );
+                    "tasks have been cleaned up by the handleAssignment callback."));
         }
     }
 
@@ -4709,10 +4695,7 @@ public class TaskManagerTest {
         );
         // The task map orders tasks based on topic group id and partition, so here
         // t1 should always be the first.
-        assertThat(
-            thrown.getMessage(),
-            equalTo("t2 close exception; it means all tasks belonging to this thread should be migrated.")
-        );
+        assertEquals("t2 close exception; it means all tasks belonging to this thread should be migrated.", thrown.getMessage());
         verify(migratedTask01, times(2)).suspend();
         verify(migratedTask02, times(2)).suspend();
         verify(stateUpdater).remove(eq(taskId01), eq(SuspendReason.MIGRATED));
@@ -4754,9 +4737,9 @@ public class TaskManagerTest {
             () -> taskManager.handleAssignment(emptyMap(), emptyMap())
         );
         // Fatal exception thrown first.
-        assertThat(thrown.getMessage(), equalTo("Encounter unexpected fatal error for task 0_2"));
+        assertEquals("Encounter unexpected fatal error for task 0_2", thrown.getMessage());
 
-        assertThat(thrown.getCause().getMessage(), equalTo("t2 illegal state exception"));
+        assertEquals("t2 illegal state exception", thrown.getCause().getMessage());
 
         verify(migratedTask01, times(2)).suspend();
         verify(migratedTask02, times(2)).suspend();
@@ -4799,11 +4782,11 @@ public class TaskManagerTest {
             () -> taskManager.handleAssignment(emptyMap(), emptyMap())
         );
 
-        assertThat(thrown.taskId().isPresent(), is(true));
-        assertThat(thrown.taskId().get(), is(taskId02));
+        assertTrue(thrown.taskId().isPresent());
+        assertEquals(taskId02, thrown.taskId().get());
 
         // Expecting the original Kafka exception wrapped in the StreamsException.
-        assertThat(thrown.getCause().getMessage(), equalTo("Kaboom for t2!"));
+        assertEquals("Kaboom for t2!", thrown.getCause().getMessage());
 
         verify(migratedTask01, times(2)).suspend();
         verify(migratedTask02, times(2)).suspend();
@@ -4824,7 +4807,7 @@ public class TaskManagerTest {
 
         when(activeTaskCreator.producerMetrics()).thenReturn(dummyProducerMetrics);
 
-        assertThat(taskManager.producerMetrics(), is(dummyProducerMetrics));
+        assertEquals(dummyProducerMetrics, taskManager.producerMetrics());
     }
 
     private void expectLockObtainedFor(final TaskId... tasks) {
@@ -4869,12 +4852,11 @@ public class TaskManagerTest {
             taskManager::commitAll
         );
 
-        assertThat(thrown.getCause(), instanceOf(CommitFailedException.class));
-        assertThat(
-            thrown.getMessage(),
-            equalTo("Consumer committing offsets failed, indicating the corresponding thread is no longer part of the group;" +
-                " it means all tasks belonging to this thread should be migrated.")
-        );
+        assertInstanceOf(CommitFailedException.class, thrown.getCause());
+        assertEquals(
+            "Consumer committing offsets failed, indicating the corresponding thread is no longer part of the group;" +
+                " it means all tasks belonging to this thread should be migrated.",
+            thrown.getMessage());
     }
 
     @SuppressWarnings("unchecked")
@@ -4902,10 +4884,10 @@ public class TaskManagerTest {
 
         doThrow(new TimeoutException("KABOOM!")).doNothing().when(consumer).commitSync(any(Map.class));
 
-        assertThat(taskManager.commit(Set.of(task00, task01)), equalTo(0));
+        assertEquals(0, taskManager.commit(Set.of(task00, task01)));
         verify(task00).maybeInitTaskTimeoutOrThrow(anyLong(), any(TimeoutException.class));
 
-        assertThat(taskManager.commit(Set.of(task00, task01)), equalTo(1));
+        assertEquals(1, taskManager.commit(Set.of(task00, task01)));
         verify(task00).clearTaskTimeout();
 
         verify(consumer, times(2)).commitSync(any(Map.class));
@@ -4952,10 +4934,7 @@ public class TaskManagerTest {
             TaskCorruptedException.class,
             () -> taskManager.commit(Set.of(task00, task01, task02))
         );
-        assertThat(
-            exception.corruptedTasks(),
-            equalTo(Set.of(taskId00, taskId01))
-        );
+        assertEquals(Set.of(taskId00, taskId01), exception.corruptedTasks());
 
         verify(consumer).groupMetadata();
     }
@@ -4984,8 +4963,8 @@ public class TaskManagerTest {
             taskManager::commitAll
         );
 
-        assertThat(thrown.getCause(), instanceOf(KafkaException.class));
-        assertThat(thrown.getMessage(), equalTo("Error encountered committing offsets via consumer"));
+        assertInstanceOf(KafkaException.class, thrown.getCause());
+        assertEquals("Error encountered committing offsets via consumer", thrown.getMessage());
 
         verify(task01).commitNeeded();
         verify(task01).prepareCommit(true);
@@ -5015,7 +4994,7 @@ public class TaskManagerTest {
             taskManager::commitAll
         );
 
-        assertThat(thrown.getMessage(), equalTo("KABOOM"));
+        assertEquals("KABOOM", thrown.getMessage());
 
         verify(task01).commitNeeded();
         verify(task01).prepareCommit(true);
@@ -5044,7 +5023,7 @@ public class TaskManagerTest {
             RuntimeException.class,
             () -> taskManager.handleRevocation(union(HashSet::new, taskId00Partitions, taskId01Partitions)));
 
-        assertThat(thrown.getCause().getMessage(), is("KABOOM!"));
+        assertEquals("KABOOM!", thrown.getCause().getMessage());
 
         // verify both tasks had suspend called
         verify(task00).suspend();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
@@ -30,10 +30,9 @@ import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TaskMetadataImplTest {
 
@@ -59,9 +58,9 @@ public class TaskMetadataImplTest {
 
     @Test
     public void shouldNotAllowModificationOfInternalStateViaGetters() {
-        assertThat(isUnmodifiable(taskMetadata.topicPartitions()), is(true));
-        assertThat(isUnmodifiable(taskMetadata.committedOffsets()), is(true));
-        assertThat(isUnmodifiable(taskMetadata.endOffsets()), is(true));
+        assertTrue(isUnmodifiable(taskMetadata.topicPartitions()));
+        assertTrue(isUnmodifiable(taskMetadata.committedOffsets()));
+        assertTrue(isUnmodifiable(taskMetadata.endOffsets()));
     }
 
     @Test
@@ -72,8 +71,8 @@ public class TaskMetadataImplTest {
             COMMITTED_OFFSETS,
             END_OFFSETS,
             TIME_CURRENT_IDLING_STARTED);
-        assertThat(taskMetadata, equalTo(same));
-        assertThat(taskMetadata.hashCode(), equalTo(same.hashCode()));
+        assertEquals(same, taskMetadata);
+        assertEquals(same.hashCode(), taskMetadata.hashCode());
     }
 
     @Test
@@ -84,8 +83,8 @@ public class TaskMetadataImplTest {
             mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
             END_OFFSETS,
             TIME_CURRENT_IDLING_STARTED);
-        assertThat(taskMetadata, equalTo(stillSameDifferCommittedOffsets));
-        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferCommittedOffsets.hashCode()));
+        assertEquals(stillSameDifferCommittedOffsets, taskMetadata);
+        assertEquals(stillSameDifferCommittedOffsets.hashCode(), taskMetadata.hashCode());
     }
 
     @Test
@@ -96,8 +95,8 @@ public class TaskMetadataImplTest {
             COMMITTED_OFFSETS,
             mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
             TIME_CURRENT_IDLING_STARTED);
-        assertThat(taskMetadata, equalTo(stillSameDifferEndOffsets));
-        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferEndOffsets.hashCode()));
+        assertEquals(stillSameDifferEndOffsets, taskMetadata);
+        assertEquals(stillSameDifferEndOffsets.hashCode(), taskMetadata.hashCode());
     }
 
     @Test
@@ -108,8 +107,8 @@ public class TaskMetadataImplTest {
             COMMITTED_OFFSETS,
             END_OFFSETS,
             Optional.empty());
-        assertThat(taskMetadata, equalTo(stillSameDifferIdlingTime));
-        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferIdlingTime.hashCode()));
+        assertEquals(stillSameDifferIdlingTime, taskMetadata);
+        assertEquals(stillSameDifferIdlingTime.hashCode(), taskMetadata.hashCode());
     }
 
     @Test
@@ -120,8 +119,8 @@ public class TaskMetadataImplTest {
             COMMITTED_OFFSETS,
             END_OFFSETS,
             TIME_CURRENT_IDLING_STARTED);
-        assertThat(taskMetadata, not(equalTo(differTaskId)));
-        assertThat(taskMetadata.hashCode(), not(equalTo(differTaskId.hashCode())));
+        assertNotEquals(differTaskId, taskMetadata);
+        assertNotEquals(differTaskId.hashCode(), taskMetadata.hashCode());
     }
 
     @Test
@@ -132,8 +131,8 @@ public class TaskMetadataImplTest {
             COMMITTED_OFFSETS,
             END_OFFSETS,
             TIME_CURRENT_IDLING_STARTED);
-        assertThat(taskMetadata, not(equalTo(differTopicPartitions)));
-        assertThat(taskMetadata.hashCode(), not(equalTo(differTopicPartitions.hashCode())));
+        assertNotEquals(differTopicPartitions, taskMetadata);
+        assertNotEquals(differTopicPartitions.hashCode(), taskMetadata.hashCode());
     }
 
     private static boolean isUnmodifiable(final Collection<?> collection) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
@@ -30,10 +30,9 @@ import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThreadMetadataImplTest {
 
@@ -83,9 +82,9 @@ public class ThreadMetadataImplTest {
 
     @Test
     public void shouldNotAllowModificationOfInternalStateViaGetters() {
-        assertThat(isUnmodifiable(threadMetadata.producerClientIds()), is(true));
-        assertThat(isUnmodifiable(threadMetadata.activeTasks()), is(true));
-        assertThat(isUnmodifiable(threadMetadata.standbyTasks()), is(true));
+        assertTrue(isUnmodifiable(threadMetadata.producerClientIds()));
+        assertTrue(isUnmodifiable(threadMetadata.activeTasks()));
+        assertTrue(isUnmodifiable(threadMetadata.standbyTasks()));
     }
 
     @Test
@@ -100,8 +99,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, equalTo(same));
-        assertThat(threadMetadata.hashCode(), equalTo(same.hashCode()));
+        assertEquals(same, threadMetadata);
+        assertEquals(same.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -116,8 +115,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differThreadName)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differThreadName.hashCode())));
+        assertNotEquals(differThreadName, threadMetadata);
+        assertNotEquals(differThreadName.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -132,8 +131,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differThreadState)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differThreadState.hashCode())));
+        assertNotEquals(differThreadState, threadMetadata);
+        assertNotEquals(differThreadState.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -148,8 +147,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differMainConsumerClientId)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differMainConsumerClientId.hashCode())));
+        assertNotEquals(differMainConsumerClientId, threadMetadata);
+        assertNotEquals(differMainConsumerClientId.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -164,8 +163,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differRestoreConsumerClientId)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differRestoreConsumerClientId.hashCode())));
+        assertNotEquals(differRestoreConsumerClientId, threadMetadata);
+        assertNotEquals(differRestoreConsumerClientId.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -180,8 +179,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differProducerClientIds)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differProducerClientIds.hashCode())));
+        assertNotEquals(differProducerClientIds, threadMetadata);
+        assertNotEquals(differProducerClientIds.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -196,8 +195,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differAdminClientId)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differAdminClientId.hashCode())));
+        assertNotEquals(differAdminClientId, threadMetadata);
+        assertNotEquals(differAdminClientId.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -212,8 +211,8 @@ public class ThreadMetadataImplTest {
             Set.of(TM_0),
             STANDBY_TASKS
         );
-        assertThat(threadMetadata, not(equalTo(differActiveTasks)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differActiveTasks.hashCode())));
+        assertNotEquals(differActiveTasks, threadMetadata);
+        assertNotEquals(differActiveTasks.hashCode(), threadMetadata.hashCode());
     }
 
     @Test
@@ -228,8 +227,8 @@ public class ThreadMetadataImplTest {
             ACTIVE_TASKS,
             Set.of(TM_0)
         );
-        assertThat(threadMetadata, not(equalTo(differStandByTasks)));
-        assertThat(threadMetadata.hashCode(), not(equalTo(differStandByTasks.hashCode())));
+        assertNotEquals(differStandByTasks, threadMetadata);
+        assertNotEquals(differStandByTasks.hashCode(), threadMetadata.hashCode());
     }
 
     private static boolean isUnmodifiable(final Collection<?> collection) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TopicPartitionMetadataTest.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TopicPartitionMetadataTest {
 
@@ -35,8 +34,8 @@ public class TopicPartitionMetadataTest {
 
         final TopicPartitionMetadata topicMeta = new TopicPartitionMetadata(100L, metadata);
 
-        assertThat(topicMeta.partitionTime(), is(100L));
-        assertThat(topicMeta.processorMetadata(), is(metadata));
+        assertEquals(100L, topicMeta.partitionTime());
+        assertEquals(metadata, topicMeta.processorMetadata());
     }
 
     @Test
@@ -49,8 +48,8 @@ public class TopicPartitionMetadataTest {
 
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
 
-        assertThat(topicMeta.partitionTime(), is(100L));
-        assertThat(topicMeta.processorMetadata(), is(new ProcessorMetadata()));
+        assertEquals(100L, topicMeta.partitionTime());
+        assertEquals(new ProcessorMetadata(), topicMeta.processorMetadata());
     }
 
     @Test
@@ -64,7 +63,7 @@ public class TopicPartitionMetadataTest {
         final String serializedString = expected.encode();
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
 
-        assertThat(topicMeta, is(expected));
+        assertEquals(expected, topicMeta);
     }
 
     @Test
@@ -73,7 +72,7 @@ public class TopicPartitionMetadataTest {
         final String serializedString = expected.encode();
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode(serializedString);
 
-        assertThat(topicMeta, is(expected));
+        assertEquals(expected, topicMeta);
     }
 
     @Test
@@ -81,7 +80,7 @@ public class TopicPartitionMetadataTest {
         final TopicPartitionMetadata expected = new TopicPartitionMetadata(RecordQueue.UNKNOWN, new ProcessorMetadata());
         final TopicPartitionMetadata topicMeta = TopicPartitionMetadata.decode("");
 
-        assertThat(topicMeta, is(expected));
+        assertEquals(expected, topicMeta);
     }
 
     @Test
@@ -91,8 +90,8 @@ public class TopicPartitionMetadataTest {
 
         final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(encodedString);
 
-        assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
-        assertThat(decoded.processorMetadata(), is(new ProcessorMetadata()));
+        assertEquals(RecordQueue.UNKNOWN, decoded.partitionTime());
+        assertEquals(new ProcessorMetadata(), decoded.processorMetadata());
     }
 
     @Test
@@ -101,7 +100,7 @@ public class TopicPartitionMetadataTest {
 
         final TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(invalidBase64String);
 
-        assertThat(decoded.partitionTime(), is(RecordQueue.UNKNOWN));
-        assertThat(decoded.processorMetadata(), is(new ProcessorMetadata()));
+        assertEquals(RecordQueue.UNKNOWN, decoded.partitionTime());
+        assertEquals(new ProcessorMetadata(), decoded.processorMetadata());
     }
 }


### PR DESCRIPTION
Remove hamcrest from a subset of tests in the
`org.apache.kafka.streams.processor.internals` package by migrating to
JUnit assertions.

Reviewers: Ken Huang <s7133700@gmail.com>, Christo Lolov
 <lolovc@amazon.com>
