### PR TITLE
KAFKA-21073: Enable SASL for the native image docker examples and sanity test

### DIFF
--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -187,13 +187,15 @@ Single Node
     - `KAFKA_OPTS` is set to point to the JAAS config file.
     - Similar to the plaintext example, two listeners are configured: one for inter-broker communication and one for client-to-broker communication. Both use the `SASL_PLAINTEXT` security protocol.
     - Two users are configured in the JAAS file: `admin` (for inter-broker) and `alice` (for clients).
-    - Note: SASL is currently not supported with the GraalVM based native image (`apache/kafka-native`) due to missing reflection configuration for `java.security.AccessController`. See [KAFKA-19584](https://issues.apache.org/jira/browse/KAFKA-19584) for details.
     - To run the example:
     ```
     # Run from root of the repo
 
     # JVM based Apache Kafka Docker Image
     $ IMAGE=apache/kafka:latest docker compose -f docker/examples/docker-compose-files/single-node/sasl_plaintext/docker-compose.yml up
+
+    # GraalVM based Native Apache Kafka Docker Image
+    $ IMAGE=apache/kafka-native:latest docker compose -f docker/examples/docker-compose-files/single-node/sasl_plaintext/docker-compose.yml up
     ```
     - To produce messages using client scripts (Ensure that java version >= 17):
     ```
@@ -256,13 +258,15 @@ Multi Node Cluster
         - Similar to Plaintext example, with SASL/PLAIN authentication added.
         - Similar to Plaintext example, two listeners are configured for inter-broker and client-to-broker communication, both using the `SASL_PLAINTEXT` security protocol. Controllers use `PLAINTEXT`.
         - Each broker mounts the same JAAS config file. In production, each broker should have its own credentials.
-        - Note: SASL is currently not supported with the GraalVM based native image (`apache/kafka-native`) due to missing reflection configuration for `java.security.AccessController`. See [KAFKA-19584](https://issues.apache.org/jira/browse/KAFKA-19584) for details.
         - To run the example:
         ```
         # Run from root of the repo
 
         # JVM based Apache Kafka Docker Image
         $ IMAGE=apache/kafka:latest docker compose -f docker/examples/docker-compose-files/cluster/combined/sasl_plaintext/docker-compose.yml up
+
+        # GraalVM based Native Apache Kafka Docker Image
+        $ IMAGE=apache/kafka-native:latest docker compose -f docker/examples/docker-compose-files/cluster/combined/sasl_plaintext/docker-compose.yml up
         ```
         - To produce messages using client scripts (Ensure that java version >= 17):
         ```
@@ -311,13 +315,15 @@ Multi Node Cluster
     - SASL_PLAINTEXT:
         - Same as combined SASL_PLAINTEXT example, with controllers and brokers separated.
         - `SASL_PLAINTEXT` is only for inter-broker and client communication. Controllers use `PLAINTEXT`.
-        - Note: SASL is currently not supported with the GraalVM based native image (`apache/kafka-native`) due to missing reflection configuration for `java.security.AccessController`. See [KAFKA-19584](https://issues.apache.org/jira/browse/KAFKA-19584) for details.
         - To run the example:
         ```
         # Run from root of the repo
 
         # JVM based Apache Kafka Docker Image
         $ IMAGE=apache/kafka:latest docker compose -f docker/examples/docker-compose-files/cluster/isolated/sasl_plaintext/docker-compose.yml up
+
+        # GraalVM based Native Apache Kafka Docker Image
+        $ IMAGE=apache/kafka-native:latest docker compose -f docker/examples/docker-compose-files/cluster/isolated/sasl_plaintext/docker-compose.yml up
         ```
         - To produce messages using client scripts (Ensure that java version >= 17):
         ```

--- a/docker/test/docker_sanity_test.py
+++ b/docker/test/docker_sanity_test.py
@@ -25,7 +25,6 @@ import test.constants as constants
 class DockerSanityTest(unittest.TestCase):
     IMAGE="apache/kafka"
     FIXTURES_DIR="."
-    MODE="jvm"
     CONTAINER_RUNTIME="docker"
 
     def compose_command(self):
@@ -195,13 +194,11 @@ class DockerSanityTest(unittest.TestCase):
         except Exception as e:
             print(constants.FILE_INPUT_ERROR_PREFIX, str(e))
             total_errors.append(str(e))
-        # SASL is not supported on native image due to missing reflection config (KAFKA-19584)
-        if self.MODE == "jvm":
-            try:
-                total_errors.extend(self.secure_flow('localhost:9095', constants.SASL_CLIENT_CONFIG, constants.SASL_FLOW_TESTS, constants.SASL_ERROR_PREFIX, constants.SASL_TOPIC))
-            except Exception as e:
-                print(constants.SASL_ERROR_PREFIX, str(e))
-                total_errors.append(str(e))
+        try:
+            total_errors.extend(self.secure_flow('localhost:9095', constants.SASL_CLIENT_CONFIG, constants.SASL_FLOW_TESTS, constants.SASL_ERROR_PREFIX, constants.SASL_TOPIC))
+        except Exception as e:
+            print(constants.SASL_ERROR_PREFIX, str(e))
+            total_errors.append(str(e))
         try:
             total_errors.extend(self.broker_restart_flow())
         except Exception as e:
@@ -229,7 +226,6 @@ class DockerSanityTestIsolatedMode(DockerSanityTest):
 def run_tests(image, mode, fixtures_dir, container_runtime="docker"):
     DockerSanityTest.IMAGE = image
     DockerSanityTest.FIXTURES_DIR = fixtures_dir
-    DockerSanityTest.MODE = mode
     DockerSanityTest.CONTAINER_RUNTIME = container_runtime
 
     cur_directory = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-21073

- Remove the three stale "SASL not supported on native" notes from
docker/examples/README.md and add the apache/kafka-native run command to
each SASL example, for parity with the other examples.
- Remove the MODE == "jvm" guard in docker_sanity_test.py so the SASL
flow runs for the native image as well as the JVM image.

Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
