### PR TITLE
KAFKA-21069: Fix flaky consumer group authentication tests

### DIFF
--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandSaslAuthenticationTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/ConsumerGroupCommandSaslAuthenticationTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.tools.consumer.group;
 
+import kafka.server.KafkaBroker;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterUserScramCredentialsResult;
 import org.apache.kafka.clients.admin.ScramCredentialInfo;
@@ -25,6 +27,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.GroupProtocol;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.CredentialCache;
+import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
@@ -109,6 +113,15 @@ public class ConsumerGroupCommandSaslAuthenticationTest {
     private void testConsumerGroupServiceWithAuthenticationSuccess(GroupProtocol groupProtocol) throws Exception {
         cluster.createTopic(TOPIC, 1, (short) 1);
         createScramCredential(SCRAM_USER, SCRAM_PASSWORD);
+        for (KafkaBroker broker : cluster.brokers().values()) {
+            CredentialCache.Cache<ScramCredential> cache =
+                    broker.credentialProvider().credentialCache
+                            .cache(KAFKA_CLIENT_SASL_MECHANISM, ScramCredential.class);
+            TestUtils.waitForCondition(
+                    () -> cache.get(SCRAM_USER) != null,
+                    "SCRAM credentials not available on broker " + broker.config().nodeId()
+            );
+        }
         try (
             ConsumerGroupCommand.ConsumerGroupService consumerGroupService = prepareConsumerGroupService();
             AutoCloseable consumerExecutor = ConsumerGroupCommandTestUtils.buildConsumers(


### PR DESCRIPTION
### Description

The controller can acknowledge a SCRAM credential update before brokers apply it. Starting clients during this window can cause authentication failures and terminate the background consumer task, leaving the test waiting for a consumer group that never forms.

Wait for the credentials to appear in each broker’s cache before starting the consumer and admin client.

### Testing

- Reproduced the failure by delaying broker-side credential publication with a debugger.
- Verified the fix with the same delay.
- All four tests in `ConsumerGroupCommandSaslAuthenticationTest` pass with breakpoints disabled.

Reviewers: majialong <majialoong@gmail.com>
