### PR TITLE
MINOR: Rename computeSinkRecordLag to computeSinkRecordActiveCount

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -870,7 +870,7 @@ class WorkerSinkTask extends WorkerTask<ConsumerRecord<byte[], byte[]>, SinkReco
             putBatchTime.add(metricGroup.metricName(registry.sinkRecordPutBatchTimeAvg), new Avg());
         }
 
-        void computeSinkRecordLag() {
+        void computeSinkRecordActiveCount() {
             Map<TopicPartition, OffsetAndMetadata> consumed = this.consumedOffsets;
             Map<TopicPartition, OffsetAndMetadata> committed = this.committedOffsets;
             long activeRecords = 0L;
@@ -915,24 +915,24 @@ class WorkerSinkTask extends WorkerTask<ConsumerRecord<byte[], byte[]>, SinkReco
 
         void recordConsumedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
             consumedOffsets.putAll(offsets);
-            computeSinkRecordLag();
+            computeSinkRecordActiveCount();
         }
 
         void recordCommittedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
             committedOffsets = offsets;
-            computeSinkRecordLag();
+            computeSinkRecordActiveCount();
         }
 
         void assignedOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
             consumedOffsets = new HashMap<>(offsets);
             committedOffsets = offsets;
-            computeSinkRecordLag();
+            computeSinkRecordActiveCount();
         }
 
         void clearOffsets(Collection<TopicPartition> topicPartitions) {
             consumedOffsets.keySet().removeAll(topicPartitions);
             committedOffsets.keySet().removeAll(topicPartitions);
-            computeSinkRecordLag();
+            computeSinkRecordActiveCount();
         }
 
         void recordOffsetCommitSuccess() {


### PR DESCRIPTION
`computeSinkRecordLag` computes `consumedOffset - committedOffset`,
which is the value backing the `sink-record-active-count` metric, not an
actual fetch lag.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
