### PR TITLE
KAFKA-21058: Simplify jsonNodeToInt and jsonNodeToLong

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/MessageUtil.java
@@ -111,55 +111,19 @@ public final class MessageUtil {
     }
 
     public static int jsonNodeToInt(JsonNode node, String about) {
-        if (node.isInt()) {
-            return node.asInt();
+        if (!node.isIntegralNumber() || !node.canConvertToInt()) {
+            throw new NumberFormatException(about + ": expected an integer type, but got " +
+                node.getNodeType());
         }
-        if (node.isTextual()) {
-            throw new NumberFormatException(about + ": expected an integer or " +
-                "string type, but got " + node.getNodeType());
-        }
-        String text = node.asText();
-        if (text.startsWith("0x")) {
-            try {
-                return Integer.parseInt(text.substring(2), 16);
-            } catch (NumberFormatException e) {
-                throw new NumberFormatException(about + ": failed to " +
-                    "parse hexadecimal number: " + e.getMessage());
-            }
-        } else {
-            try {
-                return Integer.parseInt(text);
-            } catch (NumberFormatException e) {
-                throw new NumberFormatException(about + ": failed to " +
-                    "parse number: " + e.getMessage());
-            }
-        }
+        return node.intValue();
     }
 
     public static long jsonNodeToLong(JsonNode node, String about) {
-        if (node.isLong()) {
-            return node.asLong();
+        if (!node.isIntegralNumber() || !node.canConvertToLong()) {
+            throw new NumberFormatException(about + ": expected an integer type, but got " +
+                node.getNodeType());
         }
-        if (node.isTextual()) {
-            throw new NumberFormatException(about + ": expected an integer or " +
-                "string type, but got " + node.getNodeType());
-        }
-        String text = node.asText();
-        if (text.startsWith("0x")) {
-            try {
-                return Long.parseLong(text.substring(2), 16);
-            } catch (NumberFormatException e) {
-                throw new NumberFormatException(about + ": failed to " +
-                    "parse hexadecimal number: " + e.getMessage());
-            }
-        } else {
-            try {
-                return Long.parseLong(text);
-            } catch (NumberFormatException e) {
-                throw new NumberFormatException(about + ": failed to " +
-                    "parse number: " + e.getMessage());
-            }
-        }
+        return node.longValue();
     }
 
     public static byte[] jsonNodeToBinary(JsonNode node, String about) {

--- a/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
@@ -22,7 +22,11 @@ import org.apache.kafka.common.protocol.types.RawTaggedField;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import org.junit.jupiter.api.Test;
@@ -93,6 +97,36 @@ public final class MessageUtilTest {
     public void testConstants() {
         assertEquals(MessageUtil.UNSIGNED_SHORT_MAX, 0xFFFF);
         assertEquals(MessageUtil.UNSIGNED_INT_MAX, 0xFFFFFFFFL);
+    }
+
+    @Test
+    public void testJsonNodeToInt() {
+        assertEquals(42, MessageUtil.jsonNodeToInt(new ShortNode((short) 42), "Test short"));
+        assertEquals(42, MessageUtil.jsonNodeToInt(new IntNode(42), "Test int"));
+        assertEquals(42, MessageUtil.jsonNodeToInt(new LongNode(42), "Test long"));
+
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToInt(new LongNode((long) Integer.MAX_VALUE + 1), "Test large long"));
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToInt(new DoubleNode(42.0), "Test double"));
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToInt(BooleanNode.TRUE, "Test boolean"));
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToInt(new TextNode("42"), "Test text"));
+    }
+
+    @Test
+    public void testJsonNodeToLong() {
+        assertEquals(42, MessageUtil.jsonNodeToLong(new ShortNode((short) 42), "Test short"));
+        assertEquals(42, MessageUtil.jsonNodeToLong(new IntNode(42), "Test int"));
+        assertEquals(42, MessageUtil.jsonNodeToLong(new LongNode(42), "Test long"));
+
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToLong(new DoubleNode(42.0), "Test double"));
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToLong(BooleanNode.TRUE, "Test boolean"));
+        assertThrows(NumberFormatException.class,
+            () -> MessageUtil.jsonNodeToLong(new TextNode("42"), "Test text"));
     }
 
     @Test


### PR DESCRIPTION
This PR simplifies `MessageUtil.jsonNodeToInt` and `jsonNodeToLong`. The
existing code converts compatible numeric nodes to strings and parses
them back as a fallback. The new implementation keeps this behavior by
validating the integral value and its range before returning
`intValue()` or `longValue()` directly. Tests cover supported integral
nodes, out-of-range values, and invalid node types.

### Testing

`./gradlew clients:test --tests
org.apache.kafka.common.protocol.MessageUtilTest`

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
