### PR TITLE
KAFKA-21068: Use batch.size as the producer record builder's write limit.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -351,7 +351,7 @@ public class RecordAccumulator {
 
                     final ByteBuffer batchBuffer = buffer;
                     RecordAppendResult appendResult = appendNewBatch(tp, dq, timestamp, key, value, headers, callbacks,
-                            () -> MemoryRecords.builder(batchBuffer, RecordBatch.CURRENT_MAGIC_VALUE, compression, TimestampType.CREATE_TIME, 0L),
+                            () -> MemoryRecords.builder(batchBuffer, compression, TimestampType.CREATE_TIME, 0L, this.batchSize),
                             nowMs);
                     // Set buffer to null, so that deallocate doesn't return it back to free pool, since it's used in the batch.
                     if (appendResult.newBatchCreated)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -55,6 +55,8 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
@@ -277,6 +279,156 @@ public class RecordAccumulatorTest {
     @Test
     public void testAppendLargeNonCompressed() throws Exception {
         testAppendLarge(Compression.NONE);
+    }
+
+    @Test
+    public void testOversizedRecordIsReadyWithoutWaitingForLinger() throws Exception {
+        int batchSize = 16 * 1024;
+        int lingerMs = 1000;
+        RecordAccumulator accum = createTestRecordAccumulator(
+                batchSize, 8 * 1024 * 1024, Compression.NONE, lingerMs);
+        try {
+            long now = time.milliseconds();
+            accum.append(topic, partition1, 0L, null, new byte[1024 * 1024],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, now, cluster);
+
+            Deque<ProducerBatch> batches = accum.getDeque(tp1);
+            assertEquals(1, batches.size());
+            ProducerBatch batch = batches.peekFirst();
+            assertTrue(batch.estimatedSizeInBytes() > batchSize);
+            assertTrue(batch.estimatedSizeInBytes() < batch.initialCapacity());
+            // Unused allocation space must not make an oversized batch wait for linger.
+            assertEquals(Collections.singleton(node1), accum.ready(metadataCache, now).readyNodes);
+        } finally {
+            accum.abortIncompleteBatches();
+            accum.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"GZIP", "ZSTD"})
+    public void testCompressedOversizedRecordIsReadyWithoutWaitingForLinger(CompressionType compressionType) throws Exception {
+        int batchSize = 16 * 1024;
+        int lingerMs = 1000;
+        RecordAccumulator accum = createTestRecordAccumulator(
+                batchSize, 8 * 1024 * 1024, Compression.of(compressionType).build(), lingerMs);
+        try {
+            long now = time.milliseconds();
+            accum.append(topic, partition1, 0L, null, new byte[1024 * 1024],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, now, cluster);
+
+            Deque<ProducerBatch> batches = accum.getDeque(tp1);
+            assertEquals(1, batches.size());
+            ProducerBatch batch = batches.peekFirst();
+            // Set only this builder's estimate to avoid changing the shared compression ratio estimator.
+            // 1024 * 1024 * 0.1 > 16*1024
+            batch.recordsBuilder.setEstimatedCompressionRatio(0.1f);
+            assertTrue(batch.estimatedSizeInBytes() > batchSize);
+            assertTrue(batch.estimatedSizeInBytes() < batch.initialCapacity());
+            assertEquals(Collections.singleton(node1), accum.ready(metadataCache, now).readyNodes);
+        } finally {
+            accum.abortIncompleteBatches();
+            accum.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CompressionType.class, names = {"GZIP", "ZSTD"})
+    public void testCompressedOversizedRecordWaitsForLingerBelowBatchSize(CompressionType compressionType) throws Exception {
+        int batchSize = 16 * 1024;
+        int lingerMs = 1000;
+        RecordAccumulator accum = createTestRecordAccumulator(
+                batchSize, 8 * 1024 * 1024, Compression.of(compressionType).build(), lingerMs);
+        try {
+            accum.append(topic, partition1, 0L, null, new byte[1024 * 1024],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, time.milliseconds(), cluster);
+
+            Deque<ProducerBatch> batches = accum.getDeque(tp1);
+            assertEquals(1, batches.size());
+            ProducerBatch batch = batches.peekFirst();
+            // The compressed size estimate determines readiness even when the uncompressed record is oversized. 
+            // 1024 * 1024 * 0.01 ~< 16*1024
+            batch.recordsBuilder.setEstimatedCompressionRatio(0.01f); 
+            assertTrue(batch.estimatedSizeInBytes() < batchSize);
+            assertTrue(accum.ready(metadataCache, time.milliseconds()).readyNodes.isEmpty());
+
+            time.sleep(lingerMs - 1);
+            assertTrue(accum.ready(metadataCache, time.milliseconds()).readyNodes.isEmpty());
+            time.sleep(1);
+            assertEquals(Collections.singleton(node1), accum.ready(metadataCache, time.milliseconds()).readyNodes);
+        } finally {
+            accum.abortIncompleteBatches();
+            accum.close();
+        }
+    }
+
+    @Test
+    public void testOversizedRecordDoesNotBatchWithSmallRecord() throws Exception {
+        int batchSize = 16 * 1024;
+        int lingerMs = 1000;
+        RecordAccumulator accum = createTestRecordAccumulator(
+                batchSize, 8 * 1024 * 1024, Compression.NONE, lingerMs);
+        try {
+            long now = time.milliseconds();
+            accum.append(topic, partition1, 0L, null, new byte[1024 * 1024],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, now, cluster);
+
+            Deque<ProducerBatch> batches = accum.getDeque(tp1);
+            assertEquals(1, batches.size());
+            ProducerBatch batch = batches.peekFirst();
+            assertTrue(batch.estimatedSizeInBytes() > batchSize);
+
+            byte[] smallValue = new byte[0];
+            int smallRecordSize = DefaultRecord.sizeInBytes(1, 0, -1, smallValue.length, Record.EMPTY_HEADERS);
+            int remainingCapacity = batch.initialCapacity() - batch.estimatedSizeInBytes();
+            assertTrue(smallRecordSize <= remainingCapacity,
+                    "The second record must fit in the oversized batch's unused allocation space");
+
+            // The configured batch size must prevent another append even though the buffer has room.
+            accum.append(topic, partition1, 0L, null, smallValue,
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, now, cluster);
+            assertEquals(2, batches.size());
+            assertEquals(1, batches.peekFirst().recordCount);
+            assertEquals(1, batches.peekLast().recordCount);
+        } finally {
+            accum.abortIncompleteBatches();
+            accum.close();
+        }
+    }
+
+    @Test
+    public void testLingerAfterOversizedRecord() throws Exception {
+        int batchSize = 16 * 1024;
+        int lingerMs = 1000;
+        RecordAccumulator accum = createTestRecordAccumulator(
+                batchSize, 8 * 1024 * 1024, Compression.NONE, lingerMs);
+        try {
+            accum.append(topic, partition1, 0L, null, new byte[1024 * 1024],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, time.milliseconds(), cluster);
+            time.sleep(lingerMs / 2);
+            accum.append(topic, partition1, 0L, null, new byte[100],
+                    Record.EMPTY_HEADERS, null, maxBlockTimeMs, time.milliseconds(), cluster);
+            assertEquals(2, accum.getDeque(tp1).size());
+
+            List<ProducerBatch> drained = accum.drain(metadataCache, Collections.singleton(node1),
+                    Integer.MAX_VALUE, time.milliseconds()).get(node1.id());
+            assertEquals(1, drained.size());
+            assertEquals(1, drained.get(0).recordCount);
+            assertTrue(drained.get(0).estimatedSizeInBytes() > batchSize);
+            assertEquals(1, accum.getDeque(tp1).size());
+            assertTrue(accum.ready(metadataCache, time.milliseconds()).readyNodes.isEmpty());
+
+            // The small batch's linger starts at its own creation, not the oversized batch's creation.
+            time.sleep(lingerMs / 2);
+            assertTrue(accum.ready(metadataCache, time.milliseconds()).readyNodes.isEmpty());
+            time.sleep(lingerMs / 2 - 1);
+            assertTrue(accum.ready(metadataCache, time.milliseconds()).readyNodes.isEmpty());
+            time.sleep(1);
+            assertEquals(Collections.singleton(node1), accum.ready(metadataCache, time.milliseconds()).readyNodes);
+        } finally {
+            accum.abortIncompleteBatches();
+            accum.close();
+        }
     }
 
     private void testAppendLarge(Compression compression) throws Exception {
@@ -1265,35 +1417,31 @@ public class RecordAccumulatorTest {
         assertEquals(partition1, partition.get());
         assertEquals(1, mockRandom.get());
 
-        // Produce large record, we should exceed "sticky" limit, but produce to this partition
-        // as we try to switch after the "sticky" limit is exceeded.  The switch is disabled
-        // because of incomplete batch.
+        // The oversized record still uses the current partition, but fills its batch and exceeds
+        // the sticky limit, so the next partition is selected immediately after the append.
         byte[] largeValue = new byte[batchSize];
         accum.append(topic, RecordMetadata.UNKNOWN_PARTITION, 0L, null, largeValue, Record.EMPTY_HEADERS,
                 callbacks, maxBlockTimeMs, time.milliseconds(), cluster);
         assertEquals(partition1, partition.get());
-        assertEquals(1, mockRandom.get());
+        assertEquals(2, mockRandom.get());
 
-        // Produce large record, we should switch to next partition as we complete
-        // previous batch and exceeded sticky limit.
+        // Use the partition selected by the previous append, then select the next partition.
         accum.append(topic, RecordMetadata.UNKNOWN_PARTITION, 0L, null, largeValue, Record.EMPTY_HEADERS,
                 callbacks, maxBlockTimeMs, time.milliseconds(), cluster);
         assertEquals(partition2, partition.get());
-        assertEquals(2, mockRandom.get());
+        assertEquals(3, mockRandom.get());
 
-        // Produce large record, we should switch to next partition as we complete
-        // previous batch and exceeded sticky limit.
+        // Use the partition selected by the previous append, then select the next partition.
         accum.append(topic, RecordMetadata.UNKNOWN_PARTITION, 0L, null, largeValue, Record.EMPTY_HEADERS,
                 callbacks, maxBlockTimeMs, time.milliseconds(), cluster);
         assertEquals(partition3, partition.get());
-        assertEquals(3, mockRandom.get());
+        assertEquals(4, mockRandom.get());
 
-        // Produce large record, we should switch to next partition as we complete
-        // previous batch and exceeded sticky limit.
+        // Use the partition selected by the previous append, then select the next partition.
         accum.append(topic, RecordMetadata.UNKNOWN_PARTITION, 0L, null, largeValue, Record.EMPTY_HEADERS,
                 callbacks, maxBlockTimeMs, time.milliseconds(), cluster);
         assertEquals(partition1, partition.get());
-        assertEquals(4, mockRandom.get());
+        assertEquals(5, mockRandom.get());
     }
 
     @Test


### PR DESCRIPTION
The producer currently uses the allocated buffer's remaining capacity as
the `MemoryRecordsBuilder` write limit. For an oversized record, this
capacity can exceed `batch.size`, leaving the batch unready until
`linger.ms` expires even though its estimated size already exceeds the
configured batch size.

This PR passes `batch.size` as the write limit while retaining a buffer
large enough to hold the record.

Tests cover immediate readiness for oversized batches, linger behavior
when the compressed size estimate is below `batch.size`, and preventing
additional records from being appended to oversized batches. The
existing partitioner test is also updated to reflect earlier selection
of the next partition.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
