### PR TITLE
KAFKA-20841: Bound FileRecords.readInto to the records it covers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/internal/FileRecords.java
@@ -126,8 +126,10 @@ public class FileRecords extends AbstractRecords implements Closeable {
     }
 
     /**
-     * Read log batches into the given buffer until there are no bytes remaining in the buffer or the end of the file
-     * is reached.
+     * Read log batches into the given buffer until there are no bytes remaining in the buffer or the end of these
+     * records is reached. Only the bytes belonging to these records are read: for a slice the read stops at the end
+     * of the slice rather than at the end of the underlying file, which may hold preallocated space or bytes appended
+     * after this instance was created.
      *
      * @param buffer The buffer to write the batches to
      * @param position Position in the buffer to read from
@@ -135,6 +137,10 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * possible exceptions
      */
     public void readInto(ByteBuffer buffer, int position) throws IOException {
+        int available = Math.max(0, sizeInBytes() - position);
+        if (buffer.remaining() > available) {
+            buffer.limit(buffer.position() + available);
+        }
         Utils.readFully(channel, buffer, position + this.start);
         buffer.flip();
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/internal/FileRecordsTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
@@ -48,6 +49,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.test.TestUtils.tempFile;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -783,6 +785,203 @@ public class FileRecordsTest {
                 filteredOffsets.remove(index);
             }
         }
+    }
+
+    /**
+     * A slice must not hand out bytes that lie past its end: the underlying file may hold later
+     * batches, which would then be read and replayed by callers that asked for a bounded read.
+     */
+    @Test
+    public void testReadIntoStopsAtSliceEnd() throws IOException {
+        int firstBatchSize = batches(fileRecords).get(0).sizeInBytes();
+        FileRecords slice = fileRecords.slice(0, firstBatchSize);
+
+        ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        slice.readInto(buffer, 0);
+
+        assertEquals(firstBatchSize, buffer.limit());
+        assertEquals(1, batches(MemoryRecords.readableRecords(buffer)).size());
+    }
+
+    /**
+     * With log.preallocate=true the file is longer than the data written to it. Reading up to the
+     * end of the file would return the zero-filled tail, which does not parse as a batch.
+     */
+    @Test
+    public void testReadIntoStopsAtLogicalEndOfPreallocatedFile() throws IOException {
+        File file = tempFile();
+        try (FileRecords preallocated = FileRecords.open(file, true, false, 512 * 1024, true)) {
+            append(preallocated, values);
+            int logicalSize = preallocated.sizeInBytes();
+            assertTrue(file.length() > logicalSize, "the file is expected to be preallocated");
+
+            ByteBuffer buffer = ByteBuffer.allocate(512 * 1024);
+            preallocated.readInto(buffer, 0);
+
+            assertEquals(logicalSize, buffer.limit());
+            assertEquals(values.length, batches(MemoryRecords.readableRecords(buffer)).size());
+        }
+    }
+
+    /**
+     * An empty preallocated log is the degenerate case of the same problem: there is nothing to
+     * read, but the file is megabytes long.
+     */
+    @Test
+    public void testReadIntoEmptyPreallocatedFile() throws IOException {
+        File file = tempFile();
+        try (FileRecords preallocated = FileRecords.open(file, true, false, 512 * 1024, true)) {
+            assertEquals(0, preallocated.sizeInBytes());
+            assertTrue(file.length() > 0, "the file is expected to be preallocated");
+
+            ByteBuffer buffer = ByteBuffer.allocate(512 * 1024);
+            preallocated.readInto(buffer, 0);
+
+            assertEquals(0, buffer.limit());
+        }
+    }
+
+    /**
+     * The bound must never make the read return less than the caller asked for, otherwise callers
+     * that size their buffer to a chunk would silently make less progress per call.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {1, 7, 37, 71, 72, 73})
+    public void testReadIntoFillsBufferSmallerThanTheRecords(int capacity) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(capacity);
+        fileRecords.readInto(buffer, 0);
+        assertEquals(capacity, buffer.limit());
+    }
+
+    /**
+     * LogSegment narrows the buffer to the batches it intends to copy before calling readInto, so
+     * the bound must only ever narrow the read further, never widen it.
+     */
+    @Test
+    public void testReadIntoHonoursTighterBufferLimit() throws IOException {
+        int firstBatchSize = batches(fileRecords).get(0).sizeInBytes();
+
+        ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        buffer.limit(firstBatchSize);
+        fileRecords.readInto(buffer, 0);
+
+        assertEquals(firstBatchSize, buffer.limit());
+        assertEquals(1, batches(MemoryRecords.readableRecords(buffer)).size());
+    }
+
+    /**
+     * RecordsIterator reads into the middle of a buffer it is filling up, so the bound has to be
+     * applied relative to the buffer position rather than to its capacity.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 16})
+    public void testReadIntoRespectsBufferPosition(int bufferOffset) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        buffer.position(bufferOffset);
+        fileRecords.readInto(buffer, 0);
+
+        assertEquals(bufferOffset + fileRecords.sizeInBytes(), buffer.limit());
+    }
+
+    /**
+     * Cleaner walks a segment chunk by chunk and stops on the logical size, so a read starting at
+     * or past that size must come back empty instead of returning the tail of the file.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 4096})
+    public void testReadIntoFromPositionAtOrPastTheEnd(int bytesPastTheEnd) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        fileRecords.readInto(buffer, fileRecords.sizeInBytes() + bytesPastTheEnd);
+        assertEquals(0, buffer.limit());
+    }
+
+    /**
+     * The bound is on the bytes left from the read position, not on the total size. The file has
+     * to be longer than the records for this to be observable, otherwise the read stops on the end
+     * of the file and hides the difference.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    public void testReadIntoFromTheMiddleStopsAtTheEnd(int batchesToSkip) throws IOException {
+        File file = tempFile();
+        try (FileRecords preallocated = FileRecords.open(file, true, false, 512 * 1024, true)) {
+            append(preallocated, values);
+            List<RecordBatch> allBatches = batches(preallocated);
+            int readPosition = 0;
+            for (int i = 0; i < batchesToSkip; i++) {
+                readPosition += allBatches.get(i).sizeInBytes();
+            }
+            int logicalSize = preallocated.sizeInBytes();
+
+            // Room for all the records, so only the bound can stop the read short.
+            ByteBuffer buffer = ByteBuffer.allocate(logicalSize);
+            preallocated.readInto(buffer, readPosition);
+
+            assertEquals(logicalSize - readPosition, buffer.limit());
+            assertEquals(allBatches.size() - batchesToSkip,
+                batches(MemoryRecords.readableRecords(buffer)).size());
+        }
+    }
+
+    /**
+     * A slice keeps the size it was created with, so the file underneath it can end up shorter.
+     * The read then has to stop at the end of the file instead of spinning on it.
+     */
+    @Test
+    @Timeout(30)
+    public void testReadIntoWhenTheFileIsShorterThanTheRecords() throws IOException {
+        int firstBatchSize = batches(fileRecords).get(0).sizeInBytes();
+        FileRecords staleSlice = fileRecords.slice(0, fileRecords.sizeInBytes());
+        fileRecords.truncateTo(firstBatchSize);
+
+        ByteBuffer buffer = ByteBuffer.allocate(staleSlice.sizeInBytes() * 2);
+        staleSlice.readInto(buffer, 0);
+
+        assertEquals(firstBatchSize, buffer.limit());
+    }
+
+    /**
+     * Records appended after a slice was taken are outside the bound the caller was given, while
+     * an instance covering the whole file must keep seeing data as it is appended.
+     */
+    @Test
+    public void testReadIntoIgnoresRecordsAppendedAfterTheSliceWasTaken() throws IOException {
+        int sizeBeforeAppend = fileRecords.sizeInBytes();
+        FileRecords slice = fileRecords.slice(0, sizeBeforeAppend);
+        append(fileRecords, values);
+        assertTrue(fileRecords.sizeInBytes() > sizeBeforeAppend);
+
+        ByteBuffer sliceBuffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        slice.readInto(sliceBuffer, 0);
+        assertEquals(sizeBeforeAppend, sliceBuffer.limit());
+
+        ByteBuffer wholeBuffer = ByteBuffer.allocate(fileRecords.sizeInBytes() * 2);
+        fileRecords.readInto(wholeBuffer, 0);
+        assertEquals(fileRecords.sizeInBytes(), wholeBuffer.limit());
+    }
+
+    /**
+     * Reading a segment in chunks that do not align with batch boundaries, as Cleaner does, must
+     * still reassemble the records byte for byte.
+     */
+    @Test
+    public void testReadIntoInChunksReassemblesTheRecords() throws IOException {
+        ByteBuffer whole = ByteBuffer.allocate(fileRecords.sizeInBytes());
+        fileRecords.readInto(whole, 0);
+        byte[] expected = new byte[whole.remaining()];
+        whole.get(expected);
+
+        ByteBuffer reassembled = ByteBuffer.allocate(expected.length);
+        int position = 0;
+        while (position < fileRecords.sizeInBytes()) {
+            ByteBuffer chunk = ByteBuffer.allocate(37);
+            fileRecords.readInto(chunk, position);
+            assertTrue(chunk.hasRemaining(), "a read below the logical size must return bytes");
+            position += chunk.remaining();
+            reassembled.put(chunk);
+        }
+
+        assertArrayEquals(expected, reassembled.array());
     }
 
     private static List<RecordBatch> batches(Records buffer) {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogSegmentTest.java
@@ -652,6 +652,47 @@ public class LogSegmentTest {
         }
     }
 
+    /**
+     * A preallocated segment is longer than the data written to it. Callers that copy a read into
+     * a buffer of their own, as the coordinator loaders do, must be given the records only and not
+     * the zero-filled tail of the file.
+     */
+    @Test
+    public void testReadIntoBufferFromPreallocatedSegment() throws IOException {
+        File tempDir = TestUtils.tempDirectory();
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(TopicConfig.INDEX_INTERVAL_BYTES_CONFIG, 10);
+        configMap.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, 1000);
+        configMap.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, 0);
+        LogConfig logConfig = new LogConfig(configMap);
+        int loadBufferSize = 1024 * 1024;
+
+        try (LogSegment seg = LogSegment.open(tempDir, 40, logConfig, Time.SYSTEM, loadBufferSize, true)) {
+            MemoryRecords appended = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 50,
+                Compression.NONE, TimestampType.CREATE_TIME,
+                new SimpleRecord(50_000L, "hello".getBytes()),
+                new SimpleRecord(51_000L, "there".getBytes()));
+            seg.append(51, appended);
+            assertTrue(seg.log().file().length() > seg.log().sizeInBytes(),
+                "the segment is expected to be preallocated beyond the records written to it");
+
+            FetchDataInfo read = seg.read(50, loadBufferSize);
+            FileRecords records = (FileRecords) read.records;
+            ByteBuffer buffer = ByteBuffer.allocate(loadBufferSize);
+            records.readInto(buffer, 0);
+
+            assertEquals(records.sizeInBytes(), buffer.limit());
+
+            List<Record> expected = TestUtils.toList(appended.records());
+            List<Record> actual = TestUtils.toList(MemoryRecords.readableRecords(buffer).records());
+            assertEquals(expected.size(), actual.size());
+            for (int i = 0; i < expected.size(); i++) {
+                assertEquals(expected.get(i).offset(), actual.get(i).offset());
+                assertEquals(Utils.utf8(expected.get(i).value()), Utils.utf8(actual.get(i).value()));
+            }
+        }
+    }
+
     /* create a segment with   pre allocate and clearly shut down*/
     @Test
     public void testCreateWithInitFileSizeClearShutdown() throws IOException {


### PR DESCRIPTION
`readInto` fills the buffer to the end of the file, not the end of the records it
was called on, so it returns preallocated space or bytes appended after the
instance was created. Bound it to `sizeInBytes() - position`.

This is the cause of KAFKA-13664. With `log.preallocate=true`,
`CoordinatorLoaderImpl` reads the segment's zero tail and the load dies:

```
Failed to load metadata from __consumer_offsets-0 with epoch 1 due to
    Record size 0 is less than the minimum record overhead (14)
```

followed by `Unloading group metadata` for every group on the partition. There is
no retry: `CoordinatorRuntime` moves the context to `FAILED`, so the partition
stays unloaded until leadership moves again.

Three brokers, replication factor 3, the coordinator killed so a neighbour loads
the partition from its own live preallocated replica. Same commit, one change:

|                              | trunk | patched |
|------------------------------|-------|---------|
| Failed to load metadata      | 4/4   | 0/4     |
| Finished loading of metadata | 0/4   | 4/4     |

On the released 4.3.1 the same scenario is 2/2 without the fix and 0/2 with the
bound backported.

The recovery path is unaffected: `LogSegment.recover` reads batch headers from the
channel rather than through `readInto`. Measured on an unclean restart with
`log.preallocate=true`, before and after the patch: identical, two
`CorruptRecordException` handled by recover, segment truncated to 1330002 bytes,
all 5000 records readable, broker up.

`TransactionStateManager` uses the same call pattern, so `__transaction_state`
loading looks exposed as well; I have not reproduced that.

12 new cases in `FileRecordsTest` and 2 in `LogSegmentTest`; those plus
`:clients:checkstyleMain`, `:clients:checkstyleTest` and `:storage:checkstyleTest`
pass on `c130b7382c`.
