### PR TITLE
KAFKA-21076: Return TELEMETRY_TOO_LARGE for oversize decompressed telemetry payloads

### DIFF
--- a/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
+++ b/server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java
@@ -216,6 +216,14 @@ public class ClientMetricsManager implements AutoCloseable {
                 long exportTimeStartMs = time.hiResClockMs();
                 clientTelemetryExporterPlugin.exportMetrics(requestContext, request, clientInstance.pushIntervalMs(), clientTelemetryMaxBytes);
                 clientMetricsStats.recordPluginExport(clientInstanceId, time.hiResClockMs() - exportTimeStartMs);
+            } catch (TelemetryTooLargeException exception) {
+                // The decompressed payload exceeded the configured size limit. This is retryable (the client may
+                // shrink its metric set or the broker may be reconfigured), unlike a malformed payload, so it must
+                // not be reported as INVALID_RECORD: that error tells the client to stop pushing telemetry entirely.
+                clientMetricsStats.recordPluginErrorCount(clientInstanceId);
+                clientInstance.lastKnownError(Errors.TELEMETRY_TOO_LARGE);
+                log.error("Error exporting client metrics to the plugin for client instance id: {}", clientInstanceId, exception);
+                return request.errorResponse(0, Errors.TELEMETRY_TOO_LARGE);
             } catch (Throwable exception) {
                 clientMetricsStats.recordPluginErrorCount(clientInstanceId);
                 clientInstance.lastKnownError(Errors.INVALID_RECORD);

--- a/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
+++ b/server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.TelemetryTooLargeException;
 import org.apache.kafka.common.message.GetTelemetrySubscriptionsRequestData;
 import org.apache.kafka.common.message.PushTelemetryRequestData;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -1120,6 +1121,51 @@ public class ClientMetricsManagerTest {
             // Should have default NaN value, must not register export time.
             assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-avg").metricValue());
             assertEquals(Double.NaN, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT_TIME + "-max").metricValue());
+        }
+    }
+
+    @Test
+    public void testPushTelemetryPluginTooLargeException() throws Exception {
+        // An oversize decompressed payload must be reported as TELEMETRY_TOO_LARGE (retryable at the normal
+        // interval), not INVALID_RECORD (which tells the client to stop pushing telemetry entirely).
+        ClientTelemetryExporterPlugin receiverPlugin = Mockito.mock(ClientTelemetryExporterPlugin.class);
+        Mockito.doThrow(new TelemetryTooLargeException("Decompressed telemetry metrics exceed maximum allowed size: 100"))
+                .when(receiverPlugin).exportMetrics(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt());
+
+        try (
+                Metrics kafkaMetrics = new Metrics();
+                ClientMetricsManager clientMetricsManager = new ClientMetricsManager(receiverPlugin, 100, time, 100, kafkaMetrics)
+        ) {
+
+            clientMetricsManager.updateSubscription("sub-1", ClientMetricsTestUtils.defaultTestProperties());
+            assertEquals(1, clientMetricsManager.subscriptions().size());
+
+            GetTelemetrySubscriptionsRequest subscriptionsRequest = new GetTelemetrySubscriptionsRequest.Builder(
+                    new GetTelemetrySubscriptionsRequestData(), true).build();
+
+            GetTelemetrySubscriptionsResponse subscriptionsResponse = clientMetricsManager.processGetTelemetrySubscriptionRequest(
+                    subscriptionsRequest, ClientMetricsTestUtils.requestContext());
+
+            ClientMetricsInstance instance = clientMetricsManager.clientInstance(subscriptionsResponse.data().clientInstanceId());
+            assertNotNull(instance);
+
+            PushTelemetryRequest request = new Builder(
+                    new PushTelemetryRequestData()
+                            .setClientInstanceId(subscriptionsResponse.data().clientInstanceId())
+                            .setSubscriptionId(subscriptionsResponse.data().subscriptionId())
+                            .setCompressionType(CompressionType.NONE.id)
+                            .setMetrics(ByteBuffer.wrap("test-data".getBytes(StandardCharsets.UTF_8))), true).build();
+
+            PushTelemetryResponse response = clientMetricsManager.processPushTelemetryRequest(
+                    request, ClientMetricsTestUtils.requestContext());
+
+            assertEquals(Errors.TELEMETRY_TOO_LARGE, response.error());
+            assertFalse(instance.terminating());
+            assertEquals(Errors.TELEMETRY_TOO_LARGE, instance.lastKnownError());
+            // Metrics should report 1 plugin export error and 0 successful export, same accounting as any other
+            // plugin export failure.
+            assertEquals((double) 0, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_EXPORT + "-count").metricValue());
+            assertEquals((double) 1, getMetric(kafkaMetrics, ClientMetricsManager.ClientMetricsStats.PLUGIN_ERROR + "-count").metricValue());
         }
     }
 


### PR DESCRIPTION
## Summary

Since #22327 (4.3.1, "MINOR: Fixed metrics decompression"), `ClientTelemetryUtils.decompress` throws `TelemetryTooLargeException` when the decompressed telemetry payload exceeds `telemetry.max.bytes`. That exception propagates up through `ClientTelemetryExporterPlugin.exportMetrics` into `ClientMetricsManager.processPushTelemetryRequest`, where it's caught by a generic `catch (Throwable)` that always maps to `Errors.INVALID_RECORD`.

Per KIP-714, `INVALID_RECORD` means "the client's metrics serialization is broken, stop pushing" — the Java client reacts by setting its push interval to `Integer.MAX_VALUE`, permanently disabling telemetry for that client instance until the process restarts. `TELEMETRY_TOO_LARGE` is the correct, retryable code for this case — it's exactly what the pre-decompression wire-size check already returns via `Errors.forException` in `validatePushRequest`, a few lines above in the same method.

Typical OTLP metrics decompress at 10-25x their compressed size, so any client sending a payload that's well within the compressed wire limit can still trip the decompressed-size check and get silently, permanently cut off. This was observed in production: after upgrading brokers from 4.3.0 to 4.3.1, every Kafka Streams stream-thread consumer's telemetry stopped in every environment simultaneously.

## Fix

Add `catch (TelemetryTooLargeException)` before the existing `catch (Throwable)` in `ClientMetricsManager.processPushTelemetryRequest`, mapping to `Errors.TELEMETRY_TOO_LARGE` instead of `Errors.INVALID_RECORD`. This mirrors the `catch (ApiException) -> Errors.forException(exception)` pattern already used for `validatePushRequest` just above it — no new error-handling shape introduced. `TelemetryTooLargeException` already extends `ApiException` and `Errors.TELEMETRY_TOO_LARGE` already exists (introduced with KIP-714), so this is a two-catch-block change with no protocol/config additions.

Out of scope (per the reporter's own note, and to keep this change minimal): whether the decompressed-size bound should have its own configuration or a documented multiple of `telemetry.max.bytes`, since a single value can't sensibly bound both a compressed wire size and a 10-25x larger decompressed size. That's a separate, larger discussion; this PR only fixes the error code mismatch, which is the part causing clients to be permanently and silently cut off.

## Test plan

- Added `testPushTelemetryPluginTooLargeException` to `ClientMetricsManagerTest`, mirroring the existing `testPushTelemetryPluginException` (generic-exception) test, asserting the response and the client instance's `lastKnownError` are `TELEMETRY_TOO_LARGE`, with the same plugin-error metric accounting as any other export failure.
- `./gradlew :server:test --tests "org.apache.kafka.server.ClientMetricsManagerTest"` — all tests pass.
- `./gradlew :server:checkstyleMain :server:checkstyleTest :server:spotlessCheck` — clean.

## AI assistance disclosure

Per `AI_POLICY`/`CONTRIBUTING.md`: Claude Code (Sonnet 5) was used to investigate the root cause, implement the fix, and write the test in `server/src/main/java/org/apache/kafka/server/ClientMetricsManager.java` and `server/src/test/java/org/apache/kafka/server/ClientMetricsManagerTest.java`. All changes were reviewed by me before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https: //claude.ai/code/session_01K4B9PPesZhXHiWr5Ak1PNz
Reviewers: Apoorv Mittal <apoorvmittal10@gmail.com>, Steven Schlansker <stevenschlansker@gmail.com>
