### PR TITLE
KAFKA-21084: Avoid waking the fetch buffer when requeuing paused fetches

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchBuffer.java
@@ -113,6 +113,18 @@ public class FetchBuffer implements AutoCloseable {
         }
     }
 
+    void requeue(Collection<CompletedFetch> completedFetches) {
+        if (completedFetches == null || completedFetches.isEmpty())
+            return;
+
+        try {
+            lock.lock();
+            this.completedFetches.addAll(completedFetches);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     CompletedFetch nextInLineFetch() {
         try {
             lock.lock();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchCollector.java
@@ -140,7 +140,7 @@ public class FetchCollector<K, V> {
         } finally {
             // add any polled completed fetches for paused partitions back to the completed fetches queue to be
             // re-evaluated in the next poll
-            fetchBuffer.addAll(pausedCompletedFetches);
+            fetchBuffer.requeue(pausedCompletedFetches);
         }
 
         return fetch;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchBufferTest.java
@@ -26,14 +26,18 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createFetchMetricsManager;
 import static org.apache.kafka.clients.consumer.internals.ConsumerUtils.createMetrics;
@@ -182,6 +186,57 @@ public class FetchBufferTest {
             waitingThread.start();
             fetchBuffer.wakeup();
             waitingThread.join(Duration.ofSeconds(30).toMillis());
+            assertFalse(waitingThread.isAlive());
+        }
+    }
+
+    @Test
+    public void testRequeueDoesNotWakeUpBuffer() throws Exception {
+        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+            CompletedFetch completedFetch = completedFetch(topicAPartition0);
+            fetchBuffer.requeue(List.of(completedFetch));
+
+            FutureTask<Void> awaitWakeup = new FutureTask<>(() -> {
+                fetchBuffer.awaitWakeup(time.timer(Duration.ofMinutes(1)));
+                return null;
+            });
+            Thread waitingThread = new Thread(awaitWakeup);
+            waitingThread.start();
+            try {
+                TestUtils.waitForCondition(
+                    () -> waitingThread.getState() == Thread.State.TIMED_WAITING,
+                    "Thread did not start waiting on the fetch buffer"
+                );
+                assertFalse(awaitWakeup.isDone(), "Requeuing fetches must not wake up the buffer");
+                assertSame(completedFetch, fetchBuffer.poll());
+                assertTrue(fetchBuffer.isEmpty());
+            } finally {
+                fetchBuffer.wakeup();
+                waitingThread.join(Duration.ofSeconds(30).toMillis());
+            }
+            assertFalse(waitingThread.isAlive());
+            awaitWakeup.get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testRequeuePreservesPendingWakeup() throws Exception {
+        try (FetchBuffer fetchBuffer = new FetchBuffer(logContext)) {
+            fetchBuffer.wakeup();
+            fetchBuffer.requeue(List.of(completedFetch(topicAPartition0)));
+
+            FutureTask<Void> awaitWakeup = new FutureTask<>(() -> {
+                fetchBuffer.awaitWakeup(time.timer(Duration.ofMinutes(1)));
+                return null;
+            });
+            Thread waitingThread = new Thread(awaitWakeup);
+            waitingThread.start();
+            try {
+                awaitWakeup.get(30, TimeUnit.SECONDS);
+            } finally {
+                fetchBuffer.wakeup();
+                waitingThread.join(Duration.ofSeconds(30).toMillis());
+            }
             assertFalse(waitingThread.isAlive());
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetchCollectorTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.internals.BufferSupplier;
 import org.apache.kafka.common.utils.internals.LogContext;
+import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +51,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,6 +59,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -314,6 +318,99 @@ public class FetchCollectorTest {
         // The next-in-line CompletedFetch should be null; the CompletedFetch is added to the FetchBuffer
         // queue by the FetchCollector when it detects a 'paused' partition.
         assertNull(fetchBuffer.nextInLineFetch());
+    }
+
+    @Test
+    public void testCollectPausedFetchDoesNotRegenerateWakeup() throws Exception {
+        buildDependencies();
+        assignAndSeek(topicAPartition0);
+
+        CompletedFetch completedFetch = completedFetchBuilder.build();
+        fetchBuffer.add(completedFetch);
+        // Consume the notification for the original response before testing paused fetch requeues.
+        fetchBuffer.awaitWakeup(time.timer(0));
+        subscriptions.pause(topicAPartition0);
+
+        Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+        assertTrue(fetch.isEmpty());
+        assertEquals(0, fetch.numRecords());
+        assertTrue(fetch.nextOffsets().isEmpty());
+        assertEquals(0, subscriptions.position(topicAPartition0).offset);
+        assertSame(completedFetch, fetchBuffer.peek());
+        assertNull(fetchBuffer.nextInLineFetch());
+        assertFalse(completedFetch.isConsumed());
+
+        FutureTask<Void> awaitWakeup = new FutureTask<>(() -> {
+            fetchBuffer.awaitWakeup(time.timer(Duration.ofMinutes(1)));
+            return null;
+        });
+        Thread waitingThread = new Thread(awaitWakeup);
+        waitingThread.start();
+        try {
+            TestUtils.waitForCondition(
+                () -> waitingThread.getState() == Thread.State.TIMED_WAITING,
+                "Thread did not start waiting on the fetch buffer"
+            );
+            assertFalse(awaitWakeup.isDone(), "Collecting paused fetches must not regenerate the wakeup signal");
+        } finally {
+            fetchBuffer.wakeup();
+            waitingThread.join(Duration.ofSeconds(30).toMillis());
+        }
+        assertFalse(waitingThread.isAlive());
+        awaitWakeup.get(30, TimeUnit.SECONDS);
+
+        subscriptions.resume(topicAPartition0);
+        fetch = fetchCollector.collectFetch(fetchBuffer);
+        assertEquals(DEFAULT_RECORD_COUNT, fetch.numRecords());
+        assertEquals(DEFAULT_RECORD_COUNT, subscriptions.position(topicAPartition0).offset);
+    }
+
+    @Test
+    public void testCollectMixedPausedAndUnpausedFetchesDoesNotRegenerateWakeup() throws Exception {
+        buildDependencies();
+        assign(topicAPartition0, topicAPartition1);
+        subscriptions.seek(topicAPartition0, 0);
+        subscriptions.seek(topicAPartition1, 0);
+
+        CompletedFetch pausedFetch = completedFetchBuilder.build();
+        CompletedFetch unpausedFetch = new CompletedFetchBuilder()
+            .partition(topicAPartition1)
+            .build();
+        // Put the paused partition first so collection must skip it to reach the available records.
+        fetchBuffer.addAll(List.of(pausedFetch, unpausedFetch));
+        fetchBuffer.awaitWakeup(time.timer(0));
+        subscriptions.pause(topicAPartition0);
+
+        Fetch<String, String> fetch = fetchCollector.collectFetch(fetchBuffer);
+        assertEquals(Set.of(topicAPartition1), fetch.records().keySet());
+        assertEquals(DEFAULT_RECORD_COUNT, fetch.numRecords());
+        assertEquals(DEFAULT_RECORD_COUNT, subscriptions.position(topicAPartition1).offset);
+        assertEquals(0, subscriptions.position(topicAPartition0).offset);
+        assertSame(pausedFetch, fetchBuffer.peek());
+        assertFalse(pausedFetch.isConsumed());
+
+        // After consuming the unpaused partition, only paused data remains to be collected.
+        assertTrue(fetchCollector.collectFetch(fetchBuffer).isEmpty());
+        assertEquals(Set.of(topicAPartition0), fetchBuffer.bufferedPartitions());
+
+        FutureTask<Void> awaitWakeup = new FutureTask<>(() -> {
+            fetchBuffer.awaitWakeup(time.timer(Duration.ofMinutes(1)));
+            return null;
+        });
+        Thread waitingThread = new Thread(awaitWakeup);
+        waitingThread.start();
+        try {
+            TestUtils.waitForCondition(
+                () -> waitingThread.getState() == Thread.State.TIMED_WAITING,
+                "Thread did not start waiting on the fetch buffer"
+            );
+            assertFalse(awaitWakeup.isDone(), "Requeuing the remaining paused fetch must not regenerate the wakeup signal");
+        } finally {
+            fetchBuffer.wakeup();
+            waitingThread.join(Duration.ofSeconds(30).toMillis());
+        }
+        assertFalse(waitingThread.isAlive());
+        awaitWakeup.get(30, TimeUnit.SECONDS);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
`AsyncKafkaConsumer.poll(Duration)` calls
`FetchCollector.collectFetch()` through `pollForFetches()`.

`collectFetch()` preserves fetches from paused partitions by requeuing
them through `FetchBuffer.addAll()`. However, `addAll()` also calls
`wokenup.set(true)` and `blockingCondition.signalAll()`.

When only paused fetches remain, collection returns an empty result, and
`pollForFetches()` calls `fetchBuffer.awaitWakeup(pollTimer)`. Since
`wokenup.compareAndSet(true, false)` succeeds, the method returns
immediately without calling `Condition.await()`.

Subsequent collections requeue the same paused fetches and regenerate
the wakeup signal. This can cause the application thread to repeatedly
execute the internal `poll()` loop until the timeout expires, consuming
CPU without new responses or consumption progress.

This change introduces `requeue()`, which preserves the existing wakeup
state, and uses it to restore paused fetches without   generating
unnecessary wakeup signals.

Reviewers: Lianet Magrans <lmagrans@confluent.io>
