### PR TITLE
KAFKA-21075: Skip fsync in Utils.flushFileIfExists on Windows and z/OS

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -960,7 +960,7 @@ public final class Utils {
     /**
      * Flushes dirty directories to guarantee crash consistency.
      * <p>
-     * Note: We don't fsync directories on Windows OS because otherwise it'll throw AccessDeniedException (KAFKA-13391)
+     * Note: We don't fsync directories on Windows OS and z/OS because otherwise it'll throw AccessDeniedException (KAFKA-13391)
      *
      * @throws IOException if flushing the directory fails.
      */
@@ -987,12 +987,16 @@ public final class Utils {
 
     /**
      * Flushes dirty file with swallowing {@link NoSuchFileException}
+     * <p>
+     * Note: We don't fsync files on Windows OS and z/OS because otherwise it'll throw AccessDeniedException (KAFKA-13391)
      */
     public static void flushFileIfExists(Path path) throws IOException {
-        try (FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.READ)) {
-            fileChannel.force(true);
-        } catch (NoSuchFileException e) {
-            log.warn("Failed to flush file {}", path, e);
+        if (!OperatingSystem.IS_WINDOWS && !OperatingSystem.IS_ZOS) {
+            try (FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.READ)) {
+                fileChannel.force(true);
+            } catch (NoSuchFileException e) {
+                log.warn("Failed to flush file {}", path, e);
+            }
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -608,6 +608,20 @@ public class UtilsTest {
         }
     }
 
+    @Test
+    public void testFlushFileIfExistsWithExistingFile() throws IOException {
+        Path file = TestUtils.tempFile().toPath();
+        // On non-Windows/z/OS platforms this fsyncs the file; on Windows/z/OS it is skipped. Either way it must not throw.
+        assertDoesNotThrow(() -> Utils.flushFileIfExists(file));
+    }
+
+    @Test
+    public void testFlushFileIfExistsSwallowsNoSuchFileException() {
+        Path missing = TestUtils.tempDirectory().toPath().resolve("does-not-exist");
+        // A missing file must be swallowed (NoSuchFileException), not propagated.
+        assertDoesNotThrow(() -> Utils.flushFileIfExists(missing));
+    }
+
     /**
      * Tests that `readFullyOrFail` behaves correctly if multiple `FileChannel.read` operations are required to fill
      * the destination buffer.


### PR DESCRIPTION
Ref : https://issues.apache.org/jira/browse/KAFKA-21075
Raised in review of #23316 (https://github.com/apache/kafka/pull/23316#discussion_r3992688515).

Fix: Guard the fsync in `flushFileIfExists` mirroring `flushDir`.
Reviewers: Chia-Ping Tsai <chia7712@gmail.com>
